### PR TITLE
docs(adr): ADR-0021 — adocao do AwesomeAssertions

### DIFF
--- a/docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md
+++ b/docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md
@@ -17,7 +17,7 @@ informed:
 
 A suíte de testes do `uniplus-api` adotou inicialmente `FluentAssertions 8.9.0` (`Directory.Packages.props`) como biblioteca de assertions, com 11 projetos `.csproj` de teste e 32 arquivos `.cs` referenciando `using FluentAssertions;`.
 
-A partir da versão 8, a Fluent Assertions passou a ser distribuída pela Xceed sob modelo de **licença comercial paga** para uso fora de cenários estritamente não comerciais. O `uniplus-api` é mantido por uma autarquia federal (Unifesspa) e o uso continuado da v8 sem aquisição formal de licença configura uma exposição regulatória e contratual evitável, especialmente em vista da política institucional de preferência por software open source com licenças permissivas.
+A partir da versão 8, a Fluent Assertions passou a ser distribuída pela Xceed sob modelo de **licença comercial paga**. A documentação oficial do produto exige "an active and valid license subscription [...] for all developers using the product, including those working on any application or project that integrates our components" — sem exemption explícita para projetos open source ou uso institucional. O `uniplus-api` é mantido por uma autarquia federal (Unifesspa) e o uso continuado da v8 sem aquisição formal de licença configura uma exposição regulatória e contratual evitável, agravada pela política institucional de preferência por software open source com licenças permissivas.
 
 Adicionalmente, o projeto prevê uma suíte de testes robusta para regras de negócio sensíveis (classificação de candidatos, aplicação de cotas, desempate, recursos), além de testes contratuais sobre DTOs, responses HTTP, eventos de domínio, comandos Wolverine e grafos de objetos transferidos entre módulos. A biblioteca de assertions adotada precisa suportar bem **equivalência estrutural configurável**, não apenas assertions diretas.
 
@@ -33,7 +33,7 @@ A Story `unifesspa-edu-br/uniplus-api#169` formaliza a remediação e decompõe 
 
 ## Opções consideradas
 
-- **AwesomeAssertions** (Apache-2.0) — fork comunitário do Fluent Assertions v7, mantido por `AwesomeAssertions/meenzen` no GitHub.
+- **AwesomeAssertions** (Apache-2.0) — fork comunitário do Fluent Assertions v7, mantido pela organização [`AwesomeAssertions/AwesomeAssertions`](https://github.com/AwesomeAssertions/AwesomeAssertions) ("a fork of FluentAssertions controlled by the community").
 - **Shouldly** (BSD-3-Clause) — biblioteca de assertions independente, sintaxe `Should*` direta, foco em legibilidade.
 - **`Assert` puro do xUnit** — sem biblioteca de assertions adicional.
 
@@ -72,11 +72,11 @@ Mecanismos para confirmar a decisão ao longo do tempo:
 1. **Grep no monorepo** (executável em CI ou localmente):
 
    ```bash
-   grep -rn "FluentAssertions" --include='*.cs' --include='*.csproj' --include='*.props' . \
-     | grep -v 'docs/adrs/0021'
+   grep -rn "FluentAssertions" --include='*.cs' --include='*.csproj' --include='*.props' \
+        --exclude-dir=docs --exclude-dir=.git .
    ```
 
-   Resultado esperado pós-PR-2: zero ocorrências. O PR-2 (`#171`) deve incluir a atualização das docs (`CLAUDE.md` seção *Stack e versões*, `CONTRIBUTING.md` tabela *Padrões de Código*) para evitar que o grep retorne ocorrências espúrias em arquivos de documentação que ainda listem `FluentAssertions`.
+   Resultado esperado pós-PR-2: zero ocorrências. O filtro `--exclude-dir=docs` evita falso positivo do próprio ADR-0021 e de documentação histórica. O PR-2 (`#171`) deve, ainda assim, atualizar `CLAUDE.md` (seção *Stack e versões*) e `CONTRIBUTING.md` (tabela *Padrões de Código*) para que nenhum guia ativo passe a divergir da decisão.
 
 2. **Lint rule futura** (issue de follow-up): adicionar um analisador Roslyn ou check de CI dedicado que falhe quando `using FluentAssertions;` for introduzido. Tracking em issue separada.
 
@@ -111,7 +111,8 @@ Mecanismos para confirmar a decisão ao longo do tempo:
 
 - [Repositório AwesomeAssertions](https://github.com/AwesomeAssertions/AwesomeAssertions) (fork comunitário Apache-2.0)
 - [Pacote NuGet AwesomeAssertions](https://www.nuget.org/packages/AwesomeAssertions)
-- [Documentação de equivalência estrutural (Fluent/AwesomeAssertions)](https://fluentassertions.com/objectgraphs/)
+- [Documentação oficial AwesomeAssertions](https://awesomeassertions.org) — site canônico do fork
+- [Documentação de equivalência estrutural (Fluent Assertions, API compatível)](https://fluentassertions.com/objectgraphs/) — referência histórica preservada por compatibilidade de API
 - [Política de licenciamento da Fluent Assertions / Xceed](https://xceed.com/documentation/xceed-fluent-assertions-for-net/)
 - [Documentação Shouldly](https://docs.shouldly.org/)
 - [Issue Shouldly sobre customização de `ShouldBeEquivalentTo`](https://github.com/shouldly/shouldly/issues/1116)

--- a/docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md
+++ b/docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md
@@ -1,0 +1,120 @@
+---
+status: "accepted"
+date: "2026-05-02"
+decision-makers:
+  - "Tech Lead"
+consulted:
+  - "Backend (CTIC)"
+  - "FullStack (CTIC)"
+  - "Q.A (CTIC)"
+informed:
+  - "Time Uni+"
+---
+
+# ADR-0021: Adoção de AwesomeAssertions como biblioteca de assertions de testes
+
+## Contexto e enunciado do problema
+
+A suíte de testes do `uniplus-api` adotou inicialmente `FluentAssertions 8.9.0` (`Directory.Packages.props`) como biblioteca de assertions, com 11 projetos `.csproj` de teste e 32 arquivos `.cs` referenciando `using FluentAssertions;`.
+
+A partir da versão 8, a Fluent Assertions passou a ser distribuída pela Xceed sob modelo de **licença comercial paga** para uso fora de cenários estritamente não comerciais. O `uniplus-api` é mantido por uma autarquia federal (Unifesspa) e o uso continuado da v8 sem aquisição formal de licença configura uma exposição regulatória e contratual evitável, especialmente em vista da política institucional de preferência por software open source com licenças permissivas.
+
+Adicionalmente, o projeto prevê uma suíte de testes robusta para regras de negócio sensíveis (classificação de candidatos, aplicação de cotas, desempate, recursos), além de testes contratuais sobre DTOs, responses HTTP, eventos de domínio, comandos Wolverine e grafos de objetos transferidos entre módulos. A biblioteca de assertions adotada precisa suportar bem **equivalência estrutural configurável**, não apenas assertions diretas.
+
+A Story `unifesspa-edu-br/uniplus-api#169` formaliza a remediação e decompõe a entrega em duas tasks: `#170` (esta ADR) e `#171` (refactor mecânico).
+
+## Drivers da decisão
+
+- **Compliance e licenciamento.** Eliminar dependência de pacote sob licença comercial paga não adquirida.
+- **Capacidade de equivalência estrutural.** Suportar comparação configurável de DTOs, responses, eventos e grafos complexos por shape — `BeEquivalentTo`, customização por membro/tipo/caminho, `AssertionScope`. **Critério decisivo** entre os candidatos open source.
+- **Política open source first.** Preferência institucional por bibliotecas com licenças permissivas (MIT, Apache-2.0, BSD).
+- **Continuidade de manutenção.** Optar por biblioteca com mantenedores ativos e sinal de comunidade saudável.
+- **Custo de migração.** A baixa fricção a partir do estado atual é um fator secundário desejável, não decisivo.
+
+## Opções consideradas
+
+- **AwesomeAssertions** (Apache-2.0) — fork comunitário do Fluent Assertions v7, mantido por `AwesomeAssertions/meenzen` no GitHub.
+- **Shouldly** (BSD-3-Clause) — biblioteca de assertions independente, sintaxe `Should*` direta, foco em legibilidade.
+- **`Assert` puro do xUnit** — sem biblioteca de assertions adicional.
+
+## Resultado da decisão
+
+**Escolhida:** "AwesomeAssertions", porque é o único candidato que combina licença permissiva (Apache-2.0) e capacidade avançada de equivalência estrutural configurável — os dois drivers de maior peso.
+
+A versão alvo é **AwesomeAssertions 9.x** (estável atual: 9.4.0). A migração no PR-2 (`#171`) é mecânica: trocar a entry em `Directory.Packages.props`, as 11 referências em `.csproj` de teste e os 32 `using FluentAssertions;` por `using AwesomeAssertions;`, além de atualizar as docs (`CLAUDE.md`, `CONTRIBUTING.md`) que listam a biblioteca de assertions. Nenhuma alteração no corpo dos testes é prevista.
+
+A escolha **não se reduz à facilidade de migração**. Mesmo num cenário hipotético em que a suíte fosse pequena, AwesomeAssertions ainda venceria pela capacidade de equivalência estrutural configurável — exigência projetada para a fase de implementação do motor de classificação ([ADR-0013](0013-motor-de-classificacao-como-servicos-de-dominio-puros.md)) e dos contratos REST ([ADR-0015](0015-rest-contract-first-com-openapi.md)). A continuidade da DSL fluente, embora útil, é consequência da escolha — não sua justificativa.
+
+**Guardrail de uso.** `BeEquivalentTo` e seus operadores estruturais devem ser usados com critério para validação de **contratos e shapes** (DTOs, responses HTTP, payloads de eventos). Para regras de negócio centrais — em especial decisões de aprovação, reprovação, classificação e desempate — a suíte deve preferir **assertions explícitas e nominais** sobre o resultado, evitando que uma comparação estrutural genérica mascare uma quebra semântica importante.
+
+## Consequências
+
+### Positivas
+
+- Licença Apache-2.0 elimina o risco regulatório e o custo de licenciamento associados à v8 da Xceed.
+- Migração custo-zero: a API pública de AwesomeAssertions v9 é drop-in compatível com a DSL fluente já em uso.
+- Capacidade plena de equivalência estrutural preservada para os cenários previstos (motor de classificação, contratos REST, eventos Wolverine).
+- Independência de fornecedor: o fork é mantido pela comunidade sob licença permissiva.
+
+### Negativas
+
+- AwesomeAssertions é um fork relativamente recente (publicado a partir do divisor de águas de licenciamento da v8). A maturidade do projeto upstream é alta (vem de Fluent Assertions v7), mas o time precisa monitorar a saúde do fork (releases, issues, mantenedores).
+- Adoção bem-sucedida da DSL fluente facilita escrita de assertions longas e verbosas; isso exige disciplina de revisão para não diluir a clareza dos testes.
+
+### Neutras
+
+- Versionamento divergente do upstream: AwesomeAssertions usa numeração v9.x, enquanto Fluent Assertions ficou em v8 — não há ambiguidade de versão entre as duas, mas a referência cruzada exige atenção.
+
+## Confirmação
+
+Mecanismos para confirmar a decisão ao longo do tempo:
+
+1. **Grep no monorepo** (executável em CI ou localmente):
+
+   ```bash
+   grep -rn "FluentAssertions" --include='*.cs' --include='*.csproj' --include='*.props' . \
+     | grep -v 'docs/adrs/0021'
+   ```
+
+   Resultado esperado pós-PR-2: zero ocorrências. O PR-2 (`#171`) deve incluir a atualização das docs (`CLAUDE.md` seção *Stack e versões*, `CONTRIBUTING.md` tabela *Padrões de Código*) para evitar que o grep retorne ocorrências espúrias em arquivos de documentação que ainda listem `FluentAssertions`.
+
+2. **Lint rule futura** (issue de follow-up): adicionar um analisador Roslyn ou check de CI dedicado que falhe quando `using FluentAssertions;` for introduzido. Tracking em issue separada.
+
+3. **Revisão de PRs**: o checklist de `/review-pr` deve sinalizar uso novo de `FluentAssertions` como bloqueador.
+
+## Prós e contras das opções
+
+### AwesomeAssertions
+
+- Bom, porque é Apache-2.0 (sem custo de licença, sem amarra contratual).
+- Bom, porque é drop-in compatível com a DSL fluente já em uso (32 arquivos migrados sem alteração de corpo).
+- Bom, porque oferece suporte completo a equivalência estrutural, customização por membro/tipo/caminho e `AssertionScope` — necessários para testes de contratos e grafos complexos.
+- Bom, porque preserva o tempo de aprendizado já investido pelo time na DSL.
+- Ruim, porque é um fork comunitário relativamente novo — exige acompanhamento periódico de saúde do projeto upstream.
+
+### Shouldly
+
+- Bom, porque é maduro, BSD-3-Clause, com sintaxe direta e muito legível para assertions simples.
+- Bom, porque tem comunidade ativa e ecossistema estabelecido.
+- Ruim, porque a equivalência estrutural (`ShouldBeEquivalentTo`) é menos configurável — limitada para customização por membro, tipo ou caminho. Há registro upstream da limitação na [issue shouldly/shouldly#1116](https://github.com/shouldly/shouldly/issues/1116) (aberta solicitando suporte a configuração granular de `ShouldBeEquivalentTo`, ainda sem entrega no momento desta ADR).
+- Ruim, porque a migração a partir de Fluent Assertions exigiria reescrita manual de assertions estruturais nos 32 arquivos atuais.
+- Ruim, porque a divergência de DSL impõe custo de relearning ao time.
+
+### `Assert` puro do xUnit
+
+- Bom, porque elimina qualquer dependência adicional.
+- Ruim, porque exige reescrita de toda a suíte de assertions existente.
+- Ruim, porque não oferece equivalência estrutural configurável — esse cenário precisaria ser implementado manualmente com helpers customizados.
+- Ruim, porque mensagens de erro são significativamente menos informativas que a DSL fluente para diagnóstico em CI.
+
+## Mais informações
+
+- [Repositório AwesomeAssertions](https://github.com/AwesomeAssertions/AwesomeAssertions) (fork comunitário Apache-2.0)
+- [Pacote NuGet AwesomeAssertions](https://www.nuget.org/packages/AwesomeAssertions)
+- [Documentação de equivalência estrutural (Fluent/AwesomeAssertions)](https://fluentassertions.com/objectgraphs/)
+- [Política de licenciamento da Fluent Assertions / Xceed](https://xceed.com/documentation/xceed-fluent-assertions-for-net/)
+- [Documentação Shouldly](https://docs.shouldly.org/)
+- [Issue Shouldly sobre customização de `ShouldBeEquivalentTo`](https://github.com/shouldly/shouldly/issues/1116)
+- Story: [`unifesspa-edu-br/uniplus-api#169`](https://github.com/unifesspa-edu-br/uniplus-api/issues/169)
+- Tasks: [`#170`](https://github.com/unifesspa-edu-br/uniplus-api/issues/170) (esta ADR), [`#171`](https://github.com/unifesspa-edu-br/uniplus-api/issues/171) (refactor)
+- ADRs relacionadas: [ADR-0013](0013-motor-de-classificacao-como-servicos-de-dominio-puros.md) (motor de classificação), [ADR-0015](0015-rest-contract-first-com-openapi.md) (contratos REST)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -49,6 +49,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0018](0018-opentelemetry-para-instrumentacao-do-backend.md) | OpenTelemetry para instrumentação do `uniplus-api` | accepted | 2026-04-28 |
 | [0019](0019-proibir-pii-em-path-segments-de-url.md) | Proibir PII em path segments de URL | accepted | 2026-05-01 |
 | [0020](0020-identity-brokering-govbr.md) | Identity brokering gov.br via Keycloak | accepted | 2026-05-01 |
+| [0021](0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md) | Adoção de AwesomeAssertions como biblioteca de assertions de testes | accepted | 2026-05-02 |
 
 ## Como adicionar um novo ADR
 


### PR DESCRIPTION
## Resumo

Registra a decisão de substituir `FluentAssertions 8.x` (Xceed comercial paga) por **AwesomeAssertions** (Apache-2.0, fork comunitário do Fluent Assertions v7) como biblioteca padrão de assertions de testes do `uniplus-api`.

Esta PR é a primeira de duas da Story #169 e entrega apenas a ADR. O refactor mecânico (`Directory.Packages.props`, 11 `.csproj`, 32 `using`s, atualização de `CLAUDE.md` e `CONTRIBUTING.md`) virá em PR separada cobrindo a task #171.

Closes #170

## Decisões registradas

- Adoção de **AwesomeAssertions 9.x** (estável atual: 9.4.0) como biblioteca padrão.
- **Critério decisivo:** capacidade de equivalência estrutural configurável — necessária para testes de DTOs, responses HTTP, eventos Wolverine e grafos do motor de classificação. Não é a facilidade de migração.
- **Shouldly descartada** sem desqualificar: boa biblioteca, mas com `ShouldBeEquivalentTo` menos configurável (registro upstream em [shouldly#1116](https://github.com/shouldly/shouldly/issues/1116)).
- **Guardrail:** `BeEquivalentTo` para contratos e shapes; assertions explícitas para regras centrais de aprovação/reprovação.
- **Confirmação:** grep no monorepo + lint rule futura (issue de follow-up) + checklist de revisão de PR.

## Test plan

- [x] `bash tools/adr-lint/validate.sh` → 21 ADR(s) validados sem erros
- [x] `npx markdownlint-cli2 'docs/adrs/0021-*.md' 'docs/adrs/README.md'` → 0 errors
- [x] Frontmatter MADR 4.0 completo (status, date, decision-makers, consulted, informed)
- [x] Todas as 8 seções obrigatórias presentes
- [x] Referências a Story #169, tasks #170 e #171, ADRs relacionadas (0013, 0015) e fontes externas

## Próximos passos

Após o merge desta PR, abrir PR-2 (`refactor/171-migracao-fluentassertions`) para a migração mecânica — `Closes #171` lá.