### PR TITLE
feat(outbox): configurar Wolverine produtivo com cascading messages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,8 @@
     <!-- CQRS & Messaging -->
     <PackageVersion Include="WolverineFx" Version="5.32.1" />
     <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.32.1" />
+    <PackageVersion Include="WolverineFx.Postgresql" Version="5.32.1" />
+    <PackageVersion Include="WolverineFx.Kafka" Version="5.32.1" />
     <PackageVersion Include="MediatR" Version="14.1.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
@@ -21,7 +23,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
 
     <!-- Messaging -->
-    <PackageVersion Include="Confluent.Kafka" Version="2.13.2" />
+    <PackageVersion Include="Confluent.Kafka" Version="2.14.0" />
 
     <!-- Caching -->
     <PackageVersion Include="StackExchange.Redis" Version="2.12.8" />
@@ -31,7 +33,7 @@
 
     <!-- Health Checks -->
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.5" />
-    <PackageVersion Include="Npgsql" Version="9.0.3" />
+    <PackageVersion Include="Npgsql" Version="9.0.4" />
 
     <!-- Logging & Observability -->
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -4,14 +4,12 @@ using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
 using Unifesspa.UniPlus.Infrastructure.Core.Cors;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Logging;
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Ingresso.API.Middleware;
 using Unifesspa.UniPlus.Ingresso.Application.Mappings;
 using Unifesspa.UniPlus.Ingresso.Infrastructure;
-
-using Wolverine;
-using Wolverine.EntityFrameworkCore;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -42,28 +40,14 @@ builder.Services.AddRequestLogging(builder.Configuration);
 builder.Services.AddIngressoApplication();
 builder.Services.AddIngressoInfrastructure(connectionString);
 
-// Wolverine como backbone CQRS/messaging — ver ADR-022.
+// Wolverine como backbone CQRS/messaging com outbox transacional —
+// ver ADR-022, ADR-025 e ADR-026.
 //
-// Esta configuração entrega APENAS o backbone do bus (ICommandBus → handler).
-// As policies abaixo preparam o pipeline transacional do Wolverine, mas NÃO
-// implementam outbox transacional de domain events. Em particular:
-//   - PersistMessagesWith* NÃO está configurado: domain events são entregues
-//     in-memory pelo bus, sem persistência durável de envelopes.
-//   - PublishDomainEventsFromEntityFrameworkCore NÃO está configurado:
-//     EntityBase.DomainEvents NÃO é drenado automaticamente em SaveChanges.
-//   - Atomicidade write+evento NÃO é garantida nesta fase.
-// A adoção de outbox transacional foi reprovada no spike de #135 (ver branch
-// spike/135-outbox-validation e a issue dedicada de outbox para os achados).
-//
-// UseEntityFrameworkCoreTransactions e AutoApplyTransactions são no-ops
-// efetivos nesta fase (sem outbox, envolvem apenas o SaveChanges em uma
-// transação Wolverine que não coordena nada extra). Mantidos intencionalmente
-// para reduzir o delta de configuração quando a Story #158 entregar o outbox.
-builder.Host.UseWolverine(opts =>
-{
-    opts.UseEntityFrameworkCoreTransactions();
-    opts.Policies.AutoApplyTransactions();
-});
+// Mesma forma da Selecao.API (ver Selecao.API/Program.cs): outbox
+// durável Postgres + cascading + Kafka opcional. Sem roteamento
+// específico até CandidatoConvocadoEvent/MatriculaEfetivadaEvent
+// ganharem destino cross-módulo.
+builder.Host.UseWolverineOutboxCascading(builder.Configuration, connectionStringName: "IngressoDb");
 builder.Services.AddWolverineMessaging();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -4,14 +4,16 @@ using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
 using Unifesspa.UniPlus.Infrastructure.Core.Cors;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Logging;
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Selecao.API.Middleware;
 using Unifesspa.UniPlus.Selecao.Application.Mappings;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
 using Unifesspa.UniPlus.Selecao.Infrastructure;
 
-using Wolverine;
-using Wolverine.EntityFrameworkCore;
+using Wolverine.Kafka;
+using Wolverine.Postgresql;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -40,30 +42,48 @@ builder.Services.AddOidcAuthentication(builder.Configuration, builder.Environmen
 builder.Services.AddCorrelationIdAccessor();
 builder.Services.AddRequestLogging(builder.Configuration);
 builder.Services.AddSelecaoApplication();
+// AddSelecaoInfrastructure é configurado com a connection string lida
+// eagerly do builder.Configuration. Em testes integrados, o
+// CascadingApiFactory remove e re-registra o DbContext apontando para o
+// Postgres efêmero — esta leitura eager fica restrita ao registro do
+// DbContext do módulo, não atinge o backbone Wolverine (que lê via
+// SelecaoOutboxExtension no startup, com IConfiguration final).
 builder.Services.AddSelecaoInfrastructure(connectionString);
 
-// Wolverine como backbone CQRS/messaging — ver ADR-022.
+// Wolverine como backbone CQRS/messaging com outbox transacional —
+// ver ADR-022, ADR-025 e ADR-026.
 //
-// Esta configuração entrega APENAS o backbone do bus (ICommandBus → handler).
-// As policies abaixo preparam o pipeline transacional do Wolverine, mas NÃO
-// implementam outbox transacional de domain events. Em particular:
-//   - PersistMessagesWith* NÃO está configurado: domain events são entregues
-//     in-memory pelo bus, sem persistência durável de envelopes.
-//   - PublishDomainEventsFromEntityFrameworkCore NÃO está configurado:
-//     EntityBase.DomainEvents NÃO é drenado automaticamente em SaveChanges.
-//   - Atomicidade write+evento NÃO é garantida nesta fase.
-// A adoção de outbox transacional foi reprovada no spike de #135 (ver branch
-// spike/135-outbox-validation e a issue dedicada de outbox para os achados).
+// Configuração (ADR-025 + ADR-026):
+//   - PersistMessagesWithPostgresql: outbox durável no schema "wolverine"
+//     do mesmo banco do módulo (SelecaoDb).
+//   - UseEntityFrameworkCoreTransactions + AutoApplyTransactions:
+//     atomicidade write+evento — envelope persistido na MESMA transação
+//     do SaveChanges via IEnvelopeTransaction.
+//   - UseDurableOutboxOnAllSendingEndpoints: rota durável é invariante.
+//   - PublishDomainEventsFromEntityFrameworkCore NÃO é chamado (ADR-026):
+//     drenagem de EntityBase.DomainEvents via cascading messages no
+//     retorno do handler (IEnumerable<object>), não pelo scraper EF.
+//   - Routing de EditalPublicadoEvent: PG queue "domain-events" +
+//     tópico Kafka "edital_events" quando bootstrap configurado.
 //
-// UseEntityFrameworkCoreTransactions e AutoApplyTransactions são no-ops
-// efetivos nesta fase (sem outbox, envolvem apenas o SaveChanges em uma
-// transação Wolverine que não coordena nada extra). Mantidos intencionalmente
-// para reduzir o delta de configuração quando a Story #158 entregar o outbox.
-builder.Host.UseWolverine(opts =>
-{
-    opts.UseEntityFrameworkCoreTransactions();
-    opts.Policies.AutoApplyTransactions();
-});
+// A leitura de connection string e Kafka bootstrap acontece dentro do
+// callback de UseWolverine no startup do host. Em testes integrados,
+// os overrides chegam via env vars (ConnectionStrings__SelecaoDb,
+// Kafka__BootstrapServers) — overrides via ConfigureAppConfiguration
+// não propagam para WebApplicationBuilder.Configuration em minimal API.
+builder.Host.UseWolverineOutboxCascading(
+    builder.Configuration,
+    connectionStringName: "SelecaoDb",
+    configureRouting: opts =>
+    {
+        opts.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
+        opts.ListenToPostgresqlQueue("domain-events");
+
+        if (!string.IsNullOrWhiteSpace(builder.Configuration["Kafka:BootstrapServers"]))
+        {
+            opts.PublishMessage<EditalPublicadoEvent>().ToKafkaTopic("edital_events");
+        }
+    });
 builder.Services.AddWolverineMessaging();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj
@@ -3,6 +3,8 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="WolverineFx.Postgresql" />
+    <PackageReference Include="WolverineFx.Kafka" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
@@ -1,0 +1,111 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+using Wolverine;
+using Wolverine.EntityFrameworkCore;
+using Wolverine.Kafka;
+using Wolverine.Postgresql;
+
+/// <summary>
+/// Configuração canônica do backbone Wolverine produtivo do UniPlus, conforme
+/// ADR-025 (outbox transacional) e ADR-026 (cascading messages como drenagem
+/// canônica de domain events). Aplicada por <see cref="UseWolverineOutboxCascading"/>
+/// nos hosts de cada módulo (Selecao.API, Ingresso.API).
+/// </summary>
+public static class WolverineOutboxConfiguration
+{
+    /// <summary>
+    /// Schema PostgreSQL onde Wolverine cria as tabelas de outbox/inbox/scheduled
+    /// (<c>wolverine_outgoing_envelopes</c>, <c>wolverine_incoming_envelopes</c>,
+    /// <c>wolverine_node_assignments</c> etc.).
+    /// </summary>
+    public const string PersistenceSchema = "wolverine";
+
+    /// <summary>
+    /// Chave em <see cref="IConfiguration"/> de onde o bootstrap servers Kafka é
+    /// lido por padrão. Quando o valor é nulo, vazio ou whitespace, o transporte
+    /// Kafka não é registrado — útil para ambientes locais e testes que só
+    /// exercitam a queue PG.
+    /// </summary>
+    public const string DefaultKafkaConfigKey = "Kafka:BootstrapServers";
+
+    /// <summary>
+    /// Configura o host com Wolverine + outbox transacional Postgres + (opcional)
+    /// transporte Kafka. A drenagem de domain events é feita por cascading
+    /// messages (handlers retornam <c>IEnumerable&lt;object&gt;</c>) — sem
+    /// <c>PublishDomainEventsFromEntityFrameworkCore</c>, conforme ADR-026.
+    /// </summary>
+    /// <param name="host">Host do <see cref="WebApplicationBuilder"/>.</param>
+    /// <param name="configuration"><see cref="IConfiguration"/> live do
+    /// <see cref="WebApplicationBuilder"/> (passar <c>builder.Configuration</c>).
+    /// A leitura da connection string acontece dentro do callback do
+    /// <c>UseWolverine</c>, momento em que os providers já foram materializados
+    /// — overrides aplicados via env vars ou <c>WebApplicationFactory</c> são
+    /// respeitados, desde que entrem em sources que o
+    /// <see cref="WebApplicationBuilder"/> consulta (env vars sempre entram;
+    /// <c>ConfigureAppConfiguration</c> via <c>IWebHostBuilder</c> não se
+    /// propaga para <see cref="WebApplicationBuilder.Configuration"/> em apps
+    /// minimal API — usar env vars nos testes).</param>
+    /// <param name="connectionStringName">Nome da connection string em
+    /// <see cref="IConfiguration.GetConnectionString"/> (ex.: <c>"SelecaoDb"</c>,
+    /// <c>"IngressoDb"</c>).</param>
+    /// <param name="kafkaConfigKey">Chave em <see cref="IConfiguration"/> onde o
+    /// bootstrap servers Kafka é lido. Se ausente/whitespace, o transporte Kafka
+    /// é desligado mantendo a queue PG ativa. Padrão:
+    /// <see cref="DefaultKafkaConfigKey"/>.</param>
+    /// <param name="configureRouting">Callback para roteamento específico do
+    /// módulo (ex.: <c>opts.PublishMessage&lt;EditalPublicadoEvent&gt;()
+    /// .ToPostgresqlQueue("domain-events")</c>). Executado depois das policies
+    /// transacionais; pode adicionar publishers, listeners, dead letters etc.
+    /// Pode ser nulo se o módulo ainda não tem eventos a rotear.</param>
+    public static IHostBuilder UseWolverineOutboxCascading(
+        this IHostBuilder host,
+        IConfiguration configuration,
+        string connectionStringName,
+        string kafkaConfigKey = DefaultKafkaConfigKey,
+        Action<WolverineOptions>? configureRouting = null)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kafkaConfigKey);
+
+        return host.UseWolverine(opts =>
+        {
+            string? connectionString = configuration.GetConnectionString(connectionStringName);
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new InvalidOperationException(
+                    $"Connection string '{connectionStringName}' não configurada — Wolverine não pode inicializar o outbox.");
+            }
+
+            // Persistência do outbox no mesmo banco do módulo, schema isolado.
+            // EnableMessageTransport(_ => { }) ativa o transporte interno PG queue.
+            opts.PersistMessagesWithPostgresql(connectionString, PersistenceSchema)
+                .EnableMessageTransport(_ => { });
+
+            // Atomicidade write+evento: o handler que muta agregado e retorna
+            // cascading messages tem o envelope persistido na MESMA transação do
+            // SaveChanges, via IEnvelopeTransaction instalado por
+            // EnrollDbContextInTransaction.
+            opts.UseEntityFrameworkCoreTransactions();
+            opts.Policies.AutoApplyTransactions();
+            opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
+
+            // Schema do Wolverine NÃO é auto-criado em runtime nesta camada
+            // produtiva — provisioning é responsabilidade do deploy. Testes
+            // integrados controlam o schema via fixture explícita; ver
+            // CascadingFixture no projeto de testes.
+
+            string? kafkaBootstrapServers = configuration[kafkaConfigKey];
+            if (!string.IsNullOrWhiteSpace(kafkaBootstrapServers))
+            {
+                opts.UseKafka(kafkaBootstrapServers).AutoProvision();
+            }
+
+            configureRouting?.Invoke(opts);
+        });
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="StackExchange.Redis" />
     <PackageReference Include="WolverineFx" />
     <PackageReference Include="WolverineFx.EntityFrameworkCore" />
+    <PackageReference Include="WolverineFx.Postgresql" />
+    <PackageReference Include="WolverineFx.Kafka" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/ValueObjects/NomeSocial.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/ValueObjects/NomeSocial.cs
@@ -9,10 +9,15 @@ public sealed record NomeSocial
     public bool UsaNomeSocial => !string.IsNullOrWhiteSpace(Nome);
     public string NomeExibicao => UsaNomeSocial ? Nome! : NomeCivil;
 
-    private NomeSocial(string nomeCivil, string? nomeSocial)
+    // O parâmetro do construtor de cópia é renomeado para `nome` (em vez de
+    // `nomeSocial`) para evitar ambiguidade com o nome do método de fábrica
+    // no binding do EF Core: o materializador procura propriedades com o
+    // mesmo nome (case-insensitive) dos parâmetros e dois `nomeSocial` no
+    // contexto disparam "no suitable constructor" em EnsureCreatedAsync.
+    private NomeSocial(string nomeCivil, string? nome)
     {
         NomeCivil = nomeCivil;
-        Nome = nomeSocial;
+        Nome = nome;
     }
 
     public static Result<NomeSocial> Criar(string? nomeCivil, string? nomeSocial = null)

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 
@@ -18,6 +19,17 @@ using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntryPoint>
     where TEntryPoint : class
 {
+    /// <summary>
+    /// Quando <c>true</c> (default), o factory remove o
+    /// <see cref="WolverineRuntime"/> da lista de <see cref="IHostedService"/>
+    /// — o host inicializa sem startar o Wolverine, evitando que testes que
+    /// só exercitam o pipeline HTTP precisem de Postgres ou Kafka. Subclasses
+    /// que exercitam a infra produtiva de outbox (PG queue, durable envelopes)
+    /// sobrescrevem para <c>false</c> e provisionam o Postgres efêmero por
+    /// fixture (ver <c>CascadingFixture</c>).
+    /// </summary>
+    protected virtual bool DisableWolverineRuntimeForTests => true;
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -35,6 +47,26 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
                 .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
                     TestAuthHandler.SchemeName,
                     _ => { });
+
+            if (DisableWolverineRuntimeForTests)
+            {
+                // Wolverine registra o WolverineRuntime como IHostedService via
+                // factory (ImplementationFactory != null, ImplementationType == null),
+                // o que torna a inspeção por tipo concreto inviável. A heurística
+                // estável é casar pelo assembly da fábrica: factories registradas
+                // pelo próprio assembly Wolverine são removidas — o host inicializa
+                // sem startar o runtime e, portanto, sem disparar MigrateAsync,
+                // que tentaria conectar no Postgres configurado em
+                // PersistMessagesWithPostgresql.
+                ServiceDescriptor[] hostedToRemove = [.. services
+                    .Where(d => d.ServiceType == typeof(IHostedService)
+                        && d.ImplementationFactory is not null
+                        && d.ImplementationFactory.Method.DeclaringType?.Assembly.GetName().Name == "Wolverine")];
+                foreach (ServiceDescriptor svc in hostedToRemove)
+                {
+                    services.Remove(svc);
+                }
+            }
         });
     }
 

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="WolverineFx" />
   </ItemGroup>
 
 </Project>

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingApiFactory.cs
@@ -1,0 +1,93 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// <see cref="WebApplicationFactory{TEntryPoint}"/> que sobe o Program.cs
+/// produtivo apontando para o Postgres efêmero da fixture. Re-registra o
+/// <see cref="SelecaoDbContext"/> sem <c>EnableRetryOnFailure</c> (incompatível
+/// com user-initiated transactions) e adiciona o <see cref="DomainEventCollector"/>
+/// que o handler subscritor consome.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "WebApplicationFactory<T> derivative used as collection fixture state.")]
+public sealed class CascadingApiFactory : ApiFactoryBase<Program>
+{
+    private readonly string _connectionString;
+
+    public CascadingApiFactory(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        _connectionString = connectionString;
+    }
+
+    // Esta suite valida a infra produtiva de outbox (PG queue, durable envelopes,
+    // cascading drainage). A fixture provisiona o Postgres efêmero, então
+    // o WolverineRuntime precisa rodar (não pode ser removido pelo default
+    // de ApiFactoryBase).
+    protected override bool DisableWolverineRuntimeForTests => false;
+
+    protected override IEnumerable<KeyValuePair<string, string?>> GetConfigurationOverrides() =>
+    [
+        new("ConnectionStrings:SelecaoDb", _connectionString),
+        new("Auth:Authority", "http://localhost/test-realm"),
+        new("Auth:Audience", "uniplus"),
+    ];
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<DbContextOptions<SelecaoDbContext>>();
+            services.RemoveAll<DbContextOptions>();
+            services.RemoveAll<SelecaoDbContext>();
+            services.RemoveAll<IDbContextOptionsConfiguration<SelecaoDbContext>>();
+            RemoveAllOptionsConfigurations<DbContextOptions<SelecaoDbContext>>(services);
+
+            services.AddDbContext<SelecaoDbContext>(opts =>
+                opts.UseNpgsql(_connectionString));
+
+            services.AddSingleton<DomainEventCollector>();
+        });
+    }
+
+    private static void RemoveAllOptionsConfigurations<TOptions>(IServiceCollection services)
+        where TOptions : class
+    {
+        Type[] configurationTypes =
+        [
+            typeof(IConfigureOptions<TOptions>),
+            typeof(IPostConfigureOptions<TOptions>),
+            typeof(IConfigureNamedOptions<TOptions>),
+            typeof(IOptionsChangeTokenSource<TOptions>),
+        ];
+
+        foreach (Type type in configurationTypes)
+        {
+            for (int i = services.Count - 1; i >= 0; i--)
+            {
+                if (services[i].ServiceType == type)
+                {
+                    services.RemoveAt(i);
+                }
+            }
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingCollection.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingCollection.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Diagnostics.CodeAnalysis;
+
+// DisableParallelization=true protege a env var ConnectionStrings__SelecaoDb
+// (setada pela CascadingFixture) contra interleaving com OUTRAS coleções de
+// teste rodando em paralelo no mesmo processo. Não desabilita paralelismo
+// global — somente impede que esta coleção rode simultaneamente com qualquer
+// outra. Tests dentro desta coleção já são serializados pelo ICollectionFixture.
+[CollectionDefinition(Name, DisableParallelization = true)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit ICollectionFixture<T> requires the collection definition type to be public.")]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convention name for xUnit collection definitions ends with 'Collection'.")]
+public sealed class CascadingCollection : ICollectionFixture<CascadingFixture>
+{
+    public const string Name = "outbox-cascading";
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
@@ -1,0 +1,89 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Testcontainers.PostgreSql;
+
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit ICollectionFixture<T> requires the fixture type to be public.")]
+[SuppressMessage(
+    "Reliability",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Disposable resources are released by IAsyncLifetime.DisposeAsync, which xUnit invokes deterministically for fixtures.")]
+public sealed class CascadingFixture : IAsyncLifetime
+{
+    // Overrides são injetados via env vars (formato `<Section>__<Key>`) porque, em
+    // hosting minimal (WebApplication.CreateBuilder), overrides via
+    // ConfigureAppConfiguration de WebApplicationFactory.ConfigureWebHost não chegam
+    // a WebApplicationBuilder.Configuration. Env vars sempre entram, e como esta
+    // coleção tem DisableParallelization=true, não há risco de interleaving com
+    // outras coleções no mesmo processo.
+    //
+    // Kafka é forçado a empty para desligar o transporte Kafka durante os testes —
+    // appsettings.Development.json define `localhost:9092` por padrão para dev local,
+    // o que faria Wolverine ficar em retry indefinido contra um broker inexistente
+    // no host de teste.
+    private const string ConnectionStringEnvVar = "ConnectionStrings__SelecaoDb";
+    private const string KafkaBootstrapEnvVar = "Kafka__BootstrapServers";
+
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_outbox_cascading")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    private string? _connectionStringEnvVarPrevio;
+    private string? _kafkaEnvVarPrevio;
+    private CascadingApiFactory? _factory;
+
+    public string ConnectionString => _postgres.GetConnectionString();
+
+    public CascadingApiFactory Factory =>
+        _factory ?? throw new InvalidOperationException(
+            "Factory ainda não inicializada. InitializeAsync deve rodar antes do primeiro teste.");
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync().ConfigureAwait(false);
+
+        // Cria o schema do domínio Selecao no Postgres efêmero ANTES do host
+        // Wolverine inicializar — sem isso há disputa de timing com o
+        // PostgresqlTransport e o handler reporta `relation "editais" does not exist`.
+        // O schema do Wolverine ("wolverine.*") é criado pelo próprio framework
+        // no primeiro despacho; auto-build de produção fica off-by-default
+        // conforme documentado em WolverineOutboxConfiguration.
+        DbContextOptions<SelecaoDbContext> options = new DbContextOptionsBuilder<SelecaoDbContext>()
+            .UseNpgsql(ConnectionString)
+            .Options;
+
+        await using SelecaoDbContext db = new(options);
+        await db.Database.EnsureCreatedAsync().ConfigureAwait(false);
+
+        _connectionStringEnvVarPrevio = Environment.GetEnvironmentVariable(ConnectionStringEnvVar);
+        Environment.SetEnvironmentVariable(ConnectionStringEnvVar, ConnectionString);
+
+        _kafkaEnvVarPrevio = Environment.GetEnvironmentVariable(KafkaBootstrapEnvVar);
+        Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, string.Empty);
+
+        _factory = new CascadingApiFactory(ConnectionString);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync().ConfigureAwait(false);
+        }
+
+        Environment.SetEnvironmentVariable(ConnectionStringEnvVar, _connectionStringEnvVarPrevio);
+        Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, _kafkaEnvVarPrevio);
+
+        await _postgres.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
@@ -69,7 +69,13 @@ public sealed class CascadingFixture : IAsyncLifetime
         Environment.SetEnvironmentVariable(ConnectionStringEnvVar, ConnectionString);
 
         _kafkaEnvVarPrevio = Environment.GetEnvironmentVariable(KafkaBootstrapEnvVar);
-        Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, string.Empty);
+        // Whitespace (espaço) em vez de string.Empty: em runtimes anteriores a
+        // .NET 9, Environment.SetEnvironmentVariable(name, string.Empty) apaga
+        // a variável (em vez de definir como vazia), o que faria o appsettings
+        // voltar a ser consultado e o Wolverine tentar conectar em
+        // localhost:9092. O helper produtivo desliga Kafka via IsNullOrWhiteSpace,
+        // então um espaço cobre os dois cenários sem regressão cross-runtime.
+        Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, " ");
 
         _factory = new CascadingApiFactory(ConnectionString);
     }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+// Unit test puro do handler cascading: exercita
+// <see cref="PublicarEditalCascadingHandler.Handle"/> com EF Core InMemory,
+// sem Wolverine, sem fixture, sem container. Asserta o contrato cascading
+// (retorno como <c>IEnumerable&lt;object&gt;</c> contendo o
+// <c>EditalPublicadoEvent</c> emitido pelo agregado) e o invariante
+// canônico da ADR-026: <c>DequeueDomainEvents</c> esvazia a coleção do
+// agregado no mesmo ponto da drenagem.
+//
+// Trait dedicado <c>OutboxCascadingUnit</c> separa este do conjunto de
+// testes de capacidade outbox (que exigem container Postgres).
+[Trait("Category", "OutboxCascadingUnit")]
+public sealed class CascadingHandlerUnitTests
+{
+    [Fact(DisplayName = "Handler cascading retorna EditalPublicadoEvent emitido pelo agregado, sem Wolverine no caminho")]
+    public async Task Handler_RetornaCascadingComEditalPublicadoEvent()
+    {
+        DbContextOptions<SelecaoDbContext> options = new DbContextOptionsBuilder<SelecaoDbContext>()
+            .UseInMemoryDatabase($"cascading-unit-{Guid.NewGuid():N}")
+            .Options;
+
+        await using SelecaoDbContext db = new(options);
+
+        Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: 1, ano: 2026);
+        numeroResult.IsSuccess.Should().BeTrue();
+        NumeroEdital numero = numeroResult.Value!;
+
+        var command = new PublicarEditalCascadingCommand(
+            numero,
+            "UnitTest cascading",
+            TipoProcesso.SiSU);
+
+        IEnumerable<object> cascading = await PublicarEditalCascadingHandler.Handle(
+            command,
+            db,
+            CancellationToken.None);
+
+        IReadOnlyList<object> materialized = [.. cascading];
+        materialized.Should().ContainSingle(e => e is EditalPublicadoEvent,
+            "o agregado emite EditalPublicadoEvent ao chamar Publicar() e o handler retorna a coleção de domain events como cascading messages");
+
+        EditalPublicadoEvent published = (EditalPublicadoEvent)materialized
+            .Single(e => e is EditalPublicadoEvent);
+        published.NumeroEdital.Should().Be(numero.ToString());
+        published.EditalId.Should().NotBeEmpty();
+
+        Edital? persistido = await db.Editais.FirstOrDefaultAsync(e => e.Id == published.EditalId);
+        persistido.Should().NotBeNull(
+            "SaveChangesAsync foi chamado dentro do handler — entidade deve estar materializada no contexto InMemory");
+        persistido!.DomainEvents.Should().BeEmpty(
+            "padrão canônico do ADR-026: handler usa DequeueDomainEvents() para esvaziar a coleção do agregado no mesmo ponto da drenagem");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
@@ -1,0 +1,175 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Globalization;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Npgsql;
+
+using Wolverine;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+// Cenários produtivos do outbox cascading (ADR-026). Equivalentes de
+// produção dos cenários V8/V9 do Spike S10 (ver docs/spikes/158-s10-relatorio.md).
+//
+// Os dois testes têm dupla marcação `Category=OutboxCapability` +
+// `Category=OutboxCascading` — evita ambiguidade entre as duas suítes
+// agendadas pela #164 e mantém o filtro `OutboxCapability` correspondendo
+// ao conjunto demonstrável de capacidades do outbox produtivo nesta fase.
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+[Trait("Category", "OutboxCascading")]
+public sealed class CascadingScenariosTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public CascadingScenariosTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // V8 — caminho feliz: cascading entrega EditalPublicadoEvent ao handler
+    // local da queue PG após Publicar+SaveChanges. Atomicidade write+evento
+    // verificada indiretamente: se a transação não tivesse drenado o envelope
+    // junto do SaveChanges, o listener da queue PG não receberia o evento.
+    [Fact(DisplayName =
+        "V8 — cascading entrega EditalPublicadoEvent ao handler local PG após Publicar+SaveChanges")]
+    public async Task V8_Cascading_EntregaEvento_AposPublicarEditalViaCommand()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+
+        using HttpClient _ = api.CreateClient();
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        IMessageBus bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+
+        DomainEventCollector collector = api.Services.GetRequiredService<DomainEventCollector>();
+        collector.Clear();
+
+        Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: 80, ano: 2026);
+        numeroResult.IsSuccess.Should().BeTrue();
+        NumeroEdital numero = numeroResult.Value!;
+
+        var command = new PublicarEditalCascadingCommand(
+            numero,
+            "V8 — cascading happy path",
+            TipoProcesso.SiSU);
+
+        await bus.InvokeAsync(command);
+
+        EditalPublicadoEvent? evento = await EsperarEventoAsync(collector, numero, TimeSpan.FromSeconds(15));
+
+        evento.Should().NotBeNull(
+            "cascading messages do handler devem ser persistidas pelo PersistOrSendAsync na transação ativa e entregues pelo listener da queue PG");
+        evento!.NumeroEdital.Should().Be(numero.ToString());
+        evento.EditalId.Should().NotBeEmpty();
+
+        bool persistido = await db.Editais.AsNoTracking()
+            .AnyAsync(e => e.Id == evento.EditalId);
+        persistido.Should().BeTrue();
+    }
+
+    // V9 — rollback: exceção pós-SaveChanges deve eliminar entidade e
+    // envelope. O retorno cascading sequer chega a ser executado (throw
+    // antes do return); a IEnvelopeTransaction faz o rollback no catch.
+    // Esperado: nenhuma linha em editais com o número usado e nenhum
+    // envelope em wolverine.wolverine_outgoing_envelopes referenciando o
+    // EditalPublicadoEvent dessa instância.
+    [Fact(DisplayName =
+        "V9 — rollback cascading: exceção pós-SaveChanges deixa entidade ausente e envelope sem registro")]
+    public async Task V9_RollbackCascading_DeixaEntidadeEEnvelopeAusentes()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+
+        using HttpClient _ = api.CreateClient();
+
+        DomainEventCollector collector = api.Services.GetRequiredService<DomainEventCollector>();
+        collector.Clear();
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        IMessageBus bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+
+        Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: 89, ano: 2026);
+        numeroResult.IsSuccess.Should().BeTrue();
+        NumeroEdital numero = numeroResult.Value!;
+
+        var command = new FalharAposSaveChangesCascadingCommand(
+            numero,
+            "V9 — cascading rollback",
+            TipoProcesso.SiSU);
+
+        Func<Task> act = () => bus.InvokeAsync(command);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(FalharAposSaveChangesCascadingHandler.MensagemErro);
+
+        bool entidadePersistida = await db.Editais.AsNoTracking()
+            .AnyAsync(e =>
+                e.NumeroEdital.Numero == numero.Numero &&
+                e.NumeroEdital.Ano == numero.Ano);
+        entidadePersistida.Should().BeFalse(
+            "rollback da transação Wolverine + EF deve eliminar o INSERT do edital");
+
+        int envelopes = await ContarEnvelopesEditalPublicadoAsync(numero);
+        envelopes.Should().Be(0,
+            "rollback deve eliminar também o envelope persistido em wolverine_outgoing_envelopes");
+
+        EditalPublicadoEvent? evento = await EsperarEventoAsync(
+            collector,
+            numero,
+            TimeSpan.FromSeconds(3));
+        evento.Should().BeNull(
+            "sem envelope no outbox, o listener não tem o que entregar — collector permanece vazio para esse numero");
+    }
+
+    private static async Task<EditalPublicadoEvent?> EsperarEventoAsync(
+        DomainEventCollector collector,
+        NumeroEdital numeroEsperado,
+        TimeSpan timeout)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + timeout;
+        string esperadoTexto = numeroEsperado.ToString();
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            EditalPublicadoEvent? candidato = collector.Snapshot()
+                .FirstOrDefault(e => string.Equals(e.NumeroEdital, esperadoTexto, StringComparison.Ordinal));
+
+            if (candidato is not null)
+            {
+                return candidato;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(150));
+        }
+
+        return null;
+    }
+
+    private async Task<int> ContarEnvelopesEditalPublicadoAsync(NumeroEdital numero)
+    {
+        await using NpgsqlConnection conn = new(_fixture.ConnectionString);
+        await conn.OpenAsync();
+
+        await using NpgsqlCommand cmd = conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT COUNT(*) FROM wolverine.wolverine_outgoing_envelopes
+            WHERE message_type LIKE '%EditalPublicadoEvent%'
+              AND convert_from(body, 'UTF8') LIKE @padrao;
+            """;
+        cmd.Parameters.AddWithValue("@padrao", $"%{numero.ToString()}%");
+
+        object? raw = await cmd.ExecuteScalarAsync();
+        return raw is null ? 0 : Convert.ToInt32(raw, CultureInfo.InvariantCulture);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestDiscoveryExtension.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestDiscoveryExtension.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Wolverine;
+
+/// <summary>
+/// <see cref="IWolverineExtension"/> que adiciona este assembly de testes à
+/// discovery do Wolverine. Sem isto, os handlers convencionais
+/// (<see cref="PublicarEditalCascadingHandler"/>,
+/// <see cref="FalharAposSaveChangesCascadingHandler"/>,
+/// <see cref="EditalPublicadoSubscriberHandler"/>) não são registrados —
+/// o Program.cs produtivo só inclui o entry assembly do API e seus
+/// referenciados, e o assembly de testes não está nessa cadeia.
+///
+/// Aplicada via <c>[assembly: WolverineModule&lt;T&gt;]</c> em
+/// <see cref="OutboxCascadingAssemblyInfo"/>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Tipo referenciado por [WolverineModule<T>] do AssemblyInfo do projeto de testes.")]
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciado por Wolverine via [WolverineModule<T>] do AssemblyInfo do projeto de testes.")]
+public sealed class CascadingTestDiscoveryExtension : IWolverineExtension
+{
+    public void Configure(WolverineOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.Discovery.IncludeAssembly(typeof(CascadingTestDiscoveryExtension).Assembly);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
@@ -1,0 +1,89 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+// Handler do caminho feliz: cria/publica um Edital, faz SaveChanges e
+// retorna a coleção de domain events do agregado como cascading messages.
+// O codegen do Wolverine reconhece IEnumerable<object> no retorno e instala
+// CaptureCascadingMessages no postprocessor; cada elemento entra em
+// MessageContext.EnqueueCascadingAsync. Como a chain está dentro de
+// EnrollDbContextInTransaction, Transaction != null e os envelopes são
+// gravados em wolverine_outgoing_envelopes na MESMA transação EF —
+// atomicidade write+evento (ADR-026).
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Handlers convencionais do Wolverine devem ser públicos.")]
+public sealed class PublicarEditalCascadingHandler
+{
+    public static async Task<IEnumerable<object>> Handle(
+        PublicarEditalCascadingCommand command,
+        SelecaoDbContext db,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(db);
+
+        Edital edital = Edital.Criar(command.Numero, command.Titulo, command.Tipo);
+        edital.Publicar();
+        db.Editais.Add(edital);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Cast<object> garante o switch case `IEnumerable<object>` em
+        // MessageContext.EnqueueCascadingAsync sem depender de covariância
+        // implícita do IDomainEvent (interface) para object.
+        return edital.DequeueDomainEvents().Cast<object>();
+    }
+}
+
+// Handler do rollback: cria/publica/salva e imediatamente lança exceção,
+// simulando falha pós-SaveChanges. AC esperado: rollback de entidade +
+// nenhum envelope persistido (atomicidade preservada pela transação que
+// envolve SaveChanges + persistência do envelope).
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Handlers convencionais do Wolverine devem ser públicos.")]
+public sealed class FalharAposSaveChangesCascadingHandler
+{
+    public const string MensagemErro = "Cenário V9 — exceção forçada após SaveChanges no caminho cascading";
+
+    public static async Task<IEnumerable<object>> Handle(
+        FalharAposSaveChangesCascadingCommand command,
+        SelecaoDbContext db,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(db);
+
+        Edital edital = Edital.Criar(command.Numero, command.Titulo, command.Tipo);
+        edital.Publicar();
+        db.Editais.Add(edital);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        throw new InvalidOperationException(MensagemErro);
+    }
+}
+
+// Subscritor in-memory de EditalPublicadoEvent — drena pela queue PG
+// "domain-events" registrada na configuração produtiva e grava no coletor.
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Handlers convencionais do Wolverine devem ser públicos.")]
+public sealed class EditalPublicadoSubscriberHandler
+{
+    public static void Handle(
+        EditalPublicadoEvent @event,
+        DomainEventCollector collector)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        ArgumentNullException.ThrowIfNull(collector);
+
+        collector.Record(@event);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestMessages.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestMessages.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Mensagens descobertas pela convenção do Wolverine precisam ser públicas.")]
+public sealed record PublicarEditalCascadingCommand(NumeroEdital Numero, string Titulo, TipoProcesso Tipo);
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Mensagens descobertas pela convenção do Wolverine precisam ser públicas.")]
+public sealed record FalharAposSaveChangesCascadingCommand(NumeroEdital Numero, string Titulo, TipoProcesso Tipo);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DomainEventCollector.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DomainEventCollector.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+
+/// <summary>
+/// Coletor in-memory de domain events usado pelos testes de outbox cascading
+/// para verificar que o handler subscritor recebeu o evento drenado pela
+/// configuração produtiva (PG queue → listener no mesmo host).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Singleton resolvido via DI nos handlers convencionais do Wolverine; precisa ser público.")]
+public sealed class DomainEventCollector
+{
+    private readonly ConcurrentQueue<EditalPublicadoEvent> _eventos = new();
+
+    public void Record(EditalPublicadoEvent @event) => _eventos.Enqueue(@event);
+
+    public IReadOnlyCollection<EditalPublicadoEvent> Snapshot() => [.. _eventos];
+
+    public void Clear()
+    {
+        while (_eventos.TryDequeue(out _))
+        {
+            // Drena a fila — usar Clear não é threadsafe contra Enqueue concorrente.
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/OutboxCascadingAssemblyInfo.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/OutboxCascadingAssemblyInfo.cs
@@ -1,0 +1,9 @@
+using Wolverine.Attributes;
+
+using Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+// Wolverine descobre IWolverineExtension via [assembly: WolverineModule<T>] e
+// aplica Configure() automaticamente quando o assembly é carregado pelo host.
+// Em produção este assembly de testes não é referenciado — o atributo é
+// inerte fora do contexto de testes integrados.
+[assembly: WolverineModule<CascadingTestDiscoveryExtension>]

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj
@@ -7,10 +7,15 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="WolverineFx" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Contexto

Implementa a Task #164, recalibrada pela [ADR-026](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-026-cascading-messages-como-drenagem-canonica.md). Estabelece a configuração canônica do backbone Wolverine para os módulos Selecao e Ingresso: outbox transacional Postgres + cascading messages como drenagem de domain events (sem `PublishDomainEventsFromEntityFrameworkCore`).

PRs predecessores da sequência: #166 (#165 helper `DequeueDomainEvents`), #167 (#162 evidências), #168 (#163 deps Wolverine 5.32.1 oficial).

## Configuração produtiva (`WolverineOutboxConfiguration`)

- `PersistMessagesWithPostgresql` no schema `wolverine` do banco do módulo, `EnableMessageTransport` para a queue PG interna.
- `UseEntityFrameworkCoreTransactions` + `Policies.AutoApplyTransactions`: `IEnvelopeTransaction` enrola `SaveChanges` e persistência do envelope na **mesma transação Postgres** — atomicidade write+evento.
- `Policies.UseDurableOutboxOnAllSendingEndpoints`: rota durável é invariante.
- Kafka opcional via `Kafka:BootstrapServers`. Routing por módulo via callback `configureRouting`.

A leitura da connection string acontece dentro do callback de `UseWolverine`, executado no startup do host — overrides do ambiente (env vars) são respeitados sem depender da propagação de `ConfigureAppConfiguration` via `WebApplicationFactory` (incompleta em apps minimal hosting com `WebApplicationBuilder.Configuration`).

`Selecao.API` roteia `EditalPublicadoEvent` para queue PG interna `domain-events` + tópico Kafka `edital_events` quando bootstrap está configurado. `Ingresso.API` mantém a infra produtiva sem roteamento até `CandidatoConvocadoEvent`/`MatriculaEfetivadaEvent` ganharem destino cross-módulo.

## Pacotes

- Adicionados: `WolverineFx.Postgresql`, `WolverineFx.Kafka` (5.32.1 oficial).
- Atualizados (dependências transitivas dos novos): `Confluent.Kafka` 2.13.2 → 2.14.0; `Npgsql` 9.0.3 → 9.0.4.

## Correção colateral em `NomeSocial.cs`

Renomeio do parâmetro do construtor de cópia de `nomeSocial` para `nome` — o duplicado disparava "no suitable constructor" no EF Core ao materializar a coluna `NomeSocial` em testes integrados (descoberta na primeira validação real contra Postgres pelo `EnsureCreatedAsync`). Spike S10 já tinha esta correção; consolidando aqui.

## Testes (de-spike do Spike S10, caminho B)

`tests/Selecao.IntegrationTests/Outbox/Cascading/`:

| Cenário | Categoria(s) | Demonstração |
|---|---|---|
| `V8 — cascading happy path` | `OutboxCapability` + `OutboxCascading` | Cascading entrega `EditalPublicadoEvent` ao listener da queue PG após `Publicar+SaveChanges`. |
| `V9 — rollback cascading` | `OutboxCapability` + `OutboxCascading` | Exceção pós-`SaveChanges` deixa entidade ausente e nenhum envelope em `wolverine.wolverine_outgoing_envelopes` — atomicidade transacional. |
| `CascadingHandlerUnitTests` | `OutboxCascadingUnit` | Unit test puro do handler com EF Core InMemory; valida o contrato cascading + invariante `DequeueDomainEvents` da ADR-026 sem container. |

A dupla marcação `OutboxCapability + OutboxCascading` nos cenários V8/V9 mantém a política documentada no relatório S10: as duas categorias devem ser executadas explicitamente nas validações futuras.

### Decisões de teste

- **De-spike completo**: nenhum tipo prefixado `Spike*` em produção. Handlers, fixtures e helpers nomeados pelo cenário (`PublicarEditalCascadingHandler`, `CascadingFixture`, `DomainEventCollector`).
- **Configuração via env vars** na fixture (`ConnectionStrings__SelecaoDb`, `Kafka__BootstrapServers=""`): no minimal hosting, overrides via `ConfigureAppConfiguration` do `WebApplicationFactory` não atingem `WebApplicationBuilder.Configuration` — env vars sempre entram. `Kafka:BootstrapServers` é zerado para desligar o transporte Kafka durante os testes (appsettings.Development.json define `localhost:9092` por padrão para dev local, o que faria Wolverine ficar em retry indefinido contra um broker inexistente).
- **`DisableParallelization=true` somente na collection** `outbox-cascading` — protege as env vars contra interleaving com outras coleções no mesmo processo. **Não desabilita paralelismo global**: outras suites (auth, application unit, arch) continuam paralelas.
- **`CascadingTestDiscoveryExtension`** (`IWolverineExtension` aplicada via `[assembly: WolverineModule<T>]`) adiciona o assembly de testes à discovery do Wolverine, permitindo que o `Program.cs` produtivo encontre os handlers do projeto de testes em runtime sem alterar produção.
- **`ApiFactoryBase.DisableWolverineRuntimeForTests`** (default `true`): remove o `WolverineRuntime` do conjunto de `IHostedService` nos factories que não exercitam outbox (Auth/Profile), evitando que `MigrateAsync` conecte no Postgres. `CascadingApiFactory` sobrescreve para `false`.

## Validação

- `dotnet build UniPlus.slnx`: **0 warnings, 0 errors**.
- `dotnet test UniPlus.slnx`: **244/244 verdes** (Application.Abstractions 14, Kernel 51, Infrastructure.Core 164, Selecao.Integration 9, Ingresso.Integration 6).
- `dotnet test --filter "Category=OutboxCapability"`: **2/2 verdes**, ~5 s.
- `dotnet test --filter "Category=OutboxCascading"`: **2/2 verdes**, ~5 s.
- `git diff --check`: limpo.

## Critérios de aceite (recalibrados pela #164)

- [x] Não há `PublishDomainEventsFromEntityFrameworkCore` na configuração produtiva.
- [x] Handlers produtivos que mutam agregados seguem o padrão ADR-026: cascading messages com `DequeueDomainEvents()` (validado pelos handlers de teste; o handler real do `PublicarEditalCommand` entra na #136).
- [x] AC1a/AC1b/AC2/AC3/AC5 da #158 continuam demonstráveis: V8 (happy path, idempotência via PK do envelope), V9 (rollback transacional), unit test (contrato handler).
- [x] Superfície de testes de cascading existe em `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/` (sem prefixo `Spike`), com traits `Category=OutboxCapability` e `Category=OutboxCascading`.
- [x] `dotnet test ... --filter "Category=OutboxCapability"` verde explicitamente.
- [x] `dotnet test ... --filter "Category=OutboxCascading"` verde explicitamente.
- [x] Comentários dos `Program.cs` não prometem nem negam comportamento desatualizado.
- [x] `git diff --check` limpo.

## Referências

- [ADR-022 — Backbone CQRS Wolverine](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md)
- [ADR-025 — Outbox Wolverine adotado em #158](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-025-outbox-wolverine-adotado-em-158.md)
- [ADR-026 — Cascading messages como drenagem canônica](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-026-cascading-messages-como-drenagem-canonica.md)
- Spike pai: #158 — relatórios em `docs/spikes/158-*.md`
- Próximo PR da sequência: #136 (migrar `PublicarEditalCommand` como handler real cascading).

Closes #164