### PR TITLE
docs: alinha CONTRIBUTING.md ao Guia de Commits e Integração

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Este documento descreve como contribuir com o backend da plataforma Uni+. Leia-o por completo antes de abrir sua primeira contribuição.
 
+> **Regras transversais de commits e integração:** este repositório segue o **[Guia de Commits e Integração](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/guia-commits-e-integracao.md)** — referência oficial para todos os repositórios do projeto (`uniplus-api`, `uniplus-web`, `uniplus-docs`), mantido em `uniplus-docs`. Este documento complementa o guia com regras específicas do backend.
+
 ---
 
 ## Pré-requisitos
@@ -55,10 +57,12 @@ tests/
 
 ### 1. Criar branch
 
+> **Regra de ouro:** sem issue, sem código. Toda mudança não-trivial deve ter issue vinculada no GitHub antes de criar a branch.
+
 ```bash
 git checkout main
-git pull origin main
-git checkout -b feature/{slug-descritivo}
+git pull --rebase origin main
+git checkout -b feature/{issue-number}-{slug}
 ```
 
 **Convenção de nomes:**
@@ -100,40 +104,55 @@ Todos os comandos acima devem passar antes de abrir o PR.
 
 ### 4. Commit
 
-Mensagens em **conventional commits** (pt-BR):
+As regras de formato, tipos permitidos e convenções gerais de mensagem estão definidas no **[Guia de Commits e Integração § 1–4](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/guia-commits-e-integracao.md)**. Siga-o na íntegra.
+
+**Escopos válidos neste repositório:**
+
+| Escopo | Quando usar |
+|---|---|
+| `selecao` | Código do módulo Seleção (`src/selecao/**`) |
+| `ingresso` | Código do módulo Ingresso (`src/ingresso/**`) |
+| `shared` | Código compartilhado (`src/shared/**`) |
+| `sharedkernel` | SharedKernel especificamente (entidades base, value objects, Result pattern) |
+| `domain` | Camada Domain de qualquer módulo (entidades, regras de negócio, eventos) |
+| `application` | Camada Application (commands/queries MediatR, validações FluentValidation) |
+| `infra` | Camada Infrastructure genérica (Kafka, Redis, MinIO, OpenTelemetry) |
+| `api` | Camada API (controllers, middleware, filtros) |
+| `db` | Configurações de banco (EF Core, conexão, tuning) |
+| `migrations` | Migrations EF Core |
+| `auth` | Autenticação/autorização, Keycloak, Gov.br |
+| `ci` | GitHub Actions, workflows, pipeline |
+| `docker` | Dockerfiles, `docker-compose` |
+| `deps` | Atualização de pacotes NuGet |
+
+Escopos mais granulares podem ser usados livremente quando fizerem sentido (ex.: `selecao-domain`, `selecao-api`, `test(arch)`), mantendo imperativo presente e pt-BR.
+
+**Alguns exemplos canônicos:**
 
 ```
-tipo(escopo): descrição curta
-
-Corpo opcional explicando o porquê da mudança.
+feat(selecao): adiciona endpoint de homologação de inscrição
+fix(ingresso): corrige cálculo de classificação por cota
+refactor(sharedkernel): extrai value object NotaFinal
+test(arch): adiciona testes de arquitetura para módulo Ingresso
+feat(migrations): adiciona tabela de inscrições
+chore(deps): atualiza MediatR para 14.0.1
 ```
 
-**Tipos:** `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `style`, `perf`, `ci`, `build`
+Para uma bateria completa de exemplos (bons e ruins, com justificativas), consulte [Guia § 4](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/guia-commits-e-integracao.md).
 
-**Escopo:** módulo ou camada afetada — `selecao`, `ingresso`, `shared`, `infra`, `ci`
+### 5. Rebase sobre `main`
 
-**Exemplos:**
+Integração via **rebase** — sem merge commits poluindo o histórico. Procedimento completo e regras de ouro em **[Guia de Commits e Integração § 5–6](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/guia-commits-e-integracao.md)**.
 
-```
-feat(selecao): adicionar endpoint de inscrição de candidato
-fix(ingresso): corrigir validação de CPF com dígito verificador inválido
-refactor(shared): extrair value object NotaFinal para SharedKernel
-test(selecao): adicionar testes de mutação no motor de classificação
-```
+Resumo aplicado ao `uniplus-api`: mantenha a branch rebaseada sobre `origin/main`, organize os commits com `rebase -i` (squash/reword/drop) antes do PR e use `git push --force-with-lease` ao reescrever história — nunca `--force` puro.
 
-**Regras:**
-- Primeira linha: máximo 72 caracteres, sem ponto final
-- Descrição em pt-BR
-- Nunca adicionar `Co-Authored-By`
-- Nunca usar `--no-verify`
-
-### 5. Pull Request
+### 6. Pull Request
 
 ```bash
 # Push da branch
-git push -u origin feature/{slug}
+git push -u origin feature/{issue-number}-{slug}
 
-# Criar PR
+# Criar PR (Closes #N na descrição fecha a issue automaticamente no merge)
 gh pr create --base main
 ```
 
@@ -255,6 +274,22 @@ O PR será bloqueado se qualquer gate falhar:
 - [ ] SonarQube: zero issues críticos ou bloqueadores
 - [ ] Nenhuma vulnerabilidade crítica em dependências
 - [ ] Formatação correta (`dotnet format`)
+
+---
+
+## Checklist antes de pedir merge
+
+Complementa os Quality gates acima (verificações de CI automáticas) com higiene de commits e branch — essas são verificações humanas:
+
+- [ ] Branch no padrão (`feature/{issue}-{slug}`, `fix/{issue}-{slug}`, `chore/{slug}` ou `docs/{slug}`)
+- [ ] Issue vinculada no GitHub (regra de ouro: sem issue, sem código)
+- [ ] Todos os commits seguem Conventional Commits em pt-BR
+- [ ] Verbo no **imperativo presente** (`adiciona`, `corrige`, `remove`, `atualiza`) — nunca infinitivo (`adicionar`) nem gerúndio (`Adicionando`)
+- [ ] Subject em minúsculas, sem ponto final, máx. ~72 caracteres
+- [ ] Escopo presente (do conjunto definido em [§ Commit](#4-commit)) quando aplicável
+- [ ] Branch **rebaseada** sobre a `main` mais recente
+- [ ] Commits "WIP" / "ajustes do PR" foram **squashados** via `git rebase -i`
+- [ ] PR vinculado à issue com `Closes #N` na descrição
 
 ---
 


### PR DESCRIPTION
## Resumo

Alinha o `CONTRIBUTING.md` do `uniplus-api` ao **Guia de Commits e Integração** (publicado em `uniplus-docs` via PR unifesspa-edu-br/uniplus-docs#62), seguindo o modelo enxuto estabelecido no `uniplus-docs`.

Feature: Closes #99
Epic: unifesspa-edu-br/uniplus-docs#60 (Governança e qualidade)

## O que muda

| Seção | Mudança |
|---|---|
| **Topo** | Nota introdutória linkando o guia oficial (cross-repo URL para `uniplus-docs`) |
| **§ 1 Criar branch** | Padrão atualizado para `feature/{issue-number}-{slug}` + regra de ouro "sem issue, sem código" |
| **§ 4 Commit** | Enxugada: referencia o guia para regras gerais. Tabela de **14 escopos** (era 5): `selecao`, `ingresso`, `shared`, `sharedkernel`, `domain`, `application`, `infra`, `api`, `db`, `migrations`, `auth`, `ci`, `docker`, `deps`. Exemplos em imperativo presente |
| **§ 5 Rebase** | **Nova.** Breve, remete ao guia § 5–6 para detalhes e regras de ouro |
| **§ 6 Pull Request** | Renumerada. Comando de push atualizado para novo padrão de branch |
| **Checklist** | **Nova seção.** 9 itens de higiene (branch, issue, commits, imperativo, subject, escopo, rebase, squash, Closes #N) complementando os Quality gates de CI |

## O que NÃO muda

Pré-requisitos, Estrutura do projeto (Clean Architecture), Padrões de código (.NET), Segurança, LGPD, Testes, Quality gates, Revisão de código, Dúvidas — todas intocadas.

## Referências

- Guia oficial: https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/guia-commits-e-integracao.md
- Modelo aplicado: https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/CONTRIBUTING.md (PR uniplus-docs#62)
- Par desta Feature no frontend: unifesspa-edu-br/uniplus-web#77
