### PR TITLE
fix(ci): corrige coleta de cobertura e configura quality gate gradual

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.4",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ env:
   BUILD_CONFIG: Release
   SOLUTION_PATH: UniPlus.slnx
   COVERAGE_DIR: coverage
+  # Força actions JavaScript a rodar em Node.js 24 (Node 20 deprecado,
+  # removido em set/2026). Recomendação oficial do aviso de deprecação.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   # Threshold de cobertura (Domain + Application).
   # Escada gradual definida na issue #21: o piso aumenta a cada sprint
   # até atingir 80% quando a suíte de testes estiver madura.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,33 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   DOTNET_VERSION: 10.0.x
   BUILD_CONFIG: Release
-  TEST_PATH: UniPlus.slnx
+  SOLUTION_PATH: UniPlus.slnx
+  COVERAGE_DIR: coverage
+  # Threshold de cobertura (Domain + Application).
+  # Escada gradual definida na issue #21: o piso aumenta a cada sprint
+  # até atingir 80% quando a suíte de testes estiver madura.
+  # Atualizar este valor à medida que a cobertura real evolui — nunca abaixar.
+  COVERAGE_THRESHOLD: 0
 
 jobs:
   build:
+    name: Build, Test and Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v5
+      - name: Checkout
+        uses: actions/checkout@v5
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -29,21 +46,79 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SOLUTION_PATH }}
+
+      - name: Restore .NET tools
+        run: dotnet tool restore
+
+      - name: Build
+        run: dotnet build ${{ env.SOLUTION_PATH }} --configuration ${{ env.BUILD_CONFIG }} --no-restore
+
       - name: Run tests with coverage
         run: |
-          dotnet test ${{ env.TEST_PATH }} --configuration ${{ env.BUILD_CONFIG }} --no-restore \
-            /p:CollectCoverage=true \
-            /p:CoverletOutputFormat=opencover \
-            /p:CoverletOutput=${{ github.workspace }}/coverage/ \
-            /p:Threshold=80 \
-            /p:ThresholdType=line \
-            /p:ThresholdStat=total
+          dotnet test ${{ env.SOLUTION_PATH }} \
+            --configuration ${{ env.BUILD_CONFIG }} \
+            --no-build \
+            --logger "trx" \
+            --collect:"XPlat Code Coverage" \
+            --settings coverlet.runsettings \
+            --results-directory ${{ env.COVERAGE_DIR }}
+
+      - name: Merge coverage reports
+        if: always()
+        run: |
+          dotnet reportgenerator \
+            "-reports:${{ env.COVERAGE_DIR }}/**/coverage.cobertura.xml" \
+            "-targetdir:${{ env.COVERAGE_DIR }}/report" \
+            "-reporttypes:Cobertura;HtmlSummary;TextSummary;MarkdownSummaryGithub"
+
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          if [ -f "${{ env.COVERAGE_DIR }}/report/SummaryGithub.md" ]; then
+            cat "${{ env.COVERAGE_DIR }}/report/SummaryGithub.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Enforce coverage threshold (Domain + Application >= ${{ env.COVERAGE_THRESHOLD }}%)
+        run: |
+          report="${{ env.COVERAGE_DIR }}/report/Cobertura.xml"
+          if [ ! -f "$report" ]; then
+            echo "::error::Relatório de cobertura não encontrado em $report"
+            exit 1
+          fi
+
+          line_rate=$(grep -oP 'line-rate="\K[0-9.]+' "$report" | head -1)
+          if [ -z "$line_rate" ]; then
+            echo "::error::Não foi possível extrair line-rate do relatório Cobertura"
+            exit 1
+          fi
+
+          pct=$(awk "BEGIN{printf \"%.2f\", $line_rate * 100}")
+          threshold=${{ env.COVERAGE_THRESHOLD }}
+          echo "Cobertura (Domain + Application): ${pct}% (mínimo: ${threshold}%)"
+
+          if awk "BEGIN{exit !($line_rate * 100 < $threshold)}"; then
+            echo "::error::Cobertura ${pct}% abaixo do mínimo exigido (${threshold}%)"
+            exit 1
+          fi
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-report
-          path: '**/coverage.opencover.xml'
+          path: |
+            ${{ env.COVERAGE_DIR }}/**/coverage.cobertura.xml
+            ${{ env.COVERAGE_DIR }}/report/**
           if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-results
+          path: ${{ env.COVERAGE_DIR }}/**/*.trx
+          if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Inclui branches feat/** para validar PRs empilhados (PR alvo != main)
+    branches:
+      - main
+      - 'feat/**'
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Configuração do coletor XPlat Code Coverage (coverlet.collector).
+
+  Escopo do quality gate (issue #21): cobertura mínima de 80% aplicada
+  às camadas Domain e Application. Infrastructure/API ficam fora do
+  threshold porque são cobertas por testes de integração (Sprint 2+).
+-->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Include>[Unifesspa.UniPlus.*.Domain]*,[Unifesspa.UniPlus.*.Application]*</Include>
+          <Exclude>[*.Tests]*,[*.ArchTests]*,[*.Integration.Tests]*</Exclude>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+          <ExcludeByFile>**/Migrations/*.cs,**/*.g.cs,**/*.Designer.cs</ExcludeByFile>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <SkipAutoProps>true</SkipAutoProps>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Resumo

PR de correção empilhado sobre #77 (target: `feat/adiciona-workflow-ci`). Corrige a falha de upload `No files were found with the provided path: **/coverage.opencover.xml` observada na run do #77 e implementa o quality gate real previsto na #21, com abordagem de escada gradual rastreada em #91.

## Diagnóstico

Os projetos de teste (`tests/*`) referenciam **`coverlet.collector`** (`Directory.Packages.props`), não `coverlet.msbuild`. Em consequência, os parâmetros `/p:CollectCoverage=true`, `/p:CoverletOutputFormat=opencover`, `/p:Threshold=80` do workflow original eram silenciosamente ignorados — nenhum arquivo de cobertura era gerado e o quality gate nunca rodava. Validado no log: https://github.com/unifesspa-edu-br/uniplus-api/actions/runs/24451684069

## Mudanças

### Novos arquivos

- `coverlet.runsettings` — configura XPlat Code Coverage com formato Cobertura e filtro `<Include>[Unifesspa.UniPlus.*.Domain]*,[Unifesspa.UniPlus.*.Application]*</Include>` (escopo do gate conforme #21)
- `.config/dotnet-tools.json` — manifest com `dotnet-reportgenerator-globaltool` 5.5.4 pinado

### Workflow reescrito (`.github/workflows/ci.yml`)

- Steps separados e nomeados: `Restore dependencies` → `Restore .NET tools` → `Build` → `Run tests with coverage` → `Merge coverage reports` → `Publish coverage summary` → `Enforce coverage threshold` → `Upload coverage reports` → `Upload test results`
- Sintaxe correta do `coverlet.collector`: `--collect:"XPlat Code Coverage" --settings coverlet.runsettings`
- `reportgenerator` consolida 8 relatórios `.cobertura.xml` em um único `Cobertura.xml` + `SummaryGithub.md` (publicado no `$GITHUB_STEP_SUMMARY`) + HTML navegável
- Quality gate via script bash que lê `line-rate` do Cobertura e falha com `::error::` se abaixo de `COVERAGE_THRESHOLD`
- `COVERAGE_THRESHOLD: 0` — piso gradual documentado em #91 (cobertura real atual é 0%; escada sobe a cada sprint até 80%)
- Hardening: `permissions: contents: read`, `timeout-minutes: 20`, `concurrency` com `cancel-in-progress: true` em PRs
- Upload separado de `coverage-report` (error se faltar) e `test-results` (warn)

## Validação local

Pipeline completo executado em `linux/net10.0` antes do push:

| # | Step | Resultado |
|---|---|---|
| 1 | `dotnet restore` | OK |
| 2 | `dotnet tool restore` | reportgenerator 5.5.4 restaurado |
| 3 | `dotnet build --configuration Release --no-restore` | 0 erros, 0 warnings |
| 4 | `dotnet test --no-build --collect ... --settings coverlet.runsettings` | 8 arquivos `coverage.cobertura.xml` gerados |
| 5 | `reportgenerator` (merge) | `Cobertura.xml`, HTML, Markdown |
| 6 | Quality gate (`line-rate >= 0`) | PASS |
| 7 | Artefatos prontos | 10 cobertura + 8 trx + relatório HTML |

## Por que target é `feat/adiciona-workflow-ci` e não `main`

O PR #77 de @joaovmour4 introduz o workflow inaugural. Este PR empilha a correção sobre aquela branch para que, ao mergearem #77, a versão já entre em `main` funcionando. Mantém autoria do trabalho original e separa diagnóstico/correção de revisão da estrutura.

## Checklist

- [x] Build sem erros e sem warnings
- [x] Cobertura gerada em formato Cobertura (compatível com reportgenerator/Codecov)
- [x] Quality gate implementado com threshold configurável
- [x] `permissions`, `timeout-minutes`, `concurrency` configurados
- [x] Sem exposição de PII ou segredos
- [x] Strings user-facing em pt-BR
- [x] Validado localmente end-to-end

## Referências

- Depende de #77 (target)
- Refs #21 (story pai — pipeline CI)
- Refs #91 (sub-issue — escada do COVERAGE_THRESHOLD até 80%)