### PR TITLE
refactor(tests): migrar FluentAssertions para AwesomeAssertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - **Validação:** FluentValidation 12
 - **Logging:** Serilog 10
 - **Observabilidade:** OpenTelemetry
-- **Testes:** xUnit, FluentAssertions, NSubstitute, Bogus, Testcontainers, ArchUnitNET (pacote `TngTech.ArchUnitNET`)
+- **Testes:** xUnit, AwesomeAssertions, NSubstitute, Bogus, Testcontainers, ArchUnitNET (pacote `TngTech.ArchUnitNET`) — fork comunitário Apache-2.0 do Fluent Assertions ([ADR-0021](docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md))
 
 ## Estrutura do projeto
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,7 +282,7 @@ Essas regras são aplicadas automaticamente via GitHub aos colaboradores sem per
 
 | Tipo | Onde | Framework | Quando |
 |---|---|---|---|
-| Unitário | Domain, Application | xUnit + FluentAssertions + NSubstitute | Toda lógica de negócio |
+| Unitário | Domain, Application | xUnit + AwesomeAssertions + NSubstitute | Toda lógica de negócio (ver [ADR-0021](docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md) para a escolha da biblioteca de assertions) |
 | Integração | Infrastructure, API | Testcontainers + WebApplicationFactory | Endpoints e repositórios |
 
 ### Recomendado

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,7 +45,7 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="Testcontainers" Version="4.11.0" />

--- a/tests/Unifesspa.UniPlus.Application.Abstractions.UnitTests/Interfaces/IUnitOfWorkTests.cs
+++ b/tests/Unifesspa.UniPlus.Application.Abstractions.UnitTests/Interfaces/IUnitOfWorkTests.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Application.Abstractions.UnitTests.Interfaces;
 
 using System.Reflection;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 

--- a/tests/Unifesspa.UniPlus.Application.Abstractions.UnitTests/Unifesspa.UniPlus.Application.Abstractions.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Application.Abstractions.UnitTests/Unifesspa.UniPlus.Application.Abstractions.UnitTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />

--- a/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="TngTech.ArchUnitNET" />
     <PackageReference Include="TngTech.ArchUnitNET.xUnit" />
   </ItemGroup>

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/HttpUserContextTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/HttpUserContextTests.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Authentication;
 using System.Security.Claims;
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/OidcAuthenticationConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/OidcAuthenticationConfigurationTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Authentication;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/CorrelationIdServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/CorrelationIdServiceCollectionExtensionsTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.DependencyInjection;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/RequestLoggingServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/RequestLoggingServiceCollectionExtensionsTests.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.DependencyInjection;
 
 using System.Collections.Generic;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/WolverineMessagingServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/WolverineMessagingServiceCollectionExtensionsTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.DependencyInjection;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/HealthChecks/PostgresHealthCheckTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/HealthChecks/PostgresHealthCheckTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.HealthChecks;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Infrastructure.Core.HealthChecks;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/PiiMaskingEnricherTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/PiiMaskingEnricherTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Logging;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using NSubstitute;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/Middleware/WolverineLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/Middleware/WolverineLoggingMiddlewareTests.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.Middleware;
 
 using System.Diagnostics;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.Logging;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/Middleware/WolverineValidationMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/Middleware/WolverineValidationMiddlewareTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.Middleware;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using FluentValidation;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineCommandBusEndToEndTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineCommandBusEndToEndTests.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging;
 
 using System.Diagnostics.CodeAnalysis;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineCommandBusTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineCommandBusTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using NSubstitute;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineQueryBusTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineQueryBusTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using NSubstitute;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/CorrelationIdAccessorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/CorrelationIdAccessorTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Middleware;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Middleware;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/QueryStringMaskerTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/QueryStringMaskerTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Middleware;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/RequestLoggingMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/RequestLoggingMiddlewareTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Middleware;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/AuditableInterceptorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/AuditableInterceptorTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Persistence.Interceptors;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Persistence.Interceptors;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="NSubstitute" />
   </ItemGroup>
 

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="TngTech.ArchUnitNET" />
     <PackageReference Include="TngTech.ArchUnitNET.xUnit" />
   </ItemGroup>

--- a/tests/Unifesspa.UniPlus.Ingresso.Domain.UnitTests/Unifesspa.UniPlus.Ingresso.Domain.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Ingresso.Domain.UnitTests/Unifesspa.UniPlus.Ingresso.Domain.UnitTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Bogus" />
   </ItemGroup>
 

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/AuthEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/AuthEndpointsTests.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 using Unifesspa.UniPlus.Ingresso.IntegrationTests.Infrastructure;

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/ProfileEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/ProfileEndpointsTests.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 using Unifesspa.UniPlus.Ingresso.IntegrationTests.Infrastructure;

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/Unifesspa.UniPlus.Ingresso.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/Unifesspa.UniPlus.Ingresso.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseDomainEventsTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseDomainEventsTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.Entities;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Domain.Events;

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/CpfTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/CpfTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.ValueObjects;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
 using Unifesspa.UniPlus.Kernel.Results;

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/EmailTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/EmailTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.ValueObjects;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
 using Unifesspa.UniPlus.Kernel.Results;

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/NomeSocialTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/NomeSocialTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.ValueObjects;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
 using Unifesspa.UniPlus.Kernel.Results;

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/NotaFinalTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/NotaFinalTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.ValueObjects;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
 using Unifesspa.UniPlus.Kernel.Results;

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Unifesspa.UniPlus.Kernel.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Unifesspa.UniPlus.Kernel.UnitTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Unifesspa.UniPlus.Selecao.Application.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Unifesspa.UniPlus.Selecao.Application.UnitTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="Bogus" />
   </ItemGroup>

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/Unifesspa.UniPlus.Selecao.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/Unifesspa.UniPlus.Selecao.ArchTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="TngTech.ArchUnitNET" />
     <PackageReference Include="TngTech.ArchUnitNET.xUnit" />
   </ItemGroup>

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Unifesspa.UniPlus.Selecao.Domain.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Unifesspa.UniPlus.Selecao.Domain.UnitTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Bogus" />
   </ItemGroup>
 

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/AuthEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/AuthEndpointsTests.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 using Unifesspa.UniPlus.Selecao.IntegrationTests.Infrastructure;

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Authentication/AuthE2ETests.cs
@@ -5,7 +5,7 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
 
 using System.Globalization;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
 using System.Net;
 using System.Net.Http.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProfileEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProfileEndpointsTests.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 
-using FluentAssertions;
+using AwesomeAssertions;
 
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 using Unifesspa.UniPlus.Selecao.IntegrationTests.Infrastructure;

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Testcontainers.PostgreSql" />
     <PackageReference Include="WolverineFx" />
   </ItemGroup>


### PR DESCRIPTION
## Resumo

Aplica a decisão registrada no [ADR-0021](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md) (mergeado via #255), substituindo `FluentAssertions 8.x` (Xceed comercial paga, sem licença adquirida pela Unifesspa) por `AwesomeAssertions 9.4.0` (Apache-2.0, fork comunitário do Fluent Assertions v7).

Refactor mecânico, sem alteração semântica nos testes. A API de AwesomeAssertions é drop-in compatível com a DSL fluente já internalizada nos arquivos de teste.

Esta PR fecha a Story #169 ao concluir a segunda das duas tasks (#170 já fechado pelo PR #255).

Closes #171

## Mudanças

| Arquivo / grupo | Tipo | Quantidade |
|---|---|---|
| `Directory.Packages.props` (linha 48) | Substituição da entry de pacote | 1 |
| `tests/**/*.csproj` (`PackageReference`) | Substituição mecânica | 11 |
| `tests/**/*.cs` (`using FluentAssertions;` → `using AwesomeAssertions;`) | Substituição mecânica | 32 |
| `CLAUDE.md` (seção *Stack e versões*) | Atualização de nome + referência ao ADR-0021 | 1 |
| `CONTRIBUTING.md` (tabela *Padrões de Teste*) | Atualização de nome + referência ao ADR-0021 | 1 |
| **Total** | | **46 arquivos, 46 inserções, 46 deleções** |

Nenhuma alteração em `src/`. Corpo dos testes preservado.

## Test plan

Validação local:

- [x] `dotnet restore UniPlus.slnx` → sem warning de licença/depreciação
- [x] `dotnet build UniPlus.slnx` → 0 warnings (com `TreatWarningsAsErrors` ligado)
- [x] `dotnet test` (unit + arch, filtro `!~IntegrationTests`) → 247 testes verdes
- [x] `dotnet test` (integration com Testcontainers) → 25 testes verdes (6 Ingresso + 19 Seleção)
- [x] `grep -rn "FluentAssertions" --include='*.cs' --include='*.csproj' --include='*.props' --exclude-dir=docs --exclude-dir=.git .` → **0 ocorrências**

Validação de CI esperada:

- [ ] ADR lint (MADR 4.0) — pass
- [ ] PR author is org member — pass
- [ ] Build, Test and Coverage — pass