### PR TITLE
chore(openapi): setup Microsoft.AspNetCore.OpenApi, VaultSharp e Microsoft.OpenApi.Kiota

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,13 @@
     <!-- Authentication -->
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
 
+    <!-- OpenAPI -->
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.OpenApi.Kiota" Version="1.31.1" />
+
+    <!-- Encryption -->
+    <PackageVersion Include="VaultSharp" Version="1.17.5.1" />
+
     <!-- CQRS & Messaging -->
     <PackageVersion Include="WolverineFx" Version="5.32.1" />
     <PackageVersion Include="WolverineFx.EntityFrameworkCore" Version="5.32.1" />

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="WolverineFx.Postgresql" />
     <PackageReference Include="WolverineFx.Kafka" />

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="VaultSharp" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />


### PR DESCRIPTION
## Resumo

- Adiciona `Microsoft.AspNetCore.OpenApi 10.0.7` ao `Directory.Packages.props` e referencia em `Selecao.API` e `Ingresso.API`
- Adiciona `VaultSharp 1.17.5.1` ao `Directory.Packages.props` e referencia em `Infrastructure.Core`
- Reserva `Microsoft.OpenApi.Kiota 1.31.1` no `Directory.Packages.props` (usado em T17+ codegen frontend)

## Resultado do spike — capability ✅ confirmada

Spike executado localmente com controller `Produces("application/vnd.uniplus.edital.v1+json")` + `services.AddOpenApi("selecao")` + `app.MapOpenApi("/openapi/{documentName}.json")`:

```json
{
  "openapi": "3.1.1",
  "paths": {
    "/editais/{id}": {
      "get": {
        "responses": {
          "200": {
            "content": {
              "application/vnd.uniplus.edital.v1+json": { "schema": { "$ref": "#/components/schemas/EditalResponse" } }
            }
          }
        }
      }
    }
  }
}
```

**`Microsoft.AspNetCore.OpenApi` (built-in .NET 10) emite OpenAPI 3.1.1 válido com o vendor media type refletido corretamente nas responses.** Fallback `Microsoft.OpenApi` programmatic não é necessário. Pipeline canônico da ADR-0030 liberado.

**Nota de rota:** `MapOpenApi` exige template `{documentName}` no path (ex.: `/openapi/{documentName}.json`), não path fixo — documentado no `Program.cs` definitivo em T11.

## Mudanças

### Modificados
- `Directory.Packages.props` — adiciona 3 entradas novas nos grupos OpenAPI e Encryption
- `Selecao.API.csproj` — referencia `Microsoft.AspNetCore.OpenApi`
- `Ingresso.API.csproj` — referencia `Microsoft.AspNetCore.OpenApi`
- `Infrastructure.Core.csproj` — referencia `VaultSharp`

## Testes

- Build verde: `dotnet build UniPlus.slnx` — 0 warnings, 0 errors
- Spike PoC executado e removido (código throwaway não incluído no PR)

## Referências

- ADR-0030 — OpenAPI 3.1 contract-first (este spike é o gate dia-1)
- ADR-0026 — cursor cifrado (consumidor futuro do VaultSharp)
- ADR-0027 — Idempotency-Key (consumidor futuro do VaultSharp)

Closes #292