### PR TITLE
feat(auth): desligar fullScopeAllowed e configurar scopeMappings por client

### DIFF
--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -494,6 +494,32 @@
       "roles": [
         "offline_access"
       ]
+    },
+    {
+      "client": "selecao-web",
+      "roles": [
+        "admin",
+        "gestor",
+        "avaliador",
+        "candidato"
+      ]
+    },
+    {
+      "client": "ingresso-web",
+      "roles": [
+        "admin",
+        "gestor",
+        "candidato"
+      ]
+    },
+    {
+      "client": "portal-web",
+      "roles": [
+        "admin",
+        "gestor",
+        "avaliador",
+        "candidato"
+      ]
     }
   ],
   "clientScopeMappings": {
@@ -744,7 +770,7 @@
         "pkce.code.challenge.method": "S256"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
+      "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
@@ -806,7 +832,7 @@
         "pkce.code.challenge.method": "S256"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
+      "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
@@ -980,7 +1006,7 @@
         "pkce.code.challenge.method": "S256"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
+      "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
@@ -1042,7 +1068,7 @@
         "dpop.bound.access.tokens": "false"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
+      "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",


### PR DESCRIPTION
## Resumo

Desativar `fullScopeAllowed` nos 4 clients do realm e mapear explicitamente as realm roles que cada client pode carregar nos tokens. Atende à Task #69 da Story #67 — última task do hardening.

## O que muda

`docker/keycloak/realm-export.json`:

### Em cada client
`fullScopeAllowed: true` → `false`

### Em `.scopeMappings` (preservando `offline_access` existente)
```json
[
  { "clientScope": "offline_access", "roles": ["offline_access"] },
  { "client": "selecao-web",  "roles": ["admin","gestor","avaliador","candidato"] },
  { "client": "ingresso-web", "roles": ["admin","gestor","candidato"] },
  { "client": "portal-web",   "roles": ["admin","gestor","avaliador","candidato"] }
]
```

## Motivação

Com `fullScopeAllowed=true`, o token emitido para qualquer client carrega **todas** as realm roles do usuário. Um ataque que comprometa qualquer SPA do portfólio ganha privilégios de todas as outras apps.

Com scope explícito:

- `ingresso-web` **não** recebe role `avaliador` (avaliação não faz parte do fluxo de ingresso)
- `portal-web` pode ver todas as 4 roles (é a app pública/multiperfil)
- `selecao-web` vê as 4 roles (é a app core do módulo Seleção)
- `uniplus-api` sem scopeMappings (bearer-only, não emite tokens)

## Validação empírica

Contra Keycloak local após `down -v && up -d`:

Token emitido para `candidato` (que tem apenas realm role `candidato`) via `selecao-web`:

```
--- realm_access.roles ---
[ "candidato" ]
```

Sem leak das outras realm roles (`admin`, `gestor`, `avaliador`, `offline_access`, `default-roles-unifesspa`).

Import log: `KC-SERVICES0032: Import finished successfully` ✓

## Observação

Esta é a **última Task** da Story #67 (hardening). Sugerido mergear após as demais tasks da Story, para garantir trilha de auditoria (#72) e brute force (#71) já ativos quando a restrição de scope for aplicada.

Closes #69
Part of #67