### PR TITLE
feat(auth): ajustar flags do scope uniplus-profile (M1/M2)

### DIFF
--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -1069,8 +1069,8 @@
       "description": "",
       "protocol": "openid-connect",
       "attributes": {
-        "include.in.token.scope": "false",
-        "display.on.consent.screen": "true",
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false",
         "gui.order": "",
         "consent.screen.text": "",
         "include.in.openid.provider.metadata": "true"


### PR DESCRIPTION
## Resumo

Ajustar dois atributos do client scope `uniplus-profile` para coerência, atendendo à Task #75 da Story #67.

## O que muda

`docker/keycloak/realm-export.json` — em `.clientScopes[] | select(.name=="uniplus-profile") | .attributes`:

- `include.in.token.scope`: `"false"` → `"true"` (**M1**)
- `display.on.consent.screen`: `"true"` → `"false"` (**M2**)

## Motivação

- **M1**: com `include.in.token.scope=true`, o nome `uniplus-profile` passa a aparecer na claim `scope` do access token. Isso habilita scope-based authorization no backend (ex.: `[RequiredScope("uniplus-profile")]`).
- **M2**: os 4 clients têm `consentRequired=false` (apps institucionais, sem tela de consent). Ter o scope com `display.on.consent.screen=true` era inconsistente e gerava confusão — o scope nunca seria exibido em tela.

## Validação empírica

Token emitido para `candidato` via `selecao-web` (direct grant runtime):

```
--- scope claim ---
"openid uniplus-profile profile email"
```

Import log: `KC-SERVICES0032: Import finished successfully` ✓

Closes #75
Part of #67