### PR TITLE
feat(auth): normalizar usernames dos usuários de teste

### DIFF
--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -2873,7 +2873,7 @@
   },
   "users": [
     {
-      "username": "admin@teste",
+      "username": "admin",
       "email": "admin@teste.unifesspa.edu.br",
       "enabled": true,
       "emailVerified": true,
@@ -2905,7 +2905,7 @@
       ]
     },
     {
-      "username": "gestor@teste",
+      "username": "gestor",
       "email": "gestor@teste.unifesspa.edu.br",
       "enabled": true,
       "emailVerified": true,
@@ -2937,7 +2937,7 @@
       ]
     },
     {
-      "username": "avaliador@teste",
+      "username": "avaliador",
       "email": "avaliador@teste.unifesspa.edu.br",
       "enabled": true,
       "emailVerified": true,
@@ -2969,7 +2969,7 @@
       ]
     },
     {
-      "username": "candidato@teste",
+      "username": "candidato",
       "email": "candidato@teste.unifesspa.edu.br",
       "enabled": true,
       "emailVerified": true,


### PR DESCRIPTION
## Resumo

Remover sufixo `@teste` dos usernames dos 4 usuários de teste. Atende à Task #74 da Story #67.

## O que muda

`docker/keycloak/realm-export.json` — em `.users[].username`:

| Antes              | Depois       | Email (inalterado)                     |
| ------------------ | ------------ | -------------------------------------- |
| `admin@teste`      | `admin`      | `admin@teste.unifesspa.edu.br`         |
| `gestor@teste`     | `gestor`     | `gestor@teste.unifesspa.edu.br`        |
| `avaliador@teste`  | `avaliador`  | `avaliador@teste.unifesspa.edu.br`     |
| `candidato@teste`  | `candidato`  | `candidato@teste.unifesspa.edu.br`     |

## Motivação

Username com sufixo `@teste` era incomum e destoava do padrão (Keycloak trata `username` e `email` como campos distintos). Normalizar deixa o identificador semântico:

- `username` = identificador curto do usuário (`candidato`)
- `email` = endereço completo (`candidato@teste.unifesspa.edu.br`)

O realm já tem `loginWithEmailAllowed: true`, então o formulário de login aceita **ambos**:

- `candidato` **ou** `candidato@teste.unifesspa.edu.br`

Nenhum consumer ativo depende do username antigo — frontend (`uniplus-web#5`) e backend .NET (`uniplus-api#26`) ainda não estão integrados.

## Validação empírica

Contra Keycloak local após `down -v && up -d`:

```
--- lookup by username=candidato ---
{ "username": "candidato", "email": "candidato@teste.unifesspa.edu.br",
  "id": "f72a3121-..." }

--- lookup by email=candidato@teste.unifesspa.edu.br ---
{ "username": "candidato", "email": "candidato@teste.unifesspa.edu.br",
  "id": "f72a3121-..." }  ← mesmo user
```

Import log: `KC-SERVICES0032: Import finished successfully` ✓

Closes #74
Part of #67