### PR TITLE
feat(test): T03 — VaultContainerFixture + testes de integração VaultTransit

### DIFF
--- a/UniPlus.slnx
+++ b/UniPlus.slnx
@@ -19,6 +19,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/Unifesspa.UniPlus.Application.Abstractions.UnitTests/Unifesspa.UniPlus.Application.Abstractions.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Ingresso.Domain.UnitTests/Unifesspa.UniPlus.Ingresso.Domain.UnitTests.csproj" />

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionOptions.cs
@@ -27,4 +27,11 @@ public sealed class EncryptionOptions
 
     /// <summary>Role do Vault para autenticação K8s.</summary>
     public string? KubernetesRole { get; set; }
+
+    /// <summary>
+    /// Token Vault estático para autenticação por token (testes de integração / dev sem K8s).
+    /// Quando definido, substitui o fluxo de autenticação Kubernetes.
+    /// <b>Nunca usar em produção</b> — produção sempre usa KubernetesJwtPath.
+    /// </summary>
+    public string? VaultToken { get; set; }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
@@ -5,7 +5,9 @@ using Microsoft.Extensions.Options;
 
 using VaultSharp;
 using VaultSharp.Core;
+using VaultSharp.V1.AuthMethods;
 using VaultSharp.V1.AuthMethods.Kubernetes;
+using VaultSharp.V1.AuthMethods.Token;
 using VaultSharp.V1.Commons;
 using VaultSharp.V1.SecretsEngines.Transit;
 
@@ -20,6 +22,7 @@ internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryption
     private readonly string _jwtPath;
     private readonly string _role;
     private readonly string _transitMount;
+    private readonly string? _vaultToken;
     private readonly SemaphoreSlim _refreshLock = new(1, 1);
     private readonly ILogger<VaultTransitEncryptionService> _logger;
 
@@ -42,6 +45,7 @@ internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryption
         _jwtPath = opts.KubernetesJwtPath;
         _role = opts.KubernetesRole ?? "uniplus-api";
         _transitMount = opts.VaultTransitMount;
+        _vaultToken = opts.VaultToken;
 
         _vault = CreateVaultClient();
     }
@@ -104,8 +108,10 @@ internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryption
 
     private VaultClient CreateVaultClient()
     {
-        string jwt = File.ReadAllText(_jwtPath);
-        KubernetesAuthMethodInfo authMethod = new(_role, jwt);
+        IAuthMethodInfo authMethod = string.IsNullOrWhiteSpace(_vaultToken)
+            ? new KubernetesAuthMethodInfo(_role, File.ReadAllText(_jwtPath))
+            : new TokenAuthMethodInfo(_vaultToken);
+
         return new VaultClient(new VaultClientSettings(_vaultAddress, authMethod));
     }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
@@ -108,9 +108,11 @@ internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryption
 
     private VaultClient CreateVaultClient()
     {
-        IAuthMethodInfo authMethod = string.IsNullOrWhiteSpace(_vaultToken)
+        // K8s auth tem precedência quando o arquivo JWT existe — garante que um VaultToken
+        // acidentalmente injetado em produção não substitua a identidade de workload.
+        IAuthMethodInfo authMethod = !string.IsNullOrWhiteSpace(_jwtPath) && File.Exists(_jwtPath)
             ? new KubernetesAuthMethodInfo(_role, File.ReadAllText(_jwtPath))
-            : new TokenAuthMethodInfo(_vaultToken);
+            : new TokenAuthMethodInfo(_vaultToken!);
 
         return new VaultClient(new VaultClientSettings(_vaultAddress, authMethod));
     }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Cryptography/VaultCollectionDefinition.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Cryptography/VaultCollectionDefinition.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Cryptography;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// xUnit collection que serializa a execução das classes de teste que precisam do Vault real,
+/// reaproveitando uma única instância da <see cref="VaultContainerFixture"/> entre elas.
+/// xUnit exige que a <c>[CollectionDefinition]</c> viva no mesmo assembly dos testes que a usam.
+/// </summary>
+[CollectionDefinition(VaultContainerFixture.CollectionName)]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção xUnit: o sufixo 'Collection' identifica a classe como CollectionDefinition.")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x exige que CollectionDefinitions sejam públicas para que o runner as descubra.")]
+public sealed class VaultCollection : ICollectionFixture<VaultContainerFixture>
+{
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Cryptography/VaultTransitEncryptionServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Cryptography/VaultTransitEncryptionServiceTests.cs
@@ -1,0 +1,102 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Cryptography;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+[Collection(VaultContainerFixture.CollectionName)]
+public sealed class VaultTransitEncryptionServiceTests(VaultContainerFixture vault)
+{
+    private const string KeyName = "uniplus-test";
+
+    private IUniPlusEncryptionService CriarServico() =>
+        new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(configure: opts =>
+            {
+                opts.Provider = "vault";
+                opts.VaultAddress = vault.VaultAddress;
+                opts.VaultToken = VaultContainerFixture.RootToken;
+                opts.VaultTransitMount = VaultContainerFixture.TransitMount;
+            })
+            .BuildServiceProvider()
+            .GetRequiredService<IUniPlusEncryptionService>();
+
+    // ─── Round-trip ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EncryptAsync_QuandoDecryptAsync_DeveRetornarPlaintextOriginal()
+    {
+        await vault.EnsureKeyExistsAsync(KeyName);
+        IUniPlusEncryptionService sut = CriarServico();
+        byte[] plaintext = "UniPlus — dado sensível"u8.ToArray();
+
+        byte[] ciphertext = await sut.EncryptAsync(KeyName, plaintext);
+        byte[] resultado = await sut.DecryptAsync(KeyName, ciphertext);
+
+        resultado.Should().Equal(plaintext);
+    }
+
+    // ─── Plaintext vazio ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EncryptAsync_PlaintextVazio_DeveRoundTripCorretamente()
+    {
+        await vault.EnsureKeyExistsAsync(KeyName);
+        IUniPlusEncryptionService sut = CriarServico();
+        byte[] plaintext = [];
+
+        byte[] ciphertext = await sut.EncryptAsync(KeyName, plaintext);
+        byte[] resultado = await sut.DecryptAsync(KeyName, ciphertext);
+
+        resultado.Should().BeEmpty();
+    }
+
+    // ─── Ciphertext de chave diferente rejeitado pelo Vault ──────────────────
+
+    [Fact]
+    public async Task DecryptAsync_CiphertextDeChaveDiferente_DeveLancarEncryptionFailureException()
+    {
+        const string outraChave = "uniplus-outra";
+        await vault.EnsureKeyExistsAsync(KeyName);
+        await vault.EnsureKeyExistsAsync(outraChave);
+
+        IUniPlusEncryptionService sut = CriarServico();
+        byte[] plaintext = "dado sensível"u8.ToArray();
+
+        byte[] ciphertext = await sut.EncryptAsync(KeyName, plaintext);
+
+        Func<Task> ato = () => sut.DecryptAsync(outraChave, ciphertext);
+
+        await ato.Should().ThrowAsync<EncryptionFailureException>()
+            .Where(e => e.KeyName == outraChave);
+    }
+
+    // ─── Token inválido → EncryptionFailureException (retry esgotado) ────────
+
+    [Fact]
+    public async Task EncryptAsync_TokenInvalido_DeveLancarEncryptionFailureException()
+    {
+        await vault.EnsureKeyExistsAsync(KeyName);
+
+        IUniPlusEncryptionService sut = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(configure: opts =>
+            {
+                opts.Provider = "vault";
+                opts.VaultAddress = vault.VaultAddress;
+                opts.VaultToken = "token-invalido";
+                opts.VaultTransitMount = VaultContainerFixture.TransitMount;
+            })
+            .BuildServiceProvider()
+            .GetRequiredService<IUniPlusEncryptionService>();
+
+        Func<Task> ato = () => sut.EncryptAsync(KeyName, "payload"u8.ToArray());
+
+        await ato.Should().ThrowAsync<EncryptionFailureException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Cryptography/VaultTransitEncryptionServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Cryptography/VaultTransitEncryptionServiceTests.cs
@@ -97,6 +97,7 @@ public sealed class VaultTransitEncryptionServiceTests(VaultContainerFixture vau
 
         Func<Task> ato = () => sut.EncryptAsync(KeyName, "payload"u8.ToArray());
 
-        await ato.Should().ThrowAsync<EncryptionFailureException>();
+        await ato.Should().ThrowAsync<EncryptionFailureException>()
+            .Where(e => e.KeyName == KeyName);
     }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="AwesomeAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\shared\Unifesspa.UniPlus.Infrastructure.Core\Unifesspa.UniPlus.Infrastructure.Core.csproj" />
+    <ProjectReference Include="..\Unifesspa.UniPlus.IntegrationTests.Fixtures\Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/VaultContainerFixture.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/VaultContainerFixture.cs
@@ -1,0 +1,103 @@
+namespace Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+using System.Net;
+using System.Net.Http.Json;
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+/// <summary>
+/// Sobe um container HashiCorp Vault em modo dev via Testcontainers, habilita o transit secrets engine
+/// e expõe endereço e token root para uso em testes de integração.
+/// Compartilhada via <c>[Collection("Vault")]</c> — cada assembly que a usa deve declarar sua própria
+/// <c>[CollectionDefinition]</c> com o mesmo nome (ver padrão <c>KeycloakCollection</c>).
+/// </summary>
+public sealed class VaultContainerFixture : IAsyncLifetime
+{
+    public const string Image = "hashicorp/vault:1.18";
+    public const string RootToken = "root";
+    public const string TransitMount = "transit";
+    public const string CollectionName = "Vault";
+
+    private const ushort VaultPort = 8200;
+
+    private readonly IContainer _container;
+
+    public VaultContainerFixture()
+    {
+        _container = new ContainerBuilder(Image)
+            .WithPortBinding(VaultPort, true)
+            .WithEnvironment("VAULT_DEV_ROOT_TOKEN_ID", RootToken)
+            .WithEnvironment("VAULT_DEV_LISTEN_ADDRESS", $"0.0.0.0:{VaultPort}")
+            .WithCommand("server", "-dev")
+            .WithWaitStrategy(
+                Wait.ForUnixContainer()
+                    .UntilHttpRequestIsSucceeded(r => r
+                        .ForPort(VaultPort)
+                        .ForPath("/v1/sys/health")
+                        .ForStatusCode(HttpStatusCode.OK)))
+            .Build();
+    }
+
+    /// <summary>Endereço HTTP do Vault no host com porta efêmera publicada.</summary>
+    public string VaultAddress =>
+        $"http://{_container.Hostname}:{_container.GetMappedPublicPort(VaultPort)}";
+
+    /// <summary>
+    /// Cria uma chave de transit no Vault, se ainda não existir.
+    /// Idempotente — pode ser chamado por múltiplos testes com o mesmo nome.
+    /// </summary>
+    public async Task EnsureKeyExistsAsync(string keyName, string keyType = "aes256-gcm96")
+    {
+        using HttpClient client = CreateAdminClient();
+        HttpResponseMessage response = await client
+            .PostAsJsonAsync($"/v1/{TransitMount}/keys/{keyName}", new { type = keyType })
+            .ConfigureAwait(false);
+
+        // 200 (criada) ou 400 (já existe) são ambos aceitáveis
+        if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.BadRequest)
+        {
+            string body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            throw new InvalidOperationException(
+                $"Falha ao criar chave '{keyName}' no Vault: {response.StatusCode} — {body}");
+        }
+    }
+
+    /// <summary>
+    /// Retorna um <see cref="HttpClient"/> pré-configurado com o token root para chamadas administrativas
+    /// ao Vault. O chamador é responsável pelo dispose.
+    /// </summary>
+    public HttpClient CreateAdminClient()
+    {
+        HttpClient client = new() { BaseAddress = new Uri(VaultAddress) };
+        client.DefaultRequestHeaders.Add("X-Vault-Token", RootToken);
+        return client;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync().ConfigureAwait(false);
+        await EnableTransitEngineAsync().ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _container.DisposeAsync().ConfigureAwait(false);
+    }
+
+    private async Task EnableTransitEngineAsync()
+    {
+        using HttpClient client = CreateAdminClient();
+        HttpResponseMessage response = await client
+            .PostAsJsonAsync("/v1/sys/mounts/transit", new { type = "transit" })
+            .ConfigureAwait(false);
+
+        // 400 com "path is already in use" significa que já está habilitado (dev mode pode pré-habilitar)
+        if (!response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.BadRequest)
+        {
+            string body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            throw new InvalidOperationException(
+                $"Falha ao habilitar transit engine no Vault: {response.StatusCode} — {body}");
+        }
+    }
+}


### PR DESCRIPTION
## Resumo

- Adiciona `VaultContainerFixture` (Testcontainers) que sobe Vault 1.18 em modo dev, habilita o transit engine e expõe helper `EnsureKeyExistsAsync`
- Adiciona escape hatch `VaultToken` em `EncryptionOptions` para autenticação por token em testes/dev sem K8s (produção continua usando K8s auth)
- Cria projeto `Infrastructure.Core.IntegrationTests` com 4 testes de integração contra Vault real

## Mudanças

### Novos arquivos
- `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/VaultContainerFixture.cs` — fixture compartilhada: container Vault dev + transit engine + `EnsureKeyExistsAsync` idempotente
- `tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj` — novo projeto de integração
- `tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Cryptography/VaultCollectionDefinition.cs` — definição xUnit collection com suppressions CA1711/CA1515
- `tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Cryptography/VaultTransitEncryptionServiceTests.cs` — 4 testes: round-trip, plaintext vazio, chave errada, token inválido

### Modificados
- `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionOptions.cs` — adiciona `VaultToken?` (escape hatch para testes sem K8s)
- `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs` — `CreateVaultClient()` usa `TokenAuthMethodInfo` quando `VaultToken` está definido, `KubernetesAuthMethodInfo` caso contrário
- `UniPlus.slnx` — adiciona `Infrastructure.Core.IntegrationTests` à solution

## Testes

- 196 testes unitários (todos passando)
- 4 testes de integração contra Vault real via Testcontainers (todos passando)

## Checklist

- [x] Build sem errors (0 warnings, TreatWarningsAsErrors)
- [x] Testes passando (196 unit + 4 integration)
- [x] Código revisado

Closes #296