### PR TITLE
test(arch-tests): implementa fixtures stage 1

### DIFF
--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Stage1ArchitectureRulesTests.cs
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Stage1ArchitectureRulesTests.cs
@@ -1,0 +1,102 @@
+namespace Unifesspa.UniPlus.Ingresso.ArchTests;
+
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Loader;
+using ArchUnitNET.xUnit;
+
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+using ReflectionAssembly = System.Reflection.Assembly;
+
+/// <summary>
+/// Fitness tests stage 1 do modulo Ingresso, conforme ADR-023.
+/// R1 protege a comunicacao assincrona entre modulos definida pela ADR-004,
+/// R2 protege o encapsulamento Wolverine da ADR-022 e R3 protege a direcao
+/// Clean Architecture definida pela ADR-002. O projeto Ingresso.Application foi
+/// removido na Story #207; por isso R2/R3 cobrem Domain e Infrastructure atuais.
+/// </summary>
+public sealed class Stage1ArchitectureRulesTests
+{
+    private static readonly Architecture ModuleArchitecture = LoadModuleArchitecture();
+    private static readonly Architecture WolverineGuardArchitecture = LoadWolverineGuardArchitecture();
+
+    [Fact(DisplayName = "R1: Ingresso nao referencia Selecao diretamente")]
+    public void Modulos_NaoSeReferenciam()
+    {
+        IArchRule rule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Ingresso(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao(\.|$)")
+            .Because("ADR-004 exige comunicacao cross-module por eventos Kafka, nao por referencia direta entre modulos.");
+
+        rule.Check(ModuleArchitecture);
+    }
+
+    [Fact(DisplayName = "R2: Application.Abstractions e Ingresso.Domain nao dependem de Wolverine")]
+    public void ApplicationEDomain_NaoDependemDeWolverine()
+    {
+        IArchRule rule = Types()
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Wolverine(\.|$)")
+            .Because("ADR-022 limita Wolverine a Infrastructure.Core; Application.Abstractions e Domain dependem apenas das abstracoes do projeto.");
+
+        rule.Check(WolverineGuardArchitecture);
+    }
+
+    [Fact(DisplayName = "R3: camadas do modulo Ingresso respeitam a direcao Domain -> Infrastructure -> API")]
+    public void Camadas_RespeitamDirecaoDeDependencia()
+    {
+        IArchRule domainRule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Ingresso\.Domain(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Ingresso\.Infrastructure(\.|$)")
+            .AndShould()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Ingresso\.API(\.|$)")
+            .Because("ADR-002 define Domain como camada interna, sem dependencias para camadas externas.");
+
+        IArchRule infrastructureRule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Ingresso\.Infrastructure(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Ingresso\.API(\.|$)")
+            .Because("ADR-002 deixa API como camada mais externa; Infrastructure nao pode depender dela.");
+
+        domainRule.Check(ModuleArchitecture);
+        infrastructureRule.Check(ModuleArchitecture);
+    }
+
+    private static Architecture LoadModuleArchitecture()
+    {
+        ReflectionAssembly[] assemblies =
+        [
+            typeof(Ingresso.Domain.Entities.Chamada).Assembly,
+            typeof(Ingresso.Infrastructure.Persistence.IngressoDbContext).Assembly,
+            typeof(Ingresso.API.IngressoApiAssemblyMarker).Assembly,
+            typeof(Selecao.Domain.Entities.Edital).Assembly,
+            typeof(Selecao.Application.Commands.Editais.CriarEditalCommand).Assembly,
+            typeof(Selecao.Infrastructure.Persistence.SelecaoDbContext).Assembly,
+            typeof(Selecao.API.Controllers.EditalController).Assembly,
+        ];
+
+        return new ArchLoader().LoadAssemblies(assemblies).Build();
+    }
+
+    private static Architecture LoadWolverineGuardArchitecture()
+    {
+        ReflectionAssembly[] assemblies =
+        [
+            typeof(global::Unifesspa.UniPlus.Application.Abstractions.Messaging.ICommandBus).Assembly,
+            typeof(Ingresso.Domain.Entities.Chamada).Assembly,
+        ];
+
+        return new ArchLoader().LoadAssemblies(assemblies).Build();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj
@@ -15,8 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/shared/Unifesspa.UniPlus.Application.Abstractions/Unifesspa.UniPlus.Application.Abstractions.csproj" />
     <ProjectReference Include="../../src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Unifesspa.UniPlus.Ingresso.Domain.csproj" />
     <ProjectReference Include="../../src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Unifesspa.UniPlus.Ingresso.Infrastructure.csproj" />
+    <ProjectReference Include="../../src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj" />
+    <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.Domain/Unifesspa.UniPlus.Selecao.Domain.csproj" />
+    <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.Application/Unifesspa.UniPlus.Selecao.Application.csproj" />
+    <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Unifesspa.UniPlus.Selecao.Infrastructure.csproj" />
+    <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/Stage1ArchitectureRulesTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/Stage1ArchitectureRulesTests.cs
@@ -1,0 +1,117 @@
+namespace Unifesspa.UniPlus.Selecao.ArchTests;
+
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Loader;
+using ArchUnitNET.xUnit;
+
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+using ReflectionAssembly = System.Reflection.Assembly;
+
+/// <summary>
+/// Fitness tests stage 1 do modulo Selecao, conforme ADR-023.
+/// R1 protege a comunicacao assincrona entre modulos definida pela ADR-004,
+/// R2 protege o encapsulamento Wolverine da ADR-022 e R3 protege a direcao
+/// Clean Architecture definida pela ADR-002.
+/// </summary>
+public sealed class Stage1ArchitectureRulesTests
+{
+    private static readonly Architecture ModuleArchitecture = LoadModuleArchitecture();
+    private static readonly Architecture WolverineGuardArchitecture = LoadWolverineGuardArchitecture();
+
+    [Fact(DisplayName = "R1: Selecao nao referencia Ingresso diretamente")]
+    public void Modulos_NaoSeReferenciam()
+    {
+        IArchRule rule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Ingresso(\.|$)")
+            .Because("ADR-004 exige comunicacao cross-module por eventos Kafka, nao por referencia direta entre modulos.");
+
+        rule.Check(ModuleArchitecture);
+    }
+
+    [Fact(DisplayName = "R2: Application.Abstractions, Selecao.Application e Selecao.Domain nao dependem de Wolverine")]
+    public void ApplicationEDomain_NaoDependemDeWolverine()
+    {
+        IArchRule rule = Types()
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Wolverine(\.|$)")
+            .Because("ADR-022 limita Wolverine a Infrastructure.Core; Application e Domain dependem apenas das abstracoes do projeto.");
+
+        rule.Check(WolverineGuardArchitecture);
+    }
+
+    [Fact(DisplayName = "R3: camadas do modulo Selecao respeitam a direcao Domain -> Application -> Infrastructure -> API")]
+    public void Camadas_RespeitamDirecaoDeDependencia()
+    {
+        IArchRule domainRule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.Domain(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.Application(\.|$)")
+            .AndShould()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.Infrastructure(\.|$)")
+            .AndShould()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.API(\.|$)")
+            .Because("ADR-002 define Domain como camada interna, sem dependencias para camadas externas.");
+
+        IArchRule applicationRule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.Application(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.Infrastructure(\.|$)")
+            .AndShould()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.API(\.|$)")
+            .Because("ADR-002 permite Application depender de Domain, mas nao de Infrastructure nem API.");
+
+        IArchRule infrastructureRule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.Infrastructure(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.API(\.|$)")
+            .Because("ADR-002 deixa API como camada mais externa; Infrastructure nao pode depender dela.");
+
+        domainRule.Check(ModuleArchitecture);
+        applicationRule.Check(ModuleArchitecture);
+        infrastructureRule.Check(ModuleArchitecture);
+    }
+
+    private static Architecture LoadModuleArchitecture()
+    {
+        ReflectionAssembly[] assemblies =
+        [
+            typeof(Selecao.Domain.Entities.Edital).Assembly,
+            typeof(Selecao.Application.Commands.Editais.CriarEditalCommand).Assembly,
+            typeof(Selecao.Infrastructure.Persistence.SelecaoDbContext).Assembly,
+            typeof(Selecao.API.Controllers.EditalController).Assembly,
+            typeof(Ingresso.Domain.Entities.Chamada).Assembly,
+            typeof(Ingresso.Infrastructure.Persistence.IngressoDbContext).Assembly,
+            typeof(Ingresso.API.IngressoApiAssemblyMarker).Assembly,
+        ];
+
+        return new ArchLoader().LoadAssemblies(assemblies).Build();
+    }
+
+    private static Architecture LoadWolverineGuardArchitecture()
+    {
+        ReflectionAssembly[] assemblies =
+        [
+            typeof(global::Unifesspa.UniPlus.Application.Abstractions.Messaging.ICommandBus).Assembly,
+            typeof(Selecao.Domain.Entities.Edital).Assembly,
+            typeof(Selecao.Application.Commands.Editais.CriarEditalCommand).Assembly,
+        ];
+
+        return new ArchLoader().LoadAssemblies(assemblies).Build();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/Unifesspa.UniPlus.Selecao.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/Unifesspa.UniPlus.Selecao.ArchTests.csproj
@@ -15,9 +15,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/shared/Unifesspa.UniPlus.Application.Abstractions/Unifesspa.UniPlus.Application.Abstractions.csproj" />
     <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.Domain/Unifesspa.UniPlus.Selecao.Domain.csproj" />
     <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.Application/Unifesspa.UniPlus.Selecao.Application.csproj" />
     <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Unifesspa.UniPlus.Selecao.Infrastructure.csproj" />
+    <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj" />
+    <ProjectReference Include="../../src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Unifesspa.UniPlus.Ingresso.Domain.csproj" />
+    <ProjectReference Include="../../src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Unifesspa.UniPlus.Ingresso.Infrastructure.csproj" />
+    <ProjectReference Include="../../src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Resumo

- Implementa R1/R2/R3 nos projetos Selecao.ArchTests e Ingresso.ArchTests.
- Expande as referencias dos projetos de ArchTests para carregar API, modulos opostos e Application.Abstractions.
- Mantem R4 solution-wide ja existente e documenta a ausencia de Ingresso.Application apos a Story #207.

## Validacao

- dotnet test tests/Unifesspa.UniPlus.Selecao.ArchTests/Unifesspa.UniPlus.Selecao.ArchTests.csproj -v minimal
- dotnet test tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj -v minimal
- dotnet test tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj -v minimal
- dotnet build UniPlus.slnx -m:1 -v minimal
- dotnet test UniPlus.slnx -m:1 -v minimal

Closes #140
Closes #141
Closes #142
Closes #138
Closes #133