### PR TITLE
fix(docker): usar imagem Keycloak Uni+ com cpf-matcher

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       start_period: 30s
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.5
+    image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
     restart: unless-stopped
     command: start-dev --import-realm
     environment:
@@ -137,12 +137,6 @@ services:
       - "8080:8080"
     volumes:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json
-      # SPI customizado uniplus-cpf-matcher (Authenticator de first-broker-login).
-      # O JAR é gerado pelo repositório irmão uniplus-keycloak-providers via
-      # scripts/build-keycloak-providers.sh — pré-requisito para subir o Keycloak.
-      # Em start-dev, o Keycloak detecta mudanças em providers/ e roda kc.sh build
-      # automaticamente; não precisa alterar o command.
-      - ../../uniplus-keycloak-providers/cpf-matcher/target/cpf-matcher-1.0.0-SNAPSHOT.jar:/opt/keycloak/providers/cpf-matcher.jar:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -137,6 +137,12 @@ services:
       - "8080:8080"
     volumes:
       - ./keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json
+      # SPI customizado uniplus-cpf-matcher (Authenticator de first-broker-login).
+      # O JAR é gerado pelo repositório irmão uniplus-keycloak-providers via
+      # scripts/build-keycloak-providers.sh — pré-requisito para subir o Keycloak.
+      # Em start-dev, o Keycloak detecta mudanças em providers/ e roda kc.sh build
+      # automaticamente; não precisa alterar o command.
+      - ../../uniplus-keycloak-providers/cpf-matcher/target/cpf-matcher-1.0.0-SNAPSHOT.jar:/opt/keycloak/providers/cpf-matcher.jar:ro
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/keycloak/README.md
+++ b/docker/keycloak/README.md
@@ -210,7 +210,7 @@ scripts/setup-govbr-idp.sh
 
 > ⚠️ O Keycloak HML institucional é **realm compartilhado** com outros sistemas (ex.: `ficha_facil`, `sisplad`) — **NÃO** importar `realm-export.json` lá. O script só toca em IdP gov.br, seus mappers e a role `candidato` (idempotente, defensivo).
 
-Para validar o login, abra `https://keycloak-hom.unifesspa.edu.br/realms/unifesspa/account/` → Sign In → "gov.br". Para criar conta de teste no `https://sso.staging.acesso.gov.br/`, usar:
+Para validar o login, abra `https://keycloak-hom.unifesspa.edu.br/realms/unifesspa/account/` → Sign In → "Entrar com gov.br". Para criar conta de teste no `https://sso.staging.acesso.gov.br/`, usar:
 
 - **Nome da mãe:** `MAMÃE`
 - **Data de nascimento:** `01/01/1980`
@@ -253,9 +253,176 @@ curl -X DELETE -H "Authorization: Bearer $ADMIN_TOKEN" \
 
 Os mappers do IdP são removidos em cascata pelo Keycloak. A role `candidato` permanece (não é removida pelo rollback).
 
-### Limitação conhecida — flow de first-broker-login
+### Flow customizado de first-broker-login com matching por CPF
 
-A ADR-029 prevê **auto-link por CPF** no primeiro login (Opção A). Isso requer uma execution customizada no flow `First Broker Login` (clone do flow padrão substituindo o executor `Detect Existing Broker User` para casar por atributo `cpf` em vez de e-mail). Esse flow customizado **não é configurado** por este script — usa-se o flow padrão (matching por e-mail). Endereçar antes do GO-LIVE em produção.
+A ADR-029 prevê **auto-link por CPF** no primeiro login. A execução é provida pelo SPI `uniplus-cpf-matcher` do repositório [uniplus-keycloak-providers](https://github.com/unifesspa-edu-br/uniplus-keycloak-providers).
+
+O flow `first broker login com cpf` é um clone do flow built-in `first broker login` com o execution `uniplus-cpf-matcher` adicionado no subflow `User creation or linking` como `ALTERNATIVE`, posicionado **antes** de `idp-create-user-if-unique`. Quando o matcher encontra um user existente por CPF, registra `EXISTING_USER_INFO` e o flow segue para `Handle Existing Account`. Quando não encontra, cai em `idp-create-user-if-unique` (criação de user novo).
+
+A configuração desse flow é idempotente e vive em `scripts/setup-cpf-matcher-flow.sh` — script **standalone** que pode rodar em qualquer ambiente (DEV, HML, PRD). O `setup-keycloak-dev.sh` o chama automaticamente em DEV; em HML/PRD, o operador chama direto.
+
+#### Estrutura dos scripts
+
+| Script | DEV | HML/PRD | O que faz |
+|---|---|---|---|
+| `build-keycloak-providers.sh` | ✅ | — | Builda o JAR `cpf-matcher` via Maven em container. Em HML/PRD o JAR vem por Helm/CI |
+| `setup-cpf-matcher-flow.sh` | ✅ (via dev) | ✅ | Cria o flow `first broker login com cpf` e aponta IdPs para ele. Idempotente, agnóstico de ambiente |
+| `setup-keycloak-dev.sh` | ✅ | ❌ | Orquestrador DEV: LDAP sintético, admin-cli ROPC, flow custom, mock IdP. **Não rodar em HML/PRD** |
+| `setup-govbr-idp.sh` | (estrutural) | ✅ | Configura IdP gov.br staging/produção real. Em DEV é apenas estrutural — gov.br não aceita localhost |
+| `setup-govbr-mock.sh` | ✅ | ❌ (bloqueado) | Cria realm fake `govbr-mock` que simula gov.br localmente. Falha se KC_URL não for localhost |
+| `smoke-test-cpf-matcher.sh` | ✅ | ❌ (bloqueado) | Roda o flow ponta a ponta via curl, valida auto-heal |
+
+### Fluxo DEV — gov.br MOCK como Login gov.br do dev
+
+O ambiente de desenvolvimento usa um **segundo realm no mesmo Keycloak** (`govbr-mock`) como simulador do gov.br. Isso permite exercitar todo o flow do cpf-matcher localmente, sem depender do gov.br staging (que não aceita `localhost` como redirect URI).
+
+```bash
+# 1. (uma vez) Clonar o repositório irmão dos SPIs
+cd repositories
+git clone https://github.com/unifesspa-edu-br/uniplus-keycloak-providers.git
+
+# 2. Build do JAR cpf-matcher
+cd uniplus-api
+scripts/build-keycloak-providers.sh cpf-matcher
+
+# 3. Sobe a stack (compose já monta o JAR no Keycloak)
+docker compose -f docker/docker-compose.yml up -d
+
+# 4. Setup completo do realm DEV — flow custom + LDAP sintético + mock IdP
+scripts/setup-keycloak-dev.sh
+```
+
+Após isso, o realm `unifesspa` tem dois IdPs apontando para o flow custom:
+- `govbr` (gov.br staging real — só fica funcional se `setup-govbr-idp.sh` for rodado com credenciais reais)
+- `govbr-mock` (realm fake local — pronto para uso imediato)
+
+**Login E2E pelo browser:**
+1. Abrir incognito em <http://localhost:8080/realms/unifesspa/account>
+2. Sign In → escolher `Entrar com gov.br (MOCK)`
+3. No realm fake: `username=09876543210`, `senha=Mock!1234`
+4. Voltar ao Account Console — atributo `cpf` agora canônico (11 dígitos)
+
+**Smoke programático** (curl simulando o browser):
+
+```bash
+scripts/smoke-test-cpf-matcher.sh
+```
+
+Cobre dois cenários:
+- **AUTOHEAL** — user manual `autoheal-test` no realm (cpf truncado `9876543210`). Após login mock com `sub=09876543210`, o auto-heal persiste e o `userinfo` retorna `cpf=09876543210`.
+- **LDAP_READONLY** — user `kevin.peixoto` federado de LDAP read-only (`employeeNumber=7094871422`). O matcher acha o user via fallback, mas o auto-heal falha com `ReadOnlyException` (limitação documentada). Em produção, a correção é institucional: migrar o `brPersonCPF` no LDAP da DIRSI.
+
+#### Mock users disponíveis no realm `govbr-mock`
+
+| Username (CPF) | Caso |
+|---|---|
+| `07094871422` | Match com fallback contra `kevin.peixoto` (LDAP read-only — auto-heal falha) |
+| `03776203781` | Match com fallback contra `emanuelly.fernandes` (LDAP read-only) |
+| `03425754904` | Match com fallback contra `fernando.melo` (LDAP read-only) |
+| `76323164930` | Match canônico contra `lara.almeida` (LDAP — sem fallback) |
+| `12345678901` | Sem match — exercita criação de user novo |
+| `09876543210` | Match com fallback contra user **manual** `autoheal-test` — auto-heal **persiste** |
+
+Senha de todos: `Mock!1234`.
+
+### Fluxo HML — gov.br staging real
+
+A validação E2E contra o gov.br staging acontece no Keycloak HML institucional (`keycloak-hom.unifesspa.edu.br`), onde o redirect URI já está registrado no gov.br homologação.
+
+> ⚠️ O Keycloak HML é **realm compartilhado** com outros sistemas (`ficha_facil`, `sisplad`). Os scripts abaixo só tocam recursos especificamente vinculados ao gov.br + cpf-matcher. **Nunca rodar `setup-keycloak-dev.sh` ou `setup-govbr-mock.sh` em HML.**
+
+Pré-requisito: o JAR do `cpf-matcher` precisa estar em `/opt/keycloak/providers/` na imagem do Keycloak HML (responsabilidade do pipeline Helm/CI — issue separada).
+
+```bash
+# Variáveis de ambiente HML
+export KC_URL=https://keycloak-hom.unifesspa.edu.br
+export KC_ADMIN_USER=...                      # admin do realm unifesspa
+export KC_ADMIN_PASS=...
+export GOVBR_CLIENT_ID=keycloak-hom.unifesspa.edu.br
+export GOVBR_CLIENT_SECRET=...                # canal formal gov.br — nunca commitar
+export GOVBR_ENV=staging
+
+# 1. Cria/garante o flow custom no realm unifesspa
+scripts/setup-cpf-matcher-flow.sh
+
+# 2. Configura IdP gov.br staging apontando para o flow custom
+GOVBR_FIRST_BROKER_LOGIN_FLOW="first broker login com cpf" \
+    scripts/setup-govbr-idp.sh
+```
+
+A validação:
+1. Abrir <https://keycloak-hom.unifesspa.edu.br/realms/unifesspa/account>
+2. Sign In → `gov.br`
+3. Conta de teste no <https://sso.staging.acesso.gov.br/>:
+   - **Nome da mãe:** `MAMÃE`
+   - **Data de nascimento:** `01/01/1980`
+
+### Fluxo PRD — gov.br produção
+
+Idêntico ao HML, com `GOVBR_ENV=production` e endpoints/credentials de produção.
+
+```bash
+export KC_URL=https://keycloak.unifesspa.edu.br
+export KC_ADMIN_USER=...
+export KC_ADMIN_PASS=...
+export GOVBR_CLIENT_ID=keycloak.unifesspa.edu.br
+export GOVBR_CLIENT_SECRET=...                # canal formal gov.br — produção
+export GOVBR_ENV=production
+
+scripts/setup-cpf-matcher-flow.sh
+GOVBR_FIRST_BROKER_LOGIN_FLOW="first broker login com cpf" \
+    scripts/setup-govbr-idp.sh
+```
+
+> Pré-requisitos institucionais para PRD: domínio `.edu.br` autorizado pelo gov.br (Portaria SGD/MGI 7.076/2024), client_id = hostname do Keycloak, client_secret obtido pelo canal formal gov.br produção.
+
+### Inspeção rápida do estado do flow
+
+```bash
+TOKEN=$(curl -sf -X POST "$KC_URL/realms/master/protocol/openid-connect/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=password&client_id=admin-cli&username=$KC_ADMIN_USER&password=$KC_ADMIN_PASS" \
+    | jq -r .access_token)
+
+# Ordem dos executions no subflow alvo
+curl -sf -H "Authorization: Bearer $TOKEN" \
+    "$KC_URL/admin/realms/unifesspa/authentication/flows/first%20broker%20login%20com%20cpf%20User%20creation%20or%20linking/executions" \
+    | jq '[.[] | {providerId, requirement, priority}]'
+
+# IdP aponta para o flow custom
+curl -sf -H "Authorization: Bearer $TOKEN" \
+    "$KC_URL/admin/realms/unifesspa/identity-provider/instances/govbr" \
+    | jq '{alias, firstBrokerLoginFlowAlias}'
+```
+
+Em DEV, adicionalmente:
+
+```bash
+docker logs docker-keycloak-1 2>&1 | grep uniplus-cpf-matcher
+```
+
+### Rollback — voltar ao flow built-in
+
+```bash
+TOKEN=$(curl -sf -X POST "$KC_URL/realms/master/protocol/openid-connect/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=password&client_id=admin-cli&username=$KC_ADMIN_USER&password=$KC_ADMIN_PASS" \
+    | jq -r .access_token)
+
+# 1. IdP gov.br volta para o flow built-in
+CURRENT=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+    "$KC_URL/admin/realms/unifesspa/identity-provider/instances/govbr")
+echo "$CURRENT" | jq '.firstBrokerLoginFlowAlias = "first broker login"' \
+    | curl -sf -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+        -d @- "$KC_URL/admin/realms/unifesspa/identity-provider/instances/govbr"
+
+# 2. Remover o flow customizado
+FLOW_ID=$(curl -sf -H "Authorization: Bearer $TOKEN" \
+    "$KC_URL/admin/realms/unifesspa/authentication/flows" \
+    | jq -r '.[] | select(.alias=="first broker login com cpf") | .id')
+curl -sf -X DELETE -H "Authorization: Bearer $TOKEN" \
+    "$KC_URL/admin/realms/unifesspa/authentication/flows/$FLOW_ID"
+```
 
 ## Política de senha
 

--- a/scripts/build-keycloak-providers.sh
+++ b/scripts/build-keycloak-providers.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# build-keycloak-providers.sh — Builda os artefatos do repositório
+# uniplus-keycloak-providers (SPIs customizados do Keycloak) via Maven em
+# container Docker, sem exigir Maven instalado no host.
+#
+# O resultado fica disponível no diretório target/ de cada módulo do repositório
+# irmão e é montado pelo docker-compose do uniplus-api em
+# /opt/keycloak/providers/ (ver docker/keycloak/README.md).
+#
+# Uso:
+#   scripts/build-keycloak-providers.sh                # builda tudo (mvn -pl :all)
+#   scripts/build-keycloak-providers.sh cpf-matcher    # builda apenas um módulo
+#
+# Variáveis de ambiente opcionais:
+#   PROVIDERS_REPO     (default: ../uniplus-keycloak-providers — relativo ao
+#                       uniplus-api; assume convenção repositories/)
+#   MAVEN_IMAGE        (default: maven:3.9-eclipse-temurin-21)
+#   MAVEN_OPTS         repassado para o Maven dentro do container
+#   SKIP_TESTS         se "true", roda com -DskipTests
+#
+# Requisitos:
+#   - Docker no host
+#   - Repositório uniplus-keycloak-providers clonado ao lado do uniplus-api/
+
+set -euo pipefail
+
+# ---- Logging --------------------------------------------------------------
+
+log()  { printf '\033[1;36m==> %s\033[0m\n' "$*" >&2; }
+ok()   { printf '\033[1;32m    OK %s\033[0m\n' "$*" >&2; }
+warn() { printf '\033[1;33m!! %s\033[0m\n' "$*" >&2; }
+fail() { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+# ---- Localiza repos -------------------------------------------------------
+
+# Diretório do uniplus-api (raiz do repositório, derivado da localização do script).
+API_REPO="$(cd "$(dirname "$0")/.." && pwd)"
+PROVIDERS_REPO="${PROVIDERS_REPO:-$API_REPO/../uniplus-keycloak-providers}"
+
+if [ ! -d "$PROVIDERS_REPO" ]; then
+    warn "Repositório uniplus-keycloak-providers não encontrado em: $PROVIDERS_REPO"
+    warn "Clone-o ao lado do uniplus-api seguindo a convenção repositories/:"
+    warn "  cd $(dirname "$API_REPO")"
+    fail "  git clone https://github.com/unifesspa-edu-br/uniplus-keycloak-providers.git"
+fi
+
+if [ ! -f "$PROVIDERS_REPO/pom.xml" ]; then
+    fail "pom.xml ausente em $PROVIDERS_REPO — caminho parece incorreto."
+fi
+
+PROVIDERS_REPO_ABS="$(cd "$PROVIDERS_REPO" && pwd)"
+
+# ---- Pré-checks -----------------------------------------------------------
+
+command -v docker >/dev/null 2>&1 || fail "Docker não está instalado ou não está no PATH"
+docker info >/dev/null 2>&1       || fail "Docker daemon não responde — está rodando?"
+
+# ---- Build ----------------------------------------------------------------
+
+MAVEN_IMAGE="${MAVEN_IMAGE:-maven:3.9-eclipse-temurin-21}"
+MAVEN_OPTS_VALUE="${MAVEN_OPTS:-}"
+
+# Argumentos extras conforme parâmetros do script
+MVN_TARGETS=("clean" "package")
+if [ "${SKIP_TESTS:-false}" = "true" ]; then
+    MVN_TARGETS+=("-DskipTests")
+fi
+
+MODULE=""
+if [ "$#" -gt 0 ]; then
+    MODULE="$1"
+    if [ ! -d "$PROVIDERS_REPO_ABS/$MODULE" ]; then
+        fail "Módulo '$MODULE' não existe em $PROVIDERS_REPO_ABS"
+    fi
+    MVN_TARGETS+=("-pl" "$MODULE" "-am")
+    log "Buildando módulo $MODULE"
+else
+    log "Buildando todos os módulos de uniplus-keycloak-providers"
+fi
+
+# Cache local do Maven (~/.m2) para evitar re-download entre execuções
+M2_CACHE="${HOME}/.m2"
+mkdir -p "$M2_CACHE"
+
+# Container roda como UID:GID do host para que os arquivos gerados em target/
+# tenham as permissões certas (sem precisar de sudo para limpar).
+docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -v "$PROVIDERS_REPO_ABS:/workspace" \
+    -v "$M2_CACHE:/var/maven/.m2" \
+    -e MAVEN_CONFIG=/var/maven/.m2 \
+    -e MAVEN_OPTS="$MAVEN_OPTS_VALUE" \
+    -w /workspace \
+    "$MAVEN_IMAGE" \
+    mvn -Duser.home=/var/maven "${MVN_TARGETS[@]}"
+
+# ---- Verifica saída -------------------------------------------------------
+
+# Quando o build é direcionado a um módulo específico, exigimos que o JAR
+# tenha sido gerado dentro daquele target/. Sem isso, um build que sucede
+# em dependências mas falha no módulo alvo passaria silenciosamente —
+# resultando em volume mount de arquivo inexistente no docker-compose.
+if [ -n "$MODULE" ]; then
+    JAR_PATH=$(find "$PROVIDERS_REPO_ABS/$MODULE/target" -maxdepth 1 -name '*.jar' \
+        -not -name '*-sources.jar' -not -name '*-javadoc.jar' -print -quit 2>/dev/null)
+    if [ -z "$JAR_PATH" ]; then
+        warn "Build concluiu sem erro, mas nenhum JAR foi produzido em $PROVIDERS_REPO_ABS/$MODULE/target/."
+        fail "Verifique o packaging do pom.xml e o output do Maven acima."
+    fi
+    ok "Build concluído. JAR: $JAR_PATH"
+
+    # O docker-compose monta um caminho hardcoded — se a versão no pom mudar,
+    # o mount no Keycloak vira arquivo inexistente. Avisa cedo no build.
+    if [ "$MODULE" = "cpf-matcher" ]; then
+        EXPECTED="$PROVIDERS_REPO_ABS/cpf-matcher/target/cpf-matcher-1.0.0-SNAPSHOT.jar"
+        if [ ! -f "$EXPECTED" ]; then
+            warn "JAR gerado ($JAR_PATH) não bate com o caminho esperado pelo docker-compose:"
+            warn "  $EXPECTED"
+            warn "Verifique se a versão do pom.xml foi alterada — o volume mount em"
+            warn "docker/docker-compose.yml precisa ser atualizado em sincronia."
+        fi
+    fi
+else
+    if ! find "$PROVIDERS_REPO_ABS" -path '*/target/*.jar' -not -name '*-sources.jar' -not -name '*-javadoc.jar' -print -quit | grep -q .; then
+        fail "Build concluiu sem erro, mas nenhum JAR foi produzido em target/."
+    fi
+    ok "Build concluído. JARs disponíveis em $PROVIDERS_REPO_ABS/<modulo>/target/"
+fi

--- a/scripts/setup-cpf-matcher-flow.sh
+++ b/scripts/setup-cpf-matcher-flow.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# setup-cpf-matcher-flow.sh — Configura o flow first-broker-login customizado
+# com o SPI `uniplus-cpf-matcher` em qualquer realm Keycloak (DEV, HML, PRD).
+# Aponta opcionalmente IdPs gov.br (real e/ou mock) para o flow custom.
+#
+# Reutilizável: este script é chamado por
+#   - scripts/setup-keycloak-dev.sh        (orquestrador DEV)
+#   - operadores em HML/PRD (chamada direta antes de setup-govbr-idp.sh)
+#
+# O que faz (idempotente; rodar 2x produz o mesmo estado)
+#
+#   1. Espera o realm responder.
+#   2. Obtém token de admin no master realm.
+#   3. Clona o flow built-in `first broker login` em `first broker login com cpf`.
+#   4. Adiciona execution `uniplus-cpf-matcher` no subflow
+#      `User creation or linking` como ALTERNATIVE, posicionado ANTES de
+#      `idp-create-user-if-unique`.
+#   5. Valida estado final: requirement=ALTERNATIVE, priority < idp-create...,
+#      provider carregado pelo runtime.
+#
+# Apontar IdPs para este flow é responsabilidade dos scripts que CRIAM os
+# IdPs — `setup-govbr-idp.sh` (gov.br real) e `setup-govbr-mock.sh` (mock DEV).
+# Cada um aceita a env apropriada para definir `firstBrokerLoginFlowAlias`
+# no momento da criação/atualização. O guard de downgrade silencioso no
+# `setup-govbr-idp.sh` cobre o caso de re-execução com flow divergente.
+#
+# Variáveis de ambiente
+#
+#   KC_URL                  default: http://localhost:8080
+#   KC_REALM                default: unifesspa
+#   KC_ADMIN_USER           default: admin
+#   KC_ADMIN_PASS           default: admin
+#   FLOW_ALIAS              default: "first broker login com cpf"
+#
+# Pré-requisitos
+#
+#   - Keycloak no ar com o realm `$KC_REALM` importado.
+#   - Provider `uniplus-cpf-matcher` carregado pelo runtime (em DEV: scripts/
+#     build-keycloak-providers.sh + volume mount no compose; em HML/PRD: o
+#     JAR precisa estar em /opt/keycloak/providers/ via Helm/CI).
+#
+# Uso
+#
+#   # DEV (default)
+#   scripts/setup-cpf-matcher-flow.sh
+#
+#   # HML — direcionar para o realm institucional
+#   KC_URL=https://keycloak-hom.unifesspa.edu.br \
+#   KC_ADMIN_USER=... KC_ADMIN_PASS=... \
+#   scripts/setup-cpf-matcher-flow.sh
+
+set -euo pipefail
+
+# ---- Config ---------------------------------------------------------------
+
+KC_URL="${KC_URL:-http://localhost:8080}"
+KC_REALM="${KC_REALM:-unifesspa}"
+KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
+KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+FLOW_ALIAS="${FLOW_ALIAS:-first broker login com cpf}"
+
+readonly FLOW_PARENT_BUILTIN="first broker login"
+readonly FLOW_SUBFLOW="$FLOW_ALIAS User creation or linking"
+readonly CPF_MATCHER_PROVIDER_ID="uniplus-cpf-matcher"
+
+# ---- Logging --------------------------------------------------------------
+
+log()  { printf '\033[1;36m==> %s\033[0m\n' "$*" >&2; }
+ok()   { printf '\033[1;32m    OK %s\033[0m\n' "$*" >&2; }
+warn() { printf '\033[1;33m!! %s\033[0m\n' "$*" >&2; }
+fail() { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || fail "Comando ausente: $1"
+}
+
+# ---- Auth helpers ---------------------------------------------------------
+
+ADMIN_TOKEN=""
+API=""
+
+wait_for_keycloak() {
+    log "Aguardando Keycloak responder em $KC_URL/realms/$KC_REALM"
+    local retries=30
+    while ! curl -sf "$KC_URL/realms/$KC_REALM/.well-known/openid-configuration" >/dev/null 2>&1; do
+        retries=$((retries - 1))
+        [ "$retries" -le 0 ] && fail "Timeout aguardando Keycloak. Stack no ar e realm '$KC_REALM' importado?"
+        printf '.'
+        sleep 2
+    done
+    echo
+    ok "Keycloak responde"
+}
+
+obtain_admin_token() {
+    log "Obtendo token de admin no master realm"
+    ADMIN_TOKEN=$(curl -sf -X POST "$KC_URL/realms/master/protocol/openid-connect/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "grant_type=password&client_id=admin-cli&username=$KC_ADMIN_USER&password=$KC_ADMIN_PASS" \
+        | jq -r '.access_token // empty')
+    [ -n "$ADMIN_TOKEN" ] || fail "Falha ao obter admin token. Credenciais corretas?"
+    API="$KC_URL/admin/realms/$KC_REALM"
+    ok "Admin token obtido"
+}
+
+auth()      { curl -sf -H "Authorization: Bearer $ADMIN_TOKEN" "$@"; }
+auth_json() { auth -H "Content-Type: application/json" "$@"; }
+
+url_encode_alias() {
+    jq -rn --arg s "$1" '$s | @uri'
+}
+
+# ---- 1. Garante o flow custom existe (clona builtin) ---------------------
+
+ensure_flow_exists() {
+    local existing
+    existing=$(auth "$API/authentication/flows" \
+        | jq -r --arg n "$FLOW_ALIAS" '.[] | select(.alias==$n) | .id // empty')
+
+    if [ -n "$existing" ]; then
+        ok "flow '$FLOW_ALIAS' já existe"
+        return
+    fi
+
+    local parent_encoded
+    parent_encoded=$(url_encode_alias "$FLOW_PARENT_BUILTIN")
+    auth_json -X POST "$API/authentication/flows/$parent_encoded/copy" \
+        -d "$(jq -nc --arg n "$FLOW_ALIAS" '{newName: $n}')" >/dev/null
+    ok "flow '$FLOW_ALIAS' criado a partir de '$FLOW_PARENT_BUILTIN'"
+}
+
+# ---- 2. Adiciona execution uniplus-cpf-matcher no subflow ----------------
+
+ensure_matcher_execution() {
+    local subflow_encoded executions_json existing
+    subflow_encoded=$(url_encode_alias "$FLOW_SUBFLOW")
+    executions_json=$(auth "$API/authentication/flows/$subflow_encoded/executions")
+    existing=$(echo "$executions_json" \
+        | jq -r --arg p "$CPF_MATCHER_PROVIDER_ID" '.[] | select(.providerId==$p) | .id // empty' \
+        | head -n1)
+
+    if [ -n "$existing" ]; then
+        ok "execution '$CPF_MATCHER_PROVIDER_ID' já presente em '$FLOW_SUBFLOW'"
+        return
+    fi
+
+    auth_json -X POST "$API/authentication/flows/$subflow_encoded/executions/execution" \
+        -d "$(jq -nc --arg p "$CPF_MATCHER_PROVIDER_ID" '{provider: $p}')" >/dev/null
+    ok "execution '$CPF_MATCHER_PROVIDER_ID' adicionado em '$FLOW_SUBFLOW'"
+}
+
+# ---- 3. Posiciona matcher como ALTERNATIVE antes de idp-create-user-...---
+
+ensure_matcher_position() {
+    local subflow_encoded executions_json matcher_entry create_entry matcher_id matcher_priority create_priority
+
+    subflow_encoded=$(url_encode_alias "$FLOW_SUBFLOW")
+    executions_json=$(auth "$API/authentication/flows/$subflow_encoded/executions")
+
+    matcher_entry=$(echo "$executions_json" | jq -c --arg p "$CPF_MATCHER_PROVIDER_ID" \
+        '.[] | select(.providerId==$p)')
+    create_entry=$(echo "$executions_json" | jq -c \
+        '.[] | select(.providerId=="idp-create-user-if-unique")')
+
+    [ -n "$matcher_entry" ] || fail "execution do matcher sumiu inesperadamente"
+    [ -n "$create_entry" ]  || fail "executor idp-create-user-if-unique não encontrado — flow alterado fora deste script?"
+
+    matcher_id=$(echo "$matcher_entry" | jq -r '.id // empty')
+    matcher_priority=$(echo "$matcher_entry" | jq -r '.priority // empty')
+    create_priority=$(echo "$create_entry"  | jq -r '.priority // empty')
+
+    [ -n "$matcher_id" ]       || fail "campo 'id' ausente na entry do matcher"
+    [ -n "$matcher_priority" ] || fail "campo 'priority' ausente na entry do matcher"
+    [ -n "$create_priority" ]  || fail "campo 'priority' ausente na entry de idp-create-user-if-unique"
+
+    if [ "$(echo "$matcher_entry" | jq -r '.requirement')" != "ALTERNATIVE" ]; then
+        local patched
+        patched=$(echo "$matcher_entry" | jq '.requirement = "ALTERNATIVE"')
+        auth_json -X PUT "$API/authentication/flows/$subflow_encoded/executions" -d "$patched" >/dev/null
+        ok "execution '$CPF_MATCHER_PROVIDER_ID' marcado como ALTERNATIVE"
+    fi
+
+    if [ "$matcher_priority" -gt "$create_priority" ]; then
+        local i
+        for i in $(seq 1 10); do
+            auth_json -X POST "$API/authentication/executions/$matcher_id/raise-priority" >/dev/null
+
+            executions_json=$(auth "$API/authentication/flows/$subflow_encoded/executions")
+            matcher_priority=$(echo "$executions_json" | jq -r --arg p "$CPF_MATCHER_PROVIDER_ID" \
+                '.[] | select(.providerId==$p) | .priority')
+            create_priority=$(echo "$executions_json" | jq -r \
+                '.[] | select(.providerId=="idp-create-user-if-unique") | .priority')
+
+            [ "$matcher_priority" -lt "$create_priority" ] && break
+        done
+
+        if [ "$matcher_priority" -lt "$create_priority" ]; then
+            ok "execution '$CPF_MATCHER_PROVIDER_ID' reposicionado antes de idp-create-user-if-unique"
+        else
+            fail "não foi possível reposicionar o matcher após 10 iterações"
+        fi
+    fi
+}
+
+# ---- 4. Validação estrutural ---------------------------------------------
+
+validate() {
+    log "Validando setup"
+
+    local subflow_encoded executions_json matcher_priority create_priority matcher_requirement
+    subflow_encoded=$(url_encode_alias "$FLOW_SUBFLOW")
+    executions_json=$(auth "$API/authentication/flows/$subflow_encoded/executions")
+
+    matcher_priority=$(echo "$executions_json" | jq -r --arg p "$CPF_MATCHER_PROVIDER_ID" \
+        '.[] | select(.providerId==$p) | .priority // empty')
+    matcher_requirement=$(echo "$executions_json" | jq -r --arg p "$CPF_MATCHER_PROVIDER_ID" \
+        '.[] | select(.providerId==$p) | .requirement // empty')
+    create_priority=$(echo "$executions_json" | jq -r \
+        '.[] | select(.providerId=="idp-create-user-if-unique") | .priority // empty')
+
+    [ -n "$matcher_priority" ]    || fail "execution do matcher ausente"
+    [ "$matcher_requirement" = "ALTERNATIVE" ] || fail "requirement do matcher é '$matcher_requirement', esperado ALTERNATIVE"
+    [ "$matcher_priority" -lt "$create_priority" ] || fail "matcher priority=$matcher_priority não é menor que idp-create-user-if-unique=$create_priority"
+    ok "flow OK (matcher ALTERNATIVE @priority=$matcher_priority, idp-create-user-if-unique @priority=$create_priority)"
+
+    # Validação de runtime só faz sentido contra localhost (precisa acesso ao container)
+    if [[ "$KC_URL" == http://localhost:* ]] && command -v docker >/dev/null 2>&1; then
+        if docker logs docker-keycloak-1 2>&1 | grep -q "$CPF_MATCHER_PROVIDER_ID"; then
+            ok "provider '$CPF_MATCHER_PROVIDER_ID' carregado pelo runtime"
+        else
+            warn "não encontrei evidência do provider nos logs do container — JAR montado?"
+        fi
+    fi
+}
+
+# ---- Entry point ---------------------------------------------------------
+
+main() {
+    require jq
+    require curl
+
+    wait_for_keycloak
+    obtain_admin_token
+
+    log "Configurando flow '$FLOW_ALIAS' (matching por CPF via $CPF_MATCHER_PROVIDER_ID)"
+    ensure_flow_exists
+    ensure_matcher_execution
+    ensure_matcher_position
+    validate
+}
+
+main "$@"

--- a/scripts/setup-govbr-idp.sh
+++ b/scripts/setup-govbr-idp.sh
@@ -10,12 +10,18 @@
 #   GOVBR_CLIENT_SECRET   Segredo fornecido pelo gov.br — NUNCA commitar
 #
 # Variáveis OPCIONAIS:
-#   GOVBR_ENV             staging (default) | production
-#   GOVBR_ALIAS           default: govbr  (compõe o redirect URI)
-#   KC_URL                default: http://localhost:8080
-#   KC_REALM              default: unifesspa
-#   KC_ADMIN_USER         default: admin
-#   KC_ADMIN_PASS         default: admin
+#   GOVBR_ENV                       staging (default) | production
+#   GOVBR_ALIAS                     default: govbr  (compõe o redirect URI)
+#   GOVBR_FIRST_BROKER_LOGIN_FLOW   default: "first broker login" (built-in).
+#                                   Para usar o flow customizado com matching
+#                                   por CPF, definir como "first broker login
+#                                   com cpf" — esse flow é criado pelo
+#                                   setup-keycloak-dev.sh (uniplus-cpf-matcher
+#                                   SPI). Ver Story uniplus-api#218.
+#   KC_URL                          default: http://localhost:8080
+#   KC_REALM                        default: unifesspa
+#   KC_ADMIN_USER                   default: admin
+#   KC_ADMIN_PASS                   default: admin
 #
 # Uso em homologação institucional (caminho recomendado — validado em campo):
 #   export KC_URL=https://keycloak-hom.unifesspa.edu.br
@@ -42,14 +48,13 @@
 #
 # LIMITAÇÕES CONHECIDAS (validadas em campo, HML 29/04/2026):
 #
-# 1. Flow de first-broker-login não customizado:
-#    A ADR-029 prevê auto-link por CPF (atributo) no primeiro login. Isso exige
-#    uma execution customizada no flow "First Broker Login" (clone do flow padrão
-#    substituindo o executor "Detect Existing Broker User" para casar por atributo
-#    `cpf` em vez de e-mail). Esse fluxo customizado NÃO é configurado por este
-#    script — usa-se o flow padrão do Keycloak (matching por e-mail).
-#    Servidores que já existem no realm via LDAP terão a fricção de
-#    "User already exists. Add to existing account?" no primeiro login via gov.br.
+# 1. Flow de first-broker-login (resolvido em uniplus-api#218):
+#    Auto-link por CPF é provido pelo SPI uniplus-cpf-matcher (repositório
+#    uniplus-keycloak-providers) e configurado pelo setup-keycloak-dev.sh em
+#    um clone do flow built-in chamado "first broker login com cpf". Para
+#    usar esse flow neste script, exportar
+#    GOVBR_FIRST_BROKER_LOGIN_FLOW="first broker login com cpf" antes de rodar.
+#    Default segue sendo o flow built-in para preservar comportamento histórico.
 #
 # 2. syncMode = IMPORT (não FORCE):
 #    Quando o realm tem User Federation LDAP em modo READ_ONLY (caso do realm
@@ -79,6 +84,7 @@ set -euo pipefail
 # ---- Defaults
 GOVBR_ENV="${GOVBR_ENV:-staging}"
 GOVBR_ALIAS="${GOVBR_ALIAS:-govbr}"
+GOVBR_FIRST_BROKER_LOGIN_FLOW="${GOVBR_FIRST_BROKER_LOGIN_FLOW:-first broker login}"
 KC_URL="${KC_URL:-http://localhost:8080}"
 KC_REALM="${KC_REALM:-unifesspa}"
 KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
@@ -105,9 +111,10 @@ GOVBR_ISSUER="https://${GOVBR_HOST}/"
 log()  { printf '\033[1;36m==> %s\033[0m\n' "$*" >&2; }
 ok()   { printf '\033[1;32m    OK %s\033[0m\n' "$*" >&2; }
 warn() { printf '\033[1;33m!! %s\033[0m\n' "$*" >&2; }
+fail() { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
 
 require() {
-    command -v "$1" >/dev/null 2>&1 || { warn "Comando ausente: $1"; exit 1; }
+    command -v "$1" >/dev/null 2>&1 || fail "Comando ausente: $1"
 }
 require jq
 require curl
@@ -155,16 +162,17 @@ build_idp_body() {
         --arg issuer "$GOVBR_ISSUER" \
         --arg clientId "$GOVBR_CLIENT_ID" \
         --arg clientSecret "$GOVBR_CLIENT_SECRET" \
+        --arg firstBrokerLoginFlow "$GOVBR_FIRST_BROKER_LOGIN_FLOW" \
         '{
             alias: $alias,
-            displayName: "gov.br",
+            displayName: "Entrar com gov.br",
             providerId: "oidc",
             enabled: true,
             trustEmail: true,
             storeToken: false,
             addReadTokenRoleOnCreate: false,
             linkOnly: false,
-            firstBrokerLoginFlowAlias: "first broker login",
+            firstBrokerLoginFlowAlias: $firstBrokerLoginFlow,
             config: {
                 authorizationUrl: $authUrl,
                 tokenUrl: $tokenUrl,
@@ -218,6 +226,21 @@ IDP_BODY=$(build_idp_body)
 
 case "$EXISTS_HTTP" in
     200)
+        # Guard contra downgrade silencioso: se o IdP já aponta para um flow
+        # custom (e.g., "first broker login com cpf" criado via
+        # setup-cpf-matcher-flow.sh) e o operador rodar este script sem
+        # GOVBR_FIRST_BROKER_LOGIN_FLOW, o PUT abaixo voltaria o flow para o
+        # built-in — desfazendo o matching por CPF sem nenhum aviso.
+        CURRENT_FLOW=$(auth "$API/identity-provider/instances/$GOVBR_ALIAS" \
+            | jq -r '.firstBrokerLoginFlowAlias // empty')
+        if [ -n "$CURRENT_FLOW" ] && [ "$CURRENT_FLOW" != "$GOVBR_FIRST_BROKER_LOGIN_FLOW" ]; then
+            warn "IdP '$GOVBR_ALIAS' atualmente usa o flow '$CURRENT_FLOW',"
+            warn "mas este script vai sobrescrevê-lo para '$GOVBR_FIRST_BROKER_LOGIN_FLOW'."
+            warn "Para preservar o flow atual, exporte:"
+            warn "  GOVBR_FIRST_BROKER_LOGIN_FLOW='$CURRENT_FLOW'"
+            warn "Para forçar a substituição: ALLOW_FLOW_DOWNGRADE=true"
+            [ "${ALLOW_FLOW_DOWNGRADE:-false}" = "true" ] || exit 1
+        fi
         auth_json -X PUT "$API/identity-provider/instances/$GOVBR_ALIAS" -d "$IDP_BODY" >/dev/null
         ok "IdP '$GOVBR_ALIAS' atualizado"
         ;;

--- a/scripts/setup-govbr-idp.sh
+++ b/scripts/setup-govbr-idp.sh
@@ -231,15 +231,24 @@ case "$EXISTS_HTTP" in
         # setup-cpf-matcher-flow.sh) e o operador rodar este script sem
         # GOVBR_FIRST_BROKER_LOGIN_FLOW, o PUT abaixo voltaria o flow para o
         # built-in — desfazendo o matching por CPF sem nenhum aviso.
+        #
+        # O guard só dispara em downgrade (custom → built-in) ou troca lateral
+        # (custom A → custom B). Upgrade explícito do built-in para um flow
+        # custom é o caminho documentado de rollout em HML/PRD e não exige opt-in.
+        BUILTIN_FLOW="first broker login"
         CURRENT_FLOW=$(auth "$API/identity-provider/instances/$GOVBR_ALIAS" \
             | jq -r '.firstBrokerLoginFlowAlias // empty')
         if [ -n "$CURRENT_FLOW" ] && [ "$CURRENT_FLOW" != "$GOVBR_FIRST_BROKER_LOGIN_FLOW" ]; then
-            warn "IdP '$GOVBR_ALIAS' atualmente usa o flow '$CURRENT_FLOW',"
-            warn "mas este script vai sobrescrevê-lo para '$GOVBR_FIRST_BROKER_LOGIN_FLOW'."
-            warn "Para preservar o flow atual, exporte:"
-            warn "  GOVBR_FIRST_BROKER_LOGIN_FLOW='$CURRENT_FLOW'"
-            warn "Para forçar a substituição: ALLOW_FLOW_DOWNGRADE=true"
-            [ "${ALLOW_FLOW_DOWNGRADE:-false}" = "true" ] || exit 1
+            if [ "$CURRENT_FLOW" = "$BUILTIN_FLOW" ] && [ "$GOVBR_FIRST_BROKER_LOGIN_FLOW" != "$BUILTIN_FLOW" ]; then
+                log "Upgrade de flow: '$CURRENT_FLOW' → '$GOVBR_FIRST_BROKER_LOGIN_FLOW'"
+            else
+                warn "IdP '$GOVBR_ALIAS' atualmente usa o flow '$CURRENT_FLOW',"
+                warn "mas este script vai sobrescrevê-lo para '$GOVBR_FIRST_BROKER_LOGIN_FLOW'."
+                warn "Para preservar o flow atual, exporte:"
+                warn "  GOVBR_FIRST_BROKER_LOGIN_FLOW='$CURRENT_FLOW'"
+                warn "Para forçar a substituição: ALLOW_FLOW_OVERRIDE=true"
+                [ "${ALLOW_FLOW_OVERRIDE:-${ALLOW_FLOW_DOWNGRADE:-false}}" = "true" ] || exit 1
+            fi
         fi
         auth_json -X PUT "$API/identity-provider/instances/$GOVBR_ALIAS" -d "$IDP_BODY" >/dev/null
         ok "IdP '$GOVBR_ALIAS' atualizado"

--- a/scripts/setup-govbr-mock.sh
+++ b/scripts/setup-govbr-mock.sh
@@ -1,0 +1,525 @@
+#!/usr/bin/env bash
+# setup-govbr-mock.sh — Configura um realm Keycloak fake (`govbr-mock`) que
+# atua como IdP OIDC simulando o gov.br staging localmente, e registra esse
+# realm como Identity Provider `govbr-mock` no realm `unifesspa`.
+#
+# Por que existe
+#
+#   O fluxo gov.br não roda contra `localhost` (gov.br não aceita esse host
+#   como redirect URI registrado). Para validar o cpf-matcher SPI ponta a ponta
+#   em ambiente de desenvolvimento — em particular o cenário de matching com
+#   fallback de 10 dígitos (CPF iniciado em zero, bug histórico do LDAP
+#   institucional) — este script sobe um IdP local que devolve `sub=<cpf>`
+#   no id_token, exatamente como o gov.br faz.
+#
+#   ⚠️ APENAS DEV LOCAL. Não usar em HML/PROD. O realm fake tem credenciais
+#   triviais e mappers que sobrescrevem o claim `sub` — comportamento
+#   intencionalmente inseguro para ergonomia de teste.
+#
+# Idempotência
+#
+#   Rodar duas vezes produz o mesmo estado, sem erros nem duplicação. Usa
+#   GET → POST/PUT em todos os recursos.
+#
+# Pré-requisitos
+#
+#   - Keycloak local no ar (docker compose up -d keycloak)
+#   - Realm `unifesspa` importado
+#   - Flow `first broker login com cpf` configurado pelo setup-keycloak-dev.sh
+#   - Provider uniplus-cpf-matcher carregado (ver scripts/build-keycloak-providers.sh)
+#
+# Uso
+#
+#   scripts/setup-govbr-mock.sh
+#
+#   # Login programático para gerar token de mock user (usado pelo smoke test
+#   # E2E — ver docker/keycloak/README.md):
+#   curl -X POST http://localhost:8080/realms/govbr-mock/protocol/openid-connect/token \
+#       -d grant_type=password -d client_id=unifesspa-rp \
+#       -d client_secret=mock-secret-not-real -d scope=openid \
+#       -d username=07094871422 -d password=Mock!1234
+
+set -euo pipefail
+
+# ---- Config ----------------------------------------------------------------
+
+KC_URL="${KC_URL:-http://localhost:8080}"
+TARGET_REALM="${TARGET_REALM:-unifesspa}"
+MOCK_REALM="${MOCK_REALM:-govbr-mock}"
+MOCK_CLIENT_ID="${MOCK_CLIENT_ID:-unifesspa-rp}"
+MOCK_CLIENT_SECRET="${MOCK_CLIENT_SECRET:-mock-secret-not-real}"
+MOCK_USER_PASSWORD="${MOCK_USER_PASSWORD:-Mock!1234}"
+KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
+KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+IDP_ALIAS="${IDP_ALIAS:-govbr-mock}"
+IDP_FIRST_BROKER_LOGIN_FLOW="${IDP_FIRST_BROKER_LOGIN_FLOW:-first broker login com cpf}"
+
+# Users a criar no realm fake. Cada linha é "cpf|first_name|last_name|email".
+# Os 3 CPFs com zero à esquerda batem por fallback com users LDAP cujos
+# employeeNumber estão truncados em 10 dígitos (kevin.peixoto, emanuelly.fernandes,
+# fernando.melo). Os 2 últimos exercem o caminho de matching canônico (11 dígitos).
+readonly MOCK_USERS=(
+    "07094871422|Kevin Test|Mock|kevin.test@govbr.mock"
+    "03776203781|Emanuelly Test|Mock|emanuelly.test@govbr.mock"
+    "03425754904|Fernando Test|Mock|fernando.test@govbr.mock"
+    "76323164930|Lara Test|Mock|lara.test@govbr.mock"
+    "12345678901|Novo Test|Mock|novo.test@govbr.mock"
+    # CPF dedicado à demo de auto-heal completo (user manual no realm unifesspa,
+    # não conflita com nenhum user LDAP — ver ensure_target_realm_test_user).
+    "09876543210|Autoheal Test|Mock|autoheal.test@govbr.mock"
+)
+
+# User manual no realm `unifesspa` (NÃO federado) usado para demonstrar o
+# auto-heal funcionando ponta a ponta. Cpf=10 dígitos no realm; ao logar via
+# mock com sub=11 dígitos correspondente, o cpf-matcher acha via fallback,
+# faz auto-heal escrevendo 11 dígitos canônicos. Funciona porque o user é
+# manual (sem LDAP federation), portanto setSingleAttribute persiste.
+readonly TARGET_TEST_USERNAME="autoheal-test"
+readonly TARGET_TEST_CPF_TRUNCATED="9876543210"
+readonly TARGET_TEST_EMAIL="autoheal-test@uniplus.local"
+readonly TARGET_TEST_PASSWORD="Test!1234"
+
+# ---- Logging ---------------------------------------------------------------
+
+log()  { printf '\033[1;36m==> %s\033[0m\n' "$*" >&2; }
+ok()   { printf '\033[1;32m    OK %s\033[0m\n' "$*" >&2; }
+warn() { printf '\033[1;33m!! %s\033[0m\n' "$*" >&2; }
+fail() { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || fail "Comando ausente: $1"
+}
+
+# ---- Auth helpers ----------------------------------------------------------
+
+ADMIN_TOKEN=""
+
+obtain_admin_token() {
+    log "Obtendo token de admin no master realm"
+    ADMIN_TOKEN=$(curl -sf -X POST "$KC_URL/realms/master/protocol/openid-connect/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "grant_type=password" \
+        -d "client_id=admin-cli" \
+        -d "username=$KC_ADMIN_USER" \
+        -d "password=$KC_ADMIN_PASS" \
+        | jq -r '.access_token // empty')
+    [ -n "$ADMIN_TOKEN" ] || { warn "Falha ao obter admin token. Credenciais corretas?"; exit 1; }
+    ok "Admin token obtido"
+}
+
+auth()      { curl -sf -H "Authorization: Bearer $ADMIN_TOKEN" "$@"; }
+auth_json() { auth -H "Content-Type: application/json" "$@"; }
+
+# ---- 1. Realm fake `govbr-mock` -------------------------------------------
+
+ensure_mock_realm() {
+    local http_code
+    http_code=$(curl -s -o /dev/null -w '%{http_code}' \
+        -H "Authorization: Bearer $ADMIN_TOKEN" \
+        "$KC_URL/admin/realms/$MOCK_REALM")
+
+    if [ "$http_code" = "200" ]; then
+        ok "realm '$MOCK_REALM' já existe"
+        return
+    fi
+
+    auth_json -X POST "$KC_URL/admin/realms" -d "$(jq -nc \
+        --arg r "$MOCK_REALM" \
+        '{realm: $r, enabled: true, displayName: "gov.br (mock — DEV ONLY)"}')" >/dev/null
+    ok "realm '$MOCK_REALM' criado"
+}
+
+# Realm 'govbr-mock' precisa permitir attribute 'cpf' no user — por padrão
+# Keycloak 26+ rejeita atributos não declarados no User Profile.
+ensure_mock_realm_unmanaged_attributes() {
+    local profile patched
+    profile=$(auth "$KC_URL/admin/realms/$MOCK_REALM/users/profile")
+    if [ "$(echo "$profile" | jq -r '.unmanagedAttributePolicy // "null"')" = "ENABLED" ]; then
+        ok "unmanagedAttributePolicy do '$MOCK_REALM' já está ENABLED"
+        return
+    fi
+    patched=$(echo "$profile" | jq '. + {unmanagedAttributePolicy: "ENABLED"}')
+    auth_json -X PUT "$KC_URL/admin/realms/$MOCK_REALM/users/profile" -d "$patched" >/dev/null
+    ok "unmanagedAttributePolicy do '$MOCK_REALM' setado como ENABLED"
+}
+
+# ---- 2. Cliente OIDC `unifesspa-rp` no realm fake -------------------------
+
+# O clientId é fixo; o secret é trivial intencionalmente (DEV ONLY). O
+# redirect URI casa com o broker callback do realm `unifesspa`.
+ensure_mock_client() {
+    local existing_id
+    existing_id=$(auth "$KC_URL/admin/realms/$MOCK_REALM/clients?clientId=$MOCK_CLIENT_ID" \
+        | jq -r '.[0].id // empty')
+
+    local body
+    body=$(jq -nc \
+        --arg cid "$MOCK_CLIENT_ID" \
+        --arg secret "$MOCK_CLIENT_SECRET" \
+        --arg redirect "$KC_URL/realms/$TARGET_REALM/broker/$IDP_ALIAS/endpoint" \
+        '{
+            clientId: $cid,
+            secret: $secret,
+            enabled: true,
+            protocol: "openid-connect",
+            publicClient: false,
+            standardFlowEnabled: true,
+            directAccessGrantsEnabled: true,
+            redirectUris: [$redirect],
+            attributes: {
+                "client.use.lightweight.access.token.enabled": "false"
+            }
+        }')
+
+    if [ -n "$existing_id" ]; then
+        local body_with_id
+        body_with_id=$(echo "$body" | jq --arg id "$existing_id" '. + {id: $id}')
+        auth_json -X PUT "$KC_URL/admin/realms/$MOCK_REALM/clients/$existing_id" -d "$body_with_id" >/dev/null
+        ok "client '$MOCK_CLIENT_ID' atualizado"
+    else
+        auth_json -X POST "$KC_URL/admin/realms/$MOCK_REALM/clients" -d "$body" >/dev/null
+        ok "client '$MOCK_CLIENT_ID' criado"
+    fi
+}
+
+# ---- 3. Mapper que sobrescreve o claim `sub` com o atributo `cpf` ---------
+
+# O cpf-matcher consome `brokerContext.getId()`, que vem do claim `sub` do
+# id_token recebido pelo realm `unifesspa`. Para que o sub seja o CPF (e não
+# o UUID interno do user), adicionamos um oidc-usermodel-attribute-mapper que
+# remapeia o sub. Funciona — validado empiricamente no Keycloak 26.5.
+ensure_sub_override_mapper() {
+    local client_id mapper_name existing_id body
+
+    client_id=$(auth "$KC_URL/admin/realms/$MOCK_REALM/clients?clientId=$MOCK_CLIENT_ID" \
+        | jq -r '.[0].id')
+    mapper_name="sub-from-cpf-attribute"
+
+    existing_id=$(auth "$KC_URL/admin/realms/$MOCK_REALM/clients/$client_id/protocol-mappers/models" \
+        | jq -r --arg n "$mapper_name" '.[] | select(.name==$n) | .id // empty' \
+        | head -n1)
+
+    body=$(jq -nc --arg name "$mapper_name" \
+        '{
+            name: $name,
+            protocol: "openid-connect",
+            protocolMapper: "oidc-usermodel-attribute-mapper",
+            config: {
+                "user.attribute": "cpf",
+                "claim.name": "sub",
+                "jsonType.label": "String",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "true"
+            }
+        }')
+
+    if [ -n "$existing_id" ]; then
+        local body_with_id
+        body_with_id=$(echo "$body" | jq --arg id "$existing_id" '. + {id: $id}')
+        auth_json -X PUT "$KC_URL/admin/realms/$MOCK_REALM/clients/$client_id/protocol-mappers/models/$existing_id" \
+            -d "$body_with_id" >/dev/null
+        ok "mapper '$mapper_name' atualizado"
+    else
+        auth_json -X POST "$KC_URL/admin/realms/$MOCK_REALM/clients/$client_id/protocol-mappers/models" \
+            -d "$body" >/dev/null
+        ok "mapper '$mapper_name' criado"
+    fi
+}
+
+# ---- 4. Mock users no realm fake -----------------------------------------
+
+# Cria/atualiza um user. Cada user tem username=cpf e atributo cpf=cpf, com
+# senha não-temporária para destravar testes via direct-grants se necessário.
+upsert_mock_user() {
+    local cpf="$1" first="$2" last="$3" email="$4"
+
+    local existing_id body
+    existing_id=$(auth "$KC_URL/admin/realms/$MOCK_REALM/users?username=$cpf&exact=true" \
+        | jq -r '.[0].id // empty')
+
+    body=$(jq -nc \
+        --arg u "$cpf" \
+        --arg c "$cpf" \
+        --arg f "$first" \
+        --arg l "$last" \
+        --arg e "$email" \
+        '{
+            username: $u,
+            enabled: true,
+            emailVerified: true,
+            email: $e,
+            firstName: $f,
+            lastName: $l,
+            attributes: { cpf: [$c] }
+        }')
+
+    if [ -n "$existing_id" ]; then
+        auth_json -X PUT "$KC_URL/admin/realms/$MOCK_REALM/users/$existing_id" -d "$body" >/dev/null
+    else
+        auth_json -X POST "$KC_URL/admin/realms/$MOCK_REALM/users" -d "$body" >/dev/null
+        existing_id=$(auth "$KC_URL/admin/realms/$MOCK_REALM/users?username=$cpf&exact=true" \
+            | jq -r '.[0].id')
+    fi
+
+    # Reset de senha (idempotente — sempre sobrescreve)
+    auth_json -X PUT "$KC_URL/admin/realms/$MOCK_REALM/users/$existing_id/reset-password" \
+        -d "$(jq -nc --arg p "$MOCK_USER_PASSWORD" '{type:"password", value:$p, temporary:false}')" >/dev/null
+
+    # Limpa requiredActions (algumas validations do User Profile geram
+    # VERIFY_PROFILE em dev — não queremos esse atrito no mock)
+    auth_json -X PUT "$KC_URL/admin/realms/$MOCK_REALM/users/$existing_id" \
+        -d '{"requiredActions":[]}' >/dev/null
+
+    ok "mock user '$cpf' ($first $last) configurado"
+}
+
+ensure_mock_users() {
+    local row
+    for row in "${MOCK_USERS[@]}"; do
+        IFS='|' read -r cpf first last email <<< "$row"
+        upsert_mock_user "$cpf" "$first" "$last" "$email"
+    done
+}
+
+# ---- 5. IdP `govbr-mock` no realm `unifesspa` -----------------------------
+
+ensure_idp_in_target_realm() {
+    local http body
+
+    http=$(curl -s -o /dev/null -w '%{http_code}' \
+        -H "Authorization: Bearer $ADMIN_TOKEN" \
+        "$KC_URL/admin/realms/$TARGET_REALM/identity-provider/instances/$IDP_ALIAS")
+
+    body=$(jq -nc \
+        --arg alias "$IDP_ALIAS" \
+        --arg flow "$IDP_FIRST_BROKER_LOGIN_FLOW" \
+        --arg authUrl "$KC_URL/realms/$MOCK_REALM/protocol/openid-connect/auth" \
+        --arg tokenUrl "$KC_URL/realms/$MOCK_REALM/protocol/openid-connect/token" \
+        --arg userInfoUrl "$KC_URL/realms/$MOCK_REALM/protocol/openid-connect/userinfo" \
+        --arg jwksUrl "$KC_URL/realms/$MOCK_REALM/protocol/openid-connect/certs" \
+        --arg logoutUrl "$KC_URL/realms/$MOCK_REALM/protocol/openid-connect/logout" \
+        --arg issuer "$KC_URL/realms/$MOCK_REALM" \
+        --arg clientId "$MOCK_CLIENT_ID" \
+        --arg clientSecret "$MOCK_CLIENT_SECRET" \
+        '{
+            alias: $alias,
+            displayName: "Entrar com gov.br (MOCK)",
+            providerId: "oidc",
+            enabled: true,
+            trustEmail: true,
+            storeToken: false,
+            addReadTokenRoleOnCreate: false,
+            linkOnly: false,
+            firstBrokerLoginFlowAlias: $flow,
+            config: {
+                authorizationUrl: $authUrl,
+                tokenUrl: $tokenUrl,
+                userInfoUrl: $userInfoUrl,
+                jwksUrl: $jwksUrl,
+                logoutUrl: $logoutUrl,
+                issuer: $issuer,
+                clientId: $clientId,
+                clientSecret: $clientSecret,
+                clientAuthMethod: "client_secret_basic",
+                defaultScope: "openid profile email",
+                useJwksUrl: "true",
+                validateSignature: "true",
+                syncMode: "IMPORT",
+                pkceEnabled: "true",
+                pkceMethod: "S256",
+                backchannelSupported: "false"
+            }
+        }')
+
+    case "$http" in
+        200)
+            auth_json -X PUT "$KC_URL/admin/realms/$TARGET_REALM/identity-provider/instances/$IDP_ALIAS" -d "$body" >/dev/null
+            ok "IdP '$IDP_ALIAS' atualizado em '$TARGET_REALM'"
+            ;;
+        404)
+            auth_json -X POST "$KC_URL/admin/realms/$TARGET_REALM/identity-provider/instances" -d "$body" >/dev/null
+            ok "IdP '$IDP_ALIAS' criado em '$TARGET_REALM'"
+            ;;
+        *)
+            warn "Resposta inesperada ao consultar IdP: HTTP $http"
+            exit 1
+            ;;
+    esac
+}
+
+# Espelha os mappers do IdP gov.br real, para que o broker grave os mesmos
+# atributos (cpf, given_name, family_name, email) no user criado no realm
+# `unifesspa`. Imprescindível para o cpf-matcher: ele usa o atributo `cpf`
+# do user existente para fazer matching, mas só para users LDAP-federados;
+# para users criados via mock (12345678901), o auto-create vai usar o sub.
+upsert_idp_mapper() {
+    local name="$1" type="$2" config_json="$3"
+
+    local existing_id body
+    existing_id=$(auth "$KC_URL/admin/realms/$TARGET_REALM/identity-provider/instances/$IDP_ALIAS/mappers" \
+        | jq -r --arg n "$name" '.[] | select(.name==$n) | .id // empty' \
+        | head -n1)
+
+    body=$(jq -nc \
+        --arg name "$name" \
+        --arg type "$type" \
+        --arg alias "$IDP_ALIAS" \
+        --argjson config "$config_json" \
+        '{
+            name: $name,
+            identityProviderAlias: $alias,
+            identityProviderMapper: $type,
+            config: $config
+        }')
+
+    if [ -n "$existing_id" ]; then
+        local body_with_id
+        body_with_id=$(echo "$body" | jq --arg id "$existing_id" '. + {id: $id}')
+        auth_json -X PUT "$KC_URL/admin/realms/$TARGET_REALM/identity-provider/instances/$IDP_ALIAS/mappers/$existing_id" \
+            -d "$body_with_id" >/dev/null
+        ok "IdP mapper '$name' atualizado"
+    else
+        auth_json -X POST "$KC_URL/admin/realms/$TARGET_REALM/identity-provider/instances/$IDP_ALIAS/mappers" \
+            -d "$body" >/dev/null
+        ok "IdP mapper '$name' criado"
+    fi
+}
+
+# Cria/atualiza user manual no realm `unifesspa` para demo de auto-heal.
+# Como NÃO é LDAP-federado, o auto-heal do cpf-matcher persiste o atributo —
+# diferente dos users LDAP READ_ONLY, onde o auto-heal falha por design.
+ensure_target_realm_test_user() {
+    local existing_id body
+    existing_id=$(auth "$KC_URL/admin/realms/$TARGET_REALM/users?username=$TARGET_TEST_USERNAME&exact=true" \
+        | jq -r '.[0].id // empty')
+
+    body=$(jq -nc \
+        --arg u "$TARGET_TEST_USERNAME" \
+        --arg c "$TARGET_TEST_CPF_TRUNCATED" \
+        --arg e "$TARGET_TEST_EMAIL" \
+        '{
+            username: $u,
+            enabled: true,
+            emailVerified: true,
+            email: $e,
+            firstName: "Autoheal",
+            lastName: "Test",
+            attributes: { cpf: [$c] }
+        }')
+
+    if [ -n "$existing_id" ]; then
+        auth_json -X PUT "$KC_URL/admin/realms/$TARGET_REALM/users/$existing_id" -d "$body" >/dev/null
+        ok "user '$TARGET_TEST_USERNAME' (manual, não-LDAP) atualizado em '$TARGET_REALM'"
+    else
+        auth_json -X POST "$KC_URL/admin/realms/$TARGET_REALM/users" -d "$body" >/dev/null
+        existing_id=$(auth "$KC_URL/admin/realms/$TARGET_REALM/users?username=$TARGET_TEST_USERNAME&exact=true" \
+            | jq -r '.[0].id')
+        ok "user '$TARGET_TEST_USERNAME' (manual, não-LDAP) criado em '$TARGET_REALM' com cpf=$TARGET_TEST_CPF_TRUNCATED"
+    fi
+
+    # Senha + limpa requiredActions (libera ROPC pós-flow para inspecionar userinfo)
+    auth_json -X PUT "$KC_URL/admin/realms/$TARGET_REALM/users/$existing_id/reset-password" \
+        -d "$(jq -nc --arg p "$TARGET_TEST_PASSWORD" '{type:"password", value:$p, temporary:false}')" >/dev/null
+    auth_json -X PUT "$KC_URL/admin/realms/$TARGET_REALM/users/$existing_id" \
+        -d '{"requiredActions":[]}' >/dev/null
+
+    # Garante que NÃO existe federated identity remanescente (idempotência —
+    # caso o flow tenha sido executado antes, removemos para que o matcher
+    # rode de novo no próximo login)
+    auth -X DELETE "$KC_URL/admin/realms/$TARGET_REALM/users/$existing_id/federated-identity/$IDP_ALIAS" 2>/dev/null || true
+}
+
+ensure_idp_mappers() {
+    upsert_idp_mapper "cpf" "oidc-user-attribute-idp-mapper" '{
+        "syncMode": "IMPORT",
+        "claim": "sub",
+        "user.attribute": "cpf"
+    }'
+    upsert_idp_mapper "given-name" "oidc-user-attribute-idp-mapper" '{
+        "syncMode": "IMPORT",
+        "claim": "given_name",
+        "user.attribute": "firstName"
+    }'
+    upsert_idp_mapper "family-name" "oidc-user-attribute-idp-mapper" '{
+        "syncMode": "IMPORT",
+        "claim": "family_name",
+        "user.attribute": "lastName"
+    }'
+    upsert_idp_mapper "email" "oidc-user-attribute-idp-mapper" '{
+        "syncMode": "IMPORT",
+        "claim": "email",
+        "user.attribute": "email"
+    }'
+}
+
+# ---- Resumo ---------------------------------------------------------------
+
+print_summary() {
+    log "Mock IdP gov.br configurado"
+    cat >&2 <<EOF
+
+  Realm fake:    $MOCK_REALM
+  Client:        $MOCK_CLIENT_ID  (secret: $MOCK_CLIENT_SECRET)
+  Senha mocks:   $MOCK_USER_PASSWORD
+
+  Mock users (username = CPF de 11 dígitos):
+EOF
+    local row
+    for row in "${MOCK_USERS[@]}"; do
+        IFS='|' read -r cpf first last _email <<< "$row"
+        printf '    - %s  (%s %s)\n' "$cpf" "$first" "$last" >&2
+    done
+
+    cat >&2 <<EOF
+
+  IdP no realm '$TARGET_REALM': $IDP_ALIAS  (firstBrokerLoginFlow=$IDP_FIRST_BROKER_LOGIN_FLOW)
+
+  Console admin do realm fake:
+    $KC_URL/admin/master/console/#/$MOCK_REALM/
+
+  Como validar via browser:
+    1. Abrir incognito em $KC_URL/realms/$TARGET_REALM/account/
+    2. Sign In → "Entrar com gov.br (MOCK)"
+    3. No realm fake, logar com username=07094871422 / senha=$MOCK_USER_PASSWORD
+    4. Após login, voltar pro Account Console e verificar atributo cpf
+
+  Como validar via curl:
+    scripts/smoke-test-cpf-matcher.sh
+
+EOF
+}
+
+# ---- Entry point ----------------------------------------------------------
+
+main() {
+    require jq
+    require curl
+
+    # SAFETY: este script é DEV ONLY. Cria um realm fake com mappers que
+    # sobrescrevem o claim `sub` — comportamento intencionalmente inseguro.
+    # Travamos para localhost / 127.0.0.1; rodar contra HML/PRD quebra a
+    # premissa do realm institucional.
+    if [[ "$KC_URL" != http://localhost:* ]] && [[ "$KC_URL" != http://127.0.0.1:* ]]; then
+        warn "setup-govbr-mock.sh é DEV ONLY — KC_URL='$KC_URL' não é localhost."
+        warn "Em HML/PRD use o gov.br staging/produção real via setup-govbr-idp.sh."
+        warn "Defina ALLOW_NON_LOCALHOST_MOCK=true para forçar (ciente do risco)."
+        [ "${ALLOW_NON_LOCALHOST_MOCK:-false}" = "true" ] || exit 1
+    fi
+
+    obtain_admin_token
+    log "Configurando realm fake '$MOCK_REALM'"
+    ensure_mock_realm
+    ensure_mock_realm_unmanaged_attributes
+    ensure_mock_client
+    ensure_sub_override_mapper
+    ensure_mock_users
+    log "Configurando IdP '$IDP_ALIAS' no realm '$TARGET_REALM'"
+    ensure_idp_in_target_realm
+    ensure_idp_mappers
+    log "Provisionando user manual de teste (demo de auto-heal sem LDAP)"
+    ensure_target_realm_test_user
+    print_summary
+}
+
+main "$@"

--- a/scripts/setup-keycloak-dev.sh
+++ b/scripts/setup-keycloak-dev.sh
@@ -394,7 +394,10 @@ configure_govbr_mock_idp() {
         log "Pulando setup do mock IdP (SKIP_GOVBR_MOCK=true)"
         return
     fi
-    KC_URL="$KC_URL" \
+    # TARGET_REALM precisa espelhar KC_REALM, senão o mock cria o IdP no
+    # default 'unifesspa' enquanto as etapas anteriores configuraram outro
+    # realm — desincronia silenciosa em runs com KC_REALM customizado.
+    KC_URL="$KC_URL" TARGET_REALM="$KC_REALM" \
     KC_ADMIN_USER="$KC_ADMIN_USER" KC_ADMIN_PASS="$KC_ADMIN_PASS" \
         "$SCRIPT_DIR/setup-govbr-mock.sh"
 }

--- a/scripts/setup-keycloak-dev.sh
+++ b/scripts/setup-keycloak-dev.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Setup pós-import do realm `unifesspa` para dev local. Aplica via Admin API
-# os patches que o realm-export.json versionado deliberadamente não traz por
-# refletir configuração próxima de produção.
+# Setup completo do ambiente DEV do Keycloak. Para HML/PRD use os scripts
+# standalone (setup-cpf-matcher-flow.sh + setup-govbr-idp.sh) — este script
+# é DEV-only e contém ajustes que NÃO devem rodar em HML/PRD (LDAP sintético,
+# admin-cli configurado para ROPC, mock IdP gov.br).
 #
 # Etapas (cada uma idempotente, encapsulada em função):
 #   1. wait_for_keycloak                    — probe do realm endpoint
@@ -10,18 +11,31 @@
 #                                             (libera smoke tests via curl)
 #   4. reset_test_user_passwords            — 4 users de teste, senha não-temporária
 #   5. configure_ldap_federation_if_available — User Federation contra openldap
-#                                             sintético (skip em HML/PROD)
-#   6. print_smoke_test_hint                — exemplo de uso pós-setup
+#                                             sintético
+#   6. setup-cpf-matcher-flow.sh            — clona flow built-in,
+#                                             insere uniplus-cpf-matcher,
+#                                             aponta IdPs gov.br + govbr-mock
+#                                             [delegado para script standalone]
+#   7. setup-govbr-mock.sh                  — IdP mock para validar gov.br E2E
+#                                             em ambiente local (sub=cpf)
+#                                             [SKIP_GOVBR_MOCK=true desabilita]
+#   8. print_smoke_test_hint                — exemplo de uso pós-setup
 #
-# Os ajustes feitos aqui não sobrevivem a `docker compose down -v` — re-rode
-# o script após recriar o volume do Postgres.
+# Em DEV o "Login gov.br" efetivo é o realm fake `govbr-mock` no mesmo
+# Keycloak. Em HML/PRD o IdP `govbr` aponta para o gov.br staging/produção
+# real, configurado via setup-govbr-idp.sh.
+#
+# Os ajustes deste script não sobrevivem a `docker compose down -v` — re-rode
+# após recriar o volume do Postgres.
 #
 # Pré-requisitos:
 #   - Stack docker no ar: docker compose -f docker/docker-compose.yml up -d
+#   - JAR cpf-matcher buildado: scripts/build-keycloak-providers.sh cpf-matcher
 #   - jq, curl
 #
 # Uso:
-#   scripts/setup-keycloak-dev.sh
+#   scripts/setup-keycloak-dev.sh                     # DEV completo (default)
+#   SKIP_GOVBR_MOCK=true scripts/setup-keycloak-dev.sh  # sem mock IdP
 #
 # Variáveis de ambiente opcionais:
 #   KC_URL                  (default: http://localhost:8080)
@@ -62,6 +76,9 @@ LDAP_USERS_DN="${LDAP_USERS_DN:-ou=Users,$LDAP_BASE_DN}"
 
 readonly LDAP_PROVIDER_NAME="ldap-local-sintetico"
 
+# Diretório onde vivem os scripts auxiliares chamados como subprocesso
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Definidos durante a execução
 ADMIN_TOKEN=""
 API=""
@@ -71,9 +88,10 @@ API=""
 log()  { printf '\033[1;36m==> %s\033[0m\n' "$*" >&2; }
 ok()   { printf '\033[1;32m    OK %s\033[0m\n' "$*" >&2; }
 warn() { printf '\033[1;33m!! %s\033[0m\n' "$*" >&2; }
+fail() { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
 
 require() {
-    command -v "$1" >/dev/null 2>&1 || { warn "Comando ausente: $1"; exit 1; }
+    command -v "$1" >/dev/null 2>&1 || fail "Comando ausente: $1"
 }
 
 # Helpers de chamada autenticada — assumem ADMIN_TOKEN e API setados.
@@ -351,13 +369,44 @@ configure_ldap_federation_if_available() {
     trigger_initial_sync "$ldap_id"
 }
 
-# ---- Etapa 6 — Hint de smoke test ------------------------------------------
+# ---- Etapa 6 — Flow first-broker-login com matching por CPF ----------------
+#
+# Delegado para scripts/setup-cpf-matcher-flow.sh — script standalone
+# reutilizável em DEV/HML/PRD. Repassamos as credenciais e o realm via env.
+
+configure_first_broker_login_with_cpf() {
+    KC_URL="$KC_URL" KC_REALM="$KC_REALM" \
+    KC_ADMIN_USER="$KC_ADMIN_USER" KC_ADMIN_PASS="$KC_ADMIN_PASS" \
+        "$SCRIPT_DIR/setup-cpf-matcher-flow.sh"
+}
+
+# ---- Etapa 7 — IdP mock gov.br (DEV only) ----------------------------------
+#
+# Em DEV o "Login gov.br" efetivo é o realm fake `govbr-mock`, criado pelo
+# script setup-govbr-mock.sh — passa as mesmas credenciais admin via env. O
+# script é safe-guarded contra execução fora de localhost.
+#
+# SKIP_GOVBR_MOCK=true desativa esta etapa (útil quando o dev está integrando
+# contra um IdP gov.br staging diretamente).
+
+configure_govbr_mock_idp() {
+    if [ "${SKIP_GOVBR_MOCK:-false}" = "true" ]; then
+        log "Pulando setup do mock IdP (SKIP_GOVBR_MOCK=true)"
+        return
+    fi
+    KC_URL="$KC_URL" \
+    KC_ADMIN_USER="$KC_ADMIN_USER" KC_ADMIN_PASS="$KC_ADMIN_PASS" \
+        "$SCRIPT_DIR/setup-govbr-mock.sh"
+}
+
+# ---- Etapa 8 — Hint de smoke test ------------------------------------------
 
 print_smoke_test_hint() {
     echo
-    log "Setup concluído. Teste o fluxo:"
-    cat <<EOF
+    log "Setup DEV concluído. Caminhos de validação:"
+    cat <<EOF >&2
 
+  ── Login direto via ROPC (sem broker) ──
   TOKEN=\$(curl -s -X POST '$KC_URL/realms/$KC_REALM/protocol/openid-connect/token' \\
     -H 'Content-Type: application/x-www-form-urlencoded' \\
     -d 'grant_type=password' -d 'client_id=admin-cli' \\
@@ -365,7 +414,12 @@ print_smoke_test_hint() {
 
   curl -s -H "Authorization: Bearer \$TOKEN" http://localhost:5202/api/profile/me | jq
 
-  # Listar users sintéticos do LDAP local:
+  ── Login via gov.br MOCK (E2E do cpf-matcher) ──
+  Browser:   http://localhost:8080/realms/$KC_REALM/account → "Entrar com gov.br (MOCK)"
+             user: 09876543210  senha: Mock!1234
+  Smoke:     scripts/smoke-test-cpf-matcher.sh
+
+  ── Inspeções rápidas ──
   ldapsearch -x -H ldap://$LDAP_PROBE_HOST:$LDAP_PROBE_PORT \\
     -b $LDAP_USERS_DN \\
     -D '$LDAP_BIND_DN' -w '$LDAP_BIND_CREDENTIAL' \\
@@ -380,11 +434,28 @@ main() {
     require jq
     require curl
 
+    # SAFETY: este script é DEV ONLY. Aplica patches que NÃO devem rodar em
+    # HML/PRD: reescreve `defaultClientScopes` e `lightweight access token` do
+    # admin-cli (compartilhado com ficha_facil/sisplad em HML), sobrescreve
+    # senhas dos 4 users de teste, configura LDAP federation contra OpenLDAP
+    # sintético. Para HML/PRD use setup-cpf-matcher-flow.sh + setup-govbr-idp.sh.
+    if [[ "$KC_URL" != http://localhost:* ]] && [[ "$KC_URL" != http://127.0.0.1:* ]]; then
+        warn "setup-keycloak-dev.sh é DEV ONLY — KC_URL='$KC_URL' não é localhost."
+        warn "Patches deste script (admin-cli, senhas de teste, LDAP) afetam realms"
+        warn "compartilhados em HML/PRD. Para HML/PRD use:"
+        warn "  scripts/setup-cpf-matcher-flow.sh"
+        warn "  scripts/setup-govbr-idp.sh"
+        warn "Defina ALLOW_NON_LOCALHOST_DEV=true para forçar (ciente do risco)."
+        [ "${ALLOW_NON_LOCALHOST_DEV:-false}" = "true" ] || exit 1
+    fi
+
     wait_for_keycloak
     obtain_admin_token
     configure_admin_cli_for_ropc
     reset_test_user_passwords
     configure_ldap_federation_if_available
+    configure_first_broker_login_with_cpf
+    configure_govbr_mock_idp
     print_smoke_test_hint
 }
 

--- a/scripts/smoke-test-cpf-matcher.sh
+++ b/scripts/smoke-test-cpf-matcher.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# smoke-test-cpf-matcher.sh — Roda o flow `first broker login com cpf` ponta a
+# ponta contra o IdP mock (govbr-mock) via curl, simulando o que o navegador
+# faria, e valida via Admin API + ROPC que o cpf-matcher trabalhou como
+# esperado.
+#
+# Pré-requisitos:
+#   1. scripts/setup-keycloak-dev.sh
+#   2. scripts/setup-govbr-mock.sh
+#
+# Cenários cobertos (ambos demonstram matching tolerante por CPF):
+#
+#   1. AUTOHEAL — user manual `autoheal-test` (cpf truncado 9876543210 no
+#      realm unifesspa). Login mock com sub=09876543210. Esperado:
+#        - log "matching via fallback ... aplicando auto-heal"
+#        - cpf do user no realm passa a ser 09876543210 (canônico)
+#        - userinfo do autoheal-test retorna cpf=09876543210
+#
+#   2. LDAP_READONLY_LIMITATION — user LDAP-federado kevin.peixoto
+#      (cpf 7094871422 truncado no LDAP). Login mock com sub=07094871422.
+#      Esperado (limitação documentada):
+#        - log "matching via fallback ... aplicando auto-heal"
+#        - log "auto-heal falhou ... ReadOnlyException"
+#        - cpf do user permanece 7094871422 (LDAP read-only re-lê o original)
+#        - userinfo continua com 10 dígitos — correção definitiva é
+#          institucional (migration do LDAP brPersonCPF — issue separada)
+#
+# Idempotente: cada execução limpa federated identity prévio para que o
+# matcher rode novamente.
+
+set -euo pipefail
+
+KC_URL="${KC_URL:-http://localhost:8080}"
+TARGET_REALM="${TARGET_REALM:-unifesspa}"
+MOCK_REALM="${MOCK_REALM:-govbr-mock}"
+IDP_ALIAS="${IDP_ALIAS:-govbr-mock}"
+KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
+KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+MOCK_USER_PASSWORD="${MOCK_USER_PASSWORD:-Mock!1234}"
+
+# PKCE fixo (RFC 7636 example)
+readonly PKCE_VERIFIER="dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+readonly PKCE_CHALLENGE="E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+readonly CLIENT_ID="selecao-web"
+readonly REDIRECT_URI="http://localhost:4200/callback"
+
+log()   { printf '\033[1;36m==> %s\033[0m\n' "$*" >&2; }
+ok()    { printf '\033[1;32m    OK %s\033[0m\n' "$*" >&2; }
+warn()  { printf '\033[1;33m!! %s\033[0m\n' "$*" >&2; }
+fail()  { printf '\033[1;31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || fail "Comando ausente: $1"
+}
+
+# ---- Auth helpers ---------------------------------------------------------
+
+ADMIN_TOKEN=""
+
+obtain_admin_token() {
+    ADMIN_TOKEN=$(curl -sf -X POST "$KC_URL/realms/master/protocol/openid-connect/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "grant_type=password&client_id=admin-cli&username=$KC_ADMIN_USER&password=$KC_ADMIN_PASS" \
+        | jq -r '.access_token // empty')
+    [ -n "$ADMIN_TOKEN" ] || fail "Falha obtendo admin token"
+}
+
+auth() { curl -sf -H "Authorization: Bearer $ADMIN_TOKEN" "$@"; }
+
+# ---- Limpa estado prévio do user para garantir que o flow rode de novo ----
+
+reset_user_federated_identity() {
+    local username="$1"
+    local user_id
+    user_id=$(auth "$KC_URL/admin/realms/$TARGET_REALM/users?username=$username&exact=true" \
+        | jq -r '.[0].id // empty')
+    [ -n "$user_id" ] || { warn "user '$username' não existe no realm"; return; }
+    auth -X DELETE "$KC_URL/admin/realms/$TARGET_REALM/users/$user_id/federated-identity/$IDP_ALIAS" 2>/dev/null || true
+}
+
+# ---- Roda o flow first-broker-login com mock IdP via curl -----------------
+#
+# Replica os 5 hops que um browser faria:
+#   1. GET authorize no realm unifesspa (kc_idp_hint=govbr-mock)
+#   2. POST login form do realm fake (mock user)
+#   3. GET broker callback no realm unifesspa (consome o code do mock)
+#   4. POST submitAction=linkAccount (idp-confirm-link)
+#   5. POST credenciais do user existente (re-auth do flow Account verification)
+#
+# Aceita como entrada o CPF de 11 dígitos (login no mock) e a credencial
+# do user existente no realm (username + senha) para a etapa de re-auth.
+
+run_broker_flow() {
+    local mock_cpf="$1" reauth_username="$2" reauth_password="$3"
+    local cookies state s1 s3 s4 s5 a1 loc a3 a4 page3 page4 page5
+
+    cookies=$(mktemp)
+    s1=$(mktemp); s3=$(mktemp); s4=$(mktemp); s5=$(mktemp)
+    state="smoke-$(date +%s%N)"
+
+    log "Hop 1 — GET authorize no '$TARGET_REALM' (kc_idp_hint=$IDP_ALIAS)"
+    curl -sf -c "$cookies" -L -o "$s1" \
+        "$KC_URL/realms/$TARGET_REALM/protocol/openid-connect/auth?client_id=$CLIENT_ID&redirect_uri=$(printf '%s' "$REDIRECT_URI" | jq -sRr @uri)&response_type=code&scope=openid&state=$state&kc_idp_hint=$IDP_ALIAS&code_challenge=$PKCE_CHALLENGE&code_challenge_method=S256"
+    a1=$(grep -oE 'action="[^"]*authenticate[^"]*"' "$s1" | head -1 | sed 's/^action="//; s/"$//; s/&amp;/\&/g')
+    [ -n "$a1" ] || fail "login form action ausente após Hop 1"
+
+    log "Hop 2 — POST login form no '$MOCK_REALM' (user=$mock_cpf)"
+    loc=$(curl -sf -b "$cookies" -c "$cookies" -o /dev/null -w "%{redirect_url}" \
+        -X POST "$a1" \
+        --data-urlencode "username=$mock_cpf" \
+        --data-urlencode "password=$MOCK_USER_PASSWORD" \
+        --data-urlencode "credentialId=")
+    [ -n "$loc" ] || fail "login do mock não retornou redirect (credenciais erradas?)"
+
+    log "Hop 3 — GET broker callback (cpf-matcher executa aqui)"
+    curl -sf -b "$cookies" -c "$cookies" -L -o "$s3" "$loc"
+    page3=$(grep -oE 'data-page-id="[^"]*"' "$s3" | head -1 | sed 's/^.*="//; s/"$//')
+    case "$page3" in
+        login-login-idp-link-confirm)
+            ok "matcher achou user existente — caiu no idp-confirm-link"
+            ;;
+        login-update-profile)
+            ok "matcher não achou user — caiu em update-profile (criação de user novo)"
+            rm -f "$cookies" "$s1" "$s3" "$s4" "$s5"
+            return 0
+            ;;
+        *)
+            warn "Hop 3 caiu em página inesperada: $page3"
+            return 1
+            ;;
+    esac
+
+    a3=$(grep -oE 'action="[^"]*first-broker-login[^"]*"' "$s3" | head -1 | sed 's/^action="//; s/"$//; s/&amp;/\&/g')
+    [ -n "$a3" ] || fail "action do confirm-link ausente"
+
+    log "Hop 4 — POST submitAction=linkAccount"
+    curl -sf -b "$cookies" -c "$cookies" -L -o "$s4" -X POST "$a3" \
+        --data-urlencode "submitAction=linkAccount" || true
+    page4=$(grep -oE 'data-page-id="[^"]*"' "$s4" | head -1 | sed 's/^.*="//; s/"$//')
+    if [ "$page4" != "login-login" ]; then
+        warn "Hop 4 caiu em página inesperada: $page4"
+    fi
+
+    a4=$(grep -oE 'action="[^"]*"' "$s4" | head -1 | sed 's/^action="//; s/"$//; s/&amp;/\&/g')
+    [ -n "$a4" ] || fail "action do re-auth ausente"
+
+    log "Hop 5 — POST re-auth (user=$reauth_username)"
+    curl -sf -b "$cookies" -c "$cookies" -L -o "$s5" -X POST "$a4" \
+        --data-urlencode "username=$reauth_username" \
+        --data-urlencode "password=$reauth_password" \
+        --data-urlencode "credentialId=" || true
+    page5=$(grep -oE 'data-page-id="[^"]*"' "$s5" | head -1 | sed 's/^.*="//; s/"$//' || echo "")
+    ok "Re-auth concluído (status final esperado: redirect; trailing 404 do callback é OK em curl sem JS)"
+
+    rm -f "$cookies" "$s1" "$s3" "$s4" "$s5"
+}
+
+# ---- Inspeções ------------------------------------------------------------
+
+show_user_cpf() {
+    local username="$1"
+    local user_id cpf
+    user_id=$(auth "$KC_URL/admin/realms/$TARGET_REALM/users?username=$username&exact=true" \
+        | jq -r '.[0].id // empty')
+    [ -n "$user_id" ] || { warn "user '$username' não existe"; return; }
+    cpf=$(auth "$KC_URL/admin/realms/$TARGET_REALM/users/$user_id" \
+        | jq -r '.attributes.cpf[0] // "(sem cpf)"')
+    printf '    cpf de %s no realm: %s\n' "$username" "$cpf" >&2
+}
+
+show_userinfo_via_ropc() {
+    local username="$1" password="$2"
+    local token resp
+    token=$(curl -s -X POST "$KC_URL/realms/$TARGET_REALM/protocol/openid-connect/token" \
+        -d "grant_type=password" -d "client_id=admin-cli" \
+        -d "scope=openid" \
+        -d "username=$username" -d "password=$password" \
+        | jq -r '.access_token // empty')
+    if [ -z "$token" ]; then
+        warn "ROPC falhou para '$username' (senha errada ou não autorizado)"
+        return
+    fi
+    resp=$(curl -sf -H "Authorization: Bearer $token" "$KC_URL/realms/$TARGET_REALM/protocol/openid-connect/userinfo")
+    printf '    userinfo de %s:\n' "$username" >&2
+    echo "$resp" | jq '{sub, preferred_username, name, cpf, email}' >&2
+}
+
+show_recent_matcher_logs() {
+    log "Logs do cpf-matcher (últimos 60s)"
+    docker logs --since 60s docker-keycloak-1 2>&1 \
+        | grep -E "CpfMatcher|cpf-matcher|broker.*matching" \
+        | tail -10 \
+        | sed 's/^/    /' >&2 || warn "(sem logs do matcher recentes)"
+}
+
+# ---- Cenários -------------------------------------------------------------
+
+scenario_autoheal() {
+    log "── Cenário AUTOHEAL — user manual sem LDAP, auto-heal persiste ──"
+
+    reset_user_federated_identity "autoheal-test"
+    show_user_cpf "autoheal-test"
+
+    run_broker_flow "09876543210" "autoheal-test" "Test!1234"
+    sleep 1
+
+    show_recent_matcher_logs
+    show_user_cpf "autoheal-test"
+    show_userinfo_via_ropc "autoheal-test" "Test!1234"
+}
+
+scenario_ldap_readonly() {
+    log "── Cenário LDAP_READONLY — auto-heal NÃO persiste (limitação documentada) ──"
+
+    local user_id
+    user_id=$(auth "$KC_URL/admin/realms/$TARGET_REALM/users?username=kevin.peixoto&exact=true" \
+        | jq -r '.[0].id // empty')
+    if [ -z "$user_id" ]; then
+        warn "Cenário ignorado — user 'kevin.peixoto' não existe (LDAP federation não configurada)."
+        warn "Rode 'scripts/setup-keycloak-dev.sh' antes para subir o LDAP sintético."
+        return 0
+    fi
+
+    reset_user_federated_identity "kevin.peixoto"
+    show_user_cpf "kevin.peixoto"
+
+    run_broker_flow "07094871422" "kevin.peixoto" "Changeme!123"
+    sleep 1
+
+    show_recent_matcher_logs
+    show_user_cpf "kevin.peixoto"
+    show_userinfo_via_ropc "kevin.peixoto" "Changeme!123"
+}
+
+# ---- Entry point ---------------------------------------------------------
+
+main() {
+    require jq
+    require curl
+    require docker
+
+    # SAFETY: o smoke depende do realm fake `govbr-mock` e do user de teste
+    # `autoheal-test` no realm `unifesspa`. Esses artefatos só existem em DEV.
+    if [[ "$KC_URL" != http://localhost:* ]] && [[ "$KC_URL" != http://127.0.0.1:* ]]; then
+        fail "smoke-test-cpf-matcher.sh é DEV ONLY — KC_URL='$KC_URL' não é localhost."
+    fi
+
+    obtain_admin_token
+
+    scenario_autoheal
+    echo
+    scenario_ldap_readonly
+    echo
+
+    log "Smoke test concluído."
+}
+
+main "$@"


### PR DESCRIPTION
## Resumo
- troca o serviço Keycloak do compose para a imagem publicada `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0`
- remove o volume local do JAR `cpf-matcher-1.0.0-SNAPSHOT.jar`, porque o provider já vem embutido na imagem versionada

## Validação
- `docker compose -f docker/docker-compose.yml config`
- `docker compose -f docker/docker-compose.yml pull keycloak`
- `git diff --check`

Refs #218