### PR TITLE
feat(auth): ativar refresh token rotation com reuse detection

### DIFF
--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -4,7 +4,7 @@
   "passwordPolicy": "length(8) and upperCase(1) and lowerCase(1) and digits(1) and notUsername",
   "notBefore": 0,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": false,
+  "revokeRefreshToken": true,
   "refreshTokenMaxReuse": 0,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,


### PR DESCRIPTION
## Resumo

Ativar rotação automática de refresh tokens com detecção de replay no realm `unifesspa`. Atende à Task #70 da Story #67.

## O que muda

`docker/keycloak/realm-export.json`:

- `revokeRefreshToken: false` → `true`
- `refreshTokenMaxReuse: 0` (mantido)

Efeito: cada chamada ao endpoint `/token` com `grant_type=refresh_token` emite um novo refresh token e revoga o anterior. Reuso do antigo retorna erro.

## Motivação

Public clients (SPAs) não têm `client_secret` — dependem obrigatoriamente de refresh token rotation para mitigar roubo via XSS, extensões maliciosas ou devtools aberto. Sem rotação, um refresh token vazado é reutilizável até expirar (potencialmente 30 dias).

Conformidade com:
- **OAuth 2.1 §4.13** — Refresh Token Rotation
- **BCP for Browser-Based Apps** — §rotation + replay detection

## Validação empírica

Contra Keycloak local após `down -v && up -d`:

```
rotation: ROTATION_OK

--- replay of old refresh ---
{ "error": "invalid_grant",
  "error_description": "Maximum allowed refresh token reuse exceeded" }
```

Import log: `KC-SERVICES0032: Import finished successfully` ✓

## Impacto para o frontend

O SDK OIDC do frontend (`angular-auth-oidc-client` ou similar) **precisa** lidar com rotação de refresh token — após um refresh bem-sucedido, o refresh antigo não pode mais ser tentado. A maioria dos SDKs faz isso automaticamente, mas vale confirmar na integração da Story `uniplus-web#5`.

Closes #70
Part of #67