### PR TITLE
fix(auth): adicionar id uuid ao mapper aud-uniplus

### DIFF
--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -1131,6 +1131,7 @@
           }
         },
         {
+          "id": "b34d13a5-d6f3-46e2-8131-a4ac99a9f825",
           "name": "aud-uniplus",
           "protocol": "openid-connect",
           "protocolMapper": "oidc-audience-mapper",


### PR DESCRIPTION
## Resumo

Adicionar campo `id` UUID ao protocol mapper `aud-uniplus` no client scope `uniplus-profile`.

## Problema

O mapper foi incorporado ao realm-export.json via PR #80 / hardening #67 sem o campo `id`. Sem ele, o Keycloak gera um UUID aleatório a cada import — em reimports sobre realm existente pode criar mappers duplicados (`aud-uniplus` duplicado), resultando em dois valores `"uniplus"` na claim `aud` e potencial falha na validação do backend.

## O que muda

`docker/keycloak/realm-export.json` — adiciona `"id": "b34d13a5-d6f3-46e2-8131-a4ac99a9f825"` ao mapper `aud-uniplus`, alinhando-o aos demais mappers do mesmo `protocolMappers[]` (`nomeSocial` e `cpf`) que já possuem UUID explícito.

## Referências

- ADR-019 — Audience única `uniplus` para tokens OIDC da plataforma
- Finding [I1] da revisão do PR #80

Refs #68