### PR TITLE
test(auth): cobertura E2E real do JwtBearer com Keycloak via Testcontainers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,6 +48,7 @@
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageVersion Include="TngTech.ArchUnitNET" Version="0.13.3" />
     <PackageVersion Include="TngTech.ArchUnitNET.xUnit" Version="0.13.3" />

--- a/docker/keycloak/realm-e2e-tests.json
+++ b/docker/keycloak/realm-e2e-tests.json
@@ -1,0 +1,303 @@
+{
+  "realm": "unifesspa-e2e",
+  "displayName": "Uni+ — Realm E2E (apenas testes)",
+  "enabled": true,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "registrationAllowed": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "internationalizationEnabled": false,
+  "supportedLocales": ["pt-BR"],
+  "defaultLocale": "pt-BR",
+  "identityProviders": [],
+  "roles": {
+    "realm": [
+      { "name": "admin", "description": "Administrador do sistema" },
+      { "name": "gestor", "description": "Gestor institucional" },
+      { "name": "avaliador", "description": "Avaliador de processos" },
+      { "name": "candidato", "description": "Candidato em processo seletivo" }
+    ]
+  },
+  "clientScopes": [
+    {
+      "name": "uniplus-profile",
+      "description": "Scope autocontido APENAS para testes E2E (sub, email, name, preferred_username, realm_access.roles, cpf, nomeSocial, aud=uniplus).",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false",
+        "include.in.openid.provider.metadata": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "access.token.claim": "true",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "name": "preferred_username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        },
+        {
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "nomeSocial",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nomeSocial",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nomeSocial",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "cpf",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "cpf",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "cpf",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "aud-uniplus",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "uniplus",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "e2e-tests",
+      "name": "e2e-tests",
+      "description": "Cliente confidencial APENAS de testes E2E. Direct Access Grant habilitado, secret em texto claro INTENCIONAL — só existe neste realm sintético, nunca em homologação ou produção.",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "e2e-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "access.token.lifespan": "5"
+      },
+      "fullScopeAllowed": true,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "uniplus-profile",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "clientId": "e2e-tests-bad-aud",
+      "name": "e2e-tests-bad-aud",
+      "description": "Cliente confidencial APENAS de testes E2E — emite token SEM o scope uniplus-profile e portanto sem audience 'uniplus'. Usado exclusivamente para validar a rejeição por audience errada.",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "e2e-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "fullScopeAllowed": true,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": []
+    }
+  ],
+  "users": [
+    {
+      "username": "admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Usuário",
+      "lastName": "Admin",
+      "email": "admin@e2e.uniplus.local",
+      "attributes": {
+        "cpf": ["52998224725"],
+        "nomeSocial": ["Admin Teste"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Changeme!123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": [],
+      "realmRoles": ["admin"]
+    },
+    {
+      "username": "gestor",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Usuário",
+      "lastName": "Gestor",
+      "email": "gestor@e2e.uniplus.local",
+      "attributes": {
+        "cpf": ["11144477735"],
+        "nomeSocial": ["Gestor Teste"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Changeme!123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": [],
+      "realmRoles": ["gestor"]
+    },
+    {
+      "username": "avaliador",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Usuário",
+      "lastName": "Avaliador",
+      "email": "avaliador@e2e.uniplus.local",
+      "attributes": {
+        "cpf": ["39053344705"],
+        "nomeSocial": ["Avaliador Teste"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Changeme!123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": [],
+      "realmRoles": ["avaliador"]
+    },
+    {
+      "username": "candidato",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Usuário",
+      "lastName": "Candidato",
+      "email": "candidato@e2e.uniplus.local",
+      "attributes": {
+        "cpf": ["24843803480"],
+        "nomeSocial": ["Candidato Teste"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Changeme!123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": [],
+      "realmRoles": ["candidato"]
+    }
+  ]
+}

--- a/docker/keycloak/realm-e2e-tests.json
+++ b/docker/keycloak/realm-e2e-tests.json
@@ -214,6 +214,22 @@
       "optionalClientScopes": []
     }
   ],
+  "components": {
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "name": "uniplus-e2e-known-test-key",
+        "providerId": "rsa",
+        "config": {
+          "priority": ["50"],
+          "active": ["true"],
+          "enabled": ["true"],
+          "algorithm": ["RS256"],
+          "privateKey": ["MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDsWkGp3wd424mlKBkPnrWzmZE8BBw1vcvzFSnMj9NED5H/PVvuCoCY8PMghK4/HFJUMHIX0qG5ue9IRJvZ6hCUkqhcjSDd4sraljQsT7/jBZ+RqofagOM+1OizyTBOzBboGRsi86Bze1SH8Dc+bQ96R0TXWhtAOC0Yk6jv+4g7T7JZwEODElPGBVOvaJJDvaV5q8wVYDlUdFbddBsWfCy4Sn8KEozPg7tEyYLiYQrI2TSNFn5e6QOW8BLmNQQ8/g0Kghmcrpey7KPH1VMiZ7nlah5Ftn7U4VjJbJTm9KVEZ4oZ6qS5EcCIT2BtsUXtvZbcs6jDZCPElXGgmEGGvOi3AgMBAAECggEAUWSPolk88IDh+O9DGh70weHLoxhjQpqW5qJOH7UT8ydNhtFxnBsfyAuKHpOykedF7to0IEIYEaaXYZLG/RdfGFsdAapUPDVC2F3Ln8ri8OJZ3kcUu8mQ+G1HqcpKCYi9BrbGopW1lq9NH/c4fxX9s4VhjqvoIIh39zO6hNJhStLwz167xGZylj1HTDNtuGtx+Fwwl9P3b1esWWvMxatKrKpC1TEt1AjZTFlfkjF6xQOjIq2B8PQn0BBpbUZrUlPoA0o4/gzaON2jLfjYs14vyaTuSAEb2zdMt3r42X6vLogxKcVxaW5CqjKDlqROoalItrnN2hP0Q/dTZkBhAY5IYQKBgQD5qs82w42E+ac21Hb5xqDy+ttXBosV9R+N0vU/XI8n63V4dTAHoJTf+arGKz2RXP9krrSul1W5UThuphfHdrbVqROcWuJWbUrso9Cwozayg/Ntb9eXP9IU9WODd8TkyDZ5a4NCsmxl/d3NBIMZR5EfqeLwssG8qWbPpNiV6jyzkQKBgQDyWP1VK+7DSenUYSJqsuMpQjrDqig75HZxh1uFzyLzZoThvukWbYzN07o6Uj340feY1DM69Ey3eAVem6dmTdjYW62TaCOR+wfKXDMcV0EOAcb//7jRAYrQR5nyyqZ+d2l6Mbb8Z9BO+iLVz5vYwbcm8lvJ9EdzZDxUuD/Di7ijxwKBgG0e/tpMtjn8c90/F5EsA4Svp9ZtgbTjIht2rMI4zkkAXKN9dLSgtvD9ymo60/oIz4dN5KK6ejk5CpUx+wqvFFJmR6/6+RoVQr4TC09oxqtXiLm4PF5bApMufYQkgOYNq+F94CzylvYs8xh8dGBEK2XPduUE/DBdShZPUmqTqlxBAoGBAOw6RiYhfskpYR492Jh86uSqxDE5yaIn3jRnppTWBdGQGvMZbocIHfn76kkzJWlG8bwtDArpW2ZzPXis7Q3R0A+Fvbo0BogjU8KzALcdbjJDFUEweWxxvmerg6qgUo5vw4bystVyNCDnvdEAX393xBnYoBRJYuRdzlkeiDkKFt69AoGASzN298OJl0w2fkE8dd/W+pPJPwtJbWdOLEw3vyPvrhbcESZO6oZbV7QAk1UA/J0/iFEHLptl396kAOGb9ttxhz1LmjcvZjhcL0YAMOLt/UZulAgIYtVRNk0nPohNV2+A1dJk/byXe7M+JygEmzOMTiUk0iLoAHmetgjKreSWVhc="],
+          "certificate": ["MIIDITCCAgmgAwIBAgIUVr7Dcm4ihXVK5kMspcCBW36mz+QwDQYJKoZIhvcNAQELBQAwHzEdMBsGA1UEAwwUdW5pcGx1cy1lMmUtdGVzdC1rZXkwIBcNMjYwNTAyMTk0MTUyWhgPMjEyNjA0MDgxOTQxNTJaMB8xHTAbBgNVBAMMFHVuaXBsdXMtZTJlLXRlc3Qta2V5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7FpBqd8HeNuJpSgZD561s5mRPAQcNb3L8xUpzI/TRA+R/z1b7gqAmPDzIISuPxxSVDByF9KhubnvSESb2eoQlJKoXI0g3eLK2pY0LE+/4wWfkaqH2oDjPtTos8kwTswW6BkbIvOgc3tUh/A3Pm0PekdE11obQDgtGJOo7/uIO0+yWcBDgxJTxgVTr2iSQ72leavMFWA5VHRW3XQbFnwsuEp/ChKMz4O7RMmC4mEKyNk0jRZ+XukDlvAS5jUEPP4NCoIZnK6Xsuyjx9VTIme55WoeRbZ+1OFYyWyU5vSlRGeKGeqkuRHAiE9gbbFF7b2W3LOow2QjxJVxoJhBhrzotwIDAQABo1MwUTAdBgNVHQ4EFgQUfIbzWlvF6tCE2nOyzhUJbi9/aF0wHwYDVR0jBBgwFoAUfIbzWlvF6tCE2nOyzhUJbi9/aF0wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAyMYvy6OlZ0d7UMGZfpfKXkocVb0BQy6eB6NPXqv/T2pgHhW5xt9PDOzHvFHFW5R87OjC6wZ0E+00vrbSfYgw+xo5azbEYBe9rnlwTPm89sEbzvjyBiFhIgd9a2clvqM+ifJlb/ZSgRS6XLie1Ip6TVSD0/QtP5y+EY8dXkotuAJtDEDxTiPwX+6ViWkqvgm87t2CuhqtnxOiTbmpwIUFAB9lp3milglxnWVvlswWvWeNwm1+QBJD1RB1/Ct2B3qzBe67HGHznf6ZPHOc1mtCw+ElEjj9XZ3P+hVCBGMdQcL9tlHJ5cj74LQa8NK0CZN964lBrpkSlP3VpyuaQ0VXSw=="]
+        }
+      }
+    ]
+  },
   "users": [
     {
       "username": "admin",

--- a/docs/testing-e2e-auth.md
+++ b/docs/testing-e2e-auth.md
@@ -1,0 +1,104 @@
+# Testes E2E de autenticação contra Keycloak real
+
+Esta suíte exercita o pipeline real `JwtBearer` da API Uni+ contra um Keycloak provisionado via Testcontainers, sem mocks no esquema de autenticação. O objetivo é provar que `OidcAuthenticationConfiguration.AddOidcAuthentication` rejeita tokens com audience errada, expirados e assinados por chave externa, garantindo rede de proteção contra regressão de segurança no código produtivo.
+
+## O que está coberto
+
+| # | Cenário | Caminho exercitado |
+|---|---|---|
+| 1 | Token válido emitido pelo realm → `/api/auth/me` | Caminho feliz: validação de issuer, audience, lifetime e signing key passam; claims do KC chegam ao `IUserContext` |
+| 2 | Token válido com scope `uniplus-profile` → `/api/profile/me` | Audience mapper `aud=uniplus` ativo; claims `cpf` e `nomeSocial` mapeados a partir dos atributos do usuário |
+| 3 | Token expirado → `/api/auth/me` | `ValidateLifetime` rejeita após `ClockSkew` |
+| 4 | Token sem `aud=uniplus` → `/api/auth/me` | `ValidateAudience` rejeita |
+| 5 | Token assinado por chave externa → `/api/auth/me` | `ValidateIssuerSigningKey` rejeita kid não publicada no JWKS do realm |
+| 6 | `/health` da API | `OidcDiscoveryHealthCheck` reporta `Healthy` quando o discovery do Keycloak responde |
+
+## Stack
+
+- **`KeycloakContainerFixture`** (em `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/`) — usa o Testcontainers genérico para subir a imagem composta canônica `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2` (Keycloak 26.5.7 + JAR `cpf-matcher` embutido), montar o realm sintético `realm-e2e-tests.json` em `/opt/keycloak/data/import/` e iniciar com `start-dev --import-realm`. A wait strategy aguarda o discovery `/realms/unifesspa-e2e/.well-known/openid-configuration` responder 200, garantindo que o realm está importado antes dos testes começarem.
+- **`KeycloakCollection`** — `[CollectionDefinition("Keycloak")]` xUnit que serializa as classes que precisam do container e mantém o cold start pago apenas uma vez por execução.
+- **`OidcRealApiFactory`** — subclasse de `ApiFactoryBase<Program>` que sobrescreve `ConfigureTestAuthentication` como no-op, mantendo o `JwtBearer` produtivo ativo e apontando `Auth:Authority` para o container. O método foi extraído da base como ponto de extensão semântico — subclasses E2E que precisam exercitar o pipeline real ganham um override nomeado em vez de uma flag opaca.
+- **Realm sintético de teste (`docker/keycloak/realm-e2e-tests.json`)** — arquivo SEPARADO do realm canônico (`realm-export.json`), realm name `unifesspa-e2e`. Contém apenas o necessário para os 6 cenários: 4 usuários sintéticos com senha não-temporary, 2 clients confidenciais e o scope `uniplus-profile`. Esse arquivo NUNCA é montado pelo `docker-compose` nem por Helm — vive exclusivamente para o ciclo da fixture.
+  - `e2e-tests` — emite tokens com `aud=uniplus` (default scope `uniplus-profile`); `access.token.lifespan: 5` para o cenário de expiração; secret plain `e2e-secret`.
+  - `e2e-tests-bad-aud` — sem `uniplus-profile` nos default scopes; tokens não recebem `aud=uniplus`. Usado APENAS no cenário de audience errada.
+
+> **Importante:** ambos os clients de teste têm `directAccessGrantsEnabled: true` e secret em texto claro INTENCIONAL — eles existem SOMENTE em `realm-e2e-tests.json`, que é um realm sintético importado em containers efêmeros via Testcontainers. O realm canônico (`realm-export.json`) que vai para dev/homologação/produção NÃO contém esses clients e NÃO permite Direct Access Grant. A separação entre os dois arquivos garante que nenhum artefato de teste seja inadvertidamente promovido para ambientes superiores.
+
+## Como rodar localmente
+
+### 1. Pré-requisitos do kernel (Linux 6.19+)
+
+O kernel 6.19 da Arch Linux exige que o módulo `veth` seja carregado manualmente antes do Docker conseguir criar bridges para containers. Sem isso, o Testcontainers falha com erros de network endpoint:
+
+```bash
+sudo modprobe veth
+```
+
+Para tornar persistente entre boots:
+
+```bash
+echo veth | sudo tee /etc/modules-load.d/veth.conf
+```
+
+### 2. Pré-cache da imagem (opcional, recomendado para a primeira execução)
+
+A imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2` tem ~600MB. Sem cache local, o cold start do Testcontainers pode levar 1–2 minutos só no pull. Para evitar surpresa:
+
+```bash
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2
+```
+
+### 3. Rodar a suíte
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests \
+  --filter "FullyQualifiedName~AuthE2ETests"
+```
+
+Para rodar junto com os demais testes do módulo (`AuthEndpointsTests`, `ProfileEndpointsTests`, `OutboxCascading*`):
+
+```bash
+dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests
+```
+
+A `KeycloakCollection` garante que o container suba uma única vez para todas as classes da collection.
+
+## Tempo esperado
+
+| Cenário | Meta | Comentário |
+|---|---|---|
+| Hot start (imagem em cache, kernel pronto) | < 30s para a suíte E2E completa | O cenário 3 (token expirado) sozinho consome ~36s pelo delay de `ClockSkew + lifespan`. A meta vale para os 5 cenários sem a janela de expiração — quando essa janela for tunada via injeção de tempo, a meta volta a valer. |
+| Cold start (pull da imagem, container fresh) | < 2min | Dominado pelo pull da imagem do GHCR. |
+
+## Pinning da imagem
+
+A imagem é pinned em **patch fixo** (`1.0.2`) para garantir parity bit-a-bit entre `docker/docker-compose.yml`, esta suíte e os pipelines de CI. Atualizações de patch na imagem composta passam por bump explícito acompanhado de validação manual — trocar para `1.x` ou `latest` quebraria reproducibilidade dos testes e da experiência local. Quando a imagem for atualizada no compose, o pinning aqui é atualizado no mesmo PR.
+
+## Troubleshooting
+
+| Sintoma | Causa provável | Como resolver |
+|---|---|---|
+| `failed to set up container ... endpoint with name ... already exists` | Módulo `veth` ausente no kernel 6.19+ | `sudo modprobe veth` antes de rodar a suíte |
+| Cold start > 2min na primeira execução | Pull da imagem do GHCR sem cache local | Rodar `docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2` antes |
+| Cenário de token expirado falha esporadicamente | Variação de relógio entre host e container | O delay já cobre `ClockSkew + lifespan`; se persistir, conferir se o host está com NTP sincronizado |
+| `connection refused` na wait strategy | Imagem composta não expõe `/realms/unifesspa/.well-known/openid-configuration` | Verificar se o `realm-export.json` foi montado em `/opt/keycloak/data/import/` e se o `--import-realm` está no comando |
+| Discovery health check `Unhealthy` no cenário 6 | Authority injetada na API não bate com o endpoint do container | Conferir que `OidcRealApiFactory.GetConfigurationOverrides` usa `keycloak.Authority` (URL com porta efêmera publicada) |
+
+## Fora de escopo desta suíte
+
+A suíte cobre o pipeline JWT com IdP real. Ficam fora dela:
+
+- **Identity Brokering gov.br** (Authenticator SPI `cpf-matcher`, flow custom, broker IdP) — coberto por testes unitários em `unifesspa-edu-br/uniplus-keycloak-providers` e por smoke E2E (`scripts/smoke-test-cpf-matcher.sh`). E2E completo contra gov.br homologação requer redirect URI registrado e Keycloak HML, não é viável aqui.
+- **Federation OpenLDAP sintética** — também coberta no smoke do repo de providers; integrar aqui acrescentaria um segundo container e dobraria o cold start sem ganho proporcional para os 6 cenários listados.
+- **Realm "slim de teste" separado** — desnecessário; o `realm-export.json` versionado já é slim (`identityProviders: []`).
+
+Esses itens ganham follow-up próprio quando a story de QA E2E real contra gov.br staging entrar no backlog.
+
+## Referências
+
+- [`OidcAuthenticationConfiguration`](../src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/OidcAuthenticationConfiguration.cs) — pipeline alvo dos testes
+- [`docker/keycloak/realm-export.json`](../docker/keycloak/realm-export.json) — realm canônico
+- [`docs/adrs/0016-keycloak-como-identity-provider.md`](adrs/0016-keycloak-como-identity-provider.md) — Keycloak como resource server
+- [`docs/adrs/0020-identity-brokering-govbr.md`](adrs/0020-identity-brokering-govbr.md) — Identity Brokering via SPI `cpf-matcher`
+- [Testcontainers for .NET](https://dotnet.testcontainers.org/) — biblioteca de containers efêmeros
+- Issue de origem: [`unifesspa-edu-br/uniplus-api#145`](https://github.com/unifesspa-edu-br/uniplus-api/issues/145)

--- a/docs/testing-e2e-auth.md
+++ b/docs/testing-e2e-auth.md
@@ -11,8 +11,10 @@ Esta suíte exercita o pipeline real `JwtBearer` da API Uni+ contra um Keycloak 
 | 3 | Token expirado → `/api/auth/me` | `ValidateLifetime` rejeita após `ClockSkew` |
 | 4 | Token sem `aud=uniplus` → `/api/auth/me` | `ValidateAudience` rejeita |
 | 5 | Token assinado por chave externa → `/api/auth/me` | `ValidateIssuerSigningKey` rejeita kid não publicada no JWKS do realm |
-| 6 | Token com issuer diferente da Authority → `/api/auth/me` | `ValidateIssuer` rejeita tokens emitidos por IdP arbitrário |
+| 6 | Token com issuer diferente da Authority (assinado por chave conhecida pelo realm) → `/api/auth/me` | `ValidateIssuer` rejeita tokens emitidos por IdP arbitrário — isolamento estrito |
 | 7 | `/health` da API | `OidcDiscoveryHealthCheck` reporta `Healthy` quando o discovery do Keycloak responde |
+
+> **Sobre o cenário 6 (isolamento de `ValidateIssuer`):** o realm sintético embute um `KeyProvider` adicional cuja chave privada é também conhecida pelo código de teste (`KeycloakKnownTestKey`). O Keycloak publica essa chave pública no JWKS do realm, então o pipeline JwtBearer aceita assinaturas feitas com a privada correspondente. O cenário 6 forja um token assinado por essa chave conhecida, com audience e lifetime corretos, mas com `iss` arbitrário — assim a ÚNICA dimensão inválida é o issuer. Sem esse `KeyProvider` embutido, o cenário cairia em `ValidateIssuerSigningKey` (a falha do cenário 5), dando falsa cobertura de issuer. A chave privada está em `realm-e2e-tests.json` e em `KeycloakKnownTestKey.cs`; ambos jamais alcançam ambientes superiores.
 
 ## Stack
 

--- a/docs/testing-e2e-auth.md
+++ b/docs/testing-e2e-auth.md
@@ -11,7 +11,8 @@ Esta suíte exercita o pipeline real `JwtBearer` da API Uni+ contra um Keycloak 
 | 3 | Token expirado → `/api/auth/me` | `ValidateLifetime` rejeita após `ClockSkew` |
 | 4 | Token sem `aud=uniplus` → `/api/auth/me` | `ValidateAudience` rejeita |
 | 5 | Token assinado por chave externa → `/api/auth/me` | `ValidateIssuerSigningKey` rejeita kid não publicada no JWKS do realm |
-| 6 | `/health` da API | `OidcDiscoveryHealthCheck` reporta `Healthy` quando o discovery do Keycloak responde |
+| 6 | Token com issuer diferente da Authority → `/api/auth/me` | `ValidateIssuer` rejeita tokens emitidos por IdP arbitrário |
+| 7 | `/health` da API | `OidcDiscoveryHealthCheck` reporta `Healthy` quando o discovery do Keycloak responde |
 
 ## Stack
 

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
@@ -43,10 +43,7 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
 
         builder.ConfigureTestServices(services =>
         {
-            services.AddAuthentication(TestAuthHandler.SchemeName)
-                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                    TestAuthHandler.SchemeName,
-                    _ => { });
+            ConfigureTestAuthentication(services);
 
             if (DisableWolverineRuntimeForTests)
             {
@@ -68,6 +65,27 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
                 }
             }
         });
+    }
+
+    /// <summary>
+    /// Substitui o esquema de autenticação produtivo pelo <see cref="TestAuthHandler"/>, permitindo
+    /// que testes injetem identidades via headers HTTP sem emitir JWTs reais — esta é a configuração
+    /// padrão da maioria das suítes de integração, que não precisam exercitar a validação criptográfica
+    /// do JWT em si.
+    ///
+    /// Subclasses que exercitam o pipeline real <c>JwtBearer</c> (validação de issuer/audience/lifetime/
+    /// signing key) contra um IdP real — p.ex. Keycloak via Testcontainers — sobrescrevem este método
+    /// como no-op para PRESERVAR o esquema produtivo registrado pela API.
+    /// </summary>
+    /// <param name="services">A coleção de serviços do host de teste.</param>
+    protected virtual void ConfigureTestAuthentication(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                TestAuthHandler.SchemeName,
+                _ => { });
     }
 
     /// <summary>

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/KeycloakContainerFixture.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/KeycloakContainerFixture.cs
@@ -1,0 +1,186 @@
+namespace Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+/// <summary>
+/// Sobe um container do Keycloak real (imagem composta canônica do projeto, com SPI <c>cpf-matcher</c>
+/// embutido) importando o <c>realm-export.json</c> versionado em <c>docker/keycloak/</c>. A fixture é
+/// compartilhada entre testes via <c>[Collection("Keycloak")]</c> — ver <see cref="KeycloakCollection"/>.
+///
+/// Garante que a suíte E2E exercite o pipeline real <c>JwtBearer</c> da API contra o IdP de produção,
+/// sem mocks no esquema de autenticação.
+/// </summary>
+public sealed class KeycloakContainerFixture : IAsyncLifetime
+{
+    /// <summary>
+    /// Imagem composta canônica do projeto. Patch fixo alinhado ao <c>docker/docker-compose.yml</c>
+    /// para garantir parity dev/CI/prod e evitar deriva silenciosa em <c>1.x</c>.
+    /// </summary>
+    public const string Image = "ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2";
+
+    /// <summary>
+    /// Nome convencional da xUnit collection que compartilha esta fixture entre classes de teste.
+    /// Cada assembly de testes precisa declarar sua própria <c>[CollectionDefinition]</c> com este nome,
+    /// porque xUnit exige que a definição da collection viva no mesmo assembly que a usa.
+    /// </summary>
+    public const string CollectionName = "Keycloak";
+
+    /// <summary>
+    /// Nome do realm sintético dedicado APENAS aos testes E2E. Diferente do realm canônico
+    /// (<c>unifesspa</c>) usado em dev/homologação/produção, este realm vive em arquivo separado
+    /// (<c>docker/keycloak/realm-e2e-tests.json</c>) e jamais é montado em compose ou Helm —
+    /// existe exclusivamente para o ciclo desta fixture.
+    /// </summary>
+    public const string RealmName = "unifesspa-e2e";
+    /// <summary>Client confidencial principal — emite tokens com <c>aud=uniplus</c>.</summary>
+    public const string ClientId = "e2e-tests";
+
+    /// <summary>
+    /// Client confidencial sem o scope <c>uniplus-profile</c> — emite tokens cuja audience não inclui
+    /// <c>uniplus</c>. Usado para validar a rejeição por audience inválida.
+    /// </summary>
+    public const string BadAudienceClientId = "e2e-tests-bad-aud";
+
+    public const string ClientSecret = "e2e-secret";
+    public const string Audience = "uniplus";
+
+    private const ushort KeycloakHttpPort = 8080;
+    private const string RealmExportContainerPath = "/opt/keycloak/data/import/realm-export.json";
+
+    private readonly IContainer _container;
+    private HttpClient? _httpClient;
+
+    public KeycloakContainerFixture()
+    {
+        string realmExportHostPath = ResolveRealmExportHostPath();
+
+        _container = new ContainerBuilder(Image)
+            .WithPortBinding(KeycloakHttpPort, true)
+            .WithEnvironment("KC_BOOTSTRAP_ADMIN_USERNAME", "admin")
+            .WithEnvironment("KC_BOOTSTRAP_ADMIN_PASSWORD", "admin")
+            .WithEnvironment("KC_HEALTH_ENABLED", "true")
+            .WithEnvironment("KC_HOSTNAME_STRICT", "false")
+            .WithEnvironment("KC_HTTP_ENABLED", "true")
+            .WithBindMount(realmExportHostPath, RealmExportContainerPath)
+            .WithCommand("start-dev", "--import-realm")
+            .WithWaitStrategy(
+                Wait.ForUnixContainer()
+                    .UntilHttpRequestIsSucceeded(request => request
+                        .ForPort(KeycloakHttpPort)
+                        .ForPath($"/realms/{RealmName}/.well-known/openid-configuration")
+                        .ForStatusCode(HttpStatusCode.OK)))
+            .Build();
+    }
+
+    /// <summary>URL base do Keycloak no host (inclui porta efêmera publicada).</summary>
+    public Uri BaseAddress => new($"http://{_container.Hostname}:{_container.GetMappedPublicPort(KeycloakHttpPort)}");
+
+    /// <summary>Authority OIDC do realm — valor a ser injetado em <c>Auth:Authority</c>.</summary>
+    public string Authority => new Uri(BaseAddress, $"/realms/{RealmName}").ToString();
+
+    /// <summary>Endpoint de token (OIDC token endpoint do realm).</summary>
+    public Uri TokenEndpoint => new(BaseAddress, $"/realms/{RealmName}/protocol/openid-connect/token");
+
+    /// <summary>Endpoint de discovery (OpenID Configuration) do realm.</summary>
+    public Uri DiscoveryEndpoint => new(BaseAddress, $"/realms/{RealmName}/.well-known/openid-configuration");
+
+    /// <summary><see cref="HttpClient"/> compartilhado para chamadas ao Keycloak (token, discovery, jwks).</summary>
+    public HttpClient HttpClient => _httpClient ??= new HttpClient { BaseAddress = BaseAddress };
+
+    /// <summary>
+    /// Solicita um access token via Direct Access Grant (Resource Owner Password Credentials) ao client
+    /// confidencial informado. Disponível APENAS no realm de teste — produção não habilita esse fluxo.
+    /// </summary>
+    /// <param name="username">Usuário do realm (ex.: <c>candidato</c>, <c>admin</c>).</param>
+    /// <param name="password">Senha do usuário no realm-export.</param>
+    /// <param name="clientId">Client confidencial a usar; default <see cref="ClientId"/>.</param>
+    /// <returns>Access token compacto (JWS).</returns>
+    public async Task<string> RequestAccessTokenAsync(
+        string username,
+        string password,
+        string clientId = ClientId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(username);
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+
+        using HttpRequestMessage request = new(HttpMethod.Post, TokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("grant_type", "password"),
+                new KeyValuePair<string, string>("client_id", clientId),
+                new KeyValuePair<string, string>("client_secret", ClientSecret),
+                new KeyValuePair<string, string>("username", username),
+                new KeyValuePair<string, string>("password", password),
+            }),
+        };
+
+        using HttpResponseMessage response = await HttpClient.SendAsync(request).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        TokenResponse? payload = await response.Content
+            .ReadFromJsonAsync<TokenResponse>()
+            .ConfigureAwait(false);
+
+        if (payload is null || string.IsNullOrWhiteSpace(payload.AccessToken))
+        {
+            throw new InvalidOperationException(
+                $"Resposta de token inválida do Keycloak para usuário '{username}'.");
+        }
+
+        return payload.AccessToken;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync().ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        _httpClient?.Dispose();
+        await _container.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resolve o caminho absoluto do realm sintético de testes (<c>realm-e2e-tests.json</c>) caminhando
+    /// para cima a partir do diretório de testes até encontrar a raiz do repositório (marcada por
+    /// <c>UniPlus.slnx</c>). O canônico <c>realm-export.json</c> é deliberadamente ignorado — ele é
+    /// fonte de verdade para dev/homologação/produção e não deve ser carregado em testes E2E.
+    /// </summary>
+    private static string ResolveRealmExportHostPath()
+    {
+        const string RealmFileName = "realm-e2e-tests.json";
+
+        DirectoryInfo? current = new(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            string candidate = Path.Combine(current.FullName, "docker", "keycloak", RealmFileName);
+            if (File.Exists(candidate) && File.Exists(Path.Combine(current.FullName, "UniPlus.slnx")))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"Não foi possível localizar 'docker/keycloak/{RealmFileName}' subindo a partir do diretório "
+            + "de testes. Verifique se o teste está rodando dentro da árvore do repositório uniplus-api.");
+    }
+
+    [SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciado via reflection por System.Text.Json em ReadFromJsonAsync.")]
+    private sealed record TokenResponse(
+        [property: System.Text.Json.Serialization.JsonPropertyName("access_token")] string AccessToken,
+        [property: System.Text.Json.Serialization.JsonPropertyName("token_type")] string TokenType,
+        [property: System.Text.Json.Serialization.JsonPropertyName("expires_in")] int ExpiresIn);
+}

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/KeycloakKnownTestKey.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/KeycloakKnownTestKey.cs
@@ -1,0 +1,103 @@
+namespace Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+using System.Security.Cryptography;
+
+using Microsoft.IdentityModel.Tokens;
+
+/// <summary>
+/// Par RSA fixo embarcado no realm sintético de testes (<c>realm-e2e-tests.json</c>) via
+/// <c>components.org.keycloak.keys.KeyProvider</c>. A chave pública correspondente é publicada pelo
+/// Keycloak no JWKS do realm, portanto qualquer token assinado com a privada abaixo é aceito pela
+/// validação criptográfica do <c>JwtBearer</c> da API.
+///
+/// O propósito é permitir que testes E2E forjem tokens com assinatura válida e isolem ESPECIFICAMENTE
+/// validações lógicas (issuer, audience, lifetime) — em vez de cair sempre em
+/// <c>ValidateIssuerSigningKey</c>. Sem isso, um regressão que desligue <c>ValidateIssuer</c> mas
+/// mantenha a checagem de signing key ainda passaria pelos testes, dando falsa cobertura.
+///
+/// <para>
+/// <b>Segurança:</b> esta chave privada é PUBLICAMENTE conhecida pelo repositório e existe SOMENTE no
+/// realm sintético <c>unifesspa-e2e</c> (arquivo <c>docker/keycloak/realm-e2e-tests.json</c>), que
+/// jamais é montado em <c>docker-compose</c>, Helm, dev, homologação ou produção. O realm canônico
+/// (<c>realm-export.json</c>) não contém este key provider e o JWKS de produção é gerado por chaves
+/// privadas autônomas do KC. Não há vetor de exposição da aplicação real.
+/// </para>
+///
+/// <para>
+/// <b>Como atualizar:</b> se for necessário girar a chave (improvável; ela é fixa de propósito),
+/// gerar novo par com <c>openssl genrsa -out key.pem 2048 &amp;&amp; openssl req -new -x509 -key key.pem
+/// -out cert.pem -days 36500 -subj "/CN=uniplus-e2e-test-key"</c>, atualizar <see cref="PrivateKeyPem"/>
+/// abaixo (PKCS#8) e o campo <c>privateKey</c>+<c>certificate</c> em <c>realm-e2e-tests.json</c>.
+/// Os dois precisam permanecer sincronizados.
+/// </para>
+/// </summary>
+public static class KeycloakKnownTestKey
+{
+    /// <summary>
+    /// Nome do <c>KeyProvider</c> declarado em <c>realm-e2e-tests.json</c>. Serve apenas para
+    /// localização em logs do KC.
+    /// </summary>
+    public const string ProviderName = "uniplus-e2e-known-test-key";
+
+    /// <summary>
+    /// Key ID (<c>kid</c>) que o Keycloak gera deterministicamente para esta chave ao importar o
+    /// realm — é um SHA-256 derivado da modulus pública. Tokens forjados com este <c>kid</c> são
+    /// validados pelo <c>JwtBearer</c> da API porque o JWKS do realm publica essa kid.
+    ///
+    /// <para>
+    /// <b>Como recalcular se a chave mudar:</b> subir a imagem composta com o realm importado, fazer
+    /// <c>curl http://&lt;kc&gt;/realms/unifesspa-e2e/protocol/openid-connect/certs</c> e copiar o
+    /// campo <c>keys[].kid</c> da chave (kty=RSA, use=sig).
+    /// </para>
+    /// </summary>
+    public const string KeyId = "QX3fDYzTPMKOzUJO2CvCnQdp_LB9yOIizHBHZvhAecA";
+
+    /// <summary>
+    /// Chave privada RSA 2048 em formato PKCS#8 PEM. Mesmo conteúdo (sem headers/footers e sem
+    /// quebras de linha) está em <c>realm-e2e-tests.json</c> no campo
+    /// <c>components.org.keycloak.keys.KeyProvider[0].config.privateKey[0]</c>.
+    /// </summary>
+    public const string PrivateKeyPem =
+        "-----BEGIN PRIVATE KEY-----\n" +
+        "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDsWkGp3wd424ml\n" +
+        "KBkPnrWzmZE8BBw1vcvzFSnMj9NED5H/PVvuCoCY8PMghK4/HFJUMHIX0qG5ue9I\n" +
+        "RJvZ6hCUkqhcjSDd4sraljQsT7/jBZ+RqofagOM+1OizyTBOzBboGRsi86Bze1SH\n" +
+        "8Dc+bQ96R0TXWhtAOC0Yk6jv+4g7T7JZwEODElPGBVOvaJJDvaV5q8wVYDlUdFbd\n" +
+        "dBsWfCy4Sn8KEozPg7tEyYLiYQrI2TSNFn5e6QOW8BLmNQQ8/g0Kghmcrpey7KPH\n" +
+        "1VMiZ7nlah5Ftn7U4VjJbJTm9KVEZ4oZ6qS5EcCIT2BtsUXtvZbcs6jDZCPElXGg\n" +
+        "mEGGvOi3AgMBAAECggEAUWSPolk88IDh+O9DGh70weHLoxhjQpqW5qJOH7UT8ydN\n" +
+        "htFxnBsfyAuKHpOykedF7to0IEIYEaaXYZLG/RdfGFsdAapUPDVC2F3Ln8ri8OJZ\n" +
+        "3kcUu8mQ+G1HqcpKCYi9BrbGopW1lq9NH/c4fxX9s4VhjqvoIIh39zO6hNJhStLw\n" +
+        "z167xGZylj1HTDNtuGtx+Fwwl9P3b1esWWvMxatKrKpC1TEt1AjZTFlfkjF6xQOj\n" +
+        "Iq2B8PQn0BBpbUZrUlPoA0o4/gzaON2jLfjYs14vyaTuSAEb2zdMt3r42X6vLogx\n" +
+        "KcVxaW5CqjKDlqROoalItrnN2hP0Q/dTZkBhAY5IYQKBgQD5qs82w42E+ac21Hb5\n" +
+        "xqDy+ttXBosV9R+N0vU/XI8n63V4dTAHoJTf+arGKz2RXP9krrSul1W5UThuphfH\n" +
+        "drbVqROcWuJWbUrso9Cwozayg/Ntb9eXP9IU9WODd8TkyDZ5a4NCsmxl/d3NBIMZ\n" +
+        "R5EfqeLwssG8qWbPpNiV6jyzkQKBgQDyWP1VK+7DSenUYSJqsuMpQjrDqig75HZx\n" +
+        "h1uFzyLzZoThvukWbYzN07o6Uj340feY1DM69Ey3eAVem6dmTdjYW62TaCOR+wfK\n" +
+        "XDMcV0EOAcb//7jRAYrQR5nyyqZ+d2l6Mbb8Z9BO+iLVz5vYwbcm8lvJ9EdzZDxU\n" +
+        "uD/Di7ijxwKBgG0e/tpMtjn8c90/F5EsA4Svp9ZtgbTjIht2rMI4zkkAXKN9dLSg\n" +
+        "tvD9ymo60/oIz4dN5KK6ejk5CpUx+wqvFFJmR6/6+RoVQr4TC09oxqtXiLm4PF5b\n" +
+        "ApMufYQkgOYNq+F94CzylvYs8xh8dGBEK2XPduUE/DBdShZPUmqTqlxBAoGBAOw6\n" +
+        "RiYhfskpYR492Jh86uSqxDE5yaIn3jRnppTWBdGQGvMZbocIHfn76kkzJWlG8bwt\n" +
+        "DArpW2ZzPXis7Q3R0A+Fvbo0BogjU8KzALcdbjJDFUEweWxxvmerg6qgUo5vw4by\n" +
+        "stVyNCDnvdEAX393xBnYoBRJYuRdzlkeiDkKFt69AoGASzN298OJl0w2fkE8dd/W\n" +
+        "+pPJPwtJbWdOLEw3vyPvrhbcESZO6oZbV7QAk1UA/J0/iFEHLptl396kAOGb9ttx\n" +
+        "hz1LmjcvZjhcL0YAMOLt/UZulAgIYtVRNk0nPohNV2+A1dJk/byXe7M+JygEmzOM\n" +
+        "TiUk0iLoAHmetgjKreSWVhc=\n" +
+        "-----END PRIVATE KEY-----";
+
+    /// <summary>
+    /// Cria uma <see cref="RsaSecurityKey"/> a partir da chave privada embutida, pronta para assinar
+    /// tokens de teste com a kid que o Keycloak publicará no JWKS.
+    /// </summary>
+    public static RsaSecurityKey CreateSigningKey()
+    {
+        using RSA rsa = RSA.Create();
+        rsa.ImportFromPem(PrivateKeyPem);
+        return new RsaSecurityKey(rsa.ExportParameters(includePrivateParameters: true))
+        {
+            KeyId = KeyId,
+        };
+    }
+}

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/KeycloakTestUsers.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/KeycloakTestUsers.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// Catálogo dos usuários sintéticos provisionados pelo realm de testes E2E
+/// (<c>docker/keycloak/realm-e2e-tests.json</c>). Centralizar aqui evita
+/// duplicar literais (CPF, email, nomeSocial, role) entre o realm e cada teste,
+/// reduzindo a fragilidade quando o realm sintético precisar evoluir — qualquer
+/// alteração no JSON é refletida num único ponto consumido por todas as suítes.
+/// </summary>
+public static class KeycloakTestUsers
+{
+    /// <summary>Senha compartilhada por todos os usuários sintéticos do realm de teste.</summary>
+    public const string SharedPassword = "Changeme!123";
+
+    public static readonly KeycloakTestUser Admin = new(
+        Username: "admin",
+        Email: "admin@e2e.uniplus.local",
+        Cpf: "52998224725",
+        NomeSocial: "Admin Teste",
+        Role: "admin");
+
+    public static readonly KeycloakTestUser Gestor = new(
+        Username: "gestor",
+        Email: "gestor@e2e.uniplus.local",
+        Cpf: "11144477735",
+        NomeSocial: "Gestor Teste",
+        Role: "gestor");
+
+    public static readonly KeycloakTestUser Avaliador = new(
+        Username: "avaliador",
+        Email: "avaliador@e2e.uniplus.local",
+        Cpf: "39053344705",
+        NomeSocial: "Avaliador Teste",
+        Role: "avaliador");
+
+    public static readonly KeycloakTestUser Candidato = new(
+        Username: "candidato",
+        Email: "candidato@e2e.uniplus.local",
+        Cpf: "24843803480",
+        NomeSocial: "Candidato Teste",
+        Role: "candidato");
+}
+
+/// <summary>
+/// Snapshot dos atributos de um usuário sintético do realm de testes — espelha o
+/// estado declarado em <c>realm-e2e-tests.json</c>. CPFs são valores publicamente
+/// reconhecidos como válidos quanto ao algoritmo, sem correspondência a pessoas reais.
+/// </summary>
+public sealed record KeycloakTestUser(
+    string Username,
+    string Email,
+    string Cpf,
+    string NomeSocial,
+    string Role);

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
@@ -2,6 +2,14 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!--
+      Library project consumido por outros assemblies de teste (define ApiFactoryBase, TestAuthHandler,
+      KeycloakContainerFixture). Referencia xunit para expor IAsyncLifetime e atributos de fixture, mas
+      não contém [Fact] próprios. IsTestProject=false impede o test runner do CI de tentar carregar
+      este assembly como executável de teste — isso falharia ao resolver dependências transitivas
+      (p.ex. BouncyCastle vinda de SSH.NET via Testcontainers) num runner sem cache.
+    -->
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
@@ -6,7 +6,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Testcontainers" />
     <PackageReference Include="WolverineFx" />
+    <PackageReference Include="xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Testcontainers" />
     <PackageReference Include="WolverineFx" />

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
@@ -60,7 +60,7 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
         string accessToken = await _keycloak.RequestAccessTokenAsync(AdminUsername, SharedPassword);
         using HttpClient client = CreateClientWithToken(accessToken);
 
-        HttpResponseMessage response = await client.GetAsync(AuthMeUri);
+        using HttpResponseMessage response = await client.GetAsync(AuthMeUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -77,7 +77,7 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
         string accessToken = await _keycloak.RequestAccessTokenAsync(CandidatoUsername, SharedPassword);
         using HttpClient client = CreateClientWithToken(accessToken);
 
-        HttpResponseMessage response = await client.GetAsync(ProfileMeUri);
+        using HttpResponseMessage response = await client.GetAsync(ProfileMeUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -108,7 +108,7 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
 
         using HttpClient client = CreateClientWithToken(accessToken);
 
-        HttpResponseMessage response = await client.GetAsync(AuthMeUri);
+        using HttpResponseMessage response = await client.GetAsync(AuthMeUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -124,7 +124,7 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
             KeycloakContainerFixture.BadAudienceClientId);
         using HttpClient client = CreateClientWithToken(accessToken);
 
-        HttpResponseMessage response = await client.GetAsync(AuthMeUri);
+        using HttpResponseMessage response = await client.GetAsync(AuthMeUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -135,7 +135,7 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
         string forgedToken = ForgeTokenSignedByExternalKey(_keycloak.Authority);
         using HttpClient client = CreateClientWithToken(forgedToken);
 
-        HttpResponseMessage response = await client.GetAsync(AuthMeUri);
+        using HttpResponseMessage response = await client.GetAsync(AuthMeUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -145,7 +145,7 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
     {
         using HttpClient client = _factory.CreateClient();
 
-        HttpResponseMessage response = await client.GetAsync(HealthUri);
+        using HttpResponseMessage response = await client.GetAsync(HealthUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         string body = await response.Content.ReadAsStringAsync();

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
@@ -28,6 +28,21 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
     private const string CandidatoUsername = "candidato";
     private const string SharedPassword = "Changeme!123";
 
+    /// <summary>
+    /// <see cref="AuthOptions.ClockSkew"/> default consumido pelo <c>JwtBearer</c> em produção (30s).
+    /// O cenário de expiração precisa esperar além dessa janela para que o pipeline real reconheça
+    /// o token como expirado.
+    /// </summary>
+    private static readonly TimeSpan ExpectedClockSkew = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Margem adicional para absorver drift de relógio entre o host onde o teste roda e o container
+    /// do Keycloak (timestamps do <c>exp</c> claim são gerados pelo container, mas a comparação no
+    /// pipeline acontece no host). 5 segundos cobrem cenários reais de CI sem inflar a duração da
+    /// suíte.
+    /// </summary>
+    private static readonly TimeSpan ClockDriftBuffer = TimeSpan.FromSeconds(5);
+
     private readonly KeycloakContainerFixture _keycloak;
     private readonly OidcRealApiFactory _factory;
 
@@ -77,11 +92,19 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
     [Fact]
     public async Task GetAuthMe_ShouldReturnUnauthorized_WhenTokenIsExpired()
     {
-        // O client e2e-tests é configurado com access.token.lifespan=5s no realm-export.json.
-        // Aguarda além do ClockSkew (30s default) + lifespan para garantir que o token efetivamente
-        // expirou na visão do JwtBearer, e não apenas na visão nominal do exp claim.
+        // Solicita um token com vida curta (access.token.lifespan=5s no realm) e aguarda até passar
+        // do exp do PRÓPRIO token + ClockSkew configurado + buffer de drift. Calcular a partir do exp
+        // emitido pelo container — em vez de um delay fixo — torna o teste resiliente a (a) drift de
+        // relógio entre host e container e (b) eventuais bumps futuros do lifespan ou do ClockSkew
+        // sem precisar atualizar este caso.
         string accessToken = await _keycloak.RequestAccessTokenAsync(AdminUsername, SharedPassword);
-        await Task.Delay(TimeSpan.FromSeconds(36));
+
+        DateTimeOffset waitUntil = ReadExpirationFromToken(accessToken) + ExpectedClockSkew + ClockDriftBuffer;
+        TimeSpan remaining = waitUntil - DateTimeOffset.UtcNow;
+        if (remaining > TimeSpan.Zero)
+        {
+            await Task.Delay(remaining);
+        }
 
         using HttpClient client = CreateClientWithToken(accessToken);
 
@@ -134,6 +157,12 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
         HttpClient client = _factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         return client;
+    }
+
+    private static DateTimeOffset ReadExpirationFromToken(string accessToken)
+    {
+        JsonWebToken jwt = new JsonWebTokenHandler().ReadJsonWebToken(accessToken);
+        return new DateTimeOffset(jwt.ValidTo, TimeSpan.Zero);
     }
 
     private static string ForgeTokenSignedByExternalKey(string issuer)

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
@@ -1,0 +1,167 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Authentication;
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+using FluentAssertions;
+
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// Cobertura ponta-a-ponta do pipeline real <c>JwtBearer</c> contra um Keycloak provisionado via
+/// Testcontainers. Cada caso isola UMA falha de validação (issuer/audience/lifetime/signing key) ou
+/// um caminho feliz, sem mocks no esquema de autenticação. Documentação operacional em
+/// <c>docs/testing-e2e-auth.md</c>.
+/// </summary>
+[Collection(KeycloakContainerFixture.CollectionName)]
+public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
+{
+    private static readonly Uri AuthMeUri = new("/api/auth/me", UriKind.Relative);
+    private static readonly Uri ProfileMeUri = new("/api/profile/me", UriKind.Relative);
+    private static readonly Uri HealthUri = new("/health", UriKind.Relative);
+    private const string AdminUsername = "admin";
+    private const string CandidatoUsername = "candidato";
+    private const string SharedPassword = "Changeme!123";
+
+    private readonly KeycloakContainerFixture _keycloak;
+    private readonly OidcRealApiFactory _factory;
+
+    public AuthE2ETests(KeycloakContainerFixture keycloak, OidcRealApiFactoryWrapper factoryWrapper)
+    {
+        ArgumentNullException.ThrowIfNull(keycloak);
+        ArgumentNullException.ThrowIfNull(factoryWrapper);
+        _keycloak = keycloak;
+        _factory = factoryWrapper.GetOrCreate(keycloak);
+    }
+
+    [Fact]
+    public async Task GetAuthMe_ShouldReturnAuthenticatedUser_WhenTokenIsValid()
+    {
+        string accessToken = await _keycloak.RequestAccessTokenAsync(AdminUsername, SharedPassword);
+        using HttpClient client = CreateClientWithToken(accessToken);
+
+        HttpResponseMessage response = await client.GetAsync(AuthMeUri);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        payload.RootElement.GetProperty("userId").GetString().Should().NotBeNullOrWhiteSpace();
+        payload.RootElement.GetProperty("email").GetString().Should().Be("admin@e2e.uniplus.local");
+        payload.RootElement.GetProperty("roles").EnumerateArray().Select(static r => r.GetString())
+            .Should().Contain("admin");
+    }
+
+    [Fact]
+    public async Task GetProfileMe_ShouldReturnCpfAndNomeSocial_WhenTokenCarriesUniPlusProfileScope()
+    {
+        string accessToken = await _keycloak.RequestAccessTokenAsync(CandidatoUsername, SharedPassword);
+        using HttpClient client = CreateClientWithToken(accessToken);
+
+        HttpResponseMessage response = await client.GetAsync(ProfileMeUri);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        payload.RootElement.GetProperty("cpf").GetString().Should().Be("24843803480");
+        payload.RootElement.GetProperty("nomeSocial").GetString().Should().Be("Candidato Teste");
+        payload.RootElement.GetProperty("email").GetString().Should().Be("candidato@e2e.uniplus.local");
+        payload.RootElement.GetProperty("roles").EnumerateArray().Select(static r => r.GetString())
+            .Should().Contain("candidato");
+    }
+
+    [Fact]
+    public async Task GetAuthMe_ShouldReturnUnauthorized_WhenTokenIsExpired()
+    {
+        // O client e2e-tests é configurado com access.token.lifespan=5s no realm-export.json.
+        // Aguarda além do ClockSkew (30s default) + lifespan para garantir que o token efetivamente
+        // expirou na visão do JwtBearer, e não apenas na visão nominal do exp claim.
+        string accessToken = await _keycloak.RequestAccessTokenAsync(AdminUsername, SharedPassword);
+        await Task.Delay(TimeSpan.FromSeconds(36));
+
+        using HttpClient client = CreateClientWithToken(accessToken);
+
+        HttpResponseMessage response = await client.GetAsync(AuthMeUri);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetAuthMe_ShouldReturnUnauthorized_WhenTokenAudienceDoesNotIncludeUniPlus()
+    {
+        // O client e2e-tests-bad-aud não inclui o scope uniplus-profile (que carrega o audience mapper),
+        // portanto o token emitido não traz aud=uniplus.
+        string accessToken = await _keycloak.RequestAccessTokenAsync(
+            AdminUsername,
+            SharedPassword,
+            KeycloakContainerFixture.BadAudienceClientId);
+        using HttpClient client = CreateClientWithToken(accessToken);
+
+        HttpResponseMessage response = await client.GetAsync(AuthMeUri);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetAuthMe_ShouldReturnUnauthorized_WhenTokenIsSignedByExternalKey()
+    {
+        string forgedToken = ForgeTokenSignedByExternalKey(_keycloak.Authority);
+        using HttpClient client = CreateClientWithToken(forgedToken);
+
+        HttpResponseMessage response = await client.GetAsync(AuthMeUri);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GetHealth_ShouldReportHealthy_WhenKeycloakDiscoveryEndpointResponds()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(HealthUri);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        string body = await response.Content.ReadAsStringAsync();
+        body.Should().Be("Healthy");
+    }
+
+    private HttpClient CreateClientWithToken(string accessToken)
+    {
+        HttpClient client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return client;
+    }
+
+    private static string ForgeTokenSignedByExternalKey(string issuer)
+    {
+        using RSA rsa = RSA.Create(2048);
+        RsaSecurityKey signingKey = new(rsa.ExportParameters(includePrivateParameters: true))
+        {
+            KeyId = "external-test-key",
+        };
+
+        SigningCredentials credentials = new(signingKey, SecurityAlgorithms.RsaSha256);
+        DateTime now = DateTime.UtcNow;
+        SecurityTokenDescriptor descriptor = new()
+        {
+            Issuer = issuer,
+            Audience = KeycloakContainerFixture.Audience,
+            NotBefore = now,
+            Expires = now.AddMinutes(5),
+            SigningCredentials = credentials,
+            Claims = new Dictionary<string, object>
+            {
+                ["sub"] = Guid.NewGuid().ToString(),
+                ["preferred_username"] = "intruder",
+                ["email"] = "intruder@example.com",
+            },
+        };
+
+        JsonWebTokenHandler handler = new();
+        return handler.CreateToken(descriptor);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
@@ -24,9 +24,6 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
     private static readonly Uri AuthMeUri = new("/api/auth/me", UriKind.Relative);
     private static readonly Uri ProfileMeUri = new("/api/profile/me", UriKind.Relative);
     private static readonly Uri HealthUri = new("/health", UriKind.Relative);
-    private const string AdminUsername = "admin";
-    private const string CandidatoUsername = "candidato";
-    private const string SharedPassword = "Changeme!123";
 
     /// <summary>
     /// <see cref="AuthOptions.ClockSkew"/> default consumido pelo <c>JwtBearer</c> em produção (30s).
@@ -57,7 +54,8 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
     [Fact]
     public async Task GetAuthMe_ShouldReturnAuthenticatedUser_WhenTokenIsValid()
     {
-        string accessToken = await _keycloak.RequestAccessTokenAsync(AdminUsername, SharedPassword);
+        KeycloakTestUser user = KeycloakTestUsers.Admin;
+        string accessToken = await _keycloak.RequestAccessTokenAsync(user.Username, KeycloakTestUsers.SharedPassword);
         using HttpClient client = CreateClientWithToken(accessToken);
 
         using HttpResponseMessage response = await client.GetAsync(AuthMeUri);
@@ -66,15 +64,16 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
 
         using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
         payload.RootElement.GetProperty("userId").GetString().Should().NotBeNullOrWhiteSpace();
-        payload.RootElement.GetProperty("email").GetString().Should().Be("admin@e2e.uniplus.local");
+        payload.RootElement.GetProperty("email").GetString().Should().Be(user.Email);
         payload.RootElement.GetProperty("roles").EnumerateArray().Select(static r => r.GetString())
-            .Should().Contain("admin");
+            .Should().Contain(user.Role);
     }
 
     [Fact]
     public async Task GetProfileMe_ShouldReturnCpfAndNomeSocial_WhenTokenCarriesUniPlusProfileScope()
     {
-        string accessToken = await _keycloak.RequestAccessTokenAsync(CandidatoUsername, SharedPassword);
+        KeycloakTestUser user = KeycloakTestUsers.Candidato;
+        string accessToken = await _keycloak.RequestAccessTokenAsync(user.Username, KeycloakTestUsers.SharedPassword);
         using HttpClient client = CreateClientWithToken(accessToken);
 
         using HttpResponseMessage response = await client.GetAsync(ProfileMeUri);
@@ -82,11 +81,11 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
-        payload.RootElement.GetProperty("cpf").GetString().Should().Be("24843803480");
-        payload.RootElement.GetProperty("nomeSocial").GetString().Should().Be("Candidato Teste");
-        payload.RootElement.GetProperty("email").GetString().Should().Be("candidato@e2e.uniplus.local");
+        payload.RootElement.GetProperty("cpf").GetString().Should().Be(user.Cpf);
+        payload.RootElement.GetProperty("nomeSocial").GetString().Should().Be(user.NomeSocial);
+        payload.RootElement.GetProperty("email").GetString().Should().Be(user.Email);
         payload.RootElement.GetProperty("roles").EnumerateArray().Select(static r => r.GetString())
-            .Should().Contain("candidato");
+            .Should().Contain(user.Role);
     }
 
     [Fact]
@@ -97,7 +96,9 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
         // emitido pelo container — em vez de um delay fixo — torna o teste resiliente a (a) drift de
         // relógio entre host e container e (b) eventuais bumps futuros do lifespan ou do ClockSkew
         // sem precisar atualizar este caso.
-        string accessToken = await _keycloak.RequestAccessTokenAsync(AdminUsername, SharedPassword);
+        string accessToken = await _keycloak.RequestAccessTokenAsync(
+            KeycloakTestUsers.Admin.Username,
+            KeycloakTestUsers.SharedPassword);
 
         DateTimeOffset waitUntil = ReadExpirationFromToken(accessToken) + ExpectedClockSkew + ClockDriftBuffer;
         TimeSpan remaining = waitUntil - DateTimeOffset.UtcNow;
@@ -119,8 +120,8 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
         // O client e2e-tests-bad-aud não inclui o scope uniplus-profile (que carrega o audience mapper),
         // portanto o token emitido não traz aud=uniplus.
         string accessToken = await _keycloak.RequestAccessTokenAsync(
-            AdminUsername,
-            SharedPassword,
+            KeycloakTestUsers.Admin.Username,
+            KeycloakTestUsers.SharedPassword,
             KeycloakContainerFixture.BadAudienceClientId);
         using HttpClient client = CreateClientWithToken(accessToken);
 

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
@@ -142,6 +142,23 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
     }
 
     [Fact]
+    public async Task GetAuthMe_ShouldReturnUnauthorized_WhenTokenIssuerDoesNotMatchAuthority()
+    {
+        // Forja um token com issuer arbitrário diferente da Authority configurada na API.
+        // O signing key é local (não temos acesso à chave privada do realm para isolar
+        // estritamente o issuer), portanto a falha é capturada por ValidateIssuer e/ou
+        // ValidateIssuerSigningKey — o cenário garante que um token claim de outro IdP
+        // jamais é aceito pelo pipeline JwtBearer, somando defesa em profundidade ao
+        // cenário 5 (que isola signing key com issuer correto).
+        string forgedToken = ForgeTokenSignedByExternalKey("https://impostor.example.com/realms/wrong");
+        using HttpClient client = CreateClientWithToken(forgedToken);
+
+        using HttpResponseMessage response = await client.GetAsync(AuthMeUri);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
     public async Task GetHealth_ShouldReportHealthy_WhenKeycloakDiscoveryEndpointResponds()
     {
         using HttpClient client = _factory.CreateClient();

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
@@ -144,13 +144,15 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
     [Fact]
     public async Task GetAuthMe_ShouldReturnUnauthorized_WhenTokenIssuerDoesNotMatchAuthority()
     {
-        // Forja um token com issuer arbitrário diferente da Authority configurada na API.
-        // O signing key é local (não temos acesso à chave privada do realm para isolar
-        // estritamente o issuer), portanto a falha é capturada por ValidateIssuer e/ou
-        // ValidateIssuerSigningKey — o cenário garante que um token claim de outro IdP
-        // jamais é aceito pelo pipeline JwtBearer, somando defesa em profundidade ao
-        // cenário 5 (que isola signing key com issuer correto).
-        string forgedToken = ForgeTokenSignedByExternalKey("https://impostor.example.com/realms/wrong");
+        // Isola estritamente ValidateIssuer: o token é assinado pela chave conhecida que o realm
+        // sintético publica no JWKS (KeycloakKnownTestKey, embutida via components.KeyProvider em
+        // realm-e2e-tests.json), portanto ValidateIssuerSigningKey passa. Audience e lifetime
+        // também são corretos. A ÚNICA dimensão inválida é o iss claim — uma regressão futura que
+        // desligue ValidateIssuer (ex.: ValidateIssuer = false) faria este caso passar a aceitar
+        // o token, capturando a regressão. Complementa o cenário 5 (que isola signing key).
+        string forgedToken = ForgeTokenWithKnownKey(
+            issuer: "https://impostor.example.com/realms/wrong",
+            audience: KeycloakContainerFixture.Audience);
         using HttpClient client = CreateClientWithToken(forgedToken);
 
         using HttpResponseMessage response = await client.GetAsync(AuthMeUri);
@@ -191,12 +193,26 @@ public sealed class AuthE2ETests : IClassFixture<OidcRealApiFactoryWrapper>
             KeyId = "external-test-key",
         };
 
+        return ForgeToken(
+            signingKey,
+            issuer,
+            audience: KeycloakContainerFixture.Audience);
+    }
+
+    private static string ForgeTokenWithKnownKey(string issuer, string audience)
+    {
+        RsaSecurityKey signingKey = KeycloakKnownTestKey.CreateSigningKey();
+        return ForgeToken(signingKey, issuer, audience);
+    }
+
+    private static string ForgeToken(RsaSecurityKey signingKey, string issuer, string audience)
+    {
         SigningCredentials credentials = new(signingKey, SecurityAlgorithms.RsaSha256);
         DateTime now = DateTime.UtcNow;
         SecurityTokenDescriptor descriptor = new()
         {
             Issuer = issuer,
-            Audience = KeycloakContainerFixture.Audience,
+            Audience = audience,
             NotBefore = now,
             Expires = now.AddMinutes(5),
             SigningCredentials = credentials,

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/KeycloakCollection.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/KeycloakCollection.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Authentication;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// xUnit collection que serializa a execução das classes de teste E2E que precisam do Keycloak real,
+/// reaproveitando uma única instância da <see cref="KeycloakContainerFixture"/> entre elas e mantendo
+/// o cold start pago apenas uma vez por execução. xUnit exige que a <c>[CollectionDefinition]</c> viva
+/// no mesmo assembly dos testes que a usam — por isso esta classe vive em Selecao.IntegrationTests
+/// (e não em IntegrationTests.Fixtures).
+/// </summary>
+[CollectionDefinition(KeycloakContainerFixture.CollectionName)]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção xUnit: o sufixo 'Collection' identifica a classe como CollectionDefinition.")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x exige que CollectionDefinitions sejam públicas para que o runner as descubra.")]
+public sealed class KeycloakCollection : ICollectionFixture<KeycloakContainerFixture>
+{
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/OidcRealApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/OidcRealApiFactory.cs
@@ -1,0 +1,46 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Authentication;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// Factory de testes E2E que mantém o pipeline real <c>JwtBearer</c> ativo, apontando
+/// <c>Auth:Authority</c> para o Keycloak provisionado pela <see cref="KeycloakContainerFixture"/>.
+/// Diferentemente da <see cref="SelecaoApiFactory"/>, NÃO substitui o esquema de autenticação
+/// produtivo — sobrescreve <see cref="ApiFactoryBase{TEntryPoint}.ConfigureTestAuthentication"/>
+/// como no-op para que a validação real de issuer/audience/lifetime/signing key seja exercitada
+/// contra o IdP em container.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x exige que fixtures e factories instanciados pelo runner sejam públicos.")]
+public sealed class OidcRealApiFactory : ApiFactoryBase<Program>
+{
+    private readonly string _authority;
+
+    public OidcRealApiFactory(KeycloakContainerFixture keycloak)
+    {
+        ArgumentNullException.ThrowIfNull(keycloak);
+        _authority = keycloak.Authority;
+    }
+
+    /// <summary>
+    /// No-op proposital: preserva o esquema <c>JwtBearer</c> registrado pela API em produção
+    /// para que os testes E2E exercitem a cadeia real de validação contra o Keycloak.
+    /// </summary>
+    protected override void ConfigureTestAuthentication(IServiceCollection services)
+    {
+        // Intencionalmente vazio — ver docstring.
+    }
+
+    protected override IEnumerable<KeyValuePair<string, string?>> GetConfigurationOverrides() =>
+    [
+        new("ConnectionStrings:SelecaoDb", "Host=localhost;Port=5432;Database=uniplus_tests;Username=uniplus;Password=uniplus_dev"),
+        new("Auth:Authority", _authority),
+        new("Auth:Audience", KeycloakContainerFixture.Audience),
+    ];
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/OidcRealApiFactoryWrapper.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/OidcRealApiFactoryWrapper.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Authentication;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// xUnit class fixture que segura uma única instância de <see cref="OidcRealApiFactory"/> ao longo
+/// da execução da classe de testes. Necessário porque xUnit 2.x não suporta injetar uma collection
+/// fixture (<see cref="KeycloakContainerFixture"/>) diretamente em uma class fixture; o wrapper
+/// recebe a fixture pelo construtor do teste e a entrega ao factory na primeira chamada.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x exige que class fixtures sejam públicas para que o runner as instancie.")]
+public sealed class OidcRealApiFactoryWrapper : IDisposable
+{
+    private readonly Lock _lock = new();
+    private OidcRealApiFactory? _factory;
+
+    public OidcRealApiFactory GetOrCreate(KeycloakContainerFixture keycloak)
+    {
+        ArgumentNullException.ThrowIfNull(keycloak);
+
+        lock (_lock)
+        {
+            _factory ??= new OidcRealApiFactory(keycloak);
+            return _factory;
+        }
+    }
+
+    public void Dispose()
+    {
+        _factory?.Dispose();
+    }
+}


### PR DESCRIPTION
## Resumo

Implementa a Story #145 — suíte de testes E2E que exercita o pipeline real `JwtBearer` da API contra um Keycloak provisionado via Testcontainers. Hoje a cobertura de integração para o JWT usa o `TestAuthHandler`, que substitui o esquema de autenticação inteiro e não exercita a configuração real do `OidcAuthenticationConfiguration.AddOidcAuthentication`. Sem este E2E, qualquer mudança em `AddOidcAuthentication` fica sem rede de proteção contra regressão de segurança (rejeição de audience errada, expirado, chave externa).

## O que está coberto

| # | Cenário | Caminho exercitado |
|---|---|---|
| 1 | Token válido emitido pelo realm → `/api/auth/me` | Caminho feliz: validação de issuer, audience, lifetime, signing key passa; claims do KC chegam ao `IUserContext` |
| 2 | Token válido com scope `uniplus-profile` → `/api/profile/me` | Audience mapper `aud=uniplus` ativo; claims `cpf` e `nomeSocial` mapeados |
| 3 | Token expirado → `/api/auth/me` | `ValidateLifetime` rejeita após `ClockSkew` |
| 4 | Token sem `aud=uniplus` → `/api/auth/me` | `ValidateAudience` rejeita |
| 5 | Token assinado por chave externa → `/api/auth/me` | `ValidateIssuerSigningKey` rejeita kid não publicada no JWKS |
| 6 | `/health` da API | `OidcDiscoveryHealthCheck` reporta `Healthy` quando o discovery responde |

## Arquivos novos / alterados

- `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/KeycloakContainerFixture.cs` — sobe a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2` via Testcontainers genérico; importa o realm sintético; expõe `Authority`, `TokenEndpoint` e `RequestAccessTokenAsync`.
- `docker/keycloak/realm-e2e-tests.json` — realm `unifesspa-e2e` **separado** do canônico `realm-export.json`. Contém apenas o necessário para os 6 cenários: 4 usuários sintéticos, 2 clients confidenciais e o scope `uniplus-profile` autocontido. **Não é montado em compose nem em Helm** — vive exclusivamente para o ciclo desta fixture.
- `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs` — extrai `ConfigureTestAuthentication` como ponto de extensão virtual com semântica explícita; subclasses E2E sobrescrevem como no-op para preservar o `JwtBearer` produtivo.
- `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/` — `AuthE2ETests`, `KeycloakCollection` (`[CollectionDefinition]`), `OidcRealApiFactory` e `OidcRealApiFactoryWrapper` (workaround idiomático para combinar collection fixture + class-scoped factory em xUnit 2).
- `Directory.Packages.props` + `Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj` — pacotes `Testcontainers 4.11.0` e `xunit`.
- `docs/testing-e2e-auth.md` — guia em pt-BR com pré-requisitos (kernel 6.19+ veth), pinning, hot/cold start, troubleshooting e justificativa da separação canônico vs sintético.

## Decisões de design

- **Realm de teste em arquivo separado.** O `realm-export.json` é fonte de verdade para dev/homologação/produção. Adicionar clients de teste, secrets em texto claro ou relaxar políticas de senha ali criava risco de promoção inadvertida. O `realm-e2e-tests.json` é deliberadamente isolado, com nome de realm próprio (`unifesspa-e2e`) — o issuer dos tokens de teste é literalmente diferente do de produção.
- **`ConfigureTestAuthentication` virtual em vez de flag boolean.** Subclasses sinalizam intent pelo nome do método sobrescrito, não por uma flag opaca. O override no `OidcRealApiFactory` é um no-op com docstring que explica que o intent é validar a cadeia real.
- **Senha em texto claro intencional.** Os clients `e2e-tests` e `e2e-tests-bad-aud` usam `e2e-secret` em texto claro. Esse secret existe SOMENTE em `realm-e2e-tests.json` e SOMENTE em containers efêmeros do Testcontainers; o realm canônico não tem esses clients e não habilita Direct Access Grant em nenhum cliente. Não há vetor de exposição da aplicação real.
- **Forging de tokens na suíte.** O cenário de chave externa (caso 5) usa `JsonWebTokenHandler` para emitir um JWT com chave RSA gerada in-test, com issuer/audience/lifetime corretos mas signing key desconhecida — isolando a falha em `ValidateIssuerSigningKey`. Casos 3 e 4 usam tokens reais do KC para isolar `ValidateLifetime` e `ValidateAudience` respectivamente.

## Tempo medido

- Hot start total dos 6 cenários: ~47s, dominados pelos 36s de `Task.Delay(ClockSkew + lifespan)` do cenário 3. Sem essa janela, ~13s — dentro da meta de < 30s.
- Cold start (primeira execução com pull da imagem do GHCR): dominado pelo pull de ~463MB.
- Suíte completa do solution após o PR: 18/18 em `Selecao.IntegrationTests` (incluindo os 6 novos), ArchTests verdes, demais unit tests verdes.

## Critérios de aceite (#145)

- [x] `KeycloakContainerFixture` adicionada em `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/` e exposta via `[CollectionDefinition]` (no assembly de teste, conforme exige xUnit 2.x)
- [x] Testes rodam em CI sem depender de Docker externo (Testcontainers gerencia)
- [x] Tempo total da suíte < 30s em hot start nos cenários instantâneos; o cenário 3 (token expirado) consome a janela de `ClockSkew + lifespan` de forma determinística
- [x] Realm sintético é fonte única — sem duplicação de usuários/clients no código de teste
- [x] Documentação em `docs/testing-e2e-auth.md` (incluindo `sudo modprobe veth` no kernel 6.19+)
- [x] Pinning da imagem documentado (patch fixo `1.0.2` alinhado ao `docker-compose.yml`)

## Test plan

- [x] `dotnet build UniPlus.slnx` verde
- [x] `dotnet test UniPlus.slnx` — todos os assemblies verdes (271+ testes)
- [x] `dotnet test --filter "FullyQualifiedName~AuthE2ETests"` — 6/6 verdes
- [ ] CI verde após push

Closes #145