### PR TITLE
docs(adrs): cria base canônica de decisões arquiteturais (MADR 4.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,28 @@ env:
   COVERAGE_THRESHOLD: 0
 
 jobs:
+  adr-lint:
+    name: ADR lint (MADR 4.0)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validar ADRs (MADR 4.0)
+        run: bash tools/adr-lint/validate.sh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Markdown lint (markdownlint-cli2)
+        run: npx --yes markdownlint-cli2 'docs/adrs/**/*.md'
+
   build:
     name: Build, Test and Coverage
     runs-on: ubuntu-latest

--- a/docs/adrs/.markdownlint-cli2.jsonc
+++ b/docs/adrs/.markdownlint-cli2.jsonc
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": { "siblings_only": true },
+    "MD033": false,
+    "MD041": false,
+    "MD060": false
+  },
+  "globs": ["*.md"],
+  "ignores": ["_template.md"]
+}

--- a/docs/adrs/0001-monolito-modular-como-estilo-arquitetural.md
+++ b/docs/adrs/0001-monolito-modular-como-estilo-arquitetural.md
@@ -1,0 +1,82 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+  - "P.O. CEPS"
+  - "P.O. CRCA"
+---
+
+# ADR-0001: Monolito modular como estilo arquitetural
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` precisa suportar dois bounded contexts operacionais — Seleção (CEPS) e Ingresso (CRCA) — com equipes distintas, sem o overhead operacional de microservices. A equipe é pequena, a infraestrutura da Unifesspa é própria e enxuta, e os módulos têm requisito de disponibilidade para a janela de processos seletivos.
+
+A plataforma Uni+ prevê módulos futuros (Auxílio Estudantil, Pesquisa, Mobilidade Acadêmica) que devem ser adicionados sem reescrita arquitetural.
+
+## Drivers da decisão
+
+- Equipe pequena (1 tech lead, 4 fullstacks, 1 Q.A.) sem experiência prévia em distributed systems.
+- Infraestrutura on-premises da Unifesspa, sem cloud pública e sem orçamento para cloud-managed services.
+- Necessidade de bounded contexts claros entre Seleção e Ingresso para autonomia das equipes (CEPS, CRCA).
+- Roadmap de 3–5 anos com adição incremental de módulos.
+
+## Opções consideradas
+
+- Monolito modular (deploy independente por módulo, comunicação via eventos)
+- Microservices from day one
+- Monolito tradicional sem fronteiras formais
+- Monorepo por camada técnica (sem bounded contexts)
+
+## Resultado da decisão
+
+**Escolhida:** monolito modular — cada módulo é uma aplicação .NET independente, deployável separadamente no Kubernetes, com comunicação inter-módulos exclusivamente por eventos assíncronos.
+
+A estrutura do monorepo reflete essa separação:
+
+```text
+src/
+  shared/                       # SharedKernel, Infrastructure.Common
+  selecao/                      # Domain, Application, Infrastructure, API
+  ingresso/                     # Domain, Application, Infrastructure, API
+```
+
+Regras invariantes:
+
+- Módulos comunicam-se exclusivamente via eventos (Kafka) — nunca por chamadas diretas.
+- Cada módulo tem suas próprias 4 camadas (ver ADR-0002).
+- SharedKernel apenas para value objects, domain errors e contratos de eventos base.
+- Adição de novos módulos não exige alteração nos módulos existentes.
+
+## Consequências
+
+### Positivas
+
+- Operação simples — um deploy por módulo, sem service mesh ou sidecars.
+- Bounded contexts visíveis na estrutura de pastas e nos namespaces.
+- Custo de infraestrutura inferior ao de microservices.
+- Evolução para microservices fica acessível, sem ser pré-requisito.
+- Cada setor (CEPS, CRCA) detém autonomia sobre seu módulo.
+
+### Negativas
+
+- Módulos podem compartilhar processo se deployados juntos — falha em um pode afetar outro caso o operador os una.
+- Escala horizontal é por módulo, não por aggregate root.
+- Disciplina de CI/CD é necessária para garantir que deploys sejam realmente independentes.
+
+### Neutras
+
+- Monorepo único versus repositórios separados é decisão ortogonal — atualmente o monorepo simplifica refatorações cross-module.
+
+## Confirmação
+
+- Fitness test ArchUnitNET garante que tipos de `Selecao.*` não dependem de `Ingresso.*` e vice-versa (ver ADR-0012).
+- Pipeline de CI valida que cada módulo compila e testa isoladamente.
+
+## Mais informações
+
+- ADR-0002 detalha a organização de camadas dentro de cada módulo.
+- ADR-0014 define Kafka como bus assíncrono inter-módulos.
+- ADR-0012 define ArchUnitNET como ferramenta de fitness tests.
+- **Origem:** revisão da ADR interna Uni+ ADR-001 (não publicada).

--- a/docs/adrs/0002-clean-architecture-com-quatro-camadas.md
+++ b/docs/adrs/0002-clean-architecture-com-quatro-camadas.md
@@ -1,0 +1,93 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0002: Clean Architecture com quatro camadas por módulo
+
+## Contexto e enunciado do problema
+
+Cada módulo de negócio do `uniplus-api` (Seleção, Ingresso e os futuros) tem regras complexas e sensíveis: cotas com remanejamento em cascata, fórmulas configuráveis por edital, múltiplas etapas de homologação, máquinas de estado de inscrição. Essas regras precisam ser testáveis isoladamente, sem dependência de banco, broker ou qualquer infraestrutura externa.
+
+A equipe terá rotatividade (servidores públicos, estagiários), portanto a arquitetura precisa ser previsível: todo caso de uso segue o mesmo padrão estrutural.
+
+Esta ADR trata exclusivamente da **organização de camadas** do módulo. A escolha do framework de mediação CQRS é decisão separada (ver ADR-0003).
+
+## Drivers da decisão
+
+- Regras de negócio densas e auditáveis (Lei de Cotas, RN08 — congelamento de parâmetros).
+- Testes unitários do domínio devem rodar sem banco, sem container, sem broker.
+- Previsibilidade estrutural para acomodar rotatividade de equipe.
+- Necessidade de separar policy (domínio) de mecanismo (infraestrutura).
+
+## Opções consideradas
+
+- Clean Architecture com quatro camadas (Domain → Application → Infrastructure → API)
+- Vertical Slice Architecture
+- N-tier tradicional (Controller → Service → Repository)
+- Hexagonal / Ports and Adapters
+
+## Resultado da decisão
+
+**Escolhida:** Clean Architecture com quatro camadas por módulo, com fluxo de dependências exclusivamente para dentro.
+
+| Camada | Responsabilidade | Dependências |
+|--------|------------------|--------------|
+| Domain | entities, value objects, domain events, regras de negócio | nenhuma |
+| Application | use cases, handlers, DTOs, interfaces de infraestrutura | Domain |
+| Infrastructure | EF Core, persistência, integrações externas | Domain, Application |
+| API | controllers, middleware, configuração | Application, Infrastructure |
+
+Padrões obrigatórios na camada Application e Domain:
+
+- **CQRS:** commands alteram estado; queries leem dados. Separação explícita.
+- **Validação:** FluentValidation antes da execução do handler.
+- **Result\<T\> pattern** com `DomainError` — sem exceções para fluxos esperados de negócio.
+- **Entities** com factory methods e construtores privados — nunca `new` fora da própria classe.
+- **Sealed classes** por padrão.
+- **File-scoped namespaces** em todo o código.
+
+## Consequências
+
+### Positivas
+
+- Domínio testável como função pura — regras de cotas e classificação rodam sem infraestrutura.
+- Estrutura previsível por convenção — todo handler segue Command → Validator → Handler → Result.
+- Fácil substituir implementações de infraestrutura sem tocar regra de negócio.
+- Onboarding facilitado pela uniformidade entre módulos.
+
+### Negativas
+
+- Mais boilerplate por caso de uso (Command, Validator, Handler, DTO).
+- Curva de aprendizado para quem não conhece Clean Architecture.
+- Indireção pode dificultar leitura de fluxos por desenvolvedores juniores.
+
+## Confirmação
+
+- Fitness tests ArchUnitNET enforçam direção de dependência entre camadas (ver ADR-0012).
+- Pull request review verifica conformidade com padrões obrigatórios.
+
+## Prós e contras das opções
+
+### Vertical Slice Architecture
+
+- Bom, porque agrupa tudo que pertence à mesma feature.
+- Ruim, porque a estrutura de cada slice fica a critério do autor — perde previsibilidade em equipe com rotatividade.
+
+### N-tier tradicional
+
+- Bom, porque é familiar a desenvolvedores .NET legados.
+- Ruim, porque domínio acopla a infraestrutura — classificação dependeria de EF Core para ser testada.
+
+### Hexagonal puro
+
+- Bom, porque também isola domínio de infraestrutura.
+- Ruim, porque sem CQRS as queries complexas competem com commands no mesmo modelo.
+
+## Mais informações
+
+- ADR-0003 define o framework de CQRS (Wolverine).
+- ADR-0012 define ArchUnitNET para enforcement das regras de dependência.
+- **Origem:** revisão da ADR interna Uni+ ADR-002 (não publicada) — split: o componente "Clean Architecture" desta ADR vem da ADR-002 antiga; o componente "framework CQRS" foi extraído para a ADR-0003 atual.

--- a/docs/adrs/0003-wolverine-como-backbone-cqrs.md
+++ b/docs/adrs/0003-wolverine-como-backbone-cqrs.md
@@ -1,0 +1,120 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted:
+  - "Council multi-advisor 2026-04-24"
+---
+
+# ADR-0003: Wolverine como backbone CQRS in-process
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` precisa de um backbone para despachar commands, executar handlers de domain events e (em ADR separada) suportar outbox transacional sobre `EntityFrameworkCore`. A escolha do framework é independente da decisão de adotar Clean Architecture com CQRS (ADR-0002).
+
+Três fatos forçam a decisão:
+
+1. **MediatR** migrou para licenciamento comercial em 02/07/2025 (Lucky Penny Software, dual-license RPL 1.5 + tiers comerciais por tamanho de equipe). Procurement de autarquia federal não absorve licenças comerciais por desenvolvedor.
+2. **MassTransit v9** virou comercial em Q1/2026 (Massient, Inc.); v8 fica em Apache 2.0 mas com EOL anunciado para fim de 2026.
+3. **Construir in-house** (dispatcher + outbox + retries + sagas) foi explicitamente rejeitado pela governança como "alto custo de manutenção e reinvenção da roda".
+
+A equipe não tem experiência prévia com Wolverine, Brighter ou Rebus — a curva de aprendizado é simétrica entre os candidatos.
+
+## Drivers da decisão
+
+- Licenciamento permissivo (MIT/Apache 2.0/BSD) sem tier comercial.
+- Suporte first-class a outbox transacional sobre EF Core (decisão técnica de outbox em ADR-0004).
+- Cadência ativa de releases e bus factor saudável (horizonte de projeto: 3–5 anos).
+- Substituibilidade — código de aplicação não pode importar tipos do framework diretamente.
+
+## Opções consideradas
+
+- Wolverine (MIT, JasperFx)
+- Brighter (Apache 2.0, comunidade independente)
+- Continuar em MediatR sob RPL 1.5
+- Implementar dispatcher + outbox in-house
+
+## Resultado da decisão
+
+**Escolhida:** Wolverine (MIT, JasperFx) como backbone CQRS in-process, sobre `EntityFrameworkCore` 10 + PostgreSQL.
+
+Apenas dois contratos vivem em `Application.Abstractions/Messaging/`:
+
+```csharp
+public interface ICommandBus
+{
+    Task<TResponse> Send<TResponse>(
+        ICommand<TResponse> command,
+        CancellationToken ct = default);
+}
+
+public interface IDomainEventDispatcher
+{
+    Task Publish(
+        IDomainEvent domainEvent,
+        CancellationToken ct = default);
+}
+```
+
+Implementações ficam em `Infrastructure.Core/Messaging/` e encapsulam o `IMessageBus` do Wolverine. Código de aplicação e domínio **não importam `Wolverine.*` diretamente**.
+
+Capacidades avançadas (sagas, process managers, scheduled messages, event sourcing) ficam **deliberadamente fora** desta decisão e só entram no projeto quando um caso de uso concreto exigir, com emenda a esta ADR.
+
+## Consequências
+
+### Positivas
+
+- Time pode produzir novos commands e handlers seguindo um único exemplo funcional.
+- Outbox transacional é capacidade nativa do framework (ver ADR-0004).
+- Contrato mínimo de duas abstrações mantém código de aplicação portável para Brighter como escape-hatch.
+- Padrão CQRS preservado (ADR-0002 intacto).
+
+### Negativas
+
+- Zero experiência prévia da equipe — curva de aprendizado paga em trabalho real.
+- Dependência da cadência de manutenção da JasperFx Software.
+- Ecossistema CritterStack (Marten, CritterWatch) não pode virar dependência implícita — apenas Wolverine standalone.
+
+### Riscos
+
+- **Bus factor da JasperFx.** Mitigado pelo encapsulamento via `ICommandBus`/`IDomainEventDispatcher` — migração para Brighter custa 2–6 semanas conforme uso de features avançadas. Brighter fica nomeado como escape-hatch.
+- **Features avançadas vazando para handlers.** Mitigado pela regra arquitetural enforçada por ArchUnitNET (ver ADR-0012) que proíbe imports de `Wolverine.*` fora de `Infrastructure.Core`.
+- **Drift do CritterWatch como dependência implícita.** Observabilidade fica em OpenTelemetry (ver ADR-0018); `CritterWatch` é proibido como dependência load-bearing.
+
+## Confirmação
+
+- Fitness test ArchUnitNET `ApplicationLayer_DoesNotDependOnWolverine` falha o build se houver import fora de `Infrastructure.Core` (ver ADR-0012).
+- Fitness test `SolutionDoesNotReferenceMediatR` falha o build se houver qualquer import de `MediatR.*`.
+
+## Prós e contras das opções
+
+### Wolverine
+
+- Bom, porque colapsa CQRS, outbox e Kafka transport em um framework coerente.
+- Ruim, porque o ecossistema CritterStack pode pressionar adoção implícita de outras peças.
+
+### Brighter
+
+- Bom, porque tem bus factor maior e zero risco de tier comercial.
+- Ruim, porque sagas exigem projeto separado (Darker), aumentando o footprint mental.
+
+### MediatR sob RPL 1.5
+
+- Bom, porque time já familiarizado.
+- Ruim, porque licenciamento RPL 1.5 carece de avaliação jurídica e qualquer tier pago futuro é inviável para procurement.
+
+### Dispatcher in-house
+
+- Bom, porque elimina dependência externa.
+- Ruim, porque outbox + retries + idempotência + Kafka producer + estado de saga reinventa um framework mantido — incompatível com equipe pequena em horizonte longo.
+
+## Mais informações
+
+- ADR-0004 define o outbox transacional sobre Wolverine + EF Core.
+- ADR-0005 define a estratégia de drenagem de domain events via cascading messages.
+- ADR-0012 define ArchUnitNET como ferramenta de enforcement.
+- ADR-0018 define OpenTelemetry como observabilidade obrigatória.
+- [Wolverine documentation](https://wolverinefx.net/)
+- [Brighter (escape-hatch nomeado)](https://github.com/BrighterCommand/Brighter)
+- **Origem:** revisão das ADRs internas Uni+ ADR-002 (parte CQRS) e ADR-022 (não publicadas).

--- a/docs/adrs/0003-wolverine-como-backbone-cqrs.md
+++ b/docs/adrs/0003-wolverine-como-backbone-cqrs.md
@@ -49,15 +49,19 @@ public interface ICommandBus
         CancellationToken ct = default);
 }
 
-public interface IDomainEventDispatcher
+public interface IQueryBus
 {
-    Task Publish(
-        IDomainEvent domainEvent,
+    Task<TResponse> Send<TResponse>(
+        IQuery<TResponse> query,
         CancellationToken ct = default);
 }
 ```
 
+A separação semântica entre `ICommandBus` e `IQueryBus` impede, na própria assinatura, que um `ICommand<TResponse>` seja despachado pelo bus de leitura ou um `IQuery<TResponse>` pelo bus de escrita.
+
 Implementações ficam em `Infrastructure.Core/Messaging/` e encapsulam o `IMessageBus` do Wolverine. Código de aplicação e domínio **não importam `Wolverine.*` diretamente**.
+
+A drenagem de domain events não passa por dispatcher injetado: handlers que mutam agregado devolvem os eventos no próprio retorno (`IEnumerable<object>` direto ou em tupla com a resposta), e o Wolverine despacha via cascading messages — caminho idiomático definido em ADR-0005.
 
 Capacidades avançadas (sagas, process managers, scheduled messages, event sourcing) ficam **deliberadamente fora** desta decisão e só entram no projeto quando um caso de uso concreto exigir, com emenda a esta ADR.
 
@@ -78,14 +82,14 @@ Capacidades avançadas (sagas, process managers, scheduled messages, event sourc
 
 ### Riscos
 
-- **Bus factor da JasperFx.** Mitigado pelo encapsulamento via `ICommandBus`/`IDomainEventDispatcher` — migração para Brighter custa 2–6 semanas conforme uso de features avançadas. Brighter fica nomeado como escape-hatch.
+- **Bus factor da JasperFx.** Mitigado pelo encapsulamento via `ICommandBus`/`IQueryBus` (e drenagem cascading definida em ADR-0005) — migração para Brighter custa 2–6 semanas conforme uso de features avançadas. Brighter fica nomeado como escape-hatch.
 - **Features avançadas vazando para handlers.** Mitigado pela regra arquitetural enforçada por ArchUnitNET (ver ADR-0012) que proíbe imports de `Wolverine.*` fora de `Infrastructure.Core`.
 - **Drift do CritterWatch como dependência implícita.** Observabilidade fica em OpenTelemetry (ver ADR-0018); `CritterWatch` é proibido como dependência load-bearing.
 
 ## Confirmação
 
-- Fitness test ArchUnitNET `ApplicationLayer_DoesNotDependOnWolverine` falha o build se houver import fora de `Infrastructure.Core` (ver ADR-0012).
-- Fitness test `SolutionDoesNotReferenceMediatR` falha o build se houver qualquer import de `MediatR.*`.
+- Fitness test ArchUnitNET `Stage1ArchitectureRulesTests.ApplicationEDomain_NaoDependemDeWolverine` (presente nos projetos `Unifesspa.UniPlus.Selecao.ArchTests` e `Unifesspa.UniPlus.Ingresso.ArchTests`) falha o build se `Application.Abstractions`, `Selecao.Application`/`Ingresso.Application` ou `Selecao.Domain`/`Ingresso.Domain` importarem `Wolverine.*` (ver ADR-0012).
+- Fitness test `SolutionNaoTemMediatRTests.NenhumTipoDoProdutoDependeDeMediatR` (no projeto solution-wide `Unifesspa.UniPlus.ArchTests`) falha o build se qualquer assembly do produto importar `MediatR.*`.
 
 ## Prós e contras das opções
 

--- a/docs/adrs/0004-outbox-transacional-via-wolverine.md
+++ b/docs/adrs/0004-outbox-transacional-via-wolverine.md
@@ -1,0 +1,102 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0004: Outbox transacional via Wolverine + EF Core sobre PostgreSQL
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` precisa garantir atomicidade entre a persistência de uma alteração no agregado e a publicação de seus domain events para o bus interno (Wolverine PostgreSQL transport) e para o bus externo (Kafka). Sem outbox, há risco de salvar a entidade sem despachar o evento — gap silencioso que rompe a coerência entre módulos.
+
+A primeira tentativa de adoção (uniplus-api#135) reprovou em spike por bug do `DomainEventScraper` na versão 5.32.1 do Wolverine — `Collection was modified during ScrapeEvents`. A reprovação está documentada em registro histórico interno.
+
+A retomada na uniplus-api#158 executou matriz de spikes S0–S9 com fix do scraper carregado via fork local (`5.32.1-pr2586`) sobre o PR upstream `JasperFx/wolverine#2586`. Resultado: 13 testes verdes, AC1a/AC1b/AC2/AC3/AC5 comprovados; AC4 fechado pelo versionamento de schema via migrations.
+
+A combinação de drenagem de domain events em si é decisão separada — ver ADR-0005, que adota cascading messages como caminho idiomático recomendado pelo maintainer Wolverine, removendo a dependência do fork local.
+
+## Drivers da decisão
+
+- Atomicidade transacional cross-boundary é não-negociável.
+- Persistência e transport co-residem no PostgreSQL primário (sem broker dedicado para mensagens internas).
+- Auditabilidade de processo seletivo — envelopes ficam rastreáveis em SQL.
+- Princípio de menor privilégio para a role de banco em produção.
+
+## Opções consideradas
+
+- Outbox via integração Wolverine + EF Core (Persist + Transport PostgreSQL)
+- Outbox via Hangfire job consultando tabela própria
+- Publicação direta no Kafka pelo handler (sem outbox)
+
+## Resultado da decisão
+
+**Escolhida:** outbox transacional usando a integração nativa Wolverine + EF Core, com persistence e transport ambos no PostgreSQL primário.
+
+Configuração canônica em `Program.cs` por módulo:
+
+```csharp
+builder.Host.UseWolverine(opts =>
+{
+    opts.UseEntityFrameworkCoreTransactions();
+    opts.Policies.AutoApplyTransactions();
+
+    opts
+        .PersistMessagesWithPostgresql(connectionString, schemaName: "wolverine")
+        .EnableMessageTransport(_ => { });
+
+    opts.Policies.UseDurableOutboxOnAllSendingEndpoints();
+
+    // Roteamento por domínio fica no extension de cada módulo.
+});
+```
+
+Decisões contratuais derivadas:
+
+1. **`Policies.UseDurableOutboxOnAllSendingEndpoints()` é obrigatório.** Sem isso, publicação Kafka cai em buffer in-memory do producer Confluent, perdendo durabilidade se o broker estiver indisponível ou o processo cair antes do flush.
+2. **`EnableRetryOnFailure` no `DbContext` é proibido em DbContexts usados por handlers Wolverine.** `NpgsqlRetryingExecutionStrategy` é incompatível com `Policies.AutoApplyTransactions`. Retry é centralizado em `opts.OnException<TException>().RetryTimes(N)`.
+3. **Schema versionado por migration EF.** `MapWolverineEnvelopeStorage(modelBuilder, "wolverine")` no `OnModelCreating` de cada `DbContext`. `AutoBuildMessageStorageOnStartup = AutoCreate.None` em produção.
+4. **Tabelas de queue PG (`wolverine_queues.wolverine_queue_<nome>` e `_scheduled`) são provisionadas previamente** por SQL versionado, migration manual ou time de plataforma. Em produção, a role de banco do nó Wolverine **não tem permissão DDL**.
+5. **AutoProvision Kafka apenas em dev/test.** Produção: provisão de tópicos sob governança da plataforma (ver ADR-0014).
+6. **Convenção snake_case** para queues PG e tópicos Kafka — Wolverine normaliza `-` para `_` em SQL; padronizar evita surpresas em clientes admin.
+7. **Retenção de dead letters** — `DurabilitySettings.DeadLetterQueueExpirationEnabled = true`, expiração padrão 30 dias. Default Wolverine (10 dias) não é adotado por ser inferior ao ciclo de triagem de processo seletivo.
+
+## Consequências
+
+### Positivas
+
+- Atomicidade `SaveChanges + envelope storage` garantida pela transação Postgres — agregado e mensagem sobrevivem ou perecem juntos.
+- Sem broker adicional para mensagens internas — PG transport reusa o banco primário.
+- Auditoria SQL — envelopes inspecionáveis com queries diretas.
+- Política de retenção alinhada ao ciclo de processo seletivo.
+
+### Negativas
+
+- Schema `wolverine` adicional no banco primário (8 tabelas + tabelas de queue).
+- Operadores precisam provisionar `wolverine_queues` antes do deploy produtivo.
+- Retry de EF concentrado em policies Wolverine — onboarding precisa cobrir essa restrição.
+
+### Riscos
+
+- **Crash não-gracioso (kill -9, OOM).** Mitigado pelo invariante transacional do Postgres — envelope storage e agregado vivem na mesma transação. Spike de hardening contra crash não-gracioso fica documentado como melhoria futura.
+- **Drift entre migration e runtime.** Mitigado pela combinação `AutoCreate.None` em produção + role sem permissão DDL.
+- **Versão do framework.** Decisão de drenagem em ADR-0005 elimina a dependência do fork local; atualizações futuras seguem política de drift documentada por ADR.
+
+## Confirmação
+
+- Suíte `Category=OutboxCapability` em `uniplus-api` cobre a matriz S0–S9 com 13 cenários verdes.
+- Validador de startup falha o boot se `EnableRetryOnFailure` estiver ativo em DbContext usado por handler Wolverine.
+- Validador de startup falha o boot se houver endpoint Kafka sem outbox durável marcado.
+- Logs de boot via `LoggerMessage` listam queues, topics, mode (durable/buffered) e schema de persistência.
+
+## Mais informações
+
+- ADR-0003 define Wolverine como backbone CQRS.
+- ADR-0005 define cascading messages como caminho de drenagem (substitui `PublishDomainEventsFromEntityFrameworkCore`).
+- ADR-0014 define Kafka como bus inter-módulo.
+- ADR-0007 define PostgreSQL como banco primário (provedor da persistência outbox).
+- ADR-0018 define OpenTelemetry como observabilidade obrigatória — métricas e alertas Wolverine ficam ali.
+- [Wolverine — Durable Outbox](https://wolverinefx.net/guide/durability/)
+- [JasperFx/wolverine#2586 — fix do DomainEventScraper](https://github.com/JasperFx/wolverine/pull/2586)
+- **Origem:** revisão da ADR interna Uni+ ADR-025 (não publicada). A ADR interna ADR-024, que documentou a primeira tentativa reprovada, permanece como histórico interno e não é canonizada aqui — só o estado atual.

--- a/docs/adrs/0005-cascading-messages-para-drenagem-de-domain-events.md
+++ b/docs/adrs/0005-cascading-messages-para-drenagem-de-domain-events.md
@@ -1,0 +1,100 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0005: Cascading messages como drenagem canônica de domain events
+
+## Contexto e enunciado do problema
+
+A ADR-0004 fixou outbox transacional via Wolverine + EF Core. A primeira configuração ensaiada drenava domain events com `options.PublishDomainEventsFromEntityFrameworkCore<EntityBase>(entity => entity.DomainEvents)` — caminho que dependia do fork local Wolverine `5.32.1-pr2586` (PR upstream 2586).
+
+Após o merge dessa configuração, a thread upstream `JasperFx/wolverine#2585` trouxe recomendação explícita do maintainer Jeremy D. Miller:
+
+> *"If you're greenfield though, I'd recommend using Wolverine more idiomatically and just returning cascaded messages from the handler rather than the magic EF Core scraping thing that's popular in MediatR circles. I'd still hold the Wolverine way will lead to more maintainable code."*
+
+O `uniplus-api` é greenfield. O Spike S10 validou empiricamente o caminho idiomático em 10 dimensões objetivas (acoplamento, testabilidade unitária, comportamento implícito, atomicidade transacional, alta disponibilidade, performance, manutenibilidade longitudinal, independência do fork local, entre outras). Resultado: 16 testes verdes (13 da matriz S0–S9 mais 3 do S10), com vitória clara para cascading messages.
+
+## Drivers da decisão
+
+- Idiomatismo do framework — caminho recomendado pelo próprio maintainer.
+- Testabilidade unitária — handlers passam a ser função pura, sem fixture com Postgres real.
+- Independência do fork local — cascading roda em `WolverineFx 5.32.1` oficial, eliminando dívida técnica do feed `vendors/nuget-local/`.
+- Visibilidade da drenagem — a entrega de eventos vira artefato no `return` do handler, não configuração distante no boot.
+
+## Opções consideradas
+
+- Cascading messages do retorno do handler (`Task<IEnumerable<object>>` + `DequeueDomainEvents()`)
+- `PublishDomainEventsFromEntityFrameworkCore<EntityBase>(...)` no boot
+- Pipeline middleware customizado para drenagem
+
+## Resultado da decisão
+
+**Escolhida:** cascading messages do retorno do handler como caminho canônico de drenagem de domain events.
+
+`PublishDomainEventsFromEntityFrameworkCore<EntityBase>(...)` é removido da configuração de produção. Handlers que mutam agregados passam a seguir o padrão:
+
+```csharp
+public sealed class PublicarEditalHandler
+{
+    public static async Task<IEnumerable<object>> Handle(
+        PublicarEditalCommand command,
+        SelecaoDbContext db,
+        CancellationToken ct)
+    {
+        var edital = Edital.Criar(command.Numero, command.Titulo, command.Tipo);
+        edital.Publicar();
+        db.Editais.Add(edital);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        return edital.DequeueDomainEvents().Cast<object>();
+    }
+}
+```
+
+`DequeueDomainEvents()` é helper canônico no `EntityBase` — combina snapshot atômico e clear da coleção interna. Padronização defensiva contra republicação acidental em cenários onde o agregado sobreviva ao escopo do handler (cache distribuído, sagas).
+
+Convenções:
+
+- Handlers que mutam agregado retornam `Task<IEnumerable<object>>`, drenando via `DequeueDomainEvents()`.
+- Outros formatos suportados pelo Wolverine (`OutgoingMessages`, tipo único, tupla, `IAsyncEnumerable<T>`) só com justificativa local.
+- Handlers que não emitem eventos (puros side-effects, leitura, validação) mantêm assinatura `Task` ou `Task<TResult>`.
+- O extension de cada módulo (`AddSelecaoModule`, `AddIngressoModule`) continua responsável pelo roteamento (`PublishMessage<T>().ToPostgresqlQueue(...)` / `.ToKafkaTopic(...)`), mas não pela drenagem.
+
+`PublishDomainEventsFromEntityFrameworkCore` permanece caminho válido do framework como fallback para casos legados específicos (migração de código MediatR-style, agregados de bibliotecas externas) — exige justificativa em ADR adicional.
+
+## Consequências
+
+### Positivas
+
+- Estilo idiomático Wolverine, recomendado pelo maintainer.
+- Testes unitários puros para handlers — feedback loop drasticamente menor.
+- Eliminação imediata da dependência do fork local (volta para `WolverineFx 5.32.1` oficial).
+- Imune por design ao bug do PR 2586 — cascading não passa pelo `ChangeTracker`.
+- Habilita futura redução de visibilidade de `EntityBase.DomainEvents` (encapsulamento).
+
+### Neutras
+
+- Performance ~26% pior por invocação, em magnitude absoluta sub-1ms — irrelevante para o perfil HTTP+I/O do projeto.
+
+### Negativas
+
+- Cada handler que muta agregado ganha ~5 linhas (assinatura + return).
+- Convenção exige disciplina — sempre retornar coleção de eventos. Fica documentado em guia operacional.
+- Migração dos handlers já existentes na codebase requer PR específico.
+
+## Confirmação
+
+- Suíte `Category=OutboxCascading` em `uniplus-api` cobre os cenários do Spike S10 com 3/3 testes verdes em ambiente com Wolverine 5.32.1 oficial.
+- Suíte completa `Category=OutboxCapability ∪ Category=OutboxCascading` mantém 16/16 verde.
+- Pull request review verifica que handlers que persistem agregado retornam `IEnumerable<object>` via `DequeueDomainEvents()`.
+
+## Mais informações
+
+- ADR-0003 define Wolverine como backbone CQRS.
+- ADR-0004 define o outbox transacional (configuração de transport, persistence, retenção de dead letters).
+- [Wolverine — Cascading Messages](https://wolverinefx.net/guide/handlers/cascading.html)
+- [JasperFx/wolverine#2585 — thread upstream com recomendação do maintainer](https://github.com/JasperFx/wolverine/issues/2585)
+- **Origem:** revisão da ADR interna Uni+ ADR-026 (não publicada).

--- a/docs/adrs/0006-csharp-14-e-dotnet-10-como-stack-do-backend.md
+++ b/docs/adrs/0006-csharp-14-e-dotnet-10-como-stack-do-backend.md
@@ -1,0 +1,83 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0006: C# 14 / .NET 10 como linguagem e runtime do backend
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` precisa de uma stack que comporte Clean Architecture, CQRS, processamento de classificação em lote e integrações com Keycloak, PostgreSQL, Kafka e S3. A equipe está se capacitando em .NET, alinhada com o ecossistema institucional da Unifesspa.
+
+O sistema deve absorver picos de inscrição (5000+ candidatos simultâneos), gerar PDFs e planilhas, processar importação de notas em CSV/Excel e executar o motor de classificação com fórmulas configuráveis e desempates encadeados.
+
+## Drivers da decisão
+
+- Suporte LTS de longo prazo (3+ anos) compatível com horizonte de produto.
+- Tipagem forte com null safety para reduzir erros em runtime.
+- Ecossistema enterprise maduro para todas as integrações previstas.
+- Custo zero de licenciamento.
+- Capacidade de produzir containers AOT enxutos para Kubernetes.
+
+## Opções consideradas
+
+- C# 14 / .NET 10 + EF Core 10 (Npgsql)
+- Java 21 / Spring Boot 3
+- Go (com gorm/sqlx)
+- Node.js / NestJS
+- Python / Django
+
+## Resultado da decisão
+
+**Escolhida:** C# 14 / .NET 10 como linguagem e runtime do backend, com EF Core 10 + provider Npgsql como ORM.
+
+Bibliotecas complementares de mercado:
+
+| Biblioteca | Propósito |
+|------------|-----------|
+| Wolverine | CQRS in-process e outbox (ver ADR-0003, ADR-0004) |
+| FluentValidation | validação de comandos e queries |
+| Serilog | logging estruturado com PII masking (ver ADR-0011) |
+| Stateless | máquinas de estado de inscrição, edital e recurso |
+| QuestPDF | geração de PDFs (resultados, comprovantes) |
+| ClosedXML, CsvHelper | importação e exportação de planilhas e CSV |
+| MailKit | envio de emails de notificação |
+| MinIO .NET SDK | object storage (ver ADR-0009) |
+| Asp.Versioning | versionamento de API REST |
+
+`MediatR` é proibido na codebase — a escolha de framework de mediação é Wolverine (ADR-0003), enforçada por fitness test ArchUnitNET (ADR-0012).
+
+## Consequências
+
+### Positivas
+
+- Tipagem forte com null safety reduz classes inteiras de bugs.
+- Performance excelente para APIs (Kestrel) — benchmarks consistentemente entre os melhores web frameworks.
+- Ecossistema enterprise — todas as integrações previstas têm libs maduras.
+- LTS do .NET 10 cobre horizonte de 3 anos.
+- AOT compilation possível para containers menores no Kubernetes.
+- Integração nativa com OpenTelemetry (ver ADR-0018).
+
+### Negativas
+
+- Pool de desenvolvedores .NET na região Norte é menor — mitigado por capacitação interna.
+- Runtime base maior que Go para containers simples — mitigado por AOT e multi-stage Docker builds.
+- EF Core pode ser lento para queries muito complexas — mitigado com Dapper para hot paths quando necessário.
+
+### Neutras
+
+- Verbosidade similar a Java — não é vantagem nem desvantagem em projetos longos.
+
+## Confirmação
+
+- Pipeline de CI exige build verde com `--configuration Release` e zero warnings tratados como erros.
+- `Directory.Packages.props` centraliza versões — bumps de major exigem PR dedicado com suíte completa de testes.
+
+## Mais informações
+
+- ADR-0002 define a organização de camadas que esta stack viabiliza.
+- ADR-0003, ADR-0004, ADR-0005 detalham o backbone CQRS.
+- ADR-0007 define PostgreSQL como banco primário.
+- **Origem:** revisão da ADR interna Uni+ ADR-005 (não publicada).

--- a/docs/adrs/0007-postgresql-18-como-banco-primario.md
+++ b/docs/adrs/0007-postgresql-18-como-banco-primario.md
@@ -1,0 +1,75 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0007: PostgreSQL 18 como banco de dados primário
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` precisa de um SGBD OLTP confiável para dados de editais, inscrições, candidatos, notas e classificações. Os requisitos incluem transações ACID, capacidade de criptografia por coluna para dados pessoais (LGPD), suporte a JSON para formulários dinâmicos por tipo de processo seletivo e absorção de picos de inscrição (5000+ candidatos simultâneos).
+
+## Drivers da decisão
+
+- Conformidade ACID estrita (classificação e alocação não toleram eventual consistency).
+- Custo zero de licenciamento (universidade pública, on-premises).
+- Capacidade de criptografia por coluna sem ferramenta externa.
+- Suporte JSON/JSONB para formulários dinâmicos.
+- EF Core support maduro via Npgsql.
+
+## Opções consideradas
+
+- PostgreSQL 18
+- SQL Server (edição Express ou paga)
+- MySQL 8
+- MongoDB
+- CockroachDB
+
+## Resultado da decisão
+
+**Escolhida:** PostgreSQL 18 como banco relacional primário do `uniplus-api`, com schemas logicamente separados por módulo (Seleção, Ingresso) e schema dedicado para o outbox transacional Wolverine (ver ADR-0004).
+
+Estratégias técnicas obrigatórias:
+
+- **Criptografia por coluna via `pgcrypto`** para dados PII sensíveis (CPF, renda familiar, laudos médicos), em conformidade com a LGPD.
+- **Soft delete** em todas as entidades — colunas `IsDeleted`, `DeletedAt`, `DeletedBy` em vez de exclusão física.
+- **Audit trail em tabelas append-only** com hash chain para imutabilidade de alterações em dados de candidatos e classificações.
+- **`pg_stat_statements` ativo** para identificação de queries lentas.
+- **Backup via `pgBackRest` + WAL archiving** com point-in-time recovery testado.
+- **Connection pool gerenciado pelo Npgsql** dimensionado para suportar picos.
+
+## Consequências
+
+### Positivas
+
+- ACID estrito para dados de classificação e inscrição.
+- Open source sem custo de licenciamento.
+- `pgcrypto` e `pg_stat_statements` cobrem necessidades sem dependência externa.
+- JSON/JSONB nativo viabiliza formulários dinâmicos por tipo de processo seletivo.
+- EF Core + Npgsql é integração madura e estável.
+
+### Negativas
+
+- Tuning manual de `connection pool`, `shared_buffers`, `work_mem` é necessário para picos.
+- Backup e HA exigem operação ativa (não é serviço gerenciado).
+- Sem Transparent Data Encryption nativa — criptografia em repouso depende de FS-level (LUKS) ou `pgcrypto` por coluna.
+
+### Riscos
+
+- **Ponto único de falha.** Mitigado com replica read-only e failover automático via Patroni; PgBouncer como connection pooler.
+- **Performance em picos.** Mitigado com connection pooling, cache Redis em frente das queries mais frequentes (ver ADR-0008) e índices adequados.
+
+## Confirmação
+
+- Migrations EF auditadas em PR — alterações de schema passam por revisão de DBA/plataforma.
+- Health check `/health/db` valida conexão e retorno de query simples antes de aceitar tráfego.
+
+## Mais informações
+
+- ADR-0004 define schema `wolverine` para outbox transacional.
+- ADR-0008 define Redis como cache distribuído.
+- ADR-0011 define mascaramento de CPF em logs.
+- ADR-0017 define K8s + Helm para deploy com cluster PG dedicado.
+- **Origem:** revisão da ADR interna Uni+ ADR-009 (não publicada). Detalhes operacionais sensíveis (configuração de criptografia por coluna, política de backup) permanecem em documentação interna.

--- a/docs/adrs/0008-redis-como-cache-distribuido.md
+++ b/docs/adrs/0008-redis-como-cache-distribuido.md
@@ -1,0 +1,72 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0008: Redis como cache distribuído
+
+## Contexto e enunciado do problema
+
+Mesmo com PostgreSQL como banco primário (ver ADR-0007), o `uniplus-api` precisa de cache distribuído para queries de leitura repetidas (lista de editais ativos, cursos disponíveis, vagas por modalidade), rate limiting de endpoints públicos (inscrição, consulta de resultado) e dados temporários durante processamento em lote (locks durante execução do motor de classificação).
+
+Cache local em memória do .NET (`IMemoryCache`) não atende — múltiplas réplicas no Kubernetes precisariam compartilhar estado.
+
+## Drivers da decisão
+
+- Latência sub-milissegundo para leitura.
+- Compartilhamento de estado entre réplicas no Kubernetes.
+- Custo zero de licenciamento.
+- Self-hosted, sem cloud-managed services.
+
+## Opções consideradas
+
+- Redis 8.x
+- Memcached
+- Apenas cache in-memory do .NET (`IMemoryCache`)
+
+## Resultado da decisão
+
+**Escolhida:** Redis 8.x como cache distribuído do `uniplus-api`.
+
+Casos de uso e políticas:
+
+- **Cache de queries frequentes** com TTL longo (editais ativos, cursos, vagas) — invalidação por evento de domínio.
+- **Session state complementar** para fluxo de inscrição em andamento — TTL curto.
+- **Rate limiting de endpoints públicos** via contadores Redis (ver ADR-0015).
+- **Locks distribuídos** durante execução do motor de classificação para garantir uma única execução por edital concorrente.
+
+A aplicação degrada graciosamente sem Redis — cai para PostgreSQL com perda de performance, mas não de correção. Isso é uma propriedade exigida do design.
+
+## Consequências
+
+### Positivas
+
+- Latência sub-milissegundo para hot reads.
+- Compatível com múltiplas réplicas no Kubernetes.
+- Open source, custo zero.
+- Estruturas de dados ricas (string, hash, sorted set) cobrem cache, rate limiting e locks com a mesma dependência.
+
+### Negativas
+
+- Mais um serviço para operar (mesmo que comum no ecossistema).
+- Single-node perde dados em restart — mitigado por Redis Sentinel/Cluster ou persistence (RDB + AOF).
+- Memória do Redis precisa ser dimensionada para o working set.
+
+### Riscos
+
+- **Redis como SPOF de cache.** Mitigado pelo design degradar para PostgreSQL.
+- **Inconsistência cache vs. banco.** Mitigado por invalidação por domain event publicado pelo bus interno (ver ADR-0004, ADR-0005).
+
+## Confirmação
+
+- Health check `/health/cache` valida conectividade e RT do Redis.
+- Métricas Prometheus emitidas pelo cliente .NET — hit ratio, latência p95, errors (ver ADR-0018).
+
+## Mais informações
+
+- ADR-0007 define PostgreSQL como banco primário (fallback do cache).
+- ADR-0015 define rate limiting nativo do .NET com contadores Redis.
+- ADR-0017 define K8s + Helm para o deploy.
+- **Origem:** revisão da ADR interna Uni+ ADR-010 (não publicada) — split: a parte "object storage" foi extraída para a ADR-0009.

--- a/docs/adrs/0009-minio-como-object-storage.md
+++ b/docs/adrs/0009-minio-como-object-storage.md
@@ -1,0 +1,74 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0009: MinIO como object storage S3-compatible
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` precisa de object storage para:
+
+- documentos enviados pelos candidatos (RG, laudos, comprovantes de renda) durante inscrição e recursos administrativos;
+- documentos gerados pelo sistema (PDFs de resultados, planilhas de classificação, comprovantes de inscrição);
+- versionamento e audit trail de arquivos substituídos pelo candidato.
+
+Filesystem local não escala em Kubernetes com múltiplas réplicas. Cloud storage gerenciado (AWS S3, Azure Blob) tem custo recorrente incompatível com universidade pública e move dados pessoais para fora da infraestrutura institucional, com implicações sob a LGPD.
+
+## Drivers da decisão
+
+- API S3-compatible para portabilidade futura.
+- Self-hosted, dados sob a infraestrutura da Unifesspa.
+- Custo zero de licenciamento.
+- Equipe da Unifesspa tem experiência operacional acumulada com MinIO em sistema legado.
+
+## Opções consideradas
+
+- MinIO (última versão estável)
+- Filesystem local
+- AWS S3
+- Azure Blob Storage
+
+## Resultado da decisão
+
+**Escolhida:** MinIO como object storage S3-compatible do `uniplus-api`.
+
+Práticas obrigatórias:
+
+- **Buckets separados por módulo e tipo de documento** com políticas de retenção configuráveis (ex.: documentos de processo seletivo encerrado há mais de 5 anos podem ser arquivados).
+- **Erasure coding** habilitado para redundância distribuída entre discos.
+- **Backup regular** para storage secundário institucional.
+- **Versionamento de objetos** ativo para audit trail de substituições pelo candidato.
+- **Acesso via MinIO .NET SDK** (compatível com AWS S3 SDK) — abstração sobre `IObjectStorage` em `Application.Abstractions/Storage/` mantém o cliente substituível.
+
+## Consequências
+
+### Positivas
+
+- API S3-compatible — portabilidade para AWS S3 ou outro provedor sem alteração de código de aplicação.
+- Dados permanecem na infraestrutura institucional (alinhado com LGPD).
+- Open source, custo zero de licenciamento.
+- Versionamento nativo cobre o requisito de audit trail de documentos.
+
+### Negativas
+
+- Mais um serviço para operar — exige dimensionamento de disco e backup ativos.
+- Crescimento de storage ao longo dos processos seletivos exige lifecycle rules.
+- Recuperação de desastre depende da disciplina de backup secundário.
+
+### Riscos
+
+- **Perda de dados.** Mitigado por erasure coding + backup secundário institucional.
+- **Crescimento descontrolado de storage.** Mitigado com políticas de retenção e lifecycle rules para processos seletivos encerrados há mais de 5 anos.
+
+## Confirmação
+
+- Health check `/health/storage` valida conectividade e operação de read/write em bucket de teste.
+- Métricas de uso de bucket (size, object count) emitidas para observabilidade (ver ADR-0018).
+
+## Mais informações
+
+- ADR-0017 define K8s + Helm para o deploy.
+- **Origem:** revisão da ADR interna Uni+ ADR-010 (não publicada) — split: a parte "cache distribuído" foi extraída para a ADR-0008.

--- a/docs/adrs/0010-audience-unica-uniplus-em-tokens-oidc.md
+++ b/docs/adrs/0010-audience-unica-uniplus-em-tokens-oidc.md
@@ -1,0 +1,108 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0010: Audience única `uniplus` em tokens OIDC
+
+## Contexto e enunciado do problema
+
+A ADR-0016 adota Keycloak como identity provider OIDC do projeto. Falta especificar o valor da claim `aud` (audience, RFC 7519 §4.1.3) dos access tokens emitidos para os backends da plataforma.
+
+A claim `aud` identifica o destinatário pretendido do token — o resource server a quem o token é dirigido. O backend valida essa claim antes de aceitar a requisição. Há duas convenções estabelecidas no mercado:
+
+- **Audience por API** (padrão Auth0/Okta, alinhado à RFC 8707): cada backend tem identificador próprio. Token vazado fica restrito a um único serviço.
+- **Audience por plataforma**: identificador único compartilhado por todos os backends da mesma superfície de produto. Novos módulos entram sem reconfigurar IdP nem frontend.
+
+A plataforma é hoje monolito modular (ADR-0001) com dois módulos no mesmo repositório compartilhando `SharedKernel`. É percebida pelo usuário final como produto único ("Uni+"), com SSO entre as 3 SPAs.
+
+## Drivers da decisão
+
+- Coerência com a identidade do produto Uni+ — token "pertence à plataforma".
+- Baixa fricção operacional para entrada de novos módulos.
+- Simplicidade no SSO cross-app.
+- Possibilidade de evolução aditiva para múltiplas audiences caso surja módulo com requisito de isolamento elevado.
+
+## Opções consideradas
+
+- Audience única `uniplus` (uma por plataforma)
+- Audience por API (`uniplus-api`, `uniplus-selecao-api`, `uniplus-ingresso-api`, …)
+- Audience múltipla desde o início (`aud: ["uniplus", "uniplus-api"]`)
+- Usar `clientId` do SPA como audience
+
+## Resultado da decisão
+
+**Escolhida:** audience única `uniplus` para todos os access tokens emitidos pelo Keycloak aos clients web da plataforma.
+
+Implementação:
+
+- `oidc-audience-mapper` no client scope `uniplus-profile` com `included.custom.audience: "uniplus"`.
+- Cada backend valida `ValidAudiences = ["uniplus"]`.
+- Controle de acesso granular entre módulos é feito por `realm_access.roles` e por `scope` — não por `aud`.
+- O `clientId` do resource server permanece `uniplus-api` no Keycloak (campo interno, não aparece no token).
+
+Validação obrigatória dos backends:
+
+```csharp
+TokenValidationParameters
+{
+    ValidIssuers = ["https://auth.unifesspa.edu.br/realms/unifesspa"],
+    ValidateIssuer = true,
+    ValidAudiences = ["uniplus"],
+    ValidateAudience = true,
+}
+```
+
+O par `iss + aud` é o que efetivamente identifica o token como legítimo — nunca validar somente um dos dois.
+
+## Consequências
+
+### Positivas
+
+- Coerência com a identidade do produto Uni+.
+- Novos módulos entram sem criar client bearer-only nem mapper adicional.
+- Configuração única para documentar, monitorar e auditar.
+- Compatível com SSO cross-app por construção.
+
+### Negativas
+
+- Blast radius maior — token vazado vale em qualquer backend da plataforma.
+- Menor aderência à RFC 8707 (Resource Indicators) — RFC informacional, largamente não implementada por IdPs mainstream.
+- Diverge do padrão Auth0/Okta — equipe precisa saber que o controle de acesso fino é por scope/roles.
+
+### Riscos
+
+- **Módulo futuro com requisito elevado herda audience compartilhada.** Mitigação: revisar esta ADR ao introduzir o primeiro módulo desse perfil. Migração para múltiplas audiences é aditiva e retrocompatível.
+- **Confusão entre `clientId` e `aud`.** Mitigação: documentação explícita; validação empírica obrigatória em cada novo backend.
+- **Token substitution** (token de outra instância Keycloak com mesmo `aud`). Mitigação: validação estrita do `iss` é obrigatória em todos os backends.
+
+## Confirmação
+
+- Cada novo backend implementa `TokenValidationParameters` validando `iss` e `aud`.
+- Pull request review verifica que `ValidateAudience` e `ValidateIssuer` estejam ambos `true`.
+
+## Prós e contras das opções
+
+### Audience por API
+
+- Bom, porque limita blast radius por serviço.
+- Ruim, porque cada novo módulo exige client bearer-only adicional, mapper e atualização de configuração de cada SPA — over-engineering para a fase atual do projeto.
+
+### Audience múltipla desde o início
+
+- Bom, porque combina os dois mundos em compatibilidade aditiva.
+- Ruim, porque introduz complexidade decisória ("qual audience validar?") sem benefício concreto.
+
+### `clientId` do SPA como audience
+
+- Bom, porque é comportamento default do Keycloak sem mapper.
+- Ruim, porque é semanticamente errado — o SPA é cliente do token, não destinatário; backend amarrado ao nome do frontend.
+
+## Mais informações
+
+- ADR-0016 define Keycloak como identity provider.
+- [RFC 7519 — JSON Web Token (`aud` claim)](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3)
+- [RFC 8707 — Resource Indicators for OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc8707)
+- **Origem:** revisão da ADR interna Uni+ ADR-019 (não publicada).

--- a/docs/adrs/0011-mascaramento-de-cpf-em-logs.md
+++ b/docs/adrs/0011-mascaramento-de-cpf-em-logs.md
@@ -1,0 +1,96 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0011: Mascaramento de CPF em logs via enricher Serilog
+
+## Contexto e enunciado do problema
+
+A LGPD (Lei 13.709/2018, Art. 6º inciso VII) exige medidas técnicas para que processamento acessório — incluindo logs, stdout, arquivos e sinks downstream — não exponha dados pessoais. Princípios mais detalhados de conformidade LGPD permanecem em política institucional interna.
+
+Antes da entrega da Story `uniplus-api#115`, o `PiiMaskingEnricher` existia registrado no pipeline Serilog mas com implementação no-op — o enforcement era apenas nominal.
+
+## Drivers da decisão
+
+- Conformidade LGPD enforçada por construção, não por disciplina manual.
+- Performance adequada no hot path de logging (zero alocação no caso comum).
+- Defesa em profundidade — masking permissivo no log mesmo quando o domínio rejeita CPFs malformados.
+- Encapsulamento — não expor superfície pública desnecessária.
+
+## Opções consideradas
+
+- Enricher Serilog (`ILogEventEnricher`) com regex compilada
+- Acoplar masking ao value object `Cpf.Mascarado` do SharedKernel
+- Mascarar somente no sink (template JSON, formatter)
+- Biblioteca de terceiros (`Serilog.Enrichers.Sensitive`)
+- Expor `IPiiMaskingService` como porta pública de mascaramento
+
+## Resultado da decisão
+
+**Escolhida:** `PiiMaskingEnricher` como `ILogEventEnricher` no pipeline Serilog, com as propriedades:
+
+- **Padrão de mascaramento** `***.***.***-XX` (SERPRO/Gov.br), preservando os dois dígitos verificadores.
+- **Detecção por regex compilada** (`[GeneratedRegex]`) com word boundaries ASCII — evita falsos positivos em timestamps/IDs longos e cobre CPFs formatados e não formatados.
+- **Aplicação recursiva** em todos os tipos de `LogEventPropertyValue` do Serilog (`ScalarValue`, `StructureValue`, `SequenceValue`, `DictionaryValue` — chaves e valores).
+- **Preservação de referência** quando nenhum CPF é encontrado — sem realocação de containers para logs sem PII (zero alocação no hot path).
+- **API encapsulada** via `internal` + `[InternalsVisibleTo]` no `.csproj`.
+- **Decoupling do value object `Cpf`** — VO valida estritamente para uso no domínio; enricher mascara permissivamente para defesa em profundidade.
+
+O enricher é thread-safe por construção: regex compilada é imutável, helpers são funções puras, pipeline Serilog processa cada `LogEvent` sequencialmente.
+
+## Consequências
+
+### Positivas
+
+- Conformidade LGPD por construção — não é possível "esquecer de mascarar".
+- Performance adequada no hot path (regex compilada via `[GeneratedRegex]`, spans no replace, zero alocação sem PII).
+- Camadas independentes — VO e enricher evoluem separadamente.
+- Auditável via testes automatizados que servem de evidência de enforcement em cada deploy.
+
+### Negativas
+
+- Falso negativo raro quando um CPF é concatenado a outros dígitos sem delimitador. Trade-off deliberado: preferimos preservar timestamps e IDs íntegros a mascarar dígitos ambíguos.
+- Uma alocação de array por `LogEvent` para snapshot seguro das propriedades antes da iteração — aceitável para o volume típico do Serilog.
+- Escopo limitado a CPF — outros PII (email, telefone, RG) ficam para issues dedicadas que estenderão o mesmo enricher.
+
+### Riscos
+
+- **Novo tipo de `LogEventPropertyValue`** em versão futura do Serilog não seria coberto pela recursão. Mitigação: revisar ao atualizar major version da dependência.
+- **Bypass do pipeline** (`Console.WriteLine` direto, por exemplo). Mitigação: convenção `[LoggerMessage]` obrigatória no projeto (`CA1848` como erro de build) e code review.
+
+## Confirmação
+
+- Suíte de testes do enricher cobre cenários de scalar, structure, sequence, dictionary e composição recursiva.
+- Pipeline de CI executa `dotnet test` com a categoria do enricher e falha o build em caso de regressão.
+
+## Prós e contras das opções
+
+### Acoplar ao VO `Cpf.Mascarado`
+
+- Bom, porque reutiliza a regra do domínio.
+- Ruim, porque o VO falha validação para CPFs com checksum incorreto — exatamente o tipo de entrada que precisa ser mascarada em logs.
+
+### Mascarar só no sink
+
+- Bom, porque é mais simples por sink.
+- Ruim, porque não captura propriedades estruturadas antes da serialização e precisa ser replicado por sink.
+
+### `Serilog.Enrichers.Sensitive`
+
+- Bom, porque é dependência pronta.
+- Ruim, porque é generalista, sem regex calibrada para padrões brasileiros, adiciona dependência externa em infraestrutura crítica.
+
+### `IPiiMaskingService` público
+
+- Bom, porque permite reuso fora do pipeline.
+- Ruim, porque cria ambiguidade sobre qual é a porta oficial de mascaramento sem consumidor concreto definido — YAGNI.
+
+## Mais informações
+
+- ADR-0018 define OpenTelemetry e Loki como sinks downstream — masking é aplicado antes da exportação.
+- LGPD (Lei 13.709/2018), Art. 6º inciso VII e Art. 46.
+- [Serilog wiki — Enrichment](https://github.com/serilog/serilog/wiki/Enrichment)
+- **Origem:** revisão da ADR interna Uni+ ADR-020 (não publicada).

--- a/docs/adrs/0012-archunitnet-como-fitness-tests-arquiteturais.md
+++ b/docs/adrs/0012-archunitnet-como-fitness-tests-arquiteturais.md
@@ -1,0 +1,125 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted:
+  - "Council multi-advisor 2026-04-24"
+---
+
+# ADR-0012: ArchUnitNET como biblioteca de fitness tests arquiteturais
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` declara fitness tests arquiteturais como quality gate obrigatório de CI. Esses testes enforçam invariantes não-negociáveis: isolamento entre módulos (ADR-0001), conformidade de camadas (ADR-0002), encapsulamento de Wolverine dentro de `Infrastructure.Core` (ADR-0003) e ausência de qualquer referência a `MediatR.*`.
+
+O ecossistema .NET tem dois candidatos: NetArchTest (BenMorris, MIT) e ArchUnitNET (TNG Technology Consulting, Apache 2.0).
+
+| Sinal | NetArchTest | ArchUnitNET |
+|-------|-------------|-------------|
+| Última release | 23/05/2021 | cadência mensal em 2026 |
+| Stewardship | mantenedor único | TNG (mesma org do ArchUnit/Java) |
+| Expressividade | API type-centric com cobertura fraca de members, attributes e generics | predicados first-class para classes, interfaces, attributes, methods, fields, properties; slicing para detecção de ciclos |
+
+A política de governança de dependências do projeto (definida na ADR-0003) prevê reavaliação quando a cadência de releases cai abaixo de 1 release por trimestre por dois trimestres consecutivos. Aplicado ao NetArchTest em 2026-04, o tripwire estaria disparado por sete trimestres consecutivos.
+
+A equipe não tem experiência prévia com nenhuma das duas — curva de aprendizado simétrica.
+
+## Drivers da decisão
+
+- Cadência de manutenção compatível com horizonte de 3–5 anos do projeto.
+- Stewardship organizacional, não mantenedor único.
+- Expressividade da DSL para regras de members, attributes e generics (escopo futuro).
+- Coerência com a própria política de governança de dependências.
+
+## Opções consideradas
+
+- ArchUnitNET (TNG, Apache 2.0)
+- NetArchTest (BenMorris, MIT)
+- Solução híbrida (NetArchTest stage 1 + ArchUnitNET stage 2+)
+- Analyzers Roslyn customizados
+- `NetArchTest.eNhancedEdition` (fork comunitário)
+
+## Resultado da decisão
+
+**Escolhida:** ArchUnitNET (TNG Technology Consulting, Apache 2.0) como biblioteca canônica única de fitness tests arquiteturais do `uniplus-api`.
+
+`Directory.Packages.props` declara o pacote com pinning exato (não range flutuante):
+
+```xml
+<PackageVersion Include="TngTech.ArchUnitNET" Version="0.13.3" />
+<PackageVersion Include="TngTech.ArchUnitNET.xUnit" Version="0.13.3" />
+```
+
+> **Nota sobre nomenclatura:** o publisher prefixa o package id com `TngTech.`, mas a namespace C# dentro dos assemblies é `ArchUnitNET.*` (sem prefixo). `<PackageReference>` usa `TngTech.ArchUnitNET`; `using ArchUnitNET.Fluent;` no código.
+
+Cada módulo tem projeto `*.ArchTests` próprio (`Unifesspa.UniPlus.<Modulo>.ArchTests`) que chama a DSL diretamente. **Nenhuma camada wrapper especulativa.** Helpers emergem bottom-up — extrair se a mesma forma de regra for copiada em três ou mais fixtures.
+
+Conjunto inicial mínimo de regras (todas verdes em `main` antes de qualquer outra entrega depender delas):
+
+| # | Regra | Invariante |
+|---|-------|------------|
+| R1 | `Modulos_NaoSeReferenciam` | `Selecao.*` não depende de `Ingresso.*` e vice-versa |
+| R2 | `ApplicationEDomain_NaoDependemDeWolverine` | `*.Application.*` e `*.Domain.*` não referenciam `Wolverine.*` |
+| R3 | `Camadas_RespeitamDirecaoDeDependencia` | Domain → Application → Infrastructure → API (uma só direção) |
+| R4 | `SolutionNaoTemMediatR` | nenhum tipo no monorepo referencia `MediatR.*` |
+
+Política de upgrade:
+
+- **Patch bumps** seguem o fluxo regular de dependências.
+- **Minor bumps** abrem PR dedicado executando a suíte completa de testes de arquitetura.
+- **Exit criterion:** se dois minor bumps consecutivos forçarem reescrita não-mecânica de regras, esta ADR é reaberta.
+
+## Consequências
+
+### Positivas
+
+- Biblioteca canônica única — zero bikeshedding em PR review sobre escolha.
+- DSL cobre as regras stage 2+ (semantic OOP, naming, regras estruturais) sem reescrita de fixtures.
+- Stewardship organizacional, multi-target alinhado com release train do .NET 10.
+- Pinning + política de upgrade + exit criterion tornam o risco residual auditável.
+
+### Negativas
+
+- Adoção de biblioteca com versão pré-1.0 — sinal de estabilidade mais fraco que 1.x+.
+- Equipe paga curva de aprendizado de algumas horas para a DSL antes da primeira regra rodar.
+
+### Riscos
+
+- **ArchUnitNET estagnar.** Mitigado pelo exit criterion + pinning + isolamento por módulo (`*.ArchTests`).
+- **Mudanças de API pré-1.0 disrompem regras existentes.** Mitigado pela política de PR dedicado para minor bump.
+- **Proliferação de regras sem revisão.** Mitigado pela convenção de um projeto `*.ArchTests` por módulo + code review em qualquer PR que adicione duas ou mais fitness tests novas em uma única alteração.
+
+## Confirmação
+
+- Pipeline de CI executa `dotnet test` em cada projeto `*.ArchTests` e falha o build em caso de violação.
+- PRs que adicionam regras novas passam por code review do tech lead.
+
+## Prós e contras das opções
+
+### NetArchTest
+
+- Bom, porque licença MIT sem risco de tier comercial e API menor (curva mais rasa).
+- Ruim, porque sem release há ~5 anos e cobertura fraca para regras stage 2+ que o projeto já escopou.
+
+### Solução híbrida
+
+- Bom, porque cada biblioteca aplicada onde é mais forte.
+- Ruim, porque introduz duas DSLs, dois caminhos de upgrade e bikeshedding garantido em PR review.
+
+### Analyzers Roslyn customizados
+
+- Bom, porque elimina dependência externa.
+- Ruim, porque equipe sem experiência em autoria de analyzers e prazo de Sprint 1 não comporta o setup.
+
+### `NetArchTest.eNhancedEdition`
+
+- Bom, porque é mais ativo que o upstream.
+- Ruim, porque é fork comunitário com bus factor ainda mais estreito — agrava o problema de governança.
+
+## Mais informações
+
+- ADR-0001, ADR-0002, ADR-0003, ADR-0006 declaram invariantes que esta ADR enforça.
+- [ArchUnitNET — repositório](https://github.com/TNG/ArchUnitNET)
+- [ArchUnitNET — user guide](https://archunitnet.readthedocs.io/en/stable/guide/)
+- **Origem:** revisão da ADR interna Uni+ ADR-023 (não publicada).

--- a/docs/adrs/0013-motor-de-classificacao-como-servicos-de-dominio-puros.md
+++ b/docs/adrs/0013-motor-de-classificacao-como-servicos-de-dominio-puros.md
@@ -1,0 +1,130 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+  - "P.O. CEPS"
+---
+
+# ADR-0013: Motor de classificação como serviços de domínio puros
+
+## Contexto e enunciado do problema
+
+O motor de classificação é o componente mais sensível do `uniplus-api` do ponto de vista legal e institucional. Ele calcula notas finais, ordena candidatos por modalidade, aplica desempate e executa o remanejamento de vagas de cotas. Erros têm consequências diretas — alocação errada de candidatos, violação da Lei de Cotas, judicialização e dano reputacional.
+
+O sistema precisa cobrir cinco tipos atuais de processo seletivo (PSIQ, PSE Educação do Campo, PS Convênios, PSVR, SiSU), cada um com fórmula, eliminações, desempate, bônus e regime de cotas próprios. Adicionalmente, RN08 (congelamento de parâmetros por edital) exige que o resultado de qualquer execução seja reproduzível anos depois com o snapshot da configuração vinculada ao edital.
+
+## Drivers da decisão
+
+- Determinismo: mesma entrada produz sempre a mesma saída.
+- Auditabilidade: cada passo do ranking e remanejamento rastreável.
+- Testabilidade sem infraestrutura: motor roda como função pura.
+- Operação destrava engenharia: admin do CEPS cadastra novos tipos de edital sem deploy.
+- Reaproveitabilidade: mesmo motor serve auxílio estudantil, mestrado, mobilidade etc.
+
+## Opções consideradas
+
+- Serviços de domínio puros com configuração declarativa
+- Orquestrador na camada de aplicação com queries intermediárias
+- Strategy de classes por tipo de edital
+- Biblioteca externa de programação linear (OR-Tools, LpSolveDotNet)
+- Incorporar dentro do módulo Seleção como namespace interno
+
+## Resultado da decisão
+
+**Escolhida:** motor de classificação como serviços de domínio puros e determinísticos no módulo `Classificacao`, com zero dependências de infraestrutura.
+
+Dois serviços de domínio principais:
+
+- **`MotorClassificacao`** — recebe `ConfiguracaoCalculo` declarativa congelada por edital (RN08) e a interpreta. Aplica fórmula de agregação configurada, regra de precisão, bônus, regras de eliminação, ordem de desempate e — quando o edital exige — o passo de concorrência dupla. **Não conhece** "PSIQ", "SiSU" ou qualquer tipo de processo — conhece apenas o catálogo de primitivas.
+- **`ServicoRemanejamento`** — executa a cascata de remanejamento conforme `CascataRemanejamento` configurada. Produz audit log passo-a-passo (qual vaga, qual modalidade origem, qual destino, qual candidato beneficiado, qual regra aplicada).
+
+Configuração declarativa (snapshot RN08 por edital):
+
+```text
+ConfiguracaoCalculo
+├── Etapas:               [{ codigo, peso, escala }]
+├── FormulaAgregacao:     MediaPonderada
+│                       | SomaPonderadaComFator(fator)
+│                       | MediaSimples
+│                       | MediaPonderadaEnem(pesosArea, grupo)
+├── Precisao:             Truncar2Casas | ArredondarParaCima2Casas
+├── Bonus:                opt { tipo, valor, modalidadesAplicaveis }
+├── RegrasEliminacao:     [NotaMinimaEtapa | RedacaoEnemMinima | Falta | …]
+├── OrdemDesempate:       [Idoso60 | MaiorNotaEtapa(x) | MaiorIdade | …]
+├── ConcorrenciaDupla:    bool
+└── CascataRemanejamento: refTabela
+```
+
+**Linha de corte clara:**
+
+- **Cadastrar/editar/clonar tipo de edital** (compor primitivas) → operação de admin, sem código.
+- **Adicionar primitiva matemática nova** (ex.: fórmula que nenhum dos 5 processos atuais cobre) → mudança de código com versionamento explícito (ex.: `MediaPonderadaEnem v2`).
+
+A orquestração (hidratar dados do banco, persistir resultado) fica na camada de aplicação, que invoca o motor via handler Wolverine (ADR-0003) e grava o resultado via EF Core (ADR-0007).
+
+## Consequências
+
+### Positivas
+
+- Funções puras são trivialmente testáveis — sem mock, sem banco, sem fixture.
+- Determinismo é demonstrável e enforçável por property-based tests.
+- Audit log é saída de primeira classe — rastreabilidade por construção.
+- Conformidade legal verificável por stakeholders não-técnicos via golden files.
+- Reutilizável por qualquer processo de seleção/alocação institucional sem refatoração.
+- Operação destrava engenharia — admin compõe primitivas via UI, sem deploy.
+
+### Negativas
+
+- Camada de aplicação precisa hidratar todo o dataset de entrada antes de chamar o motor.
+- Sem lazy loading, paginação ou streaming dentro do motor — conjunto inteiro processado em memória.
+- Disciplina exigida: tentativa futura de "otimizar" com acesso direto ao banco quebra a pureza e invalida a estratégia de testes.
+
+### Riscos
+
+- **Pressão de memória em processos com muitos cursos** (ex.: SiSU). Mitigação: estratégia de particionamento e execução documentada em ADR própria sobre orquestração da classificação.
+- **Alteração nas regras da Lei 14.723/2023 ou regulamentação infralegal.** Mitigação em duas camadas: (1) parâmetros novos viram reconfiguração no admin sem deploy; RN08 garante imutabilidade de editais antigos; (2) fórmulas estruturalmente novas viram nova primitiva no catálogo com versionamento explícito.
+- **Não-determinismo acidental** (ex.: `HashSet<T>` em vez de `SortedSet<T>`). Mitigação: prova de determinismo de 1000 iterações no CI.
+- **Retenção do audit log.** Documentos de processo seletivo têm retenção mínima de 5 anos. Mitigação: tratar audit log como dado de processo seletivo na política de retenção; soft delete obrigatório.
+
+## Confirmação
+
+Quatro camadas complementares de teste:
+
+1. **Property-based tests (FsCheck)** — verificam invariantes matemáticas e legais para qualquer entrada válida (total alocado ≤ vagas; ordem da cascata; determinismo de desempate; concorrência dupla; nenhum candidato em duas modalidades simultâneas).
+2. **Golden file tests** — re-executam configurações reais de editais históricos e comparam saída byte-a-byte.
+3. **Unit tests** — cobrem casos de borda (empates múltiplos, modalidade sem candidatos elegíveis, arredondamento vs. truncamento por edital, vagas fracionárias com regra de teto).
+4. **Prova de determinismo** — executa a classificação 1000 vezes com ordem de entrada embaralhada, afirmando saída idêntica em todas as iterações.
+
+Meta de cobertura: ≥95% em `MotorClassificacao` e `ServicoRemanejamento`.
+
+## Prós e contras das opções
+
+### Orquestrador na aplicação
+
+- Bom, porque segue o padrão handler CQRS típico.
+- Ruim, porque lógica de negócio vaza para a aplicação e fica mais difícil testar ranking + remanejamento como unidade pura.
+
+### Strategy de classes por tipo
+
+- Bom, porque cada tipo fica em uma classe pequena.
+- Ruim, porque novo tipo de edital vira novo deploy — viola a premissa operacional.
+
+### Biblioteca de programação linear
+
+- Bom, porque traz algoritmo pronto.
+- Ruim, porque o motor não é um problema de otimização — é aplicação determinística de regras; OR-Tools sobrepesa.
+
+### Namespace interno do Seleção
+
+- Bom, porque é mais simples no curto prazo.
+- Ruim, porque acopla classificação aos processos do CEPS; módulos futuros teriam que duplicar.
+
+## Mais informações
+
+- ADR-0001 fundamenta a separação `Classificacao` como módulo próprio.
+- ADR-0002 estabelece que regra de negócio fica no domínio.
+- ADR-0003 define Wolverine como invocador do motor.
+- ADR-0007 define PostgreSQL como persistência do resultado.
+- Legislação relevante: Lei 12.711/2012 (atualizada pela Lei 14.723/2023), Lei 13.409/2016 (PcD), Lei 10.741/2003 (Estatuto do Idoso), Portaria MEC 704/2025, Portaria MEC 18/2012, IN MGI 23/2023.
+- **Origem:** revisão da ADR interna Uni+ ADR-028 (não publicada). Detalhes da matriz de cotas, fórmulas por processo seletivo e mapeamento da legislação infralegal permanecem em base de conhecimento institucional.

--- a/docs/adrs/0014-kafka-como-bus-assincrono-inter-modulos.md
+++ b/docs/adrs/0014-kafka-como-bus-assincrono-inter-modulos.md
@@ -1,0 +1,110 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0014: Kafka como bus assíncrono inter-módulos e para integrações externas
+
+## Contexto e enunciado do problema
+
+Os módulos do `uniplus-api` (Seleção, Ingresso, futuros) precisam trocar informações ao longo do ciclo de vida do processo seletivo:
+
+- Quando a classificação é concluída em Seleção, Ingresso precisa iniciar as chamadas de vagas.
+- Quando um candidato desiste da vaga em Ingresso, Seleção atualiza a lista de espera.
+- Quando há remanejamento de cotas em Seleção, Ingresso reflete a nova classificação.
+
+Comunicação síncrona (REST entre módulos) cria acoplamento temporal — falha em um módulo trava o outro. Esta ADR define o bus assíncrono. A garantia de atomicidade entre persistência e publicação é decisão separada (ver ADR-0004 — outbox transacional).
+
+## Drivers da decisão
+
+- Desacoplamento temporal entre módulos.
+- Log de eventos auditável e replayable.
+- Self-hosted, sem cloud-managed services.
+- Compatibilidade com integrações externas (sistemas federais, Gov.br, SIGAA).
+
+## Opções consideradas
+
+- Apache Kafka 4.2 (modo KRaft, sem ZooKeeper)
+- RabbitMQ
+- Comunicação síncrona via REST entre módulos
+- Shared database
+- AWS SNS/SQS
+
+## Resultado da decisão
+
+**Escolhida:** Apache Kafka 4.2 (modo KRaft) como bus assíncrono inter-módulos do `uniplus-api` e como transport externo para integrações com sistemas federais.
+
+Regras invariantes:
+
+- **Cross-module comm via Kafka apenas** — módulos não se chamam por REST nem compartilham tabelas.
+- **Event catalog documentado** — todo domain event publicado entre módulos é registrado em catálogo compartilhado no SharedKernel.
+- **Idempotência nos consumers** — todo consumer processa o mesmo evento mais de uma vez sem efeitos colaterais (deduplicação por event ID).
+- **Atomicidade salvar + publicar** garantida pelo outbox transacional Wolverine (ver ADR-0004) — eventos nunca são publicados diretamente pelo handler.
+- **AutoProvision em dev/test apenas.** Em produção, provisão de tópicos é responsabilidade da plataforma, conforme governança Kafka da Unifesspa.
+- **Retenção configurável** para permitir replay em caso de necessidade.
+- **Convenção snake_case** para nomes de tópicos.
+
+Consumo de Kafka topics produzidos por sistemas externos (Gov.br, SIGAA, SERPRO) fica fora do escopo desta ADR — cada integração deve ser objeto de ADR específica quando aparecer.
+
+## Consequências
+
+### Positivas
+
+- Desacoplamento temporal total — módulos operam independentemente.
+- Log persistente — replay possível para reconstrução de estado ou debugging.
+- Escalabilidade horizontal de consumers via partições.
+- Auditabilidade — todo evento inter-módulo registrado no Kafka.
+
+### Negativas
+
+- Complexidade operacional adicional — cluster Kafka requer monitoramento próprio.
+- Eventual consistency entre módulos — propagação não é instantânea.
+- Debug mais difícil que chamadas síncronas — exige correlação de logs entre producer e consumer (suportada pela observabilidade — ver ADR-0018).
+
+### Riscos
+
+- **Kafka como infraestrutura crítica.** Mitigado com cluster (3+ brokers) em Kubernetes e monitoramento ativo.
+- **Mensagens perdidas.** Mitigado pelo outbox transacional Wolverine (ADR-0004) — evento permanece na tabela `wolverine_outgoing_envelopes` até publicação confirmada.
+- **Consumer lag.** Mitigado por alertas Prometheus/Grafana sobre lag por tópico e consumer group.
+
+## Confirmação
+
+- Health check `/health/kafka` valida conectividade dos brokers.
+- Pipeline de CI roda Testcontainers com Kafka KRaft para testes de contrato.
+- Métricas de lag por consumer group observáveis em Grafana (ver ADR-0018).
+
+## Prós e contras das opções
+
+### Kafka
+
+- Bom, porque é log de eventos persistente com replay e escala horizontal.
+- Ruim, porque complexidade operacional é não-trivial.
+
+### RabbitMQ
+
+- Bom, porque modelo de filas é simples e maduro em .NET.
+- Ruim, porque sem replay nativo de eventos — mensagens removidas após consumo. Inadequado para event log.
+
+### REST entre módulos
+
+- Bom, porque é trivial de implementar.
+- Ruim, porque acopla temporalmente — cascata de falhas possível.
+
+### Shared database
+
+- Bom, porque elimina message broker.
+- Ruim, porque acopla schemas; mudança em um módulo quebra o outro.
+
+### AWS SNS/SQS
+
+- Bom, porque é gerenciado e baixo overhead operacional.
+- Ruim, porque vendor lock-in cloud + custo recorrente + dados fora da infraestrutura institucional.
+
+## Mais informações
+
+- ADR-0001 estabelece monolito modular com Kafka como única forma de comunicação cross-module.
+- ADR-0004 define o outbox transacional que garante atomicidade salvar + publicar.
+- ADR-0007 define PostgreSQL como persistência do outbox.
+- **Origem:** revisão da ADR interna Uni+ ADR-004 (não publicada) — split: a parte "outbox pattern" foi movida para a ADR-0004, que detalha a integração nativa Wolverine + EF Core.

--- a/docs/adrs/0015-rest-contract-first-com-openapi.md
+++ b/docs/adrs/0015-rest-contract-first-com-openapi.md
@@ -1,0 +1,97 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0015: REST contract-first com OpenAPI 3.0 e versionamento de API
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` é consumido pelas SPAs do `uniplus-web` (Seleção, Ingresso, Portal) desenvolvidas por times paralelos. Sem contrato formal, frontend fica bloqueado até que o backend implemente os endpoints, e divergências só aparecem em integração.
+
+O contrato precisa ser fonte de verdade — implementação backend e clientes frontend derivam dele.
+
+## Drivers da decisão
+
+- Desenvolvimento paralelo de frontend e backend sem bloqueio.
+- Geração automática de clients tipados — eliminação de drift por construção.
+- Tratamento de erros padronizado para reduzir custo cognitivo.
+- Compatibilidade backward para consumidores existentes.
+
+## Opções consideradas
+
+- REST contract-first com OpenAPI 3.0
+- GraphQL
+- gRPC para comunicação interna
+- Code-first OpenAPI (gerar spec a partir do código)
+
+## Resultado da decisão
+
+**Escolhida:** REST contract-first com OpenAPI 3.0. A spec OpenAPI é o artefato de referência. Backend implementa a partir dela; frontend consome cliente gerado dela.
+
+Regras técnicas:
+
+- **Contract-first.** A spec OpenAPI vive no repositório de documentação institucional e é versionada antes da implementação.
+- **Erros padronizados via ProblemDetails (RFC 7807)** com `correlationId` para rastreabilidade.
+- **Versionamento via Asp.Versioning** — URL path `/api/v1/` para major versions e header `api-version` para minor.
+- **Geração de clientes** — clientes TypeScript gerados via NSwag ou Kiota a partir da spec.
+- **Health checks** via `Microsoft.Extensions.Diagnostics.HealthChecks` em `/health` (liveness) e `/health/ready` (readiness com checks de dependências: PostgreSQL, Kafka, Redis, MinIO, Keycloak).
+- **Rate limiting nativo do .NET** com políticas por rota — proteção contra abuso em endpoints públicos (inscrição, consulta de resultado).
+- **Testes de contrato (Pact)** para garantir que a implementação não diverge da spec.
+
+## Consequências
+
+### Positivas
+
+- Desenvolvimento paralelo frontend/backend sem bloqueios.
+- Drift eliminado por geração automática + Pact em CI.
+- ProblemDetails padroniza tratamento de erros em toda a plataforma.
+- Versionamento via URL path mantém backward compatibility.
+- Health checks habilitam readiness probes no Kubernetes.
+
+### Negativas
+
+- Disciplina exigida para manter spec sincronizada com a implementação.
+- Geração de clients pode ter edge cases (tipos polimórficos complexos).
+- REST é verboso para queries com múltiplos filtros e agregações — possíveis BFFs no futuro.
+
+### Riscos
+
+- **Spec desatualizada.** Mitigado por testes Pact que falham o CI em divergência.
+- **Over-fetching/under-fetching.** Mitigado por endpoints específicos por caso de uso (não genéricos) e BFF como evolução possível.
+
+## Confirmação
+
+- Pipeline de CI executa contract tests Pact contra a spec OpenAPI.
+- Build do frontend regenera o client e falha se a spec apontada não estiver acessível.
+
+## Prós e contras das opções
+
+### REST contract-first
+
+- Bom, porque é convenção de mercado mais consolidada e tem melhor ecossistema de ferramentas.
+- Ruim, porque é verboso para fluxos com agregações complexas.
+
+### GraphQL
+
+- Bom, porque cliente solicita exatamente o que precisa.
+- Ruim, porque ecossistema .NET menos maduro que REST; caching HTTP mais difícil; risco de N+1 sem DataLoader; equipe sem experiência.
+
+### gRPC
+
+- Bom, porque tem performance e tipagem fortes.
+- Ruim, porque módulos comunicam-se via Kafka (ADR-0014); gRPC é overkill para REST público para SPA.
+
+### Code-first OpenAPI
+
+- Bom, porque elimina dois artefatos (spec + código).
+- Ruim, porque inverte a prioridade — frontend depende do backend terminar a implementação para ter spec; elimina o benefício do desenvolvimento paralelo.
+
+## Mais informações
+
+- ADR-0006 define .NET 10 como stack que executa esta API.
+- ADR-0008 define Redis como contador de rate limiting.
+- ADR-0017 define K8s + Helm com NGINX Ingress como TLS termination e rate limiting de borda.
+- **Origem:** revisão da ADR interna Uni+ ADR-011 (não publicada).

--- a/docs/adrs/0016-keycloak-como-identity-provider.md
+++ b/docs/adrs/0016-keycloak-como-identity-provider.md
@@ -1,0 +1,105 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0016: Keycloak como identity provider OIDC do `uniplus-api`
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` precisa autenticar usuários com diferentes perfis (administrador, gestor, avaliador, candidato) e validar tokens de aplicações frontend e de integrações externas. A autenticação precisa ser centralizada, suportar SSO entre as três SPAs do `uniplus-web` e ser compatível com o Gov.br via OIDC (Login Único).
+
+## Drivers da decisão
+
+- Custo zero de licenciamento para universidade pública.
+- Suporte nativo a OIDC com federação para Gov.br.
+- Self-hosted, dados de identidade na infraestrutura institucional.
+- Compatibilidade com SSO entre múltiplos clients web.
+
+## Opções consideradas
+
+- Keycloak 26.5 (Apache 2.0, Red Hat/CNCF)
+- Auth0 (SaaS)
+- Autenticação própria com JWT customizado
+- ASP.NET Identity + Duende IdentityServer
+
+## Resultado da decisão
+
+**Escolhida:** Keycloak 26.5 como identity provider OIDC central da plataforma. O `uniplus-api` é resource server que valida tokens emitidos pelo realm `unifesspa`.
+
+Práticas obrigatórias do lado do `uniplus-api`:
+
+- **Validação stateless de tokens JWT** — backends não mantêm sessão server-side.
+- **Validação estrita de `iss` e `aud`** (ver ADR-0010 — audience única `uniplus`). Configuração canônica:
+
+```csharp
+TokenValidationParameters
+{
+    ValidIssuers = ["https://auth.unifesspa.edu.br/realms/unifesspa"],
+    ValidateIssuer = true,
+    ValidAudiences = ["uniplus"],
+    ValidateAudience = true,
+}
+```
+
+- **Verificação de `realm_access.roles`** para autorização granular.
+- **Refresh token rotation** ativo no realm.
+- **Atributos customizados** (nome social, CPF) gerenciados como claims do realm.
+
+A integração federada com Gov.br é configurada no Keycloak via Identity Provider externo (OIDC) — esta ADR cobre apenas o lado do `uniplus-api` como resource server.
+
+## Consequências
+
+### Positivas
+
+- Autenticação centralizada para toda a plataforma.
+- SSO entre as 3 SPAs sem implementação adicional.
+- Federação com Gov.br via padrão OIDC, sem código customizado.
+- Tokens JWT stateless — backends sem sessão server-side, escala horizontal trivial.
+
+### Negativas
+
+- Mais um serviço para operar (JVM + banco do Keycloak).
+- Configuração inicial complexa (realms, clients, flows, mappers, audience).
+- Keycloak consome recursos significativos (~512MB RAM mínimos).
+
+### Riscos
+
+- **Keycloak como SPOF.** Mitigado com deploy em alta disponibilidade (2+ réplicas) e health checks no Kubernetes.
+- **Confusão entre `clientId` e `aud`.** Mitigado pelo enforcement explícito da ADR-0010 e por validação empírica em cada novo backend.
+- **Token substitution.** Mitigado pela validação obrigatória de `iss` em conjunto com `aud`.
+
+## Confirmação
+
+- Health check `/health/auth` valida que a chave pública do realm é acessível e que validação de token simulado passa.
+- Suíte de integração executa fluxo de obtenção e validação de token contra realm de teste em CI.
+
+## Prós e contras das opções
+
+### Keycloak
+
+- Bom, porque é OSS Apache 2.0 com SSO nativo e federação OIDC.
+- Ruim, porque exige operação ativa (não é serviço gerenciado).
+
+### Auth0
+
+- Bom, porque elimina operação.
+- Ruim, porque custo proibitivo para volume de universidade pública e dados fora da infraestrutura institucional.
+
+### Autenticação própria
+
+- Bom, porque elimina dependência externa.
+- Ruim, porque reinventa SSO, gestão de sessão, federação com Gov.br e console administrativo — alto custo de manutenção.
+
+### Duende IdentityServer
+
+- Bom, porque é nativo do .NET.
+- Ruim, porque tem licença comercial em produção.
+
+## Mais informações
+
+- ADR-0010 define a audience única `uniplus`.
+- ADR-0017 define K8s + Helm para o deploy do `uniplus-api` (e do Keycloak via charts próprios).
+- **Origem:** revisão da ADR interna Uni+ ADR-008 (não publicada). Esta ADR cobre apenas a parte server-side; o consumo OIDC pelo frontend é decisão própria do `uniplus-web`.

--- a/docs/adrs/0017-kubernetes-com-helm-para-orquestracao.md
+++ b/docs/adrs/0017-kubernetes-com-helm-para-orquestracao.md
@@ -1,0 +1,112 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0017: Kubernetes com Helm para orquestração do `uniplus-api`
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` precisa ser deployado com zero downtime durante atualizações, auto-recuperação de falhas e capacidade de escalar durante picos de inscrição (5000+ candidatos simultâneos). A Unifesspa possui infraestrutura própria com equipe que tem experiência em containers Docker.
+
+Os módulos Seleção e Ingresso são aplicações independentes (ADR-0001) que precisam de deploy coordenado com dependências (PostgreSQL, Kafka, Redis, MinIO, Keycloak).
+
+## Drivers da decisão
+
+- Zero downtime para atualizações em janela de inscrição.
+- Self-healing de pods para reduzir intervenção operacional.
+- Auto-scaling para absorver picos.
+- Infraestrutura como código versionada.
+
+## Opções consideradas
+
+- Kubernetes com Helm + Kustomize
+- Docker Compose em produção
+- VMs com deploy via Ansible
+- PaaS gerenciado (Heroku, Railway)
+
+## Resultado da decisão
+
+**Escolhida:** Kubernetes como plataforma de orquestração e Helm como gerenciador de templates do `uniplus-api`.
+
+Práticas e ferramentas:
+
+- **Helm charts** parametrizáveis para cada módulo, com `values` por ambiente.
+- **Kustomize overlays** para ajustes adicionais por ambiente (dev, staging, prod).
+- **Deploy blue-green** — nova versão é provisionada em paralelo, tráfego alterna após health check verde.
+- **Horizontal Pod Autoscaler (HPA)** com base em CPU/memória.
+- **NGINX Ingress Controller** com TLS termination, rate limiting de borda e roteamento por path.
+- **cert-manager + Let's Encrypt** para TLS automático.
+- **Sealed Secrets ou HashiCorp Vault** para gestão de segredos.
+- **Container registry institucional** (Harbor ou registro próprio).
+- **Docker multi-stage builds** com separação de build e runtime.
+- **`AutoBuildMessageStorageOnStartup = AutoCreate.None`** em produção (ver ADR-0004) — role de banco do nó Wolverine sem permissão DDL.
+
+Ambientes:
+
+| Ambiente | Finalidade | Infraestrutura |
+|----------|------------|----------------|
+| Dev local | Desenvolvimento individual | Docker Compose |
+| Dev K8s | Feature branches, integração | Cluster compartilhado |
+| Staging | Validação pré-produção, load tests | Cluster dedicado |
+| Produção | Sistema em operação | Cluster HA |
+
+## Consequências
+
+### Positivas
+
+- Self-healing — pods recriados automaticamente em caso de falha.
+- Rolling deploys sem downtime durante inscrições.
+- Auto-scaling provisiona réplicas adicionais sob demanda.
+- Infraestrutura como código versionada no monorepo.
+- Ecossistema rico de operadores (Strimzi, CloudNativePG, MinIO Operator) facilita gestão de dependências.
+
+### Negativas
+
+- Complexidade operacional significativa — Kubernetes exige conhecimento especializado.
+- Curva de aprendizado para a equipe (kubectl, Helm, Kustomize).
+- Overhead de recursos pelo control plane.
+- Debugging distribuído mais complexo.
+
+### Riscos
+
+- **Complexidade para equipe pequena.** Mitigado por capacitação, ferramentas visuais (Lens, k9s) e automação CI/CD.
+- **Falha do cluster.** Mitigado por backups regulares do `etcd`, múltiplos master nodes em produção, e DR plan testado.
+- **Drift entre ambientes.** Mitigado por Kustomize overlays versionados e CI que valida charts antes do deploy.
+
+## Confirmação
+
+- Liveness/readiness probes em todos os deployments.
+- Pipeline de CI executa `helm lint` e `kubeval` em cada chart antes do merge.
+- HPA configurado e validado em ambiente de staging com load test antes do release.
+
+## Prós e contras das opções
+
+### Kubernetes + Helm
+
+- Bom, porque é o padrão de mercado para orquestração de containers em produção.
+- Ruim, porque a complexidade operacional é a maior dentre as opções.
+
+### Docker Compose em produção
+
+- Bom, porque é simples e familiar à equipe.
+- Ruim, porque sem self-healing robusto, sem auto-scaling, sem rolling deploys nativos.
+
+### VMs com Ansible
+
+- Bom, porque é familiar a operadores tradicionais.
+- Ruim, porque sem auto-scaling, deploys lentos, rollback complexo, não aproveita experiência da equipe com containers.
+
+### PaaS gerenciado
+
+- Bom, porque elimina operação.
+- Ruim, porque custo recorrente, dados fora da infraestrutura institucional, limitações de customização.
+
+## Mais informações
+
+- ADR-0001 estabelece monolito modular com deploy independente por módulo.
+- ADR-0006, ADR-0007, ADR-0008, ADR-0009, ADR-0014 definem os componentes que esta orquestração cobre.
+- ADR-0018 define a stack de observabilidade que opera sobre este cluster.
+- **Origem:** revisão da ADR interna Uni+ ADR-013 (não publicada).

--- a/docs/adrs/0018-opentelemetry-para-instrumentacao-do-backend.md
+++ b/docs/adrs/0018-opentelemetry-para-instrumentacao-do-backend.md
@@ -1,0 +1,126 @@
+---
+status: "accepted"
+date: "2026-04-28"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0018: OpenTelemetry para instrumentação do `uniplus-api`
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` precisa de observabilidade end-to-end durante picos de inscrição. Traces, métricas e logs precisam ser correlacionados por um único `traceId` que atravesse a API, handlers Wolverine, consumers Kafka e queries no PostgreSQL. Sem instrumentação estruturada, problemas de latência, erros silenciosos e gargalos no motor de classificação passam despercebidos até virarem falhas reportadas por candidatos.
+
+A stack de armazenamento (Loki, Grafana, Tempo, Prometheus) é decisão de plataforma — esta ADR cobre o lado do `uniplus-api` (instrumentação backend). A instrumentação frontend (RUM) é decisão própria do `uniplus-web`.
+
+## Drivers da decisão
+
+- Padrão aberto sem vendor lock-in.
+- Correlação `traceId` entre API, handlers, consumers e banco.
+- Conformidade LGPD com PII masking no pipeline antes da exportação.
+- Alertas proativos antes que problemas afetem candidatos.
+
+## Opções consideradas
+
+- OpenTelemetry SDK + OTLP exporter para stack LGTM (Loki, Grafana, Tempo, Prometheus)
+- ELK stack (Elasticsearch, Logstash, Kibana)
+- Datadog ou New Relic (SaaS)
+- Jaeger para traces (sem stack unificada)
+- Application Insights (.NET nativo)
+
+## Resultado da decisão
+
+**Escolhida:** OpenTelemetry como padrão de instrumentação do `uniplus-api`. Traces, métricas e logs exportados via OTLP para o OpenTelemetry Collector institucional, que roteia para Tempo (traces), Prometheus/Mimir (métricas) e Loki (logs).
+
+Componentes obrigatórios do `uniplus-api`:
+
+- **Auto-instrumentação .NET** — ASP.NET Core, EF Core, HttpClient, Npgsql, Wolverine.
+- **Métricas custom de negócio** — Kafka consumer lag, duração de jobs de classificação, tempo de processamento de documentos, inscrições por minuto, taxa de rejeição na homologação.
+- **Logging estruturado via Serilog** com `PiiMaskingEnricher` (ver ADR-0011) — campos sensíveis mascarados antes da exportação para Loki.
+- **Sampling adaptativo** — head-based 10% para tráfego normal; tail-based 100% para erros e latência alta.
+- **Métricas Wolverine** — `wolverine_outgoing_envelopes`, `wolverine_dead_letters`, `wolverine_node_assignments` (ver ADR-0004).
+
+SLOs declarados:
+
+- Latência API p95 < 2 s
+- Disponibilidade ≥ 99,5%
+- Taxa de erros < 0,5%
+
+Alertas obrigatórios em Grafana:
+
+- Crescimento sustentado de `wolverine_outgoing_envelopes` por mais de 5 min — sinal de lag de despacho.
+- `wolverine_dead_letters` > 10/h por handler (threshold inicial — calibrar após 30 dias).
+- Envelopes em `wolverine_node_assignments` com node owner morto há > 5 min — ownership órfão.
+- Consumer lag Kafka acima de threshold por tópico/consumer group.
+
+Política de retenção (definida em política institucional, registrada aqui para referência):
+
+| Categoria | Retenção |
+|-----------|----------|
+| Logs de segurança (auth, autorização, auditoria) | 5+ anos |
+| Logs de aplicação | 90 dias |
+| Logs de debug | 30 dias |
+| Traces | 30 dias |
+| Métricas | 1 ano (downsampled após 90 dias) |
+
+## Consequências
+
+### Positivas
+
+- Padrão aberto — instrumentação fica mesmo se backend de armazenamento mudar.
+- Correlação `traceId` end-to-end — request frontend → consumer Kafka → query PostgreSQL.
+- PII masking integrado (ADR-0011) — conformidade LGPD por construção.
+- Alertas proativos antes de candidatos perceberem problemas.
+
+### Negativas
+
+- Configuração inicial complexa — receivers, processors e exporters do Collector exigem conhecimento.
+- Curva de aprendizado para PromQL e LogQL.
+- Volume de logs/traces pode ser significativo — exige sampling e política de retenção.
+
+### Riscos
+
+- **Overhead de instrumentação em hot paths.** Mitigado por sampling adaptativo (head-based 10% normal, tail-based 100% para erro/latência).
+- **Storage crescendo indefinidamente.** Mitigado por retenção configurável e compactação automática no Loki; debug desabilitado em produção por default.
+- **Collector como SPOF.** Mitigado por deploy em DaemonSet (um por nó) com buffer local em caso de indisponibilidade do backend.
+
+## Confirmação
+
+- Health check `/health/observability` valida que o exporter OTLP consegue enviar pelo menos um span de teste.
+- Pipeline de CI executa testes que verificam emissão de traces e métricas em cenários conhecidos.
+- Dashboards Grafana institucionais cobrem os SLOs declarados.
+
+## Prós e contras das opções
+
+### OpenTelemetry + LGTM
+
+- Bom, porque é padrão aberto, OSS, sem vendor lock-in.
+- Ruim, porque exige operação ativa da stack (Collector, Tempo, Prometheus, Loki, Grafana).
+
+### ELK
+
+- Bom, porque é stack tradicional madura.
+- Ruim, porque Elasticsearch consome muita memória; licenciamento mudou para SSPL (não OSS puro); Loki é mais leve para logs.
+
+### Datadog/New Relic
+
+- Bom, porque elimina operação.
+- Ruim, porque custo proibitivo, dados fora da infraestrutura, vendor lock-in.
+
+### Jaeger
+
+- Bom, porque é OSS específico para tracing.
+- Ruim, porque Tempo integra melhor com Grafana e suporta backend S3/MinIO; Jaeger requer Elasticsearch ou Cassandra.
+
+### Application Insights
+
+- Bom, porque é nativo do .NET e tem auto-instrumentação rica.
+- Ruim, porque é vendor lock-in Azure, sem correlação nativa com frontend Angular, custo de cloud.
+
+## Mais informações
+
+- ADR-0003 e ADR-0004 detalham capacidades Wolverine que esta instrumentação cobre.
+- ADR-0011 define o `PiiMaskingEnricher` que opera no pipeline Serilog antes da exportação.
+- ADR-0014 define Kafka como bus instrumentado.
+- ADR-0017 define o cluster Kubernetes onde Collector e backends executam.
+- **Origem:** revisão da ADR interna Uni+ ADR-014 (não publicada) — split: a parte "instrumentação frontend (RUM)" foi separada e cabe ao `uniplus-web`.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,59 @@
+# Architecture Decision Records — `uniplus-api`
+
+Base canônica de decisões arquiteturais do `uniplus-api`, formato [MADR 4.0](https://adr.github.io/madr/).
+
+Cada ADR registra **uma única decisão**. Histórico de decisões institucionais que originaram parte deste acervo permanece em documentação interna não publicada — quando relevante, a seção `Mais informações` de cada ADR cita a origem como `Origem: revisão da ADR interna Uni+ ADR-NNN (não publicada)`.
+
+## Estrutura
+
+- Cada ADR em arquivo `NNNN-titulo-em-slug.md` (4 dígitos, slug ASCII).
+- Frontmatter YAML obrigatório com `status`, `date`, `decision-makers`.
+- Seções fixas: Contexto, Drivers, Opções, Resultado da decisão (única), Consequências, Confirmação opcional, Mais informações.
+- Conteúdo em pt-BR; chaves do frontmatter em inglês para compatibilidade com ferramentas MADR.
+
+## Linter
+
+Validador local em [`tools/adr-lint/`](../../tools/adr-lint/README.md):
+
+```bash
+bash tools/adr-lint/validate.sh
+```
+
+Adicionalmente:
+
+```bash
+npx markdownlint-cli2 'docs/adrs/**/*.md'
+```
+
+## Índice
+
+| ADR | Título | Status | Data |
+|-----|--------|--------|------|
+| [0001](0001-monolito-modular-como-estilo-arquitetural.md) | Monolito modular como estilo arquitetural | accepted | 2026-04-28 |
+| [0002](0002-clean-architecture-com-quatro-camadas.md) | Clean Architecture com quatro camadas por módulo | accepted | 2026-04-28 |
+| [0003](0003-wolverine-como-backbone-cqrs.md) | Wolverine como backbone CQRS in-process | accepted | 2026-04-28 |
+| [0004](0004-outbox-transacional-via-wolverine.md) | Outbox transacional via Wolverine + EF Core sobre PostgreSQL | accepted | 2026-04-28 |
+| [0005](0005-cascading-messages-para-drenagem-de-domain-events.md) | Cascading messages como drenagem canônica de domain events | accepted | 2026-04-28 |
+| [0006](0006-csharp-14-e-dotnet-10-como-stack-do-backend.md) | C# 14 / .NET 10 como linguagem e runtime do backend | accepted | 2026-04-28 |
+| [0007](0007-postgresql-18-como-banco-primario.md) | PostgreSQL 18 como banco de dados primário | accepted | 2026-04-28 |
+| [0008](0008-redis-como-cache-distribuido.md) | Redis como cache distribuído | accepted | 2026-04-28 |
+| [0009](0009-minio-como-object-storage.md) | MinIO como object storage S3-compatible | accepted | 2026-04-28 |
+| [0010](0010-audience-unica-uniplus-em-tokens-oidc.md) | Audience única `uniplus` em tokens OIDC | accepted | 2026-04-28 |
+| [0011](0011-mascaramento-de-cpf-em-logs.md) | Mascaramento de CPF em logs via enricher Serilog | accepted | 2026-04-28 |
+| [0012](0012-archunitnet-como-fitness-tests-arquiteturais.md) | ArchUnitNET como biblioteca de fitness tests arquiteturais | accepted | 2026-04-28 |
+| [0013](0013-motor-de-classificacao-como-servicos-de-dominio-puros.md) | Motor de classificação como serviços de domínio puros | accepted | 2026-04-28 |
+| [0014](0014-kafka-como-bus-assincrono-inter-modulos.md) | Kafka como bus assíncrono inter-módulos e para integrações externas | accepted | 2026-04-28 |
+| [0015](0015-rest-contract-first-com-openapi.md) | REST contract-first com OpenAPI 3.0 e versionamento de API | accepted | 2026-04-28 |
+| [0016](0016-keycloak-como-identity-provider.md) | Keycloak como identity provider OIDC do `uniplus-api` | accepted | 2026-04-28 |
+| [0017](0017-kubernetes-com-helm-para-orquestracao.md) | Kubernetes com Helm para orquestração do `uniplus-api` | accepted | 2026-04-28 |
+| [0018](0018-opentelemetry-para-instrumentacao-do-backend.md) | OpenTelemetry para instrumentação do `uniplus-api` | accepted | 2026-04-28 |
+
+## Como adicionar um novo ADR
+
+1. Identifique o próximo número sequencial (`ls docs/adrs/[0-9]*.md | wc -l`).
+2. Copie [`_template.md`](_template.md).
+3. Renomeie para `NNNN-titulo-em-slug.md` (slug ASCII em minúsculas, hífens como separador).
+4. Preencha frontmatter, contexto, drivers, opções, resultado da decisão (única), consequências.
+5. Rode o linter (`bash tools/adr-lint/validate.sh`).
+6. Adicione linha ao índice acima.
+7. Abra PR.

--- a/docs/adrs/_template.md
+++ b/docs/adrs/_template.md
@@ -1,0 +1,73 @@
+---
+status: "proposed"
+date: "YYYY-MM-DD"
+decision-makers:
+  - "Tech Lead"
+consulted: []
+informed: []
+---
+
+# ADR-NNNN: {Título curto da decisão}
+
+## Contexto e enunciado do problema
+
+{Descrição do problema, necessidade ou oportunidade que motiva a decisão.
+Pode citar requisitos funcionais, regras de negócio, ADRs anteriores ou
+restrições externas. Mantenha enxuto: 2 a 5 parágrafos.}
+
+## Drivers da decisão
+
+- {força, concern ou restrição relevante}
+- {…}
+
+## Opções consideradas
+
+- {Opção 1}
+- {Opção 2}
+- {Opção 3}
+
+## Resultado da decisão
+
+**Escolhida:** "{Opção X}", porque {justificativa central}.
+
+{Detalhamento da decisão em 1–3 parágrafos. Esta seção é única por ADR
+— uma decisão por documento (regra "1 ADR = 1 decisão").}
+
+## Consequências
+
+### Positivas
+
+- {benefício}
+- {…}
+
+### Negativas
+
+- {trade-off}
+- {…}
+
+### Neutras
+
+- {efeito sem polaridade clara, se houver}
+
+## Confirmação
+
+{Como verificar que a decisão está sendo seguida — ex.: lint rule, fitness test,
+métrica observada. Opcional, mas recomendado para decisões enforçáveis.}
+
+## Prós e contras das opções
+
+### {Opção 1}
+
+- Bom, porque …
+- Ruim, porque …
+
+### {Opção 2}
+
+- Bom, porque …
+- Ruim, porque …
+
+## Mais informações
+
+- {links para guias operacionais, ADRs relacionadas, RFCs externas}
+- {emendas posteriores, notas de revisão}
+- {se aplicável: **Origem:** revisão da ADR interna Uni+ ADR-NNN (não publicada)}

--- a/tools/adr-lint/README.md
+++ b/tools/adr-lint/README.md
@@ -1,0 +1,40 @@
+# adr-lint
+
+Validador MADR 4.0 para ADRs do projeto Uni+. Script bash sem dependências externas.
+
+## Uso
+
+```bash
+bash tools/adr-lint/validate.sh                 # valida docs/adrs
+bash tools/adr-lint/validate.sh docs/adrs       # explícito
+```
+
+Saída:
+
+- `ok   NNNN-titulo.md` — ADR válido.
+- `FAIL NNNN-titulo.md` — ADR com erros (listados abaixo).
+
+Exit code != 0 quando houver pelo menos um erro.
+
+## Regras enforçadas
+
+1. Nome de arquivo no padrão `NNNN-slug.md` (4 dígitos, slug ASCII em minúsculas).
+2. Frontmatter YAML presente entre dois `---` no topo.
+3. Campos obrigatórios: `status`, `date`, `decision-makers`.
+4. `status` ∈ `{proposed, accepted, rejected, deprecated}` ou `superseded by ADR-NNNN`.
+5. `date` em formato ISO `YYYY-MM-DD`.
+6. H1 do arquivo coincide com o número do nome (`# ADR-NNNN: ...`).
+7. Exatamente UMA seção `## Resultado da decisão` por arquivo (regra "1 ADR = 1 decisão").
+8. Seções obrigatórias presentes: `Contexto e enunciado do problema`, `Opções consideradas`, `Resultado da decisão`, `Consequências`.
+
+Mais detalhes em [`docs/adrs/_template.md`](../../docs/adrs/_template.md).
+
+## Hygiene de markdown
+
+Adicionalmente, rode `markdownlint-cli2` para verificações gerais:
+
+```bash
+npx markdownlint-cli2 'docs/adrs/**/*.md'
+```
+
+Configuração em `docs/adrs/.markdownlint-cli2.jsonc`.

--- a/tools/adr-lint/validate.sh
+++ b/tools/adr-lint/validate.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# tools/adr-lint/validate.sh — validador MADR 4.0 para ADRs do projeto Uni+.
+#
+# Uso:
+#   bash tools/adr-lint/validate.sh           # valida ./docs/adrs
+#   bash tools/adr-lint/validate.sh DIR       # valida DIR
+#
+# Sai com código != 0 se houver violações.
+
+set -euo pipefail
+
+DIR="${1:-docs/adrs}"
+ERRORS=0
+COUNT=0
+
+if [[ ! -d "$DIR" ]]; then
+  echo "ERRO: diretório $DIR não encontrado" >&2
+  exit 2
+fi
+
+shopt -s nullglob
+
+for FILE in "$DIR"/[0-9][0-9][0-9][0-9]-*.md; do
+  COUNT=$((COUNT + 1))
+  BASE=$(basename "$FILE")
+  NUM_FILE="${BASE%%-*}"
+  ERR=()
+
+  if [[ ! "$BASE" =~ ^[0-9]{4}-[a-z0-9-]+\.md$ ]]; then
+    ERR+=("nome de arquivo fora do padrão NNNN-titulo-em-slug.md")
+  fi
+
+  if ! head -1 "$FILE" | grep -q '^---$'; then
+    ERR+=("frontmatter YAML ausente (esperado --- na linha 1)")
+  fi
+
+  FM=$(awk 'BEGIN{c=0} /^---$/{c++; if (c==2) exit; next} c==1' "$FILE" 2>/dev/null || echo "")
+
+  for REQUIRED in "status" "date" "decision-makers"; do
+    if ! printf '%s\n' "$FM" | grep -q "^${REQUIRED}:"; then
+      ERR+=("frontmatter sem campo obrigatório: $REQUIRED")
+    fi
+  done
+
+  STATUS=$(printf '%s\n' "$FM" | grep '^status:' | head -1 | sed -E 's/^status:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  if [[ -n "$STATUS" ]]; then
+    if [[ ! "$STATUS" =~ ^(proposed|accepted|rejected|deprecated)$ ]] && \
+       [[ ! "$STATUS" =~ ^superseded\ by\ ADR-[0-9]{4}$ ]]; then
+      ERR+=("status inválido: '$STATUS' (esperado proposed|accepted|rejected|deprecated|superseded by ADR-NNNN)")
+    fi
+  fi
+
+  DATE=$(printf '%s\n' "$FM" | grep '^date:' | head -1 | sed -E 's/^date:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  if [[ -n "$DATE" ]] && [[ ! "$DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    ERR+=("date inválida: '$DATE' (esperado YYYY-MM-DD)")
+  fi
+
+  H1=$(grep -m1 '^# ' "$FILE" || true)
+  if [[ ! "$H1" =~ ^\#\ ADR-${NUM_FILE}:\  ]]; then
+    ERR+=("H1 não bate: esperado '# ADR-${NUM_FILE}: ...', encontrado '$H1'")
+  fi
+
+  COUNT_DECISION=$(grep -c '^## Resultado da decisão' "$FILE" || true)
+  COUNT_DECISION=${COUNT_DECISION:-0}
+  if [[ "$COUNT_DECISION" -ne 1 ]]; then
+    ERR+=("'## Resultado da decisão' deve aparecer exatamente 1 vez (encontrado: $COUNT_DECISION)")
+  fi
+
+  for SECTION in "## Contexto e enunciado do problema" "## Opções consideradas" "## Resultado da decisão" "## Consequências"; do
+    if ! grep -q "^${SECTION}\$" "$FILE"; then
+      ERR+=("seção obrigatória ausente: '$SECTION'")
+    fi
+  done
+
+  if [[ "${#ERR[@]}" -gt 0 ]]; then
+    ERRORS=$((ERRORS + ${#ERR[@]}))
+    echo "FAIL $BASE"
+    for E in "${ERR[@]}"; do
+      echo "  - $E"
+    done
+  else
+    echo "ok   $BASE"
+  fi
+done
+
+if [[ "$COUNT" -eq 0 ]]; then
+  echo "AVISO: nenhum arquivo NNNN-*.md encontrado em $DIR" >&2
+  exit 0
+fi
+
+echo
+if [[ "$ERRORS" -gt 0 ]]; then
+  echo "Total de erros: $ERRORS em $COUNT arquivo(s)."
+  exit 1
+fi
+
+echo "$COUNT ADR(s) validados sem erros."

--- a/tools/adr-lint/validate.sh
+++ b/tools/adr-lint/validate.sh
@@ -20,9 +20,17 @@ fi
 
 shopt -s nullglob
 
-for FILE in "$DIR"/[0-9][0-9][0-9][0-9]-*.md; do
-  COUNT=$((COUNT + 1))
+# Itera todo arquivo .md do diretório e exclui apenas README.md e arquivos
+# começando com "_" (ex.: _template.md). Isso garante que ADRs com nomes
+# fora do padrão NNNN-slug.md (ex.: foo.md, adr-001.md) sejam reportados
+# como falha em vez de silenciosamente ignorados.
+for FILE in "$DIR"/*.md; do
   BASE=$(basename "$FILE")
+  case "$BASE" in
+    README.md|_*.md) continue ;;
+  esac
+
+  COUNT=$((COUNT + 1))
   NUM_FILE="${BASE%%-*}"
   ERR=()
 
@@ -32,6 +40,8 @@ for FILE in "$DIR"/[0-9][0-9][0-9][0-9]-*.md; do
 
   if ! head -1 "$FILE" | grep -q '^---$'; then
     ERR+=("frontmatter YAML ausente (esperado --- na linha 1)")
+  elif ! tail -n +2 "$FILE" | head -n 50 | grep -q '^---$'; then
+    ERR+=("frontmatter YAML sem delimitador de fechamento (esperado --- após bloco YAML)")
   fi
 
   FM=$(awk 'BEGIN{c=0} /^---$/{c++; if (c==2) exit; next} c==1' "$FILE" 2>/dev/null || echo "")


### PR DESCRIPTION
## Resumo

Cria base canônica de ADRs em `docs/adrs/` com **18 decisões revisadas** no formato [MADR 4.0](https://adr.github.io/madr/), renumeradas desde `0001` — independente da numeração histórica de ADRs internas Uni+.

Acompanha:

- `docs/adrs/_template.md` como referência para novas ADRs.
- `docs/adrs/README.md` com índice e instruções de manutenção.
- `docs/adrs/.markdownlint-cli2.jsonc` para hygiene de markdown.
- `tools/adr-lint/validate.sh` — validador customizado em bash (sem deps externas) que enforça frontmatter MADR, regra "1 ADR = 1 decisão" (exatamente uma seção `## Resultado da decisão` por arquivo), nomenclatura `NNNN-slug.md` e presença das seções obrigatórias.
- `tools/adr-lint/README.md` documentando o uso local.

## ADRs canônicas

| ADR | Tema |
|-----|------|
| 0001 | Monolito modular como estilo arquitetural |
| 0002 | Clean Architecture com quatro camadas |
| 0003 | Wolverine como backbone CQRS in-process |
| 0004 | Outbox transacional via Wolverine + EF Core sobre PostgreSQL |
| 0005 | Cascading messages como drenagem canônica de domain events |
| 0006 | C# 14 / .NET 10 como stack do backend |
| 0007 | PostgreSQL 18 como banco primário |
| 0008 | Redis como cache distribuído |
| 0009 | MinIO como object storage S3-compatible |
| 0010 | Audience única `uniplus` em tokens OIDC |
| 0011 | Mascaramento de CPF em logs via enricher Serilog |
| 0012 | ArchUnitNET como biblioteca de fitness tests arquiteturais |
| 0013 | Motor de classificação como serviços de domínio puros |
| 0014 | Kafka como bus assíncrono inter-módulos |
| 0015 | REST contract-first com OpenAPI 3.0 |
| 0016 | Keycloak como identity provider OIDC |
| 0017 | Kubernetes com Helm para orquestração |
| 0018 | OpenTelemetry para instrumentação do backend |

## Splits aplicados (regra "1 ADR = 1 decisão")

ADRs internas com múltiplas decisões viraram N canônicas, conforme regra estrita do padrão:

- **Clean Arch + CQRS framework** → ADR 0002 (Clean Architecture) + ADR 0003 (Wolverine).
- **Redis + MinIO** → ADR 0008 (Redis) + ADR 0009 (MinIO).
- **Kafka + outbox** → ADR 0014 (Kafka como bus) + ADR 0004 (outbox transacional).
- **OTel server + RUM client** → ADR 0018 (server) — a parte client (RUM) cabe ao `uniplus-web`.

## Cadeia outbox consolidada

A saga histórica (escolha de framework → outbox rejeitado em #135 → outbox adotado em #158 → cascading messages) entra na canônica apenas em sua **forma atual**:

- ADR 0003 — Wolverine como backbone (decisão final).
- ADR 0004 — outbox transacional via Wolverine + EF Core.
- ADR 0005 — cascading messages como drenagem.

ADRs intermediárias (rejeições, tentativas) ficam como histórico em documentação interna.

## Validação

```text
$ bash tools/adr-lint/validate.sh
ok   0001-monolito-modular-como-estilo-arquitetural.md
... (18 ADRs)
18 ADR(s) validados sem erros.

$ npx markdownlint-cli2 'docs/adrs/**/*.md'
0 error(s)

$ grep -r "uniplus-docs" docs/adrs/ tools/adr-lint/
(zero ocorrências)
```

## Sanitização

- Nenhum link ou path para `uniplus-docs` na base canônica.
- Origem de cada ADR citada apenas pelo texto-padrão na seção `Mais informações`: *"Origem: revisão da ADR interna Uni+ ADR-NNN (não publicada)."*
- Conteúdo sensível (LGPD, evidências internas, atas, prints) permanece em documentação interna.

Closes #213