### PR TITLE
docs(claude): alinhar CLAUDE.md ao ADR-022 (Wolverine) e à decisão #155

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 - **Cache:** Redis 8
 - **Storage:** MinIO (S3-compatible)
 - **Autenticação:** Keycloak 26.5 (Gov.br)
-- **CQRS/messaging:** Wolverine 5.x — abstrações `ICommandBus` / `IDomainEventDispatcher` em `Application.Abstractions/Messaging`, outbox transacional via `WolverineFx.EntityFrameworkCore`. Ver [ADR-022](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md).
+- **CQRS/messaging:** Wolverine 5.x — abstração `ICommandBus` em `Application.Abstractions/Messaging` com implementação `WolverineCommandBus` (delega para `Wolverine.IMessageBus`). Ver [ADR-022](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md). **Outbox transacional de domain events ainda não foi adotado** — ver [ADR-024](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md) e [issue #158](https://github.com/unifesspa-edu-br/uniplus-api/issues/158); `EntityBase.DomainEvents` continua presente no domínio mas não é drenado automaticamente.
 - **Validação:** FluentValidation 12
 - **Logging:** Serilog 10
 - **Observabilidade:** OpenTelemetry
@@ -61,7 +61,7 @@ Application NUNCA depende de Infrastructure ou API.
 - **Soft delete** em todas as entidades: `IsDeleted`, `DeletedAt`, `DeletedBy`
 - **PII masking** em logs: CPF `***.***.***-XX`, nunca logar dados sensíveis — aplicado automaticamente pelo `PiiMaskingEnricher` (registrado no pipeline Serilog via `ConfigurarSerilog`) a todas as propriedades estruturadas, inclusive aninhadas (`StructureValue`, `SequenceValue`, `DictionaryValue`)
 - **Result pattern** para retorno de operações: `Result<T>` com `DomainError`
-- **CQRS** via Wolverine: commands escritos via `ICommandBus.Send`, domain events via `AddDomainEvent` na entidade + outbox transacional, queries via repositórios. Padrões e exemplos em `docs/guia-wolverine-golden-path.md` (`uniplus-docs`)
+- **CQRS** via Wolverine: commands escritos via `ICommandBus.Send`, queries via repositórios. Domain events (`AddDomainEvent` em `EntityBase`) continuam acumulando na entidade — drenagem para outbox/bus está reprovada por enquanto (ver [ADR-024](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md) e [issue #158](https://github.com/unifesspa-edu-br/uniplus-api/issues/158)). Não escrever código de aplicação que dependa do despacho automático de domain events. Padrões e exemplos em `docs/guia-wolverine-golden-path.md` (`uniplus-docs`)
 - **Value objects** para dados de domínio: `Cpf`, `Email`, `NomeSocial`, `NotaFinal`, `NumeroEdital`
 - **Factory methods** com construtores privados em todas as entidades
 - **Sealed classes** por padrão (exceto bases abstratas)
@@ -172,7 +172,6 @@ docker compose -f docker/docker-compose.yml up -d
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
 
 # Migrations EF Core — NÃO rodar para entidades de domínio até #155 definir naming convention.
-# (A outbox do Wolverine não precisa de migration: o schema é criado via AddResourceSetupOnStartup.)
 dotnet ef migrations add <Nome> --project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure --startup-project src/selecao/Unifesspa.UniPlus.Selecao.API
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 - **Cache:** Redis 8
 - **Storage:** MinIO (S3-compatible)
 - **Autenticação:** Keycloak 26.5 (Gov.br)
-- **CQRS/messaging:** Wolverine 5.x ([ADR-022](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md)) — `ICommandBus` / `IDomainEventDispatcher` em `Application.Abstractions/Messaging`, outbox transacional via `WolverineFx.EntityFrameworkCore`. **MediatR foi descontinuado** no projeto (licenciamento comercial 07/2025).
+- **CQRS/messaging:** Wolverine 5.x — abstrações `ICommandBus` / `IDomainEventDispatcher` em `Application.Abstractions/Messaging`, outbox transacional via `WolverineFx.EntityFrameworkCore`. Ver [ADR-022](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md).
 - **Validação:** FluentValidation 12
 - **Logging:** Serilog 10
 - **Observabilidade:** OpenTelemetry
@@ -61,7 +61,7 @@ Application NUNCA depende de Infrastructure ou API.
 - **Soft delete** em todas as entidades: `IsDeleted`, `DeletedAt`, `DeletedBy`
 - **PII masking** em logs: CPF `***.***.***-XX`, nunca logar dados sensíveis — aplicado automaticamente pelo `PiiMaskingEnricher` (registrado no pipeline Serilog via `ConfigurarSerilog`) a todas as propriedades estruturadas, inclusive aninhadas (`StructureValue`, `SequenceValue`, `DictionaryValue`)
 - **Result pattern** para retorno de operações: `Result<T>` com `DomainError`
-- **CQRS** via Wolverine: Commands para escrita (`ICommandBus.Send`), domain events (`AddDomainEvent` na entidade + outbox transacional), Queries via repositórios — ver `docs/guia-wolverine-golden-path.md` no repo `uniplus-docs`
+- **CQRS** via Wolverine: commands escritos via `ICommandBus.Send`, domain events via `AddDomainEvent` na entidade + outbox transacional, queries via repositórios. Padrões e exemplos em `docs/guia-wolverine-golden-path.md` (`uniplus-docs`)
 - **Value objects** para dados de domínio: `Cpf`, `Email`, `NomeSocial`, `NotaFinal`, `NumeroEdital`
 - **Factory methods** com construtores privados em todas as entidades
 - **Sealed classes** por padrão (exceto bases abstratas)
@@ -88,33 +88,17 @@ O source generator de `[LoggerMessage]` (.NET 6+) gera código que:
 Classe `partial`, método `private static partial void Log{Ação}` no fim da classe, `ILogger` como primeiro parâmetro:
 
 ```csharp
-namespace Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
-
-using Microsoft.Extensions.Logging;
-
 public sealed partial class PublicarEditalCommandHandler
 {
-    public async Task<Result<Unit>> Handle(
-        PublicarEditalCommand command,
-        SelecaoDbContext db,
-        ILogger<PublicarEditalCommandHandler> logger,
-        CancellationToken ct)
+    private readonly ILogger<PublicarEditalCommandHandler> _logger;
+
+    public void Executar(Guid editalId)
     {
-        LogProcessando(logger, command.EditalId);                   // chamada idiomática
-        Edital? edital = await db.Editais.FindAsync([command.EditalId], ct).ConfigureAwait(false);
-        if (edital is null)
-            return Result<Unit>.Failure(EditalErrors.NaoEncontrado);
-        edital.Publicar();
-        await db.SaveChangesAsync(ct).ConfigureAwait(false);
-        LogConcluido(logger, command.EditalId);
-        return Result<Unit>.Success(Unit.Value);
+        LogPublicando(_logger, editalId);   // chamada idiomática (gerada em compile time)
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Publicando edital {EditalId}")]
-    private static partial void LogProcessando(ILogger logger, Guid editalId);
-
-    [LoggerMessage(Level = LogLevel.Information, Message = "Edital {EditalId} publicado")]
-    private static partial void LogConcluido(ILogger logger, Guid editalId);
+    private static partial void LogPublicando(ILogger logger, Guid editalId);
 }
 ```
 
@@ -151,7 +135,7 @@ Sem `SkipEnabledCheck`, o source generator sempre gera a guarda internamente —
 - [CA1848 — Use the LoggerMessage delegates](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1848)
 - [CA1873 — Avoid potentially expensive logging](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1873)
 - [Compile-time logging source generation](https://learn.microsoft.com/dotnet/core/extensions/logging/source-generation)
-- Exemplos no projeto: `src/*/API/Middleware/GlobalExceptionMiddleware.cs`, `src/*/Application/Behaviors/LoggingBehavior.cs`
+- Exemplos no projeto: `src/*/API/Middleware/GlobalExceptionMiddleware.cs`, `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Middleware/RequestLoggingMiddleware.cs`
 
 ## Supressão de análise de código
 
@@ -187,8 +171,8 @@ docker compose -f docker/docker-compose.yml up -d
 # APIs em modo desenvolvimento
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
 
-# Migrations EF Core — referência de comando (NÃO rodar para entidades de domínio até issue #155
-# definir naming convention e InitialCreate revisado; outbox do Wolverine usa AddResourceSetupOnStartup)
+# Migrations EF Core — NÃO rodar para entidades de domínio até #155 definir naming convention.
+# (A outbox do Wolverine não precisa de migration: o schema é criado via AddResourceSetupOnStartup.)
 dotnet ef migrations add <Nome> --project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure --startup-project src/selecao/Unifesspa.UniPlus.Selecao.API
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 - **Cache:** Redis 8
 - **Storage:** MinIO (S3-compatible)
 - **Autenticação:** Keycloak 26.5 (Gov.br)
-- **CQRS:** MediatR 14
+- **CQRS/messaging:** Wolverine 5.x ([ADR-022](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md)) — `ICommandBus` / `IDomainEventDispatcher` em `Application.Abstractions/Messaging`, outbox transacional via `WolverineFx.EntityFrameworkCore`. **MediatR foi descontinuado** no projeto (licenciamento comercial 07/2025).
 - **Validação:** FluentValidation 12
 - **Logging:** Serilog 10
 - **Observabilidade:** OpenTelemetry
@@ -61,7 +61,7 @@ Application NUNCA depende de Infrastructure ou API.
 - **Soft delete** em todas as entidades: `IsDeleted`, `DeletedAt`, `DeletedBy`
 - **PII masking** em logs: CPF `***.***.***-XX`, nunca logar dados sensíveis — aplicado automaticamente pelo `PiiMaskingEnricher` (registrado no pipeline Serilog via `ConfigurarSerilog`) a todas as propriedades estruturadas, inclusive aninhadas (`StructureValue`, `SequenceValue`, `DictionaryValue`)
 - **Result pattern** para retorno de operações: `Result<T>` com `DomainError`
-- **CQRS** via MediatR: Commands para escrita, Queries para leitura
+- **CQRS** via Wolverine: Commands para escrita (`ICommandBus.Send`), domain events (`AddDomainEvent` na entidade + outbox transacional), Queries via repositórios — ver `docs/guia-wolverine-golden-path.md` no repo `uniplus-docs`
 - **Value objects** para dados de domínio: `Cpf`, `Email`, `NomeSocial`, `NotaFinal`, `NumeroEdital`
 - **Factory methods** com construtores privados em todas as entidades
 - **Sealed classes** por padrão (exceto bases abstratas)
@@ -88,32 +88,33 @@ O source generator de `[LoggerMessage]` (.NET 6+) gera código que:
 Classe `partial`, método `private static partial void Log{Ação}` no fim da classe, `ILogger` como primeiro parâmetro:
 
 ```csharp
-namespace Unifesspa.UniPlus.Selecao.Application.Behaviors;
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
 
-using MediatR;
 using Microsoft.Extensions.Logging;
 
-public sealed partial class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-    where TRequest : IRequest<TResponse>
+public sealed partial class PublicarEditalCommandHandler
 {
-    private readonly ILogger<LoggingBehavior<TRequest, TResponse>> _logger;
-
-    public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger) => _logger = logger;
-
-    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken ct)
+    public async Task<Result<Unit>> Handle(
+        PublicarEditalCommand command,
+        SelecaoDbContext db,
+        ILogger<PublicarEditalCommandHandler> logger,
+        CancellationToken ct)
     {
-        string requestName = typeof(TRequest).Name;
-        LogProcessando(_logger, requestName);                       // chamada idiomática
-        TResponse response = await next(ct).ConfigureAwait(false);
-        LogConcluido(_logger, requestName, stopwatch.ElapsedMilliseconds);
-        return response;
+        LogProcessando(logger, command.EditalId);                   // chamada idiomática
+        Edital? edital = await db.Editais.FindAsync([command.EditalId], ct).ConfigureAwait(false);
+        if (edital is null)
+            return Result<Unit>.Failure(EditalErrors.NaoEncontrado);
+        edital.Publicar();
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        LogConcluido(logger, command.EditalId);
+        return Result<Unit>.Success(Unit.Value);
     }
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Processando {RequestName}")]
-    private static partial void LogProcessando(ILogger logger, string requestName);
+    [LoggerMessage(Level = LogLevel.Information, Message = "Publicando edital {EditalId}")]
+    private static partial void LogProcessando(ILogger logger, Guid editalId);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Concluído {RequestName} em {ElapsedMs}ms")]
-    private static partial void LogConcluido(ILogger logger, string requestName, long elapsedMs);
+    [LoggerMessage(Level = LogLevel.Information, Message = "Edital {EditalId} publicado")]
+    private static partial void LogConcluido(ILogger logger, Guid editalId);
 }
 ```
 
@@ -186,7 +187,8 @@ docker compose -f docker/docker-compose.yml up -d
 # APIs em modo desenvolvimento
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
 
-# Migrations EF Core
+# Migrations EF Core — referência de comando (NÃO rodar para entidades de domínio até issue #155
+# definir naming convention e InitialCreate revisado; outbox do Wolverine usa AddResourceSetupOnStartup)
 dotnet ef migrations add <Nome> --project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure --startup-project src/selecao/Unifesspa.UniPlus.Selecao.API
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 - **Cache:** Redis 8
 - **Storage:** MinIO (S3-compatible)
 - **Autenticação:** Keycloak 26.5 (Gov.br)
-- **CQRS/messaging:** Wolverine 5.x — abstração `ICommandBus` em `Application.Abstractions/Messaging` com implementação `WolverineCommandBus` (delega para `Wolverine.IMessageBus`). Ver [ADR-022](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md). **Outbox transacional de domain events ainda não foi adotado** — ver [ADR-024](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md) e [issue #158](https://github.com/unifesspa-edu-br/uniplus-api/issues/158); `EntityBase.DomainEvents` continua presente no domínio mas não é drenado automaticamente.
+- **CQRS/messaging:** Wolverine 5.x ([ADR-022](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md)) — abstração `ICommandBus` em `Application.Abstractions/Messaging`. Outbox transacional de domain events **ainda não adotado** — ver [ADR-024](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md) e [issue #158](https://github.com/unifesspa-edu-br/uniplus-api/issues/158).
 - **Validação:** FluentValidation 12
 - **Logging:** Serilog 10
 - **Observabilidade:** OpenTelemetry
@@ -61,7 +61,7 @@ Application NUNCA depende de Infrastructure ou API.
 - **Soft delete** em todas as entidades: `IsDeleted`, `DeletedAt`, `DeletedBy`
 - **PII masking** em logs: CPF `***.***.***-XX`, nunca logar dados sensíveis — aplicado automaticamente pelo `PiiMaskingEnricher` (registrado no pipeline Serilog via `ConfigurarSerilog`) a todas as propriedades estruturadas, inclusive aninhadas (`StructureValue`, `SequenceValue`, `DictionaryValue`)
 - **Result pattern** para retorno de operações: `Result<T>` com `DomainError`
-- **CQRS** via Wolverine: commands escritos via `ICommandBus.Send`, queries via repositórios. Domain events (`AddDomainEvent` em `EntityBase`) continuam acumulando na entidade — drenagem para outbox/bus está reprovada por enquanto (ver [ADR-024](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md) e [issue #158](https://github.com/unifesspa-edu-br/uniplus-api/issues/158)). Não escrever código de aplicação que dependa do despacho automático de domain events. Padrões e exemplos em `docs/guia-wolverine-golden-path.md` (`uniplus-docs`)
+- **CQRS** via Wolverine: commands escritos via `ICommandBus.Send`, queries via repositórios. Domain events (`AddDomainEvent` em `EntityBase`) continuam acumulando na entidade — drenagem para outbox/bus ainda não está implementada (estratégia em definição na [issue #158](https://github.com/unifesspa-edu-br/uniplus-api/issues/158), precedida por reprovação técnica em #135 — ver [ADR-024](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md)). **Trava: não escrever código de aplicação que assuma despacho automático de domain events** — esse invariante não está garantido nesta fase. Padrões e exemplos em `docs/guia-wolverine-golden-path.md` (`uniplus-docs`)
 - **Value objects** para dados de domínio: `Cpf`, `Email`, `NomeSocial`, `NotaFinal`, `NumeroEdital`
 - **Factory methods** com construtores privados em todas as entidades
 - **Sealed classes** por padrão (exceto bases abstratas)
@@ -88,19 +88,19 @@ O source generator de `[LoggerMessage]` (.NET 6+) gera código que:
 Classe `partial`, método `private static partial void Log{Ação}` no fim da classe, `ILogger` como primeiro parâmetro:
 
 ```csharp
-public sealed partial class PublicarEditalCommandHandler
+public sealed partial class EditalLogger(ILogger<EditalLogger> logger)
 {
-    private readonly ILogger<PublicarEditalCommandHandler> _logger;
-
-    public void Executar(Guid editalId)
+    public void RegistrarPublicacao(Guid editalId)
     {
-        LogPublicando(_logger, editalId);   // chamada idiomática (gerada em compile time)
+        LogPublicando(logger, editalId);   // chamada idiomática (gerada em compile time)
     }
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Publicando edital {EditalId}")]
     private static partial void LogPublicando(ILogger logger, Guid editalId);
 }
 ```
+
+> O exemplo usa nome neutro de propósito — não é um handler Wolverine. Handlers seguem a convenção do framework (método `Handle` com o tipo do command como primeiro parâmetro); o padrão `[LoggerMessage]` aqui aplica-se a qualquer classe que precise de logging estruturado.
 
 ### Convenções de estilo
 


### PR DESCRIPTION
## Sumário

`CLAUDE.md` ainda listava `**CQRS:** MediatR 14` na stack e usava `IPipelineBehavior<TRequest, TResponse>` do MediatR no exemplo de `[LoggerMessage]` source generator — stale desde o [ADR-022](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md). Atualização evita que agentes (Claude/Gemini) e novos contribuidores adotem o framework descontinuado.

## Mudanças

- **Stack e versões → Bullet "CQRS"**: agora `Wolverine 5.x (ADR-022)` com nota sobre descontinuação do MediatR.
- **Padrões obrigatórios → Bullet "CQRS"**: reflete o caminho atual (`ICommandBus.Send`, `AddDomainEvent` na entidade + outbox transacional).
- **Exemplo `[LoggerMessage]`**: reescrito como handler Wolverine convention-based (`PublicarEditalCommandHandler`) — sem `IPipelineBehavior`. Os atributos `LogProcessando` / `LogConcluido` foram realinhados aos parâmetros do exemplo (`{EditalId}` em vez de `{RequestName}`/`{ElapsedMs}`).
- **Comandos úteis → `dotnet ef migrations add`**: aviso de que não deve rodar para entidades de domínio até #155 definir naming convention e `InitialCreate` revisado; outbox do Wolverine usa `AddResourceSetupOnStartup`.

## Por que

A errata acompanha a decisão registrada em #135/#155: o projeto não vai gerar migration EF Core ainda; toda referência a MediatR no CLAUDE.md cria ruído para agentes que consultam o arquivo como fonte de verdade.

## Test plan

- [x] Markdown bem formatado (preview no GitHub).
- [x] Exemplo de `[LoggerMessage]` consistente: chamadas, parâmetros e atributos batem.
- [x] Sem regressão em outras seções (logging, padrões, workflow).

## Referências

- Closes #156
- Refs #133, #135, #155
- ADR-022