### PR TITLE
chore(templates): adicionar templates de Epic, Story e Task

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,50 @@
+name: Epic
+description: Tema estratégico que agrupa várias Features
+title: "Epic: "
+labels: ["epic"]
+body:
+  - type: textarea
+    id: descricao
+    attributes:
+      label: Descrição
+      description: Qual o tema estratégico que este Epic representa?
+      placeholder: Visão geral do tema, problema de negócio ou capacidade técnica que justifica o Epic
+    validations:
+      required: true
+  - type: textarea
+    id: objetivos
+    attributes:
+      label: Objetivos
+      description: O que se espera entregar ao final do Epic
+      placeholder: |
+        - Objetivo 1
+        - Objetivo 2
+    validations:
+      required: true
+  - type: textarea
+    id: features
+    attributes:
+      label: Features previstas
+      description: Liste as Features que este Epic deve conter (serão criadas como sub-issues)
+      placeholder: |
+        - [ ] Feature A
+        - [ ] Feature B
+    validations:
+      required: false
+  - type: textarea
+    id: criterios
+    attributes:
+      label: Critérios de sucesso
+      description: Como validar que o Epic foi concluído
+      placeholder: |
+        - [ ] Todas as Features entregues em produção
+        - [ ] Métrica X atingida
+    validations:
+      required: false
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referências
+      description: ADRs, requisitos (RF/RN), legislação, documentos de proposta
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,0 +1,58 @@
+name: User Story
+description: Incremento implementável com critérios de aceite testáveis (sub-issue de uma Feature)
+title: "US-FX-NN: "
+labels: ["story"]
+body:
+  - type: input
+    id: feature_pai
+    attributes:
+      label: Feature pai
+      description: Número da Feature à qual esta Story pertence (use # para referenciar, ex.= #42)
+      placeholder: "#42"
+    validations:
+      required: true
+  - type: textarea
+    id: narrativa
+    attributes:
+      label: Narrativa
+      description: Formato "como/quero/para"
+      placeholder: |
+        Como [persona],
+        quero [ação],
+        para [benefício].
+    validations:
+      required: true
+  - type: textarea
+    id: criterios
+    attributes:
+      label: Critérios de aceite
+      description: Usar checkboxes para cada critério testável
+      placeholder: |
+        - [ ] Dado ..., quando ..., então ...
+        - [ ] Dado ..., quando ..., então ...
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks (decomposição técnica)
+      description: Lista preliminar de Tasks — cada uma virará sub-issue com label `task`
+      placeholder: |
+        - [ ] Task 1
+        - [ ] Task 2
+    validations:
+      required: false
+  - type: textarea
+    id: dependencias
+    attributes:
+      label: Dependências
+      description: Issues ou decisões que bloqueiam esta Story
+    validations:
+      required: false
+  - type: textarea
+    id: referencias
+    attributes:
+      label: Referências
+      description: ADRs, RFs, RNs, legislação
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,54 @@
+name: Task
+description: Unidade técnica de trabalho — 1 Task = 1 Pull Request (sub-issue de uma Story)
+title: "task(escopo): "
+labels: ["task"]
+body:
+  - type: input
+    id: story_pai
+    attributes:
+      label: Story pai
+      description: Número da Story à qual esta Task pertence (ex.= #56)
+      placeholder: "#56"
+    validations:
+      required: true
+  - type: textarea
+    id: objetivo
+    attributes:
+      label: O que precisa ser feito
+      description: Descrição objetiva e acionável
+    validations:
+      required: true
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Checklist do que caracteriza a Task como concluída
+      placeholder: |
+        - [ ] Código implementado
+        - [ ] Testes unitários cobrindo o novo comportamento
+        - [ ] Build passando
+        - [ ] PR aberto e vinculado (Closes #N)
+      value: |
+        - [ ] Código implementado
+        - [ ] Testes unitários cobrindo o novo comportamento
+        - [ ] Build passando
+        - [ ] PR aberto e vinculado (Closes #N)
+    validations:
+      required: true
+  - type: dropdown
+    id: esforco
+    attributes:
+      label: Esforço estimado
+      options:
+        - P (pequeno — até 4h)
+        - M (médio — até 1 dia)
+        - G (grande — até 3 dias; considerar dividir)
+    validations:
+      required: false
+  - type: textarea
+    id: notas
+    attributes:
+      label: Notas técnicas
+      description: Pontos de atenção, arquivos envolvidos, referências a ADRs
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -44,7 +44,7 @@ body:
         - M (médio — até 1 dia)
         - G (grande — até 3 dias; considerar dividir)
     validations:
-      required: false
+      required: true
   - type: textarea
     id: notas
     attributes:


### PR DESCRIPTION
Closes #65

## Summary

- `epic.yml` — tema estratégico com objetivos e critérios de sucesso
- `story.yml` — exige Feature pai, critérios de aceite e decomposição em Tasks
- `task.yml` — exige Story pai, Definition of Done e esforço estimado (P/M/G)

Complementa o `feature.yml` já existente. Padroniza a criação de issues conforme a hierarquia Epic → Feature → Story → Task via sub-issues estabelecida no workspace.

Contexto completo: unifesspa-edu-br/uniplus-docs#8

## Test plan

- [ ] Abrir "New issue" no repo e validar que os 4 templates aparecem
- [ ] Criar uma issue de teste com cada template e conferir que as labels são aplicadas corretamente (`epic`, `story`, `task`)
- [ ] Validar que os campos obrigatórios bloqueiam submissão quando vazios