### PR TITLE
fix(auth): corrigir redirect URIs de ingresso-web e portal-web

### DIFF
--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -714,10 +714,10 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "http://localhost:4300/*"
+        "http://localhost:4201/*"
       ],
       "webOrigins": [
-        "http://localhost:4300"
+        "http://localhost:4201"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -776,10 +776,10 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "http://localhost:4100/*"
+        "http://localhost:4202/*"
       ],
       "webOrigins": [
-        "http://localhost:4100"
+        "http://localhost:4202"
       ],
       "notBefore": 0,
       "bearerOnly": false,


### PR DESCRIPTION
## Objetivo

Alinhar os \`redirectUris\` e \`webOrigins\` dos clients OIDC com as portas reais das apps do frontend.

## O que muda

\`docker/keycloak/realm-export.json\`:

| Client | Antes | Depois |
|---|---|---|
| \`selecao-web\` | \`localhost:4200\` | \`localhost:4200\` (sem mudança) |
| \`ingresso-web\` | \`localhost:4300\` | \`localhost:4201\` |
| \`portal-web\` | \`localhost:4100\` | \`localhost:4202\` |

4 strings alteradas (1 redirectUri + 1 webOrigin por client corrigido).

## Fonte da convenção correta

As portas do frontend estão documentadas e refletem o que os devs usam no dia a dia:

- [\`uniplus-web/README.md\`](https://github.com/unifesspa-edu-br/uniplus-web/blob/main/README.md) — tabela de apps
- \`uniplus-web/CLAUDE.md\` — seção \"Comandos úteis\"
- \`uniplus-web/apps/{selecao,ingresso,portal}/project.json\` — \`targets.serve.options.port\`

## Validação

\`\`\`
jq empty docker/keycloak/realm-export.json
# JSON válido ✓
\`\`\`

Teste manual pós-merge:

\`\`\`
docker compose -f docker/docker-compose.yml down -v
docker compose -f docker/docker-compose.yml up -d keycloak
# Subir cada app e fazer login:
cd ../uniplus-web
npx nx serve ingresso    # 4201 → login Keycloak volta sem erro
npx nx serve portal      # 4202 → login Keycloak volta sem erro
npx nx serve selecao     # 4200 → já funcionava
\`\`\`

## Impacto

Sem esta correção, \`ingresso-web\` e \`portal-web\` falham no callback OIDC com \`Invalid parameter: redirect_uri\`, bloqueando a validação manual da Story [\`unifesspa-edu-br/uniplus-web#5\`](https://github.com/unifesspa-edu-br/uniplus-web/issues/5).

Closes #89