### PR TITLE
chore(docker): atualiza imagem Keycloak para 1.0.2

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       start_period: 30s
 
   keycloak:
-    image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.0
+    image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2
     restart: unless-stopped
     command: start-dev --import-realm
     environment:


### PR DESCRIPTION
## Summary

Bumpa o tag da imagem Keycloak no compose dev de `1.0.0` para `1.0.2`. Alinha o ambiente local com o que vai rodar em HML/PROD após o fix do CMD default.

## Por que

A v1.0.2 do `uniplus-keycloak` (publicada hoje) adiciona `CMD ["start"]` ao Dockerfile, eliminando o restart loop quando o operador esquece de declarar `command:` no compose. Detalhes: unifesspa-edu-br/uniplus-keycloak-providers#10.

Em DEV o `command: start-dev --import-realm` continua valendo como override legítimo. A nova imagem mantém o cpf-matcher SPI carregado normalmente.

A v1.0.1 foi pulada — release falhou por descompasso entre pom (1.0.0) e tag (v1.0.1); convenção é não reusar versões falhadas.

## Test plan

- [ ] CI verde (Build/Test/Coverage + gate `PR author is org member`)
- [ ] `docker compose -f docker/docker-compose.yml pull keycloak` puxa a 1.0.2
- [ ] `docker compose up -d keycloak` + `setup-keycloak-dev.sh` mantém comportamento igual ao validado na #218 (cpf-matcher carrega, smoke test passa)

Refs unifesspa-edu-br/uniplus-keycloak-providers#10
Refs #218
