### PR TITLE
docs(adr-0027): Idempotency-Key opt-in com store em PostgreSQL adjacente ao outbox

### DIFF
--- a/docs/adrs/0027-idempotency-key-store-postgresql.md
+++ b/docs/adrs/0027-idempotency-key-store-postgresql.md
@@ -1,0 +1,130 @@
+---
+status: "accepted"
+date: "2026-05-03"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0027: `Idempotency-Key` opt-in com store em PostgreSQL adjacente ao outbox
+
+## Contexto e enunciado do problema
+
+Comandos `POST` e `PATCH` da `uniplus-api` precisam tolerar retry de cliente sem produzir efeito colateral duplicado. Cenários reais que motivam essa decisão:
+
+- Candidato envia `POST /inscricoes` no portal; rede cai antes da resposta chegar; cliente retry — sem idempotency, duas inscrições seriam criadas, violando [RN01](../../docs/visao-do-projeto.md) ("um CPF, uma inscrição ativa por processo seletivo") apenas no banco, mas com side effects (email de confirmação, evento Kafka, gravação outbox) já em curso.
+- Operador administrativo dispara `POST /editais/{id}/publicar`; timeout de proxy retorna 504 ao cliente; operador retry — sem idempotency, evento `EditalPublicado` é despachado duas vezes, drenando notificações duplicadas.
+- Aplicação cliente integrada (ex.: integração futura com SIGAA) replays mensagens em janela de recovery — qualquer comando crítico (recurso, matrícula, recálculo) pode ser entregue múltiplas vezes.
+
+Constraints de unicidade no domínio cobrem **parte** do problema (não permitem duas inscrições ativas para o mesmo CPF), mas não cobrem side effects fora do banco (eventos, emails, integrações), e não distinguem **retry legítimo** (mesmo payload, mesma intent) de **request lógica diferente** que por acaso colide com a unique key.
+
+A IETF tem um draft em fase final (`draft-ietf-httpapi-idempotency-key-header`) padronizando o header `Idempotency-Key` que vários produtores de API (Stripe, Square, PayPal, GitHub) já implementam de forma compatível. A decisão aqui é (i) adotar essa convenção, (ii) escolher onde persistir o cache de respostas idempotentes, (iii) definir granularidade (header opt-in vs sempre obrigatório) e (iv) escolher o tratamento de violações.
+
+## Drivers da decisão
+
+- **Conformidade com regras de negócio críticas.** [RN01](../../docs/visao-do-projeto.md) exige unicidade real, e processos como recurso administrativo, publicação de edital e matrícula não toleram duplicação silenciosa. Idempotency é a primeira linha de defesa antes de constraints no domínio.
+- **Side effects fora do banco.** Outbox (ADR-0004) garante eventos no `IEnvelopeTransaction`, mas não impede que duas execuções do mesmo handler enfileirem dois eventos. Idempotency em camada anterior elimina isso.
+- **Conformidade com padrão emergente.** `draft-ietf-httpapi-idempotency-key-header-07` é o caminho que clientes e bibliotecas vão consumir nos próximos anos; alinhamento agora evita migração depois.
+- **Atomicidade entre commit do agregado e gravação do cache.** Cache em Redis cria janela onde o agregado foi commitado mas o cache não chegou (ou vice-versa). Cache no mesmo PostgreSQL onde o outbox vive permite gravação na mesma `IEnvelopeTransaction` ([ADR-0004](0004-outbox-transacional-via-wolverine.md)).
+- **Auditabilidade.** Cache em Postgres é trivial de inspecionar e exportar para auditoria; cache em Redis exige tooling adicional.
+- **LGPD baseline.** Cache contém payload de request e response — pode incluir dados pessoais. Precisa cifragem at-rest com chave gerenciada externamente ([umbrella ADR-0022](0022-contrato-rest-canonico-umbrella.md), princípio 3).
+
+## Opções consideradas
+
+- **A. `Idempotency-Key` opt-in via atributo `[RequiresIdempotencyKey]`**, store em PostgreSQL na mesma transação do agregado, conforme `draft-ietf-httpapi-idempotency-key-header-07`.
+- **B. Mesma adoção do header, mas store em Redis** ([ADR-0008](0008-redis-como-cache-distribuido.md)).
+- **C. Sem `Idempotency-Key`** — confiar em unique constraints no domínio.
+- **D. Idempotency implícita via UPSERT** em todos os comandos — sem header.
+
+## Resultado da decisão
+
+**Escolhida:** "A — `Idempotency-Key` opt-in com store em PostgreSQL adjacente ao outbox", porque é a única opção que combina (i) conformidade com o draft IETF, (ii) atomicidade transacional entre commit do agregado e gravação do cache, (iii) cobertura de side effects fora do banco, e (iv) auditabilidade nativa.
+
+### Endpoints sob `Idempotency-Key`
+
+A obrigatoriedade do header é **opt-in por endpoint**. Endpoints elegíveis são marcados com o atributo `[RequiresIdempotencyKey]` na camada `API`. Critério para marcação: endpoint é POST ou PATCH **e** sua semântica natural não é idempotente (ou seja, repetir a mesma request causaria efeito acumulativo). Categorias iniciais que exigem o atributo:
+
+- Inscrição em processo seletivo (`POST /inscricoes`).
+- Cadastro/publicação de edital (`POST /editais`, `POST /editais/{id}/publicar`).
+- Recurso administrativo (`POST /recursos`).
+- Upload de documento comprobatório vinculado a cota.
+- Matrícula no módulo Ingresso.
+
+Endpoints `GET`, `PUT` puros (substituição completa, naturalmente idempotente), `DELETE` (idempotente por semântica) e `HEAD` **não** recebem o atributo. `PATCH` puramente idempotente (ex.: `PATCH /editais/{id}` que atualiza campos com last-write-wins) é avaliado caso a caso.
+
+### Forma do header e contrato com o cliente
+
+- **Header:** `Idempotency-Key: <opaque-string>`. Recomenda-se ULID ou GUID v7; a `uniplus-api` aceita qualquer string opaca de 1 a 255 caracteres ASCII imprimíveis (sem espaços, vírgulas ou ponto e vírgula, conforme draft IETF).
+- **Header ausente em endpoint marcado** → 400 Bad Request com `code: uniplus.idempotency.key_ausente`. Cliente deve gerar key e tentar novamente.
+- **Header presente em endpoint não marcado** → ignorado silenciosamente (compatível com Stripe). Não é erro porque clientes podem enviar a key uniformemente.
+- **Header malformado** (caracteres proibidos, comprimento fora do range) → 400 com `code: uniplus.idempotency.key_malformada`.
+
+### Lookup, replay e validação
+
+Em cada request com `Idempotency-Key`, o middleware (camada API):
+
+1. Calcula a chave de lookup composta: `(scope, endpoint, idempotency_key)`. `scope` carrega tenant futuro + identificador do principal autenticado (sub do JWT) para evitar colisão entre clientes diferentes que escolham a mesma key.
+2. Calcula `body_hash` da request body via SHA-256 (estável por content-type + canonical JSON ordering quando aplicável).
+3. Consulta o cache em PostgreSQL pela chave de lookup.
+
+Resultados possíveis:
+
+- **Cache miss** — primeira execução. Handler roda; ao final, response (status + headers relevantes + body) é gravada na mesma `IEnvelopeTransaction` ([ADR-0004](0004-outbox-transacional-via-wolverine.md)) que commita o agregado. TTL de 24 horas é aplicado.
+- **Cache hit + body_hash bate** — replay legítimo. Resposta cacheada é retornada **verbatim** (mesmo status code, mesmo body, header `Idempotency-Replayed: true` adicional informativo). Handler **não** roda novamente.
+- **Cache hit + body_hash diverge** — mesma key reusada com payload diferente. 422 Unprocessable Entity com `code: uniplus.idempotency.body_mismatch`. Sinaliza bug no cliente; não tenta inferir intent.
+- **Cache expirado** — request tratada como nova; handler roda. TTL é responsabilidade do cliente (24h é o teto).
+
+### Status codes em cache
+
+Tanto **2xx** quanto **4xx** são cacheados. A motivação é a convenção Stripe: se 4xx não fosse cacheado, um atacante poderia retry com diferentes keys até encontrar uma sequência que muda o estado, ou esgotar quotas indiretamente. **5xx não é cacheado** — cliente deve poder retry após falha transitória do servidor.
+
+### Cifragem at-rest
+
+O payload do cache (request body + response body) pode conter PII (CPF, nome social, email do candidato). Cifragem AES-GCM com chave gerenciada externamente (HashiCorp Vault transit em produção; fixture local em CI), mesma infraestrutura usada pelo cursor de paginação ([ADR-0026](0026-paginacao-cursor-opaco-cifrado.md)). Chave nunca sai do gerenciador. Rotação de chave não invalida entradas existentes — TTL de 24 horas as expira naturalmente.
+
+### Esta ADR não decide
+
+- Schema exato da tabela `idempotency_cache` (índices, particionamento, política de cleanup) — tarefa de implementação.
+- Algoritmo exato de canonicalização de JSON para `body_hash` — sugestão razoável é `RFC 8785 JSON Canonicalization Scheme`, decisão final na implementação.
+- Política de cleanup de entradas expiradas (job periódico vs `pg_cron` vs partition drop) — implementação.
+- Headers cacheados além de `Content-Type` e `Location` — caso a caso na implementação.
+
+## Consequências
+
+### Positivas
+
+- **Retry seguro.** Clientes (frontend, integradores externos) podem retry com confiança em qualquer cenário de timeout/network/proxy 5xx, sem risco de duplicação semântica.
+- **Conformidade com [RN01](../../docs/visao-do-projeto.md).** Inscrição duplicada por retry deixa de ser vetor; constraint de unicidade no domínio passa a ser última linha de defesa, não primeira.
+- **Atomicidade real.** Commit do agregado + gravação do cache acontecem na mesma transação Postgres. Não existe estado intermediário onde o agregado foi gravado mas o cache não, ou vice-versa.
+- **Auditabilidade.** Cache em Postgres é inspecionável via SQL para suporte e auditoria sem tooling extra.
+- **Convergência com mercado.** Comportamento idêntico a Stripe/Square/PayPal facilita integração de clientes que já implementam o padrão.
+
+### Negativas
+
+- **Carga adicional no Postgres.** Cada request idempotente faz uma leitura + uma escrita extra na mesma transação. Mitigação: índice em `(scope, endpoint, key)` e TTL agressivo (24h); volume do cache fica limitado por janela.
+- **Complexidade de cleanup.** Entradas expiradas precisam de job periódico ou estratégia de particionamento. Sem cleanup, tabela cresce indefinidamente.
+- **Cifragem adiciona latência.** Cifragem/decifragem por request idempotente acrescenta ~ms por chamada à infraestrutura de chave. Aceitável dado o ganho de segurança.
+- **Carga cognitiva no consumidor.** Cliente precisa saber gerar key estável e quais endpoints exigem o header. Documentação no portal e biblioteca de cliente (futuro Angular client codegen) atenuam.
+
+### Neutras
+
+- A infraestrutura de chave (Vault) é a mesma usada por [ADR-0026](0026-paginacao-cursor-opaco-cifrado.md) — não introduz dependência nova; só estende o uso.
+- Endpoints existentes do `EditalController` precisam ser anotados quando refatorados como pilot — escopo do PR de migração.
+
+## Confirmação
+
+1. **Spectral rule no CI** — endpoints declarados no spec OpenAPI com método `POST`/`PATCH` que tenham `[RequiresIdempotencyKey]` declaram parâmetro de header `Idempotency-Key` como required. Endpoints sem o atributo não declaram esse header como required.
+2. **Fitness test ArchUnit** — controllers cujo nome/anotação indique categoria de comando crítico (registrar, publicar, criar recurso, criar matrícula, fazer upload comprobatório) carregam `[RequiresIdempotencyKey]`. Listagem das categorias mantida em arquivo de configuração do teste; novas categorias entram via PR.
+3. **Smoke E2E (Postman/Newman)** — cenários cobrem (a) primeira request retorna response normal; (b) replay com mesma key + mesmo body retorna response idêntica + `Idempotency-Replayed: true`; (c) replay com mesma key + body diferente retorna 422 com `uniplus.idempotency.body_mismatch`; (d) request com header malformado retorna 400 com `uniplus.idempotency.key_malformada`; (e) request sem header em endpoint marcado retorna 400 com `uniplus.idempotency.key_ausente`.
+4. **Auditoria de cache** — relatório SQL periódico (suporte/segurança) verifica padrões de uso anormal: alta taxa de body_mismatch indica bug de cliente; alta taxa de cache hit em curto intervalo indica retry storm.
+
+## Mais informações
+
+- [ADR-0022](0022-contrato-rest-canonico-umbrella.md) — umbrella (princípio 3 LGPD aplicado ao payload do cache).
+- [ADR-0023](0023-wire-formato-erro-rfc-9457.md) — wire format dos erros 400/422 desta ADR.
+- [ADR-0004](0004-outbox-transacional-via-wolverine.md) — origem da mesma `IEnvelopeTransaction` onde o cache é gravado.
+- [ADR-0026](0026-paginacao-cursor-opaco-cifrado.md) — usa a mesma infraestrutura de chave externa.
+- [ADR-0007](0007-postgresql-18-como-banco-primario.md) — banco onde o cache vive.
+- [ADR-0008](0008-redis-como-cache-distribuido.md) — opção B rejeitada referencia esta ADR.
+- [draft-ietf-httpapi-idempotency-key-header-07](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07).
+- [Stripe — Idempotent Requests](https://docs.stripe.com/api/idempotent_requests) — referência operacional para comportamento de cache de 4xx e replay verbatim.
+- [RFC 8785 — JSON Canonicalization Scheme (JCS)](https://www.rfc-editor.org/rfc/rfc8785.html) — sugestão para canonicalização de body usada no `body_hash`.

--- a/docs/adrs/0027-idempotency-key-store-postgresql.md
+++ b/docs/adrs/0027-idempotency-key-store-postgresql.md
@@ -11,7 +11,7 @@ decision-makers:
 
 Comandos `POST` e `PATCH` da `uniplus-api` precisam tolerar retry de cliente sem produzir efeito colateral duplicado. Cenários reais que motivam essa decisão:
 
-- Candidato envia `POST /inscricoes` no portal; rede cai antes da resposta chegar; cliente retry — sem idempotency, duas inscrições seriam criadas, violando [RN01](../../docs/visao-do-projeto.md) ("um CPF, uma inscrição ativa por processo seletivo") apenas no banco, mas com side effects (email de confirmação, evento Kafka, gravação outbox) já em curso.
+- Candidato envia `POST /inscricoes` no portal; rede cai antes da resposta chegar; cliente retry — sem idempotency, duas inscrições seriam criadas, violando RN01 ("um CPF, uma inscrição ativa por processo seletivo") apenas no banco, mas com side effects (email de confirmação, evento Kafka, gravação outbox) já em curso.
 - Operador administrativo dispara `POST /editais/{id}/publicar`; timeout de proxy retorna 504 ao cliente; operador retry — sem idempotency, evento `EditalPublicado` é despachado duas vezes, drenando notificações duplicadas.
 - Aplicação cliente integrada (ex.: integração futura com SIGAA) replays mensagens em janela de recovery — qualquer comando crítico (recurso, matrícula, recálculo) pode ser entregue múltiplas vezes.
 
@@ -21,7 +21,7 @@ A IETF tem um draft em fase final (`draft-ietf-httpapi-idempotency-key-header`) 
 
 ## Drivers da decisão
 
-- **Conformidade com regras de negócio críticas.** [RN01](../../docs/visao-do-projeto.md) exige unicidade real, e processos como recurso administrativo, publicação de edital e matrícula não toleram duplicação silenciosa. Idempotency é a primeira linha de defesa antes de constraints no domínio.
+- **Conformidade com regras de negócio críticas.** RN01 exige unicidade real, e processos como recurso administrativo, publicação de edital e matrícula não toleram duplicação silenciosa. Idempotency é a primeira linha de defesa antes de constraints no domínio.
 - **Side effects fora do banco.** Outbox (ADR-0004) garante eventos no `IEnvelopeTransaction`, mas não impede que duas execuções do mesmo handler enfileirem dois eventos. Idempotency em camada anterior elimina isso.
 - **Conformidade com padrão emergente.** `draft-ietf-httpapi-idempotency-key-header-07` é o caminho que clientes e bibliotecas vão consumir nos próximos anos; alinhamento agora evita migração depois.
 - **Atomicidade entre commit do agregado e gravação do cache.** Cache em Redis cria janela onde o agregado foi commitado mas o cache não chegou (ou vice-versa). Cache no mesmo PostgreSQL onde o outbox vive permite gravação na mesma `IEnvelopeTransaction` ([ADR-0004](0004-outbox-transacional-via-wolverine.md)).
@@ -93,7 +93,7 @@ O payload do cache (request body + response body) pode conter PII (CPF, nome soc
 ### Positivas
 
 - **Retry seguro.** Clientes (frontend, integradores externos) podem retry com confiança em qualquer cenário de timeout/network/proxy 5xx, sem risco de duplicação semântica.
-- **Conformidade com [RN01](../../docs/visao-do-projeto.md).** Inscrição duplicada por retry deixa de ser vetor; constraint de unicidade no domínio passa a ser última linha de defesa, não primeira.
+- **Conformidade com RN01.** Inscrição duplicada por retry deixa de ser vetor; constraint de unicidade no domínio passa a ser última linha de defesa, não primeira.
 - **Atomicidade real.** Commit do agregado + gravação do cache acontecem na mesma transação Postgres. Não existe estado intermediário onde o agregado foi gravado mas o cache não, ou vice-versa.
 - **Auditabilidade.** Cache em Postgres é inspecionável via SQL para suporte e auditoria sem tooling extra.
 - **Convergência com mercado.** Comportamento idêntico a Stripe/Square/PayPal facilita integração de clientes que já implementam o padrão.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -55,6 +55,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0024](0024-mapeamento-domain-error-http.md) | Mapeamento `DomainError → HTTP` via `IDomainErrorMapper` registry | accepted | 2026-05-03 |
 | [0025](0025-wire-formato-sucesso-body-direto.md) | Wire format de sucesso — body é a representação direta do recurso | accepted | 2026-05-03 |
 | [0026](0026-paginacao-cursor-opaco-cifrado.md) | Paginação via cursor opaco cifrado e propagação por `Link` header | accepted | 2026-05-03 |
+| [0027](0027-idempotency-key-store-postgresql.md) | `Idempotency-Key` opt-in com store em PostgreSQL adjacente ao outbox | accepted | 2026-05-03 |
 | [0029](0029-hateoas-level-1-links.md) | HATEOAS Level 1 — `_links` mínimo embutido no recurso | accepted | 2026-05-03 |
 
 ## Como adicionar um novo ADR


### PR DESCRIPTION
## Resumo

Sexta da série de 11 ADRs binding ([umbrella ADR-0022](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0022-contrato-rest-canonico-umbrella.md)), segunda do batch 3a (Wave 3 paralela com [PR #275 ADR-0026](https://github.com/unifesspa-edu-br/uniplus-api/pull/275)).

## Decisão

Adota \`Idempotency-Key\` conforme \`draft-ietf-httpapi-idempotency-key-header-07\` como **header opt-in** via atributo \`[RequiresIdempotencyKey]\` em endpoints POST/PATCH naturalmente não-idempotentes (inscrição, edital, recurso, upload, matrícula).

### Store em PostgreSQL adjacente ao outbox

Cache vive na **mesma IEnvelopeTransaction** ([ADR-0004](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0004-outbox-transacional-via-wolverine.md)) que commita o agregado — atomicidade real entre escrita de domínio e gravação do response cacheado. Cifragem AES-GCM com chave externa (mesma infra do cursor da ADR-0026).

### Comportamento

- Cache hit + body bate → response **verbatim** + \`Idempotency-Replayed: true\`
- Cache hit + body diverge → **422** com \`uniplus.idempotency.body_mismatch\`
- Header ausente em endpoint marcado → **400** \`uniplus.idempotency.key_ausente\`
- Header malformado → **400** \`uniplus.idempotency.key_malformada\`
- 2xx e 4xx cacheados (convenção Stripe); 5xx nunca cacheado
- TTL teto: **24h**

### Por que B/C/D foram rejeitadas
- **B (Redis)** — cria janela não-atômica entre commit e cache
- **C (sem header, só unique constraints)** — não cobre side effects (eventos, emails, integrações)
- **D (UPSERT implícita)** — mesma limitação de C, sem cobertura de outbox

### Esta ADR não decide
- Schema da tabela / particionamento — implementação
- Algoritmo de canonicalização do body_hash (sugestão: RFC 8785 JCS)
- Política de cleanup de expirados — implementação

## Coordenação Wave 3a

PR aberto em paralelo com [PR #275 (ADR-0026)](https://github.com/unifesspa-edu-br/uniplus-api/pull/275). Ambos modificam \`docs/adrs/README.md\` adicionando uma linha após ADR-0025; rebase manual será necessário em quem mergear depois. **Sem conflito de conteúdo** entre as duas ADRs.

## Referências cruzadas
- [ADR-0022](../docs/adrs/0022-contrato-rest-canonico-umbrella.md) — princípio 3 LGPD
- [ADR-0023](../docs/adrs/0023-wire-formato-erro-rfc-9457.md) — wire format dos erros 400/422
- [ADR-0004](../docs/adrs/0004-outbox-transacional-via-wolverine.md) — origem da IEnvelopeTransaction
- [ADR-0026](../docs/adrs/0026-paginacao-cursor-opaco-cifrado.md) — mesma infra de chave externa

## Test plan
- [x] \`bash tools/adr-lint/validate.sh\` verde (26 ADRs)
- [x] \`npx markdownlint-cli2\` verde (28 arquivos)
- [x] Frontmatter MADR 4.0 mínimo
- [x] Anti-pattern grep limpo
- [x] Sem PII; sem referência a workspace privado
- [x] Cross-account: aberto por @marmota-alpina, aprovação por @jf2s

Closes #267