### PR TITLE
feat(kernel): adicionar DequeueDomainEvents ao EntityBase

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
@@ -25,4 +25,17 @@ public abstract class EntityBase
         _domainEvents.Add(domainEvent);
 
     public void ClearDomainEvents() => _domainEvents.Clear();
+
+    // Snapshot atômico dos domain events seguido de limpeza da coleção
+    // interna. Uso canônico no caminho cascading messages do Wolverine
+    // (handlers que retornam IEnumerable<object>): drena os eventos da
+    // entidade no mesmo ponto em que o handler os entrega ao bus,
+    // evitando republicação acidental se o agregado sobreviver ao escopo
+    // do handler (cache, sagas, processadores long-lived).
+    public IReadOnlyCollection<IDomainEvent> DequeueDomainEvents()
+    {
+        IDomainEvent[] snapshot = [.. _domainEvents];
+        _domainEvents.Clear();
+        return snapshot;
+    }
 }

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseDomainEventsTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseDomainEventsTests.cs
@@ -1,0 +1,81 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.Entities;
+
+using FluentAssertions;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Events;
+
+// Cobre o contrato de drenagem de domain events do EntityBase. Foco nos
+// invariantes do método DequeueDomainEvents — padrão canônico para
+// handlers cascading do Wolverine (ADR-026).
+public sealed class EntityBaseDomainEventsTests
+{
+    [Fact(DisplayName = "DequeueDomainEvents retorna snapshot e esvazia a coleção do agregado")]
+    public void DequeueDomainEvents_RetornaSnapshotEEsvaziaColecao()
+    {
+        var entidade = new EntidadeDeTeste();
+        var evento1 = new EventoDeTeste("e1");
+        var evento2 = new EventoDeTeste("e2");
+
+        entidade.AdicionarEvento(evento1);
+        entidade.AdicionarEvento(evento2);
+
+        IReadOnlyCollection<IDomainEvent> drenados = entidade.DequeueDomainEvents();
+
+        drenados.Should().HaveCount(2)
+            .And.ContainInOrder(evento1, evento2);
+        entidade.DomainEvents.Should().BeEmpty(
+            "DequeueDomainEvents deve esvaziar a coleção do agregado para evitar republicação acidental");
+    }
+
+    [Fact(DisplayName = "DequeueDomainEvents em coleção vazia retorna coleção vazia sem efeito colateral")]
+    public void DequeueDomainEvents_ColecaoVazia_RetornaVaziaSemErro()
+    {
+        var entidade = new EntidadeDeTeste();
+
+        IReadOnlyCollection<IDomainEvent> drenados = entidade.DequeueDomainEvents();
+
+        drenados.Should().BeEmpty();
+        entidade.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "DequeueDomainEvents é atômico — snapshot não vê eventos adicionados depois")]
+    public void DequeueDomainEvents_EhAtomico_NaoVeEventosAdicionadosDepois()
+    {
+        var entidade = new EntidadeDeTeste();
+        var primeiro = new EventoDeTeste("primeiro");
+        entidade.AdicionarEvento(primeiro);
+
+        IReadOnlyCollection<IDomainEvent> drenados = entidade.DequeueDomainEvents();
+
+        var posterior = new EventoDeTeste("posterior");
+        entidade.AdicionarEvento(posterior);
+
+        drenados.Should().ContainSingle().Which.Should().Be(primeiro,
+            "snapshot é tirado antes do Clear; eventos adicionados depois pertencem à próxima drenagem");
+        entidade.DomainEvents.Should().ContainSingle().Which.Should().Be(posterior);
+    }
+
+    [Fact(DisplayName = "ClearDomainEvents continua zerando a coleção sem retornar snapshot")]
+    public void ClearDomainEvents_ZeraColecaoSemRetorno()
+    {
+        var entidade = new EntidadeDeTeste();
+        entidade.AdicionarEvento(new EventoDeTeste("e1"));
+        entidade.AdicionarEvento(new EventoDeTeste("e2"));
+
+        entidade.ClearDomainEvents();
+
+        entidade.DomainEvents.Should().BeEmpty();
+    }
+
+    private sealed class EntidadeDeTeste : EntityBase
+    {
+        public void AdicionarEvento(IDomainEvent @event) => AddDomainEvent(@event);
+    }
+
+    private sealed record EventoDeTeste(string Identificador) : IDomainEvent
+    {
+        public Guid EventId { get; } = Guid.NewGuid();
+        public DateTimeOffset OccurredOn { get; } = DateTimeOffset.UtcNow;
+    }
+}


### PR DESCRIPTION
## Contexto

Implementa a Task #165, recalibrada pela [ADR-026](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-026-cascading-messages-como-drenagem-canonica.md), que adotou cascading messages como drenagem canônica de domain events em substituição parcial à ADR-025 (apenas no mecanismo `PublishDomainEventsFromEntityFrameworkCore -> cascading messages`).

Este PR adiciona apenas o helper canônico `EntityBase.DequeueDomainEvents()` — não toca em Wolverine, feed local, dependências, handlers ou outbox. Esses passos seguem em PRs subsequentes (#162, #163, #164, #136).

## Decisão

`DequeueDomainEvents()` faz snapshot atômico dos eventos seguido de `Clear` da coleção interna. Uso canônico:

```csharp
public IEnumerable<object> Handle(PublicarEditalCommand command, ...)
{
    edital.Publicar();
    repository.Update(edital);
    return edital.DequeueDomainEvents().Cast<object>();
}
```

Isso entrega os eventos ao bus pelo caminho cascading do Wolverine sem deixar o agregado com a coleção pendente — proteção contra republicação acidental se o agregado sobreviver ao escopo do handler (cache, sagas, processadores long-lived).

## Escopo

- Adicionado `EntityBase.DequeueDomainEvents()`.
- Mantido `ClearDomainEvents()` por compatibilidade — útil para consumidores que já obtiveram o snapshot por outro meio.
- Cobertos os 4 invariantes em `EntityBaseDomainEventsTests`:
  - snapshot retorna todos os eventos na ordem de adição;
  - coleção interna fica vazia após o `Dequeue`;
  - coleção vazia retorna `Empty` sem efeito colateral;
  - atomicidade: eventos adicionados depois do `Dequeue` ficam na próxima drenagem;
  - `ClearDomainEvents()` continua zerando sem retornar snapshot.

## Fora do escopo (próximos PRs)

- Configurar Wolverine cascading no produtivo (#164).
- Sair do feed local Wolverine para 5.32.1 oficial (#163).
- Consolidar evidências S0–S10 da spike #158 (#162).
- Migrar `PublicarEditalCommand` como exemplo de referência (#136).

## Validação

- `dotnet test tests/Unifesspa.UniPlus.Kernel.UnitTests/Unifesspa.UniPlus.Kernel.UnitTests.csproj --filter "FullyQualifiedName~EntityBaseDomainEventsTests" --no-restore -v minimal` → **4/4 verdes**, 16 ms.
- Suíte completa do `Kernel.UnitTests` → **51/51 verdes**, 36 ms.
- `git diff --check` → limpo.

## Critérios de aceite

- [x] `EntityBase.DequeueDomainEvents()` implementado.
- [x] Testes unitários `EntityBaseDomainEventsTests` verdes.
- [x] Nenhum comportamento existente de `ClearDomainEvents()` quebrado.
- [x] `git diff --check` limpo.

Closes #165