### PR TITLE
chore(arch-tests): substituir NetArchTest por TngTech.ArchUnitNET (ADR-023)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - **Validação:** FluentValidation 12
 - **Logging:** Serilog 10
 - **Observabilidade:** OpenTelemetry
-- **Testes:** xUnit, FluentAssertions, NSubstitute, Bogus, Testcontainers, NetArchTest
+- **Testes:** xUnit, FluentAssertions, NSubstitute, Bogus, Testcontainers, ArchUnitNET (pacote `TngTech.ArchUnitNET`)
 
 ## Estrutura do projeto
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,8 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
-    <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
+    <PackageVersion Include="TngTech.ArchUnitNET" Version="0.13.3" />
+    <PackageVersion Include="TngTech.ArchUnitNET.xUnit" Version="0.13.3" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
   </ItemGroup>
 </Project>

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj
@@ -10,7 +10,8 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="NetArchTest.Rules" />
+    <PackageReference Include="TngTech.ArchUnitNET" />
+    <PackageReference Include="TngTech.ArchUnitNET.xUnit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/Unifesspa.UniPlus.Selecao.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/Unifesspa.UniPlus.Selecao.ArchTests.csproj
@@ -10,7 +10,8 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="NetArchTest.Rules" />
+    <PackageReference Include="TngTech.ArchUnitNET" />
+    <PackageReference Include="TngTech.ArchUnitNET.xUnit" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Resumo

- Remove `NetArchTest.Rules 1.3.2` do `Directory.Packages.props` e adiciona `TngTech.ArchUnitNET 0.13.3` + `TngTech.ArchUnitNET.xUnit 0.13.3` com pinning exato, conforme [ADR-023](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-023-biblioteca-canonica-de-fitness-tests.md).
- Sincroniza `PackageReference` em `Selecao.ArchTests` e `Ingresso.ArchTests`.
- Atualiza `CLAUDE.md` (stack de testes) para refletir a nova biblioteca.

## Mudanças

### Modificados
- `Directory.Packages.props` — swap `NetArchTest.Rules` → `TngTech.ArchUnitNET` + `TngTech.ArchUnitNET.xUnit` (versão exata `0.13.3`).
- `tests/Unifesspa.UniPlus.Selecao.ArchTests/Unifesspa.UniPlus.Selecao.ArchTests.csproj` — `PackageReference` atualizado.
- `tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj` — `PackageReference` atualizado.
- `CLAUDE.md` — linha 16, lista de stack de testes passa a citar `ArchUnitNET (pacote TngTech.ArchUnitNET)`.

## Nota técnica — package id NuGet

O publisher TNG Technology Consulting publica o pacote no NuGet sob o id **`TngTech.ArchUnitNET`** (e `TngTech.ArchUnitNET.xUnit`), não `ArchUnitNET` puro. A **namespace C#** dentro do assembly continua sendo `ArchUnitNET.*`. Esse detalhe não estava explícito no ADR-023 — a errata correspondente está em [`uniplus-docs#77`](https://github.com/unifesspa-edu-br/uniplus-docs/issues/77).

A versão `2.1.0-draft` que aparece no índice do feed NuGet está unlisted (draft de 2019 abandonado pelo publisher); `0.13.3` é genuinamente a versão estável mais recente.

## Validação local

- `dotnet restore UniPlus.slnx` — OK
- `dotnet build UniPlus.slnx --no-restore` — **0 avisos, 0 erros**
- `dotnet test UniPlus.slnx --no-build` — **232/232 testes passando** (skeletons que reportam "no tests available" — incluindo os dois `*.ArchTests` — são esperados; as fixtures R1–R4 chegam nas tasks irmãs B–E)

## Critérios de aceite (Task #139)

- [x] `Directory.Packages.props` — `NetArchTest.Rules` removido.
- [x] `Directory.Packages.props` — `TngTech.ArchUnitNET` + `TngTech.ArchUnitNET.xUnit` com pinning exato `0.13.3`.
- [x] `Unifesspa.UniPlus.Selecao.ArchTests.csproj` — referências atualizadas.
- [x] `Unifesspa.UniPlus.Ingresso.ArchTests.csproj` — referências atualizadas.
- [ ] `dotnet restore` no CI executa sem erro (validado pelo workflow do PR).

## Test plan

- [ ] CI verde (build + restore + tests)
- [ ] Confirmar que ambos `*.ArchTests` carregam após o restore
- [ ] As fixtures R1–R4 (tasks B–E da Story #138) ficam fora deste PR

## Referências

- ADR-023 — biblioteca canônica de fitness tests arquiteturais
- Story pai: #138
- Errata vinculada: uniplus-docs#77

Closes #139