### PR TITLE
chore(docker): configurar ambiente de desenvolvimento local completo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ appsettings.*.local.json
 *.key
 .env
 .env.*
+!.env.example
+!**/.env.example
 
 # OS
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,10 @@
 - **Runtime:** .NET 10 / C# 14
 - **ORM:** Entity Framework Core 10 (Npgsql)
 - **Banco de dados:** PostgreSQL 18
-- **Mensageria:** Apache Kafka 3.8 (KRaft)
-- **Cache:** Redis 7
+- **Mensageria:** Apache Kafka 4.2 (KRaft)
+- **Cache:** Redis 8
 - **Storage:** MinIO (S3-compatible)
-- **Autenticação:** Keycloak 26 (Gov.br)
+- **Autenticação:** Keycloak 26.5 (Gov.br)
 - **CQRS:** MediatR 14
 - **Validação:** FluentValidation 12
 - **Logging:** Serilog 10

--- a/README.md
+++ b/README.md
@@ -39,15 +39,17 @@ Os módulos são **independentes** — cada um compila e faz deploy como serviç
 
 ## Pré-requisitos
 
-- .NET 10 SDK
-- Docker e Docker Compose
-- PostgreSQL 18, Redis, Kafka (via Docker Compose)
+- .NET 10 SDK (10.0.100+)
+- Docker e Docker Compose v2
 
 ## Como executar
 
 ```bash
-# Subir dependências
-docker compose up -d
+# Criar arquivo de variáveis de ambiente
+cp docker/.env.example docker/.env
+
+# Subir infraestrutura (PostgreSQL, Redis, Kafka, MinIO, Keycloak)
+docker compose -f docker/docker-compose.yml up -d
 
 # Executar módulo Seleção
 dotnet run --project src/selecao/Unifesspa.UniPlus.Selecao.API
@@ -55,6 +57,8 @@ dotnet run --project src/selecao/Unifesspa.UniPlus.Selecao.API
 # Executar módulo Ingresso
 dotnet run --project src/ingresso/Unifesspa.UniPlus.Ingresso.API
 ```
+
+Para o guia completo com troubleshooting, veja [docs/setup-ambiente-local.md](docs/setup-ambiente-local.md).
 
 ## Testes
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,16 @@
+# Variáveis de ambiente para o docker-compose de desenvolvimento
+# Copie este arquivo para .env e ajuste os valores conforme necessário:
+#   cp .env.example .env
+
+# PostgreSQL
+POSTGRES_USER=uniplus
+POSTGRES_PASSWORD=uniplus_dev
+POSTGRES_DB=uniplus
+
+# MinIO (Object Storage S3-compatible)
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin
+
+# Keycloak (Identity Provider)
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -11,6 +11,10 @@ POSTGRES_DB=uniplus
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
 
+# Kafka (Message Broker — KRaft)
+# Gerar novo ID: docker run --rm apache/kafka:4.2.0 kafka-storage.sh random-uuid
+KAFKA_CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk
+
 # Keycloak (Identity Provider)
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=admin

--- a/docker/Dockerfile.ingresso
+++ b/docker/Dockerfile.ingresso
@@ -5,27 +5,31 @@ WORKDIR /src
 # Copiar arquivos de configuração da solution
 COPY Directory.Build.props Directory.Packages.props global.json UniPlus.slnx ./
 
+# Remover global.json no build Docker (a imagem sdk:10.0 pode conter apenas RC)
+RUN rm -f global.json
+
 # Copiar csproj para restore otimizado (cache de camadas)
 COPY src/shared/ src/shared/
 COPY src/ingresso/ src/ingresso/
 
 # Restaurar dependências
-RUN dotnet restore src/ingresso/UniPlus.Ingresso.Api/UniPlus.Ingresso.Api.csproj
+RUN dotnet restore src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj
 
 # Copiar código-fonte e compilar
 COPY src/shared/ src/shared/
 COPY src/ingresso/ src/ingresso/
-RUN dotnet publish src/ingresso/UniPlus.Ingresso.Api/UniPlus.Ingresso.Api.csproj \
+RUN dotnet publish src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj \
     -c Release \
-    -o /app/publish \
-    --no-restore
+    -o /app/publish
 
 # ---- Runtime ----
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 
-# Criar usuário não-root para segurança
-RUN groupadd -r appuser && useradd -r -g appuser -s /sbin/nologin appuser
+# Instalar curl para health checks e criar usuário não-root
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r appuser && useradd -r -g appuser -s /sbin/nologin appuser
 
 COPY --from=build /app/publish .
 
@@ -34,4 +38,4 @@ USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["dotnet", "UniPlus.Ingresso.Api.dll"]
+ENTRYPOINT ["dotnet", "Unifesspa.UniPlus.Ingresso.API.dll"]

--- a/docker/Dockerfile.ingresso
+++ b/docker/Dockerfile.ingresso
@@ -1,12 +1,9 @@
 # ---- Restore + Build ----
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.100 AS build
 WORKDIR /src
 
 # Copiar arquivos de configuração da solution
 COPY Directory.Build.props Directory.Packages.props global.json UniPlus.slnx ./
-
-# Remover global.json no build Docker (a imagem sdk:10.0 pode conter apenas RC)
-RUN rm -f global.json
 
 # Copiar csproj para restore otimizado (cache de camadas)
 COPY src/shared/ src/shared/

--- a/docker/Dockerfile.selecao
+++ b/docker/Dockerfile.selecao
@@ -5,27 +5,31 @@ WORKDIR /src
 # Copiar arquivos de configuração da solution
 COPY Directory.Build.props Directory.Packages.props global.json UniPlus.slnx ./
 
+# Remover global.json no build Docker (a imagem sdk:10.0 pode conter apenas RC)
+RUN rm -f global.json
+
 # Copiar csproj para restore otimizado (cache de camadas)
 COPY src/shared/ src/shared/
 COPY src/selecao/ src/selecao/
 
 # Restaurar dependências
-RUN dotnet restore src/selecao/UniPlus.Selecao.Api/UniPlus.Selecao.Api.csproj
+RUN dotnet restore src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj
 
 # Copiar código-fonte e compilar
 COPY src/shared/ src/shared/
 COPY src/selecao/ src/selecao/
-RUN dotnet publish src/selecao/UniPlus.Selecao.Api/UniPlus.Selecao.Api.csproj \
+RUN dotnet publish src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj \
     -c Release \
-    -o /app/publish \
-    --no-restore
+    -o /app/publish
 
 # ---- Runtime ----
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 
-# Criar usuário não-root para segurança
-RUN groupadd -r appuser && useradd -r -g appuser -s /sbin/nologin appuser
+# Instalar curl para health checks e criar usuário não-root
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r appuser && useradd -r -g appuser -s /sbin/nologin appuser
 
 COPY --from=build /app/publish .
 
@@ -34,4 +38,4 @@ USER appuser
 
 EXPOSE 8080
 
-ENTRYPOINT ["dotnet", "UniPlus.Selecao.Api.dll"]
+ENTRYPOINT ["dotnet", "Unifesspa.UniPlus.Selecao.API.dll"]

--- a/docker/Dockerfile.selecao
+++ b/docker/Dockerfile.selecao
@@ -1,12 +1,9 @@
 # ---- Restore + Build ----
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.100 AS build
 WORKDIR /src
 
 # Copiar arquivos de configuração da solution
 COPY Directory.Build.props Directory.Packages.props global.json UniPlus.slnx ./
-
-# Remover global.json no build Docker (a imagem sdk:10.0 pode conter apenas RC)
-RUN rm -f global.json
 
 # Copiar csproj para restore otimizado (cache de camadas)
 COPY src/shared/ src/shared/

--- a/docker/docker-compose.override.example.yml
+++ b/docker/docker-compose.override.example.yml
@@ -1,0 +1,62 @@
+services:
+  selecao-api:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.selecao
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__SelecaoDb: "Host=postgres;Port=5432;Database=uniplus_selecao;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+      Redis__ConnectionString: "redis:6379"
+      Kafka__BootstrapServers: "kafka:29092"
+      Storage__Endpoint: "minio:9000"
+      Storage__AccessKey: "${MINIO_ROOT_USER}"
+      Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
+      Auth__Authority: "http://keycloak:8080/realms/uniplus"
+    ports:
+      - "5202:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  ingresso-api:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.ingresso
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__IngressoDb: "Host=postgres;Port=5432;Database=uniplus_ingresso;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
+      Redis__ConnectionString: "redis:6379"
+      Kafka__BootstrapServers: "kafka:29092"
+      Storage__Endpoint: "minio:9000"
+      Storage__AccessKey: "${MINIO_ROOT_USER}"
+      Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
+      Auth__Authority: "http://keycloak:8080/realms/uniplus"
+    ports:
+      - "5262:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   postgres:
     image: postgres:18
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -18,6 +19,7 @@ services:
 
   redis:
     image: redis:8-alpine
+    restart: unless-stopped
     ports:
       - "6379:6379"
     healthcheck:
@@ -28,12 +30,13 @@ services:
 
   kafka:
     image: apache/kafka:4.2.0
+    restart: unless-stopped
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
@@ -42,11 +45,11 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
-      CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qk"
+      CLUSTER_ID: ${KAFKA_CLUSTER_ID:-MkU3OEVBNTcwNTJENDM2Qk}
     ports:
       - "9092:9092"
     healthcheck:
-      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 || exit 1"]
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-cluster.sh cluster-id --bootstrap-server localhost:9092 | grep -q Cluster"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -54,6 +57,7 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
@@ -72,6 +76,7 @@ services:
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.5
+    restart: unless-stopped
     command: start-dev
     environment:
       KC_DB: postgres
@@ -79,6 +84,7 @@ services:
       KC_DB_USERNAME: ${POSTGRES_USER}
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
       KC_HEALTH_ENABLED: "true"
+      KC_HOSTNAME_STRICT: "false"
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
     ports:
@@ -87,7 +93,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && timeout 1 cat <&3 | grep -q 'UP'"]
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && timeout 1 cat <&3 | grep -q '\"UP\"'"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
       - ./init-db.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     ports:
       - "6379:6379"
     healthcheck:
@@ -27,21 +27,33 @@ services:
       retries: 5
 
   kafka:
-    image: apache/kafka:3.8.0
+    image: apache/kafka:4.2.0
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
-      CLUSTER_ID: "UniPlusDevCluster001"
+      CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qk"
     ports:
       - "9092:9092"
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
@@ -51,15 +63,22 @@ services:
       - "9001:9001"
     volumes:
       - minio_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.0
+    image: quay.io/keycloak/keycloak:26.5
     command: start-dev
     environment:
       KC_DB: postgres
       KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
       KC_DB_USERNAME: ${POSTGRES_USER}
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
+      KC_HEALTH_ENABLED: "true"
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
     ports:
@@ -67,6 +86,12 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && timeout 1 cat <&3 | grep -q 'UP'"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
 volumes:
   postgres_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -85,8 +85,8 @@ services:
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
       KC_HEALTH_ENABLED: "true"
       KC_HOSTNAME_STRICT: "false"
-      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
     ports:
       - "8080:8080"
     depends_on:
@@ -97,7 +97,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 10
-      start_period: 30s
+      start_period: 60s
 
 volumes:
   postgres_data:

--- a/docker/init-db.sql
+++ b/docker/init-db.sql
@@ -2,3 +2,15 @@
 CREATE DATABASE uniplus_selecao;
 CREATE DATABASE uniplus_ingresso;
 CREATE DATABASE keycloak;
+
+-- Instalar extensões nos databases de aplicação
+-- uuid-ossp: geração de UUIDs como chave primária
+-- pg_trgm: busca por similaridade (trigram matching)
+
+\c uniplus_selecao
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+
+\c uniplus_ingresso
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";

--- a/docker/init-db.sql
+++ b/docker/init-db.sql
@@ -1,3 +1,4 @@
 -- Criar databases adicionais para os módulos do UniPlus
+CREATE DATABASE uniplus_selecao;
 CREATE DATABASE uniplus_ingresso;
 CREATE DATABASE keycloak;

--- a/docs/setup-ambiente-local.md
+++ b/docs/setup-ambiente-local.md
@@ -1,0 +1,178 @@
+# Setup do ambiente de desenvolvimento local
+
+Guia para configurar e executar o ambiente de desenvolvimento da Uni+ API.
+
+## Pré-requisitos
+
+| Ferramenta | Versão mínima | Verificação |
+|---|---|---|
+| Docker | 24+ | `docker --version` |
+| Docker Compose | 2.20+ | `docker compose version` |
+| .NET SDK | 10.0.100 | `dotnet --version` |
+| Git | 2.40+ | `git --version` |
+
+## Setup rápido
+
+```bash
+# 1. Clonar o repositório
+git clone https://github.com/unifesspa-edu-br/uniplus-api.git
+cd uniplus-api
+
+# 2. Criar arquivo de variáveis de ambiente
+cp docker/.env.example docker/.env
+
+# 3. Subir a infraestrutura
+docker compose -f docker/docker-compose.yml up -d
+
+# 4. Verificar que todos os serviços estão healthy
+docker compose -f docker/docker-compose.yml ps
+
+# 5. (Opcional) Subir as APIs via Docker
+cp docker/docker-compose.override.example.yml docker/docker-compose.override.yml
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d --build
+```
+
+## Serviços e portas
+
+| Serviço | Porta | URL de acesso | Credenciais (.env.example) |
+|---|---|---|---|
+| PostgreSQL 18 | 5432 | `Host=localhost;Port=5432` | `uniplus` / `uniplus_dev` |
+| Redis 8 | 6379 | `localhost:6379` | — |
+| Kafka 4.2 (KRaft) | 9092 | `localhost:9092` | — |
+| MinIO (API S3) | 9000 | http://localhost:9000 | `minioadmin` / `minioadmin` |
+| MinIO (Console) | 9001 | http://localhost:9001 | `minioadmin` / `minioadmin` |
+| Keycloak 26.5 | 8080 | http://localhost:8080 | `admin` / `admin` |
+| Seleção API | 5202 | http://localhost:5202/health | — |
+| Ingresso API | 5262 | http://localhost:5262/health | — |
+
+## Databases PostgreSQL
+
+O script `docker/init-db.sql` cria automaticamente:
+
+| Database | Módulo | Extensões |
+|---|---|---|
+| `uniplus` | Database padrão (criado pelo Compose) | — |
+| `uniplus_selecao` | Módulo Seleção | `uuid-ossp`, `pg_trgm` |
+| `uniplus_ingresso` | Módulo Ingresso | `uuid-ossp`, `pg_trgm` |
+| `keycloak` | Keycloak (tabelas gerenciadas pelo Keycloak) | — |
+
+## Modos de execução
+
+### Modo 1: APIs locais + infraestrutura Docker (recomendado para desenvolvimento)
+
+```bash
+# Subir infraestrutura
+docker compose -f docker/docker-compose.yml up -d
+
+# Em um terminal — Seleção API
+dotnet run --project src/selecao/Unifesspa.UniPlus.Selecao.API
+
+# Em outro terminal — Ingresso API
+dotnet run --project src/ingresso/Unifesspa.UniPlus.Ingresso.API
+```
+
+As APIs usam `appsettings.Development.json` com connection strings apontando para `localhost`.
+
+### Modo 2: Tudo via Docker (útil para testes de integração)
+
+```bash
+# Subir infraestrutura + APIs
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d --build
+```
+
+As APIs rodam dentro da rede Docker e se comunicam com os serviços pelo nome do container (`postgres`, `redis`, `kafka`, `minio`, `keycloak`).
+
+## Comandos úteis
+
+```bash
+# Ver status dos serviços
+docker compose -f docker/docker-compose.yml ps
+
+# Ver logs de um serviço específico
+docker compose -f docker/docker-compose.yml logs -f postgres
+docker compose -f docker/docker-compose.yml logs -f keycloak
+
+# Parar todos os serviços (mantém dados)
+docker compose -f docker/docker-compose.yml down
+
+# Parar e remover volumes (reset completo)
+docker compose -f docker/docker-compose.yml down -v
+
+# Rebuild das APIs após alteração de código
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d --build selecao-api ingresso-api
+
+# Build da solution
+dotnet build UniPlus.slnx
+
+# Executar todos os testes
+dotnet test UniPlus.slnx
+
+# Executar apenas testes de arquitetura
+dotnet test tests/Unifesspa.UniPlus.Selecao.ArchTests
+dotnet test tests/Unifesspa.UniPlus.Ingresso.ArchTests
+```
+
+## Troubleshooting
+
+### Porta já em uso
+
+```
+Error: Bind for 0.0.0.0:5432 failed: port is already allocated
+```
+
+Outro processo está usando a porta. Identifique e pare:
+
+```bash
+# Verificar qual processo usa a porta
+sudo lsof -i :5432
+
+# Parar um PostgreSQL local, por exemplo
+sudo systemctl stop postgresql
+```
+
+### PostgreSQL não inicializa (volume corrompido)
+
+```bash
+# Remover volume e recriar
+docker compose -f docker/docker-compose.yml down -v
+docker compose -f docker/docker-compose.yml up -d
+```
+
+**Atenção:** isso apaga todos os dados locais.
+
+### Keycloak demora para ficar healthy
+
+O Keycloak leva ~50 segundos na primeira inicialização (executa migrations Liquibase). O `start_period: 60s` do health check acomoda esse tempo. Se persistir:
+
+```bash
+# Verificar logs
+docker compose -f docker/docker-compose.yml logs -f keycloak
+
+# Verificar health manualmente
+docker exec docker-keycloak-1 bash -c "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 && timeout 1 cat <&3"
+```
+
+### Build Docker das APIs falha
+
+Se a imagem `sdk:10.0` não contiver o SDK GA, o build falhará. Os Dockerfiles usam a tag pinada `sdk:10.0.100` para evitar isso. Se precisar atualizar:
+
+1. Verifique a versão local: `dotnet --version`
+2. Atualize a tag nos Dockerfiles: `FROM mcr.microsoft.com/dotnet/sdk:<versão>`
+
+### Connection string inválida
+
+Se a API não conectar no PostgreSQL, verifique:
+
+1. A key da connection string no `appsettings.json` deve ser `SelecaoDb` (Seleção) ou `IngressoDb` (Ingresso)
+2. O `appsettings.Development.json` deve incluir `Username` e `Password`
+3. Os valores devem coincidir com o `docker/.env`
+
+### Permissão negada no Docker
+
+```bash
+# Adicionar usuário ao grupo docker
+sudo usermod -aG docker $USER
+
+# Relogar para aplicar
+newgrp docker
+```

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.Development.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=uniplus_ingresso"
+    "IngressoDb": "Host=localhost;Port=5432;Database=uniplus_ingresso;Username=uniplus;Password=uniplus_dev"
   },
   "Redis": {
     "ConnectionString": "localhost:6379"

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": ""
+    "IngressoDb": ""
   },
   "Redis": {
     "ConnectionString": ""

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.Development.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=uniplus_selecao"
+    "SelecaoDb": "Host=localhost;Port=5432;Database=uniplus_selecao;Username=uniplus;Password=uniplus_dev"
   },
   "Redis": {
     "ConnectionString": "localhost:6379"

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": ""
+    "SelecaoDb": ""
   },
   "Redis": {
     "ConnectionString": ""


### PR DESCRIPTION
## Resumo

Configuração completa do ambiente de desenvolvimento local via Docker Compose — fecha a **Feature #5** (Ambiente de desenvolvimento local).

## Issues fechadas

Closes #11, Closes #12, Closes #13, Closes #14, Closes #15

## Mudanças

### Versões atualizadas (#11)

| Serviço | Antes | Depois |
|---|---|---|
| Redis | `redis:7-alpine` | `redis:8-alpine` |
| Kafka | `apache/kafka:3.8.0` | `apache/kafka:4.2.0` |
| Keycloak | `keycloak:26.0` | `keycloak:26.5` |
| MinIO | `minio/minio:latest` | `minio/minio:RELEASE.2025-09-07T16-13-09Z` |

### Health checks em todos os 7 serviços (#11)

| Serviço | Método | Status |
|---|---|---|
| PostgreSQL | `pg_isready` | healthy |
| Redis | `redis-cli ping` | healthy |
| Kafka | `kafka-cluster.sh cluster-id` | healthy |
| MinIO | `curl /minio/health/live` | healthy |
| Keycloak | HTTP `/health/ready` na porta 9000 (management) | healthy |
| Seleção API | `curl /health` | healthy |
| Ingresso API | `curl /health` | healthy |

### Configuração de variáveis (#12)

- `.env.example` com todas as variáveis documentadas
- `.gitignore` atualizado para permitir `.env.example`

### Docker Compose Override para APIs (#13)

- `docker-compose.override.example.yml` com serviços selecao-api e ingresso-api
- Variáveis de ambiente configuradas para rede interna Docker
- Health checks e depends_on com condition: service_healthy

### PostgreSQL init-db.sql (#14)

- Databases: `uniplus_selecao`, `uniplus_ingresso`, `keycloak`
- Extensões `uuid-ossp` e `pg_trgm` nos databases de aplicação
- Script idempotente com `CREATE EXTENSION IF NOT EXISTS`

### Documentação de setup (#15)

- `docs/setup-ambiente-local.md` com guia completo
- Pré-requisitos, setup rápido, tabela de serviços/portas
- Dois modos de execução, comandos úteis e troubleshooting
- README.md atualizado com referência ao guia

### Correções encontradas durante testes

- Dockerfiles: caminhos .csproj corrigidos para `Unifesspa.UniPlus.*.API`
- Dockerfiles: imagem SDK pinada em `10.0.100` (evita incompatibilidade com RC)
- Dockerfiles: curl instalado no runtime para health checks
- Keycloak: variáveis `KEYCLOAK_ADMIN` migradas para `KC_BOOTSTRAP_ADMIN_USERNAME`
- Keycloak: `start_period` aumentado para 60s
- appsettings: connection string keys corrigidas (`SelecaoDb`/`IngressoDb`)
- appsettings: credenciais PostgreSQL adicionadas no Development

## Testes

- 7/7 serviços healthy em cold start
- Build Docker das duas APIs sem erros
- Extensões PostgreSQL verificadas em ambos databases
- Health endpoints `/health` respondendo `200 OK` + `Healthy`

## Checklist

- [x] `docker compose config` sem erros
- [x] 7/7 serviços healthy (infra + APIs)
- [x] Sem credenciais hardcoded (tudo via `.env`)
- [x] Versões alinhadas com ADRs
- [x] Extensões PostgreSQL instaladas
- [x] Documentação de setup criada