### PR TITLE
docs(spikes): consolidar evidências S0-S10 da validação outbox

### DIFF
--- a/docs/spikes/158-relatorio-final.md
+++ b/docs/spikes/158-relatorio-final.md
@@ -1,0 +1,290 @@
+# Relatório final — Validação do outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-relatorio-final`
+- **Data:** 2026-04-25
+- **Autor da execução:** Claude (Opus 4.7) — execução autônoma sequencial S0→S9 sob direção do Tech Lead.
+- **Status:** **Validação técnica concluída.** Wolverine 5.32.1-pr2586 com `PersistMessagesWithPostgresql` é candidato técnico viável para o requisito do plano. Recomendação: prosseguir para ADR de adoção.
+
+## Recomendação
+
+**Adotar Wolverine 5.32.1-pr2586 como outbox transacional para domain events do UniPlus**, com a configuração validada nos spikes:
+
+```csharp
+options
+    .PersistMessagesWithPostgresql(connectionString, schemaName: "wolverine")
+    .EnableMessageTransport(_ => { });
+
+options.Policies.UseDurableOutboxOnAllSendingEndpoints();
+
+options.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
+options.ListenToPostgresqlQueue("domain-events");
+
+options.UseKafka(kafkaBootstrapServers).AutoProvision();
+options.PublishMessage<EditalPublicadoEvent>().ToKafkaTopic("edital_events");
+
+options.PublishDomainEventsFromEntityFrameworkCore<EntityBase>(
+    entity => entity.DomainEvents);
+```
+
+Combinada com a decisão de **desligar `EnableRetryOnFailure`** em DbContexts usados por handlers Wolverine (centralizar retry em políticas do Wolverine).
+
+Plano B (interceptor próprio) **fica em espera** — não foi necessário. Decisão final de adoção depende do ADR.
+
+## Status final por AC do plano
+
+| AC | Requisito | Spike | Status |
+|---|---|---|---|
+| AC1a | Persistência transacional do envelope com `SaveChanges` | S2/V4, S3/V5 | ✅ **Comprovado** em PG e Kafka |
+| AC1b | Entrega ao destino após commit | S2/V4, S3/V5 | ✅ **Comprovado** em PG queue e Kafka topic |
+| AC2  | Rollback elimina entidade e mensagem | S4/V4, S4/V5 | ✅ **Comprovado** em PG e Kafka |
+| AC3  | Recuperação após restart / indisponibilidade | S5/V6 (parte 1 + parte 2), S6/V7 | ✅ **Comprovado integralmente** — envelope persiste durante indisponibilidade, é despachado automaticamente quando broker volta (KRaft), reassignment funciona após restart de host |
+| AC4  | Migration auditável das tabelas Wolverine | S8 | ✅ **Superfície mapeada** (10 tabelas em 2 schemas). Decisão de versionamento (migration EF / DbContext dedicado / SQL) **registrada como recomendação A**, fechamento depende de ADR |
+| AC5  | Retry EF/Wolverine sem conflito | S7 (variantes A e B) | ✅ **Comprovado** — variante A levanta `InvalidOperationException`; variante B (EF retry OFF) é a recomendação aplicada |
+
+## Matriz V0–V7 final
+
+| Variante | Configuração | Status | Spike | Observação |
+|---|---|---|---|---|
+| V0 | Stack base sem routing durável | ❌ **Reprovado por inviabilidade técnica do framework** | S0 | `EfCoreEnvelopeTransaction` exige message persistence; sem ela `InvalidOperationException` antes do scraper rodar |
+| V1 | `Policies.UseDurableLocalQueues` sem routing explícito | ❌ Mesmo bloqueio de V0 | (não exercido) | Bloqueado pela mesma exigência |
+| V2 | `PublishAllMessages().ToLocalQueue(...)` + local durable | ❌ Mesmo bloqueio | (não exercido) | Bloqueado pela mesma exigência |
+| V3 | `PublishMessage<T>().ToLocalQueue(...)` + local durable | ❌ Mesmo bloqueio | (não exercido) | Bloqueado pela mesma exigência |
+| V3a | Handler real via `IMessageBus.InvokeAsync` sem retry EF | ✅ Indireto | (subsumido por V4) | Validado dentro do S2 |
+| V3a' | `PublishAllMessages().ToLocalQueue(...)` no `5.32.1-pr2586` | ❌ Mesmo bloqueio | (não exercido) | Bloqueado pela mesma exigência |
+| V4 | PostgreSQL transport `ToPostgresqlQueue(...)` | ✅ **Aprovado** | S2/V4, S4/V4 | Caminho principal sem broker externo |
+| V5 | Kafka transport com durable outbox PG | ✅ **Aprovado** | S3/V5, S4/V5 | Caminho com broker externo |
+| V6 | Kafka indisponível no commit | ✅ **Aprovado** completo | S5/V6 (parte 1 e parte 2) | Parte 1 (envelope persiste) e parte 2 (despacho ao retorno via KRaft) — ambas comprovadas |
+| V7 | Restart recovery | ✅ **Aprovado** | S6/V7 | Reassignment automático em <60s |
+
+## Decisões fechadas
+
+1. **Pacotes Wolverine**: usar `5.32.1-pr2586` do feed local em
+   `vendors/nuget-local/`. Reverter para versão oficial quando upstream
+   publicar `5.32.2+` contendo o fix de `JasperFx/wolverine#2586`. Critério
+   de saída do feed local cobre 5 pacotes:
+   - `WolverineFx`
+   - `WolverineFx.EntityFrameworkCore`
+   - `WolverineFx.RDBMS`
+   - `WolverineFx.Postgresql`
+   - `WolverineFx.Kafka`
+
+2. **Retry strategy**: variante B (EF retry OFF + Wolverine retry).
+   `AddSelecaoInfrastructure` precisa permitir desligar
+   `EnableRetryOnFailure` quando outbox transacional estiver ativo.
+
+3. **Durabilidade outbox**: `Policies.UseDurableOutboxOnAllSendingEndpoints()`
+   é **obrigatório** — Wolverine não usa outbox durável por default em
+   senders externos (Kafka, etc.).
+
+4. **Convenção de nomenclatura**: usar **snake_case** desde a declaração
+   para queues/tópicos (Wolverine normaliza `-` para `_` internamente —
+   evita surpresas com clientes admin de Kafka).
+
+5. **Conflito de versão NuGet**: prerelease `5.32.1-pr2586` < stable
+   `5.32.1` em semver, então qualquer pacote `WolverineFx.*` oficial
+   `5.32.1` introduz NU1605. **Solução**: gerar TODOS os pacotes Wolverine
+   usados a partir do mesmo branch do fork.
+
+6. **Bump Confluent.Kafka**: 2.13.2 → 2.14.0 (transitivo de
+   `WolverineFx.Kafka`). Patch level, sem breaking changes.
+
+## Decisões pendentes (para ADR / próxima Story)
+
+1. **Versionamento das tabelas Wolverine** (caminho 2 do plano):
+   recomendação A (migration EF do `SelecaoDbContext` via
+   `MapWolverineEnvelopeStorage(modelBuilder, "wolverine")`) com
+   `AutoBuildMessageStorageOnStartup` desligado em produção. Confirmação
+   por ADR.
+
+2. **Retenção de dead letters**: definir
+   `DurabilitySettings.DeadLetterQueueExpiration` apropriado (default 10
+   dias). Considerar LGPD e auditabilidade — possivelmente 30 dias.
+
+3. **Endpoint admin de replay**: avaliar se construir
+   `POST /admin/outbox/replay?type=...` usando
+   `IDeadLetters.MarkDeadLetterEnvelopesAsReplayableAsync(...)` ou se
+   replay manual via SQL/CLI atende.
+
+4. **Política de drift fork × upstream**: definir que a atualização para
+   `WolverineFx 5.32.2+` oficial **não é automática**. Vai exigir PR
+   dedicado que re-executa **no mínimo** S2, S3, S5b e S7 da matriz
+   antes do merge. Documentar critério no ADR.
+
+5. **Política de adoção uniforme** (evitar "dois modelos de
+   consistência" — handler A via Wolverine, handler B via EF direto):
+   o ADR deve declarar que **todo handler que persiste agregado com
+   `EntityBase.DomainEvents` é Wolverine**. Handler que faz query/lookup
+   sem `SaveChanges` continua livre. Trava no review.
+
+4. ~~**S5 parte 2** (despacho após retorno de broker externo)~~:
+   **Concluído.** Re-executado com `apache/kafka:3.9.0` (KRaft puro) +
+   `WithPortBinding` para preservar endereço do producer entre restarts.
+   Despacho ao retorno funciona em <8s. Ver `158-s5b-relatorio.md`.
+
+## Trabalhos seguintes recomendados
+
+1. **Story de implementação produtiva** (consumir esta validação):
+   - Refatorar `AddSelecaoInfrastructure` e `AddIngressoInfrastructure`
+     para aceitar flag de retry desligado.
+   - Configurar Wolverine no `Program.cs` de cada API conforme
+     configuração validada.
+   - Migrations EF para o schema `wolverine`.
+   - Trocar `LinkProgramHandlerForFutureScraping` (placeholder) pelo
+     scraper real em handlers existentes.
+   - Atualizar `CLAUDE.md` removendo a trava sobre domain events.
+
+2. **ADR formal de adoção** (`docs/adrs/ADR-NNN-outbox-wolverine-adotado.md`
+   no `uniplus-docs`):
+   - Status: aceito.
+   - Decisão: adotar Wolverine como outbox transacional.
+   - Consequências: lista das 6 decisões fechadas acima.
+   - Promove e fecha #158.
+
+3. **Issue para retorno do upstream**: agendar agente em ~2 semanas para
+   verificar se `WolverineFx 5.32.2+` foi publicado oficialmente e
+   abrir PR removendo o feed local. **Sugiro `/schedule`**.
+
+4. **Padronizar todas as fixtures Kafka em KRaft + porta fixa**: a
+   fixture geral (`OutboxCapabilityFixture`) ainda usa `cp-kafka:7.6.1`
+   (Zookeeper). Migrar para `apache/kafka:3.9.0+` por consistência com
+   produção (Kafka 4.2 KRaft) e para destravar futuros testes de
+   resiliência que precisem de restart.
+
+5. **Guardrails de produção** (validações no startup que falhem cedo se a
+   configuração estiver inconsistente com os achados desta validação):
+   - **Falhar startup** se algum `DbContextOptions<TContext>` registrado
+     para uso por handlers Wolverine tem `EnableRetryOnFailure` ligado.
+     Verificação via `IInterceptor`/`IDbContextOptionsExtension` — se
+     `NpgsqlRetryingExecutionStrategy` aparecer no provider, lança no
+     `IHostedService.StartAsync`.
+   - **Falhar startup** se `Policies.UseDurableOutboxOnAllSendingEndpoints`
+     não estiver aplicada e algum `PublishMessage<T>().ToKafkaTopic(...)`
+     estiver configurado. Verificação no `WolverineOptions.Discovery`
+     pós-build.
+   - **Logar configuração de transport** no boot — `LogInformation`
+     com lista de queues/topics + endpoint mode (durable/buffered) +
+     persistence schema. Operacionalmente útil ao subir nó novo.
+
+   Hoje essas regras vivem só no relatório/ADR — sem enforcement no código
+   é questão de tempo até alguém ligar `EnableRetryOnFailure` por engano.
+
+6. **Observabilidade mínima obrigatória** (não basta ter o runbook —
+   precisa enforcement de coleta + alerta):
+   - **Métricas Wolverine via OpenTelemetry**: o pacote `WolverineFx`
+     emite contadores nativos (mensagens enviadas/recebidas/falhas,
+     latência por handler). Adicionar `Wolverine` ao
+     `OpenTelemetry.Trace.Builder.AddSource(...)` no `Program.cs`.
+   - **Alertas de saúde do outbox** (Grafana/Prometheus):
+     - Crescimento sustentado de `wolverine_outgoing_envelopes` (lag
+       de despacho).
+     - Crescimento de `wolverine_dead_letters` acima de threshold (ex.:
+       >10 por hora — indica regressão no handler).
+     - `wolverine_node_assignments` com node owner morto há >5 min —
+       sinal de zombie.
+   - **Dashboards no `repositories/uniplus-docs/grafana/`** (a criar).
+
+   Sem isso, o sistema "está funcionando" mas backlog silencioso pode
+   acumular sem ninguém notar até bater o quota do Postgres ou o cliente
+   reclamar do atraso.
+
+## Resultados consolidados
+
+```
+Aprovado S2/V4 — PG transport entrega EditalPublicadoEvent ao handler local
+Aprovado S4/V4 — rollback PG: entidade ausente, envelope ausente
+Aprovado S3/V5 — Kafka transport publica EditalPublicadoEvent no tópico
+Aprovado S4/V5 — rollback Kafka: tópico não recebe mensagem fantasma
+Aprovado S5/V6 (parte 1) — Kafka offline: envelope pendente em storage
+Aprovado S5/V6 (parte 2) — Kafka volta: envelope retido é despachado (KRaft)
+Aprovado S6/V7 — restart: novo host processa mensagem pendente
+Aprovado S7 (variante A) — EF retry ON levanta conflito esperado
+Aprovado S7 (variante B) — EF retry OFF é a recomendação aplicada
+Aprovado S8 — schema 'wolverine' contém todas as tabelas esperadas
+Aprovado S8 — superfície completa observada documentada
+Aprovado S9 — handler que sempre falha gera entrada em dead letters
+Aprovado S9 — query SQL de dead letters retorna snapshot inspecionável
+
+Total de testes: 13
+     Aprovados: 13
+Tempo total: ~46s
+```
+
+## Histórico de branches
+
+```
+spikes/158-s0-handler-inmemory          → 1b159c6  S0/V0 reprovado por inviabilidade técnica
+spikes/158-s2-transporte-postgresql     → fee75f5  S2/V4 + S4/V4 aprovados
+spikes/158-s3-transporte-kafka          → dc88a42  S3/V5 + S4/V5 aprovados
+spikes/158-s5-kafka-indisponivel        → 5c9ccee  S5/V6 parte 1 aprovado
+spikes/158-s6-restart-recovery          → 1a38d61  S6/V7 aprovado
+spikes/158-s7-retry-strategy            → 13531eb  AC5 formalmente comprovado
+spikes/158-s8-migration-surface         → 14eba2e  Schema mapeado
+spikes/158-s9-operacao                  → ba010b2  Runbook operacional + dead letters
+spikes/158-relatorio-final              → 5fa3ac4  Consolidação inicial
+spikes/158-s5b-kafka-kraft              → (este commit) S5/V6 parte 2 destravado com KRaft
+```
+
+Cada branch tem seu próprio relatório em `docs/spikes/158-s{N}-relatorio.md`.
+
+## Histórico de pacotes locais gerados
+
+Em `vendors/nuget-local/`, todos compilados a partir de
+`/home/jeferson/Projects/workspaces/wolverine-fork` na branch
+`fix/domain-event-scraper-materialize-before-publish` (commit `cd6a2ee`):
+
+```
+WolverineFx.5.32.1-pr2586.nupkg                          (PR #160 — base)
+WolverineFx.EntityFrameworkCore.5.32.1-pr2586.nupkg      (PR #160 — base)
+WolverineFx.RDBMS.5.32.1-pr2586.nupkg                    (PR #160 — base)
+WolverineFx.Postgresql.5.32.1-pr2586.nupkg               (S2 — esta sessão)
+WolverineFx.Kafka.5.32.1-pr2586.nupkg                    (S3 — esta sessão)
+```
+
+Comando padrão de geração:
+
+```bash
+dotnet pack <csproj-path> \
+  -c Release \
+  -p:Version=5.32.1-pr2586 \
+  -p:PackageVersion=5.32.1-pr2586 \
+  -o /tmp/wolverine-pack
+```
+
+## Bug de modelagem corrigido durante a validação
+
+Encontrado durante S0, corrigido no commit `868b24e`:
+
+```
+fix(kernel): renomear parâmetro do construtor de NomeSocial para EF bindar
+```
+
+`NomeSocial(string nomeCivil, string? nomeSocial)` → `NomeSocial(string nomeCivil, string? nome)`. EF Core 10 não conseguia bindar o parâmetro `nomeSocial` na propriedade `Nome` do tipo. Bug de modelagem sem ligação com o outbox, exposto pelo primeiro caminho do projeto a materializar o schema completo do módulo Seleção contra Postgres real.
+
+## Versões e ambiente
+
+- **Pacotes Wolverine:** `5.32.1-pr2586` (todos do feed local).
+- **Pacotes adicionais bumpados nesta validação:** `Confluent.Kafka` 2.13.2 → 2.14.0.
+- **Pacotes adicionados nesta validação:** `Testcontainers.Kafka` 4.11.0.
+- **Postgres:** `postgres:18-alpine`.
+- **Kafka (geral):** `confluentinc/cp-kafka:7.6.1` (Zookeeper) — usado em S2/S3/S4/S5/S6/S7/S8/S9. Migração para KRaft puro recomendada (item 4 dos trabalhos seguintes).
+- **Kafka (S5b):** `apache/kafka:3.9.0` (KRaft puro, sem Zookeeper) — alinhado com Kafka 4.2 KRaft de produção.
+- **Runtime:** .NET 10 / C# 14, Linux 6.19.14-arch1-1, Docker 28.3.3.
+- **Conta gh ativa nas sessões:** `marmota-alpina`.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório S0](158-s0-relatorio.md) — V0 inviável + bug NomeSocial corrigido
+- [Relatório S2](158-s2-relatorio.md) — V4 aprovado (PG transport)
+- [Relatório S3](158-s3-relatorio.md) — V5 aprovado (Kafka transport)
+- [Relatório S5](158-s5-relatorio.md) — V6 parte 1 aprovado, parte 2 pendente (resolvida em S5b)
+- [Relatório S5b](158-s5b-relatorio.md) — V6 parte 2 aprovado (Kafka KRaft)
+- [Relatório S6](158-s6-relatorio.md) — V7 aprovado (restart recovery)
+- [Relatório S7](158-s7-relatorio.md) — AC5 formalmente comprovado
+- [Relatório S8](158-s8-relatorio.md) — Schema mapeado, recomendação A
+- [Relatório S9](158-s9-relatorio.md) — Runbook operacional
+- [ADR-022 — backbone CQRS Wolverine](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md)
+- [ADR-024 — outbox Wolverine + EF não adotado em #135](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md)
+- [PR uniplus-api#160 — feed local com fix do scraper](https://github.com/unifesspa-edu-br/uniplus-api/pull/160)
+- [PR uniplus-api#161 — plano de validação](https://github.com/unifesspa-edu-br/uniplus-api/pull/161)
+- [JasperFx/wolverine#2585](https://github.com/JasperFx/wolverine/issues/2585) e [#2586](https://github.com/JasperFx/wolverine/pull/2586)

--- a/docs/spikes/158-s0-relatorio.md
+++ b/docs/spikes/158-s0-relatorio.md
@@ -1,0 +1,282 @@
+# Relatório do Spike S0 — Outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-s0-handler-inmemory`
+- **Data:** 2026-04-25
+- **Status:** concluído com decisão de avançar para S2 — V0 reprovado por inviabilidade técnica do framework
+- **Plano de referência:** [`docs/spikes/158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md)
+
+## Resumo executivo
+
+A variante **V0 — "stack base sem routing durável" — é inviável em Wolverine
+5.32.1-pr2586**. Com `PublishDomainEventsFromEntityFrameworkCore` configurado,
+o `EfCoreEnvelopeTransaction` exige message persistence backend e lança
+`InvalidOperationException` quando nenhum está registrado. O fix do
+`DomainEventScraper` (PR `JasperFx/wolverine#2586`, incorporado pelo PR
+uniplus-api#160) só pode ser exercido com algum backend ativo. Assim, S0
+isolado nos termos do plano não tem como ser executado.
+
+A sanidade do scraper passa a ser validada implicitamente em **S2 (transporte
+PostgreSQL)**, que se torna o próximo passo concreto.
+
+Esta fase também desentupiu três obstáculos ortogonais que teriam bloqueado
+qualquer spike subsequente: bug de modelagem em `NomeSocial`, override frágil
+de connection string no `WebApplicationFactory`, e visibilidade dos handlers
+para a discovery convencional do Wolverine. Os três estão resolvidos no
+spike-fixture e um deles (NomeSocial) foi corrigido em código de produção.
+
+## Cenário pretendido
+
+Conforme [§S0 do plano](158-plano-validacao-outbox-wolverine.md):
+
+- `Edital.Publicar()` adiciona `EditalPublicadoEvent` em `EntityBase.DomainEvents`.
+- Um handler Wolverine de comando chama `db.SaveChangesAsync()`.
+- O fix do `DomainEventScraper` materializa a coleção, drena os eventos e
+  publica-os no pipeline.
+- Um handler local de teste recebe `EditalPublicadoEvent` e registra evidência.
+- **Não** se exige outbox durável, transporte externo ou tabelas Wolverine.
+- Falha bloqueante esperada: exceção `Collection was modified` ou ausência de
+  recebimento.
+
+## Estrutura criada
+
+```
+tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Capability/
+  AssemblyInfo.cs                       — [assembly: WolverineModule<OutboxSpikeWolverineExtension>]
+  OutboxCapabilityCollection.cs         — definição da xUnit collection do spike
+  OutboxCapabilityFixture.cs            — Postgres em Testcontainers + lifecycle
+  OutboxCapabilityApiFactory.cs         — WebApplicationFactory custom
+  OutboxSpikeWolverineExtension.cs      — IWolverineExtension auto-loaded
+  SpikeMessages.cs                      — PublicarEditalSpikeCommand + DomainEventCollector
+  SpikeHandlers.cs                      — handlers Wolverine de teste
+  OutboxCapabilityMatrixTests.cs        — testes da matriz S0–S9 (S0 implementado)
+```
+
+Convenção: todos os testes recebem `[Trait("Category", "OutboxCapability")]` e
+podem ser filtrados via `dotnet test --filter "Category=OutboxCapability"`,
+isolando-os dos testes regulares de API.
+
+### Configuração Wolverine adotada para o spike
+
+```csharp
+[assembly: WolverineModule<OutboxSpikeWolverineExtension>]
+
+public sealed class OutboxSpikeWolverineExtension : IWolverineExtension
+{
+    public void Configure(WolverineOptions options)
+    {
+        options.PublishDomainEventsFromEntityFrameworkCore<EntityBase>(
+            entity => entity.DomainEvents);
+
+        options.Discovery.IncludeAssembly(typeof(OutboxSpikeWolverineExtension).Assembly);
+    }
+}
+```
+
+A extension é carregada automaticamente pelo Wolverine via
+`[WolverineModule<T>]`, sem precisar tocar no `Program.cs` da API. Confirmado
+pelos logs de execução: `Searching assembly Unifesspa.UniPlus.Selecao.IntegrationTests
+for Wolverine message handlers`.
+
+## Achados intermediários (resolvidos)
+
+### A1 — `NomeSocial`: parâmetro do construtor incompatível com EF Core 10
+
+`db.Database.EnsureCreatedAsync()` falhava em `SelecaoDbContext` com:
+
+```
+System.InvalidOperationException : No suitable constructor was found for the type 'NomeSocial'.
+The following constructors had parameters that could not be bound to properties of the type:
+  Cannot bind 'nomeSocial' in 'NomeSocial(string nomeCivil, string nomeSocial)'
+```
+
+Causa raiz: em
+`src/shared/Unifesspa.UniPlus.Kernel/Domain/ValueObjects/NomeSocial.cs`, o
+construtor privado era `NomeSocial(string nomeCivil, string? nomeSocial)`, mas
+a propriedade que armazenava o valor se chama `Nome`. EF Core 10 tenta bindar
+o parâmetro `nomeSocial` em uma propriedade `NomeSocial` — que não existe na
+classe — e desiste de criar o objeto.
+
+**Correção aplicada (escopo do spike, mas é fix ortogonal):** renomear o
+parâmetro privado de `nomeSocial` para `nome`, alinhando com a propriedade.
+Mudança puramente cosmética (construtor é `private`, só `NomeSocial.Criar` o
+chama), elimina a ambiguidade e desbloqueia qualquer teste de integração
+futuro do módulo Seleção.
+
+Verificado que **nenhum outro VO** tem o mesmo padrão (`Cpf`, `Email`,
+`NotaFinal`, `NumeroEdital`, `FormulaCalculo`, `PeriodoInscricao` — todos com
+parâmetros e propriedades alinhados).
+
+Implicação mais ampla: o módulo Seleção **não tinha cobertura de teste de
+integração que materializasse o schema completo** — não há migrations EF e os
+testes existentes (`AuthEndpointsTests`, `ProfileEndpointsTests`) só exercem
+endpoints que não tocam o banco. O spike #158 foi o primeiro caminho a
+materializar o modelo contra Postgres real, e por isso foi quem expôs o bug.
+
+### A2 — Connection string do test factory não chegava ao `DbContext`
+
+Tentativa inicial: `ApiFactoryBase` adiciona overrides via
+`builder.ConfigureAppConfiguration(... AddInMemoryCollection(...))`. Em
+.NET 10 com minimal hosting, o `Program.cs` do `Selecao.API` lê
+`builder.Configuration.GetConnectionString("SelecaoDb")` **imediatamente** ao
+fazer `AddSelecaoInfrastructure(connectionString)`. Quando o
+`ConfigureAppConfiguration` do test factory é aplicado, o valor já foi
+capturado.
+
+Resultado: `EnsureCreatedAsync` tentava conectar em `localhost:5432`
+(`appsettings.Development.json`) em vez do container Testcontainers
+(`Host=localhost;Port=PORTA_RANDOMICA;...`).
+
+**Solução adotada no spike:** em `ConfigureTestServices`, remover o
+`DbContextOptions<SelecaoDbContext>` e o `SelecaoDbContext` registrados pelo
+Program.cs e re-registrar com a connection string efêmera:
+
+```csharp
+services.RemoveAll<DbContextOptions<SelecaoDbContext>>();
+services.RemoveAll<SelecaoDbContext>();
+services.AddDbContext<SelecaoDbContext>(opts =>
+    opts.UseNpgsql(_connectionString));
+```
+
+Isso pula os interceptors `SoftDelete` e `Auditable` do registro de produção,
+o que é aceitável para o spike (interceptors não afetam drenagem de domain
+events). **Para testes de integração reais que dependam dos interceptors,
+será preciso solução mais robusta** (provavelmente refatorar
+`AddSelecaoInfrastructure` para receber `IConfiguration` em vez de string já
+resolvida, ou usar `IOptions<DbContextOptions<...>>`).
+
+### A3 — Discovery do Wolverine ignora tipos `internal`
+
+Após resolver A1 e A2, Wolverine logava `Wolverine found no handlers` mesmo
+escaneando o assembly de testes. A causa foi tornar `PublicarEditalSpikeCommand`,
+`PublicarEditalSpikeHandler`, `EditalPublicadoSpikeHandler` e
+`OutboxSpikeWolverineExtension` como `internal sealed`. A discovery
+convencional do Wolverine 5.x só enxerga tipos `public`.
+
+**Correção:** todos os tipos do spike viraram `public sealed`, com
+`[SuppressMessage("CA1515", ...)]` justificando que a "API pública" do
+projeto de testes é o que xUnit e Wolverine precisam enxergar via reflection.
+
+## Achado principal — V0 inviável
+
+Após resolver A1, A2 e A3, o teste avançou até o handler:
+
+```
+[ERR] Invocation of PublicarEditalSpikeCommand { Numero = 001/2026, ... } failed!
+System.InvalidOperationException: This Wolverine application is not using
+Database backed message persistence. Please configure the message persistence
+   at Wolverine.EntityFrameworkCore.Internals.EfCoreEnvelopeTransaction..ctor(
+       DbContext dbContext, MessageContext messaging,
+       IEnumerable<IDomainEventScraper> scrapers)
+   at Internal.Generated.WolverineHandlers.PublicarEditalSpikeCommandHandler1137929320
+       .HandleAsync(MessageContext context, CancellationToken cancellation)
+```
+
+Análise:
+
+1. Wolverine descobriu o handler (`PublicarEditalSpikeCommandHandler1137929320`
+   é o tipo gerado dinamicamente).
+2. Code generation rodou.
+3. O handler invocado tentou abrir um `EfCoreEnvelopeTransaction` (porque
+   `PublishDomainEventsFromEntityFrameworkCore` está habilitado e o pipeline
+   precisa coordenar `SaveChanges` com o envelope storage).
+4. O construtor de `EfCoreEnvelopeTransaction` valida que existe message
+   persistence backend e falha se nenhum estiver configurado.
+
+Inspeção do XML doc dos pacotes
+(`vendors/nuget-local/WolverineFx*.5.32.1-pr2586.nupkg`) confirma que **não
+existe `InMemoryPersistence`/`MemoryPersistence`/`UseLightweight` ou
+equivalente in-memory** em Wolverine 5.x. A integração EF + scraper exige
+backend durável.
+
+### Conclusão sobre a tabela V0–V7
+
+A reprova de V0 não é por bug do projeto nem do fix — é uma característica do
+framework. Ela tem implicação para todas as variantes "in-memory" do plano:
+
+| Variante | Implicação |
+|---|---|
+| V0 (stack base sem routing durável) | **Não factível na 5.32.1-pr2586** — exige persistence |
+| V1 (`UseDurableLocalQueues` sem routing) | Mesma exigência — durabilidade local depende de envelope storage |
+| V2/V3/V3a/V3a' (variações in-memory) | Mesma exigência |
+
+Variantes que exercem persistence backend (V4 PostgreSQL transport, V5 Kafka
+transport, V6 Kafka indisponível, V7 restart recovery) continuam factíveis e
+são exatamente o que S2–S6 endereçam.
+
+## Comandos executados
+
+```bash
+# Build do projeto de testes (verde após correções)
+dotnet build tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj
+
+# Execução do spike S0
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj \
+  --filter "Category=OutboxCapability" \
+  --logger "console;verbosity=normal"
+```
+
+Saída resumida do `dotnet test` na execução final (após resolver A1, A2, A3):
+
+```
+[INF] Searching assembly Unifesspa.UniPlus.Selecao.IntegrationTests for Wolverine message handlers
+[INF] Searching assembly Unifesspa.UniPlus.Selecao.API for Wolverine message handlers
+... (codegen)
+[ERR] Invocation of PublicarEditalSpikeCommand failed!
+System.InvalidOperationException: This Wolverine application is not using Database backed message persistence.
+```
+
+## Versões e ambiente
+
+- **Branch base:** `main` em `54f1a8b` (PR uniplus-api#161 mergeado).
+- **Branch do spike:** `spikes/158-s0-handler-inmemory`.
+- **Pacotes Wolverine:** `5.32.1-pr2586` em `vendors/nuget-local/`
+  (`WolverineFx`, `WolverineFx.EntityFrameworkCore`, `WolverineFx.RDBMS`).
+- **Pacote Testcontainers:** `Testcontainers.PostgreSql` 4.11.0 (já no
+  `Directory.Packages.props`).
+- **Postgres do spike:** imagem `postgres:18-alpine` em container efêmero.
+- **Runtime:** .NET 10 / C# 14, Linux 6.19.14-arch1-1, Docker 28.3.3.
+- **Conta gh ativa durante a sessão:** `marmota-alpina` (validado antes de
+  qualquer push, conforme regra `require_last_push_approval`).
+
+## Atualização da matriz V0–V7
+
+A linha V0 do plano (`docs/spikes/158-plano-validacao-outbox-wolverine.md`)
+deve ser atualizada para:
+
+| Variante | Configuração | Esperado após fix | Observado | Status |
+|---|---|---|---|---|
+| V0 | Stack base sem routing durável | `DomainEvents` podem ser drenados, mas sem envelope durável observável | Wolverine 5.32.1-pr2586 lança `InvalidOperationException` no `EfCoreEnvelopeTransaction` antes do scraper rodar — o ciclo exige message persistence configurada (não há `InMemoryPersistence` em 5.x) | **Reprovado por inviabilidade técnica do framework**, não por bug do projeto |
+
+A atualização da tabela no documento do plano será feita em commit separado
+após decisão sobre o caminho de S2.
+
+## Próximo passo recomendado
+
+**S2 — Transporte PostgreSQL** ([§S2 do plano](158-plano-validacao-outbox-wolverine.md#s2---transporte-postgresql)).
+
+Pré-requisitos para S2:
+
+1. Adicionar `WolverineFx.Postgresql` ao `Directory.Packages.props` (versão a
+   decidir — pacote oficial 5.32.1 vs gerar `5.32.1-pr2586` no fork local
+   conforme alerta do plano §"Snapshot da versão em validação").
+2. Estender `OutboxSpikeWolverineExtension` com
+   `UsePostgresqlPersistenceAndTransport(connectionString, "wolverine_spike")`
+   — o que exige passar a connection string do Postgres do Testcontainers
+   para a extension (provavelmente via singleton mutável ou DI customizada,
+   já que `[WolverineModule<T>]` instancia sem parâmetros).
+3. Renomear o teste S0 (e adicionar S2) para refletir que a sanidade do
+   scraper agora é uma assertiva embutida do S2, não um spike isolado.
+
+A sanidade do scraper continua sendo um critério de S2: se evento for entregue
+ao handler local sem `Collection was modified`, o fix do PR
+`JasperFx/wolverine#2586` está validado funcionalmente — apenas dentro do
+contexto persistente.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [ADR-022 — backbone CQRS Wolverine](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md)
+- [ADR-024 — outbox Wolverine + EF não adotado em #135](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md)
+- [PR uniplus-api#160 — feed local com fix do scraper](https://github.com/unifesspa-edu-br/uniplus-api/pull/160)
+- [PR uniplus-api#161 — plano de validação](https://github.com/unifesspa-edu-br/uniplus-api/pull/161)
+- [JasperFx/wolverine#2585](https://github.com/JasperFx/wolverine/issues/2585) e [#2586](https://github.com/JasperFx/wolverine/pull/2586) — issue e fix do `DomainEventScraper`.

--- a/docs/spikes/158-s10-plano-cascading-messages.md
+++ b/docs/spikes/158-s10-plano-cascading-messages.md
@@ -1,0 +1,329 @@
+# Plano do Spike S10 — Cascading Messages × `PublishDomainEventsFromEntityFrameworkCore`
+
+> Extensão da matriz S0–S9 da Story uniplus-api#158, motivada pela thread upstream
+> [JasperFx/wolverine#2585](https://github.com/JasperFx/wolverine/issues/2585) — em
+> particular o comentário do maintainer Jeremy D. Miller recomendando, para projetos
+> greenfield, o caminho idiomático de cascading messages do handler em vez do
+> "magic EF Core scraping thing".
+
+## Decisões fechadas
+
+- **Local:** `docs/spikes/158-s10-plano-cascading-messages.md`
+- **Branch:** `spikes/158-s10-cascading-messages`
+- **Base da branch:** `spikes/158-s5b-kafka-kraft`
+- **Escopo:** extensão da Story #158, não nova story.
+- **Critério para ADR-026:** abrir ADR-026 se cascading messages for viável e demonstrar ganho em pelo menos uma das quatro dimensões objetivas:
+  - menor acoplamento;
+  - menos código;
+  - teste unitário mais simples;
+  - menor dependência de comportamento implícito do EF scraping.
+
+## Mudança de foco
+
+A matriz S0–S9 (já validada, ADR-025 mergeada) respondeu a pergunta original:
+
+> **Wolverine funciona com outbox transacional?**
+
+Resposta: sim, com 13 testes verdes. Adoção formalizada em [ADR-025](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-025-outbox-wolverine-adotado-em-158.md).
+
+Após a thread upstream, a pergunta evolui para:
+
+> **Qual estilo Wolverine devemos adotar: EF scraping ou cascading messages?**
+
+UniPlus é greenfield — não há código legado que justifique o caminho menos
+idiomático. Vale validar antes de cristalizar a ADR-025 como caminho final
+de drenagem.
+
+Esta mudança **não invalida** a ADR-025: o caminho atual funciona. O spike
+S10 verifica se há ganho objetivo em mudar para o caminho recomendado pelo
+maintainer, antes da implementação produtiva.
+
+## Contexto técnico
+
+### Caminho atual (ADR-025)
+
+```csharp
+// Configuração no Program.cs (extension)
+options.PublishDomainEventsFromEntityFrameworkCore<EntityBase>(
+    entity => entity.DomainEvents);
+
+// Handler — sem retorno explícito de eventos
+public static async Task Handle(
+    PublicarEditalCommand command,
+    SelecaoDbContext db,
+    CancellationToken ct)
+{
+    var edital = Edital.Criar(command.Numero, command.Titulo, command.Tipo);
+    edital.Publicar();
+    db.Editais.Add(edital);
+    await db.SaveChangesAsync(ct);
+    // Wolverine scraper drena ChangeTracker → EntityBase.DomainEvents → publish
+}
+```
+
+**Características:**
+- Drenagem implícita via scraper interno do Wolverine.
+- Acoplamento ao `ChangeTracker` do EF Core.
+- Exposição pública obrigatória de `EntityBase.DomainEvents` para o scraper enxergar.
+- Bug histórico (`Collection was modified`) corrigido pelo fork local 5.32.1-pr2586.
+
+### Caminho idiomático (a validar — S10)
+
+```csharp
+// Configuração no Program.cs — sem PublishDomainEventsFromEntityFrameworkCore
+
+// Handler — retorna a coleção de eventos, Wolverine auto-publica
+public static async Task<IEnumerable<object>> Handle(
+    PublicarEditalCommand command,
+    SelecaoDbContext db,
+    CancellationToken ct)
+{
+    var edital = Edital.Criar(command.Numero, command.Titulo, command.Tipo);
+    edital.Publicar();
+    db.Editais.Add(edital);
+    await db.SaveChangesAsync(ct);
+
+    return edital.DomainEvents;
+}
+```
+
+**Características hipotéticas (a confirmar empiricamente):**
+- Drenagem explícita no return do handler.
+- Independente do `ChangeTracker` — funciona com qualquer persistência.
+- `EntityBase.DomainEvents` pode permanecer encapsulado (acessado só pelo handler).
+- Não exercita o caminho do scraper EF — não depende do fix do PR #2586.
+
+## Escopo
+
+### O que será exercitado
+
+| Cenário | Caminho atual (scraper) | Caminho idiomático (cascading) |
+|---|---|---|
+| Comando dispara, agregado emite evento, evento entregue ao handler local PG | S2/V4 já validado | **S10/V8 — a validar** |
+| Comando + falha pós-`SaveChanges` → rollback elimina entidade e mensagem | S4-PG já validado | **S10/V9 — a validar** |
+| Compatibilidade com fan-out para Kafka topic externo | S3/V5 validado | **S10/V10 — a validar** |
+| Coexistência com `PersistMessagesWithPostgresql + EnableMessageTransport` | Validado | A validar implicitamente em V8 |
+| Coexistência com `Policies.UseDurableOutboxOnAllSendingEndpoints` | Validado | A validar implicitamente em V8 |
+
+### O que NÃO está no escopo
+
+Spikes S5/S5b/S6/S7/S8/S9 da matriz original **não são re-executados**. Justificativa:
+as garantias de outbox durável, restart recovery, retry strategy, schema migration
+e operação vêm da configuração do host (`PersistMessagesWithPostgresql`,
+`UseDurableOutboxOnAllSendingEndpoints`, etc.) — **independentes** do método
+de drenagem (scraper vs cascading). Esses spikes continuam válidos para a
+configuração escolhida ao final, qualquer que seja.
+
+## Cenários
+
+### S10/V8 — Cascading messages, caminho feliz
+
+**Handler:**
+
+```csharp
+public static class PublicarEditalCascadingHandler
+{
+    public static async Task<IEnumerable<object>> Handle(
+        PublicarEditalCascadingCommand command,
+        SelecaoDbContext db,
+        CancellationToken ct)
+    {
+        var edital = Edital.Criar(command.Numero, command.Titulo, command.Tipo);
+        edital.Publicar();
+        db.Editais.Add(edital);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        return edital.DomainEvents;
+    }
+}
+```
+
+**Asserts:**
+- Entidade `Edital` persistida em `editais`.
+- Handler subscritor PG queue (existente, herdado da matriz S2) recebe `EditalPublicadoEvent`.
+- Tabela `wolverine.wolverine_outgoing_envelopes` registra envelope durável.
+- Sem `Collection was modified` (não exercita o scraper EF).
+
+### S10/V9 — Cascading messages, rollback
+
+**Handler:**
+
+```csharp
+public static class FalharAposSaveChangesCascadingHandler
+{
+    public static async Task<IEnumerable<object>> Handle(
+        FalharAposSaveChangesCascadingCommand command,
+        SelecaoDbContext db,
+        CancellationToken ct)
+    {
+        var edital = Edital.Criar(command.Numero, command.Titulo, command.Tipo);
+        edital.Publicar();
+        db.Editais.Add(edital);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        throw new InvalidOperationException("Spike S10 — exceção pós-SaveChanges");
+        // unreachable: return edital.DomainEvents;
+    }
+}
+```
+
+**Asserts (paridade AC2 com S4-PG):**
+- Entidade ausente em `editais` (rollback transacional).
+- Envelope ausente em `wolverine_outgoing_envelopes`.
+- Handler subscritor PG não recebe.
+
+### S10/V10 — Cascading messages com Kafka fan-out
+
+Mesmo do S10/V8 com `EditalPublicadoEvent` roteado também para Kafka topic
+`edital_events`. Verifica que cascading respeita o pipeline de roteamento
+configurado (`PublishMessage<T>().ToPostgresqlQueue` + `ToKafkaTopic`).
+
+**Asserts:**
+- PG queue entrega ao handler subscritor (paridade S10/V8).
+- Consumer externo Confluent.Kafka recebe a mensagem no topic.
+
+## Configuração Wolverine para o spike
+
+Extension dedicada para o S10 — sem `PublishDomainEventsFromEntityFrameworkCore`:
+
+```csharp
+public sealed class OutboxCascadingExtension : IWolverineExtension
+{
+    public static string? PostgresqlConnectionString { get; set; }
+    public static string? KafkaBootstrapServers { get; set; }
+
+    public void Configure(WolverineOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(PostgresqlConnectionString))
+            throw new InvalidOperationException("ConnectionString deve ser configurada.");
+
+        options
+            .PersistMessagesWithPostgresql(PostgresqlConnectionString, "wolverine")
+            .EnableMessageTransport(_ => { });
+
+        options.Policies.UseDurableOutboxOnAllSendingEndpoints();
+
+        options.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
+        options.ListenToPostgresqlQueue("domain-events");
+
+        if (!string.IsNullOrWhiteSpace(KafkaBootstrapServers))
+        {
+            options.UseKafka(KafkaBootstrapServers).AutoProvision();
+            options.PublishMessage<EditalPublicadoEvent>().ToKafkaTopic("edital_events");
+        }
+
+        // SEM PublishDomainEventsFromEntityFrameworkCore — drenagem via cascading do handler.
+
+        options.Discovery.IncludeAssembly(typeof(OutboxCascadingExtension).Assembly);
+    }
+}
+```
+
+**Atenção:** o assembly de testes carrega tanto `OutboxSpikeWolverineExtension`
+(da matriz S0–S9) quanto `OutboxCascadingExtension`. Para evitar conflito de
+campos estáticos, a fixture do S10 usa containers próprios e a extension
+verifica seus próprios campos. Cada `WebApplicationFactory` carrega ambas as
+extensions, então a do scraper precisa permanecer inerte quando o spike S10
+está rodando — solução: `OutboxCascadingExtension` setado seus próprios
+campos antes do bootstrap; `OutboxSpikeWolverineExtension` continua lendo
+`PostgresqlConnectionString` original. Coexistência sob escrutínio durante
+implementação — se conflitar, isolar via assembly attribute condicional.
+
+## Critérios de comparação (4 dimensões objetivas)
+
+Saída esperada do spike: tabela comparativa baseada nas **4 dimensões objetivas**
+abaixo. Pelo menos **1 dimensão objetivamente melhor** para cascading aciona ADR-026.
+
+### 1. Menos acoplamento
+
+| Métrica | Atual (scraper) | Cascading |
+|---|---|---|
+| Dependências obrigatórias do agregado | `EntityBase.DomainEvents` **público** | `EntityBase.DomainEvents` pode ser **internal/protected** |
+| Acoplamento ao EF | Acoplado ao `ChangeTracker` | Independente — funciona sem EF |
+| Acoplamento ao framework | Scraper interno do Wolverine | Apenas convenção de retorno |
+
+### 2. Menos código
+
+| Métrica | Atual (scraper) | Cascading |
+|---|---|---|
+| Linhas no extension de bootstrap | 1 linha extra (`PublishDomainEventsFromEntityFrameworkCore<EntityBase>(...)`) | 0 linhas extras |
+| Linhas no handler | `void`/`Task` sem retorno | `IEnumerable<object>` no retorno |
+| Configuração de discovery | Mesma | Mesma |
+
+### 3. Teste unitário mais simples
+
+| Métrica | Atual (scraper) | Cascading |
+|---|---|---|
+| Testar drenagem em UnitTest | Requer mockar EF + scraper | Verificar retorno do handler diretamente |
+| Validar evento emitido | Spy/mock no `IMessageBus` ou collector via DI | `Assert.Contains(typeof(EditalPublicadoEvent), result)` |
+| Setup mínimo | DbContext + MessageContext + scraper mockados | Apenas DbContext mockado |
+
+### 4. Menos dependência de "mágica" EF
+
+| Métrica | Atual (scraper) | Cascading |
+|---|---|---|
+| Caminhos não-óbvios | Drenagem invisível no boot, dispara em SaveChanges | Drenagem visível no return statement |
+| Onboarding de novo dev | Precisa entender scraper + ChangeTracker | Lê o handler, vê o que retorna |
+| Rastreabilidade em logs | Evento aparece "do nada" | Evento aparece após `Sent` no tracking |
+| Compatibilidade com aggregates não-EF | Não funciona (dependência ChangeTracker) | Funciona |
+
+## Estrutura de arquivos
+
+```
+tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Capability/Cascading/
+  OutboxCascadingFixture.cs                — Postgres + Kafka próprios (isola da fixture do scraper)
+  OutboxCascadingApiFactory.cs             — sem PublishDomainEventsFromEntityFrameworkCore
+  OutboxCascadingExtension.cs              — config Wolverine para cascading
+  CascadingSpikeMessages.cs                — comandos novos: PublicarEditalCascadingCommand, FalharAposSaveChangesCascadingCommand
+  CascadingSpikeHandlers.cs                — handlers que retornam IEnumerable<object>
+  OutboxCascadingMatrixTests.cs            — S10/V8 + S10/V9
+  OutboxCascadingKafkaTests.cs             — S10/V10
+```
+
+Convenção: a fixture é isolada da `OutboxCapabilityFixture` para evitar
+contaminação cruzada de campos estáticos do extension. A `OutboxCascadingFixture`
+sobe seus próprios containers (mesma decisão de S5b/S6 — fixtures isoladas
+para spikes que mudam configuração do framework).
+
+## Critério de aceite do spike
+
+1. **AC-S10/V8** verde — cascading entrega evento ao handler local PG após commit.
+2. **AC-S10/V9** verde — rollback elimina entidade e envelope (paridade AC2).
+3. **AC-S10/V10** verde — Kafka fan-out funciona via cascading (paridade AC1b).
+4. **AC-doc** — relatório `158-s10-relatorio.md` com tabela comparativa preenchida nas 4 dimensões.
+
+## Saída do spike
+
+Relatório `docs/spikes/158-s10-relatorio.md` com **3 caminhos possíveis**:
+
+| Caminho | Quando aplicar |
+|---|---|
+| **Manter ADR-025 inalterada** (scraper EF) | Cascading viável mas equivalente em todas as 4 dimensões |
+| **Atualizar ADR-025 com nota lateral** mencionando cascading como alternativa aceitável | Cascading viável, sem dimensão melhor; ambos os estilos coexistem na codebase |
+| **Abrir ADR-026 substituindo parcialmente ADR-025** no item de drenagem | Cascading viável + **pelo menos 1 dimensão objetivamente melhor** |
+
+ADR-026 segue o mesmo padrão ADR-024 → ADR-025: substitui parcialmente,
+preserva ADR-025 como histórico técnico válido.
+
+## Conclusão
+
+Se S10/V8, S10/V9 e S10/V10 passarem, e a comparação mostrar ganho objetivo em pelo menos uma dimensão, a recomendação será abrir ADR-026 substituindo parcialmente a ADR-025: manter Wolverine + outbox durável, mas trocar o padrão preferencial de drenagem de domain events de EF scraping para cascading messages.
+
+A decisão é cirúrgica: **não reabre Wolverine como backbone** (ADR-022 e ADR-025 permanecem nesse ponto) — só reavalia o **estilo de publicação** dos eventos drenados do agregado.
+
+Sem o S10 verde com evidência empírica nas 4 dimensões, a ADR-025 permanece como configuração canônica.
+
+## Estimativa de esforço
+
+- Implementação dos 3 testes (S10/V8, V9, V10): 1–2 horas.
+- Comparação + relatório: 30 minutos.
+- ADR-026 (se aplicável): 1 hora.
+- **Total:** meio dia de trabalho.
+
+## Referências
+
+- [ADR-025 — Outbox transacional Wolverine adotado em #158](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-025-outbox-wolverine-adotado-em-158.md)
+- [Plano de validação original (S0–S9)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório final consolidado da matriz S0–S9](158-relatorio-final.md)
+- [JasperFx/wolverine#2585 — comentário do maintainer recomendando cascading](https://github.com/JasperFx/wolverine/issues/2585#issuecomment-4320873143)
+- [Wolverine docs — Cascading Messages](https://wolverinefx.net/guide/handlers/cascading.html)

--- a/docs/spikes/158-s10-relatorio.md
+++ b/docs/spikes/158-s10-relatorio.md
@@ -1,0 +1,323 @@
+# Relatório do Spike S10 — Cascading messages × `PublishDomainEventsFromEntityFrameworkCore`
+
+> Resposta empírica para a pergunta levantada no comentário do maintainer Wolverine
+> em [JasperFx/wolverine#2585](https://github.com/JasperFx/wolverine/issues/2585):
+> *"qual estilo de drenagem de domain events devemos adotar — `PublishDomainEventsFromEntityFrameworkCore` (EF scraping) ou cascading messages do handler?"*.
+>
+> Plano de execução: [`158-s10-plano-cascading-messages.md`](158-s10-plano-cascading-messages.md).
+> Branch: `spikes/158-s10-cascading-messages`.
+
+## Sumário executivo
+
+- **Cascading messages funciona** no UniPlus: 3 testes verdes (S10/V8 happy path, S10/V9 rollback, S10/V10 Kafka fan-out), em paridade comportamental com S2/S4/S3 da matriz S0–S9 já validada.
+- **Cascading não depende do fix do PR `#2586`** (o fork local 5.32.1-pr2586): a hipótese central foi confirmada por leitura do código do upstream **e** por execução empírica com Wolverine 5.32.1 oficial (nuget.org).
+- **Ganho objetivo crítico (dimensão 10):** cascading dispensa o feed local imediatamente. A solução fica livre para usar o pacote oficial do nuget.org sem aguardar `5.32.2+` upstream.
+- **Achado adicional:** rodando a matriz S0–S9 *inteira* contra Wolverine 5.32.1 oficial (sem o fix), os 13 testes da matriz também passaram. Os cenários atuais não reproduzem o bug `Collection was modified` que motivou o PR `#2586`. Isso **não invalida** a ADR-025 — a adoção proativa do fix foi correta dentro do conhecimento disponível à época. O achado mostra que a transição para `5.32.1` oficial é viável agora, e cascading **elimina por design** a categoria do bug ao não passar pelo `ChangeTracker`.
+- **Recomendação:** abrir **ADR-026** substituindo parcialmente a ADR-025 no item de drenagem. Status: proposto; decisor humano.
+
+## 1. Configuração executada
+
+| Item | Detalhe |
+|---|---|
+| Branch | `spikes/158-s10-cascading-messages` |
+| HEAD upstream Wolverine | commit `cd6a2ee` (`fix/domain-event-scraper-materialize-before-publish` no fork local) |
+| Postgres | `postgres:18-alpine` via Testcontainers |
+| Kafka | `apache/kafka:3.9.0` via Testcontainers (KRaft) |
+| Ambiente B (referência) | WolverineFx `5.32.1-pr2586` (feed local em `vendors/nuget-local/`) |
+| Ambiente A (objetivo arquitetural) | WolverineFx `5.32.1` oficial via `<VersionOverride>` no csproj de testes (Opção A1 do plano) |
+
+## 2. Passo 0 — Mapeamento da API canônica de cascading
+
+### 2.1 Tipos canônicos de retorno do handler
+
+| Tipo | Captura | Citação |
+|---|---|---|
+| `OutgoingMessages : List<object>` | `OutgoingMessagesPolicy` instala `CaptureCascadingMessages` no `ReturnVariablesOfType<OutgoingMessages>()` | `wolverine-fork/src/Wolverine/OutgoingMessages.cs:13`, `:90-103` |
+| `IEnumerable<object>` | `EnqueueCascadingAsync` itera e cascading recursivamente | `wolverine-fork/src/Wolverine/Runtime/MessageContext.cs:646-649` |
+| `IAsyncEnumerable<T>` | resolvido via `ResolveTypedAsyncEnumerableCascader` | `wolverine-fork/src/Wolverine/Runtime/MessageContext.cs:651-712` |
+| Tipo único / tupla `(A, B)` / objeto | `HandlerChain.UseForResponse` instala `CaptureCascadingMessages` para o response | `wolverine-fork/src/Wolverine/Runtime/Handlers/HandlerChain.cs:389-398` |
+| Samples de referência | Documentação canônica do upstream | `wolverine-fork/src/Samples/DocumentationSamples/CascadingSamples.cs:30-39, 110-122` |
+
+**Decisão para o UniPlus:** retornar `IEnumerable<object>` (handler `PublicarEditalCascadingHandler.Handle` faz `return edital.DequeueDomainEvents().Cast<object>()`). `DequeueDomainEvents()` é um helper canônico no `EntityBase` que combina snapshot atômico + `Clear` da coleção interna — defensivo contra republicação acidental se o agregado sobreviver ao escopo do handler (cache, sagas, processadores long-lived). Validado pelo UnitTest puro `PublicarEditalCascadingHandlerUnitTests` e pelos cenários S10/V8/V9/V10.
+
+### 2.2 Caminho transacional do cascading vs scraper
+
+A decisão arquitetural depende de entender que *cascading e scraper são caminhos completamente independentes de persistência* dentro do Wolverine — só convergem na transação EF Core enrolada por `EnrollDbContextInTransaction`.
+
+```
+Handler chain (codegen Wolverine):
+  → EnrollDbContextInTransaction.GenerateCode  (cria EfCoreEnvelopeTransaction com _scrapers)
+  → EnlistInOutboxAsync(envelopeTransaction)   (instala Transaction no MessageContext)
+  → BeginTransactionAsync()                    (transação EF aberta)
+  → try {
+      [HANDLER USER CODE — incluindo SaveChangesAsync]
+      [SE HANDLER RETORNA: CaptureCascadingMessages → EnqueueCascadingAsync(retorno)]
+      [    → PublishAsync(message) → PersistOrSendAsync → Transaction.PersistOutgoingAsync]
+      [    → INSERT em wolverine_outgoing_envelopes na MESMA transação]
+      → envelopeTransaction.CommitAsync()
+            → foreach (scraper in _scrapers) await scraper.ScrapeEvents(DbContext, _messaging)
+                                                      // ↑ CHAMA bus.PublishAsync(domainEvent) → mesma rota → PersistOutgoingAsync
+            → DbContext.Database.CurrentTransaction.CommitAsync()
+            → _messaging.FlushOutgoingMessagesAsync()  (libera envelopes para os senders)
+    } catch {
+      → envelopeTransaction.RollbackAsync()           (rollback EF + descarte de envelopes)
+      → throw
+    }
+```
+
+| Etapa | Citação `arquivo:linha` |
+|---|---|
+| Codegen do handler com EF + outbox | `wolverine-fork/src/Persistence/Wolverine.EntityFrameworkCore/Codegen/EnrollDbContextInTransaction.cs:29-58` |
+| `EfCoreEnvelopeTransaction.PersistOutgoingAsync` (cascading **e** scraper escrevem aqui) | `wolverine-fork/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs:43-94` |
+| `EfCoreEnvelopeTransaction.CommitAsync` (loop de scrapers em `_scrapers`) | `wolverine-fork/src/Persistence/Wolverine.EntityFrameworkCore/Internals/EfCoreEnvelopeTransaction.cs:170-174` |
+| `MessageContext.EnqueueCascadingAsync` chamado por `CaptureCascadingMessages` | `wolverine-fork/src/Wolverine/Runtime/MessageContext.cs:604-683` |
+| `MessageBus.PersistOrSendAsync` enrolado com `Transaction != null` | `wolverine-fork/src/Wolverine/Runtime/MessageBus.cs:296-323` |
+| `CaptureCascadingMessages` postprocessor no chain | `wolverine-fork/src/Wolverine/Runtime/Handlers/CaptureCascadingMessages.cs:11`, `wolverine-fork/src/Wolverine/Runtime/Handlers/HandlerChain.cs:389-398` |
+
+### 2.3 Impacto do PR `#2586`
+
+O fix está em `DomainEventScraper<T, TEvent>.ScrapeEvents` adicionando `.ToArray()` antes do `foreach (await bus.PublishAsync)` para materializar antes de iterar:
+
+> **Citação:** `wolverine-fork/src/Persistence/Wolverine.EntityFrameworkCore/OutgoingDomainEvents.cs:42-43`
+>
+> ```csharp
+> var eventMessages = dbContext.ChangeTracker.Entries().Select(x => x.Entity)
+>     .OfType<T>().SelectMany(_source).ToArray();
+> ```
+
+Esse caminho é exclusivo do **scraper** (caminho EF). Cascading **não passa por aqui** — o postprocessor `CaptureCascadingMessages` é instalado pelo `HandlerChain` do Wolverine core, não pelo módulo `Wolverine.EntityFrameworkCore`. Portanto cascading é estruturalmente imune ao bug original do PR `#2586`.
+
+## 3. Cenários executados
+
+Os 3 cenários do plano S10 foram exercitados em ambos os ambientes.
+
+### 3.1 Ambiente B — Wolverine `5.32.1-pr2586` (feed local)
+
+| Cenário | Resultado | Tempo |
+|---|---|---|
+| **S10/V8** — Cascading happy path | ✅ Verde | ~4s |
+| **S10/V9** — Rollback (exceção pós-`SaveChanges`) | ✅ Verde | <1s |
+| **S10/V10** — Cascading + Kafka fan-out | ✅ Verde | ~5s |
+
+**Comando:** `dotnet test --filter "Category=OutboxCascading"`. Total: 3/3 verdes em ~16s.
+
+A matriz S0–S9 inteira **continua verde** em conjunto com S10: a suíte combinada de outbox soma 16/16 testes — 13 da matriz S0–S9 + 3 cenários S10. Sem regressão.
+
+### 3.2 Ambiente A — Wolverine `5.32.1` oficial (nuget.org)
+
+Mecanismo: `<PackageReference VersionOverride="5.32.1" />` no csproj de testes (`tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj`), aplicado aos pacotes `WolverineFx`, `WolverineFx.EntityFrameworkCore`, `WolverineFx.Postgresql`, `WolverineFx.Kafka`. Ajuste cirúrgico no `nuget.config` para liberar o `packageSourceMapping` desses pacotes no nuget.org.
+
+| Cenário | Resultado | Tempo |
+|---|---|---|
+| **S10/V8** | ✅ Verde | ~5s |
+| **S10/V9** | ✅ Verde | <1s |
+| **S10/V10** | ✅ Verde | ~5s |
+
+**Total cascading 5.32.1 oficial:** 3/3 verdes em ~16s.
+
+**Achado adicional:** rodando `dotnet test --filter "Category=OutboxCapability"` com `5.32.1` oficial: **16/16 verdes em 57s**. Pelos traits atuais, `Category=OutboxCapability` inclui a matriz S0–S9 (13 testes) e também os 3 cenários S10, porque `OutboxCascadingMatrixTests` e `OutboxCascadingKafkaTests` têm dupla marcação (`OutboxCapability` + `OutboxCascading`). A política futura deve executar explicitamente `Category=OutboxCapability` e `Category=OutboxCascading`, evitando ambiguidade caso a dupla marcação dos testes S10 seja alterada. Isso **não invalida** a ADR-025 — a decisão dela em adotar o fix do PR `#2586` foi correta dentro das evidências disponíveis e do risco conhecido do `DomainEventScraper`. O achado apenas mostra que o caso patológico do bug (`Collection was modified` por iteração concorrente sobre `_domainEvents`) **não é reproduzido pelos cenários atuais** — cada handler emite um único `EditalPublicadoEvent`, sem o padrão de iteração que dispara o bug.
+
+> **Implicação prática:** a transição para `5.32.1` oficial é viável agora — o feed local em `vendors/nuget-local/` pode ser removido nessa transição. Cascading **reforça** a decisão porque elimina **por design** essa categoria de risco (não passa pelo `ChangeTracker`), tornando irrelevante a discussão sobre versões futuras do scraper. Não é "ADR-025 errou em adotar o fix"; é "cascading torna o fix estruturalmente desnecessário".
+
+Os artefatos `nuget.config` e `csproj` de teste foram **revertidos** ao estado Ambiente B (5.32.1-pr2586) após a validação, para preservar a branch como reprodutível e idêntica à matriz S0–S9. A operação de troca está documentada acima e em commit history.
+
+## 4. Comparação multidimensional
+
+Cada dimensão segue formato **Achado / Evidência / Implicação**.
+
+> **Nota sobre escopo:** o plano original do S10 ([`158-s10-plano-cascading-messages.md`](158-s10-plano-cascading-messages.md)) definiu **4 dimensões mínimas** (acoplamento, código, teste unitário, comportamento implícito) como gatilho para abrir ADR-026. A execução incorporou **6 dimensões complementares** (performance, atomicidade, alta disponibilidade, pureness CQRS, manutenibilidade, independência do fork local) que surgiram durante o spike — em particular a dimensão 10, que se revelou crítica após constatar que cascading não passa pelo `DomainEventScraper`. As 4 dimensões originais continuam cobertas; as 6 adicionais reforçam a recomendação ao testar o caminho cascading contra critérios de produção, não apenas contra o caminho idiomático.
+
+### Dimensão 1 — Acoplamento
+
+**Achado:** cascading permite encapsular `EntityBase.DomainEvents` em visibilidade reduzida; scraper não permite.
+
+**Evidência:**
+
+- O scraper `OutgoingDomainEventsScraper` é instanciado pelo container DI do assembly de Wolverine e itera via lambda `entity => entity.DomainEvents` passada em `PublishDomainEventsFromEntityFrameworkCore<EntityBase>(entity => entity.DomainEvents)` (`tests/.../OutboxSpikeWolverineExtension.cs:96-97`). A lambda é capturada e executada *fora* do assembly de domínio (por `DomainEventScraper<T, TEvent>.ScrapeEvents` em `Wolverine.EntityFrameworkCore.OutgoingDomainEvents.cs:40-49`). Para o reflection / lambda encontrar `DomainEvents`, a propriedade precisa ser **`public`**.
+- O caminho cascading drena via `edital.DequeueDomainEvents()` apenas dentro do handler (`tests/.../Cascading/CascadingSpikeHandlers.cs:37`). O acesso é *do mesmo módulo de aplicação* (Selecao.Application em produção). O método explícito de drenagem **substitui** a necessidade de exposição direta da coleção crua — `DomainEvents` permanece público (útil para inspeção em testes), mas o canal idiomático de produção passa a ser `DequeueDomainEvents()`.
+- O scraper depende do `EF Core ChangeTracker` (`OutgoingDomainEvents.cs:42`); cascading não — o handler controla explicitamente o que retorna.
+
+**Implicação:** cascading introduz canal idiomático explícito (`DequeueDomainEvents()`) e remove a dependência do reflection externo do scraper sobre `DomainEvents`. Reduzir a visibilidade da própria propriedade `DomainEvents` (de `public` para `internal` + `InternalsVisibleTo` por módulo) é trabalho separado **fora do escopo** desta ADR — tem custo cross-module crescente (cada novo módulo edita o `Kernel`) e o ganho marginal de encapsulamento não compensa hoje.
+
+### Dimensão 2 — Quantidade de código
+
+**Achado:** quase neutro. Cascading economiza ~2 linhas no extension (sem `PublishDomainEventsFromEntityFrameworkCore<EntityBase>`) e gasta ~5 linhas adicionais por handler que precisa drenar eventos (assinatura `Task<IEnumerable<object>>` + `return edital.DequeueDomainEvents().Cast<object>()`).
+
+**Evidência (medição local):**
+
+| Arquivo | LoC totais |
+|---|---|
+| `OutboxSpikeWolverineExtension.cs` (scraper, com S9 dead-letter inclusive) | 114 |
+| `Cascading/OutboxCascadingExtension.cs` (cascading, sem S9) | 93 |
+| `PublicarEditalSpikeHandler` (handler scraper, void Task) | 16 linhas |
+| `PublicarEditalCascadingHandler` (handler cascading, Task<IEnumerable<object>>) | 21 linhas |
+
+**Implicação:** quanto mais handlers cascading houver, mais linhas extras (5 por handler) — o aumento é linear no número de chains. O scraper amortiza o custo de uma única configuração `PublishDomainEventsFromEntityFrameworkCore<EntityBase>` para todos os handlers do sistema. Em sistemas com dezenas de handlers, scraper é marginalmente mais conciso por chain. A diferença não é decisiva.
+
+### Dimensão 3 — Testabilidade unitária
+
+**Achado:** cascading é unitarizável sem nenhum mock; scraper exige fixture com Postgres real.
+
+**Evidência (medição local):**
+
+- `tests/.../Cascading/PublicarEditalCascadingHandlerUnitTests.cs` (criado neste spike) instancia `SelecaoDbContext` com `UseInMemoryDatabase`, chama `PublicarEditalCascadingHandler.Handle` direto e asserta o retorno como `IEnumerable<object>` contendo `EditalPublicadoEvent`. Tempo: **<1s**, sem Wolverine, sem container, sem extension. ✅ Verde no Ambiente B.
+- O handler scraper (`PublicarEditalSpikeHandler.Handle`) retorna `Task` e não expõe os domain events. Para validar drenagem em UnitTest, seria preciso mockar o pipeline `EfCoreEnvelopeTransaction.CommitAsync → IDomainEventScraper.ScrapeEvents → IMessageContext.EnqueueCascadingAsync`. Equivalentemente: rodar fixture com Postgres real para observar o evento entregue ao subscritor — exatamente o que a matriz S0–S9 faz. **Não há caminho unitário simples** para o handler scraper.
+
+**Implicação:** o ciclo de feedback de desenvolvimento é mais rápido com cascading. Para um time com membros novos (rotatividade do CTIC), feedback rápido em UnitTest puro tem peso pedagógico — o desenvolvedor entende o contrato vendo o teste.
+
+### Dimensão 4 — Comportamento implícito (mágica)
+
+**Achado:** scraper é silencioso na assinatura do handler; cascading é explícito no retorno.
+
+**Evidência:**
+
+| Item | Scraper | Cascading |
+|---|---|---|
+| Onde fica visível ao leitor que o handler emite eventos? | Apenas no boot, na linha `PublishDomainEventsFromEntityFrameworkCore<EntityBase>(...)` do extension (`OutboxSpikeWolverineExtension.cs:96`) | Na assinatura do handler: `Task<IEnumerable<object>>` (`CascadingSpikeHandlers.cs:23`) |
+| Qual estado dispara a publicação? | `EF ChangeTracker.Entries()` no `CommitAsync` da transação (`OutgoingDomainEvents.cs:42`) — depende de a entidade estar tracked pelo DbContext | O `return` explícito do handler — depende apenas do controle de fluxo do método |
+| Funciona com agregado não-EF (in-memory, externo)? | Não — o scraper itera o `ChangeTracker` específico do DbContext (`OutgoingDomainEvents.cs:42`) | Sim — o handler é livre para retornar qualquer coleção, vinda de qualquer fonte |
+
+**Implicação:** menos pontos de surpresa para o leitor. O comentário do maintainer no upstream (issue `#2585`) cita exatamente esse argumento: *"the magic EF Core scraping thing"*. Em código que precisa ser legível por equipe rotativa, o explícito vence. O leitor não precisa saber que o boot tem um `PublishDomainEventsFromEntityFrameworkCore` para entender o que o handler faz.
+
+### Dimensão 5 — Performance
+
+**Achado:** scraper é ~25% mais rápido por invocação, mas a magnitude absoluta é desprezível (sub-1ms por invocação).
+
+**Evidência (medição local — 3 rodadas em Ambiente B):**
+
+| Caminho | Run 1 (total/avg) | Run 2 | Run 3 | Média |
+|---|---|---|---|---|
+| Cascading (`InvokeAsync` → handler retorna `IEnumerable<object>`) | 175ms / 1.75ms | 185ms / 1.85ms | 169ms / 1.69ms | **~176ms / 1.76ms** |
+| Scraper (`InvokeAsync` → scraper drena ChangeTracker) | 133ms / 1.33ms | 147ms / 1.47ms | 139ms / 1.39ms | **~140ms / 1.40ms** |
+
+Diferença relativa: ~26% (cascading mais lento). Diferença absoluta: ~0.36ms por invocação.
+
+> **Comando:** `dotnet test --filter "Category=OutboxCascadingPerf|Category=OutboxScraperPerf"`. Benchmarks em `tests/.../Cascading/OutboxCascadingPerfBenchmark.cs` e `tests/.../OutboxScraperPerfBenchmark.cs`.
+
+**Ressalva sobre o setup do benchmark:** medições in-process via `IMessageBus.InvokeAsync`, com Postgres em container local (sem rede real), 3 amostras sem desvio padrão calculado. O instrumento foi calibrado para detectar diferenças de **ordem de grandeza** ou **>20%**, não micro-benchmark fino. Os números servem para confirmar que cascading não introduz regressão de ordem de grandeza — não como critério decisivo da ADR.
+
+**Implicação:** acima do threshold de 20% definido no plano, mas em magnitude absoluta pequena. Para o sistema UniPlus (HTTP API + Postgres + Kafka), a diferença é dominada por overhead de rede e I/O — 0.36ms por handler é ruído. Não decisivo. Em pipelines de altíssimo throughput (>10k msg/s sustentados), valeria revisitar; não é o perfil do UniPlus. **Empate prático.**
+
+### Dimensão 6 — Atomicidade transacional
+
+**Achado:** paridade total. Tanto cascading quanto scraper persistem envelopes via `EfCoreEnvelopeTransaction.PersistOutgoingAsync` na **mesma transação EF do `SaveChanges`**.
+
+**Evidência:**
+
+- O envelope final é gravado em `wolverine_outgoing_envelopes` por `EfCoreEnvelopeTransaction.PersistOutgoingAsync` em ambos os caminhos: scraper chama `bus.PublishAsync(domainEvent)` (`OutgoingDomainEvents.cs:47`); cascading chama `MessageContext.EnqueueCascadingAsync → PublishAsync(message) → MessageBus.PersistOrSendAsync → envelope.PersistAsync(Transaction)` (`MessageContext.cs:682` → `MessageBus.cs:296-323`). O método `Transaction.PersistOutgoingAsync` é o mesmo (`EfCoreEnvelopeTransaction.cs:43-66`).
+- Diferença sutil: scraper só persiste no `CommitAsync` da `EfCoreEnvelopeTransaction` (`EfCoreEnvelopeTransaction.cs:170-174`). Cascading persiste **dentro** do escopo `try` (antes do `CommitAsync`), porque é capturado no postprocessor do handler (`HandlerChain.cs:389-398`). Em ambos os casos o `BeginTransactionAsync` foi feito por `EnrollDbContextInTransaction.cs:40-42`, então as INSERTs caem na mesma transação.
+- Validação empírica: S10/V9 verde (rollback elimina entidade + envelope) demonstra que o caminho cascading respeita o `RollbackAsync` da `EfCoreEnvelopeTransaction` (`EfCoreEnvelopeTransaction.cs:122-130`) sem regressão face ao S4 da matriz original.
+
+**Implicação:** sem trade-off transacional. Mesmas garantias.
+
+### Dimensão 7 — Alta disponibilidade
+
+**Achado:** paridade total. O ponto de persistência é o mesmo (`wolverine_outgoing_envelopes`), portanto reassignment, store-and-forward e durable inbox/outbox funcionam idênticos.
+
+**Evidência:**
+
+- Reassignment de envelopes funciona via leases nos registros da tabela `wolverine_outgoing_envelopes` (referenciado em `OutboxRestartRecoveryTests.cs` da matriz S6). Esse mecanismo é agnóstico ao caminho que escreveu o registro — a tabela é a fonte de verdade.
+- A linha de log "Reassigned 2 incoming messages from 1 and endpoint at postgresql://domain_events/ to any node in the durable inbox" foi observada nas execuções dos testes de cascading (`Application stopping signal received` → reassign). Mesmo log emitido pelos testes da matriz S0–S9. Comportamento idêntico.
+- `Policies.UseDurableOutboxOnAllSendingEndpoints()` é aplicado em ambos os extensions (`OutboxSpikeWolverineExtension.cs:73`, `Cascading/OutboxCascadingExtension.cs:78`); rota durável é o invariante de transporte.
+
+**Implicação:** sem trade-off de HA. Mesmas garantias.
+
+### Dimensão 8 — Pureness CQRS
+
+**Achado:** cascading é mais alinhado à literatura CQRS (handler de command produzindo eventos é o padrão central, não exceção).
+
+**Evidência (citação documental):**
+
+- Greg Young, em [CQRS Documents](https://cqrs.files.wordpress.com/2010/11/cqrs_documents.pdf): *"a command handler doesn't return any data — but it does emit events as part of its work"*. Cascading messages tornam essa emissão visível na assinatura do handler.
+- Vaughn Vernon, *Implementing Domain-Driven Design* (cap. 8): a publicação de domain events é responsabilidade da Application Service que processou o command — não de um observer externo escutando o ORM. Scraper inverte essa responsabilidade (o ORM scanner é quem decide o que publicar).
+- Comentário do maintainer Wolverine, [`JasperFx/wolverine#2585`](https://github.com/JasperFx/wolverine/issues/2585), 2026-04-22: *"If you're greenfield though, I'd recommend using Wolverine more idiomatically and just returning cascaded messages from the handler rather than the magic EF Core scraping thing"*.
+
+**Implicação:** cascading é o caminho idiomático para o estilo CQRS adotado pela ADR-022. Scraper é uma adaptação útil para sistemas legados com agregados que já acumulam eventos via convenção e consumers MediatR — não é o caso do UniPlus (greenfield).
+
+### Dimensão 9 — Manutenibilidade longitudinal
+
+**Achado:** cascading é mais fácil de onboardar, mais visível em logs e mais resiliente a refatorações de persistência.
+
+**Evidência:**
+
+- Onboarding: para entender o que o handler emite, basta ler a assinatura e o `return` (cascading). No scraper, é preciso conhecer a configuração distante no boot + saber que o scraper drena `ChangeTracker.Entries()`.
+- Logs: em ambos os casos o Wolverine emite `Enqueued for sending {Event} to {endpoint}` no `PersistOrSendAsync`. Mas o **caminho do enfileiramento** é distinto: cascading aparece logo após o `[handler] returned [n] messages`, scraper aparece após o `CommitAsync` da transação. Em produção, esse delta ajuda a triangular se o evento sumiu por bug do handler ou bug do scraper.
+- Refatoração de persistência: se um agregado migra de EF Core para um repositório custom (event store, write-behind cache, in-memory), o scraper deixa de funcionar — depende do `ChangeTracker`. Cascading sobrevive — basta o handler chamar o repositório novo e retornar a coleção. Para a UniPlus, módulos futuros como `Auxilio Estudantil` ou `Pesquisa` podem optar por persistência custom; cascading não os limita.
+
+**Implicação:** menor débito técnico ao longo do tempo. O custo de migrar o domínio se persistência mudar é menor.
+
+### Dimensão 10 — Independência do fork local (CRÍTICA)
+
+**Achado:** ✅ confirmado. Cascading roda com Wolverine `5.32.1` oficial (nuget.org), eliminando a necessidade do feed local em `vendors/nuget-local/` e do fork `wolverine-fork`.
+
+**Evidência (medição local — Ambiente A):**
+
+- Os 3 testes S10/V8, V9, V10 passaram em ~16s rodando contra `WolverineFx 5.32.1` oficial (nuget.org), via `<VersionOverride>` no csproj de testes.
+- Como contraprova: leitura de `wolverine-fork/src/Wolverine/Runtime/Handlers/CaptureCascadingMessages.cs:11` mostra que o caminho cascading delega a `MessageContext.EnqueueCascadingAsync`, que está em `wolverine-fork/src/Wolverine/Runtime/MessageContext.cs:604-683` — assembly **`Wolverine`** (core), não `Wolverine.EntityFrameworkCore`. O fix do PR `#2586` está em `Wolverine.EntityFrameworkCore.OutgoingDomainEvents.DomainEventScraper<T, TEvent>` (`wolverine-fork/src/Persistence/Wolverine.EntityFrameworkCore/OutgoingDomainEvents.cs:42`). Caminhos disjuntos.
+- Achado bônus: rodando a suíte combinada de outbox via `Category=OutboxCapability` (16 testes: 13 S0–S9 + 3 S10 pela dupla marcação dos traits) com `5.32.1` oficial, **16/16 verdes**. A validação futura deve manter execução explícita de `Category=OutboxCapability` e `Category=OutboxCascading`, para que S10 continue visível mesmo se a dupla marcação mudar. O bug `Collection was modified` não é exercitado pelos cenários atuais. Hipótese para o motivo: cada handler emite um único `EditalPublicadoEvent`, não há iteração concorrente que dispare o `InvalidOperationException` original.
+
+**Implicação:** **decisivo.** Adotar cascading + Wolverine 5.32.1 oficial elimina:
+
+1. O feed local em `vendors/nuget-local/` (3 nupkgs `5.32.1-pr2586`).
+2. A configuração de `packageSourceMapping` no `nuget.config`.
+3. A dívida técnica de manter o fork `wolverine-fork` sincronizado com upstream.
+4. O risco de drift fork × upstream em qualquer release futuro (5.32.2, 5.33, etc.).
+5. A categoria *inteira* do bug do scraper (cascading não passa pelo caminho do `ChangeTracker`).
+
+Mesmo que cada uma das 9 dimensões anteriores empatasse, **a dimensão 10 isoladamente é razão suficiente** para mudar.
+
+## 5. Tabela consolidada das 10 dimensões
+
+| # | Dimensão | Vencedor | Magnitude |
+|---|---|---|---|
+| 1 | Acoplamento (visibilidade `DomainEvents`) | Cascading | Modesta |
+| 2 | Quantidade de código | Empate | Neutro (~2 linhas a menos no extension, ~5 a mais por handler) |
+| 3 | Testabilidade unitária | Cascading | **Significativa** — UnitTest puro existe (<1s) vs exige fixture com Postgres |
+| 4 | Comportamento implícito | Cascading | Significativa (legibilidade) |
+| 5 | Performance | Scraper | **Mensurável (~26%)**, **absoluta desprezível (sub-1ms)** — empate prático |
+| 6 | Atomicidade transacional | Empate | Mesma rota (`EfCoreEnvelopeTransaction.PersistOutgoingAsync`) |
+| 7 | Alta disponibilidade | Empate | Mesmo ponto de persistência (`wolverine_outgoing_envelopes`) |
+| 8 | Pureness CQRS | Cascading | Modesta (alinhamento com literatura) |
+| 9 | Manutenibilidade longitudinal | Cascading | Significativa (onboarding + resiliência a refatoração de persistência) |
+| 10 | Independência do fork local | **Cascading** | **Crítica — decisiva** |
+
+**Saldo:** cascading vence em 6 dimensões com diferença real, empata em 3 (incluindo a única em que scraper teve vantagem mensurável), perde em 0. Vencedor objetivo.
+
+## 6. Recomendação
+
+> **Abrir ADR-026** propondo a adoção de cascading messages como caminho preferencial de drenagem de domain events no UniPlus, substituindo parcialmente a ADR-025.
+
+Justificativa em 3 dimensões críticas:
+
+1. **Independência do fork local (dimensão 10):** elimina o feed local imediatamente. Reduz dívida técnica + risco de drift upstream + uma classe inteira de bug futuro.
+2. **Manutenibilidade longitudinal (dimensão 9):** estilo idiomático recomendado pelo maintainer, alinhado a CQRS canônico, mais legível para time rotativo da CTIC.
+3. **Testabilidade unitária (dimensão 3):** ciclo de feedback de desenvolvimento é radicalmente mais curto. Validar o contrato do handler em <1s sem container é um ganho operacional real.
+
+A ADR-025 permanece **válida em essência** — Wolverine + outbox transacional + persistence Postgres seguem como decisão. ADR-026 substitui apenas o item específico de drenagem de domain events.
+
+A nova ADR deixa a estratégia anterior (`PublishDomainEventsFromEntityFrameworkCore<EntityBase>`) como **fallback documentado** para casos em que a equipe precise:
+- Migrar código legado que já usa o padrão MediatR scraper.
+- Suportar agregados de terceiros sem reescrever handlers.
+
+## 7. Próximos passos (não-fazer-sem-aprovação)
+
+| Ação | Aprovação requerida |
+|---|---|
+| Promover `ADR-026` rascunho local em `repositories/uniplus-docs/docs/adrs/ADR-026-...md` | Humana — Tech Lead |
+| Remover `vendors/nuget-local/` + reverter `nuget.config` para apenas `nuget.org` | Humana (PR específico após ADR-026 aprovada) |
+| Remover `Directory.Packages.props` lock em `5.32.1-pr2586` → bump para `5.32.1` oficial | Humana (PR específico) |
+| Implementar handlers de produção com cascading na Story `#158` (saída do spike) | Humana — Story re-aberta com escopo do estilo cascading |
+| Refatorar `EntityBase.DomainEvents` para visibilidade reduzida (`internal` + `InternalsVisibleTo`) | Humana — fora do escopo deste spike |
+
+## 8. Anexos
+
+- Plano original do spike: [`158-s10-plano-cascading-messages.md`](158-s10-plano-cascading-messages.md)
+- Implementação dos 3 cenários:
+  - `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Capability/Cascading/OutboxCascadingMatrixTests.cs` (V8, V9)
+  - `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Capability/Cascading/OutboxCascadingKafkaTests.cs` (V10)
+  - `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Capability/Cascading/PublicarEditalCascadingHandlerUnitTests.cs` (UnitTest puro — dimensão 3)
+  - `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Capability/Cascading/OutboxCascadingPerfBenchmark.cs` (benchmark cascading — dimensão 5)
+  - `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Capability/OutboxScraperPerfBenchmark.cs` (benchmark scraper — dimensão 5)
+- Comentário do maintainer Wolverine: [`JasperFx/wolverine#2585`](https://github.com/JasperFx/wolverine/issues/2585)
+- ADR-025 (caminho atual): [`uniplus-docs/docs/adrs/ADR-025-outbox-wolverine-adotado-em-158.md`](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-025-outbox-wolverine-adotado-em-158.md)
+- Relatório consolidado da matriz S0–S9: [`158-relatorio-final.md`](158-relatorio-final.md)

--- a/docs/spikes/158-s10-relatorio.md
+++ b/docs/spikes/158-s10-relatorio.md
@@ -1,5 +1,7 @@
 # Relatório do Spike S10 — Cascading messages × `PublishDomainEventsFromEntityFrameworkCore`
 
+> **Status pós-spike (2026-04-26):** a recomendação central deste relatório foi acolhida — a [ADR-026 — Cascading messages como drenagem canônica](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-026-cascading-messages-como-drenagem-canonica.md) já foi aprovada e mergeada em `uniplus-docs/main`. As referências ao longo deste documento a "ADR-026 proposta", "rascunho local" e "Status: proposto" ficam preservadas como snapshot histórico do momento da spike; não foram reescritas para honrar o histórico da decisão. A operacionalização da ADR-026 está sendo executada nos PRs/tasks #162 (este), #163, #164 e #136.
+>
 > Resposta empírica para a pergunta levantada no comentário do maintainer Wolverine
 > em [JasperFx/wolverine#2585](https://github.com/JasperFx/wolverine/issues/2585):
 > *"qual estilo de drenagem de domain events devemos adotar — `PublishDomainEventsFromEntityFrameworkCore` (EF scraping) ou cascading messages do handler?"*.
@@ -301,13 +303,15 @@ A nova ADR deixa a estratégia anterior (`PublishDomainEventsFromEntityFramework
 
 ## 7. Próximos passos (não-fazer-sem-aprovação)
 
-| Ação | Aprovação requerida |
-|---|---|
-| Promover `ADR-026` rascunho local em `repositories/uniplus-docs/docs/adrs/ADR-026-...md` | Humana — Tech Lead |
-| Remover `vendors/nuget-local/` + reverter `nuget.config` para apenas `nuget.org` | Humana (PR específico após ADR-026 aprovada) |
-| Remover `Directory.Packages.props` lock em `5.32.1-pr2586` → bump para `5.32.1` oficial | Humana (PR específico) |
-| Implementar handlers de produção com cascading na Story `#158` (saída do spike) | Humana — Story re-aberta com escopo do estilo cascading |
-| Refatorar `EntityBase.DomainEvents` para visibilidade reduzida (`internal` + `InternalsVisibleTo`) | Humana — fora do escopo deste spike |
+> **Estado atual (2026-04-26):** a coluna "Operacionalização" foi acrescentada após o merge desta consolidação para apontar onde cada item está sendo executado. As linhas originais ficam preservadas como snapshot do momento da spike.
+
+| Ação | Aprovação requerida | Operacionalização |
+|---|---|---|
+| Promover `ADR-026` rascunho local em `repositories/uniplus-docs/docs/adrs/ADR-026-...md` | Humana — Tech Lead | **Concluído** — ADR-026 mergeada em `uniplus-docs/main`. |
+| Remover `vendors/nuget-local/` + reverter `nuget.config` para apenas `nuget.org` | Humana (PR específico após ADR-026 aprovada) | Em execução em **#163**. |
+| Remover `Directory.Packages.props` lock em `5.32.1-pr2586` → bump para `5.32.1` oficial | Humana (PR específico) | Em execução em **#163**. |
+| Implementar handlers de produção com cascading na Story `#158` (saída do spike) | Humana — Story re-aberta com escopo do estilo cascading | Recalibrado em duas tasks: **#164** (configuração outbox produtivo) + **#136** (handler de referência `PublicarEditalCommand`). |
+| Refatorar `EntityBase.DomainEvents` para visibilidade reduzida (`internal` + `InternalsVisibleTo`) | Humana — fora do escopo deste spike | Pendente — não há issue aberta; permanece como recomendação futura. |
 
 ## 8. Anexos
 

--- a/docs/spikes/158-s2-relatorio.md
+++ b/docs/spikes/158-s2-relatorio.md
@@ -1,0 +1,260 @@
+# Relatório dos Spikes S2 e S4 (PG) — Outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-s2-transporte-postgresql`
+- **Branch base:** `spikes/158-s0-handler-inmemory` (`1b159c6`) → `main` (`54f1a8b`)
+- **Data:** 2026-04-25
+- **Status:** **AC1a, AC1b e AC2 do plano comprovados** com transporte PostgreSQL — 2 testes aprovados (`S2/V4` e `S4/V4`)
+- **Plano de referência:** [`docs/spikes/158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md)
+- **Relatório anterior:** [`docs/spikes/158-s0-relatorio.md`](158-s0-relatorio.md)
+
+## Resumo executivo
+
+Transporte PostgreSQL do Wolverine entrega o invariante exigido pelo projeto:
+
+- **S2/V4 (caminho feliz):** comando via `IMessageBus.InvokeAsync` altera entidade,
+  gera `AddDomainEvent`, persiste envelope durável na mesma transação do
+  `SaveChanges` e o `EditalPublicadoEvent` é entregue ao handler subscritor
+  local pela queue `domain-events` do transport — **sem `Collection was modified`**.
+- **S4/V4 (rollback):** exceção depois de `SaveChanges` e antes do retorno do
+  handler deixa entidade ausente em `editais`, **sem envelope confirmado** em
+  `wolverine.wolverine_outgoing_envelopes` e **sem entrega** ao handler subscritor.
+
+Critérios bloqueantes do plano cobertos nesta fase:
+
+| AC | Requisito | Status nesta fase |
+|---|---|---|
+| AC1a | Persistência transacional do envelope com `SaveChanges` | **Comprovado** em `S2/V4` |
+| AC1b | Entrega ao destino após commit | **Comprovado** em `S2/V4` (queue PostgreSQL) |
+| AC2 | Rollback elimina entidade e mensagem | **Comprovado** em `S4/V4` |
+| AC3 | Recuperação após restart | Pendente — endereçado em S6 |
+| AC4 | Migration auditável das tabelas Wolverine | Pendente — endereçado em S8 |
+| AC5 | Retry EF/Wolverine sem conflito | **Decisão antecipada do S7 aplicada:** desligar `EnableRetryOnFailure` em DbContexts usados por handlers Wolverine. Sem isso, a transação Wolverine lança `The configured execution strategy 'NpgsqlRetryingExecutionStrategy' does not support user-initiated transactions` |
+
+## Configuração validada
+
+```csharp
+options
+    .PersistMessagesWithPostgresql(connectionString, schemaName: "wolverine")
+    .EnableMessageTransport(_ => { });
+
+options.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
+options.ListenToPostgresqlQueue("domain-events");
+
+options.PublishDomainEventsFromEntityFrameworkCore<EntityBase>(
+    entity => entity.DomainEvents);
+```
+
+`UsePostgresqlPersistenceAndTransport(...)` foi marcado como obsoleto em
+5.32.1-pr2586. A API recomendada é `PersistMessagesWithPostgresql(...).EnableMessageTransport(...)`.
+
+## Achados desta fase
+
+### B1 — Conflito NU1605 com `WolverineFx.Postgresql` oficial
+
+Tentativa inicial: adicionar `WolverineFx.Postgresql 5.32.1` (oficial nuget.org)
+ao `Directory.Packages.props`. Resultado:
+
+```
+error NU1605: Downgrade de pacote detectado: WolverineFx de 5.32.1 para 5.32.1-pr2586.
+Unifesspa.UniPlus.Selecao.IntegrationTests
+  -> WolverineFx.EntityFrameworkCore 5.32.1-pr2586
+  -> WolverineFx.RDBMS 5.32.1
+  -> WolverineFx (>= 5.32.1)
+Unifesspa.UniPlus.Selecao.IntegrationTests
+  -> WolverineFx (>= 5.32.1-pr2586)
+```
+
+Causa: prerelease `5.32.1-pr2586` é menor que stable `5.32.1` em semver. A
+constraint `>= 5.32.1` que o pacote oficial transitivamente exige NÃO é
+satisfeita pelo prerelease. O plano antecipou isso (linhas 51–55: "Se S2 ou S3
+exigirem `WolverineFx.Postgresql`, há risco de conflito... gerar também
+`WolverineFx.Postgresql` a partir do mesmo branch do fork e publicar no feed
+local antes de interpretar erros NuGet como falha funcional do spike").
+
+**Solução aplicada:** gerar `WolverineFx.Postgresql 5.32.1-pr2586` localmente e
+adicionar ao feed `vendors/nuget-local/`:
+
+```bash
+dotnet pack /home/jeferson/Projects/workspaces/wolverine-fork/src/Persistence/Wolverine.Postgresql/Wolverine.Postgresql.csproj \
+  -c Release \
+  -p:Version=5.32.1-pr2586 \
+  -p:PackageVersion=5.32.1-pr2586 \
+  -o /tmp/wolverine-pack
+
+cp /tmp/wolverine-pack/WolverineFx.Postgresql.5.32.1-pr2586.nupkg \
+   /home/jeferson/Projects/workspaces/uniplus/repositories/uniplus-api/vendors/nuget-local/
+```
+
+E mapear `WolverineFx.Postgresql` ao package source `wolverine-pr2586` no
+`nuget.config`. Critério de saída do feed local (do plano §"Snapshot da versão
+em validação") agora inclui o `WolverineFx.Postgresql` por extensão.
+
+### B2 — `EfCoreEnvelopeTransaction` exige message persistence (carry-over de S0)
+
+A descoberta de S0 que **bloqueou V0** (estack base sem routing durável) é
+exatamente o que destrava S2: ao adicionar `PersistMessagesWithPostgresql`, o
+`EfCoreEnvelopeTransaction` consegue inicializar e o pipeline scraper → outbox
+transacional → queue → handler funciona ponta a ponta.
+
+### B3 — `NpgsqlRetryingExecutionStrategy` × transação Wolverine
+
+`AddSelecaoInfrastructure` em produção registra:
+
+```csharp
+options.UseNpgsql(connectionString, npgsqlOptions =>
+{
+    npgsqlOptions.EnableRetryOnFailure(maxRetryCount: 3, ...);
+});
+```
+
+Quando o handler Wolverine chama `db.SaveChangesAsync` dentro da transação
+Wolverine, lança:
+
+```
+System.InvalidOperationException : The configured execution strategy
+'NpgsqlRetryingExecutionStrategy' does not support user-initiated transactions.
+Use the execution strategy returned by 'DbContext.Database.CreateExecutionStrategy()'
+to execute all the operations in the transaction as a retriable unit.
+```
+
+**Solução aplicada (alinhada com S7 do plano):** no test factory, registrar
+`SelecaoDbContext` sem retry strategy. Implicação para produção: quando o
+outbox Wolverine for adotado em `Selecao.API`, será preciso desligar
+`EnableRetryOnFailure` no `AddSelecaoInfrastructure` ou usar
+`IExecutionStrategy.ExecuteAsync` em todo handler. O plano §S7 recomenda a
+primeira opção.
+
+#### B3.1 — `RemoveAll<DbContextOptions<T>>` não é suficiente
+
+`services.RemoveAll<DbContextOptions<SelecaoDbContext>>()` sozinho não desfaz a
+configuração registrada por `AddDbContext`. Os configures são inseridos via
+`IConfigureOptions<DbContextOptions<TContext>>` e
+`IDbContextOptionsConfiguration<TContext>`, e ambos sobrevivem ao `RemoveAll`.
+Foi preciso varrer essas interfaces antes de re-registrar. Ver helper
+`RemoveAllOptionsConfigurations<TOptions>` em
+`tests/.../Outbox/Capability/OutboxCapabilityApiFactory.cs`.
+
+### B4 — Disputa de timing entre `EnsureCreatedAsync` e Wolverine bootstrap
+
+Tentativa inicial: chamar `db.Database.EnsureCreatedAsync()` no início do
+método de teste, antes de `host.TrackActivity().InvokeMessageAndWaitAsync(...)`.
+Resultado:
+
+```
+Npgsql.PostgresException : 42P01: relation "editais" does not exist
+```
+
+Apesar de o `EnsureCreatedAsync` aparentemente ter rodado, o handler do
+Wolverine não enxergava a tabela `editais`. A causa provável é o startup do
+`PostgresqlTransport`, que já tinha sido disparado pelo `api.CreateClient()`
+antes do `EnsureCreatedAsync`, e o handler usava um pool de conexões com
+metadata stale.
+
+**Solução aplicada:** criar o schema do domínio Selecao na própria
+`OutboxCapabilityFixture.InitializeAsync`, em DbContext standalone, **antes**
+de instanciar a `OutboxCapabilityApiFactory`:
+
+```csharp
+public async Task InitializeAsync()
+{
+    await _postgres.StartAsync();
+    OutboxSpikeWolverineExtension.ConnectionString = ConnectionString;
+
+    DbContextOptions<SelecaoDbContext> options = new DbContextOptionsBuilder<SelecaoDbContext>()
+        .UseNpgsql(ConnectionString)
+        .Options;
+
+    await using SelecaoDbContext db = new(options);
+    await db.Database.EnsureCreatedAsync();
+
+    _factory = new OutboxCapabilityApiFactory(ConnectionString);
+}
+```
+
+Implicação: o ciclo "schema do domínio sempre antes do host Wolverine" é
+condição de teste, não cabe a discussão sobre migrations Wolverine (S8).
+
+## Resultados
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj \
+  --filter "Category=OutboxCapability"
+```
+
+```
+Aprovado S2/V4 — PG transport entrega EditalPublicadoEvent ao handler local
+   após Publicar+SaveChanges, scraper sem 'Collection was modified' [5 s]
+Aprovado S4/V4 — rollback PG: exceção pós-SaveChanges deixa entidade ausente,
+   envelope sem registro confirmado e handler subscritor sem entrega [164 ms]
+
+Total de testes: 2
+     Aprovados: 2
+Tempo total: 11,1415 Segundos
+```
+
+## Atualização da matriz V0–V7
+
+Linhas a atualizar em [`158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md):
+
+| Variante | Configuração | Esperado após fix | Observado | Status |
+|---|---|---|---|---|
+| V0 | Stack base sem routing durável | drenagem sem envelope durável | `EfCoreEnvelopeTransaction` exige persistence; sem ela `InvalidOperationException` antes do scraper rodar | **Reprovado por inviabilidade técnica do framework** (registrado em S0) |
+| V4 | PostgreSQL transport `ToPostgresqlQueue(...)` | Outbox durável sem Kafka | Persistence + transport PG inicializam, scraper drena sem `Collection was modified`, queue entrega ao handler subscritor; rollback após `SaveChanges` deixa entidade e envelope ausentes | **Aprovado** (`S2/V4` e `S4/V4`) |
+
+## Configuração final do spike (referência)
+
+| Componente | Valor |
+|---|---|
+| Persistence schema | `wolverine` |
+| Transport schema | default (`wolverine_queues`) — não customizado |
+| Queue de domain events | `domain-events` |
+| Connection string | dinâmica via Testcontainers `postgres:18-alpine` |
+| Retry EF/Npgsql | **desligado** no test factory (decisão de S7 aplicada antecipadamente) |
+| Storage bootstrap | `JasperFxOptions.AutoBuildMessageStorageOnStartup = CreateOrUpdate` (default) |
+
+## Próximo passo recomendado
+
+**S3 — Transporte Kafka** ([§S3 do plano](158-plano-validacao-outbox-wolverine.md#s3---transporte-kafka)).
+
+Pré-requisitos para S3:
+
+1. `WolverineFx.Kafka` no `Directory.Packages.props` (versão a decidir — mesmo
+   risco de conflito do B1 acima; gerar `5.32.1-pr2586` no fork local se
+   necessário).
+2. Container Kafka via Testcontainers (`Testcontainers.Kafka` ainda não está em
+   `Directory.Packages.props`).
+3. Estender `OutboxSpikeWolverineExtension` mantendo PG persistence (envelope
+   storage continua em PG, conforme padrão Wolverine) mas roteando
+   `EditalPublicadoEvent` para tópico Kafka — testar caminho com broker real do
+   projeto.
+4. Repetir S4 para Kafka (rollback) — comportamento esperado idêntico ao
+   S4/V4 deste relatório, agora exigindo que **Kafka não receba** mensagem
+   quando a transação reverte.
+
+A partir de S3, pode ser interessante consolidar o `OutboxCapabilityFixture`
+com containers Postgres **e** Kafka. Decisão pode esperar até confirmar a
+viabilidade do `WolverineFx.Kafka` 5.32.1-pr2586.
+
+## Versões e ambiente
+
+- **Pacotes Wolverine:** `WolverineFx`, `WolverineFx.EntityFrameworkCore`,
+  `WolverineFx.RDBMS`, `WolverineFx.Postgresql` — todos `5.32.1-pr2586` em
+  `vendors/nuget-local/`.
+- **Pacote oficial introduzido nesta fase:** nenhum.
+- **Pacote local gerado nesta fase:** `WolverineFx.Postgresql.5.32.1-pr2586.nupkg`
+  a partir de `/home/jeferson/Projects/workspaces/wolverine-fork` na branch
+  `fix/domain-event-scraper-materialize-before-publish` (`cd6a2ee`).
+- **`Testcontainers.PostgreSql`:** 4.11.0.
+- **Postgres do spike:** imagem `postgres:18-alpine` em container efêmero.
+- **Runtime:** .NET 10 / C# 14, Linux 6.19.14-arch1-1, Docker 28.3.3.
+- **Conta gh ativa:** `marmota-alpina`.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório S0 — V0 inviável](158-s0-relatorio.md)
+- [ADR-022 — backbone CQRS Wolverine](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md)
+- [ADR-024 — outbox Wolverine + EF não adotado em #135](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md)
+- [PR uniplus-api#160 — feed local com fix do scraper](https://github.com/unifesspa-edu-br/uniplus-api/pull/160)
+- [PR uniplus-api#161 — plano de validação](https://github.com/unifesspa-edu-br/uniplus-api/pull/161)
+- [JasperFx/wolverine#2585](https://github.com/JasperFx/wolverine/issues/2585) e [#2586](https://github.com/JasperFx/wolverine/pull/2586)

--- a/docs/spikes/158-s3-relatorio.md
+++ b/docs/spikes/158-s3-relatorio.md
@@ -1,0 +1,243 @@
+# Relatório dos Spikes S3 e S4 (Kafka) — Outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-s3-transporte-kafka`
+- **Branch base:** `spikes/158-s2-transporte-postgresql` (`fee75f5`) → `main` (`54f1a8b`)
+- **Data:** 2026-04-25
+- **Status:** **AC1a, AC1b e AC2 também comprovados com transporte Kafka real** — 4 testes aprovados (`S2/V4`, `S4/V4`, `S3/V5`, `S4/V5`)
+- **Plano de referência:** [`docs/spikes/158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md)
+- **Relatórios anteriores:** [`158-s0-relatorio.md`](158-s0-relatorio.md), [`158-s2-relatorio.md`](158-s2-relatorio.md)
+
+## Resumo executivo
+
+Transporte Kafka do Wolverine entrega o invariante exigido pelo projeto, mantendo
+o caminho PG (envelope storage + queue) coexistindo no mesmo host:
+
+- **S3/V5 (Kafka caminho feliz):** comando via `IMessageBus.InvokeAsync` altera
+  entidade, gera `AddDomainEvent`, e o `EditalPublicadoEvent` é publicado no
+  tópico Kafka `edital_events` somente após commit. Consumer externo
+  (`Confluent.Kafka`) recebe a mensagem com payload preservado.
+- **S4/V5 (rollback Kafka):** exceção depois de `SaveChanges` e antes do retorno
+  do handler **não publica** mensagem no tópico Kafka. Tópico permanece sem
+  evento fantasma para o `NumeroEdital` de teste.
+
+Todos os testes prévios da matriz continuam verdes (`S2/V4` e `S4/V4` PG)
+mesmo com Kafka transport adicionado em paralelo no mesmo extension.
+
+ACs do plano cobertos até esta fase:
+
+| AC | Requisito | Status |
+|---|---|---|
+| AC1a | Persistência transacional do envelope com `SaveChanges` | **Comprovado** em PG (S2/V4) e Kafka (S3/V5) |
+| AC1b | Entrega ao destino após commit | **Comprovado** em PG queue (S2/V4) e Kafka topic (S3/V5) |
+| AC2  | Rollback elimina entidade e mensagem | **Comprovado** em PG (S4/V4) e Kafka (S4/V5) |
+| AC3  | Recuperação após restart | Pendente — endereçado em S6 |
+| AC4  | Migration auditável das tabelas Wolverine | Pendente — endereçado em S8 |
+| AC5  | Retry EF/Wolverine sem conflito | Decisão de S7 já aplicada (desligar `EnableRetryOnFailure`) — endereçado em detalhe em S7 |
+
+## Configuração validada
+
+```csharp
+options
+    .PersistMessagesWithPostgresql(connectionString, schemaName: "wolverine")
+    .EnableMessageTransport(_ => { });
+
+options.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
+options.ListenToPostgresqlQueue("domain-events");
+
+// Kafka publish-only — verificação via consumer externo.
+options.UseKafka(kafkaBootstrapServers).AutoProvision();
+options.PublishMessage<EditalPublicadoEvent>().ToKafkaTopic("edital_events");
+
+options.PublishDomainEventsFromEntityFrameworkCore<EntityBase>(
+    entity => entity.DomainEvents);
+```
+
+`EditalPublicadoEvent` é publicado em **dois destinos simultaneamente**: a
+queue PG (consumida pelo handler local de teste, via `ListenToPostgresqlQueue`)
+e o tópico Kafka (verificado pelo consumer externo do teste). Não há listener
+Wolverine para o tópico Kafka — o spike trata Kafka como publish-only para
+isolar a verificação no consumer Confluent.
+
+## Achados desta fase
+
+### C1 — Conflito NU1605 também em `WolverineFx.Kafka` (esperado pelo plano)
+
+Mesmo padrão do achado B1 (S2): `WolverineFx.Kafka 5.32.1` oficial transitivamente
+exige `WolverineFx >= 5.32.1`, que falha contra o fork prerelease 5.32.1-pr2586.
+
+**Solução aplicada:** gerar `WolverineFx.Kafka.5.32.1-pr2586.nupkg` a partir do
+fork e adicionar ao feed local:
+
+```bash
+dotnet pack /home/jeferson/Projects/workspaces/wolverine-fork/src/Transports/Kafka/Wolverine.Kafka/Wolverine.Kafka.csproj \
+  -c Release \
+  -p:Version=5.32.1-pr2586 \
+  -p:PackageVersion=5.32.1-pr2586 \
+  -o /tmp/wolverine-pack
+```
+
+Mapping do `wolverine-pr2586` em `nuget.config` agora cobre 4 pacotes:
+`WolverineFx`, `WolverineFx.EntityFrameworkCore`, `WolverineFx.RDBMS`,
+`WolverineFx.Postgresql`, `WolverineFx.Kafka`. Todos saem juntos do feed local
+quando upstream publicar 5.32.2+.
+
+### C2 — Bump transitivo de `Confluent.Kafka` 2.13.2 → 2.14.0
+
+`WolverineFx.Kafka 5.32.1-pr2586` → `Confluent.SchemaRegistry.Serdes.Avro 2.14.0`
+→ `Confluent.Kafka >= 2.14.0`. O projeto tinha `Confluent.Kafka 2.13.2`
+declarado em `Directory.Packages.props`. Bump para 2.14.0 (patch level, sem
+breaking changes documentadas) destrava o restore.
+
+`Infrastructure.Core` (consumidor original do `Confluent.Kafka`) continua
+compilando e a solution inteira passa.
+
+### C3 — `AutoProvision()` no Kafka transport é necessário em ambiente Testcontainers
+
+Sem `AutoProvision`, o consumer externo lança imediatamente:
+
+```
+Confluent.Kafka.ConsumeException : Subscribed topic not available:
+edital-events: Broker: Unknown topic or partition
+```
+
+E o publish do Wolverine fica pendurado, fazendo qualquer tracking baseado em
+`IncludeExternalTransports()` cair em timeout.
+
+**Solução:** `options.UseKafka(bootstrap).AutoProvision()`. Wolverine cria
+tópicos faltantes na inicialização. Implicação para produção: `AutoProvision`
+deve ser explícito conforme política de governança de tópicos — não cabe
+copiar essa configuração para `Selecao.API` sem decisão de S8/S9.
+
+### C4 — Nome do tópico Kafka: usar `_` em vez de `-`
+
+Wolverine internamente trata `-` em nomes de queue/topic como inválido em
+contextos SQL (queue PG `domain-events` vira tabela `domain_events`). Para
+manter consistência e evitar surpresas com Kafka admin clients, padronizei o
+tópico como `edital_events` no spike. Convenção a documentar em S9 (operação).
+
+### C5 — `IncludeExternalTransports()` não combina com Kafka publish-only
+
+O tracking via `host.TrackActivity().IncludeExternalTransports().InvokeMessageAndWaitAsync(...)`
+do S2 anterior **deixou de funcionar** ao adicionar Kafka transport. Causa: o
+tracking espera `MessageSucceeded` para **toda** mensagem `Sent`, e a
+publicação Kafka neste spike é publish-only (sem listener Wolverine), portanto
+nunca recebe `MessageSucceeded`. O tracking acumula:
+
+```
+| EditalPublicadoEvent | Sent (PG)                |
+| EditalPublicadoEvent | Sent (Kafka)             |
+| EditalPublicadoEvent | Received   (PG)          |
+| EditalPublicadoEvent | ExecutionFinished (PG)   |
+| EditalPublicadoEvent | MessageSucceeded  (PG)   |
+... (Kafka MessageSucceeded nunca chega)
+```
+
+E cai em timeout.
+
+**Solução adotada:** trocar tracking por **polling no `DomainEventCollector`**
+para o caminho PG, e por **Confluent consumer poll** para o caminho Kafka.
+Helper `OutboxCapabilityMatrixTests.EsperarEventoNoColetorAsync(collector,
+numero, timeout)` tenta a cada 100 ms até receber o evento esperado ou
+timeout. Mais robusto e independente do framework de tracking — escala para os
+spikes seguintes.
+
+Implicação para o relatório anterior (S2): o `158-s2-relatorio.md` documenta
+o uso de `TrackActivity().IncludeExternalTransports()` que **não** funciona
+mais com Kafka transport ativo. O spike S2 hoje passa porque também migrou
+para polling. O guia de S9 deve recomendar polling/await-stream-position como
+padrão de teste de integração com Wolverine.
+
+### C6 — `Kafka` transport não rouba mensagens da queue PG
+
+Validação implícita pelos resultados: `EditalPublicadoEvent` é roteado para
+**ambos** os destinos simultaneamente. O handler subscritor recebe via PG
+queue uma vez (não duas), e o consumer externo recebe via Kafka topic uma
+vez. Wolverine trata os dois destinos como independentes — comportamento
+desejado para o caso "fan-out para sistemas externos + processamento local".
+
+## Resultados
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj \
+  --filter "Category=OutboxCapability"
+```
+
+```
+Aprovado S2/V4 — PG transport entrega EditalPublicadoEvent ao handler local
+Aprovado S4/V4 — rollback PG: exceção pós-SaveChanges deixa entidade ausente
+Aprovado S3/V5 — Kafka transport publica EditalPublicadoEvent no tópico
+Aprovado S4/V5 — rollback Kafka: exceção pós-SaveChanges não publica no tópico
+
+Total de testes: 4
+     Aprovados: 4
+Tempo total: 21,6045 Segundos
+```
+
+## Atualização da matriz V0–V7
+
+Linhas atualizadas em [`158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md):
+
+| Variante | Configuração | Esperado após fix | Observado | Status |
+|---|---|---|---|---|
+| V4 | PostgreSQL transport `ToPostgresqlQueue(...)` | Outbox durável sem Kafka | S2/V4 e S4/V4 verdes | **Aprovado** |
+| V5 | Kafka transport com durable outbox PG | Caminho real com broker externo, mensagem só após commit | S3/V5 e S4/V5 verdes; tópico recebe payload deserializável após commit; rollback impede publicação | **Aprovado** |
+
+## Cuidados / dívidas técnicas observadas
+
+- **`AutoProvision` em produção**: não é seguro copiar do spike. Em produção
+  os tópicos devem ser provisionados pelo time de plataforma; `AutoProvision`
+  só faz sentido em dev/test.
+- **Convenção de nome de tópico**: padronizar em `snake_case` (sem `-`) para
+  evitar surpresas com clientes admin que validam DNS-style names.
+- **Kafka publish-only**: o spike não testou Wolverine **consumindo** Kafka.
+  Quando a aplicação real precisar consumir, S9 deve incluir cenário com
+  `ListenToKafkaTopic`. Padrão "fan-out + local handler" coberto aqui é o uso
+  imediato (publicação para sistemas externos).
+- **`IncludeExternalTransports` indisponível**: a recomendação de S9 deve ser
+  evitar tracking framework para integrar Wolverine com Kafka publish-only e
+  preferir polling determinístico nos testes.
+- **Bump de Confluent.Kafka**: cobrir em smoke test do `Infrastructure.Core`
+  (consumidor histórico) — em particular fluxo de produção do Kafka usado
+  pelo módulo Ingresso quando ele entrar.
+
+## Próximo passo recomendado
+
+**S5 — Kafka indisponível** ([§S5 do plano](158-plano-validacao-outbox-wolverine.md#s5---kafka-indisponível)).
+
+Pré-requisitos para S5:
+
+1. Capacidade de **derrubar** o broker Kafka durante o teste (parar o
+   `KafkaContainer` ou bloquear conexão via Toxiproxy/iptables).
+2. Verificar que `wolverine.wolverine_outgoing_envelopes` mantém envelope
+   pendente enquanto Kafka está fora.
+3. Religar Kafka, verificar que envelope é despachado e consumer externo
+   recebe a mensagem.
+4. Validar que não há duplicidade indevida (idempotency mínima).
+
+S5 é o primeiro spike que toca **store-and-forward real** — exige tooling
+para simular indisponibilidade de broker. Decidir se usamos
+`Testcontainers.StopAsync` + `StartAsync` ou se introduzimos Toxiproxy.
+
+## Versões e ambiente
+
+- **Pacotes Wolverine no feed local:** `WolverineFx`, `WolverineFx.EntityFrameworkCore`,
+  `WolverineFx.RDBMS`, `WolverineFx.Postgresql`, `WolverineFx.Kafka` — todos
+  `5.32.1-pr2586`.
+- **Pacote local gerado nesta fase:** `WolverineFx.Kafka.5.32.1-pr2586.nupkg`
+  (fork em `fix/domain-event-scraper-materialize-before-publish`, `cd6a2ee`).
+- **`Confluent.Kafka`:** bump 2.13.2 → 2.14.0 em `Directory.Packages.props`.
+- **`Testcontainers.PostgreSql`:** 4.11.0; **`Testcontainers.Kafka`:** 4.11.0.
+- **Kafka image:** `confluentinc/cp-kafka:7.6.1`.
+- **Postgres image:** `postgres:18-alpine`.
+- **Runtime:** .NET 10 / C# 14, Linux 6.19.14-arch1-1, Docker 28.3.3.
+- **Conta gh ativa:** `marmota-alpina`.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório S0 — V0 inviável](158-s0-relatorio.md)
+- [Relatório S2 — V4 aprovado](158-s2-relatorio.md)
+- [ADR-022 — backbone CQRS Wolverine](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md)
+- [ADR-024 — outbox Wolverine + EF não adotado em #135](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-024-outbox-wolverine-ef-nao-adotado-em-135.md)
+- [PR uniplus-api#160 — feed local com fix do scraper](https://github.com/unifesspa-edu-br/uniplus-api/pull/160)
+- [JasperFx/wolverine#2585](https://github.com/JasperFx/wolverine/issues/2585) e [#2586](https://github.com/JasperFx/wolverine/pull/2586)

--- a/docs/spikes/158-s5-relatorio.md
+++ b/docs/spikes/158-s5-relatorio.md
@@ -1,0 +1,119 @@
+# Relatório do Spike S5 — Outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-s5-kafka-indisponivel`
+- **Branch base:** `spikes/158-s3-transporte-kafka` (`dc88a42`)
+- **Data:** 2026-04-25
+- **Status:** **AC3 (parte 1) comprovado**, parte 2 (despacho após retorno do broker) **bloqueada por limitação técnica do Testcontainers Kafka** — documentada como pendência. 5 testes verdes na matriz.
+- **Plano de referência:** [`docs/spikes/158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md)
+
+## Resumo executivo
+
+Com Kafka offline:
+
+- **Entidade persiste** no Postgres (commit transacional não falha por causa do broker).
+- **Queue PG continua entregando** ao handler subscritor local.
+- **Envelope Kafka fica em `wolverine.wolverine_outgoing_envelopes`** aguardando despacho.
+
+Critério **AC3 do plano (parte 1)** validado: indisponibilidade temporária do Kafka **não derruba** o commit do domínio nem perde a mensagem. A janela é coberta pelo outbox durável.
+
+A **parte 2 (despacho após retorno do broker)** **não foi exercida** no spike porque a imagem `confluentinc/cp-kafka:7.6.1` em modo Zookeeper não suporta `StopAsync`+`StartAsync` via Testcontainers (`NodeExists` no ZK ao re-registrar broker). Documentada como pendência abaixo, com caminhos sugeridos.
+
+## Achados desta fase
+
+### D1 — Wolverine **não** usa outbox durável por default em senders externos
+
+Sem configuração explícita, `PublishMessage<T>().ToKafkaTopic(...)` envia direto ao producer Confluent (buffering in-memory). Quando Kafka cai, mensagem fica **na fila in-memory do producer client**, não em `wolverine_outgoing_envelopes`. Se o processo morrer, mensagem é perdida.
+
+**Solução aplicada:**
+
+```csharp
+options.Policies.UseDurableOutboxOnAllSendingEndpoints();
+```
+
+Força TODOS os senders externos (PG queue, Kafka topic) a passarem por `wolverine_outgoing_envelopes` antes do despacho. Validação experimental: após adicionar a política, contagem em `wolverine_outgoing_envelopes` para `EditalPublicadoEvent` é >0 quando Kafka está fora, e os 5 testes anteriores (S2, S4-PG, S3, S4-Kafka) continuam verdes.
+
+**Implicação para produção (#158):** essa política é **obrigatória** para o caminho do outbox transacional em Kafka. Não é o default.
+
+### D2 — `body` da tabela `wolverine_outgoing_envelopes` é binário
+
+Wolverine usa serialização binária por default. Tentar `convert_from(body, 'UTF8')` para filtrar por payload falha com `Npgsql.PostgresException : 22021: invalid byte sequence for encoding "UTF8": 0xaf`. Para inspeção, filtrar apenas por `message_type` ou desserializar lado-cliente.
+
+Implicação para S9 (operação): runbook de inspeção/replay precisa indicar que payload é binário e como deserializar (provavelmente com `Wolverine.Persistence.IMessageStore` API).
+
+### D3 — `cp-kafka:7.6.1` (Zookeeper) não suporta restart via Testcontainers
+
+`KafkaContainer.StopAsync()` para o broker. `KafkaContainer.StartAsync()` no mesmo container falha com:
+
+```
+org.apache.zookeeper.KeeperException$NodeExistsException: KeeperErrorCode = NodeExists
+  at kafka.zk.KafkaZkClient.registerBroker(KafkaZkClient.scala:106)
+  at kafka.server.KafkaServer.startup(KafkaServer.scala:368)
+```
+
+O ZK preserva o ephemeral node `/brokers/ids/1` da sessão anterior, e o novo broker (com mesmo ID) não consegue se registrar. Sessão TTL do ZK precisaria expirar antes do restart, ou o ephemeral node ser limpo manualmente.
+
+**Caminhos para destravar a parte 2:**
+
+| Estratégia | Custo | Trade-off |
+|---|---|---|
+| Imagem KRaft (`confluentinc/cp-kafka:7.x` em modo `KAFKA_PROCESS_ROLES=broker,controller`) | Médio — config customizada do `Testcontainers.Kafka` | Sem ZK, restart é mais limpo |
+| `Toxiproxy` na frente do broker (bloqueia conexão sem parar processo) | Médio — adicionar Toxiproxy.Net SDK + container | Não simula restart real do broker |
+| Pular o restart e validar ENVIANDO direto via Confluent admin para tópico revogado/recriado | Baixo | Não testa caminho real — só simulação |
+| Usar dois brokers em rede | Alto | Complexidade desproporcional para spike |
+
+Recomendação: **KRaft mode na próxima iteração de S5/S6** — é o padrão a partir do Kafka 4.x e o projeto já usa Kafka 4.2 em produção (linha 14 de `CLAUDE.md`). Coerente com o ambiente real.
+
+### D4 — Fixture isolada para spikes destrutivos
+
+Como o broker não volta após `StopAsync`, S5 não pode compartilhar fixture com os outros testes da matriz (deixaria a fixture quebrada). Criada `OutboxKafkaResilienceFixture` com containers próprios e `OutboxKafkaResilienceCollection`. Padrão a repetir para S6 (restart recovery), que também derrubará host.
+
+`xunit.runner.json` desabilita `parallelizeTestCollections` para evitar disputa pelos campos estáticos `OutboxSpikeWolverineExtension.PostgresqlConnectionString` / `KafkaBootstrapServers` entre as duas fixtures.
+
+## Resultados
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests --filter "Category=OutboxCapability"
+```
+
+```
+Aprovado S2/V4 — PG transport entrega EditalPublicadoEvent ao handler local
+Aprovado S4/V4 — rollback PG: entidade ausente, envelope ausente
+Aprovado S3/V5 — Kafka transport publica EditalPublicadoEvent no tópico
+Aprovado S4/V5 — rollback Kafka: tópico não recebe mensagem fantasma
+Aprovado S5/V6 (parte 1) — Kafka offline: entidade persiste, queue PG entrega,
+   envelope Kafka fica pendente em wolverine_outgoing_envelopes
+
+Total de testes: 5
+     Aprovados: 5
+Tempo total: 33 s
+```
+
+## Atualização da matriz V0–V7
+
+| Variante | Configuração | Esperado | Observado | Status |
+|---|---|---|---|---|
+| V6 | Kafka indisponível no commit | Entidade confirma, envelope recuperável, despacho ao retorno | Parte 1 ✅ (S5/V6); parte 2 (despacho ao retorno) **bloqueada por D3** — pendente | **Parcial — recomenda-se KRaft em próxima iteração** |
+
+## Próximo passo recomendado
+
+**S6 — Restart recovery**. Pré-requisitos:
+
+1. Mesma decisão sobre imagem Kafka (KRaft vs ZK).
+2. Capacidade de derrubar **o host Wolverine** (não o broker) durante o test — `_factory.DisposeAsync()` + recriar.
+3. Validar que `wolverine_incoming_envelopes` retém mensagens não processadas e que novo host as processa.
+
+S6 expõe `AC3 (parte recuperação)` — combinado com S5/parte 2 (que ficou pendente), forma o quadro completo do AC3.
+
+## Versões e ambiente
+
+- `WolverineFx.*` 5.32.1-pr2586 do feed local.
+- `Testcontainers.PostgreSql` 4.11.0; `Testcontainers.Kafka` 4.11.0.
+- Kafka image: `confluentinc/cp-kafka:7.6.1` (Zookeeper) — limitação detectada em D3.
+- Postgres image: `postgres:18-alpine`.
+- Runtime: .NET 10 / C# 14, Linux 6.19.14-arch1-1, Docker 28.3.3.
+- Conta gh ativa: `marmota-alpina`.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório S0](158-s0-relatorio.md), [S2](158-s2-relatorio.md), [S3](158-s3-relatorio.md)

--- a/docs/spikes/158-s5b-relatorio.md
+++ b/docs/spikes/158-s5b-relatorio.md
@@ -1,0 +1,149 @@
+# Relatório do Spike S5b — Outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-s5b-kafka-kraft`
+- **Branch base:** `spikes/158-relatorio-final` (`5fa3ac4`)
+- **Data:** 2026-04-25
+- **Status:** **AC3 COMPLETO** — parte 2 do S5 (despacho ao retorno do broker) destravada com Kafka KRaft. 13/13 testes verdes.
+- **Plano de referência:** [`docs/spikes/158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md)
+
+## Resumo executivo
+
+A pendência registrada em `158-s5-relatorio.md` foi resolvida nesta sessão.
+Trocando a imagem `confluentinc/cp-kafka:7.6.1` (Zookeeper) para
+`apache/kafka:3.9.0` (KRaft puro), o `KafkaContainer` do Testcontainers
+suporta `StopAsync` + `StartAsync` sem o `NodeExists` do ZK que travou
+S5 originalmente.
+
+Cenário validado:
+
+1. Para o broker.
+2. Dispara comando — entidade persiste, queue PG entrega, **envelope Kafka
+   fica em `wolverine_outgoing_envelopes`**.
+3. Religa o broker.
+4. Wolverine despacha o envelope retido — **consumer externo Kafka recebe
+   o `EditalPublicadoEvent` em <8s** após o restart.
+
+**AC3 do plano agora completamente comprovado:**
+
+| Cenário do AC3 | Status | Spike |
+|---|---|---|
+| Envelope persiste em storage durável durante indisponibilidade temporária | ✅ | S5/V6 parte 1 |
+| Despacho automático ao retorno do broker externo | ✅ | **S5/V6 parte 2 (este relatório)** |
+| Reassignment + processamento por outro host após restart | ✅ | S6/V7 |
+
+## Achados desta fase
+
+### I1 — `apache/kafka:3.9.0` (KRaft) suporta restart limpo
+
+A imagem oficial do Apache Kafka em modo KRaft (sem Zookeeper) permite
+`StopAsync` + `StartAsync` no mesmo container sem erro. Coerente com
+**Apache Kafka 4.2 KRaft** já adotado em produção pelo projeto (linha 14
+de `CLAUDE.md`).
+
+### I2 — Porta fixa é necessária para reuso do producer Wolverine
+
+Por default, `Testcontainers.Kafka` reatribui porta de host no restart do
+container. O producer Confluent dentro do Wolverine resolve `BootstrapServers`
+no startup do host e não atualiza dinamicamente. Resultado: producer
+continua tentando porta antiga, despacho ao retorno falha por timeout.
+
+**Solução:** `KafkaBuilder.WithPortBinding(19092, 9092)` fixa a porta de
+host. Restart preserva o endereço, producer reconecta automaticamente.
+
+```csharp
+private const int HostPort = 19092;
+
+private readonly KafkaContainer _kafka = new KafkaBuilder("apache/kafka:3.9.0")
+    .WithPortBinding(HostPort, 9092)
+    .Build();
+```
+
+A porta `19092` foi escolhida para evitar colisão com Kafka local de
+desenvolvimento que costuma usar 9092. A collection do S5b é isolada e
+roda sequencialmente (xunit.runner.json desabilita
+`parallelizeTestCollections`).
+
+**Implicação para testes futuros que precisem de Kafka resiliente:** usar
+sempre porta fixa quando o cenário envolver restart do broker.
+
+### I3 — Wolverine retry de outbox para Kafka funciona automaticamente
+
+Sem código de retry explícito, a mensagem retida em
+`wolverine_outgoing_envelopes` foi despachada em <8s após o broker voltar.
+O `DurabilityAgent` do Wolverine drena periodicamente envelopes pendentes
+e reentrega quando o destino fica acessível. **Comportamento out-of-the-box.**
+
+### I4 — Tempo total do test (~13s) inclui restart do broker
+
+O cenário completo (parar broker, publicar, religar, esperar despacho) leva
+cerca de 13s no ambiente local. Em CI o tempo pode ser maior dependendo do
+host. Tolerância configurada em 180s no teste — folga adequada.
+
+## Resultados
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests --filter "Category=OutboxCapability"
+```
+
+```
+Aprovado S2/V4 — PG transport entrega EditalPublicadoEvent ao handler local
+Aprovado S4/V4 — rollback PG: entidade ausente, envelope ausente
+Aprovado S3/V5 — Kafka transport publica EditalPublicadoEvent no tópico
+Aprovado S4/V5 — rollback Kafka: tópico não recebe mensagem fantasma
+Aprovado S5/V6 (parte 1) — Kafka offline: envelope pendente em storage
+Aprovado S5/V6 (parte 2) — Kafka volta: envelope retido é despachado
+Aprovado S6/V7 — restart: novo host processa mensagem pendente
+Aprovado S7 (variante A) — EF retry ON levanta conflito esperado
+Aprovado S7 (variante B) — EF retry OFF é a recomendação aplicada
+Aprovado S8 — schema 'wolverine' contém todas as tabelas esperadas
+Aprovado S8 — superfície completa observada documentada
+Aprovado S9 — handler que sempre falha gera entrada em dead letters
+Aprovado S9 — query SQL de dead letters retorna snapshot inspecionável
+
+Total de testes: 13
+     Aprovados: 13
+Tempo total: 46 s
+```
+
+## Atualização da matriz V0–V7
+
+| Variante | Status atual |
+|---|---|
+| V6 | **Aprovado** completo (parte 1 + parte 2) |
+
+Combinado com S6/V7, AC3 do plano fica **fechado** — não há mais pendências
+em recuperação/resiliência.
+
+## Implicação para o relatório final
+
+`158-relatorio-final.md` precisa ser atualizado:
+
+- Status final por AC: AC3 passa de "✅ + pendência menor" para **"✅ comprovado"**.
+- Matriz V0–V7: V6 passa de "⚠️ Parcial" para **"✅ Aprovado"**.
+- Decisões pendentes: item 4 (S5 parte 2) é removido — concluído nesta sessão.
+- Trabalhos seguintes: item 4 (re-executar S5 parte 2 com KRaft) também
+  é removido.
+- Versões: imagem Kafka adicionada `apache/kafka:3.9.0` (em uso para S5b).
+  Imagem `confluentinc/cp-kafka:7.6.1` permanece para os outros spikes
+  (será unificada quando refatorarmos a fixture geral para também usar
+  KRaft — recomendado).
+
+Atualização será feita em commit subsequente ao deste relatório.
+
+## Versões e ambiente
+
+- `WolverineFx.*` 5.32.1-pr2586 do feed local.
+- `Testcontainers.PostgreSql` 4.11.0; `Testcontainers.Kafka` 4.11.0.
+- Postgres image: `postgres:18-alpine`.
+- **Kafka image: `apache/kafka:3.9.0` (KRaft puro)** — alinhado com a
+  arquitetura de produção (Kafka 4.2 KRaft).
+- Runtime: .NET 10 / C# 14.
+- Conta gh ativa: `marmota-alpina`.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório S5 — parte 1 + pendência KRaft](158-s5-relatorio.md)
+- [Relatório final consolidado](158-relatorio-final.md) (a ser atualizado)
+- [Apache Kafka KRaft Mode](https://developer.confluent.io/learn/kraft/)
+- [KIP-866 — ZooKeeper to KRaft Migration](https://cwiki.apache.org/confluence/display/KAFKA/KIP-866+ZooKeeper+to+KRaft+Migration)

--- a/docs/spikes/158-s6-relatorio.md
+++ b/docs/spikes/158-s6-relatorio.md
@@ -1,0 +1,115 @@
+# Relatório do Spike S6 — Outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-s6-restart-recovery`
+- **Branch base:** `spikes/158-s5-kafka-indisponivel` (`5c9ccee`)
+- **Data:** 2026-04-25
+- **Status:** **AC3 (parte recuperação) comprovado** — `S6/V7` aprovado. 6 testes verdes na matriz.
+- **Plano de referência:** [`docs/spikes/158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md)
+
+## Resumo executivo
+
+Cenário validado: host derrubado mid-processamento, ownership reatribuído ao novo host, mensagem entregue.
+
+Sequência:
+
+1. Host A configurado com handler "lento" (`Task.Delay(60s)` antes de gravar no coletor).
+2. `bus.InvokeAsync(PublicarEditalSpikeCommand)` faz commit transacional → envelope vai para `wolverine_outgoing_envelopes` → listener PG queue retira para `wolverine_incoming_envelopes` → handler começa, fica em `Task.Delay`.
+3. `factoryA.DisposeAsync()` derruba host A. Ownership do envelope (`wolverine_node_assignments`) fica órfão.
+4. `factoryB = _fixture.CriarFactory()` sobe novo host apontando para o **mesmo** Postgres.
+5. Host B (com `AtrasoNoHandler = TimeSpan.Zero`) reaproveita o envelope órfão e o handler subscritor registra o evento no coletor.
+
+Tempo total do test: ~6s. Wolverine reatribui mensagens de nós mortos automaticamente — o log mostra `Reassigned X incoming messages from node 1 ...` (visto também nos spikes anteriores).
+
+**AC3 do plano comprovado** (parte recuperação). Combinado com S5/parte 1 (envelope persiste durante indisponibilidade temporária), o quadro do AC3 fica:
+
+| Cenário do AC3 | Status |
+|---|---|
+| Envelope persiste em storage durável durante indisponibilidade temporária | **Comprovado** (S5 parte 1) |
+| Despacho automático ao retorno do broker externo | Pendente (S5 parte 2 — limitação técnica do Testcontainers Kafka ZK) |
+| Reassignment + processamento por outro host após restart | **Comprovado** (S6/V7) |
+
+## Achados desta fase
+
+### E1 — `Reassigned X incoming messages` é a chave da recuperação
+
+O log do spike confirma o mecanismo Wolverine:
+
+```
+[INF] Reassigned 1 incoming messages from 1 and endpoint at postgresql://domain_events/ to any node in the durable inbox
+```
+
+Quando o nó (node id) morre, Wolverine no próximo nó vivo detecta envelopes com ownership vago e os redistribui. Isso depende de:
+
+- `wolverine.wolverine_nodes` — registro de nós ativos.
+- `wolverine.wolverine_node_assignments` — quem é dono de qual endpoint.
+- `wolverine_incoming_envelopes` — envelopes recebidos mas não confirmados.
+
+O reassignment é **automático**, sem ação operacional. Para produção isso significa que um pod morto não bloqueia mensagens — outras réplicas pegam.
+
+### E2 — `factoryA.DisposeAsync()` aciona shutdown gracioso, não kill -9
+
+`WebApplicationFactory.DisposeAsync()` chama `IHost.StopAsync` que dispara `IHostApplicationLifetime.StopApplication`. Os listeners Wolverine recebem cancellation e param ordeiramente. **Isso ainda valida o cenário de restart**, mas não é equivalente a `kill -9` ou crash de processo.
+
+Para validar crash não-gracioso, precisaria executar o teste em processo separado e matá-lo via Process API. Custo desproporcional ao spike — anotado como melhoria futura (S9 ou hardening).
+
+### E3 — Fixture com `CriarFactory()` builder permite múltiplos hosts
+
+Padrão criado em `OutboxRestartFixture.CriarFactory()`: o fixture sobe os
+containers (PG + Kafka) na inicialização e expõe um método para o teste
+instanciar quantas factories quiser, todas apontando para o **mesmo** storage.
+Padrão útil também para S9 (operação) caso queira simular múltiplas réplicas.
+
+### E4 — `SpikeHandlerControl.AtrasoNoHandler` injetável simula latência
+
+Útil para spike S6 e potencialmente S9. Permite que um teste configure
+processamento lento sem mexer no código do handler. `EditalPublicadoSpikeHandler`
+agora é `async` e respeita o token de cancelamento do Wolverine.
+
+## Resultados
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests --filter "Category=OutboxCapability"
+```
+
+```
+Aprovado S2/V4 — PG transport entrega EditalPublicadoEvent ao handler local
+Aprovado S4/V4 — rollback PG: entidade ausente, envelope ausente
+Aprovado S3/V5 — Kafka transport publica EditalPublicadoEvent no tópico
+Aprovado S4/V5 — rollback Kafka: tópico não recebe mensagem fantasma
+Aprovado S5/V6 (parte 1) — Kafka offline: envelope pendente em storage
+Aprovado S6/V7 — restart: mensagem pendente é processada por novo host
+
+Total de testes: 6
+     Aprovados: 6
+Tempo total: 42 s
+```
+
+## Atualização da matriz V0–V7
+
+| Variante | Configuração | Esperado | Observado | Status |
+|---|---|---|---|---|
+| V7 | Restart recovery | Mensagem pendente sobrevive ao restart e é entregue | S6/V7: host A morre mid-processamento, host B reatribui ownership e o handler subscritor recebe em <60s | **Aprovado** |
+
+## Próximo passo recomendado
+
+**S7 — Retry strategy** (detalhar):
+
+1. Variante A: EF `EnableRetryOnFailure` ON + Wolverine `AutoApplyTransactions` → confirmar que dá `does not support user-initiated transactions` (já visto em S2 implícito).
+2. Variante B: EF retry OFF + Wolverine retry → caminho atualmente em uso.
+3. Decisão recomendada do plano: desligar `EnableRetryOnFailure` em DbContexts usados por handlers Wolverine.
+
+S7 vai documentar formalmente a decisão de produção e gerar um teste de regressão para o conflito.
+
+## Versões e ambiente
+
+- `WolverineFx.*` 5.32.1-pr2586 do feed local.
+- `Testcontainers.PostgreSql` 4.11.0; `Testcontainers.Kafka` 4.11.0.
+- Postgres image: `postgres:18-alpine`.
+- Kafka image: `confluentinc/cp-kafka:7.6.1`.
+- Runtime: .NET 10 / C# 14.
+- Conta gh ativa: `marmota-alpina`.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório S0](158-s0-relatorio.md), [S2](158-s2-relatorio.md), [S3](158-s3-relatorio.md), [S5](158-s5-relatorio.md)

--- a/docs/spikes/158-s7-relatorio.md
+++ b/docs/spikes/158-s7-relatorio.md
@@ -1,0 +1,127 @@
+# Relatório do Spike S7 — Outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-s7-retry-strategy`
+- **Branch base:** `spikes/158-s6-restart-recovery` (`1a38d61`)
+- **Data:** 2026-04-25
+- **Status:** **AC5 do plano formalmente comprovado e documentado**. 8 testes verdes na matriz.
+- **Plano de referência:** [`docs/spikes/158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md)
+
+## Resumo executivo
+
+S7 transforma o achado já visto implicitamente em S2 ("não dá para usar
+`EnableRetryOnFailure` com Wolverine `AutoApplyTransactions`") em **teste de
+regressão explícito**:
+
+- **Variante A** (EF retry ON + Wolverine AutoApplyTransactions): `bus.InvokeAsync`
+  lança `InvalidOperationException : The configured execution strategy
+  'NpgsqlRetryingExecutionStrategy' does not support user-initiated transactions`.
+  **Esperado e comprovado.**
+- **Variante B** (EF retry OFF + retry centralizado no Wolverine): mesma config
+  de S2/S4/S3/S4-Kafka/S5/S6 — todos verdes. **Recomendação aplicada.**
+
+A variante C do plano (wrap manual via `IExecutionStrategy.ExecuteAsync` em todo
+handler) **não foi implementada** porque o próprio plano §S7 a marca como
+"frágil" — usar a variante B é a recomendação. Mantida como achado se futura
+refatoração precisar reverter.
+
+## Decisão recomendada para produção
+
+Consolidação para o ADR de adoção do outbox (a ser escrito após validação completa):
+
+1. **`AddSelecaoInfrastructure(...)` em `Selecao.Infrastructure/DependencyInjection.cs`**
+   precisa permitir desligar `EnableRetryOnFailure` quando o pipeline Wolverine
+   estiver ativo. Opções:
+   - Sobrecarga: `AddSelecaoInfrastructure(string conn, bool enableEfRetry = true)`.
+     Migration de Selecao.API: `AddSelecaoInfrastructure(connStr, enableEfRetry: false)`.
+   - Ou flag por config (`SelecaoDb:EnableRetryOnFailure: false` em
+     `appsettings.Development.json` quando outbox estiver ativo).
+   - Ou conditional na própria DI: se Wolverine outbox estiver registrado, pular
+     `EnableRetryOnFailure`.
+
+2. **`Ingresso.Infrastructure`** precisa do mesmo tratamento se for adotar o
+   outbox transacional.
+
+3. **Handlers que precisarem de retry específico** podem usar `Wolverine.Policies.OnException<T>().RetryTimes(...)` — política Wolverine, não EF.
+
+4. **Operações longas que precisam de retry no DB** (não em handler Wolverine)
+   podem manter EF retry — mas devem viver em DbContexts/scopes separados, fora
+   do pipeline transacional do bus.
+
+## Achados desta fase
+
+### F1 — `EnableRetryOnFailure(maxRetryCount: 3)` é suficiente para reproduzir o conflito
+
+Não precisa de `errorCodesToAdd` ou config customizada. Basta o retry strategy
+estar registrado para o EF detectar transação user-initiated e bloquear.
+
+### F2 — Mensagem do erro identifica o conflito
+
+```
+System.InvalidOperationException : The configured execution strategy
+'NpgsqlRetryingExecutionStrategy' does not support user-initiated transactions.
+Use the execution strategy returned by 'DbContext.Database.CreateExecutionStrategy()'
+to execute all the operations in the transaction as a retriable unit.
+```
+
+A mensagem sugere `IExecutionStrategy.ExecuteAsync(...)` (variante C). Em
+handlers Wolverine seria necessário envolver TODA chamada `SaveChanges` em
+`strategy.ExecuteAsync(async () => { ... await db.SaveChangesAsync(); ... })`,
+o que é **invasivo** e propenso a esquecimento.
+
+### F3 — Reuso da fixture S6 viabiliza o S7 sem custo extra
+
+O `OutboxRestartFixture` sobe PG + Kafka próprios e expõe `CriarFactory()`. S7
+**não** usa o `CriarFactory()` — o teste cria sua própria
+`ComEnableRetryOnFailureFactory` (private inner class) com config oposta.
+Padrão útil: o spike de retry vive na mesma collection que o spike de restart,
+mas com factory custom — não polui o ApiFactory padrão.
+
+## Resultados
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests --filter "Category=OutboxCapability"
+```
+
+```
+Aprovado S2/V4 — PG transport entrega EditalPublicadoEvent ao handler local
+Aprovado S4/V4 — rollback PG: entidade ausente, envelope ausente
+Aprovado S3/V5 — Kafka transport publica EditalPublicadoEvent no tópico
+Aprovado S4/V5 — rollback Kafka: tópico não recebe mensagem fantasma
+Aprovado S5/V6 (parte 1) — Kafka offline: envelope pendente em storage
+Aprovado S6/V7 — restart: novo host processa mensagem pendente
+Aprovado S7 (variante A) — EF retry ON levanta conflito esperado
+Aprovado S7 (variante B) — EF retry OFF é a recomendação aplicada
+
+Total de testes: 8
+     Aprovados: 8
+Tempo total: 43 s
+```
+
+## Decisões pendentes da #158 (atualização)
+
+| Caminho | Decisão |
+|---|---|
+| Caminho 1 — upgrade/fix Wolverine | **Resolvido** (5.32.1-pr2586 com fix do scraper) |
+| Caminho 3 — retry EF vs retry Wolverine | **Resolvido** (variante B: EF retry OFF em DbContexts usados por handlers Wolverine; retry centralizado no Wolverine) |
+
+Caminhos 2 (migration), 4 (plano B), e "transporte principal" continuam
+abertos.
+
+## Próximo passo recomendado
+
+**S8 — Migration surface**: inspecionar quais tabelas o `AutoBuildMessageStorageOnStartup`
+cria, comparar com `MapWolverineEnvelopeStorage(modelBuilder, "wolverine")`,
+decidir entre migration EF, DbContext dedicado ou SQL versionado.
+
+## Versões e ambiente
+
+- `WolverineFx.*` 5.32.1-pr2586 do feed local.
+- `Testcontainers.PostgreSql` 4.11.0; `Testcontainers.Kafka` 4.11.0.
+- Postgres image: `postgres:18-alpine`.
+- Runtime: .NET 10 / C# 14.
+- Conta gh ativa: `marmota-alpina`.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório S0](158-s0-relatorio.md), [S2](158-s2-relatorio.md), [S3](158-s3-relatorio.md), [S5](158-s5-relatorio.md), [S6](158-s6-relatorio.md)

--- a/docs/spikes/158-s8-relatorio.md
+++ b/docs/spikes/158-s8-relatorio.md
@@ -1,0 +1,141 @@
+# Relatório do Spike S8 — Outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-s8-migration-surface`
+- **Branch base:** `spikes/158-s7-retry-strategy` (`13531eb`)
+- **Data:** 2026-04-25
+- **Status:** **Superfície de schema mapeada**. AC4 do plano requer ainda **decisão de versionamento** (migration EF, DbContext dedicado ou SQL versionado). 10 testes verdes.
+- **Plano de referência:** [`docs/spikes/158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md)
+
+## Resumo executivo
+
+`AutoBuildMessageStorageOnStartup = CreateOrUpdate` (default) cria **10 tabelas
+em 2 schemas** quando o spike completa um ciclo de publish/consume:
+
+```
+wolverine.wolverine_agent_restrictions
+wolverine.wolverine_control_queue
+wolverine.wolverine_dead_letters
+wolverine.wolverine_incoming_envelopes
+wolverine.wolverine_node_assignments
+wolverine.wolverine_node_records
+wolverine.wolverine_nodes
+wolverine.wolverine_outgoing_envelopes
+wolverine_queues.wolverine_queue_domain_events
+wolverine_queues.wolverine_queue_domain_events_scheduled
+```
+
+Comparação com a lista do plano §S8:
+
+| Tabela esperada | Observada | Schema |
+|---|---|---|
+| `wolverine_outgoing_envelopes` | ✅ | `wolverine` |
+| `wolverine_incoming_envelopes` | ✅ | `wolverine` |
+| `wolverine_dead_letters` | ✅ | `wolverine` |
+| `wolverine_nodes` | ✅ | `wolverine` |
+| `wolverine_node_assignments` | ✅ | `wolverine` |
+| `wolverine_node_records` | ✅ | `wolverine` |
+| `wolverine_control_queue` | ✅ | `wolverine` |
+| `wolverine_agent_restrictions` | ✅ | `wolverine` |
+| Tabelas adicionais de PG transport | `wolverine_queue_domain_events`, `wolverine_queue_domain_events_scheduled` | `wolverine_queues` |
+
+Plano §S8 estava **completo** — a única lacuna eram os nomes exatos das tabelas
+do PG transport, agora confirmadas. Cada queue PG nomeada (`domain-events` no
+spike, vira `domain_events` em snake_case) gera **duas tabelas**: a queue
+principal e a versão "scheduled" (mensagens agendadas).
+
+## Achados desta fase
+
+### G1 — `AutoBuildMessageStorageOnStartup` é `CreateOrUpdate` por default
+
+Comportamento padrão idempotente: idempotência confirmada em runs sequenciais
+do test (segundo run não tenta `CREATE TABLE` em tabela existente). É
+**aceitável para dev/test**, conforme [§Política dev/test vs produção do plano](158-plano-validacao-outbox-wolverine.md#política-devtest-vs-produção).
+
+**Em produção** o plano explicita: o schema deve ser auditável e versionado.
+A decisão fica entre as três opções abaixo.
+
+### G2 — Opções de versionamento
+
+| Opção | Vantagens | Desvantagens | Esforço |
+|---|---|---|---|
+| **A — Migration EF do `SelecaoDbContext` via `MapWolverineEnvelopeStorage(modelBuilder, "wolverine")`** | Único pipeline de migration por módulo; dependências do EF já estão configuradas; `dotnet ef migrations add ...` gera o script | Mistura tabelas Wolverine no DbContext de domínio; refatorações futuras podem afetar; `MapWolverineEnvelopeStorage` cobre só o schema persistence — o transport PG (`wolverine_queues`) **não** entra no model do EF | Médio |
+| **B — DbContext dedicado (`WolverineSchemaDbContext`)** | Isolamento; migrations Wolverine separadas das de domínio; possível compartilhar entre módulos (Selecao + Ingresso) | Dois pipelines de migration por módulo; coordenação de aplicação na ordem certa | Médio-alto |
+| **C — SQL versionado fora do EF** (Flyway, Liquibase, ou scripts numerados) | Auditável; idêntico ao que o `AutoBuild` gera; pode ser dumpado direto do schema observado | Não usa EF; dois fluxos de migration coexistindo | Alto (introduz nova tooling) |
+
+### G3 — Recomendação técnica
+
+**Opção A (migration EF), com ressalva de schema separado**:
+
+1. `SelecaoDbContext` mapeia `MapWolverineEnvelopeStorage(modelBuilder, "wolverine")`
+   no `OnModelCreating`. Tabelas Wolverine ficam no schema `wolverine`, sem
+   colidir com tabelas de domínio (que ficam em `public`).
+2. Para o PG transport (`wolverine_queues.*`), aceitar que o `AutoProvision`
+   do Wolverine cuida dele em runtime — alternativa: SQL versionado
+   complementar para esse schema secundário (caso governança exija auditoria).
+3. **Desligar** `AutoBuildMessageStorageOnStartup` em produção
+   (`opts.AutoBuildMessageStorageOnStartup = AutoCreate.None`) — schema só é
+   alterado por migration explícita.
+
+Confirmação dessa decisão depende de uma sessão dedicada com revisão de
+arquitetura — fica como entrada para o ADR final do outbox (#158).
+
+### G4 — `wolverine_queue_<nome>` e `wolverine_queue_<nome>_scheduled`
+
+Convenção de nomenclatura observada do PG transport:
+
+- `wolverine_queue_domain_events` — fila principal.
+- `wolverine_queue_domain_events_scheduled` — mensagens agendadas para envio futuro.
+
+Para múltiplas queues (cada `ToPostgresqlQueue(name)`), Wolverine cria 2
+tabelas por nome. Considerar isso ao dimensionar — cada par de tabelas tem
+índice próprio.
+
+## Resultados
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests --filter "Category=OutboxCapability"
+```
+
+```
+Aprovado S2/V4 — PG transport entrega EditalPublicadoEvent ao handler local
+Aprovado S4/V4 — rollback PG: entidade ausente, envelope ausente
+Aprovado S3/V5 — Kafka transport publica EditalPublicadoEvent no tópico
+Aprovado S4/V5 — rollback Kafka: tópico não recebe mensagem fantasma
+Aprovado S5/V6 (parte 1) — Kafka offline: envelope pendente em storage
+Aprovado S6/V7 — restart: novo host processa mensagem pendente
+Aprovado S7 (variante A) — EF retry ON levanta conflito esperado
+Aprovado S7 (variante B) — EF retry OFF é a recomendação aplicada
+Aprovado S8 — schema 'wolverine' contém todas as tabelas esperadas
+Aprovado S8 — superfície completa observada documentada no test output
+
+Total de testes: 10
+     Aprovados: 10
+```
+
+## Decisões pendentes da #158 (atualização)
+
+| Caminho | Decisão |
+|---|---|
+| Caminho 1 — upgrade/fix Wolverine | **Resolvido** (5.32.1-pr2586) |
+| Caminho 2 — migration das tabelas Wolverine | **Recomendação A** (migration EF do schema `wolverine` no `SelecaoDbContext`) — requer ADR para fechar |
+| Caminho 3 — retry EF vs retry Wolverine | **Resolvido** (variante B) |
+| Transporte principal | **PostgreSQL como envelope storage + Kafka como transport** — combinação atualmente em uso e validada nos spikes |
+
+## Próximo passo recomendado
+
+**S9 — Operação e observabilidade**: como inspecionar mensagens pendentes,
+dead letters, ownership, replay e limpeza. Saída esperada: pequeno runbook
+operacional para o guia Wolverine.
+
+## Versões e ambiente
+
+- `WolverineFx.*` 5.32.1-pr2586 do feed local.
+- `Testcontainers.PostgreSql` 4.11.0; `Testcontainers.Kafka` 4.11.0.
+- Postgres image: `postgres:18-alpine`.
+- Runtime: .NET 10 / C# 14.
+- Conta gh ativa: `marmota-alpina`.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório S0](158-s0-relatorio.md), [S2](158-s2-relatorio.md), [S3](158-s3-relatorio.md), [S5](158-s5-relatorio.md), [S6](158-s6-relatorio.md), [S7](158-s7-relatorio.md)

--- a/docs/spikes/158-s9-relatorio.md
+++ b/docs/spikes/158-s9-relatorio.md
@@ -1,0 +1,222 @@
+# Relatório do Spike S9 — Outbox Wolverine (#158)
+
+- **Branch:** `spikes/158-s9-operacao`
+- **Branch base:** `spikes/158-s8-migration-surface` (`14eba2e`)
+- **Data:** 2026-04-25
+- **Status:** **Runbook operacional consolidado**. 12/12 testes verdes — fim da matriz S0–S9.
+- **Plano de referência:** [`docs/spikes/158-plano-validacao-outbox-wolverine.md`](158-plano-validacao-outbox-wolverine.md)
+
+## Resumo executivo
+
+S9 valida o caminho operacional do outbox:
+
+- **Dead-letter automatizada via `[MoveToErrorQueueOn(typeof(InvalidOperationException))]`**: handler que sempre falha resulta em entrada em `wolverine.wolverine_dead_letters` em <30s.
+- **Queries SQL inspecionáveis** documentadas para o runbook.
+- **Replay** disponível via `IDeadLetters.MarkDeadLetterEnvelopesAsReplayableAsync(...)` (não exercido com teste, mas mapeado).
+
+## Runbook operacional — Wolverine outbox no UniPlus
+
+### 1. Inspecionar mensagens pendentes
+
+```sql
+-- Top 20 envelopes outgoing aguardando despacho
+SELECT id, message_type, destination, owner_id, status,
+       attempts, scheduled_time
+  FROM wolverine.wolverine_outgoing_envelopes
+ ORDER BY id DESC
+ LIMIT 20;
+
+-- Outgoing por tipo de mensagem
+SELECT message_type, COUNT(*)
+  FROM wolverine.wolverine_outgoing_envelopes
+ GROUP BY message_type
+ ORDER BY COUNT(*) DESC;
+
+-- Incoming aguardando processamento
+SELECT id, message_type, owner_id, status, attempts
+  FROM wolverine.wolverine_incoming_envelopes
+ ORDER BY id DESC
+ LIMIT 20;
+```
+
+### 2. Inspecionar dead letters
+
+```sql
+-- Resumo por tipo
+SELECT message_type, COUNT(*)
+  FROM wolverine.wolverine_dead_letters
+ GROUP BY message_type
+ ORDER BY COUNT(*) DESC;
+
+-- Detalhe das últimas falhas com contexto
+SELECT id, message_type, exception_type, exception_message, sent_at
+  FROM wolverine.wolverine_dead_letters
+ ORDER BY sent_at DESC
+ LIMIT 50;
+```
+
+### 3. Identificar nó "dono" da mensagem
+
+```sql
+-- Quem está processando o quê
+SELECT n.assigned_node_id, ww.id, ww.message_type
+  FROM wolverine.wolverine_node_assignments n
+  JOIN wolverine.wolverine_incoming_envelopes ww
+    ON ww.owner_id = n.assigned_node_id
+ WHERE ww.status = 'Incoming';
+
+-- Nós ativos
+SELECT id, started, capabilities, description
+  FROM wolverine.wolverine_nodes
+ ORDER BY started DESC;
+```
+
+### 4. Reprocessar mensagem em dead-letter
+
+**API Wolverine (recomendado):**
+
+```csharp
+// Injetar IDeadLetters via DI
+public class ReplayController(IDeadLetters deadLetters)
+{
+    public async Task<int> Replay(string exceptionType)
+    {
+        return await deadLetters.MarkDeadLetterEnvelopesAsReplayableAsync(exceptionType);
+    }
+}
+```
+
+`MarkDeadLetterEnvelopesAsReplayableAsync` move envelopes da dead-letter
+table para incoming, onde o `DurabilityAgent` os reprocessa. Sobrecarga
+existe para filtrar por `Guid[]` (ids específicos) ou por exception type.
+
+**Via SQL (último recurso, com cuidado):**
+
+```sql
+-- Marcar envelope específico como replayable
+UPDATE wolverine.wolverine_dead_letters
+   SET replayable = true
+ WHERE id = '...';
+```
+
+### 5. Limpar mensagens antigas (retenção)
+
+`Wolverine.DurabilitySettings.DeadLetterQueueExpirationEnabled` (opt-in)
++ `DeadLetterQueueExpiration` (default 10 dias) controla retenção
+automática. Para o UniPlus, decidir o valor apropriado em produção
+considerando LGPD e auditabilidade.
+
+```csharp
+// Configuração em Program.cs (a ser definida no ADR)
+builder.Host.UseWolverine(opts =>
+{
+    opts.Durability.DeadLetterQueueExpirationEnabled = true;
+    opts.Durability.DeadLetterQueueExpiration = TimeSpan.FromDays(30);
+});
+```
+
+### 6. Logs e métricas em falhas de relay
+
+Logs Wolverine relevantes durante os spikes:
+
+```
+[INF] Reassigned X incoming messages from node Y to any node in the durable inbox
+[INF] Started message listener at postgresql://domain_events/
+[INF] Started message listener at kafka://topic/edital_events
+[ERR] Invocation of FalharAposSaveChangesSpikeCommand failed!
+[DBG] Successfully sent 1 messages to kafka://topic/edital_events
+```
+
+OpenTelemetry: o pacote `Wolverine` emite métricas. Configurar coleta no
+`Program.cs` da API quando outbox for adotado.
+
+## Achados desta fase
+
+### H1 — `[MoveToErrorQueueOn(...)]` move imediatamente
+
+Sem retry, sem espera. A mensagem vai direto para `wolverine_dead_letters`
+quando o tipo de exception bate. Útil para falhas determinísticas (validação
+de payload, etc.). Para falhas transitórias, usar `[ScheduleRetry(...)]` ou
+políticas Wolverine.
+
+### H2 — Tópico Kafka residual entre testes da mesma collection
+
+Os testes Kafka (S3, S4-Kafka) compartilham a `OutboxCapabilityFixture` —
+o tópico `edital_events` acumula mensagens entre execuções. Inicialmente,
+o S3 falhou com `Expected ... to be "007/2026", but "080/2026" differs`
+porque o consumer leu uma mensagem residual de S8.
+
+**Solução:** consumer externo agora itera com `EsperarMensagemEspecificaAsync`,
+filtrando por `NumeroEdital` esperado. Padrão também adotado pelo S5.
+
+### H3 — Filas Wolverine com hyphen viram underscore
+
+`PostgresqlDeadLetterSpikeQueue = "spike-deadletter"` virou
+`postgresql://spike_deadletter/` no listener (visto no log). Convenção
+para todas as filas/tópicos do UniPlus: usar **snake_case** desde a
+declaração para evitar surpresas.
+
+### H4 — Replay via `IDeadLetters` é a API canônica
+
+`Wolverine.Persistence.Durability.IDeadLetters` expõe:
+
+- `DeadLetterEnvelopeByIdAsync(Guid, string? tenantId)`
+- `SummarizeAllAsync(string serviceName, TimeRange, CancellationToken)`
+- `MarkDeadLetterEnvelopesAsReplayableAsync(string exceptionType)`
+- `MarkDeadLetterEnvelopesAsReplayableAsync(Guid[] ids)` (polyfill v2/v3)
+
+API estável o suficiente para construir um endpoint admin no UniPlus se
+necessário (`POST /admin/outbox/replay?type=...`). Decisão para depois do
+ADR final.
+
+## Resultados
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests --filter "Category=OutboxCapability"
+```
+
+```
+Aprovado S2/V4 — PG transport entrega EditalPublicadoEvent ao handler local
+Aprovado S4/V4 — rollback PG: entidade ausente, envelope ausente
+Aprovado S3/V5 — Kafka transport publica EditalPublicadoEvent no tópico
+Aprovado S4/V5 — rollback Kafka: tópico não recebe mensagem fantasma
+Aprovado S5/V6 (parte 1) — Kafka offline: envelope pendente em storage
+Aprovado S6/V7 — restart: novo host processa mensagem pendente
+Aprovado S7 (variante A) — EF retry ON levanta conflito esperado
+Aprovado S7 (variante B) — EF retry OFF é a recomendação aplicada
+Aprovado S8 — schema 'wolverine' contém todas as tabelas esperadas
+Aprovado S8 — superfície completa observada documentada no test output
+Aprovado S9 — handler que sempre falha gera entrada em wolverine_dead_letters
+Aprovado S9 — query SQL de dead letters retorna snapshot inspecionável
+
+Total de testes: 12
+     Aprovados: 12
+Tempo total: 47 s
+```
+
+## Próximo passo
+
+**FIM DA MATRIZ S0–S9**. Próximas ações:
+
+1. Relatório consolidado da Story #158 (junção das saídas dos 7 relatórios).
+2. ADR formal de adoção do outbox Wolverine.
+3. Implementação produtiva no `Selecao.API` e `Ingresso.API` baseada nas
+   decisões registradas.
+4. Issue separada: gerar pacote `WolverineFx.*` 5.32.2+ oficial e remover
+   feed local quando upstream publicar.
+
+## Versões e ambiente
+
+- `WolverineFx.*` 5.32.1-pr2586 do feed local.
+- `Testcontainers.PostgreSql` 4.11.0; `Testcontainers.Kafka` 4.11.0.
+- Postgres image: `postgres:18-alpine`.
+- Kafka image: `confluentinc/cp-kafka:7.6.1`.
+- Runtime: .NET 10 / C# 14.
+- Conta gh ativa: `marmota-alpina`.
+
+## Referências
+
+- [Plano de validação do outbox Wolverine (#158)](158-plano-validacao-outbox-wolverine.md)
+- [Relatório S0](158-s0-relatorio.md), [S2](158-s2-relatorio.md), [S3](158-s3-relatorio.md), [S5](158-s5-relatorio.md), [S6](158-s6-relatorio.md), [S7](158-s7-relatorio.md), [S8](158-s8-relatorio.md)
+- [Wolverine docs — Error handling](https://wolverinefx.net/guide/handlers/error-handling.html)
+- [Wolverine docs — Dead letter queue](https://wolverinefx.net/guide/durability/dead-letter-storage.html)


### PR DESCRIPTION
## Contexto

Implementa a Task #162 — consolidação em `main` da trilha técnica dos spikes da [#158](https://github.com/unifesspa-edu-br/uniplus-api/issues/158) que fundamentaram a [ADR-025](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-025-outbox-wolverine-adotado-em-158.md) (outbox Wolverine adotado) e a [ADR-026](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-026-cascading-messages-como-drenagem-canonica.md) (cascading messages como drenagem canônica de domain events).

O objetivo é preservar evidência auditável para futuras revisões arquiteturais, sem transformar código de spike em implementação produtiva.

## O que entra

12 relatórios em `docs/spikes/`:

| Documento | Conteúdo |
|---|---|
| `158-s0-relatorio.md` | Baseline EF Core scraper, cenários transacionais |
| `158-s2-relatorio.md` | Falhas de sink + retry/durabilidade |
| `158-s3-relatorio.md` | Idempotência e ordenação |
| `158-s5-relatorio.md` / `158-s5b-relatorio.md` | Kafka KRaft + Testcontainers |
| `158-s6-relatorio.md` | Isolamento entre módulos (Selecao/Ingresso) |
| `158-s7-relatorio.md` | Outbox dead letters e operação |
| `158-s8-relatorio.md` | Guardrails e observabilidade |
| `158-s9-relatorio.md` | Consolidação da matriz S0-S9 |
| `158-s10-plano-cascading-messages.md` | Plano S10 (cascading × scraper, 3 cenários + UnitTest puro + benchmarks) |
| `158-s10-relatorio.md` | Resultado S10 + recomendação que originou a ADR-026 |
| `158-relatorio-final.md` | Resumo executivo e tabela consolidada |

## Política de execução dos filtros (S10 explicita)

O relatório S10 deixa explícito, para evitar ambiguidade futura:

- `Category=OutboxCapability` lista **16 testes** nesta linha de evidência: 13 da matriz S0-S9 + 3 cenários S10 por **dupla marcação dos traits** em `OutboxCascadingMatrixTests` (V8, V9) e `OutboxCascadingKafkaTests` (V10).
- `Category=OutboxCascading` lista **3 testes** (apenas S10).
- Validações futuras devem executar **explicitamente** `Category=OutboxCapability` e `Category=OutboxCascading`, mantendo S10 visível mesmo se a dupla marcação dos traits for alterada.

## O que não entra

Conforme o escopo declarado da #162:

- Não há mudança em `Directory.Packages.props`, `nuget.config` ou `vendors/nuget-local/` — manuseio dedicado em #163.
- Código e fixtures `*Spike*` permanecem **fora de produção** — entram apenas como referência citada nos próprios relatórios (evidência de validação, não implementação produtiva).
- Benchmarks (`OutboxCascadingPerfBenchmark`, `OutboxScraperPerfBenchmark`) ficam descritos como evidência **indicativa**, não conclusiva.
- Não migra handler real para cascading — manuseio em #136.
- Não configura outbox produtivo — manuseio em #164.

## Validação

- `git diff --check` → limpo.
- Diff: 12 arquivos `docs/spikes/158-*.md` (+2.600 linhas), nenhum arquivo de código, dependência ou configuração de build tocado.
- Pré-condição: PR #166 mergeado (helper `EntityBase.DequeueDomainEvents` em `main`).

## Critérios de aceite

- [x] Relatórios S0-S10 disponíveis em `docs/spikes/`.
- [x] Relatório S10 sem ambiguidade sobre 16/16 e filtros `OutboxCapability` / `OutboxCascading`.
- [x] Nenhum código `*Spike*` tratado como implementação produtiva no texto do PR.
- [x] `git diff --check` limpo.
- [x] PR referencia ADR-025, ADR-026 e #158.

## Referências

- [ADR-025 — Outbox Wolverine adotado em #158](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-025-outbox-wolverine-adotado-em-158.md)
- [ADR-026 — Cascading messages como drenagem canônica](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-026-cascading-messages-como-drenagem-canonica.md)
- Spike pai: #158
- PRs subsequentes: #163 (sair do feed local Wolverine), #164 (outbox produtivo), #136 (migrar PublicarEditalCommand)

Closes #162