### PR TITLE
feat(auth): hardening do realm Keycloak (#67)

### DIFF
--- a/docker/keycloak/README.md
+++ b/docker/keycloak/README.md
@@ -1,37 +1,119 @@
 # Keycloak local
 
-Este diretório contém a configuração do realm `unifesspa` utilizada no ambiente local.
+Este diretório contém a configuração do realm `unifesspa` usada no ambiente de desenvolvimento local.
 
 ## Por que existe um `realm-export.json` versionado
 
-O arquivo `realm-export.json` foi versionado para garantir que qualquer desenvolvedor consiga subir o ambiente local com o realm `unifesspa` já configurado, sem necessidade de criar manualmente clients, roles, groups, usuários ou atributos no painel do Keycloak.
+O arquivo `realm-export.json` é versionado para que qualquer pessoa do time suba o ambiente local com o realm `unifesspa` já configurado — clients OIDC, roles, client scopes, mappers e usuários de teste — sem precisar criar nada manualmente na console do Keycloak.
 
-Com isso, a configuração de autenticação e autorização do projeto fica padronizada, reproduzível e compartilhada entre todos os membros do time.
+Isso mantém a configuração de autenticação e autorização do projeto padronizada, reproduzível e compartilhada.
+
+> ⚠️ **Apenas para ambiente local.** Este realm contém credenciais de teste e configurações voltadas para desenvolvimento. Nunca importar este arquivo em homologação ou produção.
+
+## Como subir
+
+```bash
+docker compose -f docker/docker-compose.yml up -d keycloak
+```
+
+- Console admin: http://localhost:8080
+- Credenciais master: `admin` / `admin` (definidas em `docker-compose.yml`)
+- OIDC discovery do realm: http://localhost:8080/realms/unifesspa/.well-known/openid-configuration
+
+## Clients configurados
+
+| `clientId`     | Tipo                | Uso                              | Redirect URI              |
+| -------------- | ------------------- | -------------------------------- | ------------------------- |
+| `selecao-web`  | público + PKCE S256 | App Angular **Seleção**          | `http://localhost:4200/*` |
+| `ingresso-web` | público + PKCE S256 | App Angular **Ingresso**         | `http://localhost:4300/*` |
+| `portal-web`   | público + PKCE S256 | App Angular **Portal**           | `http://localhost:4100/*` |
+| `uniplus-api`  | confidential        | Backend .NET (validação de JWT)  | —                         |
+
+Os 3 clients web são **públicos** (SPA) com **PKCE S256 obrigatório** — sem `client_secret`, conforme OAuth 2.1 / BCP for Browser-Based Apps.
+
+## Client scope `uniplus-profile`
+
+Scope compartilhado pelos clients, com dois mappers que injetam atributos do usuário como claims no ID Token, Access Token e `/userinfo`:
+
+- `cpf` — string (tipo `String`, `multivalued: false`)
+- `nomeSocial` — string
+
+Esses claims são consumidos pelo frontend para preencher o perfil do usuário autenticado sem chamada extra ao backend.
+
+## Roles (realm roles)
+
+- `admin`
+- `gestor`
+- `avaliador`
+- `candidato`
+
+Correspondem às personas do sistema.
 
 ## Usuários de teste
 
-| Usuário           | Papel     | Senha inicial      |
-|-------------------|-----------|--------------------|
-| admin@teste       | admin     | definida no `realm-export.json` |
-| gestor@teste      | gestor    | definida no `realm-export.json` |
-| avaliador@teste   | avaliador | definida no `realm-export.json` |
-| candidato@teste   | candidato | definida no `realm-export.json` |
+Os quatro usuários abaixo são criados pela importação do realm.
 
-* ⚠️ Troque a senha de todos os usuários no primeiro login.
-* As credenciais iniciais podem ser consultadas no arquivo `realm-export.json`.
-* Essas contas são destinadas exclusivamente ao ambiente local.
-* Login: `http://localhost:8080/realms/unifesspa/account`
-* O host e a porta podem variar conforme a configuração do ambiente.
+| `username`           | Email                                   | Papel        |
+| -------------------- | --------------------------------------- | ------------ |
+| `admin@teste`        | `admin@teste.unifesspa.edu.br`          | `admin`      |
+| `gestor@teste`       | `gestor@teste.unifesspa.edu.br`         | `gestor`     |
+| `avaliador@teste`    | `avaliador@teste.unifesspa.edu.br`      | `avaliador`  |
+| `candidato@teste`    | `candidato@teste.unifesspa.edu.br`      | `candidato`  |
+
+- **Senha inicial (temporária):** `Changeme!123`
+- No primeiro login o Keycloak exige trocar a senha (`temporary: true`).
+- Cada usuário possui atributos `cpf` (CPF sintético com DV válido) e `nomeSocial`, expostos pelo scope `uniplus-profile`.
+
+### Login por username ou email
+
+A flag `loginWithEmailAllowed: true` do realm permite que o formulário de login aceite qualquer um dos dois identificadores:
+
+- `admin@teste` ou `admin@teste.unifesspa.edu.br`
+- (análogo para os demais usuários)
+
+O campo `email` permanece único (`duplicateEmailsAllowed: false`) — requisito para que o email funcione como identificador de login. `registrationEmailAsUsername` fica `false`, mantendo `username` e `email` como campos distintos.
+
+## Política de senha
+
+O realm aplica a seguinte `passwordPolicy`:
+
+```
+length(8) and upperCase(1) and lowerCase(1) and digits(1) and notUsername
+```
+
+A senha escolhida na troca do primeiro login precisa atender a essas regras. A mesma política deve valer em produção, para alinhar dev com o ambiente real.
 
 ## Como forçar a reimportação
 
-Se o Keycloak já tiver sido inicializado anteriormente, o realm existente pode impedir a reimportação automática do arquivo.
+A estratégia de import é `IGNORE_EXISTING` — se o realm `unifesspa` já existir no banco do Keycloak, edições no `realm-export.json` não serão aplicadas em um restart simples.
 
-Para forçar uma importação limpa, remova os containers e volumes e depois suba o ambiente novamente:
+Para forçar importação limpa, derrubar o ambiente com o volume do Postgres e subir novamente:
 
 ```bash
 docker compose -f docker/docker-compose.yml down -v
-docker compose -f docker/docker-compose.yml up --build
+docker compose -f docker/docker-compose.yml up -d keycloak
 ```
 
-Esse processo recria o ambiente e permite que o Keycloak importe novamente o realm-export.json.
+Confira o log esperado:
+
+```
+INFO  [ImportUtils] Realm 'unifesspa' imported
+INFO  [services] KC-SERVICES0032: Import finished successfully
+```
+
+## Como regenerar o `realm-export.json`
+
+Após ajustar clients, roles, scopes ou usuários pela console admin, exportar o realm:
+
+```bash
+docker compose -f docker/docker-compose.yml exec keycloak \
+  /opt/keycloak/bin/kc.sh export \
+  --realm unifesspa \
+  --file /tmp/realm-export.json \
+  --users realm_file
+
+docker compose -f docker/docker-compose.yml cp \
+  keycloak:/tmp/realm-export.json docker/keycloak/realm-export.json
+```
+
+Revisar o diff antes de commitar — o Keycloak mascara `client_secret` de clients confidential como `**********` no export. Se isso aparecer, converter o client para bearer-only (se for resource server) ou injetar o secret via variável de ambiente.

--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -4,7 +4,7 @@
   "passwordPolicy": "length(8) and upperCase(1) and lowerCase(1) and digits(1) and notUsername",
   "notBefore": 0,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": false,
+  "revokeRefreshToken": true,
   "refreshTokenMaxReuse": 0,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,
@@ -36,16 +36,16 @@
   "duplicateEmailsAllowed": false,
   "resetPasswordAllowed": true,
   "editUsernameAllowed": false,
-  "bruteForceProtected": false,
+  "bruteForceProtected": true,
   "permanentLockout": false,
   "maxTemporaryLockouts": 0,
   "bruteForceStrategy": "MULTIPLE",
   "maxFailureWaitSeconds": 900,
-  "minimumQuickLoginWaitSeconds": 60,
+  "minimumQuickLoginWaitSeconds": 10,
   "waitIncrementSeconds": 60,
   "quickLoginCheckMilliSeconds": 1000,
   "maxDeltaTimeSeconds": 43200,
-  "failureFactor": 30,
+  "failureFactor": 5,
   "roles": {
     "realm": [
       {
@@ -494,6 +494,32 @@
       "roles": [
         "offline_access"
       ]
+    },
+    {
+      "client": "selecao-web",
+      "roles": [
+        "admin",
+        "gestor",
+        "avaliador",
+        "candidato"
+      ]
+    },
+    {
+      "client": "ingresso-web",
+      "roles": [
+        "admin",
+        "gestor",
+        "candidato"
+      ]
+    },
+    {
+      "client": "portal-web",
+      "roles": [
+        "admin",
+        "gestor",
+        "avaliador",
+        "candidato"
+      ]
     }
   ],
   "clientScopeMappings": {
@@ -714,10 +740,10 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "http://localhost:4300/*"
+        "http://localhost:4201/*"
       ],
       "webOrigins": [
-        "http://localhost:4300"
+        "http://localhost:4201"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -744,7 +770,7 @@
         "pkce.code.challenge.method": "S256"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
+      "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
@@ -776,10 +802,10 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "http://localhost:4100/*"
+        "http://localhost:4202/*"
       ],
       "webOrigins": [
-        "http://localhost:4100"
+        "http://localhost:4202"
       ],
       "notBefore": 0,
       "bearerOnly": false,
@@ -806,7 +832,7 @@
         "pkce.code.challenge.method": "S256"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
+      "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
@@ -980,7 +1006,7 @@
         "pkce.code.challenge.method": "S256"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
+      "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
@@ -1011,38 +1037,32 @@
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
-      "redirectUris": [
-        "/*"
-      ],
-      "webOrigins": [
-        "/*"
-      ],
+      "redirectUris": [],
+      "webOrigins": [],
       "notBefore": 0,
-      "bearerOnly": false,
+      "bearerOnly": true,
       "consentRequired": false,
-      "standardFlowEnabled": true,
+      "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "publicClient": false,
-      "frontchannelLogout": true,
+      "frontchannelLogout": false,
       "protocol": "openid-connect",
       "attributes": {
         "logout.confirmation.enabled": "false",
         "realm_client": "false",
         "oidc.ciba.grant.enabled": "false",
-        "client.secret.creation.time": "1775766916",
         "backchannel.logout.session.required": "true",
         "standard.token.exchange.enabled": "false",
         "frontchannel.logout.session.required": "true",
-        "post.logout.redirect.uris": "+",
         "display.on.consent.screen": "false",
         "oauth2.device.authorization.grant.enabled": "false",
         "backchannel.logout.revoke.offline.tokens": "false",
         "dpop.bound.access.tokens": "false"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
+      "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": -1,
       "defaultClientScopes": [
         "web-origins",
@@ -1069,8 +1089,8 @@
       "description": "",
       "protocol": "openid-connect",
       "attributes": {
-        "include.in.token.scope": "false",
-        "display.on.consent.screen": "true",
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false",
         "gui.order": "",
         "consent.screen.text": "",
         "include.in.openid.provider.metadata": "true"
@@ -1108,6 +1128,18 @@
             "access.token.claim": "true",
             "claim.name": "cpf",
             "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "aud-uniplus",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "uniplus",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
           }
         }
       ]
@@ -1826,13 +1858,35 @@
     "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
   "smtpServer": {},
-  "eventsEnabled": false,
+  "eventsEnabled": true,
   "eventsListeners": [
     "jboss-logging"
   ],
-  "enabledEventTypes": [],
-  "adminEventsEnabled": false,
-  "adminEventsDetailsEnabled": false,
+  "enabledEventTypes": [
+    "LOGIN",
+    "LOGIN_ERROR",
+    "LOGOUT",
+    "LOGOUT_ERROR",
+    "REFRESH_TOKEN",
+    "REFRESH_TOKEN_ERROR",
+    "CODE_TO_TOKEN",
+    "CODE_TO_TOKEN_ERROR",
+    "UPDATE_PASSWORD",
+    "UPDATE_PASSWORD_ERROR",
+    "SEND_RESET_PASSWORD",
+    "SEND_RESET_PASSWORD_ERROR",
+    "RESET_PASSWORD",
+    "RESET_PASSWORD_ERROR",
+    "IDENTITY_PROVIDER_LOGIN",
+    "IDENTITY_PROVIDER_LOGIN_ERROR",
+    "CLIENT_LOGIN",
+    "CLIENT_LOGIN_ERROR",
+    "TOKEN_EXCHANGE",
+    "TOKEN_EXCHANGE_ERROR",
+    "PERMISSION_TOKEN"
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": true,
   "identityProviders": [],
   "identityProviderMappers": [],
   "components": {
@@ -2873,7 +2927,7 @@
   },
   "users": [
     {
-      "username": "admin@teste",
+      "username": "admin",
       "email": "admin@teste.unifesspa.edu.br",
       "enabled": true,
       "emailVerified": true,
@@ -2905,7 +2959,7 @@
       ]
     },
     {
-      "username": "gestor@teste",
+      "username": "gestor",
       "email": "gestor@teste.unifesspa.edu.br",
       "enabled": true,
       "emailVerified": true,
@@ -2937,7 +2991,7 @@
       ]
     },
     {
-      "username": "avaliador@teste",
+      "username": "avaliador",
       "email": "avaliador@teste.unifesspa.edu.br",
       "enabled": true,
       "emailVerified": true,
@@ -2969,7 +3023,7 @@
       ]
     },
     {
-      "username": "candidato@teste",
+      "username": "candidato",
       "email": "candidato@teste.unifesspa.edu.br",
       "enabled": true,
       "emailVerified": true,
@@ -2999,5 +3053,6 @@
         }
       ]
     }
-  ]
+  ],
+  "eventsExpiration": 2592000
 }


### PR DESCRIPTION
## Resumo

Consolidação da Story [#67](https://github.com/unifesspa-edu-br/uniplus-api/issues/67) — *hardening OIDC do realm Keycloak unifesspa* — em um único PR. Reúne o conteúdo dos 10 PRs individuais abertos entre 2026-04-14 e 2026-04-15, já revisados pelo @marciliomarques.

O `docker/keycloak/realm-export.json` deste PR é **bit-idêntico** ao estado da branch local `local/hardened-realm`, **validado ao vivo em 2026-04-14 com os perfis admin e candidato** durante o desenvolvimento do frontend da Story [uniplus-web#5](https://github.com/unifesspa-edu-br/uniplus-web/issues/5).

## Por que consolidar

Os 10 PRs originais foram criados independentemente a partir de `origin/main`, cada um editando o mesmo `realm-export.json` (JSON monolítico de 3000+ linhas). Merge em série causava conflitos cosméticos no `git` (commas e braces de fechamento) a cada iteração, mesmo sendo semanticamente disjuntos. Com `dismiss_stale_reviews: true` na branch protection, cada rebase exigiria nova aprovação — custo de review desproporcional ao risco.

**Lição aprendida:** mudanças coordenadas num mesmo arquivo monolítico devem ir em um PR único por Story, não em PRs-por-task. Documentar isso no CONTRIBUTING.md como follow-up.

## Commits

```
16238f3 feat(auth): hardening do realm Keycloak (#67)
315a06d docs(keycloak): reescrever README do realm unifesspa (refs #76, PR #83)
```

## Mudanças técnicas consolidadas

Todas aplicadas ao realm `unifesspa`:

- **Auditoria** — `eventsEnabled`, `adminEventsEnabled`, `eventsExpiration` ativos (refs #72 / PR #78)
- **Brute force protection** — `bruteForceProtected`, `failureFactor`, parâmetros de lockout (refs #71 / PR #79)
- **Audience-mapper** — OIDC audience `"uniplus"` no scope `uniplus-profile` (refs #68 / PR #80)
- **Scope M1/M2** — flags do `uniplus-profile` ajustadas (refs #75 / PR #82)
- **Refresh rotation** — `revokeRefreshToken: true`, `refreshTokenMaxReuse: 0` (refs #70 / PR #84)
- **Bearer-only** — client `uniplus-api` convertido (refs #73 / PR #85)
- **Usernames** — normalização dos usuários de teste (refs #74 / PR #86)
- **scopeMappings** — `fullScopeAllowed: false` + mapeamentos explícitos por client (refs #69 / PR #87)
- **Redirect URIs** — `ingresso-web: 4201`, `portal-web: 4202` (refs #89 / PR #90)
- **Docs** — README do realm reescrito (refs #76 / PR #83)

## Revisão simplificada

Sugestão de verificação para o review (@marciliomarques):

1. Abrir `diff` do PR e confirmar que os blocos de cada tema acima correspondem ao que você já aprovou individualmente.
2. O JSON final pode ser comparado bit-a-bit contra a branch local usada em dev (`local/hardened-realm`) via:
   ```
   git show local/hardened-realm:docker/keycloak/realm-export.json | diff - <(git show feature/67-hardening-realm-keycloak:docker/keycloak/realm-export.json)
   ```
   Resultado esperado: sem diferenças.

## Fechamentos automáticos

`Closes #78, closes #79, closes #80, closes #82, closes #83, closes #84, closes #85, closes #86, closes #87, closes #90`

## Referências

- Story: #67 — *US-FX-19: hardening do realm Keycloak*
- Feature pai: #8 — *Realm Keycloak Uni+*
- Epic: #4 — *Infraestrutura e fundação técnica*
- Branch de desenvolvimento local (referência): `local/hardened-realm` (commit `8a61156`, não publicado)