### PR TITLE
feat(selecao): migrar PublicarEditalCommand como fluxo cascading fim-a-fim

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
@@ -1,9 +1,12 @@
 namespace Unifesspa.UniPlus.Selecao.API.Controllers;
 
+using System.Diagnostics.CodeAnalysis;
+
 using MediatR;
 
 using Microsoft.AspNetCore.Mvc;
 
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
 using Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
 using Unifesspa.UniPlus.Selecao.Application.DTOs;
 using Unifesspa.UniPlus.Selecao.Application.Queries.Editais;
@@ -11,13 +14,19 @@ using Unifesspa.UniPlus.Kernel.Results;
 
 [ApiController]
 [Route("api/v1/editais")]
-internal sealed class EditalController : ControllerBase
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public; sem isso o MVC ignora a classe e nenhum endpoint é registrado.")]
+public sealed class EditalController : ControllerBase
 {
     private readonly ISender _sender;
+    private readonly ICommandBus _commandBus;
 
-    public EditalController(ISender sender)
+    public EditalController(ISender sender, ICommandBus commandBus)
     {
         _sender = sender;
+        _commandBus = commandBus;
     }
 
     [HttpPost]
@@ -40,5 +49,26 @@ internal sealed class EditalController : ControllerBase
         return resultado.IsSuccess
             ? Ok(resultado.Value)
             : NotFound(resultado.Error);
+    }
+
+    // Despacha PublicarEditalCommand pelo ICommandBus (Wolverine). O handler
+    // convention-based atualiza o agregado e drena EditalPublicadoEvent por
+    // cascading messages — atomicidade write+evento garantida pela
+    // IEnvelopeTransaction da configuração produtiva (ADR-026).
+    [HttpPost("{id:guid}/publicar")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Publicar(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus.Send(new PublicarEditalCommand(id), cancellationToken);
+        if (resultado.IsSuccess)
+        {
+            return NoContent();
+        }
+
+        return resultado.Error!.Code == "Edital.NaoEncontrado"
+            ? NotFound(resultado.Error)
+            : BadRequest(resultado.Error);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/InscricaoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/InscricaoController.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.API.Controllers;
 
+using System.Diagnostics.CodeAnalysis;
+
 using MediatR;
 
 using Microsoft.AspNetCore.Mvc;
@@ -11,7 +13,11 @@ using Unifesspa.UniPlus.Kernel.Results;
 
 [ApiController]
 [Route("api/v1/inscricoes")]
-internal sealed class InscricaoController : ControllerBase
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public; sem isso o MVC ignora a classe e nenhum endpoint é registrado.")]
+public sealed class InscricaoController : ControllerBase
 {
     private readonly ISender _sender;
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -8,6 +8,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Selecao.API.Middleware;
+using Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
 using Unifesspa.UniPlus.Selecao.Application.Mappings;
 using Unifesspa.UniPlus.Selecao.Domain.Events;
 using Unifesspa.UniPlus.Selecao.Infrastructure;
@@ -76,6 +77,11 @@ builder.Host.UseWolverineOutboxCascading(
     connectionStringName: "SelecaoDb",
     configureRouting: opts =>
     {
+        // Wolverine escaneia o entry assembly (Selecao.API) por padrão; handlers
+        // produtivos vivem em Selecao.Application — incluir explicitamente para
+        // que PublicarEditalCommandHandler (e futuros) sejam descobertos.
+        opts.Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly);
+
         opts.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
         opts.ListenToPostgresqlQueue("domain-events");
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/PublicarEditalCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/PublicarEditalCommand.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Comando para publicar um edital existente. Após a publicação,
+/// <see cref="Domain.Entities.Edital.Publicar"/> emite o
+/// <see cref="Domain.Events.EditalPublicadoEvent"/>, drenado por cascading
+/// messages no handler (ADR-026).
+/// </summary>
+public sealed record PublicarEditalCommand(Guid EditalId) : ICommand<Result>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/PublicarEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/PublicarEditalCommandHandler.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+/// <summary>
+/// Handler convention-based do <see cref="PublicarEditalCommand"/> — primeiro
+/// fluxo de referência cascading messages do UniPlus, conforme ADR-026.
+///
+/// <para>O retorno em tupla <c>(Result, IEnumerable&lt;object&gt;)</c> entrega
+/// duas coisas no mesmo caminho:
+/// <list type="bullet">
+///   <item><description><c>Result</c>: resposta tipada que o
+///   <see cref="Application.Abstractions.Messaging.ICommandBus"/> propaga até
+///   o caller (controller/teste) — encapsula sucesso ou
+///   <see cref="DomainError"/> de regra de negócio sem usar exceção para
+///   fluxo esperado de erro.</description></item>
+///   <item><description><c>IEnumerable&lt;object&gt;</c>: cascading messages
+///   drenadas via <see cref="Domain.Entities.EntityBase.DequeueDomainEvents"/>.
+///   O <c>CaptureCascadingMessages</c> do Wolverine percorre cada elemento e
+///   instala o envelope no <c>wolverine_outgoing_envelopes</c> dentro da
+///   <c>IEnvelopeTransaction</c> ativa — atomicidade write+evento conforme
+///   ADR-026.</description></item>
+/// </list>
+/// </para>
+///
+/// <para>Wolverine reconhece o padrão tupla `(TResponse, IEnumerable&lt;object&gt;)`
+/// e separa a resposta do cascading; <c>InvokeAsync&lt;Result&gt;</c> retorna o
+/// primeiro elemento, e o segundo é despachado pelas regras de roteamento
+/// (PG queue + Kafka opcional, ver <c>SelecaoOutboxExtension</c>... no
+/// <c>Program.cs</c>).</para>
+/// </summary>
+public sealed class PublicarEditalCommandHandler
+{
+    public static async Task<(Result Resposta, IEnumerable<object> Eventos)> Handle(
+        PublicarEditalCommand command,
+        IEditalRepository editalRepository,
+        IUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(editalRepository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        Edital? edital = await editalRepository.ObterPorIdAsync(command.EditalId, cancellationToken).ConfigureAwait(false);
+        if (edital is null)
+        {
+            return (
+                Result.Failure(new DomainError("Edital.NaoEncontrado", $"Edital '{command.EditalId}' não encontrado.")),
+                []);
+        }
+
+        if (edital.Status == StatusEdital.Publicado)
+        {
+            return (
+                Result.Failure(new DomainError("Edital.JaPublicado", $"Edital '{command.EditalId}' já está publicado.")),
+                []);
+        }
+
+        edital.Publicar();
+        editalRepository.Atualizar(edital);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Padrão canônico ADR-026: drenagem por cascading messages.
+        // Cast<object> garante o switch case `IEnumerable<object>` em
+        // MessageContext.EnqueueCascadingAsync sem depender de covariância
+        // implícita do IDomainEvent (interface) para object.
+        return (Result.Success(), edital.DequeueDomainEvents().Cast<object>());
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Events/Editais/EditalPublicadoEventHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Events/Editais/EditalPublicadoEventHandler.cs
@@ -1,0 +1,40 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Events.Editais;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+
+/// <summary>
+/// Handler exemplar do <see cref="EditalPublicadoEvent"/> — registra o evento
+/// drenado via cascading messages (ADR-026). Demonstra o padrão para
+/// subscritores de domain events do UniPlus: handler convention-based, método
+/// <c>Handle</c> público, dependências por parâmetro do método. Logging via
+/// <c>[LoggerMessage]</c> source generator (regra obrigatória — ver CLAUDE.md
+/// do uniplus-api).
+/// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção do projeto: subscritores de domain events terminam em EventHandler, conforme AC da #136.")]
+public sealed partial class EditalPublicadoEventHandler
+{
+    public static void Handle(
+        EditalPublicadoEvent @event,
+        ILogger<EditalPublicadoEventHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        LogEditalPublicadoRecebido(logger, @event.EditalId, @event.NumeroEdital);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "EditalPublicadoEvent recebido. EditalId={EditalId} NumeroEdital={NumeroEdital}")]
+    private static partial void LogEditalPublicadoRecebido(
+        ILogger logger,
+        Guid editalId,
+        string numeroEdital);
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
@@ -132,7 +132,7 @@ public sealed class CascadingScenariosTests
             "sem envelope no outbox, o listener não tem o que entregar — collector permanece vazio para esse numero");
     }
 
-    private static async Task<EditalPublicadoEvent?> EsperarEventoAsync(
+    internal static async Task<EditalPublicadoEvent?> EsperarEventoAsync(
         DomainEventCollector collector,
         NumeroEdital numeroEsperado,
         TimeSpan timeout)

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
@@ -1,0 +1,128 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Net;
+using System.Net.Http.Json;
+
+using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+// Cenário fim-a-fim do fluxo de referência ADR-026: HTTP request →
+// PublicarEditalCommand → handler convention-based produtivo → Edital.Publicar()
+// emite EditalPublicadoEvent via AddDomainEvent → handler retorna
+// (Result, IEnumerable<object>) com o evento drenado por
+// DequeueDomainEvents().Cast<object>() → CaptureCascadingMessages persiste
+// envelope na MESMA transação do SaveChanges → listener da queue PG entrega
+// ao subscritor (EditalPublicadoSubscriberHandler do teste, que registra no
+// coletor; o EditalPublicadoEventHandler produtivo também é invocado pela
+// fan-out, executa logging estruturado e não interfere no estado do coletor).
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+[Trait("Category", "OutboxCascading")]
+public sealed class PublicarEditalEndpointTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public PublicarEditalEndpointTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName =
+        "POST /editais/{id}/publicar dispara cascading e entrega EditalPublicadoEvent ao subscritor")]
+    public async Task PublicarEdital_FluxoCompleto_DispatchaCascadingMessages()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        DomainEventCollector collector = api.Services.GetRequiredService<DomainEventCollector>();
+        collector.Clear();
+
+        Edital edital = await SemearEditalAsync(api);
+
+        HttpResponseMessage response = await client.PostAsync(new Uri($"/api/v1/editais/{edital.Id}/publicar", UriKind.Relative), content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        EditalPublicadoEvent? evento = await CascadingScenariosTests.EsperarEventoAsync(
+            collector,
+            edital.NumeroEdital,
+            TimeSpan.FromSeconds(15));
+
+        evento.Should().NotBeNull(
+            "o handler produtivo retorna o evento via cascading; o listener PG entrega ao subscritor de teste");
+        evento!.EditalId.Should().Be(edital.Id);
+        evento.NumeroEdital.Should().Be(edital.NumeroEdital.ToString());
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        Edital? persistido = await db.Editais.AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == edital.Id);
+        persistido.Should().NotBeNull();
+        persistido!.Status.Should().Be(StatusEdital.Publicado);
+    }
+
+    [Fact(DisplayName =
+        "POST /editais/{id}/publicar retorna 404 quando o edital não existe")]
+    public async Task PublicarEdital_QuandoEditalNaoExiste_Retorna404()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        var inexistente = Guid.NewGuid();
+
+        HttpResponseMessage response = await client.PostAsync(new Uri($"/api/v1/editais/{inexistente}/publicar", UriKind.Relative), content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        DomainError? erro = await response.Content.ReadFromJsonAsync<DomainError>();
+        erro!.Code.Should().Be("Edital.NaoEncontrado");
+    }
+
+    [Fact(DisplayName =
+        "POST /editais/{id}/publicar é idempotente — segunda chamada retorna 400 com Edital.JaPublicado")]
+    public async Task PublicarEdital_QuandoJaPublicado_Retorna400()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        Edital edital = await SemearEditalAsync(api);
+
+        HttpResponseMessage primeira = await client.PostAsync(new Uri($"/api/v1/editais/{edital.Id}/publicar", UriKind.Relative), content: null);
+        primeira.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage segunda = await client.PostAsync(new Uri($"/api/v1/editais/{edital.Id}/publicar", UriKind.Relative), content: null);
+        segunda.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        DomainError? erro = await segunda.Content.ReadFromJsonAsync<DomainError>();
+        erro!.Code.Should().Be("Edital.JaPublicado");
+    }
+
+    private static async Task<Edital> SemearEditalAsync(CascadingApiFactory api)
+    {
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+
+        // Numero estável derivado de NewGuid — Edital.Numero é int (1..9999),
+        // colisão com testes paralelos é evitada pelo CollectionFixture (1
+        // fixture por collection, fixture é singleton dentro do test run).
+        int numeroSeed = Math.Abs(Guid.NewGuid().GetHashCode() % 9000) + 1;
+        Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: numeroSeed, ano: 2026);
+        numeroResult.IsSuccess.Should().BeTrue();
+        Edital edital = Edital.Criar(numeroResult.Value!, "PublicarEditalEndpointTests seed", TipoProcesso.SiSU);
+        // O agregado já tem domain events na coleção (do `Criar`/Publicar futuro).
+        // Como esta seed bypassa o handler produtivo, drenamos manualmente para
+        // não vazar eventos no coletor antes do POST.
+        edital.ClearDomainEvents();
+        await db.Editais.AddAsync(edital);
+        await db.SaveChangesAsync();
+
+        return edital;
+    }
+}


### PR DESCRIPTION
## Contexto

Implementa a Task #136 — primeiro fluxo de negócio real do UniPlus exercitando ponta a ponta o backbone Wolverine + outbox produtivo + cascading messages estabelecidos em #164. Fecha a sequência da Spike #158:
- #166 helper `EntityBase.DequeueDomainEvents` (#165)
- #167 evidências S0-S10 (#162)
- #168 deps Wolverine 5.32.1 oficial (#163)
- #172 outbox produtivo + de-spike testes (#164)
- **#173 (este) — PublicarEditalCommand fim-a-fim (#136)**

## Fluxo demonstrado

```
HTTP POST /api/v1/editais/{id}/publicar
  → EditalController.Publicar (controller MVC público)
  → ICommandBus.Send<Result>(PublicarEditalCommand)
  → Wolverine resolve PublicarEditalCommandHandler (convention-based)
  → Edital.Publicar() emite EditalPublicadoEvent via AddDomainEvent
  → handler retorna (Result, IEnumerable<object>) com eventos drenados por
    edital.DequeueDomainEvents().Cast<object>()
  → CaptureCascadingMessages persiste o envelope no
    wolverine_outgoing_envelopes na MESMA transação do SaveChanges
  → listener da queue PG entrega ao subscritor
    (EditalPublicadoEventHandler produtivo + handler de teste)
```

## `PublicarEditalCommand` + handler convention-based

```csharp
public sealed record PublicarEditalCommand(Guid EditalId) : ICommand<Result>;

public sealed class PublicarEditalCommandHandler
{
    public static async Task<(Result Resposta, IEnumerable<object> Eventos)> Handle(
        PublicarEditalCommand command,
        IEditalRepository editalRepository,
        IUnitOfWork unitOfWork,
        CancellationToken cancellationToken)
    {
        // ...validações sem throw...
        edital.Publicar();
        editalRepository.Atualizar(edital);
        await unitOfWork.SalvarAlteracoesAsync(cancellationToken);
        return (Result.Success(), edital.DequeueDomainEvents().Cast<object>());
    }
}
```

### Decisão sobre o retorno do handler

A Task #136 deixou em aberto a forma de combinar resposta de negócio com cascading. Adotada a tupla `(Result, IEnumerable<object>)` porque:

- Wolverine 5.32.1 reconhece o padrão tupla (`TResponse, IEnumerable<object>`) nativamente: `InvokeAsync<Result>` extrai o primeiro elemento como resposta, e o segundo é despachado pelo `CaptureCascadingMessages` como cascading.
- Mantém o contrato do `ICommandBus.Send<Result>` do projeto (ADR-022) sem interface secundária ou bus side-channel.
- Validações de negócio (edital não encontrado, já publicado) viajam via `Result.Failure(DomainError)` sem usar exceção para fluxo esperado de erro — atende ao AC explícito da #136.

## `EditalPublicadoEventHandler`

Handler exemplar de subscritor cascading. Logging via `[LoggerMessage]` source generator (regra obrigatória do `CLAUDE.md` do `uniplus-api`). Único acesso a `Microsoft.Extensions.Logging` na Application layer; sem dependência direta de `Wolverine.*` fora dos contratos permitidos pelo projeto.

## Endpoint HTTP

`POST /api/v1/editais/{id:guid}/publicar`
- **204 NoContent** em sucesso.
- **404 NotFound** + `DomainError(Code: "Edital.NaoEncontrado")` quando o id não existe.
- **400 BadRequest** + `DomainError(Code: "Edital.JaPublicado")` quando idempotente.

## Discovery da Selecao.Application no Wolverine

Wolverine escaneia o entry assembly (`Selecao.API`) por padrão; handlers produtivos vivem em `Selecao.Application`. Adicionado `Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly)` no callback de `UseWolverineOutboxCascading` em `Program.cs` da `Selecao.API`. Sem isso, o handler é silenciosamente ignorado e a chamada cai em `IndeterminateRoutesException`.

## Bug latente colateral: controllers eram `internal sealed`

`EditalController` e `InscricaoController` estavam declarados `internal sealed`. O `ControllerFeatureProvider` do ASP.NET Core MVC só descobre controllers `public`, portanto os endpoints existentes (`Criar`, `ObterPorId`) **nunca haviam sido routados**. Este PR é o primeiro que exercita HTTP routing nesses controllers e revelou o gap (route 404 antes de qualquer handler). Suprimido `CA1515` com justificativa inline. Outros endpoints existentes ganham roteamento funcional como efeito colateral.

## Testes

`tests/.../Outbox/Cascading/PublicarEditalEndpointTests.cs` — dual-trait `OutboxCapability` + `OutboxCascading`:

| Cenário | Verifica |
|---|---|
| `FluxoCompleto` | 204 + `EditalPublicadoEvent` entregue ao coletor + `Edital.Status == Publicado` no DB |
| `QuandoEditalNaoExiste` | 404 + `DomainError` com `Code == Edital.NaoEncontrado` |
| `QuandoJaPublicado` | Chamada idempotente — segunda invocação 400 + `Edital.JaPublicado` |

`EsperarEventoAsync` de `CascadingScenariosTests` promovido a `internal` para reuso (era `private`; manter levaria a duplicação).

## Validação

- `dotnet build UniPlus.slnx`: **0 warnings, 0 errors**.
- `dotnet test UniPlus.slnx`: **247/247 verdes**.
- `dotnet test --filter "Category=OutboxCapability"`: **5/5** (V8/V9 da #164 + 3 deste PR).
- `dotnet test --filter "Category=OutboxCascading"`: **5/5** (mesmos).
- `git diff --check`: limpo.

## Critérios de aceite (recalibrados pela #164)

- [x] `PublicarEditalCommand.cs` criado com contrato alinhado ao `ICommandBus`.
- [x] `PublicarEditalCommandHandler` convention-based, público, com método `Handle`, sem `IRequestHandler<,>`.
- [x] Handler recebe `IEditalRepository`, `IUnitOfWork` e `CancellationToken` por parâmetros do método (preserva Clean Architecture; `SelecaoDbContext` direto violaria a regra de dependência da camada Application).
- [x] Handler executa validações de negócio sem `throw` para fluxo esperado de erro.
- [x] Handler drena domain events por cascading messages com `edital.DequeueDomainEvents().Cast<object>()`.
- [x] Tupla `(Result, IEnumerable<object>)` documentada como formato Wolverine suportado para preservar resultado de negócio + cascading no mesmo handler.
- [x] `EditalPublicadoEventHandler` em `Application/Events/Editais/`.
- [x] Endpoint `POST /editais/{id}/publicar` em `Selecao.API`.
- [x] Teste de integração: request HTTP → command dispatched → entidade publicada → event handler invocado → outbox/cascading processado.
- [x] Zero uso direto de `Wolverine.*` em Application/Domain.

## Referências

- [ADR-022 — Backbone CQRS Wolverine](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-022-backbone-cqrs-wolverine.md)
- [ADR-026 — Cascading messages como drenagem canônica](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/adrs/ADR-026-cascading-messages-como-drenagem-canonica.md)
- Story #133 / #158
- PRs predecessores desta sequência: #166, #167, #168, #172.

Closes #136