### PR TITLE
feat(auth): ativa eventos de auditoria no realm Keycloak

### DIFF
--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -1826,13 +1826,35 @@
     "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
   "smtpServer": {},
-  "eventsEnabled": false,
+  "eventsEnabled": true,
   "eventsListeners": [
     "jboss-logging"
   ],
-  "enabledEventTypes": [],
-  "adminEventsEnabled": false,
-  "adminEventsDetailsEnabled": false,
+  "enabledEventTypes": [
+    "LOGIN",
+    "LOGIN_ERROR",
+    "LOGOUT",
+    "LOGOUT_ERROR",
+    "REFRESH_TOKEN",
+    "REFRESH_TOKEN_ERROR",
+    "CODE_TO_TOKEN",
+    "CODE_TO_TOKEN_ERROR",
+    "UPDATE_PASSWORD",
+    "UPDATE_PASSWORD_ERROR",
+    "SEND_RESET_PASSWORD",
+    "SEND_RESET_PASSWORD_ERROR",
+    "RESET_PASSWORD",
+    "RESET_PASSWORD_ERROR",
+    "IDENTITY_PROVIDER_LOGIN",
+    "IDENTITY_PROVIDER_LOGIN_ERROR",
+    "CLIENT_LOGIN",
+    "CLIENT_LOGIN_ERROR",
+    "TOKEN_EXCHANGE",
+    "TOKEN_EXCHANGE_ERROR",
+    "PERMISSION_TOKEN"
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": true,
   "identityProviders": [],
   "identityProviderMappers": [],
   "components": {
@@ -2999,5 +3021,6 @@
         }
       ]
     }
-  ]
+  ],
+  "eventsExpiration": 2592000
 }


### PR DESCRIPTION
## Resumo

Liga eventos de usuário e administrativos no realm `unifesspa`, atendendo à Task #72 da Story de hardening do Keycloak (#67).

## O que muda

`docker/keycloak/realm-export.json`:

- `eventsEnabled: true`
- `eventsExpiration: 2592000` (retenção 30 dias)
- `enabledEventTypes`: 21 tipos (LOGIN, LOGIN_ERROR, LOGOUT, REFRESH_TOKEN, UPDATE_PASSWORD, SEND_RESET_PASSWORD, IDENTITY_PROVIDER_LOGIN, CLIENT_LOGIN, TOKEN_EXCHANGE, PERMISSION_TOKEN, e seus `_ERROR` correspondentes)
- `adminEventsEnabled: true`
- `adminEventsDetailsEnabled: true`

## Motivação

**LGPD Art. 46** — Controlador e operador devem adotar medidas de segurança aptas a proteger dados pessoais, incluindo registro das operações de tratamento. Sem trilha de auditoria de autenticação, operações sobre dados de candidatos ficam sem rastreabilidade.

## Validação empírica

Contra Keycloak local após `down -v && up -d`:

```
--- events config (runtime) ---
{ "eventsEnabled": true, "adminEventsEnabled": true,
  "adminEventsDetailsEnabled": true, "enabledEventTypes_count": 21 }

--- login errado para gerar evento ---
HTTP 400

--- stream de eventos LOGIN_ERROR ---
[{ "type": "LOGIN_ERROR", "clientId": "selecao-web",
   "ipAddress": "192.168.64.1", "time": 1776207018347 }]
```

Import log: `KC-SERVICES0032: Import finished successfully` ✓

## Checklist

- [x] Mudança aplicada no JSON
- [x] Import limpo (`down -v && up -d`)
- [x] Evento LOGIN_ERROR capturado no stream `/events`
- [x] `/events/config` via admin API confirma todas as flags

## Observações para a próxima fase

Em produção, conectar event listener adicional para exportar eventos estruturados ao SIEM/Loki (fora do escopo desta Task — será feito quando a stack de observabilidade estiver no ar).

Closes #72
Part of #67