### PR TITLE
docs(adrs): adiciona ADR-0019 — proibir PII em path segments de URL

### DIFF
--- a/docs/adrs/0019-proibir-pii-em-path-segments-de-url.md
+++ b/docs/adrs/0019-proibir-pii-em-path-segments-de-url.md
@@ -1,0 +1,98 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0019: Proibir PII em path segments de URL
+
+## Contexto e enunciado do problema
+
+A LGPD (Lei 13.709/2018, Art. 6º inciso VII) exige medidas técnicas que evitem a exposição de dados pessoais em processamento acessório — incluindo logs, sinks downstream e qualquer trânsito de URL fora do controle direto da aplicação. Em APIs REST, há uma diferença prática entre dados em **query string** e dados em **path segments** quanto à superfície de vazamento.
+
+O `RequestLoggingMiddleware` do `uniplus-api` mascara apenas valores de query string via `QueryStringMasker` (ADR-0011 cobre o lado de logs estruturados). Esse controle é compensatório: roda dentro do pipeline ASP.NET, depois que a request já passou por camadas anteriores. Quando a PII vai no caminho — por exemplo `GET /candidatos/{cpf}` — vaza fatalmente em vetores que o middleware **não** alcança:
+
+- access logs do nginx / proxy reverso, antes de qualquer middleware da aplicação;
+- WAF, CDN e load balancer (AWS ALB, Cloudflare, etc.), que costumam logar `request_uri` por padrão;
+- cabeçalho `Referer`, transmitido pelo navegador a terceiros quando o usuário clica em links externos a partir da página;
+- histórico do navegador, ferramentas de rede e qualquer print/share da URL.
+
+A discussão se origina no review do PR #119 (RequestLoggingMiddleware com PII masking) e no PR #233, que removeu um cross-link cosmético em código-fonte porque a regra precisava ser fixada como ADR canônica do `uniplus-api`. A regra já é seguida na prática nos slices entregues (rotas usam `Guid` como identificador opaco em todos os módulos). Esta ADR formaliza a regra como decisão arquitetural enforçável, não dependente de disciplina ad hoc por code review.
+
+## Drivers da decisão
+
+- Conformidade LGPD por construção, removendo o vazamento na origem em vez de mascarar a posteriori.
+- Defesa em profundidade — query string já tem masking via `QueryStringMasker`, mas path não tem nem como tê-lo de forma efetiva (camadas anteriores).
+- Auditabilidade: access logs de infra (nginx, WAF, CDN) precisam ficar livres de PII para que possam ser arquivados, exportados e analisados sem tratamento adicional.
+- Alinhamento com a Lei 14.129/2021 (Governo Digital) e com o princípio da minimização de dados.
+- Evitar acoplar a confidencialidade de PII ao cabeçalho `Referer` do navegador, que escapa do nosso controle.
+
+## Opções consideradas
+
+- Path segments com identificadores opacos (UUID); PII só em query string ou body.
+- Path segments com PII e masking adicional via middleware do `uniplus-api`.
+- Path segments com PII criptografada ou hasheada.
+- Apenas comentário/convenção informal, sem ADR formal.
+
+## Resultado da decisão
+
+**Escolhida:** path segments com identificadores opacos (UUID); PII só em query string (mascarada por `QueryStringMasker`) ou no corpo da requisição.
+
+A regra vale para **todos os módulos** do Uni+ — Seleção, Ingresso e quaisquer módulos futuros — em qualquer API REST exposta interna ou externamente. Identificadores de recursos de domínio são tipados como `Guid` (UUID v4 ou v7) e roteados em path segments (`GET /candidatos/{id}`); valores como CPF, e-mail, nome, RG, telefone, número de matrícula e demais dados pessoais nunca aparecem como segmento de caminho. Quando a operação requer lookup por dado pessoal (caso típico: busca de candidato pelo CPF), o dado vai em query string ou body de uma rota cujo path é fixo (por exemplo `POST /candidatos/buscar` com CPF no body, ou `GET /candidatos?cpf={cpf}` ciente de que a query string será mascarada nos logs estruturados).
+
+Esta decisão é **preventiva**: evita gerar a PII no path em primeiro lugar. Difere do `QueryStringMasker` (ADR-0011 do lado de logs / ADR de pipeline), que é **compensatório** — protege o que a aplicação loga, mas não o que nginx/WAF/CDN logam antes de a request chegar ao código.
+
+## Consequências
+
+### Positivas
+
+- Zero PII em access logs de nginx, WAF, CDN e load balancer — sem necessidade de configurar masking nessas camadas.
+- Zero PII em cabeçalho `Referer` enviado a terceiros.
+- Zero PII em histórico de navegador, screenshots de URL e ferramentas de rede.
+- Conformidade LGPD por construção — não dá para "esquecer de mascarar" porque o dado nunca esteve no path.
+- Reduz a superfície de auditoria: logs de infra podem ser exportados/arquivados sem etapa adicional de tratamento de PII.
+
+### Negativas
+
+- Lookups por PII deixam de ser `GET /recurso/{pii}` e passam a `POST /recurso/buscar` (com PII no body) ou `GET /recurso?atributo={pii}` (com query string mascarada). Trade-off deliberado: prefere-se semântica de rota menos óbvia a vazamento estrutural.
+- Design de rotas exige disciplina — quem desenha a API precisa pensar em identificadores opacos desde o início.
+- Eventuais redirects de sistemas legados (COC, UDOCS) que usavam PII em path precisam de tradução na borda de integração.
+
+### Riscos
+
+- Rota legada introduzindo PII em path passar pelo review e chegar a produção. Mitigação: code review enforça; planeja-se uma fitness rule (ArchUnitNET, ADR-0012) varrendo controllers/minimal APIs e sinalizando parâmetros de path tipados como `Cpf`, `Email`, `string` com nome sugestivo (`cpf`, `email`, `nome`).
+
+## Confirmação
+
+- Code review enforça a regra em todo PR que adiciona ou altera roteamento.
+- O `<remarks>` do `RequestLoggingMiddleware` referencia esta ADR como ponteiro acionável a partir do código.
+- Sugestão de evolução: fitness rule arquitetural (ArchUnitNET) reprovando tipos como `Cpf`/`Email` em parâmetros de rota anotados como `[FromRoute]` ou em templates de minimal API. Item rastreado fora desta ADR.
+
+## Prós e contras das opções
+
+### Path segments com PII e masking via middleware
+
+- Bom, porque mantém a semântica de rota REST tradicional (`/recurso/{id-natural}`).
+- Ruim, porque masking só roda dentro do pipeline ASP.NET — nginx, WAF, CDN e `Referer` não são alcançados. Resolve o sintoma errado (logs da app) deixando a doença (URL com PII) intacta.
+
+### Path segments com PII criptografada ou hasheada
+
+- Bom, porque o dado claro nunca aparece no canal externo.
+- Ruim, porque adiciona complexidade desproporcional (chave, rotação, KMS), continua deixando o token único em `Referer` (rastreável), e não resolve o caso de o token derivado ser reversível por dicionário (CPF tem espaço enumerável).
+
+### Apenas comentário/convenção informal, sem ADR formal
+
+- Bom, porque é leve.
+- Ruim, porque sem documento canônico no `docs/adrs/` a regra depende de memória institucional. Já houve cross-link removido em código (PR #233) por não haver alvo estável para apontar.
+
+## Mais informações
+
+- ADR-0011 — Mascaramento de CPF em logs via enricher Serilog (peer arquitetural; cobre o lado de logs estruturados, complementar a esta ADR).
+- ADR-0012 — ArchUnitNET como biblioteca canônica de fitness tests (caminho para a fitness rule sugerida na seção Confirmação).
+- LGPD (Lei 13.709/2018), Art. 6º inciso VII e Art. 46.
+- Lei 14.129/2021 — Governo Digital.
+- Issue origem (cross-repo): `unifesspa-edu-br/uniplus-docs#68`.
+- Issue espelho deste repositório: #234.
+- PR #119 — finding I1 da revisão do `RequestLoggingMiddleware`, que originou a discussão.
+- PR #233 — removeu cross-link cosmético em `RequestLoggingMiddleware` por política de código-fonte; esta ADR substitui o ponteiro removido.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -47,6 +47,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0016](0016-keycloak-como-identity-provider.md) | Keycloak como identity provider OIDC do `uniplus-api` | accepted | 2026-04-28 |
 | [0017](0017-kubernetes-com-helm-para-orquestracao.md) | Kubernetes com Helm para orquestração do `uniplus-api` | accepted | 2026-04-28 |
 | [0018](0018-opentelemetry-para-instrumentacao-do-backend.md) | OpenTelemetry para instrumentação do `uniplus-api` | accepted | 2026-04-28 |
+| [0019](0019-proibir-pii-em-path-segments-de-url.md) | Proibir PII em path segments de URL | accepted | 2026-05-01 |
 
 ## Como adicionar um novo ADR
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Middleware/RequestLoggingMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Middleware/RequestLoggingMiddleware.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Options;
 /// Mascara valores de query string via <see cref="QueryStringMasker"/>, mas não segmentos
 /// de path — PII em path segments vaza em camadas anteriores ao middleware (nginx, WAF, CDN,
 /// cabeçalho Referer). Rotas devem usar identificadores opacos (UUID), nunca dados sensíveis
-/// em path.
+/// em path. Ver ADR-0019.
 /// </remarks>
 public sealed partial class RequestLoggingMiddleware
 {


### PR DESCRIPTION
## Resumo

Adiciona a ADR-0019, formalizando a regra arquitetural de nunca usar dados protegidos pela LGPD (CPF, e-mail, nome, RG, etc.) em path segments de URL em qualquer API do Uni+. Identificadores de recursos em rotas usam UUID; PII só em query string (mascarada por `QueryStringMasker`) ou body.

## Motivação

Durante o review do PR #119 ficou claro que o `QueryStringMasker` cobre apenas query strings. Path segments com PII vazam em vetores fora do alcance do middleware:

- access logs do nginx / proxy reverso (antes do middleware da app);
- WAF, CDN, load balancer;
- cabeçalho `Referer` (transmitido a terceiros em links externos);
- histórico do navegador, screenshots e ferramentas de rede.

Masking na aplicação é controle compensatório; a ADR fecha o problema na origem como controle preventivo (security by design). O PR #233 removeu um cross-link cosmético em código apontando para `uniplus-docs#68` por política de não vincular código-fonte a `uniplus-docs` — esta ADR substitui o ponteiro removido.

A regra já é seguida na prática (todos os slices entregues usam `Guid` como identificador opaco), por isso `status: accepted` e não `proposed`.

## Mudanças

- **Cria** `docs/adrs/0019-proibir-pii-em-path-segments-de-url.md` (MADR 4.0).
- **Atualiza** `docs/adrs/README.md` com a entrada da ADR-0019 no índice.
- **Recoloca** ponteiro `Ver ADR-0019` no `<remarks>` de `RequestLoggingMiddleware` (`src/shared/Unifesspa.UniPlus.Infrastructure.Core/Middleware/RequestLoggingMiddleware.cs`).

## Plano de testes

- [x] `bash tools/adr-lint/validate.sh` — 19 ADRs validados sem erros.
- [x] `npx markdownlint-cli2 'docs/adrs/**/*.md'` — 0 erros.
- [x] `dotnet build UniPlus.slnx` — 0 avisos, 0 erros.
- [x] `grep "ADR-0019" src/shared/Unifesspa.UniPlus.Infrastructure.Core/Middleware/RequestLoggingMiddleware.cs` — ponteiro presente no `<remarks>`.

## Checklist

- [x] ADR no padrão MADR 4.0 com frontmatter `status`/`date`/`decision-makers` e seções fixas.
- [x] Contexto documenta vetores de vazamento (nginx, WAF, CDN, Referer, histórico).
- [x] Alternativas registradas: path masking via middleware, criptografia/hash, convenção informal.
- [x] Consequências cobrem positivos, trade-offs negativos e riscos com mitigação.
- [x] Confirmação aponta para code review e fitness rule futura (ArchUnitNET, ADR-0012).
- [x] Linter ADR + markdownlint + build verdes.
- [x] Sem PII real em qualquer parte do texto.

Closes #234