### PR TITLE
feat(encryption): IUniPlusEncryptionService + VaultTransit + LocalAES

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionFailureException.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionFailureException.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+/// <summary>
+/// Lançada quando qualquer operação de criptografia ou decriptografia falha.
+/// Não expõe detalhes internos (mensagem da causa) para não vazar informação sensível.
+/// </summary>
+public sealed class EncryptionFailureException : Exception
+{
+    public string KeyName { get; } = string.Empty;
+
+    public EncryptionFailureException() { }
+
+    public EncryptionFailureException(string message) : base(message) { }
+
+    public EncryptionFailureException(string keyName, Exception inner)
+        : base($"Falha na operação de criptografia para a chave '{keyName}'.", inner)
+    {
+        KeyName = keyName;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionOptions.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+using System.ComponentModel.DataAnnotations;
+
+public sealed class EncryptionOptions
+{
+    public const string SectionName = "UniPlus:Encryption";
+
+    /// <summary>Provedor ativo: "vault" (produção) ou "local" (dev/CI).</summary>
+    [Required]
+    public string Provider { get; set; } = "local";
+
+    /// <summary>
+    /// Chave AES-GCM 256 em Base64 (32 bytes). Lida de env var ou appsettings.
+    /// Obrigatória quando Provider = "local". Nunca commitar valor real.
+    /// </summary>
+    public string? LocalKey { get; set; }
+
+    /// <summary>Endereço do Vault (ex.: https://vault.unifesspa.edu.br). Obrigatório quando Provider = "vault".</summary>
+    public string? VaultAddress { get; set; }
+
+    /// <summary>Nome do mount do transit engine no Vault (padrão: "transit").</summary>
+    public string VaultTransitMount { get; set; } = "transit";
+
+    /// <summary>Path do service account JWT para autenticação K8s (padrão: /var/run/secrets/kubernetes.io/serviceaccount/token).</summary>
+    public string KubernetesJwtPath { get; set; } = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+
+    /// <summary>Role do Vault para autenticação K8s.</summary>
+    public string? KubernetesRole { get; set; }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/IUniPlusEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/IUniPlusEncryptionService.cs
@@ -3,6 +3,11 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
 /// <summary>
 /// Abstração de criptografia simétrica orientada a chaves nomeadas.
 /// Implementações concretas: Vault transit engine (produção) e AES-GCM local (dev/CI).
+/// <para>
+/// <b>Uso restrito a Infrastructure</b> — injetar exclusivamente em camadas de Infrastructure
+/// (ex.: EF Core value converters, repositórios). Application nunca deve depender diretamente
+/// desta interface; handlers trabalham com valores de domínio em texto claro.
+/// </para>
 /// </summary>
 public interface IUniPlusEncryptionService
 {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/IUniPlusEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/IUniPlusEncryptionService.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+/// <summary>
+/// Abstração de criptografia simétrica orientada a chaves nomeadas.
+/// Implementações concretas: Vault transit engine (produção) e AES-GCM local (dev/CI).
+/// </summary>
+public interface IUniPlusEncryptionService
+{
+    /// <summary>Cifra <paramref name="plaintext"/> usando a chave <paramref name="keyName"/>.</summary>
+    /// <exception cref="EncryptionFailureException">Qualquer falha na operação.</exception>
+    Task<byte[]> EncryptAsync(string keyName, byte[] plaintext, CancellationToken cancellationToken = default);
+
+    /// <summary>Decifra <paramref name="ciphertext"/> usando a chave <paramref name="keyName"/>.</summary>
+    /// <exception cref="EncryptionFailureException">Qualquer falha na operação, incluindo adulteração.</exception>
+    Task<byte[]> DecryptAsync(string keyName, byte[] ciphertext, CancellationToken cancellationToken = default);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/LocalAesEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/LocalAesEncryptionService.cs
@@ -63,7 +63,8 @@ internal sealed partial class LocalAesEncryptionService : IUniPlusEncryptionServ
             byte[] tag = new byte[TagSizeBytes];
 
             using AesGcm aes = new(_key, TagSizeBytes);
-            aes.Encrypt(nonce, plaintext, ciphertext, tag);
+            aes.Encrypt(nonce, plaintext, ciphertext, tag,
+                associatedData: System.Text.Encoding.UTF8.GetBytes(keyName));
 
             byte[] result = new byte[NonceSizeBytes + TagSizeBytes + ciphertext.Length];
             nonce.CopyTo(result, 0);
@@ -100,7 +101,8 @@ internal sealed partial class LocalAesEncryptionService : IUniPlusEncryptionServ
             byte[] plaintext = new byte[encrypted.Length];
 
             using AesGcm aes = new(_key, TagSizeBytes);
-            aes.Decrypt(nonce, encrypted, tag, plaintext);
+            aes.Decrypt(nonce, encrypted, tag, plaintext,
+                associatedData: System.Text.Encoding.UTF8.GetBytes(keyName));
 
             LogDecrypt(_logger, keyName);
             return Task.FromResult(plaintext);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/LocalAesEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/LocalAesEncryptionService.cs
@@ -1,0 +1,123 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+using System.Security.Cryptography;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Implementação AES-GCM 256 para dev/CI. Não usar em produção.
+/// Formato do ciphertext: nonce (12 bytes) || tag (16 bytes) || dados cifrados.
+/// </summary>
+internal sealed partial class LocalAesEncryptionService : IUniPlusEncryptionService
+{
+    private const int NonceSizeBytes = 12;
+    private const int TagSizeBytes = 16;
+
+    private readonly byte[] _key;
+    private readonly ILogger<LocalAesEncryptionService> _logger;
+
+    public LocalAesEncryptionService(IOptions<EncryptionOptions> options, ILogger<LocalAesEncryptionService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _logger = logger;
+
+        string localKey = options.Value.LocalKey
+            ?? throw new InvalidOperationException(
+                "UniPlus:Encryption:LocalKey é obrigatório quando Provider = 'local'. " +
+                "Defina via env var UNIPLUS__ENCRYPTION__LOCALKEY (base64, 32 bytes).");
+
+        byte[] keyBytes;
+        try
+        {
+            keyBytes = Convert.FromBase64String(localKey);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException(
+                "UniPlus:Encryption:LocalKey não é uma string Base64 válida.", ex);
+        }
+
+        if (keyBytes.Length != 32)
+        {
+            throw new InvalidOperationException(
+                $"UniPlus:Encryption:LocalKey deve ter 32 bytes (256 bits). Recebido: {keyBytes.Length} bytes.");
+        }
+
+        _key = keyBytes;
+    }
+
+    public Task<byte[]> EncryptAsync(string keyName, byte[] plaintext, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyName);
+        ArgumentNullException.ThrowIfNull(plaintext);
+
+        try
+        {
+            byte[] nonce = new byte[NonceSizeBytes];
+            RandomNumberGenerator.Fill(nonce);
+
+            byte[] ciphertext = new byte[plaintext.Length];
+            byte[] tag = new byte[TagSizeBytes];
+
+            using AesGcm aes = new(_key, TagSizeBytes);
+            aes.Encrypt(nonce, plaintext, ciphertext, tag);
+
+            byte[] result = new byte[NonceSizeBytes + TagSizeBytes + ciphertext.Length];
+            nonce.CopyTo(result, 0);
+            tag.CopyTo(result, NonceSizeBytes);
+            ciphertext.CopyTo(result, NonceSizeBytes + TagSizeBytes);
+
+            LogEncrypt(_logger, keyName);
+            return Task.FromResult(result);
+        }
+        catch (Exception ex) when (ex is not EncryptionFailureException)
+        {
+            throw new EncryptionFailureException(keyName, ex);
+        }
+    }
+
+    public Task<byte[]> DecryptAsync(string keyName, byte[] ciphertext, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyName);
+        ArgumentNullException.ThrowIfNull(ciphertext);
+
+        int minLength = NonceSizeBytes + TagSizeBytes + 1;
+        if (ciphertext.Length < minLength)
+        {
+            throw new EncryptionFailureException(keyName,
+                new CryptographicException("Ciphertext inválido: tamanho insuficiente."));
+        }
+
+        try
+        {
+            ReadOnlySpan<byte> nonce = ciphertext.AsSpan(0, NonceSizeBytes);
+            ReadOnlySpan<byte> tag = ciphertext.AsSpan(NonceSizeBytes, TagSizeBytes);
+            ReadOnlySpan<byte> encrypted = ciphertext.AsSpan(NonceSizeBytes + TagSizeBytes);
+
+            byte[] plaintext = new byte[encrypted.Length];
+
+            using AesGcm aes = new(_key, TagSizeBytes);
+            aes.Decrypt(nonce, encrypted, tag, plaintext);
+
+            LogDecrypt(_logger, keyName);
+            return Task.FromResult(plaintext);
+        }
+        catch (CryptographicException ex)
+        {
+            throw new EncryptionFailureException(keyName, ex);
+        }
+        catch (Exception ex) when (ex is not EncryptionFailureException)
+        {
+            throw new EncryptionFailureException(keyName, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Encrypt concluído para chave '{KeyName}'")]
+    private static partial void LogEncrypt(ILogger logger, string keyName);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Decrypt concluído para chave '{KeyName}'")]
+    private static partial void LogDecrypt(ILogger logger, string keyName);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/LocalAesEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/LocalAesEncryptionService.cs
@@ -84,7 +84,7 @@ internal sealed partial class LocalAesEncryptionService : IUniPlusEncryptionServ
         ArgumentException.ThrowIfNullOrEmpty(keyName);
         ArgumentNullException.ThrowIfNull(ciphertext);
 
-        int minLength = NonceSizeBytes + TagSizeBytes + 1;
+        int minLength = NonceSizeBytes + TagSizeBytes;
         if (ciphertext.Length < minLength)
         {
             throw new EncryptionFailureException(keyName,

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 using VaultSharp;
+using VaultSharp.Core;
 using VaultSharp.V1.AuthMethods.Kubernetes;
 using VaultSharp.V1.Commons;
 using VaultSharp.V1.SecretsEngines.Transit;
@@ -12,10 +13,14 @@ using VaultSharp.V1.SecretsEngines.Transit;
 /// Implementação de produção via HashiCorp Vault transit engine.
 /// Chaves nunca saem do Vault; autenticação via Kubernetes auth method.
 /// </summary>
-internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryptionService
+internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryptionService, IDisposable
 {
-    private readonly VaultClient _vault;
+    private volatile VaultClient _vault;
+    private readonly string _vaultAddress;
+    private readonly string _jwtPath;
+    private readonly string _role;
     private readonly string _transitMount;
+    private readonly SemaphoreSlim _refreshLock = new(1, 1);
     private readonly ILogger<VaultTransitEncryptionService> _logger;
 
     public VaultTransitEncryptionService(IOptions<EncryptionOptions> options, ILogger<VaultTransitEncryptionService> logger)
@@ -33,13 +38,12 @@ internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryption
                 "UniPlus:Encryption:VaultAddress é obrigatório quando Provider = 'vault'.");
         }
 
-        string jwt = File.ReadAllText(opts.KubernetesJwtPath);
-
-        KubernetesAuthMethodInfo authMethod = new(opts.KubernetesRole ?? "uniplus-api", jwt);
-        VaultClientSettings settings = new(opts.VaultAddress, authMethod);
-
-        _vault = new VaultClient(settings);
+        _vaultAddress = opts.VaultAddress;
+        _jwtPath = opts.KubernetesJwtPath;
+        _role = opts.KubernetesRole ?? "uniplus-api";
         _transitMount = opts.VaultTransitMount;
+
+        _vault = CreateVaultClient();
     }
 
     public async Task<byte[]> EncryptAsync(string keyName, byte[] plaintext, CancellationToken cancellationToken = default)
@@ -47,18 +51,21 @@ internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryption
         ArgumentException.ThrowIfNullOrEmpty(keyName);
         ArgumentNullException.ThrowIfNull(plaintext);
 
+        // VaultSharp 1.17.5.1 Transit não expõe CancellationToken — parâmetro recebido mas não propagável.
         try
         {
-            string base64Plain = Convert.ToBase64String(plaintext);
-            EncryptRequestOptions request = new() { Base64EncodedPlainText = base64Plain };
+            return await ExecuteWithAuthRetryAsync(keyName, async vault =>
+            {
+                string base64Plain = Convert.ToBase64String(plaintext);
+                EncryptRequestOptions request = new() { Base64EncodedPlainText = base64Plain };
 
-            Secret<EncryptionResponse> response = await _vault.V1.Secrets.Transit
-                .EncryptAsync(keyName, request, _transitMount)
-                .ConfigureAwait(false);
+                Secret<EncryptionResponse> response = await vault.V1.Secrets.Transit
+                    .EncryptAsync(keyName, request, _transitMount)
+                    .ConfigureAwait(false);
 
-            string ciphertext = response.Data.CipherText;
-            LogEncrypt(_logger, keyName);
-            return System.Text.Encoding.UTF8.GetBytes(ciphertext);
+                LogEncrypt(_logger, keyName);
+                return System.Text.Encoding.UTF8.GetBytes(response.Data.CipherText);
+            }).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not EncryptionFailureException)
         {
@@ -71,22 +78,65 @@ internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryption
         ArgumentException.ThrowIfNullOrEmpty(keyName);
         ArgumentNullException.ThrowIfNull(ciphertext);
 
+        // VaultSharp 1.17.5.1 Transit não expõe CancellationToken — parâmetro recebido mas não propagável.
         try
         {
-            string vaultCiphertext = System.Text.Encoding.UTF8.GetString(ciphertext);
-            DecryptRequestOptions request = new() { CipherText = vaultCiphertext };
+            return await ExecuteWithAuthRetryAsync(keyName, async vault =>
+            {
+                string vaultCiphertext = System.Text.Encoding.UTF8.GetString(ciphertext);
+                DecryptRequestOptions request = new() { CipherText = vaultCiphertext };
 
-            Secret<DecryptionResponse> response = await _vault.V1.Secrets.Transit
-                .DecryptAsync(keyName, request, _transitMount)
-                .ConfigureAwait(false);
+                Secret<DecryptionResponse> response = await vault.V1.Secrets.Transit
+                    .DecryptAsync(keyName, request, _transitMount)
+                    .ConfigureAwait(false);
 
-            byte[] plaintext = Convert.FromBase64String(response.Data.Base64EncodedPlainText);
-            LogDecrypt(_logger, keyName);
-            return plaintext;
+                LogDecrypt(_logger, keyName);
+                return Convert.FromBase64String(response.Data.Base64EncodedPlainText);
+            }).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not EncryptionFailureException)
         {
             throw new EncryptionFailureException(keyName, ex);
+        }
+    }
+
+    public void Dispose() => _refreshLock.Dispose();
+
+    private VaultClient CreateVaultClient()
+    {
+        string jwt = File.ReadAllText(_jwtPath);
+        KubernetesAuthMethodInfo authMethod = new(_role, jwt);
+        return new VaultClient(new VaultClientSettings(_vaultAddress, authMethod));
+    }
+
+    private async Task RefreshVaultClientAsync()
+    {
+        await _refreshLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            _vault = CreateVaultClient();
+        }
+        finally
+        {
+            _refreshLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Executa <paramref name="operation"/> com retry automático quando o Vault retorna 403.
+    /// O retry relê o JWT do disco, garantindo que tokens K8s rotacionados sejam absorvidos sem restart.
+    /// </summary>
+    private async Task<T> ExecuteWithAuthRetryAsync<T>(string keyName, Func<VaultClient, Task<T>> operation)
+    {
+        try
+        {
+            return await operation(_vault).ConfigureAwait(false);
+        }
+        catch (VaultApiException vex) when (vex.StatusCode == 403)
+        {
+            LogAuthRefresh(_logger, keyName);
+            await RefreshVaultClientAsync().ConfigureAwait(false);
+            return await operation(_vault).ConfigureAwait(false);
         }
     }
 
@@ -95,4 +145,7 @@ internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryption
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Vault decrypt concluído para chave '{KeyName}'")]
     private static partial void LogDecrypt(ILogger logger, string keyName);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Vault retornou 403 para chave '{KeyName}'; recriando cliente com JWT atualizado e repetindo")]
+    private static partial void LogAuthRefresh(ILogger logger, string keyName);
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
@@ -1,0 +1,98 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using VaultSharp;
+using VaultSharp.V1.AuthMethods.Kubernetes;
+using VaultSharp.V1.Commons;
+using VaultSharp.V1.SecretsEngines.Transit;
+
+/// <summary>
+/// Implementação de produção via HashiCorp Vault transit engine.
+/// Chaves nunca saem do Vault; autenticação via Kubernetes auth method.
+/// </summary>
+internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryptionService
+{
+    private readonly VaultClient _vault;
+    private readonly string _transitMount;
+    private readonly ILogger<VaultTransitEncryptionService> _logger;
+
+    public VaultTransitEncryptionService(IOptions<EncryptionOptions> options, ILogger<VaultTransitEncryptionService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _logger = logger;
+
+        EncryptionOptions opts = options.Value;
+
+        if (string.IsNullOrWhiteSpace(opts.VaultAddress))
+        {
+            throw new InvalidOperationException(
+                "UniPlus:Encryption:VaultAddress é obrigatório quando Provider = 'vault'.");
+        }
+
+        string jwt = File.ReadAllText(opts.KubernetesJwtPath);
+
+        KubernetesAuthMethodInfo authMethod = new(opts.KubernetesRole ?? "uniplus-api", jwt);
+        VaultClientSettings settings = new(opts.VaultAddress, authMethod);
+
+        _vault = new VaultClient(settings);
+        _transitMount = opts.VaultTransitMount;
+    }
+
+    public async Task<byte[]> EncryptAsync(string keyName, byte[] plaintext, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyName);
+        ArgumentNullException.ThrowIfNull(plaintext);
+
+        try
+        {
+            string base64Plain = Convert.ToBase64String(plaintext);
+            EncryptRequestOptions request = new() { Base64EncodedPlainText = base64Plain };
+
+            Secret<EncryptionResponse> response = await _vault.V1.Secrets.Transit
+                .EncryptAsync(keyName, request, _transitMount)
+                .ConfigureAwait(false);
+
+            string ciphertext = response.Data.CipherText;
+            LogEncrypt(_logger, keyName);
+            return System.Text.Encoding.UTF8.GetBytes(ciphertext);
+        }
+        catch (Exception ex) when (ex is not EncryptionFailureException)
+        {
+            throw new EncryptionFailureException(keyName, ex);
+        }
+    }
+
+    public async Task<byte[]> DecryptAsync(string keyName, byte[] ciphertext, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyName);
+        ArgumentNullException.ThrowIfNull(ciphertext);
+
+        try
+        {
+            string vaultCiphertext = System.Text.Encoding.UTF8.GetString(ciphertext);
+            DecryptRequestOptions request = new() { CipherText = vaultCiphertext };
+
+            Secret<DecryptionResponse> response = await _vault.V1.Secrets.Transit
+                .DecryptAsync(keyName, request, _transitMount)
+                .ConfigureAwait(false);
+
+            byte[] plaintext = Convert.FromBase64String(response.Data.Base64EncodedPlainText);
+            LogDecrypt(_logger, keyName);
+            return plaintext;
+        }
+        catch (Exception ex) when (ex is not EncryptionFailureException)
+        {
+            throw new EncryptionFailureException(keyName, ex);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Vault encrypt concluído para chave '{KeyName}'")]
+    private static partial void LogEncrypt(ILogger logger, string keyName);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Vault decrypt concluído para chave '{KeyName}'")]
+    private static partial void LogDecrypt(ILogger logger, string keyName);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/CryptographyServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/CryptographyServiceCollectionExtensions.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+public static class CryptographyServiceCollectionExtensions
+{
+    public static IServiceCollection AddUniPlusEncryption(
+        this IServiceCollection services,
+        IConfiguration? configuration = null,
+        Action<EncryptionOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        OptionsBuilder<EncryptionOptions> optionsBuilder = services.AddOptions<EncryptionOptions>();
+
+        if (configuration is not null)
+        {
+            IConfigurationSection section = configuration.GetSection(EncryptionOptions.SectionName);
+            if (section.Exists())
+            {
+                optionsBuilder.Bind(section);
+            }
+        }
+
+        if (configure is not null)
+        {
+            optionsBuilder.Configure(configure);
+        }
+
+        optionsBuilder.ValidateDataAnnotations().ValidateOnStart();
+
+        services.AddSingleton<IUniPlusEncryptionService>(sp =>
+        {
+            EncryptionOptions opts = sp.GetRequiredService<IOptions<EncryptionOptions>>().Value;
+
+            if (string.Equals(opts.Provider, "vault", StringComparison.OrdinalIgnoreCase))
+            {
+                return ActivatorUtilities.CreateInstance<VaultTransitEncryptionService>(sp);
+            }
+
+            if (string.Equals(opts.Provider, "local", StringComparison.OrdinalIgnoreCase))
+            {
+                return ActivatorUtilities.CreateInstance<LocalAesEncryptionService>(sp);
+            }
+
+            throw new InvalidOperationException(
+                $"UniPlus:Encryption:Provider inválido: '{opts.Provider}'. Use 'vault' ou 'local'.");
+        });
+
+        return services;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/CryptographyDiTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/CryptographyDiTests.cs
@@ -1,0 +1,57 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Cryptography;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+public sealed class CryptographyDiTests
+{
+    private static IConfiguration CriarConfig(string provider, string? localKey = null)
+    {
+        Dictionary<string, string?> values = new()
+        {
+            ["UniPlus:Encryption:Provider"] = provider,
+        };
+
+        if (localKey is not null)
+        {
+            values["UniPlus:Encryption:LocalKey"] = localKey;
+        }
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
+    [Fact]
+    public void AddUniPlusEncryption_ProviderLocal_DeveResolverLocalAesEncryptionService()
+    {
+        string chaveValida = Convert.ToBase64String(new byte[32]);
+        ServiceProvider sp = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(CriarConfig("local", chaveValida))
+            .BuildServiceProvider();
+
+        IUniPlusEncryptionService servico = sp.GetRequiredService<IUniPlusEncryptionService>();
+
+        servico.Should().BeOfType<LocalAesEncryptionService>();
+    }
+
+    [Fact]
+    public void AddUniPlusEncryption_ProviderInvalido_DeveLancarInvalidOperationExceptionAoResolver()
+    {
+        ServiceProvider sp = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(CriarConfig("desconhecido"))
+            .BuildServiceProvider();
+
+        Action ato = () => sp.GetRequiredService<IUniPlusEncryptionService>();
+
+        ato.Should().Throw<InvalidOperationException>()
+            .WithMessage("*'desconhecido'*");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/LocalAesEncryptionServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/LocalAesEncryptionServiceTests.cs
@@ -31,6 +31,20 @@ public sealed class LocalAesEncryptionServiceTests
         resultado.Should().Equal(plaintext);
     }
 
+    // ─── Plaintext vazio ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EncryptAsync_PlaintextVazio_DeveRoundTripCorretamente()
+    {
+        LocalAesEncryptionService sut = CriarServico();
+        byte[] plaintext = [];
+
+        byte[] ciphertext = await sut.EncryptAsync("cursor", plaintext);
+        byte[] resultado = await sut.DecryptAsync("cursor", ciphertext);
+
+        resultado.Should().BeEmpty();
+    }
+
     // ─── IV aleatório ────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/LocalAesEncryptionServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/LocalAesEncryptionServiceTests.cs
@@ -1,0 +1,110 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Cryptography;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+public sealed class LocalAesEncryptionServiceTests
+{
+    private static readonly byte[] ValidKey = new byte[32];
+    private static readonly string ValidKeyBase64 = Convert.ToBase64String(ValidKey);
+
+    private static LocalAesEncryptionService CriarServico(string? localKey = null) =>
+        new(
+            Options.Create(new EncryptionOptions { Provider = "local", LocalKey = localKey ?? ValidKeyBase64 }),
+            NullLogger<LocalAesEncryptionService>.Instance);
+
+    // ─── Round-trip ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EncryptAsync_QuandoDecryptAsync_DeveRetornarPlaintextOriginal()
+    {
+        LocalAesEncryptionService sut = CriarServico();
+        byte[] plaintext = "UniPlus — dado sensível"u8.ToArray();
+
+        byte[] ciphertext = await sut.EncryptAsync("cursor", plaintext);
+        byte[] resultado = await sut.DecryptAsync("cursor", ciphertext);
+
+        resultado.Should().Equal(plaintext);
+    }
+
+    // ─── IV aleatório ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EncryptAsync_MesmoPlaintext_DeveProduzirCiphertextsDiferentes()
+    {
+        LocalAesEncryptionService sut = CriarServico();
+        byte[] plaintext = "mesmo conteúdo"u8.ToArray();
+
+        byte[] ct1 = await sut.EncryptAsync("cursor", plaintext);
+        byte[] ct2 = await sut.EncryptAsync("cursor", plaintext);
+
+        ct1.Should().NotEqual(ct2);
+    }
+
+    // ─── Tamper detection ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DecryptAsync_CiphertextAdulterado_DeveLancarEncryptionFailureException()
+    {
+        LocalAesEncryptionService sut = CriarServico();
+        byte[] plaintext = "dado a proteger"u8.ToArray();
+        byte[] ciphertext = await sut.EncryptAsync("cursor", plaintext);
+
+        // Adulterar o último byte dos dados cifrados
+        ciphertext[^1] ^= 0xFF;
+
+        Func<Task> ato = () => sut.DecryptAsync("cursor", ciphertext);
+
+        await ato.Should().ThrowAsync<EncryptionFailureException>()
+            .Where(e => e.KeyName == "cursor");
+    }
+
+    [Fact]
+    public async Task DecryptAsync_CiphertextMuitoCurto_DeveLancarEncryptionFailureException()
+    {
+        LocalAesEncryptionService sut = CriarServico();
+        byte[] ciphertextInvalido = new byte[10];
+
+        Func<Task> ato = () => sut.DecryptAsync("cursor", ciphertextInvalido);
+
+        await ato.Should().ThrowAsync<EncryptionFailureException>();
+    }
+
+    // ─── Chave inválida ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Construtor_ChaveAusente_DeveLancarInvalidOperationException()
+    {
+        Action ato = () => CriarServicoComOpcoes(new EncryptionOptions { Provider = "local", LocalKey = null });
+
+        ato.Should().Throw<InvalidOperationException>()
+            .WithMessage("*UniPlus:Encryption:LocalKey*");
+    }
+
+    private static LocalAesEncryptionService CriarServicoComOpcoes(EncryptionOptions opts) =>
+        new(Options.Create(opts), NullLogger<LocalAesEncryptionService>.Instance);
+
+    [Fact]
+    public void Construtor_ChaveBase64Invalida_DeveLancarInvalidOperationException()
+    {
+        Action ato = () => CriarServico(localKey: "não-é-base64!!!");
+
+        ato.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Base64*");
+    }
+
+    [Fact]
+    public void Construtor_ChaveComTamanhoErrado_DeveLancarInvalidOperationException()
+    {
+        string chave16Bytes = Convert.ToBase64String(new byte[16]);
+
+        Action ato = () => CriarServico(localKey: chave16Bytes);
+
+        ato.Should().Throw<InvalidOperationException>()
+            .WithMessage("*32 bytes*");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/LocalAesEncryptionServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/LocalAesEncryptionServiceTests.cs
@@ -59,6 +59,21 @@ public sealed class LocalAesEncryptionServiceTests
         ct1.Should().NotEqual(ct2);
     }
 
+    // ─── KeyName como AAD ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DecryptAsync_KeyNameDiferente_DeveLancarEncryptionFailureException()
+    {
+        LocalAesEncryptionService sut = CriarServico();
+        byte[] plaintext = "dado sensível"u8.ToArray();
+        byte[] ciphertext = await sut.EncryptAsync("cursor-cpf", plaintext);
+
+        Func<Task> ato = () => sut.DecryptAsync("cursor-nome", ciphertext);
+
+        await ato.Should().ThrowAsync<EncryptionFailureException>()
+            .Where(e => e.KeyName == "cursor-nome");
+    }
+
     // ─── Tamper detection ────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Resumo

- Cria abstração `IUniPlusEncryptionService` em `Infrastructure.Core/Cryptography/` com duas implementações
- `LocalAesEncryptionService`: AES-GCM 256 com IV aleatório por operação (dev/CI)
- `VaultTransitEncryptionService`: Vault transit engine via VaultSharp + K8s auth (produção)
- `AddUniPlusEncryption`: DI extension com selector por `UniPlus:Encryption:Provider`
- 9 unit tests — todos passando

## Mudanças

### Novos arquivos
- `Infrastructure.Core/Cryptography/IUniPlusEncryptionService.cs` — interface com `EncryptAsync`/`DecryptAsync` por `keyName`
- `Infrastructure.Core/Cryptography/EncryptionFailureException.cs` — exceção selada, não vaza detalhes internos
- `Infrastructure.Core/Cryptography/EncryptionOptions.cs` — `Provider`, `LocalKey`, `VaultAddress`, configuração K8s auth
- `Infrastructure.Core/Cryptography/LocalAesEncryptionService.cs` — AES-GCM 256, nonce 12 bytes, tag 16 bytes, formato `nonce||tag||dados`
- `Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs` — VaultSharp transit `encrypt/{key}` + `decrypt/{key}`
- `Infrastructure.Core/DependencyInjection/CryptographyServiceCollectionExtensions.cs` — `AddUniPlusEncryption`
- `tests/.../Cryptography/LocalAesEncryptionServiceTests.cs` — 7 casos (round-trip, IV aleatório, tamper, construtores)
- `tests/.../Cryptography/CryptographyDiTests.cs` — 2 casos (DI provider selector)

## Decisões de implementação

- **ArchUnit**: `Infrastructure.Core/Cryptography/` sem dependência `Microsoft.AspNetCore.*` — apenas `System.Security.Cryptography` e `Microsoft.Extensions.*`
- **Logging**: `[LoggerMessage]` source generator em ambas implementações; nunca loga plaintext, ciphertext nem chave — apenas `keyName` e resultado da operação
- **Tamper detection**: AES-GCM autentica automaticamente com a tag — qualquer adulteração lança `CryptographicException` encapsulada em `EncryptionFailureException`
- **Integration tests** com `VaultContainerFixture`: entregues em T03 (depende do fixture Testcontainers)

## Testes

194 total, 0 falhas (`dotnet test Infrastructure.Core.UnitTests`)

## Referências

- ADR-0026 (cursor cifrado) e ADR-0027 (Idempotency-Key) — consumidores desta abstração em T07 e T05

Closes #294