### PR TITLE
feat(auth): adicionar oidc-audience-mapper "uniplus" no scope uniplus-profile

### DIFF
--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -1109,6 +1109,18 @@
             "claim.name": "cpf",
             "jsonType.label": "String"
           }
+        },
+        {
+          "name": "aud-uniplus",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "uniplus",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
         }
       ]
     },


### PR DESCRIPTION
## Resumo

Adicionar mapper de audience ao client scope `uniplus-profile` com `included.custom.audience: "uniplus"`, conforme ADR-019 (audience única para tokens OIDC da plataforma).

## O que muda

`docker/keycloak/realm-export.json` — novo item em `.clientScopes[] | select(.name=="uniplus-profile") | .protocolMappers`:

```json
{
  "name": "aud-uniplus",
  "protocol": "openid-connect",
  "protocolMapper": "oidc-audience-mapper",
  "consentRequired": false,
  "config": {
    "included.custom.audience": "uniplus",
    "id.token.claim": "false",
    "access.token.claim": "true",
    "introspection.token.claim": "true"
  }
}
```

## Motivação

Base para o backend .NET validar `ValidAudiences = ["uniplus"]` (story #26). Sem este mapper, o `aud` do token é resolvido pelo `oidc-audience-resolve-mapper` do scope `roles`, que **só inclui clients para os quais o user tem client-level roles** — como `uniplus-api` usa realm-level roles, o `aud` jamais incluiria `uniplus-api`, e o backend rejeitaria todos os tokens.

## Validação empírica

Token emitido via `selecao-web` (direct grant runtime) para `candidato`:

```
--- aud claim ---
[ "uniplus", "account" ]
```

Import log: `KC-SERVICES0032: Import finished successfully` ✓

## Referências

- ADR-019 — Audience única `uniplus` para tokens OIDC da plataforma
- RFC 7519 §4.1.3 — JWT `aud` claim

Closes #68
Part of #67