### PR TITLE
feat(shared): implementar correlation ID middleware (Story #28)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -43,7 +43,9 @@ indent_size = 2
 [*.md]
 trim_trailing_whitespace = false
 
-# Projetos de teste — nomes de métodos xUnit usam underscores por convenção
-# (Fato_QuandoCondicao_DeveProduzirResultado). CA1707 é suprimido apenas aqui.
+# Projetos de teste — convenções xUnit:
+# - CA1707: nomes de métodos com underscores (Fato_QuandoCondicao_DeveProduzirResultado)
+# - CA2007: xUnit não usa SynchronizationContext; ConfigureAwait é desnecessário
 [tests/**/*.cs]
 dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA2007.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -42,3 +42,8 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+# Projetos de teste — nomes de métodos xUnit usam underscores por convenção
+# (Fato_QuandoCondicao_DeveProduzirResultado). CA1707 é suprimido apenas aqui.
+[tests/**/*.cs]
+dotnet_diagnostic.CA1707.severity = none

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,89 @@ Application NUNCA depende de Infrastructure ou API.
 - **File-scoped namespaces** em todos os arquivos .cs
 - **ConfigureAwait(false)** em awaits de código de biblioteca
 - **TreatWarningsAsErrors** habilitado globalmente
+- **Logging com `[LoggerMessage]` source generator** — nunca usar `_logger.LogInformation(...)` e similares diretamente (ver seção abaixo)
+
+## Logging de alta performance — `[LoggerMessage]` source generator
+
+**Regra obrigatória:** toda chamada a `ILogger` deve passar por um método `partial` decorado com `[LoggerMessage]`. Chamadas diretas a `_logger.LogInformation`, `_logger.LogWarning`, etc. são **proibidas** — o analisador `CA1848` trata isso como erro por causa do `TreatWarningsAsErrors`.
+
+### Por que
+
+O source generator de `[LoggerMessage]` (.NET 6+) gera código que:
+
+1. **Evita avaliação de argumentos quando o log level está desativado** — o `IsEnabled(LogLevel.X)` é chamado antes de tocar nos parâmetros. Com `_logger.LogInformation("valor {V}", ObterValor())`, o `ObterValor()` executa sempre, mesmo quando `Information` está desligado em produção.
+2. **Elimina boxing de value types** (structs, ints, longs, DateTimeOffset, etc.).
+3. **Parseia o message template uma única vez**, na compilação — não a cada chamada.
+4. **Zero alocações temporárias** para o array `params object[]` das extensões padrão.
+
+### Padrão idiomático
+
+Classe `partial`, método `private static partial void Log{Ação}` no fim da classe, `ILogger` como primeiro parâmetro:
+
+```csharp
+namespace Unifesspa.UniPlus.Selecao.Application.Behaviors;
+
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+public sealed partial class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly ILogger<LoggingBehavior<TRequest, TResponse>> _logger;
+
+    public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger) => _logger = logger;
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
+    {
+        string requestName = typeof(TRequest).Name;
+        LogProcessando(_logger, requestName);                       // chamada idiomática
+        TResponse response = await next(ct).ConfigureAwait(false);
+        LogConcluido(_logger, requestName, stopwatch.ElapsedMilliseconds);
+        return response;
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Processando {RequestName}")]
+    private static partial void LogProcessando(ILogger logger, string requestName);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Concluído {RequestName} em {ElapsedMs}ms")]
+    private static partial void LogConcluido(ILogger logger, string requestName, long elapsedMs);
+}
+```
+
+### Convenções de estilo
+
+- **Método é `private static partial void`** — `static` aproveita-se do fato de `ILogger` vir como parâmetro, evitando captura de `this`.
+- **Nome começa com `Log`** seguido do verbo/ação (`LogProcessando`, `LogConcluido`, `LogValidationError`).
+- **Placeholders em `{PascalCase}`** batendo com o nome do parâmetro. O Serilog e os enrichers (ex.: `PiiMaskingEnricher`) usam esses nomes como chave estruturada.
+- **`Exception` sempre como último parâmetro** quando presente — o source generator reconhece e emite no `LogEvent.Exception` sem precisar `{Exception}` no template.
+- **`EventId` opcional** — incluir apenas se houver consumidor que filtra por ID (raro no Uni+). Se omitido, o gerador atribui um automaticamente.
+
+### Casos especiais — `SkipEnabledCheck`
+
+Quando o argumento passado ao log envolver computação cara (ex.: serialização de DTO, formatação complexa), usar `SkipEnabledCheck = true` + guarda manual `IsEnabled` no call site para evitar também a avaliação do argumento **na chamada**:
+
+```csharp
+public void RegistrarResultado(ResultadoInscricao resultado)
+{
+    if (_logger.IsEnabled(LogLevel.Debug))
+    {
+        string snapshot = JsonSerializer.Serialize(resultado);   // só executa se Debug está ligado
+        LogResultadoDetalhado(_logger, snapshot);
+    }
+}
+
+[LoggerMessage(Level = LogLevel.Debug, Message = "Resultado detalhado: {Snapshot}", SkipEnabledCheck = true)]
+private static partial void LogResultadoDetalhado(ILogger logger, string snapshot);
+```
+
+Sem `SkipEnabledCheck`, o source generator sempre gera a guarda internamente — mas a `JsonSerializer.Serialize(resultado)` executa antes da chamada do método, no call site, antes da guarda. Esse é o cenário que o analisador `CA1873` (Avoid potentially expensive logging) sinaliza.
+
+### Referências
+
+- [CA1848 — Use the LoggerMessage delegates](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848)
+- [CA1873 — Avoid potentially expensive logging](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1873)
+- [Compile-time logging source generation](https://learn.microsoft.com/dotnet/core/extensions/logging/source-generation)
+- Exemplos no projeto: `src/*/API/Middleware/GlobalExceptionMiddleware.cs`, `src/*/Application/Behaviors/LoggingBehavior.cs`
 
 ## Comandos úteis
 

--- a/UniPlus.slnx
+++ b/UniPlus.slnx
@@ -17,6 +17,7 @@
     <Project Path="src/shared/Unifesspa.UniPlus.SharedKernel/Unifesspa.UniPlus.SharedKernel.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Unifesspa.UniPlus.Infrastructure.Common.Tests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Ingresso.Application.Tests/Unifesspa.UniPlus.Ingresso.Application.Tests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Ingresso.Domain.Tests/Unifesspa.UniPlus.Ingresso.Domain.Tests.csproj" />

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 using Unifesspa.UniPlus.Ingresso.API.Middleware;
 using Unifesspa.UniPlus.Ingresso.Application.Mappings;
 using Unifesspa.UniPlus.Ingresso.Infrastructure;
@@ -7,7 +8,9 @@ using Unifesspa.UniPlus.Ingresso.Infrastructure;
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((context, loggerConfig) =>
-    loggerConfig.ReadFrom.Configuration(context.Configuration));
+    loggerConfig
+        .ReadFrom.Configuration(context.Configuration)
+        .Enrich.FromLogContext());
 
 builder.Services.AddControllers()
     .AddJsonOptions(options =>
@@ -20,6 +23,7 @@ builder.Services.AddEndpointsApiExplorer();
 string connectionString = builder.Configuration.GetConnectionString("IngressoDb")
     ?? throw new InvalidOperationException("Connection string 'IngressoDb' não configurada.");
 
+builder.Services.AddCorrelationIdAccessor();
 builder.Services.AddIngressoApplication();
 builder.Services.AddIngressoInfrastructure(connectionString);
 
@@ -27,6 +31,7 @@ builder.Services.AddHealthChecks();
 
 WebApplication app = builder.Build();
 
+app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseMiddleware<GlobalExceptionMiddleware>();
 app.MapControllers();
 app.MapHealthChecks("/health");

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 
+using Unifesspa.UniPlus.Infrastructure.Common.Logging;
 using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 using Unifesspa.UniPlus.Ingresso.API.Middleware;
 using Unifesspa.UniPlus.Ingresso.Application.Mappings;
@@ -8,9 +9,7 @@ using Unifesspa.UniPlus.Ingresso.Infrastructure;
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((context, loggerConfig) =>
-    loggerConfig
-        .ReadFrom.Configuration(context.Configuration)
-        .Enrich.FromLogContext());
+    loggerConfig.ConfigurarSerilog(context.Configuration));
 
 builder.Services.AddControllers()
     .AddJsonOptions(options =>

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 
+using Unifesspa.UniPlus.Infrastructure.Common.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Common.Logging;
 using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 using Unifesspa.UniPlus.Ingresso.API.Middleware;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 
+using Unifesspa.UniPlus.Infrastructure.Common.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Common.Logging;
 using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 using Unifesspa.UniPlus.Selecao.API.Middleware;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 
+using Unifesspa.UniPlus.Infrastructure.Common.Logging;
 using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 using Unifesspa.UniPlus.Selecao.API.Middleware;
 using Unifesspa.UniPlus.Selecao.Application.Mappings;
@@ -8,9 +9,7 @@ using Unifesspa.UniPlus.Selecao.Infrastructure;
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((context, loggerConfig) =>
-    loggerConfig
-        .ReadFrom.Configuration(context.Configuration)
-        .Enrich.FromLogContext());
+    loggerConfig.ConfigurarSerilog(context.Configuration));
 
 builder.Services.AddControllers()
     .AddJsonOptions(options =>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 using Unifesspa.UniPlus.Selecao.API.Middleware;
 using Unifesspa.UniPlus.Selecao.Application.Mappings;
 using Unifesspa.UniPlus.Selecao.Infrastructure;
@@ -7,7 +8,9 @@ using Unifesspa.UniPlus.Selecao.Infrastructure;
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((context, loggerConfig) =>
-    loggerConfig.ReadFrom.Configuration(context.Configuration));
+    loggerConfig
+        .ReadFrom.Configuration(context.Configuration)
+        .Enrich.FromLogContext());
 
 builder.Services.AddControllers()
     .AddJsonOptions(options =>
@@ -20,6 +23,7 @@ builder.Services.AddEndpointsApiExplorer();
 string connectionString = builder.Configuration.GetConnectionString("SelecaoDb")
     ?? throw new InvalidOperationException("Connection string 'SelecaoDb' não configurada.");
 
+builder.Services.AddCorrelationIdAccessor();
 builder.Services.AddSelecaoApplication();
 builder.Services.AddSelecaoInfrastructure(connectionString);
 
@@ -27,6 +31,7 @@ builder.Services.AddHealthChecks();
 
 WebApplication app = builder.Build();
 
+app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseMiddleware<GlobalExceptionMiddleware>();
 app.MapControllers();
 app.MapHealthChecks("/health");

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/CorrelationIdServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/CorrelationIdServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
-namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+namespace Unifesspa.UniPlus.Infrastructure.Common.DependencyInjection;
 
 using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
 public static class CorrelationIdServiceCollectionExtensions
 {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdAccessor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdAccessor.cs
@@ -2,6 +2,10 @@ namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
 public sealed class CorrelationIdAccessor : ICorrelationIdAccessor
 {
+    // AsyncLocal estático de propósito: o isolamento vem do ExecutionContext,
+    // não da instância do accessor. Permite registro Singleton no DI sem risco
+    // de cross-talk entre requests — cada request roda em seu próprio fluxo
+    // lógico e o AsyncLocal.Value é copiado/restaurado automaticamente.
     private static readonly AsyncLocal<string?> _current = new();
 
     public string? CorrelationId => _current.Value;

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdAccessor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdAccessor.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
-public sealed class CorrelationIdAccessor : ICorrelationIdAccessor
+public sealed class CorrelationIdAccessor : ICorrelationIdWriter
 {
     // AsyncLocal estático de propósito: o isolamento vem do ExecutionContext,
     // não da instância do accessor. Permite registro Singleton no DI sem risco

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdAccessor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdAccessor.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+public sealed class CorrelationIdAccessor : ICorrelationIdAccessor
+{
+    private static readonly AsyncLocal<string?> _current = new();
+
+    public string? CorrelationId => _current.Value;
+
+    public void SetCorrelationId(string correlationId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
+        _current.Value = correlationId;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+using Microsoft.AspNetCore.Http;
+
+using Serilog.Context;
+
+public sealed class CorrelationIdMiddleware
+{
+    public const string HeaderName = "X-Correlation-Id";
+    public const string LogContextProperty = "CorrelationId";
+
+    private readonly RequestDelegate _next;
+
+    public CorrelationIdMiddleware(RequestDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(next);
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context, ICorrelationIdAccessor accessor)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(accessor);
+
+        string correlationId = ObterOuGerarCorrelationId(context);
+
+        accessor.SetCorrelationId(correlationId);
+        context.Response.Headers[HeaderName] = correlationId;
+
+        using (LogContext.PushProperty(LogContextProperty, correlationId))
+        {
+            await _next(context).ConfigureAwait(false);
+        }
+    }
+
+    private static string ObterOuGerarCorrelationId(HttpContext context)
+    {
+        if (context.Request.Headers.TryGetValue(HeaderName, out Microsoft.Extensions.Primitives.StringValues valor))
+        {
+            string? existente = valor.ToString();
+            if (!string.IsNullOrWhiteSpace(existente))
+            {
+                return existente;
+            }
+        }
+
+        return Guid.NewGuid().ToString("D");
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 
 using Serilog.Context;
 
@@ -8,6 +9,7 @@ public sealed class CorrelationIdMiddleware
 {
     public const string HeaderName = "X-Correlation-Id";
     public const string LogContextProperty = "CorrelationId";
+    public const int MaxCorrelationIdLength = 128;
 
     private readonly RequestDelegate _next;
 
@@ -35,10 +37,10 @@ public sealed class CorrelationIdMiddleware
 
     private static string ObterOuGerarCorrelationId(HttpContext context)
     {
-        if (context.Request.Headers.TryGetValue(HeaderName, out Microsoft.Extensions.Primitives.StringValues valor))
+        if (context.Request.Headers.TryGetValue(HeaderName, out StringValues valor))
         {
-            string? existente = valor.ToString();
-            if (!string.IsNullOrWhiteSpace(existente))
+            string existente = valor.ToString();
+            if (!string.IsNullOrWhiteSpace(existente) && existente.Length <= MaxCorrelationIdLength)
             {
                 return existente;
             }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
@@ -1,11 +1,13 @@
 namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
+using System.Text.RegularExpressions;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
 using Serilog.Context;
 
-public sealed class CorrelationIdMiddleware
+public sealed partial class CorrelationIdMiddleware
 {
     public const string HeaderName = "X-Correlation-Id";
     public const string LogContextProperty = "CorrelationId";
@@ -40,7 +42,7 @@ public sealed class CorrelationIdMiddleware
         if (context.Request.Headers.TryGetValue(HeaderName, out StringValues valor))
         {
             string existente = valor.ToString();
-            if (!string.IsNullOrWhiteSpace(existente) && existente.Length <= MaxCorrelationIdLength)
+            if (FormatoValido().IsMatch(existente))
             {
                 return existente;
             }
@@ -48,4 +50,11 @@ public sealed class CorrelationIdMiddleware
 
         return Guid.NewGuid().ToString("D");
     }
+
+    // Restringe valores aceitos do cliente a ASCII imprimível [A-Za-z0-9\-_.],
+    // 1..128 chars. Rejeita controle (\r\n, NULL), whitespace e não-ASCII —
+    // previne log injection e poluição de dashboards estruturados downstream.
+    // O upper bound do quantificador deve espelhar MaxCorrelationIdLength.
+    [GeneratedRegex(@"^[A-Za-z0-9\-_.]{1,128}$")]
+    private static partial Regex FormatoValido();
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
@@ -29,7 +29,16 @@ public sealed partial class CorrelationIdMiddleware
         string correlationId = ObterOuGerarCorrelationId(context);
 
         writer.SetCorrelationId(correlationId);
-        context.Response.Headers[HeaderName] = correlationId;
+
+        // Postergar a escrita do header até o início do flush da resposta
+        // garante que o valor sobreviva a qualquer mutação feita por
+        // middlewares/filtros downstream e seja comprometido logo antes do
+        // status line ser enviado ao cliente.
+        context.Response.OnStarting(() =>
+        {
+            context.Response.Headers[HeaderName] = correlationId;
+            return Task.CompletedTask;
+        });
 
         using (LogContext.PushProperty(LogContextProperty, correlationId))
         {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdMiddleware.cs
@@ -21,14 +21,14 @@ public sealed partial class CorrelationIdMiddleware
         _next = next;
     }
 
-    public async Task InvokeAsync(HttpContext context, ICorrelationIdAccessor accessor)
+    public async Task InvokeAsync(HttpContext context, ICorrelationIdWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
-        ArgumentNullException.ThrowIfNull(accessor);
+        ArgumentNullException.ThrowIfNull(writer);
 
         string correlationId = ObterOuGerarCorrelationId(context);
 
-        accessor.SetCorrelationId(correlationId);
+        writer.SetCorrelationId(correlationId);
         context.Response.Headers[HeaderName] = correlationId;
 
         using (LogContext.PushProperty(LogContextProperty, correlationId))

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+using Microsoft.Extensions.DependencyInjection;
+
+public static class CorrelationIdServiceCollectionExtensions
+{
+    public static IServiceCollection AddCorrelationIdAccessor(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddSingleton<ICorrelationIdAccessor, CorrelationIdAccessor>();
+        return services;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/CorrelationIdServiceCollectionExtensions.cs
@@ -7,7 +7,14 @@ public static class CorrelationIdServiceCollectionExtensions
     public static IServiceCollection AddCorrelationIdAccessor(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
-        services.AddSingleton<ICorrelationIdAccessor, CorrelationIdAccessor>();
+
+        // Registrar a implementação concreta como singleton e resolver as duas
+        // interfaces para a MESMA instância. ICorrelationIdAccessor fica
+        // disponível amplamente (read-only); ICorrelationIdWriter é usado
+        // apenas pelo middleware.
+        services.AddSingleton<CorrelationIdAccessor>();
+        services.AddSingleton<ICorrelationIdAccessor>(sp => sp.GetRequiredService<CorrelationIdAccessor>());
+        services.AddSingleton<ICorrelationIdWriter>(sp => sp.GetRequiredService<CorrelationIdAccessor>());
         return services;
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/ICorrelationIdAccessor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/ICorrelationIdAccessor.cs
@@ -1,0 +1,8 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+public interface ICorrelationIdAccessor
+{
+    string? CorrelationId { get; }
+
+    void SetCorrelationId(string correlationId);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/ICorrelationIdAccessor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/ICorrelationIdAccessor.cs
@@ -1,8 +1,9 @@
 namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
+// Contract somente-leitura exposto a qualquer consumer do DI. Separar da
+// capacidade de escrita (ICorrelationIdWriter) previne que handlers
+// downstream sobrescrevam o ID do request em andamento por acidente.
 public interface ICorrelationIdAccessor
 {
     string? CorrelationId { get; }
-
-    void SetCorrelationId(string correlationId);
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/ICorrelationIdWriter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/ICorrelationIdWriter.cs
@@ -1,0 +1,9 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+// Contract de escrita, injetado apenas no CorrelationIdMiddleware.
+// Estende o reader para permitir que o próprio middleware leia de volta
+// o valor (útil em testes e composições).
+public interface ICorrelationIdWriter : ICorrelationIdAccessor
+{
+    void SetCorrelationId(string correlationId);
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/DependencyInjection/CorrelationIdServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/DependencyInjection/CorrelationIdServiceCollectionExtensionsTests.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.DependencyInjection;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Infrastructure.Common.DependencyInjection;
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+public class CorrelationIdServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddCorrelationIdAccessor_DeveResolverMesmaInstanciaParaAmbasInterfaces()
+    {
+        // Protege o invariante da registração: ICorrelationIdAccessor (reader)
+        // e ICorrelationIdWriter (writer) devem apontar para a MESMA singleton
+        // concreta. Se alguém trocar por AddSingleton<I, Impl>() separado, as
+        // duas interfaces passam a resolver instâncias distintas e o fluxo de
+        // correlação entre middleware e consumers se quebra silenciosamente.
+        ServiceCollection services = new();
+        services.AddCorrelationIdAccessor();
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        ICorrelationIdAccessor reader = sp.GetRequiredService<ICorrelationIdAccessor>();
+        ICorrelationIdWriter writer = sp.GetRequiredService<ICorrelationIdWriter>();
+        CorrelationIdAccessor concreta = sp.GetRequiredService<CorrelationIdAccessor>();
+
+        reader.Should().BeSameAs(writer);
+        reader.Should().BeSameAs(concreta);
+    }
+
+    [Fact]
+    public void AddCorrelationIdAccessor_ComServicesNulo_DeveLancarArgumentNullException()
+    {
+        IServiceCollection? services = null;
+
+        Action acao = () => services!.AddCorrelationIdAccessor();
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdAccessorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdAccessorTests.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.Middleware;
+
+using FluentAssertions;
+
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+public class CorrelationIdAccessorTests
+{
+    [Fact]
+    public void SetCorrelationId_ComValorValido_DeveArmazenarValor()
+    {
+        CorrelationIdAccessor accessor = new();
+        const string esperado = "abc-123";
+
+        accessor.SetCorrelationId(esperado);
+
+        accessor.CorrelationId.Should().Be(esperado);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SetCorrelationId_ComValorVazioOuEmBranco_DeveLancarArgumentException(string valor)
+    {
+        CorrelationIdAccessor accessor = new();
+
+        Action acao = () => accessor.SetCorrelationId(valor);
+
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void SetCorrelationId_ComValorNulo_DeveLancarArgumentNullException()
+    {
+        CorrelationIdAccessor accessor = new();
+
+        Action acao = () => accessor.SetCorrelationId(null!);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task CorrelationId_DeveFluirEntreContinuacoesAsync()
+    {
+        CorrelationIdAccessor accessor = new();
+        const string id = "flow-test";
+
+        accessor.SetCorrelationId(id);
+        await Task.Yield();
+
+        accessor.CorrelationId.Should().Be(id);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdAccessorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdAccessorTests.cs
@@ -50,4 +50,30 @@ public class CorrelationIdAccessorTests
 
         accessor.CorrelationId.Should().Be(id);
     }
+
+    [Fact]
+    public async Task CorrelationId_EmContextosParalelos_DeveIsolarValores()
+    {
+        CorrelationIdAccessor accessor = new();
+        string? observadoEmCtx1 = null;
+        string? observadoEmCtx2 = null;
+
+        await Task.WhenAll(
+            Task.Run(async () =>
+            {
+                accessor.SetCorrelationId("ctx-1");
+                await Task.Delay(10);
+                observadoEmCtx1 = accessor.CorrelationId;
+            }),
+            Task.Run(async () =>
+            {
+                accessor.SetCorrelationId("ctx-2");
+                await Task.Delay(10);
+                observadoEmCtx2 = accessor.CorrelationId;
+            })
+        );
+
+        observadoEmCtx1.Should().Be("ctx-1");
+        observadoEmCtx2.Should().Be("ctx-2");
+    }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -6,6 +6,10 @@ using Microsoft.AspNetCore.Http;
 
 using NSubstitute;
 
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+
 using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
 public class CorrelationIdMiddlewareTests
@@ -92,5 +96,79 @@ public class CorrelationIdMiddlewareTests
         await middleware.InvokeAsync(context, accessor);
 
         proximoFoiChamado.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ComHeaderAcimaDoTamanhoMaximo_DeveGerarNovoUuid()
+    {
+        string idAbusivo = new('a', CorrelationIdMiddleware.MaxCorrelationIdLength + 1);
+        DefaultHttpContext context = new();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idAbusivo;
+        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context, accessor);
+
+        string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
+        headerResposta.Should().NotBe(idAbusivo);
+        headerResposta!.Length.Should().BeLessThanOrEqualTo(CorrelationIdMiddleware.MaxCorrelationIdLength);
+        Guid.TryParse(headerResposta, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DeveEnriquecerLogContextComCorrelationId()
+    {
+        const string id = "log-ctx-test";
+        List<LogEvent> capturados = new();
+        CapturingSink sink = new(capturados);
+
+        Logger loggerDeTeste = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        ILogger loggerOriginal = Log.Logger;
+        Log.Logger = loggerDeTeste;
+
+        try
+        {
+            DefaultHttpContext context = new();
+            context.Request.Headers[CorrelationIdMiddleware.HeaderName] = id;
+
+            CorrelationIdMiddleware middleware = new(_ =>
+            {
+                Log.Information("log dentro do pipeline");
+                return Task.CompletedTask;
+            });
+
+            await middleware.InvokeAsync(context, new CorrelationIdAccessor());
+        }
+        finally
+        {
+            Log.Logger = loggerOriginal;
+            await loggerDeTeste.DisposeAsync();
+        }
+
+        capturados.Should().ContainSingle();
+        capturados[0].Properties.Should().ContainKey(CorrelationIdMiddleware.LogContextProperty);
+        capturados[0].Properties[CorrelationIdMiddleware.LogContextProperty]
+            .ToString().Trim('"').Should().Be(id);
+    }
+
+    private sealed class CapturingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _eventos;
+
+        public CapturingSink(List<LogEvent> eventos)
+        {
+            _eventos = eventos;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            ArgumentNullException.ThrowIfNull(logEvent);
+            _eventos.Add(logEvent);
+        }
     }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -185,37 +185,32 @@ public class CorrelationIdMiddlewareTests
     [Fact]
     public async Task InvokeAsync_DeveEnriquecerLogContextComCorrelationId()
     {
+        // LogContext.PushProperty (chamada pelo middleware) atua sobre um
+        // AsyncLocal estático, não sobre uma instância de ILogger. Portanto
+        // qualquer logger com Enrich.FromLogContext() enxerga a propriedade,
+        // inclusive um logger local. Isso permite testar o enrichment sem
+        // substituir o singleton Log.Logger — swap global seria frágil se o
+        // xUnit passasse a paralelizar testes entre classes.
         const string id = "log-ctx-test";
         List<LogEvent> capturados = new();
         CapturingSink sink = new(capturados);
 
-        Logger loggerDeTeste = new LoggerConfiguration()
+        await using Logger loggerDeTeste = new LoggerConfiguration()
             .MinimumLevel.Verbose()
             .Enrich.FromLogContext()
             .WriteTo.Sink(sink)
             .CreateLogger();
 
-        ILogger loggerOriginal = Log.Logger;
-        Log.Logger = loggerDeTeste;
+        (DefaultHttpContext context, _) = CriarContexto();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = id;
 
-        try
+        CorrelationIdMiddleware middleware = new(_ =>
         {
-            (DefaultHttpContext context, _) = CriarContexto();
-            context.Request.Headers[CorrelationIdMiddleware.HeaderName] = id;
+            loggerDeTeste.Information("log dentro do pipeline");
+            return Task.CompletedTask;
+        });
 
-            CorrelationIdMiddleware middleware = new(_ =>
-            {
-                Log.Information("log dentro do pipeline");
-                return Task.CompletedTask;
-            });
-
-            await middleware.InvokeAsync(context, new CorrelationIdAccessor());
-        }
-        finally
-        {
-            Log.Logger = loggerOriginal;
-            await loggerDeTeste.DisposeAsync();
-        }
+        await middleware.InvokeAsync(context, new CorrelationIdAccessor());
 
         capturados.Should().ContainSingle();
         capturados[0].Properties.Should().ContainKey(CorrelationIdMiddleware.LogContextProperty);

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -1,0 +1,96 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.Middleware;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Http;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+public class CorrelationIdMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_SemHeaderNoRequest_DeveGerarUuidValido()
+    {
+        DefaultHttpContext context = new();
+        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context, accessor);
+
+        string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
+        headerResposta.Should().NotBeNullOrWhiteSpace();
+        Guid.TryParse(headerResposta, out _).Should().BeTrue();
+        accessor.Received(1).SetCorrelationId(headerResposta!);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ComHeaderExistenteNoRequest_DeveReutilizarValor()
+    {
+        const string idExistente = "request-12345";
+        DefaultHttpContext context = new();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idExistente;
+        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context, accessor);
+
+        context.Response.Headers[CorrelationIdMiddleware.HeaderName].ToString().Should().Be(idExistente);
+        accessor.Received(1).SetCorrelationId(idExistente);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ComHeaderEmBrancoNoRequest_DeveGerarNovoUuid()
+    {
+        DefaultHttpContext context = new();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = "   ";
+        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context, accessor);
+
+        string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
+        headerResposta.Should().NotBeNullOrWhiteSpace();
+        headerResposta.Should().NotBe("   ");
+        Guid.TryParse(headerResposta, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DurantePipeline_AccessorDeveRetornarMesmoValor()
+    {
+        const string idExistente = "scoped-flow";
+        DefaultHttpContext context = new();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idExistente;
+        CorrelationIdAccessor accessor = new();
+        string? idObservadoDentroDoPipeline = null;
+
+        CorrelationIdMiddleware middleware = new(_ =>
+        {
+            idObservadoDentroDoPipeline = accessor.CorrelationId;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context, accessor);
+
+        idObservadoDentroDoPipeline.Should().Be(idExistente);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DeveChamarProximoMiddleware()
+    {
+        DefaultHttpContext context = new();
+        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        bool proximoFoiChamado = false;
+
+        CorrelationIdMiddleware middleware = new(_ =>
+        {
+            proximoFoiChamado = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.InvokeAsync(context, accessor);
+
+        proximoFoiChamado.Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -18,7 +18,7 @@ public class CorrelationIdMiddlewareTests
     public async Task InvokeAsync_SemHeaderNoRequest_DeveGerarUuidValido()
     {
         DefaultHttpContext context = new();
-        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
@@ -35,7 +35,7 @@ public class CorrelationIdMiddlewareTests
         const string idExistente = "request-12345";
         DefaultHttpContext context = new();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idExistente;
-        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
@@ -49,7 +49,7 @@ public class CorrelationIdMiddlewareTests
     {
         DefaultHttpContext context = new();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = "   ";
-        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
@@ -84,7 +84,7 @@ public class CorrelationIdMiddlewareTests
     public async Task InvokeAsync_DeveChamarProximoMiddleware()
     {
         DefaultHttpContext context = new();
-        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         bool proximoFoiChamado = false;
 
         CorrelationIdMiddleware middleware = new(_ =>
@@ -104,7 +104,7 @@ public class CorrelationIdMiddlewareTests
         string idAbusivo = new('a', CorrelationIdMiddleware.MaxCorrelationIdLength + 1);
         DefaultHttpContext context = new();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idAbusivo;
-        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
@@ -125,7 +125,7 @@ public class CorrelationIdMiddlewareTests
     {
         DefaultHttpContext context = new();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idMalicioso;
-        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
@@ -144,7 +144,7 @@ public class CorrelationIdMiddlewareTests
     {
         DefaultHttpContext context = new();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idInvalido;
-        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.Middleware;
 using FluentAssertions;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 
 using NSubstitute;
 
@@ -17,11 +18,12 @@ public class CorrelationIdMiddlewareTests
     [Fact]
     public async Task InvokeAsync_SemHeaderNoRequest_DeveGerarUuidValido()
     {
-        DefaultHttpContext context = new();
+        (DefaultHttpContext context, Func<Task> dispararOnStarting) = CriarContexto();
         ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
+        await dispararOnStarting();
 
         string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
         headerResposta.Should().NotBeNullOrWhiteSpace();
@@ -33,12 +35,13 @@ public class CorrelationIdMiddlewareTests
     public async Task InvokeAsync_ComHeaderExistenteNoRequest_DeveReutilizarValor()
     {
         const string idExistente = "request-12345";
-        DefaultHttpContext context = new();
+        (DefaultHttpContext context, Func<Task> dispararOnStarting) = CriarContexto();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idExistente;
         ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
+        await dispararOnStarting();
 
         context.Response.Headers[CorrelationIdMiddleware.HeaderName].ToString().Should().Be(idExistente);
         accessor.Received(1).SetCorrelationId(idExistente);
@@ -47,12 +50,13 @@ public class CorrelationIdMiddlewareTests
     [Fact]
     public async Task InvokeAsync_ComHeaderEmBrancoNoRequest_DeveGerarNovoUuid()
     {
-        DefaultHttpContext context = new();
+        (DefaultHttpContext context, Func<Task> dispararOnStarting) = CriarContexto();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = "   ";
         ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
+        await dispararOnStarting();
 
         string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
         headerResposta.Should().NotBeNullOrWhiteSpace();
@@ -64,7 +68,7 @@ public class CorrelationIdMiddlewareTests
     public async Task InvokeAsync_DurantePipeline_AccessorDeveRetornarMesmoValor()
     {
         const string idExistente = "scoped-flow";
-        DefaultHttpContext context = new();
+        (DefaultHttpContext context, Func<Task> dispararOnStarting) = CriarContexto();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idExistente;
         CorrelationIdAccessor accessor = new();
         string? idObservadoDentroDoPipeline = null;
@@ -76,6 +80,7 @@ public class CorrelationIdMiddlewareTests
         });
 
         await middleware.InvokeAsync(context, accessor);
+        await dispararOnStarting();
 
         idObservadoDentroDoPipeline.Should().Be(idExistente);
     }
@@ -83,7 +88,7 @@ public class CorrelationIdMiddlewareTests
     [Fact]
     public async Task InvokeAsync_DeveChamarProximoMiddleware()
     {
-        DefaultHttpContext context = new();
+        (DefaultHttpContext context, _) = CriarContexto();
         ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         bool proximoFoiChamado = false;
 
@@ -102,12 +107,13 @@ public class CorrelationIdMiddlewareTests
     public async Task InvokeAsync_ComHeaderAcimaDoTamanhoMaximo_DeveGerarNovoUuid()
     {
         string idAbusivo = new('a', CorrelationIdMiddleware.MaxCorrelationIdLength + 1);
-        DefaultHttpContext context = new();
+        (DefaultHttpContext context, Func<Task> dispararOnStarting) = CriarContexto();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idAbusivo;
         ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
+        await dispararOnStarting();
 
         string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
         headerResposta.Should().NotBe(idAbusivo);
@@ -123,12 +129,13 @@ public class CorrelationIdMiddlewareTests
     [InlineData("valor\0com\0null")]
     public async Task InvokeAsync_ComHeaderContendoCaracteresDeControle_DeveGerarNovoUuid(string idMalicioso)
     {
-        DefaultHttpContext context = new();
+        (DefaultHttpContext context, Func<Task> dispararOnStarting) = CriarContexto();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idMalicioso;
         ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
+        await dispararOnStarting();
 
         string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
         headerResposta.Should().NotBe(idMalicioso);
@@ -142,16 +149,37 @@ public class CorrelationIdMiddlewareTests
     [InlineData("espaco interno")]
     public async Task InvokeAsync_ComHeaderContendoCaracteresInvalidos_DeveGerarNovoUuid(string idInvalido)
     {
-        DefaultHttpContext context = new();
+        (DefaultHttpContext context, Func<Task> dispararOnStarting) = CriarContexto();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idInvalido;
         ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
         CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
 
         await middleware.InvokeAsync(context, accessor);
+        await dispararOnStarting();
 
         string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
         headerResposta.Should().NotBe(idInvalido);
         Guid.TryParse(headerResposta, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_HeaderEscritoSomenteNoFlushDaResposta()
+    {
+        // Garante que a escrita foi registrada via OnStarting e não aplicada
+        // imediatamente. Protege o invariante contra alguém desfazer a
+        // mudança e voltar para a escrita síncrona.
+        (DefaultHttpContext context, Func<Task> dispararOnStarting) = CriarContexto();
+        ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
+        CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context, accessor);
+
+        context.Response.Headers.ContainsKey(CorrelationIdMiddleware.HeaderName).Should().BeFalse(
+            "o header só deve ser aplicado quando o flush da resposta disparar OnStarting");
+
+        await dispararOnStarting();
+
+        context.Response.Headers.ContainsKey(CorrelationIdMiddleware.HeaderName).Should().BeTrue();
     }
 
     [Fact]
@@ -172,7 +200,7 @@ public class CorrelationIdMiddlewareTests
 
         try
         {
-            DefaultHttpContext context = new();
+            (DefaultHttpContext context, _) = CriarContexto();
             context.Request.Headers[CorrelationIdMiddleware.HeaderName] = id;
 
             CorrelationIdMiddleware middleware = new(_ =>
@@ -193,6 +221,40 @@ public class CorrelationIdMiddlewareTests
         capturados[0].Properties.Should().ContainKey(CorrelationIdMiddleware.LogContextProperty);
         capturados[0].Properties[CorrelationIdMiddleware.LogContextProperty]
             .ToString().Trim('"').Should().Be(id);
+    }
+
+    // Cria um DefaultHttpContext com IHttpResponseFeature customizado que
+    // captura os callbacks registrados em Response.OnStarting (o feature
+    // default lança NotSupportedException). Retorna também um delegate que
+    // dispara os callbacks na ordem LIFO, emulando o comportamento de
+    // Kestrel ao iniciar o flush da resposta.
+    private static (DefaultHttpContext, Func<Task>) CriarContexto()
+    {
+        TestHttpResponseFeature feature = new();
+        DefaultHttpContext context = new();
+        context.Features.Set<IHttpResponseFeature>(feature);
+        return (context, feature.DispararOnStartingAsync);
+    }
+
+    private sealed class TestHttpResponseFeature : HttpResponseFeature
+    {
+        private readonly List<(Func<object, Task> Callback, object State)> _callbacks = new();
+
+        public override void OnStarting(Func<object, Task> callback, object state)
+        {
+            ArgumentNullException.ThrowIfNull(callback);
+            ArgumentNullException.ThrowIfNull(state);
+            _callbacks.Add((callback, state));
+        }
+
+        public async Task DispararOnStartingAsync()
+        {
+            // LIFO conforme Kestrel
+            for (int i = _callbacks.Count - 1; i >= 0; i--)
+            {
+                await _callbacks[i].Callback(_callbacks[i].State);
+            }
+        }
     }
 
     private sealed class CapturingSink : ILogEventSink

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -67,6 +67,9 @@ public class CorrelationIdMiddlewareTests
     [Fact]
     public async Task InvokeAsync_DurantePipeline_AccessorDeveRetornarMesmoValor()
     {
+        // Instanciação direta é segura aqui porque o AsyncLocal que guarda o
+        // valor é estático: qualquer CorrelationIdAccessor enxerga o mesmo
+        // fluxo lógico. Em produção a instância vem via DI como Singleton.
         const string idExistente = "scoped-flow";
         (DefaultHttpContext context, Func<Task> dispararOnStarting) = CriarContexto();
         context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idExistente;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -115,6 +115,45 @@ public class CorrelationIdMiddlewareTests
         Guid.TryParse(headerResposta, out _).Should().BeTrue();
     }
 
+    [Theory]
+    [InlineData("abc\r\n\r\n[admin] linha forjada")]
+    [InlineData("valor\rcom\rcarriage-return")]
+    [InlineData("valor\ncom\nnewline")]
+    [InlineData("valor\tcom\ttab")]
+    [InlineData("valor\0com\0null")]
+    public async Task InvokeAsync_ComHeaderContendoCaracteresDeControle_DeveGerarNovoUuid(string idMalicioso)
+    {
+        DefaultHttpContext context = new();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idMalicioso;
+        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context, accessor);
+
+        string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
+        headerResposta.Should().NotBe(idMalicioso);
+        Guid.TryParse(headerResposta, out _).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("válido-acentuado")]
+    [InlineData("测试中文")]
+    [InlineData("emoji-😀-teste")]
+    [InlineData("espaco interno")]
+    public async Task InvokeAsync_ComHeaderContendoCaracteresInvalidos_DeveGerarNovoUuid(string idInvalido)
+    {
+        DefaultHttpContext context = new();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = idInvalido;
+        ICorrelationIdAccessor accessor = Substitute.For<ICorrelationIdAccessor>();
+        CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
+
+        await middleware.InvokeAsync(context, accessor);
+
+        string? headerResposta = context.Response.Headers[CorrelationIdMiddleware.HeaderName];
+        headerResposta.Should().NotBe(idInvalido);
+        Guid.TryParse(headerResposta, out _).Should().BeTrue();
+    }
+
     [Fact]
     public async Task InvokeAsync_DeveEnriquecerLogContextComCorrelationId()
     {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Unifesspa.UniPlus.Infrastructure.Common.Tests.csproj
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Unifesspa.UniPlus.Infrastructure.Common.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <!-- CA1707: nomes de testes xUnit usam underscores por convenção -->
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/shared/Unifesspa.UniPlus.Infrastructure.Common/Unifesspa.UniPlus.Infrastructure.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Unifesspa.UniPlus.Infrastructure.Common.Tests.csproj
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Unifesspa.UniPlus.Infrastructure.Common.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <!-- CA1707: nomes de testes xUnit usam underscores por convenção -->
-    <NoWarn>$(NoWarn);CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Resumo

- Implementa rastreabilidade de requisições em todo o pipeline HTTP via `X-Correlation-Id`, propagado nos logs, no header de resposta e acessível via DI aos serviços
- Fecha as 5 tasks da Story #28 (tasks #60–#64) originais + 4 tasks adicionais (#111–#114) criadas após review de qualidade
- Consolida a configuração do Serilog via `ConfigurarSerilog` (extension method existente), que passa a registrar o `PiiMaskingEnricher` no pipeline — a implementação efetiva do `Enrich()` do enricher está rastreada na story #115 (fora do escopo deste PR)

## Issues fechadas

- Closes #28 — Story pai
- Closes #60 — `CorrelationIdMiddleware` em Infrastructure.Common
- Closes #61 — `ICorrelationIdAccessor` com `AsyncLocal<T>`
- Closes #62 — integração com Serilog `LogContext`
- Closes #63 — registro do middleware no pipeline
- Closes #64 — testes unitários
- Closes #111 — validação de formato de header X-Correlation-Id recebido
- Closes #112 — separação de `ICorrelationIdAccessor` (reader) e `ICorrelationIdWriter` (writer)
- Closes #113 — persistir header via `Response.OnStarting`
- Closes #114 — isolar teste de `LogContext` sem swap global de `Log.Logger`

## Mudanças

### Novos arquivos

**Infrastructure.Common/Middleware/** — módulo novo
- `ICorrelationIdAccessor.cs` — interface read-only (`CorrelationId` get)
- `ICorrelationIdWriter.cs` — interface de escrita (`SetCorrelationId`), estende o reader; injetada apenas no middleware
- `CorrelationIdAccessor.cs` — implementação baseada em `AsyncLocal<string?>` estático, registrada como Singleton e exposta via as duas interfaces
- `CorrelationIdMiddleware.cs` — gera UUID se `X-Correlation-Id` não vier, reutiliza se vier e passar na regex `^[A-Za-z0-9\-_.]{1,128}$` (valida ASCII imprimível + cap de 128 chars); escreve no header de resposta via `Response.OnStarting(...)` e enriquece Serilog `LogContext`
- `CorrelationIdServiceCollectionExtensions.cs` — extension method `AddCorrelationIdAccessor()` registrando a classe concreta + duas interfaces para a mesma singleton

**Projeto de testes novo** — `Unifesspa.UniPlus.Infrastructure.Common.Tests`
- `CorrelationIdAccessorTests.cs` (5 testes)
- `CorrelationIdMiddlewareTests.cs` (18 testes — 13 originais + 5 validação de formato + 1 `OnStarting`/flush)
- `.csproj` com `FrameworkReference Microsoft.AspNetCore.App`
- `UniPlus.slnx` atualizado

### Modificados

- `src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs` — `AddCorrelationIdAccessor` + `UseMiddleware<CorrelationIdMiddleware>` antes do `GlobalExceptionMiddleware` + Serilog via `ConfigurarSerilog`
- `src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs` — idem
- `.editorconfig` — regra escopada `[tests/**/*.cs]` desabilitando `CA1707` (underscores em nomes xUnit) e `CA2007` (xUnit não usa SynchronizationContext). Aplicado em toda a solução, evita precisar editar csproj de testes futuros
- `CLAUDE.md` — nova seção documentando o padrão obrigatório `[LoggerMessage]` source generator (CA1848/CA1873), com exemplos idiomáticos do projeto e casos especiais `SkipEnabledCheck`

## Revisão e refinamentos aplicados

### Review local (commit `ef4f6c9`) — 2 findings importantes + 4 sugestões

| ID | Finding | Status |
|---|---|---|
| I1 | Program.cs não usava `ConfigurarSerilog` — `PiiMaskingEnricher` não registrado no pipeline | ✅ corrigido (enricher registrado; implementação do `Enrich()` rastreada em #115) |
| I2 | Sem cap de tamanho no header recebido (log amplification) | ✅ `MaxCorrelationIdLength = 128` + teste |
| S1 | `StringValues` totalmente qualificado | ✅ `using Microsoft.Extensions.Primitives` |
| S2 | `AsyncLocal` estático sem comentário explicativo | ✅ documentado |
| S3 | Sem teste do `LogContext` enrichment | ✅ teste com `CapturingSink` custom |
| S4 | Sem teste de isolamento paralelo | ✅ teste `EmContextosParalelos_DeveIsolarValores` |

### Review adicional (commits `4fd202a`, `fce6ef4`, `4a1db56`, `0fe3a6d`) — 4 tasks novas

| Task | Commit | Status |
|---|---|---|
| #111 — validar formato do header | `4fd202a` | ✅ regex `^[A-Za-z0-9\-_.]{1,128}$` via `[GeneratedRegex]`; rejeita CRLF, controle, não-ASCII, whitespace |
| #112 — split `ICorrelationIdAccessor` / `ICorrelationIdWriter` | `fce6ef4` | ✅ reader exposto ao DI, writer apenas no middleware; ambas as interfaces resolvem para a mesma singleton |
| #113 — persistir header via `Response.OnStarting` | `4a1db56` | ✅ header escrito apenas no início do flush; teste garante invariante |
| #114 — isolar teste de `LogContext` sem swap global | `0fe3a6d` | ✅ logger local passado ao next delegate; zero mudança em Log.Logger |

## Follow-up

Durante o design surgiu a discussão sobre como identificar origem de fluxos quando eles cruzam múltiplas APIs (Selecao ↔ Ingresso ↔ Portal ↔ Gov.br) e eventos Kafka. Para evitar decisão ad-hoc, foi criada a rota formal via ADR:

- **[unifesspa-edu-br/uniplus-docs#65](https://github.com/unifesspa-edu-br/uniplus-docs/issues/65)** — Story para escrever ADR definindo a estratégia (`ServiceName` estruturado vs `X-Correlation-Origin` separado + propagação em Kafka), alinhada a OpenTelemetry Semantic Conventions e ADR-014
- **#101** — Story para implementar o que a ADR definir (bloqueada pela ADR). Enrichment de `ServiceName` no Serilog + propagação em HTTP headers e eventos Kafka
- **#110** — Propagar `correlation_id` como Activity span attribute (bloqueada pelo merge deste PR + Story #30 de OTel wiring)
- **#115** — Implementar `PiiMaskingEnricher.Enrich()` efetivamente (hoje é no-op — o enricher está registrado mas não executa masking). Alta prioridade LGPD.

## Testes

- **Build:** ✅ `0 warnings / 0 errors` (`TreatWarningsAsErrors` + `AnalysisLevel=latest-all`)
- **Testes unitários:** ✅ **23/23 aprovados** (~100 ms)
- Casos cobertos: sem header / com header existente / header em branco / header acima do cap / header com CRLF / header com controle (`\r`, `\n`, `\t`, `\0`) / header com caracteres não-ASCII / accessor retorna mesmo valor dentro do pipeline / chama próximo middleware / enriquece LogContext / `SetCorrelationId` rejeita null/empty/whitespace / valor flui entre continuações async / isolamento paralelo / header escrito apenas no flush da resposta

## Checklist

- [x] Build sem errors (0 warnings / 0 errors)
- [x] Testes passando (23/23)
- [x] Review local realizado — findings tratados
- [x] Review adicional de qualidade realizado — 4 tasks adicionais aplicadas em commits atômicos
- [x] Convenções do projeto respeitadas (file-scoped namespace, sealed, ConfigureAwait, `[LoggerMessage]` quando aplicável)
- [x] CLAUDE.md atualizado com padrão obrigatório de logging
- [x] Cross-repo follow-ups rastreados