### PR TITLE
docs(keycloak): documenta imagem composta uniplus-keycloak nas docs e ADRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - **Mensageria:** Apache Kafka 4.2 (KRaft)
 - **Cache:** Redis 8
 - **Storage:** MinIO (S3-compatible)
-- **Autenticação:** Keycloak 26.5 (Gov.br)
+- **Autenticação:** Keycloak 26.5 (Gov.br) — imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.x` (base `26.5.7` + JAR `cpf-matcher` embutido). Não é Keycloak vanilla. Detalhes em [`docker/keycloak/README.md`](docker/keycloak/README.md#imagem-do-keycloak)
 - **CQRS/messaging:** Wolverine 5.x ([ADR-0003](docs/adrs/0003-wolverine-como-backbone-cqrs.md)) — abstrações `ICommandBus` e `IQueryBus` em `Application.Abstractions/Messaging`. Validação e logging do pipeline aplicados como middleware Wolverine (`WolverineValidationMiddleware`, `WolverineLoggingMiddleware` em `Infrastructure.Core/Messaging/Middleware`). Outbox transacional sobre EF Core / PostgreSQL ([ADR-0004](docs/adrs/0004-outbox-transacional-via-wolverine.md)); drenagem de domain events via cascading messages ([ADR-0005](docs/adrs/0005-cascading-messages-para-drenagem-de-domain-events.md)).
 - **Validação:** FluentValidation 12
 - **Logging:** Serilog 10

--- a/docker/keycloak/README.md
+++ b/docker/keycloak/README.md
@@ -10,6 +10,48 @@ Isso mantém a configuração de autenticação e autorização do projeto padro
 
 > ⚠️ **Apenas para ambiente local.** Este realm contém credenciais de teste e configurações voltadas para desenvolvimento. Nunca importar este arquivo em homologação ou produção.
 
+## Imagem do Keycloak
+
+O Uni+ **não** usa a imagem oficial Keycloak vanilla. A imagem consumida em todos os ambientes (dev, CI, HML, PROD) é a composta publicada pelo repo [`unifesspa-edu-br/uniplus-keycloak-providers`](https://github.com/unifesspa-edu-br/uniplus-keycloak-providers):
+
+```text
+ghcr.io/unifesspa-edu-br/uniplus-keycloak
+```
+
+Componentes:
+
+- **Base:** `quay.io/keycloak/keycloak:26.5.7`
+- **JAR `cpf-matcher-*.jar`** embutido em `/opt/keycloak/providers/` — Authenticator Java SPI custom que resolve auto-link por CPF no first-broker-login do gov.br (ver [ADR-0020](../../docs/adrs/0020-identity-brokering-govbr.md))
+
+### Tags publicadas
+
+| Tag | Quando usar |
+|---|---|
+| `1.0.2` | Pinning patch fixo — usado pelo `docker-compose.yml` deste repo |
+| `1.0` | Float dentro do minor `1.0.x` |
+| `1.x` | Float dentro do major `1.x.y` — recomendado para CI/Testcontainers (pega patches automaticamente) |
+| `latest` | Disponível, mas evitar em ambientes reproduzíveis (compose, CI) |
+
+A imagem é **pública** — pull sem credenciais.
+
+### Política de pinning recomendada
+
+| Cenário | Tag recomendada | Por quê |
+|---|---|---|
+| `docker-compose.yml` (dev local) | Patch fixo (`1.0.2`) | Reproducibilidade entre devs do time; mudança de versão é commit explícito e revisável |
+| CI / Testcontainers | Float minor (`1.x`) | Patches absorvidos automaticamente; cold start de pull em PR vale o trade-off |
+| HML / PROD (Helm) | Patch fixo | Atualização controlada via PR de chart |
+
+### Ciclo de release
+
+Push de tag `v*.*.*` no repo `unifesspa-edu-br/uniplus-keycloak-providers` dispara o workflow `release.yml`, que:
+
+1. Builda o JAR via Maven 3.9 / Eclipse Temurin 21
+2. Publica o JAR no GitHub Release (artefato auditável)
+3. Builda e publica a imagem composta no GHCR com tags semver (`1.0.2`, `1.0`, `1.x`, `latest`)
+
+Para devs do `uniplus-api` consumirem uma versão nova, basta atualizar a tag em `docker-compose.yml` (e Helm em HML/PROD). **Não há build manual de JAR para devs/operadores** — o consumo padrão é puxar a imagem pronta. O JAR continua publicado no Release apenas como artefato de auditoria.
+
 ## Como subir
 
 ```bash
@@ -265,7 +307,7 @@ A configuração desse flow é idempotente e vive em `scripts/setup-cpf-matcher-
 
 | Script | DEV | HML/PRD | O que faz |
 |---|---|---|---|
-| `build-keycloak-providers.sh` | ✅ | — | Builda o JAR `cpf-matcher` via Maven em container. Em HML/PRD o JAR vem por Helm/CI |
+| `build-keycloak-providers.sh` | opcional | — | Builda o JAR `cpf-matcher` via Maven em container. **Não é mais necessário no fluxo padrão** — a imagem composta `ghcr.io/.../uniplus-keycloak` já traz o JAR embutido. Útil apenas para iterar localmente no SPI quando se contribui no repo `uniplus-keycloak-providers`. Em HML/PRD o JAR vem na imagem |
 | `setup-cpf-matcher-flow.sh` | ✅ (via dev) | ✅ | Cria o flow `first broker login com cpf` e aponta IdPs para ele. Idempotente, agnóstico de ambiente |
 | `setup-keycloak-dev.sh` | ✅ | ❌ | Orquestrador DEV: LDAP sintético, admin-cli ROPC, flow custom, mock IdP. **Não rodar em HML/PRD** |
 | `setup-govbr-idp.sh` | (estrutural) | ✅ | Configura IdP gov.br staging/produção real. Em DEV é apenas estrutural — gov.br não aceita localhost |
@@ -277,20 +319,14 @@ A configuração desse flow é idempotente e vive em `scripts/setup-cpf-matcher-
 O ambiente de desenvolvimento usa um **segundo realm no mesmo Keycloak** (`govbr-mock`) como simulador do gov.br. Isso permite exercitar todo o flow do cpf-matcher localmente, sem depender do gov.br staging (que não aceita `localhost` como redirect URI).
 
 ```bash
-# 1. (uma vez) Clonar o repositório irmão dos SPIs
-cd repositories
-git clone https://github.com/unifesspa-edu-br/uniplus-keycloak-providers.git
-
-# 2. Build do JAR cpf-matcher
-cd uniplus-api
-scripts/build-keycloak-providers.sh cpf-matcher
-
-# 3. Sobe a stack (compose já monta o JAR no Keycloak)
+# 1. Sobe a stack (a imagem ghcr.io/.../uniplus-keycloak:1.0.2 já traz o JAR embutido)
 docker compose -f docker/docker-compose.yml up -d
 
-# 4. Setup completo do realm DEV — flow custom + LDAP sintético + mock IdP
+# 2. Setup completo do realm DEV — flow custom + LDAP sintético + mock IdP
 scripts/setup-keycloak-dev.sh
 ```
+
+> Não é mais necessário clonar `uniplus-keycloak-providers` lado a lado nem rodar `build-keycloak-providers.sh` — o JAR `cpf-matcher` está embutido na imagem composta consumida pelo `docker-compose.yml`. Ver bloco "Imagem do Keycloak" no início deste README. O script `build-keycloak-providers.sh` continua existindo para iterar localmente no SPI quando você for contribuir no repo de providers — fora desse caso, ignorar.
 
 Após isso, o realm `unifesspa` tem dois IdPs apontando para o flow custom:
 - `govbr` (gov.br staging real — só fica funcional se `setup-govbr-idp.sh` for rodado com credenciais reais)
@@ -331,7 +367,7 @@ A validação E2E contra o gov.br staging acontece no Keycloak HML institucional
 
 > ⚠️ O Keycloak HML é **realm compartilhado** com outros sistemas (`ficha_facil`, `sisplad`). Os scripts abaixo só tocam recursos especificamente vinculados ao gov.br + cpf-matcher. **Nunca rodar `setup-keycloak-dev.sh` ou `setup-govbr-mock.sh` em HML.**
 
-Pré-requisito: o JAR do `cpf-matcher` precisa estar em `/opt/keycloak/providers/` na imagem do Keycloak HML (responsabilidade do pipeline Helm/CI — issue separada).
+Pré-requisito: o Keycloak HML precisa estar rodando a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.x` (que já traz o JAR `cpf-matcher` embutido em `/opt/keycloak/providers/`). O pipeline Helm/CI institucional cuida do deploy da imagem — issue separada.
 
 ```bash
 # Variáveis de ambiente HML

--- a/docker/keycloak/README.md
+++ b/docker/keycloak/README.md
@@ -367,7 +367,7 @@ A validação E2E contra o gov.br staging acontece no Keycloak HML institucional
 
 > ⚠️ O Keycloak HML é **realm compartilhado** com outros sistemas (`ficha_facil`, `sisplad`). Os scripts abaixo só tocam recursos especificamente vinculados ao gov.br + cpf-matcher. **Nunca rodar `setup-keycloak-dev.sh` ou `setup-govbr-mock.sh` em HML.**
 
-Pré-requisito: o Keycloak HML precisa estar rodando a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.x` (que já traz o JAR `cpf-matcher` embutido em `/opt/keycloak/providers/`). O pipeline Helm/CI institucional cuida do deploy da imagem — issue separada.
+Pré-requisito: o Keycloak HML precisa estar rodando a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak` em **patch pinado** (ex.: `1.0.2`), conforme a política descrita no bloco "Imagem do Keycloak" deste README — HML/PROD nunca usam float (`1.x`/`latest`), para garantir reprodutibilidade e atualização controlada via PR de chart. A imagem já traz o JAR `cpf-matcher` embutido em `/opt/keycloak/providers/`. O pipeline Helm/CI institucional cuida do deploy da imagem — issue separada.
 
 ```bash
 # Variáveis de ambiente HML

--- a/docs/adrs/0016-keycloak-como-identity-provider.md
+++ b/docs/adrs/0016-keycloak-como-identity-provider.md
@@ -50,6 +50,8 @@ TokenValidationParameters
 
 A integração federada com Gov.br é configurada no Keycloak via Identity Provider externo (OIDC) — esta ADR cobre apenas o lado do `uniplus-api` como resource server. A configuração do brokering gov.br (alias, mappers, flow customizado de first-broker-login com SPI `cpf-matcher`, `client_id` por hostname, `client_secret_basic`) é detalhada na ADR-0020.
 
+> **Imagem do Keycloak.** Em todos os ambientes (dev, CI, HML, PROD) o Uni+ usa a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.x` — base `quay.io/keycloak/keycloak:26.5.7` + JAR `cpf-matcher` embutido. Não é Keycloak vanilla. O artefato e o ciclo de release vivem no repo `unifesspa-edu-br/uniplus-keycloak-providers` e a documentação de consumo está em [`docker/keycloak/README.md`](../../docker/keycloak/README.md#imagem-do-keycloak).
+
 ## Consequências
 
 ### Positivas

--- a/docs/adrs/0020-identity-brokering-govbr.md
+++ b/docs/adrs/0020-identity-brokering-govbr.md
@@ -11,7 +11,7 @@ decision-makers:
 
 A plataforma Uni+ é o sistema institucional de identificação digital e controle de acesso aos serviços digitais da Unifesspa. O Keycloak (ADR-0016) atua como provedor central de identidade do `uniplus-api`, mas o lado de federação externa não estava detalhado: a ADR-0016 menciona "federação com Gov.br via padrão OIDC" sem especificar a estratégia de brokering, deixando configuração de realm, mappers e flows sujeita a re-decisão a cada implementação.
 
-A Story `uniplus-api#218` (cpf-matcher SPI) foi entregue em 01/05/2026 (PR #228 mergeado): SPI publicada na v1.0.0, smoke E2E ok, integração funcional do Keycloak com gov.br via Identity Provider OIDC e flow customizado de first-broker-login. Esta ADR formaliza a decisão arquitetural por trás da entrega.
+A Story `uniplus-api#218` (cpf-matcher SPI) foi entregue em 01/05/2026 (PR #228 mergeado): SPI publicada na v1.0.2, smoke E2E ok, integração funcional do Keycloak com gov.br via Identity Provider OIDC e flow customizado de first-broker-login. O artefato canônico de consumo é a **imagem Docker composta** `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.x` (base `quay.io/keycloak/keycloak:26.5.7` + JAR `cpf-matcher` embutido em `/opt/keycloak/providers/`), publicada pelo repo `unifesspa-edu-br/uniplus-keycloak-providers` a cada tag `v*.*.*`. O fluxo antigo (clonar o repo de providers lado a lado, buildar o JAR via Maven e fazer mount como volume) está obsoleto — devs e operadores apenas consomem a imagem pronta. O JAR continua sendo publicado no GitHub Release como artefato auditável. Esta ADR formaliza a decisão arquitetural por trás da entrega.
 
 A integração precisa atender:
 
@@ -100,7 +100,7 @@ Ao primeiro login via gov.br, executa-se um flow customizado clonado de `First B
 3. Se encontrar, **vincula automaticamente** a conta do gov.br ao usuário existente, sem confirmação por e-mail.
 4. Se não encontrar, **cria automaticamente** novo usuário no realm, com `cpf`, `email`, `firstName`, `lastName` e role `candidato`.
 
-A SPI `cpf-matcher` foi publicada na v1.0.0 e validada por smoke E2E na entrega da Story #218. Fluxo padrão do Keycloak usa **e-mail** como chave de matching, o que falha quando o candidato muda de e-mail entre processos seletivos — CPF é estável e já garantido único pela RN01.
+A SPI `cpf-matcher` foi publicada na v1.0.2 e validada por smoke E2E na entrega da Story #218. Fluxo padrão do Keycloak usa **e-mail** como chave de matching, o que falha quando o candidato muda de e-mail entre processos seletivos — CPF é estável e já garantido único pela RN01.
 
 ### Configurações operacionais
 
@@ -139,7 +139,7 @@ A SPI `cpf-matcher` foi publicada na v1.0.0 e validada por smoke E2E na entrega 
 
 ## Confirmação
 
-- SPI `cpf-matcher` v1.0.0 publicada e validada por smoke E2E na entrega da Story #218.
+- SPI `cpf-matcher` v1.0.2 publicada (como JAR no GitHub Release e embutido na imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2`) e validada por smoke E2E na entrega da Story #218.
 - Suíte de smoke executa fluxo completo (autorize → callback → first-broker-login → token no `uniplus-api`) contra realm de homologação, sem PII real.
 - Health check `/health/auth` valida que a chave pública do realm é acessível e que validação de token simulado passa.
 - ADR-0016 referencia esta ADR na seção `Mais informações` como ponteiro acionável.
@@ -181,4 +181,5 @@ A SPI `cpf-matcher` foi publicada na v1.0.0 e validada por smoke E2E na entrega 
 - Documentação Identidade Digital para Gestores Públicos: [gov.br/governodigital — identidade digital](https://www.gov.br/governodigital/pt-br/identidade/identidade-digital-para-gestores-publico).
 - Story de implementação: #218 (cpf-matcher SPI integrado, mergeada via PR #228).
 - Issue espelho deste repositório: #231.
+- Repositório que builda e publica a imagem composta + JAR: [`unifesspa-edu-br/uniplus-keycloak-providers`](https://github.com/unifesspa-edu-br/uniplus-keycloak-providers) — workflow `release.yml` dispara em tag `v*.*.*` e publica em GHCR (`ghcr.io/unifesspa-edu-br/uniplus-keycloak`) com tags semver `1.0.2`, `1.0`, `1.x`, `latest`. Política de pinning recomendada documentada em [`docker/keycloak/README.md`](../../docker/keycloak/README.md#imagem-do-keycloak).
 - **Origem:** revisão da ADR interna Uni+ ADR-029 (não publicada). Esta promoção mantém o escopo gov.br; a federação institucional via LDAP/AD para servidores fica fora desta ADR e deverá ser tratada em ADR própria quando entrar no backlog.


### PR DESCRIPTION
## Resumo

Documenta a imagem Docker composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak` (base `quay.io/keycloak/keycloak:26.5.7` + JAR `cpf-matcher` embutido em `/opt/keycloak/providers/`) como artefato canônico de consumo do Keycloak no Uni+. As docs públicas e ADRs ainda descreviam o fluxo antigo (clonar `uniplus-keycloak-providers` lado a lado, buildar JAR via Maven, fazer mount como volume), que está obsoleto desde o consumo da imagem pelo `docker/docker-compose.yml`.

## Mudanças

- **`docker/keycloak/README.md`** — novo bloco "## Imagem do Keycloak" antes de "## Como subir" com composição, tags publicadas (`1.0.2`, `1.0`, `1.x`, `latest`), política de pinning (compose dev = patch fixo; CI/Testcontainers = `1.x`) e ciclo de release. Seção DEV simplificada (não pede mais clonar repo de providers nem buildar JAR). Tabela de scripts atualizada marcando `build-keycloak-providers.sh` como opcional. Pré-requisito HML reescrito apontando para a imagem composta.
- **`docs/adrs/0020-identity-brokering-govbr.md`** — atualiza versão da SPI `v1.0.0 → v1.0.2`, descreve a imagem composta como artefato canônico no Contexto e na Confirmação, adiciona link para o repo de providers em "Mais informações".
- **`docs/adrs/0016-keycloak-como-identity-provider.md`** — referência cruzada explícita para ADR-0020 e para a imagem composta no fim da seção "Resultado da decisão", evitando que quem leia 0016 isolado pense em Keycloak vanilla.
- **`CLAUDE.md`** — linha extra na stack apontando para `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.x` e para `docker/keycloak/README.md`.

## Por que destrava #145

A issue #145 (cobertura E2E com Keycloak via Testcontainers) foi atualizada para usar `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.x` (parity com o compose). Este PR documenta formalmente a imagem que ela vai consumir, dando referência única para o time.

## Validação

- `bash tools/adr-lint/validate.sh` → 20 ADRs OK.
- `npx markdownlint-cli2 'docs/adrs/**/*.md'` → 0 errors (job que o CI executa).
- Sem mudança em código ou em scripts — só Markdown.

Closes #242
