### PR TITLE
chore(ci): lint rule contra reintrodução de FluentAssertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,20 @@ jobs:
       - name: Markdown lint (markdownlint-cli2)
         run: npx --yes markdownlint-cli2 'docs/adrs/**/*.md'
 
+  forbidden-deps:
+    name: Forbidden dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Verificar pacotes proibidos
+        run: bash tools/forbidden-deps/check.sh
+
   build:
     name: Build, Test and Coverage
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,6 +327,25 @@ O PR será bloqueado se qualquer gate falhar:
 - [ ] SonarQube: zero issues críticos ou bloqueadores
 - [ ] Nenhuma vulnerabilidade crítica em dependências
 - [ ] Formatação correta (`dotnet format`)
+- [ ] Pacotes proibidos ausentes (`bash tools/forbidden-deps/check.sh`) — ver [§ Pacotes proibidos](#pacotes-proibidos)
+
+### Pacotes proibidos
+
+Algumas dependências foram banidas por ADR (licença incompatível, segurança, manutenção interrompida etc.). O job **`Forbidden dependencies`** do CI executa [`tools/forbidden-deps/check.sh`](tools/forbidden-deps/check.sh) e bloqueia o merge se encontrar reintrodução. Veja [`tools/forbidden-deps/README.md`](tools/forbidden-deps/README.md) para o detalhamento do mecanismo.
+
+Para checar localmente antes do push:
+
+```bash
+bash tools/forbidden-deps/check.sh
+```
+
+Banidos atualmente:
+
+| Pacote | Substituto | ADR |
+|--------|-----------|-----|
+| `FluentAssertions` (v8+) | [`AwesomeAssertions`](https://www.nuget.org/packages/AwesomeAssertions) | [ADR-0021](docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md) |
+
+Para banir uma nova dependência: criar/atualizar a ADR correspondente, adicionar entrada em [`tools/forbidden-deps/check.sh`](tools/forbidden-deps/check.sh) e atualizar a tabela em [`tools/forbidden-deps/README.md`](tools/forbidden-deps/README.md).
 
 ---
 

--- a/tools/forbidden-deps/README.md
+++ b/tools/forbidden-deps/README.md
@@ -24,7 +24,7 @@ Exit code != 0 quando houver pelo menos uma ocorrência ativa.
 
 ## Como adicionar nova proibição
 
-1. Acrescente uma entrada ao array `FORBIDDEN` em [`check.sh`](check.sh) no formato `'nome~regex_para_cs~regex_para_csproj_e_props~motivo~ADR'`. O separador é `~` (escolhido por não colidir com sintaxe de regex de alternation `|` nem com nomes de pacote .NET).
+1. Acrescente uma entrada ao array `FORBIDDEN` em [`check.sh`](check.sh) no formato `'nome~regex_para_cs~regex_para_csproj_e_props~motivo~ADR'`. O separador é `~` (escolhido por não colidir com sintaxe de regex de alternation `|` nem com nomes de pacote .NET). **Nenhum campo pode conter `~`** — o script falha alto (exit 2) se detectar entrada malformada.
 2. Atualize a tabela acima com o novo pacote.
 3. Escreva (ou referencie) uma ADR registrando a decisão de banir o pacote — toda proibição precisa ter uma ADR vinculada para rastreabilidade.
 
@@ -40,3 +40,7 @@ Esse recorte é intencional: o objetivo é impedir o uso de produção/teste do 
 ## Integração com CI
 
 O check roda como job dedicado em [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) sob o nome **`Forbidden dependencies`**. Falha no CI bloqueia o merge.
+
+## Relação com a *Confirmação* do ADR-0021
+
+A seção *Confirmação* do [ADR-0021](../../docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md) documenta um grep amplo (`grep -rn "FluentAssertions" ...`) como mecanismo de verificação manual. Esta lint rule é a **implementação automatizada** desse mecanismo, com uma diferença deliberada: usa regex restritos (`using` efetivo, `Include="..."`) em vez do match genérico do nome. Isso elimina falsos positivos em comentários de código e strings literais, sem perder cobertura dos vetores reais de reintrodução. Os dois mecanismos são complementares — o grep amplo serve para auditoria humana exploratória, a lint rule serve como guarda contínua no CI.

--- a/tools/forbidden-deps/README.md
+++ b/tools/forbidden-deps/README.md
@@ -1,0 +1,42 @@
+# forbidden-deps
+
+Guarda contra reintrodução de dependências de teste vetadas pelo projeto Uni+. Script bash sem dependências externas — roda igual no laptop do dev e no CI.
+
+## Uso
+
+```bash
+bash tools/forbidden-deps/check.sh           # varre o repo a partir de .
+bash tools/forbidden-deps/check.sh tests     # restringe a um subdiretório
+```
+
+Saída:
+
+- `ok   {pacote} — sem ocorrências ativas (referência: ADR-XXXX)` — pacote permanece banido sem violações.
+- `FAIL {pacote} (N ocorrência(s))` — pacote proibido foi reintroduzido; lista os arquivos/linhas e referencia a ADR que vetou seu uso.
+
+Exit code != 0 quando houver pelo menos uma ocorrência ativa.
+
+## Pacotes vetados
+
+| Pacote | Motivo | Referência |
+|--------|--------|-----------|
+| `FluentAssertions` | Biblioteca de assertions Xceed comercial paga a partir da v8. Usar [`AwesomeAssertions`](https://www.nuget.org/packages/AwesomeAssertions) (Apache-2.0). | [ADR-0021](../../docs/adrs/0021-adocao-awesomeassertions-como-biblioteca-de-assertions.md) |
+
+## Como adicionar nova proibição
+
+1. Acrescente uma entrada ao array `FORBIDDEN` em [`check.sh`](check.sh) no formato `'nome~regex_para_cs~regex_para_csproj_e_props~motivo~ADR'`. O separador é `~` (escolhido por não colidir com sintaxe de regex de alternation `|` nem com nomes de pacote .NET).
+2. Atualize a tabela acima com o novo pacote.
+3. Escreva (ou referencie) uma ADR registrando a decisão de banir o pacote — toda proibição precisa ter uma ADR vinculada para rastreabilidade.
+
+Os regex devem ser **específicos da forma efetiva de uso** (ex.: `using XYZ;`, `Include="XYZ"`), não casos genéricos de menção, para evitar falso positivo em comentários, strings literais ou nomes de pacote semelhantes.
+
+## Escopo da varredura
+
+- **Inclui:** `*.cs`, `*.csproj`, `*.props`.
+- **Exclui:** `docs/` (ADRs e documentos podem citar o nome do pacote legitimamente como contexto histórico), `bin/`, `obj/`, `.git/`.
+
+Esse recorte é intencional: o objetivo é impedir o uso de produção/teste do pacote, não censurar a discussão sobre ele em documentação técnica.
+
+## Integração com CI
+
+O check roda como job dedicado em [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) sob o nome **`Forbidden dependencies`**. Falha no CI bloqueia o merge.

--- a/tools/forbidden-deps/check.sh
+++ b/tools/forbidden-deps/check.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# tools/forbidden-deps/check.sh — guarda contra reintrodução de dependências
+# de teste vetadas pelo projeto Uni+.
+#
+# Uso:
+#   bash tools/forbidden-deps/check.sh           # varre o repo a partir de .
+#   bash tools/forbidden-deps/check.sh DIR       # varre a partir de DIR
+#
+# Sai com código != 0 se encontrar pelo menos uma ocorrência ativa.
+
+set -euo pipefail
+
+ROOT="${1:-.}"
+
+if [[ ! -d "$ROOT" ]]; then
+  echo "ERRO: diretório $ROOT não encontrado" >&2
+  exit 2
+fi
+
+# Pacotes proibidos. Cada entrada usa '~' como separador (escolhido por não
+# colidir com sintaxe de regex nem com nomes de pacote .NET), com 5 campos:
+#   nome ~ regex_para_cs ~ regex_para_csproj_e_props ~ motivo ~ ADR
+#
+# Os regex são propositalmente específicos (forma efetiva de uso) para evitar
+# falso positivo em comentários, strings e nomes parecidos. Para adicionar nova
+# proibição, acrescente uma linha aqui e (se relevante) crie/atualize a ADR.
+FORBIDDEN=(
+  'FluentAssertions~^[[:space:]]*using[[:space:]]+(static[[:space:]]+)?FluentAssertions[[:space:];.]~Include="FluentAssertions"~biblioteca de assertions Xceed comercial paga (v8+); usar AwesomeAssertions~ADR-0021'
+)
+
+EXIT_CODE=0
+TOTAL_HITS=0
+
+for ENTRY in "${FORBIDDEN[@]}"; do
+  IFS='~' read -r NAME CS_PATTERN PROJ_PATTERN REASON ADR <<< "$ENTRY"
+
+  # Busca em duas frentes:
+  #   - .cs                : `using` (incluindo `using static`) que importe o namespace.
+  #   - .csproj / .props   : referência efetiva ao pacote (Central Package Management ou direta).
+  # Exclui docs/ (ADRs e guias citam o nome legitimamente como contexto histórico)
+  # e diretórios gerados (bin/, obj/, .git/).
+  HITS_CS=$(grep -rnE "$CS_PATTERN" "$ROOT" \
+    --include='*.cs' \
+    --exclude-dir=docs \
+    --exclude-dir=bin \
+    --exclude-dir=obj \
+    --exclude-dir=.git \
+    2>/dev/null || true)
+
+  HITS_PROJ=$(grep -rnE "$PROJ_PATTERN" "$ROOT" \
+    --include='*.csproj' \
+    --include='*.props' \
+    --exclude-dir=docs \
+    --exclude-dir=bin \
+    --exclude-dir=obj \
+    --exclude-dir=.git \
+    2>/dev/null || true)
+
+  HITS=$(printf '%s\n%s\n' "$HITS_CS" "$HITS_PROJ" | sed '/^$/d')
+
+  if [[ -n "$HITS" ]]; then
+    COUNT=$(echo "$HITS" | wc -l)
+    TOTAL_HITS=$((TOTAL_HITS + COUNT))
+    EXIT_CODE=1
+    echo "FAIL $NAME ($COUNT ocorrência(s))"
+    echo "  Motivo: $REASON"
+    echo "  Referência: $ADR"
+    echo "  Ocorrências:"
+    echo "$HITS" | sed 's/^/    /'
+    echo
+  else
+    echo "ok   $NAME — sem ocorrências ativas (referência: $ADR)"
+  fi
+done
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+  echo
+  echo "Falhou: $TOTAL_HITS ocorrência(s) de pacote(s) proibido(s) encontrada(s)."
+  echo "Remova as referências ou justifique no PR. Veja a ADR citada para o contexto."
+fi
+
+exit $EXIT_CODE

--- a/tools/forbidden-deps/check.sh
+++ b/tools/forbidden-deps/check.sh
@@ -32,7 +32,18 @@ EXIT_CODE=0
 TOTAL_HITS=0
 
 for ENTRY in "${FORBIDDEN[@]}"; do
-  IFS='~' read -r NAME CS_PATTERN PROJ_PATTERN REASON ADR <<< "$ENTRY"
+  IFS='~' read -r NAME CS_PATTERN PROJ_PATTERN REASON ADR EXTRA <<< "$ENTRY"
+
+  # Defesa em profundidade: o separador '~' é literal; se uma entrada futura
+  # introduzir '~' em qualquer campo (motivo ou ADR são os candidatos mais
+  # prováveis), o split distribui o conteúdo errado entre as variáveis.
+  # Falhar alto evita mensagens de erro confusas em CI.
+  if [[ -z "$NAME" || -z "$CS_PATTERN" || -z "$PROJ_PATTERN" || -z "$REASON" || -z "$ADR" || -n "$EXTRA" ]]; then
+    echo "ERRO: entrada FORBIDDEN malformada (esperados 5 campos separados por '~'):" >&2
+    echo "  $ENTRY" >&2
+    echo "  Verifique se nenhum campo contém o caractere '~'." >&2
+    exit 2
+  fi
 
   # Busca em duas frentes:
   #   - .cs                : `using` (incluindo `using static`) que importe o namespace.


### PR DESCRIPTION
## Resumo

Implementa o **mecanismo #2 da seção *Confirmação* do ADR-0021** (lint rule). Falha de forma automática quando alguém reintroduz `using FluentAssertions;` em `.cs` ou `<PackageReference Include="FluentAssertions" />` em `.csproj`/`.props`.

Closes #257

## Decisão técnica

A issue propôs três opções (Roslyn analyzer, CI check, combinação). Escolhi **CI check + script bash local executável** porque:

- Segue o pattern existente de [`tools/adr-lint/`](tools/adr-lint/README.md) — zero ferramental novo a manter.
- Cobre 100% dos cenários pré-merge sem custo adicional.
- YAGNI: Roslyn analyzer só se justificaria se múltiplas regras precisassem feedback contínuo no IDE.

## Mudanças

| Arquivo | Tipo |
|---------|------|
| `tools/forbidden-deps/check.sh` | NOVO — script bash sem dependências externas |
| `tools/forbidden-deps/README.md` | NOVO — documentação no padrão `tools/adr-lint/` |
| `.github/workflows/ci.yml` | Novo job `Forbidden dependencies` (timeout 2min) |
| `CONTRIBUTING.md` | Subseção *Pacotes proibidos* em *Quality gates* |

### Sobre o script

Cada pacote vetado tem **dois regex específicos** — um para `.cs` (`^[[:space:]]*using[[:space:]]+(static[[:space:]]+)?FluentAssertions[[:space:];.]`) e outro para `.csproj`/`.props` (`Include="FluentAssertions"`). Patterns específicos eliminam falso positivo em comentários de migração ou nomes parecidos. Separador de campos é `~` para não colidir com `|` de alternation de regex (bug pego no self-review).

## Test plan

Validação local em 6 cenários (todos com comportamento esperado):

| # | Cenário | Esperado | Resultado |
|---|---------|----------|-----------|
| 1 | Tree limpo | `ok`, exit 0 | ✅ |
| 2 | Comentário `// migrar de FluentAssertions...` em `.cs` | `ok`, exit 0 (sem falso positivo) | ✅ |
| 3 | `using FluentAssertions;` em `.cs` | `FAIL`, exit 1 | ✅ |
| 4 | `using static FluentAssertions.Foo;` em `.cs` | `FAIL`, exit 1 | ✅ |
| 5 | `<PackageReference Include="FluentAssertions" />` em `.csproj` | `FAIL`, exit 1 | ✅ |
| 6 | Tree limpo após cleanup | `ok`, exit 0 | ✅ |

CI esperado:

- [ ] ADR lint (MADR 4.0)
- [ ] PR author is org member
- [ ] **Forbidden dependencies** (novo)
- [ ] Build, Test and Coverage

## Critérios de aceite (#257)

- [x] Reintroduzir `using FluentAssertions;` em qualquer `.cs` provoca falha de CI antes do merge.
- [x] Adicionar `<PackageReference Include="FluentAssertions" />` em qualquer `.csproj` provoca falha de CI antes do merge.
- [x] Mecanismo documentado em `CONTRIBUTING.md` (seção *Pacotes proibidos*).
- [x] `docs/adrs/0021-*.md` tratado como falso positivo esperado (excluído via `--exclude-dir=docs`).