### PR TITLE
chore(tests): atualiza ponteiros para ADRs canônicas em arquivos de teste

### DIFF
--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/SolutionNaoTemMediatRTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/SolutionNaoTemMediatRTests.cs
@@ -14,7 +14,7 @@ using ReflectionAssembly = System.Reflection.Assembly;
 /// <summary>
 /// Fitness function R4 da Story #138 — sentinela contra reintrodução do
 /// MediatR no <c>uniplus-api</c>. Pareada à Story #207 que removeu o pacote
-/// e migrou todos os slices para Wolverine puro (ADR-022). Falha no
+/// e migrou todos os slices para Wolverine puro (ADR-0003). Falha no
 /// momento em que qualquer assembly do produto introduzir uma dependência
 /// IL-level em <c>MediatR.*</c>, antes que a regressão chegue ao deploy.
 /// </summary>
@@ -43,7 +43,7 @@ public sealed class SolutionNaoTemMediatRTests
             .AndShould()
             .NotDependOnAnyTypesThat()
             .ResideInNamespace("MediatR")
-            .Because("MediatR foi removido do uniplus-api (Story #207, ADR-022) — toda mensageria CQRS roda sobre Wolverine via ICommandBus/IQueryBus.");
+            .Because("MediatR foi removido do uniplus-api (Story #207, ADR-0003) — toda mensageria CQRS roda sobre Wolverine via ICommandBus/IQueryBus.");
 
         rule.Check(ProductArchitecture);
     }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/WolverineMessagingServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/WolverineMessagingServiceCollectionExtensionsTests.cs
@@ -15,7 +15,7 @@ public class WolverineMessagingServiceCollectionExtensionsTests
     [Fact]
     public void AddWolverineMessaging_DeveRegistrarICommandBusComoWolverineCommandBus()
     {
-        // Protege o contrato da extension: ICommandBus (canônico do projeto, ADR-022)
+        // Protege o contrato da extension: ICommandBus (canônico do projeto, ADR-0003)
         // resolve para WolverineCommandBus, que é o único caminho aprovado para
         // delegar a Wolverine.IMessageBus. Se alguém remover a registração ou
         // trocar por outra implementação, este teste quebra antes do startup.

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Stage1ArchitectureRulesTests.cs
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Stage1ArchitectureRulesTests.cs
@@ -12,7 +12,7 @@ using ReflectionAssembly = System.Reflection.Assembly;
 /// <summary>
 /// Fitness tests stage 1 do modulo Ingresso, conforme ADR-023.
 /// R1 protege a comunicacao assincrona entre modulos definida pela ADR-004,
-/// R2 protege o encapsulamento Wolverine da ADR-022 e R3 protege a direcao
+/// R2 protege o encapsulamento Wolverine da ADR-0003 e R3 protege a direcao
 /// Clean Architecture definida pela ADR-002. O projeto Ingresso.Application foi
 /// removido na Story #207; por isso R2/R3 cobrem Domain e Infrastructure atuais.
 /// </summary>
@@ -42,7 +42,7 @@ public sealed class Stage1ArchitectureRulesTests
             .Should()
             .NotDependOnAnyTypesThat()
             .ResideInNamespaceMatching(@"^Wolverine(\.|$)")
-            .Because("ADR-022 limita Wolverine a Infrastructure.Core; Application.Abstractions e Domain dependem apenas das abstracoes do projeto.");
+            .Because("ADR-0003 limita Wolverine a Infrastructure.Core; Application.Abstractions e Domain dependem apenas das abstracoes do projeto.");
 
         rule.Check(WolverineGuardArchitecture);
     }

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseDomainEventsTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseDomainEventsTests.cs
@@ -7,7 +7,7 @@ using Unifesspa.UniPlus.Kernel.Domain.Events;
 
 // Cobre o contrato de drenagem de domain events do EntityBase. Foco nos
 // invariantes do método DequeueDomainEvents — padrão canônico para
-// handlers cascading do Wolverine (ADR-026).
+// handlers cascading do Wolverine (ADR-0005).
 public sealed class EntityBaseDomainEventsTests
 {
     [Fact(DisplayName = "DequeueDomainEvents retorna snapshot e esvazia a coleção do agregado")]

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/Stage1ArchitectureRulesTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/Stage1ArchitectureRulesTests.cs
@@ -12,7 +12,7 @@ using ReflectionAssembly = System.Reflection.Assembly;
 /// <summary>
 /// Fitness tests stage 1 do modulo Selecao, conforme ADR-023.
 /// R1 protege a comunicacao assincrona entre modulos definida pela ADR-004,
-/// R2 protege o encapsulamento Wolverine da ADR-022 e R3 protege a direcao
+/// R2 protege o encapsulamento Wolverine da ADR-0003 e R3 protege a direcao
 /// Clean Architecture definida pela ADR-002.
 /// </summary>
 public sealed class Stage1ArchitectureRulesTests
@@ -41,7 +41,7 @@ public sealed class Stage1ArchitectureRulesTests
             .Should()
             .NotDependOnAnyTypesThat()
             .ResideInNamespaceMatching(@"^Wolverine(\.|$)")
-            .Because("ADR-022 limita Wolverine a Infrastructure.Core; Application e Domain dependem apenas das abstracoes do projeto.");
+            .Because("ADR-0003 limita Wolverine a Infrastructure.Core; Application e Domain dependem apenas das abstracoes do projeto.");
 
         rule.Check(WolverineGuardArchitecture);
     }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
@@ -16,7 +16,7 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 // sem Wolverine, sem fixture, sem container. Asserta o contrato cascading
 // (retorno como <c>IEnumerable&lt;object&gt;</c> contendo o
 // <c>EditalPublicadoEvent</c> emitido pelo agregado) e o invariante
-// canônico da ADR-026: <c>DequeueDomainEvents</c> esvazia a coleção do
+// canônico da ADR-0005: <c>DequeueDomainEvents</c> esvazia a coleção do
 // agregado no mesmo ponto da drenagem.
 //
 // Trait dedicado <c>OutboxCascadingUnit</c> separa este do conjunto de
@@ -60,6 +60,6 @@ public sealed class CascadingHandlerUnitTests
         persistido.Should().NotBeNull(
             "SaveChangesAsync foi chamado dentro do handler — entidade deve estar materializada no contexto InMemory");
         persistido!.DomainEvents.Should().BeEmpty(
-            "padrão canônico do ADR-026: handler usa DequeueDomainEvents() para esvaziar a coleção do agregado no mesmo ponto da drenagem");
+            "padrão canônico do ADR-0005: handler usa DequeueDomainEvents() para esvaziar a coleção do agregado no mesmo ponto da drenagem");
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
@@ -17,7 +17,7 @@ using Unifesspa.UniPlus.Selecao.Domain.Events;
 using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
-// Cenários produtivos do outbox cascading (ADR-026). Equivalentes de
+// Cenários produtivos do outbox cascading (ADR-0005). Equivalentes de
 // produção dos cenários V8/V9 do Spike S10 (ver docs/spikes/158-s10-relatorio.md).
 //
 // Os dois testes têm dupla marcação `Category=OutboxCapability` +

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
@@ -13,7 +13,7 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 // MessageContext.EnqueueCascadingAsync. Como a chain está dentro de
 // EnrollDbContextInTransaction, Transaction != null e os envelopes são
 // gravados em wolverine_outgoing_envelopes na MESMA transação EF —
-// atomicidade write+evento (ADR-026).
+// atomicidade write+evento (ADR-0005).
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
@@ -15,7 +15,7 @@ using Unifesspa.UniPlus.Selecao.Domain.Events;
 using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
-// Cenário fim-a-fim do fluxo de referência ADR-026: HTTP request →
+// Cenário fim-a-fim do fluxo de referência ADR-0005: HTTP request →
 // PublicarEditalCommand → handler convention-based produtivo → Edital.Publicar()
 // emite EditalPublicadoEvent via AddDomainEvent → handler retorna
 // (Result, IEnumerable<object>) com o evento drenado por


### PR DESCRIPTION
Closes #236

## Resumo

- Continua o cleanup da Story #230 (PR #233) em arquivos de teste: `ADR-022` → **ADR-0003** (Wolverine como backbone CQRS) e `ADR-026` → **ADR-0005** (cascading messages).
- 13 ocorrências em 9 arquivos de `tests/` — apenas comentários e mensagens descritivas em `.Because(...)`/comentários inline. Zero código funcional alterado, nenhum predicate ArchUnitNET tocado.

## Motivação

A #230 (PR #233) estabeleceu como CA o `grep -rn "uniplus-docs" src/` vazio e `grep -rn "ADR-022\|ADR-024\|ADR-025\|ADR-026" src/` vazio — escopo limitado a `src/` + `CLAUDE.md`. Durante o review do #233 identificou-se drift residual em `tests/` que o reviewer julgou não-bloqueante para aquele PR. Esta issue (#236) finaliza a renumeração.

| Antiga | Canônica |
|---|---|
| ADR-022 — Wolverine como backbone CQRS | **ADR-0003** |
| ADR-026 — Cascading messages como drenagem | **ADR-0005** |

## Mudanças

### ArchTests (3 arquivos, 6 ocorrências) — `ADR-022` → `ADR-0003`

- `tests/Unifesspa.UniPlus.Ingresso.ArchTests/Stage1ArchitectureRulesTests.cs` (linhas 15, 45)
- `tests/Unifesspa.UniPlus.Selecao.ArchTests/Stage1ArchitectureRulesTests.cs` (linhas 15, 44)
- `tests/Unifesspa.UniPlus.ArchTests/SolutionRules/SolutionNaoTemMediatRTests.cs` (linhas 17, 46)

Trocas em XML doc e nas mensagens `.Because(...)` que documentam por que cada regra existe — o ArchUnitNET usa essas strings em mensagens de falha, mas elas não fazem parte do predicate; as 7 fitness rules continuam verdes.

### UnitTests (2 arquivos, 2 ocorrências)

- `tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseDomainEventsTests.cs` (linha 10) — `ADR-026` → `ADR-0005`.
- `tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/WolverineMessagingServiceCollectionExtensionsTests.cs` (linha 18) — `ADR-022` → `ADR-0003`.

### IntegrationTests (4 arquivos, 5 ocorrências) — `ADR-026` → `ADR-0005`

- `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs` (linha 16)
- `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs` (linha 18)
- `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs` (linha 20)
- `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs` (linhas 19, 63)

## Plano de testes

- [x] `grep -rn "ADR-022\|ADR-024\|ADR-025\|ADR-026" tests/` — vazio.
- [x] `dotnet build UniPlus.slnx` — 0 warnings, 0 erros.
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` — 240 testes verdes (Kernel: 51, Application.Abstractions: 4, Infrastructure.Core: 185, ArchTests: 1, Selecao.ArchTests: 3, Ingresso.ArchTests: 3 — incluindo as 3 fitness rules cuja `.Because(...)` foi tocada).
- [ ] CI roda a suíte completa, incluindo `IntegrationTests` (Testcontainers).

## Estatísticas

- **9 arquivos** alterados, **13 insertions, 13 deletions** — apenas comentários, zero código funcional.

## Checklist

- [x] Build sem erros, sem warnings novos.
- [x] Testes não-integration passando localmente.
- [x] `grep` confirma `tests/` limpo.
- [ ] CI verde.
- [ ] Aprovação cross-account.