### PR TITLE
feat(middleware): request logging HTTP com PII masking em query strings

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -24,6 +24,7 @@ string connectionString = builder.Configuration.GetConnectionString("IngressoDb"
     ?? throw new InvalidOperationException("Connection string 'IngressoDb' não configurada.");
 
 builder.Services.AddCorrelationIdAccessor();
+builder.Services.AddRequestLogging(builder.Configuration);
 builder.Services.AddIngressoApplication();
 builder.Services.AddIngressoInfrastructure(connectionString);
 

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -32,6 +32,7 @@ builder.Services.AddHealthChecks();
 WebApplication app = builder.Build();
 
 app.UseMiddleware<CorrelationIdMiddleware>();
+app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<GlobalExceptionMiddleware>();
 app.MapControllers();
 app.MapHealthChecks("/health");

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -24,6 +24,7 @@ string connectionString = builder.Configuration.GetConnectionString("SelecaoDb")
     ?? throw new InvalidOperationException("Connection string 'SelecaoDb' não configurada.");
 
 builder.Services.AddCorrelationIdAccessor();
+builder.Services.AddRequestLogging(builder.Configuration);
 builder.Services.AddSelecaoApplication();
 builder.Services.AddSelecaoInfrastructure(connectionString);
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -32,6 +32,7 @@ builder.Services.AddHealthChecks();
 WebApplication app = builder.Build();
 
 app.UseMiddleware<CorrelationIdMiddleware>();
+app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<GlobalExceptionMiddleware>();
 app.MapControllers();
 app.MapHealthChecks("/health");

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/RequestLoggingServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/RequestLoggingServiceCollectionExtensions.cs
@@ -33,14 +33,13 @@ public static class RequestLoggingServiceCollectionExtensions
 
         // Binder de IConfiguration e Action<T> agregam às listas pré-populadas
         // em vez de substituí-las. Normalizar aqui: remover brancos, deduplicar
-        // case-insensitive e preservar ordem de inserção. Para o caso de uso
-        // (masking PII + silêncio de paths) essa semântica "defaults como piso,
-        // config amplia" é a mais segura — impede que um appsettings remova
-        // acidentalmente `cpf` da proteção.
+        // case-insensitive e preservar ordem de inserção. Mutação in-place
+        // respeita o contrato get-only da propriedade — nunca reassignamos,
+        // apenas editamos a lista que já foi construída com os defaults.
         optionsBuilder.PostConfigure(opts =>
         {
-            opts.NomesParametrosSensiveis = NormalizarLista(opts.NomesParametrosSensiveis);
-            opts.PrefixosSilenciados = NormalizarLista(opts.PrefixosSilenciados);
+            NormalizarListaInPlace(opts.NomesParametrosSensiveis);
+            NormalizarListaInPlace(opts.PrefixosSilenciados);
         });
 
         // Validação executada uma vez ao materializar `IOptions<T>`. O flag
@@ -55,29 +54,38 @@ public static class RequestLoggingServiceCollectionExtensions
         return services;
     }
 
-    private static List<string> NormalizarLista(IList<string>? entrada)
+    private static void NormalizarListaInPlace(IList<string> lista)
     {
-        if (entrada is null || entrada.Count == 0)
+        if (lista.Count == 0)
         {
-            return [];
+            return;
         }
 
+        // Duas passadas: a primeira coleta o estado normalizado em buffer
+        // temporário (trim + dedup case-insensitive + skip de brancos,
+        // preservando ordem de primeira ocorrência). A segunda substitui o
+        // conteúdo da lista original via Clear + Add. Evita a complexidade
+        // e o custo O(N²) de remoções sucessivas em IList durante iteração.
         HashSet<string> vistos = new(StringComparer.OrdinalIgnoreCase);
-        List<string> saida = new(entrada.Count);
-        foreach (string item in entrada)
+        List<string> normalizada = new(lista.Count);
+        foreach (string item in lista)
         {
             if (string.IsNullOrWhiteSpace(item))
             {
                 continue;
             }
 
-            string normalizado = item.Trim();
-            if (vistos.Add(normalizado))
+            string trimmed = item.Trim();
+            if (vistos.Add(trimmed))
             {
-                saida.Add(normalizado);
+                normalizada.Add(trimmed);
             }
         }
 
-        return saida;
+        lista.Clear();
+        foreach (string item in normalizada)
+        {
+            lista.Add(item);
+        }
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/RequestLoggingServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/RequestLoggingServiceCollectionExtensions.cs
@@ -31,21 +31,14 @@ public static class RequestLoggingServiceCollectionExtensions
             optionsBuilder.Configure(configure);
         }
 
-        // Binder de IConfiguration e Action<T> agregam às listas pré-populadas
-        // em vez de substituí-las. Normalizar aqui: remover brancos, deduplicar
-        // case-insensitive e preservar ordem de inserção. Mutação in-place
-        // respeita o contrato get-only da propriedade — nunca reassignamos,
-        // apenas editamos a lista que já foi construída com os defaults.
+        // Binder do IConfiguration agrega sem deduplicar; normalizar in-place.
         optionsBuilder.PostConfigure(opts =>
         {
             NormalizarListaInPlace(opts.NomesParametrosSensiveis);
             NormalizarListaInPlace(opts.PrefixosSilenciados);
         });
 
-        // Validação executada uma vez ao materializar `IOptions<T>`. O flag
-        // ValidateOnStart garante falha de startup se algum appsettings
-        // remover a lista de parâmetros sensíveis — impede regressão LGPD
-        // passar despercebida em produção.
+        // ValidateOnStart: falha no boot se appsettings remover masking LGPD.
         services.AddSingleton<IValidateOptions<RequestLoggingOptions>, RequestLoggingOptionsValidator>();
         optionsBuilder.ValidateOnStart();
 
@@ -54,6 +47,7 @@ public static class RequestLoggingServiceCollectionExtensions
         return services;
     }
 
+    // Duas passadas (coleta + rewrite) evitam O(N²) de RemoveAt em single-pass.
     private static void NormalizarListaInPlace(IList<string> lista)
     {
         if (lista.Count == 0)
@@ -61,11 +55,6 @@ public static class RequestLoggingServiceCollectionExtensions
             return;
         }
 
-        // Duas passadas: a primeira coleta o estado normalizado em buffer
-        // temporário (trim + dedup case-insensitive + skip de brancos,
-        // preservando ordem de primeira ocorrência). A segunda substitui o
-        // conteúdo da lista original via Clear + Add. Evita a complexidade
-        // e o custo O(N²) de remoções sucessivas em IList durante iteração.
         HashSet<string> vistos = new(StringComparer.OrdinalIgnoreCase);
         List<string> normalizada = new(lista.Count);
         foreach (string item in lista)

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/RequestLoggingServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/RequestLoggingServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ public static class RequestLoggingServiceCollectionExtensions
         optionsBuilder.PostConfigure(opts =>
         {
             opts.NomesParametrosSensiveis = NormalizarLista(opts.NomesParametrosSensiveis);
-            opts.PathsSilenciados = NormalizarLista(opts.PathsSilenciados);
+            opts.PrefixosSilenciados = NormalizarLista(opts.PrefixosSilenciados);
         });
 
         // Validação executada uma vez ao materializar `IOptions<T>`. O flag

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/RequestLoggingServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/RequestLoggingServiceCollectionExtensions.cs
@@ -1,0 +1,83 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.DependencyInjection;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+public static class RequestLoggingServiceCollectionExtensions
+{
+    public static IServiceCollection AddRequestLogging(
+        this IServiceCollection services,
+        IConfiguration? configuration = null,
+        Action<RequestLoggingOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        OptionsBuilder<RequestLoggingOptions> optionsBuilder = services.AddOptions<RequestLoggingOptions>();
+
+        if (configuration is not null)
+        {
+            IConfigurationSection secao = configuration.GetSection(RequestLoggingOptions.SectionName);
+            if (secao.Exists())
+            {
+                optionsBuilder.Bind(secao);
+            }
+        }
+
+        if (configure is not null)
+        {
+            optionsBuilder.Configure(configure);
+        }
+
+        // Binder de IConfiguration e Action<T> agregam às listas pré-populadas
+        // em vez de substituí-las. Normalizar aqui: remover brancos, deduplicar
+        // case-insensitive e preservar ordem de inserção. Para o caso de uso
+        // (masking PII + silêncio de paths) essa semântica "defaults como piso,
+        // config amplia" é a mais segura — impede que um appsettings remova
+        // acidentalmente `cpf` da proteção.
+        optionsBuilder.PostConfigure(opts =>
+        {
+            opts.NomesParametrosSensiveis = NormalizarLista(opts.NomesParametrosSensiveis);
+            opts.PathsSilenciados = NormalizarLista(opts.PathsSilenciados);
+        });
+
+        // Validação executada uma vez ao materializar `IOptions<T>`. O flag
+        // ValidateOnStart garante falha de startup se algum appsettings
+        // remover a lista de parâmetros sensíveis — impede regressão LGPD
+        // passar despercebida em produção.
+        services.AddSingleton<IValidateOptions<RequestLoggingOptions>, RequestLoggingOptionsValidator>();
+        optionsBuilder.ValidateOnStart();
+
+        services.AddSingleton<QueryStringMasker>();
+
+        return services;
+    }
+
+    private static List<string> NormalizarLista(IList<string>? entrada)
+    {
+        if (entrada is null || entrada.Count == 0)
+        {
+            return [];
+        }
+
+        HashSet<string> vistos = new(StringComparer.OrdinalIgnoreCase);
+        List<string> saida = new(entrada.Count);
+        foreach (string item in entrada)
+        {
+            if (string.IsNullOrWhiteSpace(item))
+            {
+                continue;
+            }
+
+            string normalizado = item.Trim();
+            if (vistos.Add(normalizado))
+            {
+                saida.Add(normalizado);
+            }
+        }
+
+        return saida;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/QueryStringMasker.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/QueryStringMasker.cs
@@ -4,19 +4,26 @@ using System.Collections.Frozen;
 using System.Text;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
-public static class QueryStringMasker
+public sealed class QueryStringMasker
 {
-    public const string MaskedValue = "***";
+    private readonly FrozenSet<string> _nomesSensiveis;
+    private readonly string _valorMascarado;
 
-    // Comparador ordinal case-insensitive cobre variantes como "CPF", "Cpf" e "cpf"
-    // sem depender de cultura — critério LGPD aplica-se igual ao parâmetro qualquer
-    // que seja a grafia enviada pelo cliente.
-    internal static readonly FrozenSet<string> NomesSensiveis = FrozenSet.ToFrozenSet(
-        new[] { "cpf", "email", "senha", "password", "token" },
-        StringComparer.OrdinalIgnoreCase);
+    public QueryStringMasker(IOptions<RequestLoggingOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        RequestLoggingOptions valor = options.Value;
 
-    public static string Mascarar(QueryString queryString)
+        // Snapshot imutável das opções no momento da construção: o masker é
+        // singleton de longa duração e FrozenSet oferece lookup mais rápido
+        // do que HashSet normal a um custo de build pago uma única vez aqui.
+        _nomesSensiveis = FrozenSet.ToFrozenSet(valor.NomesParametrosSensiveis, StringComparer.OrdinalIgnoreCase);
+        _valorMascarado = valor.ValorMascarado;
+    }
+
+    public string Mascarar(QueryString queryString)
     {
         if (!queryString.HasValue || queryString.Value!.Length <= 1)
         {
@@ -51,14 +58,15 @@ public static class QueryStringMasker
 
             string keyEncoded = pedaco[..eqIdx];
             // Decodifica a chave para comparar com a lista ignorando URL-encoding,
-            // mas preserva o encoding original ao reescrever o par.
+            // mas preserva o encoding original ao reescrever o par — evita vetores
+            // de bypass como `?%63%70%66=123` escaparem do masking.
             string keyDecoded = Uri.UnescapeDataString(keyEncoded);
 
             sb.Append(keyEncoded);
             sb.Append('=');
-            if (NomesSensiveis.Contains(keyDecoded))
+            if (_nomesSensiveis.Contains(keyDecoded))
             {
-                sb.Append(MaskedValue);
+                sb.Append(_valorMascarado);
             }
             else
             {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/QueryStringMasker.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/QueryStringMasker.cs
@@ -16,9 +16,7 @@ public sealed class QueryStringMasker
         ArgumentNullException.ThrowIfNull(options);
         RequestLoggingOptions valor = options.Value;
 
-        // Snapshot imutável das opções no momento da construção: o masker é
-        // singleton de longa duração e FrozenSet oferece lookup mais rápido
-        // do que HashSet normal a um custo de build pago uma única vez aqui.
+        // FrozenSet: build custoso amortizado (singleton), lookup mais rápido que HashSet.
         _nomesSensiveis = FrozenSet.ToFrozenSet(valor.NomesParametrosSensiveis, StringComparer.OrdinalIgnoreCase);
         _valorMascarado = valor.ValorMascarado;
     }
@@ -57,9 +55,8 @@ public sealed class QueryStringMasker
             }
 
             string keyEncoded = pedaco[..eqIdx];
-            // Decodifica a chave para comparar com a lista ignorando URL-encoding,
-            // mas preserva o encoding original ao reescrever o par — evita vetores
-            // de bypass como `?%63%70%66=123` escaparem do masking.
+            // Segurança: compara a chave decodificada para não deixar bypass via
+            // percent-encoding (ex.: `?%63%70%66=123` equivale a `?cpf=123`).
             string keyDecoded = Uri.UnescapeDataString(keyEncoded);
 
             sb.Append(keyEncoded);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/QueryStringMasker.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/QueryStringMasker.cs
@@ -1,0 +1,71 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+using System.Collections.Frozen;
+using System.Text;
+
+using Microsoft.AspNetCore.Http;
+
+public static class QueryStringMasker
+{
+    public const string MaskedValue = "***";
+
+    // Comparador ordinal case-insensitive cobre variantes como "CPF", "Cpf" e "cpf"
+    // sem depender de cultura — critério LGPD aplica-se igual ao parâmetro qualquer
+    // que seja a grafia enviada pelo cliente.
+    internal static readonly FrozenSet<string> NomesSensiveis = FrozenSet.ToFrozenSet(
+        new[] { "cpf", "email", "senha", "password", "token" },
+        StringComparer.OrdinalIgnoreCase);
+
+    public static string Mascarar(QueryString queryString)
+    {
+        if (!queryString.HasValue || queryString.Value!.Length <= 1)
+        {
+            return queryString.Value ?? string.Empty;
+        }
+
+        string raw = queryString.Value![1..];
+        StringBuilder sb = new(queryString.Value.Length);
+        sb.Append('?');
+
+        bool primeiro = true;
+        foreach (string pedaco in raw.Split('&'))
+        {
+            if (pedaco.Length == 0)
+            {
+                continue;
+            }
+
+            if (!primeiro)
+            {
+                sb.Append('&');
+            }
+
+            primeiro = false;
+
+            int eqIdx = pedaco.IndexOf('=', StringComparison.Ordinal);
+            if (eqIdx < 0)
+            {
+                sb.Append(pedaco);
+                continue;
+            }
+
+            string keyEncoded = pedaco[..eqIdx];
+            // Decodifica a chave para comparar com a lista ignorando URL-encoding,
+            // mas preserva o encoding original ao reescrever o par.
+            string keyDecoded = Uri.UnescapeDataString(keyEncoded);
+
+            sb.Append(keyEncoded);
+            sb.Append('=');
+            if (NomesSensiveis.Contains(keyDecoded))
+            {
+                sb.Append(MaskedValue);
+            }
+            else
+            {
+                sb.Append(pedaco.AsSpan(eqIdx + 1));
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
-using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.Diagnostics;
 
 using Microsoft.AspNetCore.Http;
@@ -12,7 +12,7 @@ public sealed partial class RequestLoggingMiddleware
     private readonly RequestDelegate _next;
     private readonly ILogger<RequestLoggingMiddleware> _logger;
     private readonly QueryStringMasker _masker;
-    private readonly FrozenSet<string> _pathsSilenciados;
+    private readonly ImmutableArray<string> _prefixosSilenciados;
 
     public RequestLoggingMiddleware(
         RequestDelegate next,
@@ -27,9 +27,17 @@ public sealed partial class RequestLoggingMiddleware
         _next = next;
         _logger = logger;
         _masker = masker;
-        _pathsSilenciados = FrozenSet.ToFrozenSet(
-            options.Value.PathsSilenciados,
-            StringComparer.OrdinalIgnoreCase);
+
+        // Prefixos são normalizados removendo trailing slash (exceto o caso
+        // especial "/", preservado como raiz). Armazenados como ImmutableArray
+        // ordenado para iteração em hot path sem custo de enumerator —
+        // FrozenSet.Contains não serve porque precisamos de prefix match com
+        // boundary, não igualdade.
+        _prefixosSilenciados = options.Value.PathsSilenciados
+            .Select(NormalizarPrefixo)
+            .Where(p => p.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToImmutableArray();
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -79,12 +87,44 @@ public sealed partial class RequestLoggingMiddleware
             {
                 LogRequestClientError(_logger, method, path, query, statusCode, elapsedMs);
             }
-            else if (!_pathsSilenciados.Contains(path))
+            else if (!DeveSilenciar(path))
             {
                 LogRequestSucesso(_logger, method, path, query, statusCode, elapsedMs);
             }
         }
     }
+
+    // Match case-insensitive por prefixo com boundary em `/`. Aceita o path
+    // exato ou subpaths (`/health`, `/health/`, `/health/db`) mas rejeita
+    // falsos positivos que meramente começam com o prefixo (`/healthy`,
+    // `/health-ui`). O boundary garante que apenas separadores hierárquicos
+    // de URL contam como extensão do prefixo.
+    private bool DeveSilenciar(string path)
+    {
+        string pathNormalizado = NormalizarPrefixo(path);
+        foreach (string prefixo in _prefixosSilenciados)
+        {
+            if (pathNormalizado.Equals(prefixo, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (pathNormalizado.Length > prefixo.Length &&
+                pathNormalizado.StartsWith(prefixo, StringComparison.OrdinalIgnoreCase) &&
+                pathNormalizado[prefixo.Length] == '/')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Normaliza removendo trailing slash exceto no caso raiz "/", que é
+    // preservado como path canônico da raiz. Strings vazias são tratadas
+    // como "/" pelo chamador (ver InvokeAsync).
+    private static string NormalizarPrefixo(string valor) =>
+        valor.Length > 1 && valor.EndsWith('/') ? valor.TrimEnd('/') : valor;
 
     [LoggerMessage(Level = LogLevel.Information, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
     private static partial void LogRequestSucesso(ILogger logger, string method, string path, string query, int statusCode, double elapsedMs);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -37,14 +37,22 @@ public sealed partial class RequestLoggingMiddleware
         ArgumentNullException.ThrowIfNull(context);
 
         long startTimestamp = Stopwatch.GetTimestamp();
+        Exception? falha = null;
 
-        // try/finally garante registro do log mesmo quando um middleware
-        // downstream (ex.: GlobalExceptionMiddleware) modifica o status code
-        // durante o desenrolar da pilha. Não capturamos a exception — apenas
-        // a deixamos propagar após registrar.
+        // try/catch/throw + finally: capturamos a exception apenas como
+        // contexto para o log (mantendo stack trace via `throw;`) e a
+        // deixamos propagar para o GlobalExceptionMiddleware decidir a
+        // resposta. Sem essa captura, uma exception que escapasse daria
+        // um log Information com status 200 (default) — mascarando falha
+        // como sucesso.
         try
         {
             await _next(context).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            falha = ex;
+            throw;
         }
         finally
         {
@@ -54,15 +62,18 @@ public sealed partial class RequestLoggingMiddleware
             string query = _masker.Mascarar(context.Request.QueryString);
             int statusCode = context.Response.StatusCode;
 
-            // Severidade proporcional à categoria HTTP: 5xx é falha do servidor,
+            // Presença de exception força nível Error independentemente do
+            // status code observado — evita que uma falha silenciosa (status
+            // não alterado) apareça como sucesso no log. Severidade
+            // proporcional à categoria HTTP: 5xx é falha do servidor,
             // 4xx sinaliza problema no lado do cliente e demais respostas são
             // tráfego operacional normal. Paths de infraestrutura (health,
             // metrics) são silenciados quando bem-sucedidos para não saturar
             // observabilidade com probes de liveness/readiness; respostas de
             // erro continuam sendo reportadas porque sinalizam problema real.
-            if (statusCode >= 500)
+            if (falha is not null || statusCode >= 500)
             {
-                LogRequestServerError(_logger, method, path, query, statusCode, elapsedMs);
+                LogRequestServerError(_logger, method, path, query, statusCode, elapsedMs, falha);
             }
             else if (statusCode >= 400)
             {
@@ -81,6 +92,10 @@ public sealed partial class RequestLoggingMiddleware
     [LoggerMessage(Level = LogLevel.Warning, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
     private static partial void LogRequestClientError(ILogger logger, string method, string path, string query, int statusCode, long elapsedMs);
 
+    // Exception é o último parâmetro (convenção do source generator de
+    // LoggerMessage): o gerador reconhece o tipo e emite no LogEvent.Exception
+    // em vez de no template de mensagem — preserva stack trace estruturada
+    // nos sinks sem polui-lo com a representação textual.
     [LoggerMessage(Level = LogLevel.Error, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
-    private static partial void LogRequestServerError(ILogger logger, string method, string path, string query, int statusCode, long elapsedMs);
+    private static partial void LogRequestServerError(ILogger logger, string method, string path, string query, int statusCode, long elapsedMs, Exception? ex);
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+using System.Diagnostics;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+public sealed partial class RequestLoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<RequestLoggingMiddleware> _logger;
+
+    public RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger)
+    {
+        ArgumentNullException.ThrowIfNull(next);
+        ArgumentNullException.ThrowIfNull(logger);
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        long startTimestamp = Stopwatch.GetTimestamp();
+
+        // try/finally garante registro do log mesmo quando um middleware
+        // downstream (ex.: GlobalExceptionMiddleware) modifica o status code
+        // durante o desenrolar da pilha. Não capturamos a exception — apenas
+        // a deixamos propagar após registrar.
+        try
+        {
+            await _next(context).ConfigureAwait(false);
+        }
+        finally
+        {
+            long elapsedMs = (long)Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+            string method = context.Request.Method;
+            string path = context.Request.Path.HasValue ? context.Request.Path.Value! : "/";
+            string query = QueryStringMasker.Mascarar(context.Request.QueryString);
+            int statusCode = context.Response.StatusCode;
+
+            // Severidade proporcional à categoria HTTP: 5xx é falha do servidor,
+            // 4xx sinaliza problema no lado do cliente e demais respostas são
+            // tráfego operacional normal.
+            if (statusCode >= 500)
+            {
+                LogRequestServerError(_logger, method, path, query, statusCode, elapsedMs);
+            }
+            else if (statusCode >= 400)
+            {
+                LogRequestClientError(_logger, method, path, query, statusCode, elapsedMs);
+            }
+            else
+            {
+                LogRequestSucesso(_logger, method, path, query, statusCode, elapsedMs);
+            }
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
+    private static partial void LogRequestSucesso(ILogger logger, string method, string path, string query, int statusCode, long elapsedMs);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
+    private static partial void LogRequestClientError(ILogger logger, string method, string path, string query, int statusCode, long elapsedMs);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
+    private static partial void LogRequestServerError(ILogger logger, string method, string path, string query, int statusCode, long elapsedMs);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -33,7 +33,7 @@ public sealed partial class RequestLoggingMiddleware
         // ordenado para iteração em hot path sem custo de enumerator —
         // FrozenSet.Contains não serve porque precisamos de prefix match com
         // boundary, não igualdade.
-        _prefixosSilenciados = options.Value.PathsSilenciados
+        _prefixosSilenciados = options.Value.PrefixosSilenciados
             .Select(NormalizarPrefixo)
             .Where(p => p.Length > 0)
             .Distinct(StringComparer.OrdinalIgnoreCase)

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -56,7 +56,7 @@ public sealed partial class RequestLoggingMiddleware
         }
         finally
         {
-            long elapsedMs = (long)Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
+            double elapsedMs = Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
             string method = context.Request.Method;
             string path = context.Request.Path.HasValue ? context.Request.Path.Value! : "/";
             string query = _masker.Mascarar(context.Request.QueryString);
@@ -87,15 +87,15 @@ public sealed partial class RequestLoggingMiddleware
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
-    private static partial void LogRequestSucesso(ILogger logger, string method, string path, string query, int statusCode, long elapsedMs);
+    private static partial void LogRequestSucesso(ILogger logger, string method, string path, string query, int statusCode, double elapsedMs);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
-    private static partial void LogRequestClientError(ILogger logger, string method, string path, string query, int statusCode, long elapsedMs);
+    private static partial void LogRequestClientError(ILogger logger, string method, string path, string query, int statusCode, double elapsedMs);
 
     // Exception é o último parâmetro (convenção do source generator de
     // LoggerMessage): o gerador reconhece o tipo e emite no LogEvent.Exception
     // em vez de no template de mensagem — preserva stack trace estruturada
     // nos sinks sem polui-lo com a representação textual.
     [LoggerMessage(Level = LogLevel.Error, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
-    private static partial void LogRequestServerError(ILogger logger, string method, string path, string query, int statusCode, long elapsedMs, Exception? ex);
+    private static partial void LogRequestServerError(ILogger logger, string method, string path, string query, int statusCode, double elapsedMs, Exception? ex);
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -9,13 +9,19 @@ public sealed partial class RequestLoggingMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly ILogger<RequestLoggingMiddleware> _logger;
+    private readonly QueryStringMasker _masker;
 
-    public RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger)
+    public RequestLoggingMiddleware(
+        RequestDelegate next,
+        ILogger<RequestLoggingMiddleware> logger,
+        QueryStringMasker masker)
     {
         ArgumentNullException.ThrowIfNull(next);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(masker);
         _next = next;
         _logger = logger;
+        _masker = masker;
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -37,7 +43,7 @@ public sealed partial class RequestLoggingMiddleware
             long elapsedMs = (long)Stopwatch.GetElapsedTime(startTimestamp).TotalMilliseconds;
             string method = context.Request.Method;
             string path = context.Request.Path.HasValue ? context.Request.Path.Value! : "/";
-            string query = QueryStringMasker.Mascarar(context.Request.QueryString);
+            string query = _masker.Mascarar(context.Request.QueryString);
             int statusCode = context.Response.StatusCode;
 
             // Severidade proporcional à categoria HTTP: 5xx é falha do servidor,

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -7,6 +7,13 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+/// <summary>Middleware de logging estruturado de requests HTTP.</summary>
+/// <remarks>
+/// Mascara valores de query string via <see cref="QueryStringMasker"/>, mas não segmentos
+/// de path — PII em path segments vaza em camadas anteriores ao middleware (nginx, WAF, CDN,
+/// cabeçalho Referer). Rotas devem usar identificadores opacos (UUID), nunca dados sensíveis
+/// em path. Ver unifesspa-edu-br/uniplus-docs#68.
+/// </remarks>
 public sealed partial class RequestLoggingMiddleware
 {
     private readonly RequestDelegate _next;

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -1,27 +1,35 @@
 namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
+using System.Collections.Frozen;
 using System.Diagnostics;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 public sealed partial class RequestLoggingMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly ILogger<RequestLoggingMiddleware> _logger;
     private readonly QueryStringMasker _masker;
+    private readonly FrozenSet<string> _pathsSilenciados;
 
     public RequestLoggingMiddleware(
         RequestDelegate next,
         ILogger<RequestLoggingMiddleware> logger,
-        QueryStringMasker masker)
+        QueryStringMasker masker,
+        IOptions<RequestLoggingOptions> options)
     {
         ArgumentNullException.ThrowIfNull(next);
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(masker);
+        ArgumentNullException.ThrowIfNull(options);
         _next = next;
         _logger = logger;
         _masker = masker;
+        _pathsSilenciados = FrozenSet.ToFrozenSet(
+            options.Value.PathsSilenciados,
+            StringComparer.OrdinalIgnoreCase);
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -48,7 +56,10 @@ public sealed partial class RequestLoggingMiddleware
 
             // Severidade proporcional à categoria HTTP: 5xx é falha do servidor,
             // 4xx sinaliza problema no lado do cliente e demais respostas são
-            // tráfego operacional normal.
+            // tráfego operacional normal. Paths de infraestrutura (health,
+            // metrics) são silenciados quando bem-sucedidos para não saturar
+            // observabilidade com probes de liveness/readiness; respostas de
+            // erro continuam sendo reportadas porque sinalizam problema real.
             if (statusCode >= 500)
             {
                 LogRequestServerError(_logger, method, path, query, statusCode, elapsedMs);
@@ -57,7 +68,7 @@ public sealed partial class RequestLoggingMiddleware
             {
                 LogRequestClientError(_logger, method, path, query, statusCode, elapsedMs);
             }
-            else
+            else if (!_pathsSilenciados.Contains(path))
             {
                 LogRequestSucesso(_logger, method, path, query, statusCode, elapsedMs);
             }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -99,19 +99,29 @@ public sealed partial class RequestLoggingMiddleware
     // falsos positivos que meramente começam com o prefixo (`/healthy`,
     // `/health-ui`). O boundary garante que apenas separadores hierárquicos
     // de URL contam como extensão do prefixo.
+    //
+    // Trabalha com `ReadOnlySpan<char>` em vez de `string` para não alocar
+    // em requests com trailing slash — hot path executa por request. Os
+    // prefixos em `_prefixosSilenciados` já estão normalizados (sem trailing
+    // slash, exceto "/") desde o construtor.
     private bool DeveSilenciar(string path)
     {
-        string pathNormalizado = NormalizarPrefixo(path);
+        ReadOnlySpan<char> pathSpan = path.AsSpan();
+        if (pathSpan.Length > 1 && pathSpan[^1] == '/')
+        {
+            pathSpan = pathSpan.TrimEnd('/');
+        }
+
         foreach (string prefixo in _prefixosSilenciados)
         {
-            if (pathNormalizado.Equals(prefixo, StringComparison.OrdinalIgnoreCase))
+            if (pathSpan.Equals(prefixo, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
 
-            if (pathNormalizado.Length > prefixo.Length &&
-                pathNormalizado.StartsWith(prefixo, StringComparison.OrdinalIgnoreCase) &&
-                pathNormalizado[prefixo.Length] == '/')
+            if (pathSpan.Length > prefixo.Length &&
+                pathSpan.StartsWith(prefixo, StringComparison.OrdinalIgnoreCase) &&
+                pathSpan[prefixo.Length] == '/')
             {
                 return true;
             }
@@ -121,8 +131,9 @@ public sealed partial class RequestLoggingMiddleware
     }
 
     // Normaliza removendo trailing slash exceto no caso raiz "/", que é
-    // preservado como path canônico da raiz. Strings vazias são tratadas
-    // como "/" pelo chamador (ver InvokeAsync).
+    // preservado como path canônico da raiz. Usado apenas no construtor
+    // (caminho frio) — o hot path do DeveSilenciar faz a normalização
+    // equivalente via span sem alocação.
     private static string NormalizarPrefixo(string valor) =>
         valor.Length > 1 && valor.EndsWith('/') ? valor.TrimEnd('/') : valor;
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs
@@ -28,11 +28,7 @@ public sealed partial class RequestLoggingMiddleware
         _logger = logger;
         _masker = masker;
 
-        // Prefixos são normalizados removendo trailing slash (exceto o caso
-        // especial "/", preservado como raiz). Armazenados como ImmutableArray
-        // ordenado para iteração em hot path sem custo de enumerator —
-        // FrozenSet.Contains não serve porque precisamos de prefix match com
-        // boundary, não igualdade.
+        // ImmutableArray (não FrozenSet): matching é prefix+boundary, não igualdade.
         _prefixosSilenciados = options.Value.PrefixosSilenciados
             .Select(NormalizarPrefixo)
             .Where(p => p.Length > 0)
@@ -47,12 +43,9 @@ public sealed partial class RequestLoggingMiddleware
         long startTimestamp = Stopwatch.GetTimestamp();
         Exception? falha = null;
 
-        // try/catch/throw + finally: capturamos a exception apenas como
-        // contexto para o log (mantendo stack trace via `throw;`) e a
-        // deixamos propagar para o GlobalExceptionMiddleware decidir a
-        // resposta. Sem essa captura, uma exception que escapasse daria
-        // um log Information com status 200 (default) — mascarando falha
-        // como sucesso.
+        // Capturamos para elevar o log a Error; `throw;` preserva stack para o
+        // GlobalExceptionMiddleware. Sem isso, exception que escapa o pipeline
+        // aparece como Information 200 no log (default do status code).
         try
         {
             await _next(context).ConfigureAwait(false);
@@ -70,15 +63,6 @@ public sealed partial class RequestLoggingMiddleware
             string query = _masker.Mascarar(context.Request.QueryString);
             int statusCode = context.Response.StatusCode;
 
-            // Presença de exception força nível Error independentemente do
-            // status code observado — evita que uma falha silenciosa (status
-            // não alterado) apareça como sucesso no log. Severidade
-            // proporcional à categoria HTTP: 5xx é falha do servidor,
-            // 4xx sinaliza problema no lado do cliente e demais respostas são
-            // tráfego operacional normal. Paths de infraestrutura (health,
-            // metrics) são silenciados quando bem-sucedidos para não saturar
-            // observabilidade com probes de liveness/readiness; respostas de
-            // erro continuam sendo reportadas porque sinalizam problema real.
             if (falha is not null || statusCode >= 500)
             {
                 LogRequestServerError(_logger, method, path, query, statusCode, elapsedMs, falha);
@@ -94,16 +78,7 @@ public sealed partial class RequestLoggingMiddleware
         }
     }
 
-    // Match case-insensitive por prefixo com boundary em `/`. Aceita o path
-    // exato ou subpaths (`/health`, `/health/`, `/health/db`) mas rejeita
-    // falsos positivos que meramente começam com o prefixo (`/healthy`,
-    // `/health-ui`). O boundary garante que apenas separadores hierárquicos
-    // de URL contam como extensão do prefixo.
-    //
-    // Trabalha com `ReadOnlySpan<char>` em vez de `string` para não alocar
-    // em requests com trailing slash — hot path executa por request. Os
-    // prefixos em `_prefixosSilenciados` já estão normalizados (sem trailing
-    // slash, exceto "/") desde o construtor.
+    // Span evita alocação no hot path em requests com trailing slash.
     private bool DeveSilenciar(string path)
     {
         ReadOnlySpan<char> pathSpan = path.AsSpan();
@@ -130,10 +105,6 @@ public sealed partial class RequestLoggingMiddleware
         return false;
     }
 
-    // Normaliza removendo trailing slash exceto no caso raiz "/", que é
-    // preservado como path canônico da raiz. Usado apenas no construtor
-    // (caminho frio) — o hot path do DeveSilenciar faz a normalização
-    // equivalente via span sem alocação.
     private static string NormalizarPrefixo(string valor) =>
         valor.Length > 1 && valor.EndsWith('/') ? valor.TrimEnd('/') : valor;
 
@@ -143,10 +114,8 @@ public sealed partial class RequestLoggingMiddleware
     [LoggerMessage(Level = LogLevel.Warning, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
     private static partial void LogRequestClientError(ILogger logger, string method, string path, string query, int statusCode, double elapsedMs);
 
-    // Exception é o último parâmetro (convenção do source generator de
-    // LoggerMessage): o gerador reconhece o tipo e emite no LogEvent.Exception
-    // em vez de no template de mensagem — preserva stack trace estruturada
-    // nos sinks sem polui-lo com a representação textual.
+    // Exception no último parâmetro: convenção do source generator do LoggerMessage —
+    // vai para LogEvent.Exception (stack estruturada nos sinks), não para o template.
     [LoggerMessage(Level = LogLevel.Error, Message = "HTTP {Method} {Path}{Query} respondeu {StatusCode} em {ElapsedMs}ms")]
     private static partial void LogRequestServerError(ILogger logger, string method, string path, string query, int statusCode, double elapsedMs, Exception? ex);
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
@@ -68,12 +68,6 @@ internal sealed class RequestLoggingOptionsValidator : IValidateOptions<RequestL
 
     private static void ValidarPrefixosSilenciados(IList<string> lista, List<string> erros)
     {
-        if (lista is null)
-        {
-            erros.Add($"{nameof(RequestLoggingOptions.PrefixosSilenciados)} não pode ser nulo — use uma lista vazia para desativar o silenciamento.");
-            return;
-        }
-
         if (lista.Any(p => !p.StartsWith('/')))
         {
             erros.Add($"{nameof(RequestLoggingOptions.PrefixosSilenciados)} contém path inválido — cada entrada deve começar com '/'.");

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
@@ -37,15 +37,9 @@ public sealed class RequestLoggingOptions
     /// </summary>
     public string ValorMascarado { get; set; } = "***";
 
-    // Os defaults são expostos para que validadores e testes possam checar a
-    // intenção inicial da configuração sem depender de uma nova instância.
     public static IList<string> DefaultsNomesParametrosSensiveis() =>
         ["cpf", "email", "senha", "password", "token"];
 
-    // Cada entrada é tratada como prefixo de rota pelo middleware (match por
-    // prefixo com boundary em `/`). Assim `/health` cobre automaticamente
-    // `/health/ready`, `/health/live`, `/health/db/postgresql` e qualquer
-    // outro subpath exposto por libraries de health-check.
     public static IList<string> DefaultsPrefixosSilenciados() =>
         ["/health", "/metrics"];
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
@@ -26,8 +26,12 @@ public sealed class RequestLoggingOptions
     public static IList<string> DefaultsNomesParametrosSensiveis() =>
         ["cpf", "email", "senha", "password", "token"];
 
+    // Cada entrada é tratada como prefixo de rota pelo middleware (match por
+    // prefixo com boundary em `/`). Assim `/health` cobre automaticamente
+    // `/health/ready`, `/health/live`, `/health/db/postgresql` e qualquer
+    // outro subpath exposto por libraries de health-check.
     public static IList<string> DefaultsPathsSilenciados() =>
-        ["/health", "/health/ready", "/health/live", "/metrics"];
+        ["/health", "/metrics"];
 }
 
 internal sealed class RequestLoggingOptionsValidator : IValidateOptions<RequestLoggingOptions>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.Options;
+
+public sealed class RequestLoggingOptions
+{
+    public const string SectionName = "RequestLogging";
+
+    // Listas são `IList<string>` mutáveis (setter público) porque o binder
+    // de `IConfiguration.Bind` e `Configure<T>(Action<T>)` precisam mutar a
+    // instância após construção. CA2227 é suprimido: DTOs de Options são
+    // explicitamente projetados para esse ciclo de vida. Os consumidores
+    // internos copiam o conteúdo para `FrozenSet` e não mutam a lista.
+    [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "DTO de IOptions: binder exige setter mutável.")]
+    public IList<string> NomesParametrosSensiveis { get; set; } = DefaultsNomesParametrosSensiveis();
+
+    [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "DTO de IOptions: binder exige setter mutável.")]
+    public IList<string> PathsSilenciados { get; set; } = DefaultsPathsSilenciados();
+
+    public string ValorMascarado { get; set; } = "***";
+
+    // Os defaults são expostos para que validadores e testes possam checar a
+    // intenção inicial da configuração sem depender de uma nova instância.
+    public static IList<string> DefaultsNomesParametrosSensiveis() =>
+        ["cpf", "email", "senha", "password", "token"];
+
+    public static IList<string> DefaultsPathsSilenciados() =>
+        ["/health", "/health/ready", "/health/live", "/metrics"];
+}
+
+internal sealed class RequestLoggingOptionsValidator : IValidateOptions<RequestLoggingOptions>
+{
+    public ValidateOptionsResult Validate(string? name, RequestLoggingOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        List<string> erros = new();
+
+        // Entradas em branco são normalizadas (dropadas) pelo PostConfigure do
+        // DI extension — aqui validamos apenas o estado final, após normalização.
+        if (options.NomesParametrosSensiveis is null || options.NomesParametrosSensiveis.Count == 0)
+        {
+            erros.Add($"{nameof(RequestLoggingOptions.NomesParametrosSensiveis)} não pode estar vazio — remover masking de PII viola LGPD.");
+        }
+
+        if (options.PathsSilenciados is null)
+        {
+            erros.Add($"{nameof(RequestLoggingOptions.PathsSilenciados)} não pode ser nulo — use uma lista vazia para desativar o silenciamento.");
+        }
+        else if (options.PathsSilenciados.Any(p => !p.StartsWith('/')))
+        {
+            erros.Add($"{nameof(RequestLoggingOptions.PathsSilenciados)} contém path inválido — cada entrada deve começar com '/'.");
+        }
+
+        if (string.IsNullOrEmpty(options.ValorMascarado))
+        {
+            erros.Add($"{nameof(RequestLoggingOptions.ValorMascarado)} não pode ser vazio — valor mascarado é o que aparece nos logs no lugar do dado sensível.");
+        }
+
+        return erros.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(erros);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
@@ -1,7 +1,5 @@
 namespace Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
-using System.Diagnostics.CodeAnalysis;
-
 using Microsoft.Extensions.Options;
 
 public sealed class RequestLoggingOptions
@@ -13,10 +11,11 @@ public sealed class RequestLoggingOptions
     /// (comparação case-insensitive após decodificação percent-encoding). Defaults
     /// cobrem o mínimo regulatório LGPD: cpf, email, senha, password, token.
     /// Configuração amplia os defaults em vez de substituir — é impossível
-    /// acidentalmente remover um parâmetro sensível via appsettings.
+    /// acidentalmente remover um parâmetro sensível via appsettings. Para substituir
+    /// integralmente os defaults, chamar <c>Clear()</c> antes de adicionar novos
+    /// valores via <c>Configure&lt;T&gt;(Action)</c>.
     /// </summary>
-    [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "DTO de IOptions: binder exige setter mutável.")]
-    public IList<string> NomesParametrosSensiveis { get; set; } = DefaultsNomesParametrosSensiveis();
+    public IList<string> NomesParametrosSensiveis { get; } = DefaultsNomesParametrosSensiveis();
 
     /// <summary>
     /// Prefixos de path silenciados para respostas de sucesso (status &lt; 400).
@@ -30,8 +29,7 @@ public sealed class RequestLoggingOptions
     /// logadas — silenciar falhas equivaleria a apagar alarmes.
     /// Lista vazia desativa o silenciamento.
     /// </summary>
-    [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "DTO de IOptions: binder exige setter mutável.")]
-    public IList<string> PrefixosSilenciados { get; set; } = DefaultsPrefixosSilenciados();
+    public IList<string> PrefixosSilenciados { get; } = DefaultsPrefixosSilenciados();
 
     /// <summary>
     /// String que substitui o valor de parâmetros sensíveis no log. Default "***".
@@ -59,28 +57,40 @@ internal sealed class RequestLoggingOptionsValidator : IValidateOptions<RequestL
         ArgumentNullException.ThrowIfNull(options);
 
         List<string> erros = new();
+        ValidarNomesParametrosSensiveis(options.NomesParametrosSensiveis, erros);
+        ValidarPrefixosSilenciados(options.PrefixosSilenciados, erros);
+        ValidarValorMascarado(options.ValorMascarado, erros);
 
-        // Entradas em branco são normalizadas (dropadas) pelo PostConfigure do
-        // DI extension — aqui validamos apenas o estado final, após normalização.
-        if (options.NomesParametrosSensiveis is null || options.NomesParametrosSensiveis.Count == 0)
+        return erros.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(erros);
+    }
+
+    private static void ValidarNomesParametrosSensiveis(IList<string> lista, List<string> erros)
+    {
+        if (lista is null || lista.Count == 0)
         {
             erros.Add($"{nameof(RequestLoggingOptions.NomesParametrosSensiveis)} não pode estar vazio — remover masking de PII viola LGPD.");
         }
+    }
 
-        if (options.PrefixosSilenciados is null)
+    private static void ValidarPrefixosSilenciados(IList<string> lista, List<string> erros)
+    {
+        if (lista is null)
         {
             erros.Add($"{nameof(RequestLoggingOptions.PrefixosSilenciados)} não pode ser nulo — use uma lista vazia para desativar o silenciamento.");
+            return;
         }
-        else if (options.PrefixosSilenciados.Any(p => !p.StartsWith('/')))
+
+        if (lista.Any(p => !p.StartsWith('/')))
         {
             erros.Add($"{nameof(RequestLoggingOptions.PrefixosSilenciados)} contém path inválido — cada entrada deve começar com '/'.");
         }
+    }
 
-        if (string.IsNullOrEmpty(options.ValorMascarado))
+    private static void ValidarValorMascarado(string valor, List<string> erros)
+    {
+        if (string.IsNullOrEmpty(valor))
         {
             erros.Add($"{nameof(RequestLoggingOptions.ValorMascarado)} não pode ser vazio — valor mascarado é o que aparece nos logs no lugar do dado sensível.");
         }
-
-        return erros.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(erros);
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs
@@ -8,17 +8,35 @@ public sealed class RequestLoggingOptions
 {
     public const string SectionName = "RequestLogging";
 
-    // Listas são `IList<string>` mutáveis (setter público) porque o binder
-    // de `IConfiguration.Bind` e `Configure<T>(Action<T>)` precisam mutar a
-    // instância após construção. CA2227 é suprimido: DTOs de Options são
-    // explicitamente projetados para esse ciclo de vida. Os consumidores
-    // internos copiam o conteúdo para `FrozenSet` e não mutam a lista.
+    /// <summary>
+    /// Nomes de parâmetros de query string cujo valor deve ser mascarado no log
+    /// (comparação case-insensitive após decodificação percent-encoding). Defaults
+    /// cobrem o mínimo regulatório LGPD: cpf, email, senha, password, token.
+    /// Configuração amplia os defaults em vez de substituir — é impossível
+    /// acidentalmente remover um parâmetro sensível via appsettings.
+    /// </summary>
     [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "DTO de IOptions: binder exige setter mutável.")]
     public IList<string> NomesParametrosSensiveis { get; set; } = DefaultsNomesParametrosSensiveis();
 
+    /// <summary>
+    /// Prefixos de path silenciados para respostas de sucesso (status &lt; 400).
+    /// Match case-insensitive com boundary em '/': <c>/health</c> cobre
+    /// <c>/health</c>, <c>/health/</c>, <c>/health/ready</c>, <c>/health/db/postgresql</c>,
+    /// mas <b>não</b> <c>/healthy</c>, <c>/health-ui</c> ou <c>/healthcheck</c> —
+    /// apenas separadores hierárquicos de URL são aceitos como extensão do prefixo.
+    /// Trailing slash na entrada ou no request é normalizado. Para silenciar apenas
+    /// uma rota exata, declare-a sem filhos (o match também casa o prefixo puro).
+    /// Respostas de erro (status &ge; 400) em paths silenciados são <b>sempre</b>
+    /// logadas — silenciar falhas equivaleria a apagar alarmes.
+    /// Lista vazia desativa o silenciamento.
+    /// </summary>
     [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "DTO de IOptions: binder exige setter mutável.")]
-    public IList<string> PathsSilenciados { get; set; } = DefaultsPathsSilenciados();
+    public IList<string> PrefixosSilenciados { get; set; } = DefaultsPrefixosSilenciados();
 
+    /// <summary>
+    /// String que substitui o valor de parâmetros sensíveis no log. Default "***".
+    /// Não pode ser vazio — validado na inicialização.
+    /// </summary>
     public string ValorMascarado { get; set; } = "***";
 
     // Os defaults são expostos para que validadores e testes possam checar a
@@ -30,7 +48,7 @@ public sealed class RequestLoggingOptions
     // prefixo com boundary em `/`). Assim `/health` cobre automaticamente
     // `/health/ready`, `/health/live`, `/health/db/postgresql` e qualquer
     // outro subpath exposto por libraries de health-check.
-    public static IList<string> DefaultsPathsSilenciados() =>
+    public static IList<string> DefaultsPrefixosSilenciados() =>
         ["/health", "/metrics"];
 }
 
@@ -49,13 +67,13 @@ internal sealed class RequestLoggingOptionsValidator : IValidateOptions<RequestL
             erros.Add($"{nameof(RequestLoggingOptions.NomesParametrosSensiveis)} não pode estar vazio — remover masking de PII viola LGPD.");
         }
 
-        if (options.PathsSilenciados is null)
+        if (options.PrefixosSilenciados is null)
         {
-            erros.Add($"{nameof(RequestLoggingOptions.PathsSilenciados)} não pode ser nulo — use uma lista vazia para desativar o silenciamento.");
+            erros.Add($"{nameof(RequestLoggingOptions.PrefixosSilenciados)} não pode ser nulo — use uma lista vazia para desativar o silenciamento.");
         }
-        else if (options.PathsSilenciados.Any(p => !p.StartsWith('/')))
+        else if (options.PrefixosSilenciados.Any(p => !p.StartsWith('/')))
         {
-            erros.Add($"{nameof(RequestLoggingOptions.PathsSilenciados)} contém path inválido — cada entrada deve começar com '/'.");
+            erros.Add($"{nameof(RequestLoggingOptions.PrefixosSilenciados)} contém path inválido — cada entrada deve começar com '/'.");
         }
 
         if (string.IsNullOrEmpty(options.ValorMascarado))

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/DependencyInjection/RequestLoggingServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/DependencyInjection/RequestLoggingServiceCollectionExtensionsTests.cs
@@ -95,18 +95,18 @@ public class RequestLoggingServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddRequestLogging_ComPathSilenciadoInvalido_DeveFalharValidacao()
+    public void AddRequestLogging_ComPrefixoSilenciadoInvalido_DeveFalharValidacao()
     {
         ServiceCollection services = new();
 
         services.AddRequestLogging(configure: opts =>
-            opts.PathsSilenciados.Add("health"));   // falta '/' inicial
+            opts.PrefixosSilenciados.Add("health"));   // falta '/' inicial
 
         using ServiceProvider provider = services.BuildServiceProvider();
         Func<RequestLoggingOptions> acao = () => provider.GetRequiredService<IOptions<RequestLoggingOptions>>().Value;
 
         acao.Should().Throw<OptionsValidationException>()
-            .WithMessage("*PathsSilenciados*");
+            .WithMessage("*PrefixosSilenciados*");
     }
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/DependencyInjection/RequestLoggingServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/DependencyInjection/RequestLoggingServiceCollectionExtensionsTests.cs
@@ -30,13 +30,16 @@ public class RequestLoggingServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddRequestLogging_ComActionConfigure_DeveSobrescreverDefaults()
+    public void AddRequestLogging_ComActionConfigureLimpandoDefaults_DeveSubstituirCompletamente()
     {
         ServiceCollection services = new();
 
         services.AddRequestLogging(configure: opts =>
         {
-            opts.NomesParametrosSensiveis = ["matricula"];
+            // Limpar + adicionar expressa substituição explícita. Sem Clear,
+            // a semântica seria merge com os defaults (ver teste abaixo).
+            opts.NomesParametrosSensiveis.Clear();
+            opts.NomesParametrosSensiveis.Add("matricula");
             opts.ValorMascarado = "[hidden]";
         });
 
@@ -118,7 +121,7 @@ public class RequestLoggingServiceCollectionExtensionsTests
         // já chegou no sink de logs em produção.
         ServiceCollection services = new();
 
-        services.AddRequestLogging(configure: opts => opts.NomesParametrosSensiveis = []);
+        services.AddRequestLogging(configure: opts => opts.NomesParametrosSensiveis.Clear());
 
         using ServiceProvider provider = services.BuildServiceProvider();
         Func<RequestLoggingOptions> acao = () => provider.GetRequiredService<IOptions<RequestLoggingOptions>>().Value;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/DependencyInjection/RequestLoggingServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/DependencyInjection/RequestLoggingServiceCollectionExtensionsTests.cs
@@ -1,0 +1,151 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.DependencyInjection;
+
+using System.Collections.Generic;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Common.DependencyInjection;
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+public class RequestLoggingServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddRequestLogging_SemConfiguracao_DeveResolverMaskerComDefaults()
+    {
+        ServiceCollection services = new();
+
+        services.AddRequestLogging();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        QueryStringMasker masker = provider.GetRequiredService<QueryStringMasker>();
+        IOptions<RequestLoggingOptions> options = provider.GetRequiredService<IOptions<RequestLoggingOptions>>();
+
+        options.Value.NomesParametrosSensiveis.Should().Contain(["cpf", "email", "senha", "password", "token"]);
+        masker.Mascarar(new QueryString("?cpf=123")).Should().Be("?cpf=***");
+    }
+
+    [Fact]
+    public void AddRequestLogging_ComActionConfigure_DeveSobrescreverDefaults()
+    {
+        ServiceCollection services = new();
+
+        services.AddRequestLogging(configure: opts =>
+        {
+            opts.NomesParametrosSensiveis = ["matricula"];
+            opts.ValorMascarado = "[hidden]";
+        });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        QueryStringMasker masker = provider.GetRequiredService<QueryStringMasker>();
+
+        masker.Mascarar(new QueryString("?matricula=98765&cpf=123"))
+            .Should().Be("?matricula=[hidden]&cpf=123");
+    }
+
+    [Fact]
+    public void AddRequestLogging_ComConfiguration_DeveMesclarDefaultsComValoresBindados()
+    {
+        // Binder do IConfiguration agrega às listas pré-populadas (semântica
+        // "defaults como piso, config amplia"). Isso impede que um appsettings
+        // acidentalmente remova `cpf` da proteção — o máximo que config pode
+        // fazer é ampliar o conjunto protegido.
+        Dictionary<string, string?> valores = new()
+        {
+            [$"{RequestLoggingOptions.SectionName}:NomesParametrosSensiveis:0"] = "documento",
+            [$"{RequestLoggingOptions.SectionName}:NomesParametrosSensiveis:1"] = "rg",
+            [$"{RequestLoggingOptions.SectionName}:ValorMascarado"] = "[REDACTED]",
+        };
+        IConfiguration configuration = new ConfigurationBuilder().AddInMemoryCollection(valores).Build();
+        ServiceCollection services = new();
+
+        services.AddRequestLogging(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        RequestLoggingOptions options = provider.GetRequiredService<IOptions<RequestLoggingOptions>>().Value;
+
+        options.NomesParametrosSensiveis.Should()
+            .BeEquivalentTo(["cpf", "email", "senha", "password", "token", "documento", "rg"]);
+        options.ValorMascarado.Should().Be("[REDACTED]");
+    }
+
+    [Fact]
+    public void AddRequestLogging_ComEntradasDuplicadasOuEmBranco_DeveNormalizarLista()
+    {
+        ServiceCollection services = new();
+
+        services.AddRequestLogging(configure: opts =>
+        {
+            // "CPF" duplica defaults (case-insensitive), "  " é entrada em branco,
+            // "rg" é válida. PostConfigure deve manter apenas entradas normalizadas.
+            opts.NomesParametrosSensiveis.Add("CPF");
+            opts.NomesParametrosSensiveis.Add("  ");
+            opts.NomesParametrosSensiveis.Add("rg");
+        });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        RequestLoggingOptions options = provider.GetRequiredService<IOptions<RequestLoggingOptions>>().Value;
+
+        options.NomesParametrosSensiveis.Should()
+            .BeEquivalentTo(["cpf", "email", "senha", "password", "token", "rg"]);
+    }
+
+    [Fact]
+    public void AddRequestLogging_ComPathSilenciadoInvalido_DeveFalharValidacao()
+    {
+        ServiceCollection services = new();
+
+        services.AddRequestLogging(configure: opts =>
+            opts.PathsSilenciados.Add("health"));   // falta '/' inicial
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Func<RequestLoggingOptions> acao = () => provider.GetRequiredService<IOptions<RequestLoggingOptions>>().Value;
+
+        acao.Should().Throw<OptionsValidationException>()
+            .WithMessage("*PathsSilenciados*");
+    }
+
+    [Fact]
+    public void AddRequestLogging_ComListaVazia_DeveFalharValidacaoAoResolverOptions()
+    {
+        // Proteção crítica: appsettings.json que zere a lista de parâmetros
+        // sensíveis equivale a desabilitar masking de PII. Falhar cedo
+        // (na inicialização) evita descobrir o problema só quando o vazamento
+        // já chegou no sink de logs em produção.
+        ServiceCollection services = new();
+
+        services.AddRequestLogging(configure: opts => opts.NomesParametrosSensiveis = []);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Func<RequestLoggingOptions> acao = () => provider.GetRequiredService<IOptions<RequestLoggingOptions>>().Value;
+
+        acao.Should().Throw<OptionsValidationException>()
+            .WithMessage("*NomesParametrosSensiveis*");
+    }
+
+    [Fact]
+    public void AddRequestLogging_ComValorMascaradoVazio_DeveFalharValidacao()
+    {
+        ServiceCollection services = new();
+
+        services.AddRequestLogging(configure: opts => opts.ValorMascarado = string.Empty);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Func<RequestLoggingOptions> acao = () => provider.GetRequiredService<IOptions<RequestLoggingOptions>>().Value;
+
+        acao.Should().Throw<OptionsValidationException>()
+            .WithMessage("*ValorMascarado*");
+    }
+
+    [Fact]
+    public void AddRequestLogging_ComServicesNulo_DeveLancarArgumentNullException()
+    {
+        Func<IServiceCollection> acao = () => RequestLoggingServiceCollectionExtensions.AddRequestLogging(null!);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/QueryStringMaskerTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/QueryStringMaskerTests.cs
@@ -36,6 +36,7 @@ public class QueryStringMaskerTests
     [InlineData("?senha=123abc", "?senha=***")]
     [InlineData("?password=secret", "?password=***")]
     [InlineData("?token=jwt.abc.def", "?token=***")]
+    [InlineData("?cpf=", "?cpf=***")]
     public void Mascarar_ParametroSensivelIsolado_DeveSubstituirValor(string entrada, string esperado)
     {
         QueryStringMasker masker = CriarMasker();

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/QueryStringMaskerTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/QueryStringMaskerTests.cs
@@ -147,7 +147,10 @@ public class QueryStringMaskerTests
         // Garante que o masker respeita a configuração injetada, não uma lista
         // hardcoded — requisito para que appsettings possa ampliar a proteção
         // sem recompilar (ex.: adicionar "matricula" em produção).
-        RequestLoggingOptions opcoes = new() { NomesParametrosSensiveis = ["matricula", "rg"] };
+        RequestLoggingOptions opcoes = new();
+        opcoes.NomesParametrosSensiveis.Clear();
+        opcoes.NomesParametrosSensiveis.Add("matricula");
+        opcoes.NomesParametrosSensiveis.Add("rg");
         QueryStringMasker masker = CriarMasker(opcoes);
         QueryString query = new("?cpf=123&matricula=98765&rg=AB-12");
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/QueryStringMaskerTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/QueryStringMaskerTests.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.Middleware;
 using FluentAssertions;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
 
@@ -11,7 +12,9 @@ public class QueryStringMaskerTests
     [Fact]
     public void Mascarar_QueryVazia_DeveRetornarStringVazia()
     {
-        string resultado = QueryStringMasker.Mascarar(QueryString.Empty);
+        QueryStringMasker masker = CriarMasker();
+
+        string resultado = masker.Mascarar(QueryString.Empty);
 
         resultado.Should().BeEmpty();
     }
@@ -19,9 +22,10 @@ public class QueryStringMaskerTests
     [Fact]
     public void Mascarar_QueryApenasComInterrogacao_DevePreservar()
     {
+        QueryStringMasker masker = CriarMasker();
         QueryString query = new("?");
 
-        string resultado = QueryStringMasker.Mascarar(query);
+        string resultado = masker.Mascarar(query);
 
         resultado.Should().Be("?");
     }
@@ -34,7 +38,9 @@ public class QueryStringMaskerTests
     [InlineData("?token=jwt.abc.def", "?token=***")]
     public void Mascarar_ParametroSensivelIsolado_DeveSubstituirValor(string entrada, string esperado)
     {
-        string resultado = QueryStringMasker.Mascarar(new QueryString(entrada));
+        QueryStringMasker masker = CriarMasker();
+
+        string resultado = masker.Mascarar(new QueryString(entrada));
 
         resultado.Should().Be(esperado);
     }
@@ -47,9 +53,10 @@ public class QueryStringMaskerTests
     [InlineData("Email")]
     public void Mascarar_NomeSensivelComGrafiaVariada_DeveMascararCaseInsensitive(string chave)
     {
+        QueryStringMasker masker = CriarMasker();
         QueryString query = new($"?{chave}=valor-sensivel");
 
-        string resultado = QueryStringMasker.Mascarar(query);
+        string resultado = masker.Mascarar(query);
 
         resultado.Should().Be($"?{chave}=***");
     }
@@ -57,9 +64,10 @@ public class QueryStringMaskerTests
     [Fact]
     public void Mascarar_ComParametrosNaoSensiveis_DevePreservarValores()
     {
+        QueryStringMasker masker = CriarMasker();
         QueryString query = new("?page=1&sort=asc");
 
-        string resultado = QueryStringMasker.Mascarar(query);
+        string resultado = masker.Mascarar(query);
 
         resultado.Should().Be("?page=1&sort=asc");
     }
@@ -67,9 +75,10 @@ public class QueryStringMaskerTests
     [Fact]
     public void Mascarar_MisturaDeParametros_DeveMascararApenasSensiveis()
     {
+        QueryStringMasker masker = CriarMasker();
         QueryString query = new("?page=2&cpf=12345678900&sort=asc&email=foo@bar.com");
 
-        string resultado = QueryStringMasker.Mascarar(query);
+        string resultado = masker.Mascarar(query);
 
         resultado.Should().Be("?page=2&cpf=***&sort=asc&email=***");
     }
@@ -77,9 +86,10 @@ public class QueryStringMaskerTests
     [Fact]
     public void Mascarar_ParametroSemValor_DevePreservar()
     {
+        QueryStringMasker masker = CriarMasker();
         QueryString query = new("?flag");
 
-        string resultado = QueryStringMasker.Mascarar(query);
+        string resultado = masker.Mascarar(query);
 
         resultado.Should().Be("?flag");
     }
@@ -87,9 +97,10 @@ public class QueryStringMaskerTests
     [Fact]
     public void Mascarar_ValoresUrlEncoded_DevePreservarEncodingEmNaoSensiveis()
     {
+        QueryStringMasker masker = CriarMasker();
         QueryString query = new("?nome=Jos%C3%A9&cidade=S%C3%A3o%20Paulo");
 
-        string resultado = QueryStringMasker.Mascarar(query);
+        string resultado = masker.Mascarar(query);
 
         resultado.Should().Be("?nome=Jos%C3%A9&cidade=S%C3%A3o%20Paulo");
     }
@@ -99,9 +110,10 @@ public class QueryStringMaskerTests
     {
         // "%63%70%66" é "cpf" percent-encoded. A comparação precisa ignorar o
         // encoding para não deixar cliente ofuscar a chave e vazar PII.
+        QueryStringMasker masker = CriarMasker();
         QueryString query = new("?%63%70%66=12345678900");
 
-        string resultado = QueryStringMasker.Mascarar(query);
+        string resultado = masker.Mascarar(query);
 
         resultado.Should().Be("?%63%70%66=***");
     }
@@ -109,9 +121,10 @@ public class QueryStringMaskerTests
     [Fact]
     public void Mascarar_ParametrosSensiveisDuplicados_DeveMascararTodasOcorrencias()
     {
+        QueryStringMasker masker = CriarMasker();
         QueryString query = new("?cpf=111&cpf=222&cpf=333");
 
-        string resultado = QueryStringMasker.Mascarar(query);
+        string resultado = masker.Mascarar(query);
 
         resultado.Should().Be("?cpf=***&cpf=***&cpf=***");
     }
@@ -119,10 +132,53 @@ public class QueryStringMaskerTests
     [Fact]
     public void Mascarar_AmpersandsConsecutivos_NaoDeveProduzirParSeparadorVazio()
     {
+        QueryStringMasker masker = CriarMasker();
         QueryString query = new("?a=1&&b=2");
 
-        string resultado = QueryStringMasker.Mascarar(query);
+        string resultado = masker.Mascarar(query);
 
         resultado.Should().Be("?a=1&b=2");
+    }
+
+    [Fact]
+    public void Mascarar_ComNomesCustomizadosViaOpcoes_DeveAplicarConfiguracaoInjetada()
+    {
+        // Garante que o masker respeita a configuração injetada, não uma lista
+        // hardcoded — requisito para que appsettings possa ampliar a proteção
+        // sem recompilar (ex.: adicionar "matricula" em produção).
+        RequestLoggingOptions opcoes = new() { NomesParametrosSensiveis = ["matricula", "rg"] };
+        QueryStringMasker masker = CriarMasker(opcoes);
+        QueryString query = new("?cpf=123&matricula=98765&rg=AB-12");
+
+        string resultado = masker.Mascarar(query);
+
+        // cpf não está mais na lista customizada — preserva. matricula e rg são mascarados.
+        resultado.Should().Be("?cpf=123&matricula=***&rg=***");
+    }
+
+    [Fact]
+    public void Mascarar_ComValorMascaradoCustomizado_DeveUsarMascaraInjetada()
+    {
+        RequestLoggingOptions opcoes = new() { ValorMascarado = "[REDACTED]" };
+        QueryStringMasker masker = CriarMasker(opcoes);
+        QueryString query = new("?cpf=12345678900");
+
+        string resultado = masker.Mascarar(query);
+
+        resultado.Should().Be("?cpf=[REDACTED]");
+    }
+
+    [Fact]
+    public void Construtor_ComOptionsNulas_DeveLancarArgumentNullException()
+    {
+        Func<QueryStringMasker> acao = () => new QueryStringMasker(null!);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    private static QueryStringMasker CriarMasker(RequestLoggingOptions? opcoes = null)
+    {
+        opcoes ??= new RequestLoggingOptions();
+        return new QueryStringMasker(Options.Create(opcoes));
     }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/QueryStringMaskerTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/QueryStringMaskerTests.cs
@@ -1,0 +1,128 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.Middleware;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Http;
+
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+public class QueryStringMaskerTests
+{
+    [Fact]
+    public void Mascarar_QueryVazia_DeveRetornarStringVazia()
+    {
+        string resultado = QueryStringMasker.Mascarar(QueryString.Empty);
+
+        resultado.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Mascarar_QueryApenasComInterrogacao_DevePreservar()
+    {
+        QueryString query = new("?");
+
+        string resultado = QueryStringMasker.Mascarar(query);
+
+        resultado.Should().Be("?");
+    }
+
+    [Theory]
+    [InlineData("?cpf=12345678900", "?cpf=***")]
+    [InlineData("?email=teste@teste.com", "?email=***")]
+    [InlineData("?senha=123abc", "?senha=***")]
+    [InlineData("?password=secret", "?password=***")]
+    [InlineData("?token=jwt.abc.def", "?token=***")]
+    public void Mascarar_ParametroSensivelIsolado_DeveSubstituirValor(string entrada, string esperado)
+    {
+        string resultado = QueryStringMasker.Mascarar(new QueryString(entrada));
+
+        resultado.Should().Be(esperado);
+    }
+
+    [Theory]
+    [InlineData("CPF")]
+    [InlineData("Cpf")]
+    [InlineData("CpF")]
+    [InlineData("EMAIL")]
+    [InlineData("Email")]
+    public void Mascarar_NomeSensivelComGrafiaVariada_DeveMascararCaseInsensitive(string chave)
+    {
+        QueryString query = new($"?{chave}=valor-sensivel");
+
+        string resultado = QueryStringMasker.Mascarar(query);
+
+        resultado.Should().Be($"?{chave}=***");
+    }
+
+    [Fact]
+    public void Mascarar_ComParametrosNaoSensiveis_DevePreservarValores()
+    {
+        QueryString query = new("?page=1&sort=asc");
+
+        string resultado = QueryStringMasker.Mascarar(query);
+
+        resultado.Should().Be("?page=1&sort=asc");
+    }
+
+    [Fact]
+    public void Mascarar_MisturaDeParametros_DeveMascararApenasSensiveis()
+    {
+        QueryString query = new("?page=2&cpf=12345678900&sort=asc&email=foo@bar.com");
+
+        string resultado = QueryStringMasker.Mascarar(query);
+
+        resultado.Should().Be("?page=2&cpf=***&sort=asc&email=***");
+    }
+
+    [Fact]
+    public void Mascarar_ParametroSemValor_DevePreservar()
+    {
+        QueryString query = new("?flag");
+
+        string resultado = QueryStringMasker.Mascarar(query);
+
+        resultado.Should().Be("?flag");
+    }
+
+    [Fact]
+    public void Mascarar_ValoresUrlEncoded_DevePreservarEncodingEmNaoSensiveis()
+    {
+        QueryString query = new("?nome=Jos%C3%A9&cidade=S%C3%A3o%20Paulo");
+
+        string resultado = QueryStringMasker.Mascarar(query);
+
+        resultado.Should().Be("?nome=Jos%C3%A9&cidade=S%C3%A3o%20Paulo");
+    }
+
+    [Fact]
+    public void Mascarar_ChaveSensivelUrlEncoded_DeveReconhecerAposDecodificar()
+    {
+        // "%63%70%66" é "cpf" percent-encoded. A comparação precisa ignorar o
+        // encoding para não deixar cliente ofuscar a chave e vazar PII.
+        QueryString query = new("?%63%70%66=12345678900");
+
+        string resultado = QueryStringMasker.Mascarar(query);
+
+        resultado.Should().Be("?%63%70%66=***");
+    }
+
+    [Fact]
+    public void Mascarar_ParametrosSensiveisDuplicados_DeveMascararTodasOcorrencias()
+    {
+        QueryString query = new("?cpf=111&cpf=222&cpf=333");
+
+        string resultado = QueryStringMasker.Mascarar(query);
+
+        resultado.Should().Be("?cpf=***&cpf=***&cpf=***");
+    }
+
+    [Fact]
+    public void Mascarar_AmpersandsConsecutivos_NaoDeveProduzirParSeparadorVazio()
+    {
+        QueryString query = new("?a=1&&b=2");
+
+        string resultado = QueryStringMasker.Mascarar(query);
+
+        resultado.Should().Be("?a=1&b=2");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -207,9 +207,9 @@ public class RequestLoggingMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeAsync_ComListaDePathsSilenciadosCustomizada_DeveRespeitarConfiguracaoInjetada()
+    public async Task InvokeAsync_ComListaDePrefixosSilenciadosCustomizada_DeveRespeitarConfiguracaoInjetada()
     {
-        RequestLoggingOptions opcoes = new() { PathsSilenciados = ["/custom/noise"] };
+        RequestLoggingOptions opcoes = new() { PrefixosSilenciados = ["/custom/noise"] };
         List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", "/custom/noise", 200, opcoes: opcoes);
         List<LogEvent> eventosHealth = await ExecutarERetornarLogsAsync("GET", "/health", 200, opcoes: opcoes);
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -5,8 +5,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
-using NSubstitute;
+using Microsoft.Extensions.Options;
 
 using Serilog;
 using Serilog.Context;
@@ -30,7 +29,8 @@ public class RequestLoggingMiddlewareTests
                 proximoFoiChamado = true;
                 return Task.CompletedTask;
             },
-            NullLogger<RequestLoggingMiddleware>.Instance);
+            NullLogger<RequestLoggingMiddleware>.Instance,
+            CriarMasker());
 
         await middleware.InvokeAsync(context);
 
@@ -116,7 +116,8 @@ public class RequestLoggingMiddlewareTests
             using SerilogLoggerFactory factory = new(logger);
             RequestLoggingMiddleware middleware = new(
                 _ => throw new InvalidOperationException("falha simulada"),
-                factory.CreateLogger<RequestLoggingMiddleware>());
+                factory.CreateLogger<RequestLoggingMiddleware>(),
+                CriarMasker());
 
             Func<Task> acao = () => middleware.InvokeAsync(context);
 
@@ -150,7 +151,8 @@ public class RequestLoggingMiddlewareTests
                     context.Response.StatusCode = 200;
                     return Task.CompletedTask;
                 },
-                factory.CreateLogger<RequestLoggingMiddleware>());
+                factory.CreateLogger<RequestLoggingMiddleware>(),
+                CriarMasker());
 
             using (LogContext.PushProperty(CorrelationIdMiddleware.LogContextProperty, correlationId))
             {
@@ -171,11 +173,13 @@ public class RequestLoggingMiddlewareTests
     [Fact]
     public async Task Construtor_ComNext_OuLogger_Nulo_DeveLancar()
     {
-        Func<RequestLoggingMiddleware> criarSemNext = () => new RequestLoggingMiddleware(null!, NullLogger<RequestLoggingMiddleware>.Instance);
-        Func<RequestLoggingMiddleware> criarSemLogger = () => new RequestLoggingMiddleware(_ => Task.CompletedTask, null!);
+        Func<RequestLoggingMiddleware> criarSemNext = () => new RequestLoggingMiddleware(null!, NullLogger<RequestLoggingMiddleware>.Instance, CriarMasker());
+        Func<RequestLoggingMiddleware> criarSemLogger = () => new RequestLoggingMiddleware(_ => Task.CompletedTask, null!, CriarMasker());
+        Func<RequestLoggingMiddleware> criarSemMasker = () => new RequestLoggingMiddleware(_ => Task.CompletedTask, NullLogger<RequestLoggingMiddleware>.Instance, null!);
 
         criarSemNext.Should().Throw<ArgumentNullException>();
         criarSemLogger.Should().Throw<ArgumentNullException>();
+        criarSemMasker.Should().Throw<ArgumentNullException>();
 
         await Task.CompletedTask;
     }
@@ -185,7 +189,8 @@ public class RequestLoggingMiddlewareTests
     {
         RequestLoggingMiddleware middleware = new(
             _ => Task.CompletedTask,
-            NullLogger<RequestLoggingMiddleware>.Instance);
+            NullLogger<RequestLoggingMiddleware>.Instance,
+            CriarMasker());
 
         Func<Task> acao = () => middleware.InvokeAsync(null!);
 
@@ -210,7 +215,8 @@ public class RequestLoggingMiddlewareTests
                     context.Response.StatusCode = statusCode;
                     return Task.CompletedTask;
                 },
-                factory.CreateLogger<RequestLoggingMiddleware>());
+                factory.CreateLogger<RequestLoggingMiddleware>(),
+                CriarMasker());
 
             await middleware.InvokeAsync(context);
         }
@@ -234,6 +240,9 @@ public class RequestLoggingMiddlewareTests
 
         return context;
     }
+
+    private static QueryStringMasker CriarMasker(RequestLoggingOptions? opcoes = null) =>
+        new(Options.Create(opcoes ?? new RequestLoggingOptions()));
 
     private static (Logger Logger, List<LogEvent> Eventos) CriarLoggerSerilog()
     {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -268,7 +268,7 @@ public class RequestLoggingMiddlewareTests
     }
 
     [Fact]
-    public async Task Construtor_ComDependenciaNula_DeveLancarArgumentNullException()
+    public void Construtor_ComDependenciaNula_DeveLancarArgumentNullException()
     {
         Func<RequestLoggingMiddleware> semNext =
             () => new RequestLoggingMiddleware(null!, NullLogger<RequestLoggingMiddleware>.Instance, CriarMasker(), CriarOptions());
@@ -283,8 +283,6 @@ public class RequestLoggingMiddlewareTests
         semLogger.Should().Throw<ArgumentNullException>();
         semMasker.Should().Throw<ArgumentNullException>();
         semOptions.Should().Throw<ArgumentNullException>();
-
-        await Task.CompletedTask;
     }
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -1,0 +1,265 @@
+namespace Unifesspa.UniPlus.Infrastructure.Common.Tests.Middleware;
+
+using FluentAssertions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+
+using Serilog;
+using Serilog.Context;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Extensions.Logging;
+
+using Unifesspa.UniPlus.Infrastructure.Common.Middleware;
+
+public class RequestLoggingMiddlewareTests
+{
+    [Fact]
+    public async Task InvokeAsync_DeveChamarProximoMiddleware()
+    {
+        DefaultHttpContext context = CriarContexto("GET", "/api/recurso");
+        bool proximoFoiChamado = false;
+
+        RequestLoggingMiddleware middleware = new(
+            _ =>
+            {
+                proximoFoiChamado = true;
+                return Task.CompletedTask;
+            },
+            NullLogger<RequestLoggingMiddleware>.Instance);
+
+        await middleware.InvokeAsync(context);
+
+        proximoFoiChamado.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(200)]
+    [InlineData(201)]
+    [InlineData(204)]
+    [InlineData(301)]
+    [InlineData(399)]
+    public async Task InvokeAsync_StatusAbaixo400_DeveLogarNoNivelInformation(int statusCode)
+    {
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", "/api/x", statusCode);
+
+        eventos.Should().ContainSingle();
+        eventos[0].Level.Should().Be(LogEventLevel.Information);
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(401)]
+    [InlineData(404)]
+    [InlineData(422)]
+    [InlineData(499)]
+    public async Task InvokeAsync_Status4xx_DeveLogarNoNivelWarning(int statusCode)
+    {
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("POST", "/api/x", statusCode);
+
+        eventos.Should().ContainSingle();
+        eventos[0].Level.Should().Be(LogEventLevel.Warning);
+    }
+
+    [Theory]
+    [InlineData(500)]
+    [InlineData(502)]
+    [InlineData(503)]
+    public async Task InvokeAsync_Status5xx_DeveLogarNoNivelError(int statusCode)
+    {
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", "/api/x", statusCode);
+
+        eventos.Should().ContainSingle();
+        eventos[0].Level.Should().Be(LogEventLevel.Error);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DeveIncluirPropriedadesMethodPathStatusEDuracao()
+    {
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("POST", "/api/editais", 201);
+
+        LogEvent log = eventos.Should().ContainSingle().Subject;
+        log.Properties["Method"].ToString().Trim('"').Should().Be("POST");
+        log.Properties["Path"].ToString().Trim('"').Should().Be("/api/editais");
+        log.Properties["StatusCode"].ToString().Should().Be("201");
+        long elapsed = long.Parse(log.Properties["ElapsedMs"].ToString(), System.Globalization.CultureInfo.InvariantCulture);
+        elapsed.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ComQueryStringSensivel_DeveRegistrarValorMascarado()
+    {
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync(
+            "GET",
+            "/api/candidatos",
+            200,
+            query: "?cpf=12345678900&page=1");
+
+        LogEvent log = eventos.Should().ContainSingle().Subject;
+        string queryValue = log.Properties["Query"].ToString().Trim('"');
+        queryValue.Should().Be("?cpf=***&page=1");
+        queryValue.Should().NotContain("12345678900");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoProximoLancaExcecao_DeveRegistrarLogEPropagar()
+    {
+        DefaultHttpContext context = CriarContexto("GET", "/api/x");
+        (Logger logger, List<LogEvent> eventos) = CriarLoggerSerilog();
+
+        try
+        {
+            using SerilogLoggerFactory factory = new(logger);
+            RequestLoggingMiddleware middleware = new(
+                _ => throw new InvalidOperationException("falha simulada"),
+                factory.CreateLogger<RequestLoggingMiddleware>());
+
+            Func<Task> acao = () => middleware.InvokeAsync(context);
+
+            await acao.Should().ThrowAsync<InvalidOperationException>();
+        }
+        finally
+        {
+            await logger.DisposeAsync();
+        }
+
+        eventos.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DentroDoEscopoDeLogContext_DeveEnriquecerComCorrelationId()
+    {
+        // Middleware vive dentro do escopo criado por CorrelationIdMiddleware,
+        // que faz LogContext.PushProperty("CorrelationId", ...). O enrichment
+        // aplica-se automaticamente a qualquer log emitido dentro desse escopo —
+        // teste confirma que o log do request carrega o correlation id.
+        const string correlationId = "req-logging-test-id";
+        DefaultHttpContext context = CriarContexto("GET", "/api/x");
+        (Logger logger, List<LogEvent> eventos) = CriarLoggerSerilog();
+
+        try
+        {
+            using SerilogLoggerFactory factory = new(logger);
+            RequestLoggingMiddleware middleware = new(
+                _ =>
+                {
+                    context.Response.StatusCode = 200;
+                    return Task.CompletedTask;
+                },
+                factory.CreateLogger<RequestLoggingMiddleware>());
+
+            using (LogContext.PushProperty(CorrelationIdMiddleware.LogContextProperty, correlationId))
+            {
+                await middleware.InvokeAsync(context);
+            }
+        }
+        finally
+        {
+            await logger.DisposeAsync();
+        }
+
+        LogEvent log = eventos.Should().ContainSingle().Subject;
+        log.Properties.Should().ContainKey(CorrelationIdMiddleware.LogContextProperty);
+        log.Properties[CorrelationIdMiddleware.LogContextProperty]
+            .ToString().Trim('"').Should().Be(correlationId);
+    }
+
+    [Fact]
+    public async Task Construtor_ComNext_OuLogger_Nulo_DeveLancar()
+    {
+        Func<RequestLoggingMiddleware> criarSemNext = () => new RequestLoggingMiddleware(null!, NullLogger<RequestLoggingMiddleware>.Instance);
+        Func<RequestLoggingMiddleware> criarSemLogger = () => new RequestLoggingMiddleware(_ => Task.CompletedTask, null!);
+
+        criarSemNext.Should().Throw<ArgumentNullException>();
+        criarSemLogger.Should().Throw<ArgumentNullException>();
+
+        await Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ComContextoNulo_DeveLancarArgumentNullException()
+    {
+        RequestLoggingMiddleware middleware = new(
+            _ => Task.CompletedTask,
+            NullLogger<RequestLoggingMiddleware>.Instance);
+
+        Func<Task> acao = () => middleware.InvokeAsync(null!);
+
+        await acao.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    private static async Task<List<LogEvent>> ExecutarERetornarLogsAsync(
+        string method,
+        string path,
+        int statusCode,
+        string? query = null)
+    {
+        DefaultHttpContext context = CriarContexto(method, path, query);
+        (Logger logger, List<LogEvent> eventos) = CriarLoggerSerilog();
+
+        try
+        {
+            using SerilogLoggerFactory factory = new(logger);
+            RequestLoggingMiddleware middleware = new(
+                _ =>
+                {
+                    context.Response.StatusCode = statusCode;
+                    return Task.CompletedTask;
+                },
+                factory.CreateLogger<RequestLoggingMiddleware>());
+
+            await middleware.InvokeAsync(context);
+        }
+        finally
+        {
+            await logger.DisposeAsync();
+        }
+
+        return eventos;
+    }
+
+    private static DefaultHttpContext CriarContexto(string method, string path, string? query = null)
+    {
+        DefaultHttpContext context = new();
+        context.Request.Method = method;
+        context.Request.Path = path;
+        if (!string.IsNullOrEmpty(query))
+        {
+            context.Request.QueryString = new QueryString(query);
+        }
+
+        return context;
+    }
+
+    private static (Logger Logger, List<LogEvent> Eventos) CriarLoggerSerilog()
+    {
+        List<LogEvent> eventos = new();
+        CapturingSink sink = new(eventos);
+        Logger logger = new LoggerConfiguration()
+            .MinimumLevel.Verbose()
+            .Enrich.FromLogContext()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        return (logger, eventos);
+    }
+
+    private sealed class CapturingSink : ILogEventSink
+    {
+        private readonly List<LogEvent> _eventos;
+
+        public CapturingSink(List<LogEvent> eventos)
+        {
+            _eventos = eventos;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            ArgumentNullException.ThrowIfNull(logEvent);
+            _eventos.Add(logEvent);
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -30,7 +30,8 @@ public class RequestLoggingMiddlewareTests
                 return Task.CompletedTask;
             },
             NullLogger<RequestLoggingMiddleware>.Instance,
-            CriarMasker());
+            CriarMasker(),
+            CriarOptions());
 
         await middleware.InvokeAsync(context);
 
@@ -105,6 +106,59 @@ public class RequestLoggingMiddlewareTests
         queryValue.Should().NotContain("12345678900");
     }
 
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/health/ready")]
+    [InlineData("/health/live")]
+    [InlineData("/metrics")]
+    public async Task InvokeAsync_ComPathSilenciadoESucesso_NaoDeveEmitirLog(string path)
+    {
+        // Probes Kubernetes (liveness/readiness) batem endpoints de infra a
+        // cada poucos segundos. Silenciar respostas bem-sucedidas evita
+        // saturar observabilidade com tráfego sem valor acionável, preservando
+        // signal-to-noise útil para debugging.
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", path, 200);
+
+        eventos.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("/HEALTH")]
+    [InlineData("/Health")]
+    [InlineData("/HeAlTh/ReAdY")]
+    public async Task InvokeAsync_ComPathSilenciadoEmGrafiaVariada_DeveIgnorarCaseInsensitive(string path)
+    {
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", path, 200);
+
+        eventos.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(500)]
+    [InlineData(503)]
+    public async Task InvokeAsync_ComPathSilenciadoERespostaErro_DeveLogarParaVisibilidadeDeFalha(int statusCode)
+    {
+        // Health check que retorna 503 (dependência down) é informação crítica —
+        // silêncio em erros equivale a apagar alarme. Mantemos o log.
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", "/health", statusCode);
+
+        eventos.Should().ContainSingle();
+        eventos[0].Level.Should().Be(LogEventLevel.Error);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ComListaDePathsSilenciadosCustomizada_DeveRespeitarConfiguracaoInjetada()
+    {
+        RequestLoggingOptions opcoes = new() { PathsSilenciados = ["/custom/noise"] };
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", "/custom/noise", 200, opcoes: opcoes);
+        List<LogEvent> eventosHealth = await ExecutarERetornarLogsAsync("GET", "/health", 200, opcoes: opcoes);
+
+        // /custom/noise silenciado por config; /health volta a ser logado porque
+        // a lista customizada substituiu a default.
+        eventos.Should().BeEmpty();
+        eventosHealth.Should().ContainSingle();
+    }
+
     [Fact]
     public async Task InvokeAsync_QuandoProximoLancaExcecao_DeveRegistrarLogEPropagar()
     {
@@ -117,7 +171,8 @@ public class RequestLoggingMiddlewareTests
             RequestLoggingMiddleware middleware = new(
                 _ => throw new InvalidOperationException("falha simulada"),
                 factory.CreateLogger<RequestLoggingMiddleware>(),
-                CriarMasker());
+                CriarMasker(),
+            CriarOptions());
 
             Func<Task> acao = () => middleware.InvokeAsync(context);
 
@@ -152,7 +207,8 @@ public class RequestLoggingMiddlewareTests
                     return Task.CompletedTask;
                 },
                 factory.CreateLogger<RequestLoggingMiddleware>(),
-                CriarMasker());
+                CriarMasker(),
+            CriarOptions());
 
             using (LogContext.PushProperty(CorrelationIdMiddleware.LogContextProperty, correlationId))
             {
@@ -171,15 +227,21 @@ public class RequestLoggingMiddlewareTests
     }
 
     [Fact]
-    public async Task Construtor_ComNext_OuLogger_Nulo_DeveLancar()
+    public async Task Construtor_ComDependenciaNula_DeveLancarArgumentNullException()
     {
-        Func<RequestLoggingMiddleware> criarSemNext = () => new RequestLoggingMiddleware(null!, NullLogger<RequestLoggingMiddleware>.Instance, CriarMasker());
-        Func<RequestLoggingMiddleware> criarSemLogger = () => new RequestLoggingMiddleware(_ => Task.CompletedTask, null!, CriarMasker());
-        Func<RequestLoggingMiddleware> criarSemMasker = () => new RequestLoggingMiddleware(_ => Task.CompletedTask, NullLogger<RequestLoggingMiddleware>.Instance, null!);
+        Func<RequestLoggingMiddleware> semNext =
+            () => new RequestLoggingMiddleware(null!, NullLogger<RequestLoggingMiddleware>.Instance, CriarMasker(), CriarOptions());
+        Func<RequestLoggingMiddleware> semLogger =
+            () => new RequestLoggingMiddleware(_ => Task.CompletedTask, null!, CriarMasker(), CriarOptions());
+        Func<RequestLoggingMiddleware> semMasker =
+            () => new RequestLoggingMiddleware(_ => Task.CompletedTask, NullLogger<RequestLoggingMiddleware>.Instance, null!, CriarOptions());
+        Func<RequestLoggingMiddleware> semOptions =
+            () => new RequestLoggingMiddleware(_ => Task.CompletedTask, NullLogger<RequestLoggingMiddleware>.Instance, CriarMasker(), null!);
 
-        criarSemNext.Should().Throw<ArgumentNullException>();
-        criarSemLogger.Should().Throw<ArgumentNullException>();
-        criarSemMasker.Should().Throw<ArgumentNullException>();
+        semNext.Should().Throw<ArgumentNullException>();
+        semLogger.Should().Throw<ArgumentNullException>();
+        semMasker.Should().Throw<ArgumentNullException>();
+        semOptions.Should().Throw<ArgumentNullException>();
 
         await Task.CompletedTask;
     }
@@ -190,7 +252,8 @@ public class RequestLoggingMiddlewareTests
         RequestLoggingMiddleware middleware = new(
             _ => Task.CompletedTask,
             NullLogger<RequestLoggingMiddleware>.Instance,
-            CriarMasker());
+            CriarMasker(),
+            CriarOptions());
 
         Func<Task> acao = () => middleware.InvokeAsync(null!);
 
@@ -201,7 +264,8 @@ public class RequestLoggingMiddlewareTests
         string method,
         string path,
         int statusCode,
-        string? query = null)
+        string? query = null,
+        RequestLoggingOptions? opcoes = null)
     {
         DefaultHttpContext context = CriarContexto(method, path, query);
         (Logger logger, List<LogEvent> eventos) = CriarLoggerSerilog();
@@ -216,7 +280,8 @@ public class RequestLoggingMiddlewareTests
                     return Task.CompletedTask;
                 },
                 factory.CreateLogger<RequestLoggingMiddleware>(),
-                CriarMasker());
+                CriarMasker(opcoes),
+                CriarOptions(opcoes));
 
             await middleware.InvokeAsync(context);
         }
@@ -243,6 +308,9 @@ public class RequestLoggingMiddlewareTests
 
     private static QueryStringMasker CriarMasker(RequestLoggingOptions? opcoes = null) =>
         new(Options.Create(opcoes ?? new RequestLoggingOptions()));
+
+    private static IOptions<RequestLoggingOptions> CriarOptions(RequestLoggingOptions? opcoes = null) =>
+        Options.Create(opcoes ?? new RequestLoggingOptions());
 
     private static (Logger Logger, List<LogEvent> Eventos) CriarLoggerSerilog()
     {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -136,6 +136,63 @@ public class RequestLoggingMiddlewareTests
         eventos.Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task InvokeAsync_ComPathSilenciadoEQueryString_DeveContinuarSilenciandoPorqueHttpRequestPathExcluiQuery()
+    {
+        // Regressão explícita: ASP.NET separa HttpRequest.Path e HttpRequest.QueryString
+        // em propriedades distintas. Um atacante (ou ferramenta de probe) que inclua
+        // query params em /health não consegue driblar o silêncio — o path comparado
+        // é exatamente "/health".
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", "/health", 200, query: "?cpf=12345678900&v=1");
+
+        eventos.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("/health/")]
+    [InlineData("/metrics/")]
+    public async Task InvokeAsync_ComPathSilenciadoETrailingSlash_DeveSilenciar(string path)
+    {
+        // Clientes (proxies, load balancers, Kubernetes probes) podem adicionar
+        // trailing slash ao path. Sem normalização, `/health/` escaparia do match
+        // exato contra `/health` — fazendo com que metade das probes caísse no
+        // log operacional.
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", path, 200);
+
+        eventos.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("/health/db")]
+    [InlineData("/health/redis")]
+    [InlineData("/health/db/postgresql")]
+    [InlineData("/metrics/prometheus")]
+    public async Task InvokeAsync_ComSubpathDePathSilenciado_DeveSilenciar(string path)
+    {
+        // Libraries como AspNetCore.HealthChecks.UI expõem subpaths granulares.
+        // Match por prefixo com boundary em `/` permite silenciar a família
+        // inteira declarando apenas o prefixo-pai.
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", path, 200);
+
+        eventos.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("/healthy")]       // "/health" + "y" — não é subpath
+    [InlineData("/health-ui")]     // "/health" + "-ui" — não é subpath
+    [InlineData("/healthcheck")]   // "/health" + "check" — não é subpath
+    [InlineData("/metricsxpto")]   // "/metrics" + "xpto" — não é subpath
+    public async Task InvokeAsync_ComPathSimilarMasSemBoundary_NaoDeveSilenciar(string path)
+    {
+        // Boundary guard: prefix match só aceita `/` como separador após o prefixo.
+        // Caso contrário, rotas de negócio com nomes que começam com "health"
+        // ("/healthy", "/health-report") cairiam silenciosamente no vazio.
+        List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", path, 200);
+
+        eventos.Should().ContainSingle();
+        eventos[0].Level.Should().Be(LogEventLevel.Information);
+    }
+
     [Theory]
     [InlineData(500)]
     [InlineData(503)]

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -209,7 +209,9 @@ public class RequestLoggingMiddlewareTests
     [Fact]
     public async Task InvokeAsync_ComListaDePrefixosSilenciadosCustomizada_DeveRespeitarConfiguracaoInjetada()
     {
-        RequestLoggingOptions opcoes = new() { PrefixosSilenciados = ["/custom/noise"] };
+        RequestLoggingOptions opcoes = new();
+        opcoes.PrefixosSilenciados.Clear();
+        opcoes.PrefixosSilenciados.Add("/custom/noise");
         List<LogEvent> eventos = await ExecutarERetornarLogsAsync("GET", "/custom/noise", 200, opcoes: opcoes);
         List<LogEvent> eventosHealth = await ExecutarERetornarLogsAsync("GET", "/health", 200, opcoes: opcoes);
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -87,8 +87,11 @@ public class RequestLoggingMiddlewareTests
         log.Properties["Method"].ToString().Trim('"').Should().Be("POST");
         log.Properties["Path"].ToString().Trim('"').Should().Be("/api/editais");
         log.Properties["StatusCode"].ToString().Should().Be("201");
-        long elapsed = long.Parse(log.Properties["ElapsedMs"].ToString(), System.Globalization.CultureInfo.InvariantCulture);
-        elapsed.Should().BeGreaterThanOrEqualTo(0);
+        double elapsed = double.Parse(log.Properties["ElapsedMs"].ToString(), System.Globalization.CultureInfo.InvariantCulture);
+        elapsed.Should().BeGreaterThanOrEqualTo(0d);
+        // Tipo preservado como ScalarValue de double: testar o tipo subjacente
+        // evita regressão que reintroduza truncamento para long.
+        ((Serilog.Events.ScalarValue)log.Properties["ElapsedMs"]).Value.Should().BeOfType<double>();
     }
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -328,7 +328,7 @@ public class RequestLoggingMiddlewareTests
                 },
                 factory.CreateLogger<RequestLoggingMiddleware>(),
                 CriarMasker(),
-            CriarOptions());
+                CriarOptions());
 
             using (LogContext.PushProperty(CorrelationIdMiddleware.LogContextProperty, correlationId))
             {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -160,23 +160,60 @@ public class RequestLoggingMiddlewareTests
     }
 
     [Fact]
-    public async Task InvokeAsync_QuandoProximoLancaExcecao_DeveRegistrarLogEPropagar()
+    public async Task InvokeAsync_QuandoProximoLancaExcecao_DeveLogarNivelErrorComExceptionEPropagar()
     {
+        // Cenário defensivo: GlobalExceptionMiddleware normalmente absorve
+        // exceções e seta status 5xx. Se por algum motivo a exception
+        // escapar (bug no pipeline, middleware removido), o request-logger
+        // precisa sinalizar a falha — não pode aparecer como Information 200.
         DefaultHttpContext context = CriarContexto("GET", "/api/x");
+        (Logger logger, List<LogEvent> eventos) = CriarLoggerSerilog();
+        InvalidOperationException falhaSimulada = new("falha simulada");
+
+        try
+        {
+            using SerilogLoggerFactory factory = new(logger);
+            RequestLoggingMiddleware middleware = new(
+                _ => throw falhaSimulada,
+                factory.CreateLogger<RequestLoggingMiddleware>(),
+                CriarMasker(),
+                CriarOptions());
+
+            Func<Task> acao = () => middleware.InvokeAsync(context);
+
+            await acao.Should().ThrowAsync<InvalidOperationException>()
+                .Where(ex => ReferenceEquals(ex, falhaSimulada));
+        }
+        finally
+        {
+            await logger.DisposeAsync();
+        }
+
+        LogEvent log = eventos.Should().ContainSingle().Subject;
+        log.Level.Should().Be(LogEventLevel.Error);
+        log.Exception.Should().BeSameAs(falhaSimulada);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_QuandoProximoLancaExcecaoEmPathSilenciado_DeveAindaLogar()
+    {
+        // Silenciamento aplica-se apenas a requests bem-sucedidos. Falha
+        // (exception) em /health não pode desaparecer — é exatamente quando
+        // o oncall precisa enxergar.
+        DefaultHttpContext context = CriarContexto("GET", "/health");
         (Logger logger, List<LogEvent> eventos) = CriarLoggerSerilog();
 
         try
         {
             using SerilogLoggerFactory factory = new(logger);
             RequestLoggingMiddleware middleware = new(
-                _ => throw new InvalidOperationException("falha simulada"),
+                _ => throw new InvalidOperationException("dependência indisponível"),
                 factory.CreateLogger<RequestLoggingMiddleware>(),
                 CriarMasker(),
-            CriarOptions());
+                CriarOptions());
 
-            Func<Task> acao = () => middleware.InvokeAsync(context);
-
-            await acao.Should().ThrowAsync<InvalidOperationException>();
+            await FluentActions.Invoking(() => middleware.InvokeAsync(context))
+                .Should().ThrowAsync<InvalidOperationException>();
         }
         finally
         {
@@ -184,6 +221,7 @@ public class RequestLoggingMiddlewareTests
         }
 
         eventos.Should().ContainSingle();
+        eventos[0].Level.Should().Be(LogEventLevel.Error);
     }
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Common.Tests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -207,6 +207,26 @@ public class RequestLoggingMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_ComListaDePrefixosVazia_DeveLogarTodosOsPathsIncluindoHealth()
+    {
+        // Validator aceita PrefixosSilenciados vazia explicitamente — é o modo
+        // documentado de desativar o silenciamento. Este teste trava esse
+        // contrato: se alguma normalização futura começar a reintroduzir
+        // defaults quando a lista está vazia, o teste falha antes de entrar
+        // em produção.
+        RequestLoggingOptions opcoes = new();
+        opcoes.PrefixosSilenciados.Clear();
+
+        List<LogEvent> eventosHealth = await ExecutarERetornarLogsAsync("GET", "/health", 200, opcoes: opcoes);
+        List<LogEvent> eventosMetrics = await ExecutarERetornarLogsAsync("GET", "/metrics", 200, opcoes: opcoes);
+
+        eventosHealth.Should().ContainSingle();
+        eventosHealth[0].Level.Should().Be(LogEventLevel.Information);
+        eventosMetrics.Should().ContainSingle();
+        eventosMetrics[0].Level.Should().Be(LogEventLevel.Information);
+    }
+
+    [Fact]
     public async Task InvokeAsync_ComListaDePrefixosSilenciadosCustomizada_DeveRespeitarConfiguracaoInjetada()
     {
         RequestLoggingOptions opcoes = new();


### PR DESCRIPTION
## Resumo

- Adiciona `RequestLoggingMiddleware` em `Infrastructure.Common` que loga HTTP method, path, status code e duração (double ms) com nível proporcional ao status (Info <400, Warn 4xx, Error 5xx) e eleva para Error em qualquer exceção capturada no pipeline.
- Introduz `QueryStringMasker` como serviço DI configurável via `RequestLoggingOptions`, com defaults LGPD (`cpf`, `email`, `senha`, `password`, `token`) que appsettings amplia sem conseguir remover — validador `IValidateOptions<T>` com `ValidateOnStart` falha o boot se alguma configuração zerar o masking.
- Silencia logs de sucesso em paths de infraestrutura (`/health`, `/metrics` e subpaths) via match por prefixo com boundary em `/` — elimina ruído de probes Kubernetes sem abrir falso positivo para rotas de negócio (`/healthy`, `/health-ui`).

## Arquivos

### Produção (4)

- `src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingOptions.cs` — DTO de options com XML-doc documentando semântica de merge+dedup, prefix match com boundary, silêncio condicional por status. Coleções `{ get; }` (get-only, sem setter) — idiomático para Options, zero suppressões de analisador. Validator separado em três métodos por regra (`ValidarNomesParametrosSensiveis`, `ValidarPrefixosSilenciados`, `ValidarValorMascarado`).
- `src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/QueryStringMasker.cs` — sealed injetável, `FrozenSet` construído uma vez do `IOptions<T>`. Decodifica chave antes de comparar para impedir bypass via percent-encoding (`?%63%70%66=123`).
- `src/shared/Unifesspa.UniPlus.Infrastructure.Common/Middleware/RequestLoggingMiddleware.cs` — `try/catch/throw` + `finally` captura exceção para elevar nível do log preservando stack trace via `throw;`. `DeveSilenciar(path)` opera sobre `ReadOnlySpan<char>` (zero-alloc) com boundary guard em `/`. Três `[LoggerMessage]` com `Exception?` no último parâmetro (convenção do source generator).
- `src/shared/Unifesspa.UniPlus.Infrastructure.Common/DependencyInjection/RequestLoggingServiceCollectionExtensions.cs` — `AddRequestLogging(IConfiguration?, Action<RequestLoggingOptions>?)` com bind condicional por `.Exists()`, `PostConfigure` mutando listas in-place (trim + dedup case-insensitive), `ValidateOnStart` para fail-fast LGPD.

### Testes (3, 134 testes)

- `tests/.../Middleware/QueryStringMaskerTests.cs` — 15 testes: parâmetros sensíveis isolados (incluindo valor vazio `?cpf=`), variações case, preservação de URL-encoding, bypass por chave percent-encoded, duplicatas, ampersands consecutivos, customização via options.
- `tests/.../Middleware/RequestLoggingMiddlewareTests.cs` — 28 testes: níveis de log por status (5+5+3 theories), propriedades estruturadas no log event (Method/Path/StatusCode/ElapsedMs como double), masking em query, silêncio de `/health`/`/metrics` + subpaths, boundary guard para `/healthy`/`/health-ui`/`/healthcheck`, regressão de query string (ASP.NET separa Path de QueryString), preservação de log em erros e exceções em paths silenciados, propagação de correlation id via `LogContext`, lista de prefixos vazia, exceção elevada a Error, validação de todas as dependências nulas.
- `tests/.../DependencyInjection/RequestLoggingServiceCollectionExtensionsTests.cs` — 8 testes: defaults sem configuração, substituição via Clear+Add, bind de `IConfiguration`, normalização in-place, fail-fast por lista vazia, valor mascarado vazio, path sem `/` inicial, arg nulo.

### Modificados (2)

- `src/selecao/.../Program.cs` e `src/ingresso/.../Program.cs` — `AddRequestLogging(builder.Configuration)` logo após `AddCorrelationIdAccessor`; `UseMiddleware<RequestLoggingMiddleware>()` entre `CorrelationIdMiddleware` e `GlobalExceptionMiddleware`.

## Critérios de aceite atendidos

- [x] Middleware loga method, path, status code e duração em ms (como double, preserva sub-ms para P95/P99).
- [x] Query strings com parâmetros sensíveis mascaradas (`?cpf=***`).
- [x] Request body **não** é lido nem logado.
- [x] Log level: Information para <400, Warning para 4xx, Error para 5xx (exceção força Error independente do status).
- [x] Correlation ID incluído nos logs via `LogContext` do middleware upstream.
- [x] Testes unitários do middleware.

## Decisões arquiteturais

- **Options pattern com validação fail-fast**: `IValidateOptions<T>` + `ValidateOnStart` impede deploy em produção com masking LGPD quebrado por appsettings.
- **Semântica merge+dedup, não replace**: config amplia defaults em vez de substituir — appsettings não consegue acidentalmente remover `cpf` da proteção. Substituição exige `Clear()` explícito, tornando o intent visível no código.
- **Prefix match com boundary em `/`**: `/health` cobre `/health/`, `/health/ready`, `/health/db/postgresql` mas rejeita `/healthy`/`/health-ui`. Resolve silenciamento de dashboards de health-check sem abrir falso positivo.
- **Exception captured, não swallowed**: `catch → capturar referência → throw;` preserva stack trace para `GlobalExceptionMiddleware` e eleva nível do log a Error mesmo quando status code não foi alterado.
- **Zero suppressões de analisador**: coleções são `{ get; }` com inicializador (padrão idiomático do .NET Options), `IConfiguration.Bind` e `Configure<T>()` mutam via `.Add()`; não precisamos lutar contra `CA2227`.

## Verificação

- Build: `dotnet build UniPlus.slnx` — `0 Aviso(s), 0 Erro(s)` sob `TreatWarningsAsErrors=true`.
- Infrastructure.Common.Tests: **134/134** aprovados (51 novos + 83 pré-existentes).
- SharedKernel.Tests: **19/19** aprovados.

## Referências

- Closes #31
- Depende de #28 (Correlation ID middleware) — concluído
- ADR-012 (LGPD by design) · ADR-014 (OpenTelemetry / logging estruturado)

## Checklist

- [x] Build sem errors
- [x] Testes passando
- [ ] Code review