### PR TITLE
feat(shared): mascaramento efetivo de CPF em logs Serilog (#115)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Application NUNCA depende de Infrastructure ou API.
 ## Padrões obrigatórios
 
 - **Soft delete** em todas as entidades: `IsDeleted`, `DeletedAt`, `DeletedBy`
-- **PII masking** em logs: CPF `***.***.***-XX`, nunca logar dados sensíveis
+- **PII masking** em logs: CPF `***.***.***-XX`, nunca logar dados sensíveis — aplicado automaticamente pelo `PiiMaskingEnricher` (registrado no pipeline Serilog via `ConfigurarSerilog`) a todas as propriedades estruturadas, inclusive aninhadas (`StructureValue`, `SequenceValue`, `DictionaryValue`)
 - **Result pattern** para retorno de operações: `Result<T>` com `DomainError`
 - **CQRS** via MediatR: Commands para escrita, Queries para leitura
 - **Value objects** para dados de domínio: `Cpf`, `Email`, `NomeSocial`, `NotaFinal`, `NumeroEdital`

--- a/UniPlus.slnx
+++ b/UniPlus.slnx
@@ -26,5 +26,6 @@
     <Project Path="tests/Unifesspa.UniPlus.Selecao.ArchTests/Unifesspa.UniPlus.Selecao.ArchTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Selecao.Domain.Tests/Unifesspa.UniPlus.Selecao.Domain.Tests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Selecao.Integration.Tests/Unifesspa.UniPlus.Selecao.Integration.Tests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.SharedKernel.Tests/Unifesspa.UniPlus.SharedKernel.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Logging/PiiMaskingEnricher.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Logging/PiiMaskingEnricher.cs
@@ -22,7 +22,7 @@ public sealed partial class PiiMaskingEnricher : ILogEventEnricher
         }
     }
 
-    public static string MascararCpf(string texto)
+    internal static string MascararCpf(string texto)
     {
         if (string.IsNullOrEmpty(texto))
         {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Logging/PiiMaskingEnricher.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Logging/PiiMaskingEnricher.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Common.Logging;
 
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 using Serilog.Core;
@@ -9,17 +10,156 @@ public sealed partial class PiiMaskingEnricher : ILogEventEnricher
 {
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        // Enricher registrado no pipeline do Serilog para garantir
-        // que CPFs não sejam logados em texto claro
+        ArgumentNullException.ThrowIfNull(logEvent);
+
+        foreach (KeyValuePair<string, LogEventPropertyValue> propriedade in logEvent.Properties.ToArray())
+        {
+            LogEventPropertyValue mascarado = MascararValor(propriedade.Value);
+            if (!ReferenceEquals(mascarado, propriedade.Value))
+            {
+                logEvent.AddOrUpdateProperty(new LogEventProperty(propriedade.Key, mascarado));
+            }
+        }
     }
 
-    [GeneratedRegex(@"\d{3}\.?\d{3}\.?\d{3}-?\d{2}", RegexOptions.Compiled)]
-    private static partial Regex CpfPattern();
-
-    public static string MascararCpf(string texto) =>
-        CpfPattern().Replace(texto, match =>
+    public static string MascararCpf(string texto)
+    {
+        if (string.IsNullOrEmpty(texto))
         {
-            string digitos = new(match.Value.Where(char.IsDigit).ToArray());
-            return digitos.Length == 11 ? $"***.***.***.{digitos[9..]}" : match.Value;
-        });
+            return texto;
+        }
+
+        return CpfPattern().Replace(texto, static match =>
+            string.Concat("***.***.***-".AsSpan(), match.ValueSpan[^2..]));
+    }
+
+    private static LogEventPropertyValue MascararValor(LogEventPropertyValue valor) => valor switch
+    {
+        ScalarValue scalar when scalar.Value is string texto => MascararScalar(scalar, texto),
+        StructureValue estrutura => MascararEstrutura(estrutura),
+        SequenceValue sequencia => MascararSequencia(sequencia),
+        DictionaryValue dicionario => MascararDicionario(dicionario),
+        _ => valor,
+    };
+
+    private static ScalarValue MascararScalar(ScalarValue original, string texto)
+    {
+        string mascarado = MascararCpf(texto);
+        return ReferenceEquals(mascarado, texto) ? original : new ScalarValue(mascarado);
+    }
+
+    private static StructureValue MascararEstrutura(StructureValue original)
+    {
+        LogEventProperty[]? propriedadesMascaradas = null;
+
+        for (int i = 0; i < original.Properties.Count; i++)
+        {
+            LogEventProperty propriedadeOriginal = original.Properties[i];
+            LogEventPropertyValue valorMascarado = MascararValor(propriedadeOriginal.Value);
+
+            if (!ReferenceEquals(valorMascarado, propriedadeOriginal.Value))
+            {
+                if (propriedadesMascaradas is null)
+                {
+                    propriedadesMascaradas = new LogEventProperty[original.Properties.Count];
+                    for (int j = 0; j < i; j++)
+                    {
+                        propriedadesMascaradas[j] = original.Properties[j];
+                    }
+                }
+
+                propriedadesMascaradas[i] = new LogEventProperty(propriedadeOriginal.Name, valorMascarado);
+            }
+            else if (propriedadesMascaradas is not null)
+            {
+                propriedadesMascaradas[i] = propriedadeOriginal;
+            }
+        }
+
+        return propriedadesMascaradas is null
+            ? original
+            : new StructureValue(propriedadesMascaradas, original.TypeTag);
+    }
+
+    private static SequenceValue MascararSequencia(SequenceValue original)
+    {
+        LogEventPropertyValue[]? elementosMascarados = null;
+
+        for (int i = 0; i < original.Elements.Count; i++)
+        {
+            LogEventPropertyValue elementoOriginal = original.Elements[i];
+            LogEventPropertyValue valorMascarado = MascararValor(elementoOriginal);
+
+            if (!ReferenceEquals(valorMascarado, elementoOriginal))
+            {
+                if (elementosMascarados is null)
+                {
+                    elementosMascarados = new LogEventPropertyValue[original.Elements.Count];
+                    for (int j = 0; j < i; j++)
+                    {
+                        elementosMascarados[j] = original.Elements[j];
+                    }
+                }
+
+                elementosMascarados[i] = valorMascarado;
+            }
+            else if (elementosMascarados is not null)
+            {
+                elementosMascarados[i] = elementoOriginal;
+            }
+        }
+
+        return elementosMascarados is null ? original : new SequenceValue(elementosMascarados);
+    }
+
+    private static DictionaryValue MascararDicionario(DictionaryValue original)
+    {
+        KeyValuePair<ScalarValue, LogEventPropertyValue>[]? entradasMascaradas = null;
+        int indice = 0;
+
+        foreach (KeyValuePair<ScalarValue, LogEventPropertyValue> entrada in original.Elements)
+        {
+            ScalarValue chaveMascarada = entrada.Key.Value is string textoChave
+                ? MascararScalar(entrada.Key, textoChave)
+                : entrada.Key;
+            LogEventPropertyValue valorMascarado = MascararValor(entrada.Value);
+
+            bool chaveAlterada = !ReferenceEquals(chaveMascarada, entrada.Key);
+            bool valorAlterado = !ReferenceEquals(valorMascarado, entrada.Value);
+
+            if (chaveAlterada || valorAlterado)
+            {
+                if (entradasMascaradas is null)
+                {
+                    entradasMascaradas = new KeyValuePair<ScalarValue, LogEventPropertyValue>[original.Elements.Count];
+                    int j = 0;
+                    foreach (KeyValuePair<ScalarValue, LogEventPropertyValue> preservada in original.Elements)
+                    {
+                        if (j == indice)
+                        {
+                            break;
+                        }
+
+                        entradasMascaradas[j++] = preservada;
+                    }
+                }
+
+                entradasMascaradas[indice] = new KeyValuePair<ScalarValue, LogEventPropertyValue>(chaveMascarada, valorMascarado);
+            }
+            else if (entradasMascaradas is not null)
+            {
+                entradasMascaradas[indice] = entrada;
+            }
+
+            indice++;
+        }
+
+        return entradasMascaradas is null ? original : new DictionaryValue(entradasMascaradas);
+    }
+
+    // Word boundaries ((?<!\d) / (?!\d)) impedem casar sub-sequências de 11 dígitos
+    // dentro de números maiores (timestamps, IDs), evitando tanto falsos positivos
+    // (log corruption) quanto falsos negativos onde dígitos do CPF vazariam fora do match.
+    [GeneratedRegex(@"(?<![0-9])[0-9]{3}\.?[0-9]{3}\.?[0-9]{3}-?[0-9]{2}(?![0-9])")]
+    private static partial Regex CpfPattern();
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Unifesspa.UniPlus.Infrastructure.Common.csproj
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Unifesspa.UniPlus.Infrastructure.Common.csproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="..\Unifesspa.UniPlus.SharedKernel\Unifesspa.UniPlus.SharedKernel.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Unifesspa.UniPlus.Infrastructure.Common.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/shared/Unifesspa.UniPlus.SharedKernel/Domain/ValueObjects/Cpf.cs
+++ b/src/shared/Unifesspa.UniPlus.SharedKernel/Domain/ValueObjects/Cpf.cs
@@ -21,7 +21,7 @@ public sealed record Cpf
         return Result<Cpf>.Success(new Cpf(apenasDigitos));
     }
 
-    public string Mascarado => $"***.***.***.{Valor[9..]}";
+    public string Mascarado => $"***.***.***-{Valor[9..]}";
 
     public override string ToString() => Mascarado;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricher.feature
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricher.feature
@@ -1,0 +1,132 @@
+# language: pt
+# Story: #115 — PiiMaskingEnricher.Enrich para mascaramento efetivo de CPF em logs
+# Referências: LGPD Art. 6º, ADR-012, RN-LGPD
+# Arquivo-alvo: src/shared/Unifesspa.UniPlus.Infrastructure.Common/Logging/PiiMaskingEnricher.cs
+
+Funcionalidade: Mascaramento de CPF em logs estruturados do Serilog
+  Como operador do sistema Uni+
+  Quero que CPFs sejam automaticamente mascarados em todos os registros de log
+  Para garantir conformidade com a LGPD e evitar vazamento de dados pessoais em saídas estruturadas (stdout, Loki, arquivos)
+
+  Contexto:
+    Dado que o pipeline do Serilog está configurado com o enricher "PiiMaskingEnricher"
+    E que o padrão de mascaramento definido pela LGPD é "***.***.***-XX", preservando os dois últimos dígitos verificadores
+    E que um sink capturador de eventos está anexado ao logger para inspeção dos LogEvents emitidos
+
+  # ── Cenários felizes ──────────────────────────────────────
+
+  Cenário: CA-01 — Mascarar CPF formatado em propriedade estruturada
+    Dado um LogEvent com a propriedade "CpfCandidato" contendo o valor "123.456.789-01"
+    Quando o enricher processar o evento
+    Então a propriedade "CpfCandidato" deve conter o valor "***.***.***-01"
+    E nenhum dígito verificador do meio deve aparecer em texto claro
+
+  Cenário: CA-02 — Mascarar CPF não-formatado (somente dígitos)
+    Dado um LogEvent com a propriedade "CpfCandidato" contendo o valor "12345678901"
+    Quando o enricher processar o evento
+    Então a propriedade "CpfCandidato" deve conter o valor "***.***.***-01"
+    E o formato do retorno deve seguir o padrão SERPRO/Gov.br
+
+  Cenário: CA-04 — Mascarar múltiplas ocorrências na mesma string
+    Dado um LogEvent com a propriedade "Mensagem" contendo o texto "candidatos 123.456.789-01 e 987.654.321-02 homologados"
+    Quando o enricher processar o evento
+    Então a propriedade "Mensagem" deve conter o texto "candidatos ***.***.***-01 e ***.***.***-02 homologados"
+    E nenhum CPF em texto claro deve permanecer na saída
+
+  # ── Cenários de borda ─────────────────────────────────────
+
+  Cenário: CA-03 — Log sem CPF preserva valor original sem alocação extra
+    Dado um LogEvent com a propriedade "Mensagem" contendo o valor "processo seletivo iniciado com sucesso"
+    Quando o enricher processar o evento
+    Então a propriedade "Mensagem" deve conter o valor "processo seletivo iniciado com sucesso"
+    E a referência da string retornada deve ser a mesma instância original (sem realocação)
+
+  Cenário: CPF com 11 dígitos inválido (fora do padrão regex) não é alterado
+    Dado um LogEvent com a propriedade "Texto" contendo o valor "codigo-ABC-123"
+    Quando o enricher processar o evento
+    Então a propriedade "Texto" deve conter o valor "codigo-ABC-123"
+    E o enricher não deve emitir alertas ou warnings
+
+  Cenário: Propriedade com valor nulo é ignorada silenciosamente
+    Dado um LogEvent com a propriedade "CpfCandidato" contendo valor nulo
+    Quando o enricher processar o evento
+    Então a propriedade "CpfCandidato" deve permanecer com valor nulo
+    E nenhuma exceção deve ser lançada
+
+  # ── Cenários compostos (recursivos) ───────────────────────
+
+  Cenário: CA-05 — Mascaramento recursivo em StructureValue aninhado
+    Dado um LogEvent com a propriedade estruturada "Candidato" contendo os campos:
+      | campo | valor            |
+      | Nome  | João da Silva    |
+      | Cpf   | 123.456.789-01   |
+    Quando o enricher processar o evento
+    Então o campo "Cpf" do StructureValue "Candidato" deve conter "***.***.***-01"
+    E o campo "Nome" deve permanecer inalterado com o valor "João da Silva"
+
+  Cenário: Mascaramento recursivo em SequenceValue de strings
+    Dado um LogEvent com a propriedade "CpfsHomologados" contendo a sequência ["123.456.789-01", "987.654.321-02"]
+    Quando o enricher processar o evento
+    Então a sequência "CpfsHomologados" deve conter os valores ["***.***.***-01", "***.***.***-02"]
+
+  Cenário: Mascaramento recursivo em estruturas profundamente aninhadas (Structure dentro de Sequence)
+    Dado um LogEvent com a propriedade "Lote" contendo uma sequência de objetos "Candidato", cada um com o campo "Cpf" preenchido
+    Quando o enricher processar o evento
+    Então cada campo "Cpf" de cada elemento da sequência deve estar mascarado no padrão "***.***.***-XX"
+
+  # ── Cenários parametrizados ───────────────────────────────
+
+  Esquema do Cenário: Mascarar CPF em variações de formatação
+    Dado um LogEvent com a propriedade "CpfCandidato" contendo o valor "<entrada>"
+    Quando o enricher processar o evento
+    Então a propriedade "CpfCandidato" deve conter o valor "<saida>"
+
+    Exemplos:
+      | entrada           | saida            |
+      | 123.456.789-01    | ***.***.***-01   |
+      | 12345678901       | ***.***.***-01   |
+      | 123.45678901      | ***.***.***-01   |
+      | 123456789-01      | ***.***.***-01   |
+      | 000.000.000-00    | ***.***.***-00   |
+      | 999.999.999-99    | ***.***.***-99   |
+
+  # ── Cenário de integração (end-to-end Serilog) ────────────
+
+  Cenário: CA-07 — Integração com ILogger real e sink capturador
+    Dado um host configurado com Serilog usando "PiiMaskingEnricher" no pipeline
+    E um sink em memória anexado para capturar os LogEvents emitidos
+    Quando o código da aplicação invocar um método "[LoggerMessage]" passando o CPF "123.456.789-01" como parâmetro estruturado "CpfCandidato"
+    Então o LogEvent capturado deve conter a propriedade "CpfCandidato" com o valor "***.***.***-01"
+    E a saída renderizada do template (`RenderMessage()`) não deve conter o CPF em texto claro
+    E nenhum dígito intermediário do CPF deve aparecer na mensagem final
+
+  # ── Cenário de conformidade LGPD ──────────────────────────
+
+  Cenário: Todos os sinks herdam o mascaramento (stdout, Loki, arquivo)
+    Dado um host configurado com múltiplos sinks Serilog (Console, Arquivo, Loki)
+    E o enricher "PiiMaskingEnricher" registrado no pipeline raiz
+    Quando um log for emitido contendo CPF em qualquer propriedade estruturada
+    Então o CPF mascarado deve aparecer em todos os sinks configurados
+    E nenhum sink deve receber o valor original em texto claro
+
+---
+
+## Mapeamento para implementação
+
+**Projeto de teste unitário:**
+- Arquivo: `tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricherTests.cs`
+- Framework: xUnit + FluentAssertions
+- Cobertura-alvo: CA-01, CA-02, CA-03, CA-04, CA-05, CA-06 (≥90%)
+
+**Projeto de teste de integração:**
+- Arquivo: `tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricherIntegrationTests.cs`
+- Setup: `LoggerConfiguration` real + sink capturador (`InMemorySink` ou implementação própria de `ILogEventSink`)
+- Cobertura-alvo: CA-07
+
+**Fixtures necessárias:**
+- Factory de `LogEvent` com propriedades variadas (scalar, structure, sequence, aninhadas)
+- Helper para construir `StructureValue` e `SequenceValue` com Serilog.Events
+
+**Referências cruzadas:**
+- `MascararCpf` (método estático existente) — **corrigir bug**: usa ponto no separador final; deve ser hífen conforme padrão SERPRO/Gov.br
+- `[LoggerMessage]` source generator (CLAUDE.md do uniplus-api) — obrigatório no teste de integração

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricherIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricherIntegrationTests.cs
@@ -1,0 +1,88 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.Logging;
+
+using System.Collections.Concurrent;
+using System.Globalization;
+
+using FluentAssertions;
+
+using Microsoft.Extensions.Logging;
+
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Extensions.Logging;
+
+using Unifesspa.UniPlus.Infrastructure.Common.Logging;
+
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+public sealed partial class PiiMaskingEnricherIntegrationTests
+{
+    [Fact]
+    public void LoggerMessage_DadoCpfComoParametroEstruturado_QuandoLogEmitido_EntaoSaiMascarado()
+    {
+        CapturingSink sink = new();
+        using Serilog.Core.Logger serilog = new LoggerConfiguration()
+            .Enrich.With<PiiMaskingEnricher>()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        using SerilogLoggerFactory factory = new(serilog);
+        ILogger<PiiMaskingEnricherIntegrationTests> logger = factory.CreateLogger<PiiMaskingEnricherIntegrationTests>();
+
+        LogInscricaoHomologada(logger, "123.456.789-01");
+
+        LogEvent capturado = sink.Eventos.Should().ContainSingle().Which;
+
+        ScalarValue cpfMascarado = (ScalarValue)capturado.Properties["CpfCandidato"];
+        cpfMascarado.Value.Should().Be("***.***.***-01");
+
+        string mensagemRenderizada = capturado.RenderMessage(CultureInfo.InvariantCulture);
+        mensagemRenderizada.Should().Contain("***.***.***-01");
+        mensagemRenderizada.Should().NotContain("123.456.789-01", "o CPF original não pode aparecer em texto claro");
+        mensagemRenderizada.Should().NotContain("456.789", "nenhum dígito intermediário do CPF pode vazar");
+    }
+
+    [Fact]
+    public void LoggerMessage_DadoCpfDentroDeObjetoEstruturado_QuandoLogEmitido_EntaoMascaraRecursivamente()
+    {
+        CapturingSink sink = new();
+        using Serilog.Core.Logger serilog = new LoggerConfiguration()
+            .Enrich.With<PiiMaskingEnricher>()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        using SerilogLoggerFactory factory = new(serilog);
+        ILogger<PiiMaskingEnricherIntegrationTests> logger = factory.CreateLogger<PiiMaskingEnricherIntegrationTests>();
+
+        CandidatoDto candidato = new("João da Silva", "123.456.789-01");
+        LogCandidatoHomologado(logger, candidato);
+
+        LogEvent capturado = sink.Eventos.Should().ContainSingle().Which;
+
+        StructureValue estrutura = (StructureValue)capturado.Properties["Candidato"];
+        ScalarValue cpf = (ScalarValue)estrutura.Properties.First(p => p.Name == "Cpf").Value;
+        cpf.Value.Should().Be("***.***.***-01");
+
+        ScalarValue nome = (ScalarValue)estrutura.Properties.First(p => p.Name == "Nome").Value;
+        nome.Value.Should().Be("João da Silva");
+
+        capturado.RenderMessage(CultureInfo.InvariantCulture)
+            .Should().NotContain("123.456.789-01");
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Inscrição homologada para candidato {CpfCandidato}")]
+    private static partial void LogInscricaoHomologada(ILogger logger, string cpfCandidato);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Candidato homologado: {@Candidato}")]
+    private static partial void LogCandidatoHomologado(ILogger logger, CandidatoDto candidato);
+
+    private sealed record CandidatoDto(string Nome, string Cpf);
+
+    private sealed class CapturingSink : ILogEventSink
+    {
+        public ConcurrentQueue<LogEvent> Eventos { get; } = new();
+
+        public void Emit(LogEvent logEvent) => Eventos.Enqueue(logEvent);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricherTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricherTests.cs
@@ -1,0 +1,453 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.Logging;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+
+using Unifesspa.UniPlus.Infrastructure.Common.Logging;
+
+public sealed class PiiMaskingEnricherTests
+{
+    private readonly PiiMaskingEnricher _enricher = new();
+    private readonly ILogEventPropertyFactory _propertyFactory = Substitute.For<ILogEventPropertyFactory>();
+
+    // ─── CA-01 ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Enrich_DadoCpfFormatadoEmScalarValue_QuandoEnricherProcessar_EntaoDeveMascararComHifen()
+    {
+        LogEvent evento = CriarEventoComPropriedade("CpfCandidato", "123.456.789-01");
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ValorDaPropriedade(evento, "CpfCandidato").Should().Be("***.***.***-01");
+    }
+
+    // ─── CA-02 ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Enrich_DadoCpfSomenteDigitos_QuandoEnricherProcessar_EntaoDeveAplicarFormatoSerpro()
+    {
+        LogEvent evento = CriarEventoComPropriedade("CpfCandidato", "12345678901");
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ValorDaPropriedade(evento, "CpfCandidato").Should().Be("***.***.***-01");
+    }
+
+    // ─── CA-03 ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Enrich_DadoPropriedadeSemCpf_QuandoEnricherProcessar_EntaoDevePreservarReferenciaOriginal()
+    {
+        const string textoOriginal = "processo seletivo iniciado com sucesso";
+        LogEvent evento = CriarEventoComPropriedade("Mensagem", textoOriginal);
+        LogEventPropertyValue valorAntes = evento.Properties["Mensagem"];
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        LogEventPropertyValue valorDepois = evento.Properties["Mensagem"];
+        valorDepois.Should().BeSameAs(valorAntes, "sem CPF, o enricher não deve realocar o ScalarValue");
+    }
+
+    // ─── CA-04 ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Enrich_DadoMultiplasOcorrenciasDeCpfNaMesmaString_QuandoEnricherProcessar_EntaoDeveMascararTodas()
+    {
+        const string mensagem = "candidatos 123.456.789-01 e 987.654.321-02 homologados";
+        LogEvent evento = CriarEventoComPropriedade("Mensagem", mensagem);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ValorDaPropriedade(evento, "Mensagem")
+            .Should().Be("candidatos ***.***.***-01 e ***.***.***-02 homologados");
+    }
+
+    // ─── CA-05 ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Enrich_DadoCpfEmStructureValueAninhado_QuandoEnricherProcessar_EntaoDeveMascararRecursivamente()
+    {
+        LogEventProperty[] camposCandidato =
+        [
+            new("Nome", new ScalarValue("João da Silva")),
+            new("Cpf", new ScalarValue("123.456.789-01")),
+        ];
+        StructureValue candidato = new(camposCandidato, typeTag: "Candidato");
+        LogEvent evento = CriarEventoComPropriedade("Candidato", candidato);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        StructureValue candidatoMascarado = (StructureValue)evento.Properties["Candidato"];
+        ValorDoCampo(candidatoMascarado, "Cpf").Should().Be("***.***.***-01");
+        ValorDoCampo(candidatoMascarado, "Nome").Should().Be("João da Silva");
+        candidatoMascarado.TypeTag.Should().Be("Candidato", "TypeTag deve ser preservado ao reconstruir a estrutura");
+    }
+
+    [Fact]
+    public void Enrich_DadoCpfEmSequenceValue_QuandoEnricherProcessar_EntaoDeveMascararTodosOsElementos()
+    {
+        SequenceValue sequencia = new(
+        [
+            new ScalarValue("123.456.789-01"),
+            new ScalarValue("987.654.321-02"),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("CpfsHomologados", sequencia);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        SequenceValue sequenciaMascarada = (SequenceValue)evento.Properties["CpfsHomologados"];
+        ValorDoElemento(sequenciaMascarada, 0).Should().Be("***.***.***-01");
+        ValorDoElemento(sequenciaMascarada, 1).Should().Be("***.***.***-02");
+    }
+
+    [Fact]
+    public void Enrich_DadoStructureDentroDeSequence_QuandoEnricherProcessar_EntaoDeveMascararRecursivamenteEmProfundidade()
+    {
+        StructureValue primeiro = new(
+        [
+            new LogEventProperty("Cpf", new ScalarValue("123.456.789-01")),
+        ]);
+        StructureValue segundo = new(
+        [
+            new LogEventProperty("Cpf", new ScalarValue("987.654.321-02")),
+        ]);
+        SequenceValue lote = new([primeiro, segundo]);
+        LogEvent evento = CriarEventoComPropriedade("Lote", lote);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        SequenceValue loteMascarado = (SequenceValue)evento.Properties["Lote"];
+        ValorDoCampo((StructureValue)loteMascarado.Elements[0], "Cpf").Should().Be("***.***.***-01");
+        ValorDoCampo((StructureValue)loteMascarado.Elements[1], "Cpf").Should().Be("***.***.***-02");
+    }
+
+    [Fact]
+    public void Enrich_DadoCpfComoValorEmDictionaryValue_QuandoEnricherProcessar_EntaoDeveMascararOValor()
+    {
+        DictionaryValue dicionario = new(
+        [
+            new(new ScalarValue("candidato-a"), new ScalarValue("123.456.789-01")),
+            new(new ScalarValue("candidato-b"), new ScalarValue("987.654.321-02")),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("CpfsPorChave", dicionario);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        DictionaryValue dicionarioMascarado = (DictionaryValue)evento.Properties["CpfsPorChave"];
+        dicionarioMascarado.Elements
+            .Select(e => ((ScalarValue)e.Value).Value)
+            .Should().BeEquivalentTo(["***.***.***-01", "***.***.***-02"]);
+    }
+
+    // ─── CA-03 complementar ────────────────────────────────────────────────
+
+    [Fact]
+    public void Enrich_DadoStructureValueSemCpf_QuandoEnricherProcessar_EntaoDevePreservarReferenciaDoStructure()
+    {
+        StructureValue estrutura = new(
+        [
+            new LogEventProperty("Nome", new ScalarValue("Maria Souza")),
+            new LogEventProperty("Curso", new ScalarValue("Engenharia")),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("Candidato", estrutura);
+        LogEventPropertyValue valorAntes = evento.Properties["Candidato"];
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        evento.Properties["Candidato"].Should().BeSameAs(valorAntes);
+    }
+
+    // ─── Cobertura dos ramos mistos (preservação parcial) ──────────────────
+
+    [Fact]
+    public void Enrich_DadoStructureComCpfSeguidoDeCampoSemCpf_QuandoEnricherProcessar_EntaoDevePreservarCampoInalteradoNaCopia()
+    {
+        StructureValue estrutura = new(
+        [
+            new LogEventProperty("Cpf", new ScalarValue("123.456.789-01")),
+            new LogEventProperty("Curso", new ScalarValue("Engenharia")),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("Candidato", estrutura);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        StructureValue mascarada = (StructureValue)evento.Properties["Candidato"];
+        ValorDoCampo(mascarada, "Cpf").Should().Be("***.***.***-01");
+        ValorDoCampo(mascarada, "Curso").Should().Be("Engenharia");
+    }
+
+    [Fact]
+    public void Enrich_DadoSequenceComElementoSemCpfAntesDeCpf_QuandoEnricherProcessar_EntaoDeveCopiarElementosPreservadosNoBackfill()
+    {
+        SequenceValue sequencia = new(
+        [
+            new ScalarValue("sem cpf aqui"),
+            new ScalarValue("123.456.789-01"),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("Itens", sequencia);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        SequenceValue mascarada = (SequenceValue)evento.Properties["Itens"];
+        ValorDoElemento(mascarada, 0).Should().Be("sem cpf aqui");
+        ValorDoElemento(mascarada, 1).Should().Be("***.***.***-01");
+    }
+
+    [Fact]
+    public void Enrich_DadoSequenceComCpfSeguidoDeElementoSemCpf_QuandoEnricherProcessar_EntaoDevePreservarElementoInalterado()
+    {
+        SequenceValue sequencia = new(
+        [
+            new ScalarValue("123.456.789-01"),
+            new ScalarValue("sem cpf aqui"),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("Itens", sequencia);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        SequenceValue mascarada = (SequenceValue)evento.Properties["Itens"];
+        ValorDoElemento(mascarada, 0).Should().Be("***.***.***-01");
+        ValorDoElemento(mascarada, 1).Should().Be("sem cpf aqui");
+    }
+
+    [Fact]
+    public void Enrich_DadoDictionaryComValorSemCpfAntesDeCpf_QuandoEnricherProcessar_EntaoDeveCopiarEntradasPreservadasNoBackfill()
+    {
+        DictionaryValue dicionario = new(
+        [
+            new(new ScalarValue("curso"), new ScalarValue("Engenharia")),
+            new(new ScalarValue("cpf"), new ScalarValue("123.456.789-01")),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("Dados", dicionario);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        DictionaryValue mascarada = (DictionaryValue)evento.Properties["Dados"];
+        List<KeyValuePair<ScalarValue, LogEventPropertyValue>> entradas = [.. mascarada.Elements];
+        ((ScalarValue)entradas[0].Value).Value.Should().Be("Engenharia");
+        ((ScalarValue)entradas[1].Value).Value.Should().Be("***.***.***-01");
+    }
+
+    [Fact]
+    public void Enrich_DadoDictionaryComCpfSeguidoDeValorSemCpf_QuandoEnricherProcessar_EntaoDevePreservarEntradaInalterada()
+    {
+        DictionaryValue dicionario = new(
+        [
+            new(new ScalarValue("cpf"), new ScalarValue("123.456.789-01")),
+            new(new ScalarValue("curso"), new ScalarValue("Engenharia")),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("Dados", dicionario);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        DictionaryValue mascarada = (DictionaryValue)evento.Properties["Dados"];
+        List<KeyValuePair<ScalarValue, LogEventPropertyValue>> entradas = [.. mascarada.Elements];
+        ((ScalarValue)entradas[0].Value).Value.Should().Be("***.***.***-01");
+        ((ScalarValue)entradas[1].Value).Value.Should().Be("Engenharia");
+    }
+
+    // ─── Word boundary — anti-falso-positivo e anti-falso-negativo ─────────
+
+    [Fact]
+    public void Enrich_DadoTimestampComQuatorzeDigitos_QuandoEnricherProcessar_EntaoNaoDeveCorromperLog()
+    {
+        LogEvent evento = CriarEventoComPropriedade("Timestamp", "20240523120456");
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ValorDaPropriedade(evento, "Timestamp").Should().Be("20240523120456");
+    }
+
+    [Fact]
+    public void Enrich_DadoIdNumericoDeDozeDigitos_QuandoEnricherProcessar_EntaoNaoDeveMascarar()
+    {
+        LogEvent evento = CriarEventoComPropriedade("IdExterno", "112345678901");
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ValorDaPropriedade(evento, "IdExterno").Should().Be("112345678901");
+    }
+
+    [Fact]
+    public void Enrich_DadoCpfAdjacenteALetras_QuandoEnricherProcessar_EntaoDeveMascarar()
+    {
+        LogEvent evento = CriarEventoComPropriedade("Mensagem", "candidato cpf12345678901 homologado");
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ValorDaPropriedade(evento, "Mensagem").Should().Be("candidato cpf***.***.***-01 homologado");
+    }
+
+    [Fact]
+    public void Enrich_DadoTimestampConcatenadoComCpf_QuandoEnricherProcessar_EntaoNaoDeveMascararParaEvitarCorrupcaoDeLog()
+    {
+        LogEvent evento = CriarEventoComPropriedade("Concatenado", "202405231212345678901");
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ValorDaPropriedade(evento, "Concatenado").Should().Be("202405231212345678901",
+            "21 dígitos consecutivos são ambíguos; preferimos preservar o log a mascarar dígitos errados");
+    }
+
+    // ─── DictionaryValue com CPF em chave ─────────────────────────────────
+
+    [Fact]
+    public void Enrich_DadoDictionaryComCpfNaChave_QuandoEnricherProcessar_EntaoDeveMascararAChave()
+    {
+        DictionaryValue dicionario = new(
+        [
+            new(new ScalarValue("123.456.789-01"), new ScalarValue("homologado")),
+            new(new ScalarValue("987.654.321-02"), new ScalarValue("pendente")),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("StatusLote", dicionario);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        DictionaryValue mascarada = (DictionaryValue)evento.Properties["StatusLote"];
+        mascarada.Elements.Select(e => ((ScalarValue)e.Key).Value)
+            .Should().BeEquivalentTo(new object[] { "***.***.***-01", "***.***.***-02" });
+        mascarada.Elements.Select(e => ((ScalarValue)e.Value).Value)
+            .Should().BeEquivalentTo(new object[] { "homologado", "pendente" });
+    }
+
+    [Fact]
+    public void Enrich_DadoDictionaryComCpfEmChaveEValor_QuandoEnricherProcessar_EntaoDeveMascararAmbos()
+    {
+        DictionaryValue dicionario = new(
+        [
+            new(new ScalarValue("123.456.789-01"), new ScalarValue("parceiro 987.654.321-02")),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("Relacionamento", dicionario);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        DictionaryValue mascarada = (DictionaryValue)evento.Properties["Relacionamento"];
+        KeyValuePair<ScalarValue, LogEventPropertyValue> unica = mascarada.Elements.Single();
+        unica.Key.Value.Should().Be("***.***.***-01");
+        ((ScalarValue)unica.Value).Value.Should().Be("parceiro ***.***.***-02");
+    }
+
+    [Fact]
+    public void Enrich_DadoDictionaryComChaveNaoString_QuandoEnricherProcessar_EntaoDevePreservarChaveEReferenciaDoValorQuandoIntacto()
+    {
+        DictionaryValue dicionario = new(
+        [
+            new(new ScalarValue(1), new ScalarValue("primeiro")),
+            new(new ScalarValue(2), new ScalarValue("segundo")),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("Ordenados", dicionario);
+        LogEventPropertyValue antes = evento.Properties["Ordenados"];
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        evento.Properties["Ordenados"].Should().BeSameAs(antes);
+    }
+
+    [Fact]
+    public void Enrich_DadoDictionaryComSomenteChaveCpfAlterada_QuandoEnricherProcessar_EntaoDeveReconstituirDicionarioComValorOriginal()
+    {
+        ScalarValue valorOriginal = new("homologado");
+        DictionaryValue dicionario = new(
+        [
+            new(new ScalarValue("123.456.789-01"), valorOriginal),
+        ]);
+        LogEvent evento = CriarEventoComPropriedade("StatusPorCpf", dicionario);
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        DictionaryValue mascarada = (DictionaryValue)evento.Properties["StatusPorCpf"];
+        KeyValuePair<ScalarValue, LogEventPropertyValue> unica = mascarada.Elements.Single();
+        unica.Key.Value.Should().Be("***.***.***-01");
+        unica.Value.Should().BeSameAs(valorOriginal, "valor sem CPF deve preservar referência original");
+    }
+
+    // ─── Cenários de borda ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Enrich_DadoScalarValueNaoString_QuandoEnricherProcessar_EntaoDevePreservarValor()
+    {
+        LogEvent evento = CriarEventoComPropriedade("Idade", new ScalarValue(42));
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ((ScalarValue)evento.Properties["Idade"]).Value.Should().Be(42);
+    }
+
+    [Fact]
+    public void Enrich_DadoScalarValueNulo_QuandoEnricherProcessar_EntaoDevePreservarSemErro()
+    {
+        LogEvent evento = CriarEventoComPropriedade("CpfCandidato", new ScalarValue(null));
+
+        Action acao = () => _enricher.Enrich(evento, _propertyFactory);
+
+        acao.Should().NotThrow();
+        ((ScalarValue)evento.Properties["CpfCandidato"]).Value.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("123.456.789-01", "***.***.***-01")]
+    [InlineData("12345678901", "***.***.***-01")]
+    [InlineData("123.45678901", "***.***.***-01")]
+    [InlineData("123456789-01", "***.***.***-01")]
+    [InlineData("000.000.000-00", "***.***.***-00")]
+    [InlineData("999.999.999-99", "***.***.***-99")]
+    public void MascararCpf_DadoVariacoesDeFormatacao_DeveRetornarMascaraNoPadraoSerpro(string entrada, string esperado)
+    {
+        PiiMaskingEnricher.MascararCpf(entrada).Should().Be(esperado);
+    }
+
+    [Fact]
+    public void MascararCpf_DadoStringVazia_DeveRetornarMesmaReferencia()
+    {
+        string vazio = string.Empty;
+
+        PiiMaskingEnricher.MascararCpf(vazio).Should().BeSameAs(vazio);
+    }
+
+    [Fact]
+    public void MascararCpf_DadoTextoSemCpf_DeveRetornarMesmaReferencia()
+    {
+        const string texto = "processo de homologação iniciado";
+
+        PiiMaskingEnricher.MascararCpf(texto).Should().BeSameAs(texto);
+    }
+
+    [Fact]
+    public void Enrich_DadoLogEventNulo_EntaoDeveLancarArgumentNullException()
+    {
+        Action acao = () => _enricher.Enrich(null!, _propertyFactory);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private static LogEvent CriarEventoComPropriedade(string nome, string valor)
+        => CriarEventoComPropriedade(nome, new ScalarValue(valor));
+
+    private static LogEvent CriarEventoComPropriedade(string nome, LogEventPropertyValue valor)
+    {
+        MessageTemplate template = new MessageTemplateParser().Parse("template");
+        return new LogEvent(
+            DateTimeOffset.UtcNow,
+            LogEventLevel.Information,
+            exception: null,
+            template,
+            [new LogEventProperty(nome, valor)]);
+    }
+
+    private static object? ValorDaPropriedade(LogEvent evento, string nome)
+        => ((ScalarValue)evento.Properties[nome]).Value;
+
+    private static object? ValorDoCampo(StructureValue estrutura, string nomeCampo)
+        => ((ScalarValue)estrutura.Properties.First(p => p.Name == nomeCampo).Value).Value;
+
+    private static object? ValorDoElemento(SequenceValue sequencia, int indice)
+        => ((ScalarValue)sequencia.Elements[indice]).Value;
+}

--- a/tests/Unifesspa.UniPlus.SharedKernel.Tests/Domain/ValueObjects/CpfTests.cs
+++ b/tests/Unifesspa.UniPlus.SharedKernel.Tests/Domain/ValueObjects/CpfTests.cs
@@ -51,22 +51,16 @@ public sealed class CpfTests
         resultado.Error!.Code.Should().Be("Cpf.Vazio");
     }
 
-    [Fact]
-    public void Criar_DadoCpfComMenosDeOnzeDigitos_DeveRetornarFailureCpfInvalido()
+    [Theory]
+    [InlineData("123.456.789", "menos de 11 dígitos")]
+    [InlineData("123.456.789-0123", "mais de 11 dígitos")]
+    [InlineData("abcdefghijk", "sem dígitos suficientes após extração")]
+    public void Criar_DadoCpfComQuantidadeDeDigitosInvalida_DeveRetornarFailure(string cpfInvalido, string razao)
     {
-        Result<Cpf> resultado = Cpf.Criar("123.456.789");
+        Result<Cpf> resultado = Cpf.Criar(cpfInvalido);
 
-        resultado.IsFailure.Should().BeTrue();
-        resultado.Error!.Code.Should().Be("Cpf.Invalido");
-    }
-
-    [Fact]
-    public void Criar_DadoCpfComMaisDeOnzeDigitos_DeveRetornarFailureCpfInvalido()
-    {
-        Result<Cpf> resultado = Cpf.Criar("123.456.789-0123");
-
-        resultado.IsFailure.Should().BeTrue();
-        resultado.Error!.Code.Should().Be("Cpf.Invalido");
+        resultado.IsFailure.Should().BeTrue(razao);
+        resultado.Error!.Code.Should().Be("Cpf.Invalido", razao);
     }
 
     [Theory]

--- a/tests/Unifesspa.UniPlus.SharedKernel.Tests/Domain/ValueObjects/CpfTests.cs
+++ b/tests/Unifesspa.UniPlus.SharedKernel.Tests/Domain/ValueObjects/CpfTests.cs
@@ -1,0 +1,136 @@
+namespace Unifesspa.UniPlus.SharedKernel.Tests.Domain.ValueObjects;
+
+using FluentAssertions;
+
+using Unifesspa.UniPlus.SharedKernel.Domain.ValueObjects;
+using Unifesspa.UniPlus.SharedKernel.Results;
+
+public sealed class CpfTests
+{
+    // ─── Factory — caminhos felizes ────────────────────────────────────────
+
+    [Theory]
+    [InlineData("529.982.247-25", "52998224725")]
+    [InlineData("52998224725", "52998224725")]
+    [InlineData("529.98224725", "52998224725")]
+    [InlineData("529982247-25", "52998224725")]
+    public void Criar_DadoCpfValidoEmDiferentesFormatos_DeveNormalizarParaApenasDigitos(string entrada, string esperado)
+    {
+        Result<Cpf> resultado = Cpf.Criar(entrada);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Valor.Should().Be(esperado);
+    }
+
+    // ─── Factory — validações ──────────────────────────────────────────────
+
+    [Fact]
+    public void Criar_DadoCpfNulo_DeveRetornarFailureCpfVazio()
+    {
+        Result<Cpf> resultado = Cpf.Criar(null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Cpf.Vazio");
+    }
+
+    [Fact]
+    public void Criar_DadoStringVazia_DeveRetornarFailureCpfVazio()
+    {
+        Result<Cpf> resultado = Cpf.Criar(string.Empty);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Cpf.Vazio");
+    }
+
+    [Fact]
+    public void Criar_DadoWhitespace_DeveRetornarFailureCpfVazio()
+    {
+        Result<Cpf> resultado = Cpf.Criar("   ");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Cpf.Vazio");
+    }
+
+    [Fact]
+    public void Criar_DadoCpfComMenosDeOnzeDigitos_DeveRetornarFailureCpfInvalido()
+    {
+        Result<Cpf> resultado = Cpf.Criar("123.456.789");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Cpf.Invalido");
+    }
+
+    [Fact]
+    public void Criar_DadoCpfComMaisDeOnzeDigitos_DeveRetornarFailureCpfInvalido()
+    {
+        Result<Cpf> resultado = Cpf.Criar("123.456.789-0123");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Cpf.Invalido");
+    }
+
+    [Theory]
+    [InlineData("00000000000")]
+    [InlineData("11111111111")]
+    [InlineData("99999999999")]
+    public void Criar_DadoCpfComDigitosRepetidos_DeveRetornarFailure(string cpfInvalido)
+    {
+        Result<Cpf> resultado = Cpf.Criar(cpfInvalido);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Cpf.Invalido");
+    }
+
+    [Theory]
+    [InlineData("12345678901")]
+    [InlineData("111.222.333-44")]
+    public void Criar_DadoCpfComChecksumInvalido_DeveRetornarFailure(string cpfInvalido)
+    {
+        Result<Cpf> resultado = Cpf.Criar(cpfInvalido);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Cpf.Invalido");
+    }
+
+    // ─── Mascaramento (LGPD) ───────────────────────────────────────────────
+
+    [Fact]
+    public void Mascarado_DeveUsarHifenComoSeparadorDosDigitosVerificadores()
+    {
+        Cpf cpf = Cpf.Criar("529.982.247-25").Value!;
+
+        cpf.Mascarado.Should().Be("***.***.***-25",
+            "o padrão SERPRO/Gov.br exige hífen antes dos dois dígitos verificadores");
+    }
+
+    [Fact]
+    public void Mascarado_DevePreservarApenasOsDoisUltimosDigitos()
+    {
+        Cpf cpf = Cpf.Criar("52998224725").Value!;
+
+        cpf.Mascarado.Should().EndWith("-25");
+        cpf.Mascarado.Should().NotContain("52998224", "dígitos intermediários não podem vazar");
+    }
+
+    [Fact]
+    public void ToString_DeveRetornarFormatoMascarado()
+    {
+        Cpf cpf = Cpf.Criar("529.982.247-25").Value!;
+
+        cpf.ToString().Should().Be(cpf.Mascarado);
+        cpf.ToString().Should().Be("***.***.***-25");
+    }
+
+    // ─── Igualdade de record ───────────────────────────────────────────────
+
+    [Fact]
+    public void Cpf_DoisCpfsComMesmoValor_DevemSerIguais()
+    {
+        Cpf cpf1 = Cpf.Criar("529.982.247-25").Value!;
+        Cpf cpf2 = Cpf.Criar("52998224725").Value!;
+
+        cpf1.Should().Be(cpf2, "record compara por valor após normalização");
+        (cpf1 == cpf2).Should().BeTrue();
+        cpf1.GetHashCode().Should().Be(cpf2.GetHashCode());
+    }
+}

--- a/tests/Unifesspa.UniPlus.SharedKernel.Tests/Unifesspa.UniPlus.SharedKernel.Tests.csproj
+++ b/tests/Unifesspa.UniPlus.SharedKernel.Tests/Unifesspa.UniPlus.SharedKernel.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/shared/Unifesspa.UniPlus.SharedKernel/Unifesspa.UniPlus.SharedKernel.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Resumo

- Implementa o método `Enrich` do `PiiMaskingEnricher` (antes no-op) com mascaramento recursivo de CPF em todas as propriedades estruturadas do Serilog, tornando efetiva a conformidade LGPD prometida pela infraestrutura (ADR-012).
- Corrige dois bugs idênticos de separador no padrão de masking (ponto → hífen): um no próprio enricher e outro descoberto no VO `Cpf.Mascarado` (`SharedKernel`) durante a investigação.
- Endurece o regex com word boundaries para evitar corrupção de timestamps/IDs e vazamento de dígitos em concatenações.
- Cobre chaves de `DictionaryValue` além dos valores, fechando o gap de PII exposure identificado em security review local.
- Encapsula `MascararCpf` como `internal` + `[InternalsVisibleTo]` conforme Microsoft Framework Design Guidelines.
- Introduz o projeto `Unifesspa.UniPlus.SharedKernel.Tests` (antes inexistente), fechando gap de cobertura do VO `Cpf` com 19 testes.
- Formaliza todas as decisões arquiteturais no [ADR-020](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-020-mascaramento-de-cpf-em-logs.md), já mergeado.

## Commits (6)

1. `feat(shared): implementar mascaramento efetivo de CPF em logs` — `Enrich` funcional, recursão em Structure/Sequence/Dictionary (chaves e valores), regex ASCII com word boundaries, `ReadOnlySpan<char>` no hot path
2. `test(shared): cobrir mascaramento de CPF em cenários estruturados` — 33 testes unitários + 2 de integração + `.feature` Gherkin
3. `docs(claude): documentar cobertura efetiva do PiiMaskingEnricher` — atualiza `CLAUDE.md` do uniplus-api
4. `fix(sharedkernel): corrigir separador do Cpf.Mascarado para hífen` — bug LGPD idêntico no VO + scaffolding de `SharedKernel.Tests`
5. `refactor(shared): encapsular MascararCpf como internal com InternalsVisibleTo` — reduz surface pública
6. `test(sharedkernel): consolidar casos de CPF com quantidade inválida em Theory` — endereça sugestão do review

## Arquivos alterados

### Modificados

- `src/shared/Unifesspa.UniPlus.Infrastructure.Common/Logging/PiiMaskingEnricher.cs` — `Enrich` implementado com recursão completa; `MascararCpf` otimizado e encapsulado como `internal`
- `src/shared/Unifesspa.UniPlus.Infrastructure.Common/Unifesspa.UniPlus.Infrastructure.Common.csproj` — `[InternalsVisibleTo]` para o projeto de testes
- `src/shared/Unifesspa.UniPlus.SharedKernel/Domain/ValueObjects/Cpf.cs` — correção do separador em `Mascarado`
- `UniPlus.slnx` — registro do novo projeto de testes
- `CLAUDE.md` — documenta cobertura efetiva do enricher

### Novos arquivos

- `tests/Unifesspa.UniPlus.SharedKernel.Tests/` — projeto novo: `.csproj` + `Domain/ValueObjects/CpfTests.cs` com 19 testes cobrindo factory, validações (checksum, dígitos repetidos, quantidade), mascaramento no padrão SERPRO e igualdade de record
- `tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricherTests.cs` — 33 testes unitários cobrindo CA-01 a CA-06 e findings da review
- `tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricherIntegrationTests.cs` — 2 testes de integração com Serilog real, sink capturador e `[LoggerMessage]`
- `tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Logging/PiiMaskingEnricher.feature` — documentação viva em Gherkin (pt-BR) com 12 cenários BDD

## Decisões arquiteturais

Registradas integralmente no [ADR-020](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-020-mascaramento-de-cpf-em-logs.md):

- **Regex com word boundaries** e `[0-9]` ASCII para evitar tanto falsos positivos (timestamps mascarados incorretamente) quanto falsos negativos (dígitos vazando). Trade-off: CPF concatenado a dígitos sem delimitador não é detectado — preferimos integridade de log a mascaramento ambíguo.
- **Preservação de referência** via `ReferenceEquals` em todos os níveis (CA-03 em profundidade).
- **Performance no hot path:** `static` lambda no `MatchEvaluator`, `ValueSpan[^2..]` + `string.Concat`, `[GeneratedRegex]`. Regex linear (zero ReDoS).
- **`internal` + `[InternalsVisibleTo]`** conforme Microsoft Framework Design Guidelines (padrão .NET 10, declarado em `.csproj`).
- **Decoupling entre VO `Cpf` (validação estrita) e enricher (defesa em profundidade permissiva):** responsabilidades distintas, camadas distintas — detalhado no ADR.
- **BDD sem framework novo:** `.feature` como documentação viva, testes via xUnit idiomático (Reqnroll adiável via ADR próprio).

## Testes

- **78 testes totais** — 60 de `Infrastructure.Common.Tests` + 19 de `SharedKernel.Tests` (novo projeto, -1 pelo agrupamento em Theory)
- **35 testes dedicados ao enricher** (33 unitários + 2 de integração)
- **19 testes do VO `Cpf`** (factory, validações, mascaramento, igualdade)
- **Cobertura:** 100% linhas, 98.3% ramos em `PiiMaskingEnricher.cs`
- **Build da solução (`dotnet build UniPlus.slnx --no-incremental`):** 0 warnings, 0 erros (`TreatWarningsAsErrors` habilitado)

## Critérios de aceite

- [x] CA-01: CPF formatado (`123.456.789-01`) mascarado como `***.***.***-01`
- [x] CA-02: CPF não-formatado (`12345678901`) mascarado como `***.***.***-01`
- [x] CA-03: Log sem CPF preserva referência original (sem realocação)
- [x] CA-04: Múltiplas ocorrências na mesma string mascaradas
- [x] CA-05: Masking recursivo em `StructureValue`, `SequenceValue` e `DictionaryValue` (chaves e valores)
- [x] CA-06: Cobertura ≥ 90% (obtido 100% linhas / 98.3% ramos)
- [x] CA-07: Teste de integração com `ILogger` real + sink capturador + `[LoggerMessage]`

## Reviews endereçadas

Todos os findings do peer review (jf2s) foram resolvidos:

- **[I1]** `MascararCpf` público → `internal` + `[InternalsVisibleTo]`
- **[S1]** ADR do trade-off → [ADR-020](https://github.com/unifesspa-edu-br/uniplus-docs/pull/66) criado e mergeado em `uniplus-docs`
- **[S2]** `.ToArray()` alloc → registrado como trade-off consciente no ADR-020
- **[S3]** Duplicação nos 3 helpers → registrado como decisão consciente no ADR-020
- **Bônus:** bug LGPD idêntico descoberto em `Cpf.Mascarado` do VO e corrigido

## Checklist

- [x] Build sem warnings (`TreatWarningsAsErrors`)
- [x] Testes passando (78/78)
- [x] Cobertura de testes ≥ 90% no alvo
- [x] Revisão local (code-reviewer agent + security-review skill + peer review cruzado)
- [x] Sem `Co-Authored-By` em commits
- [x] ADR-020 mergeado em `uniplus-docs` (#66)
- [ ] Pós-merge: comentar em #31 atualizando "Estado atual"

Closes #115