### PR TITLE
feat(kernel): adotar Guid v7 como identidade de entidades de domínio (story #311)

### DIFF
--- a/docs/adrs/0032-guid-v7-para-identidade-de-entidades.md
+++ b/docs/adrs/0032-guid-v7-para-identidade-de-entidades.md
@@ -1,0 +1,90 @@
+---
+status: "proposed"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0032: Guid v7 (RFC 9562) como identidade de entidades de domínio
+
+## Contexto e enunciado do problema
+
+O projeto usa `EntityBase.Id` como chave primária de todas as entidades de domínio, gerada via `Guid.NewGuid()` (UUID v4 random) desde o scaffold inicial. A inconsistência foi detectada durante a review da [story #288](https://github.com/unifesspa-edu-br/uniplus-api/pull/310) (cursor pagination): o resto do projeto **já** usa `Guid.CreateVersion7()` em outros pontos (`Instance` e `traceId` de ProblemDetails em `ResultExtensions`, `GlobalExceptionMiddleware`, `VendorMediaTypeAttribute`), e a [ADR-0026](0026-paginacao-cursor-opaco-cifrado.md) (cursor pagination keyset-based) ganharia semântica temporal natural se os IDs fossem ordenáveis.
+
+Adicionalmente, o ecossistema convergiu: **Npgsql 9 / EFCore.PG 10 já adota UUID v7** como default para `GuidValueGenerator`, **PostgreSQL 18** introduziu a função nativa `uuidv7()`, e **.NET 9+** inclui `Guid.CreateVersion7()` na BCL. A escolha agora não é "v4 vs v7 emergente", é "v4 legado vs v7 padrão da plataforma".
+
+A questão a decidir é: **adotamos v7 universalmente, ou mantemos v4 em entidades com PII (Candidato, Inscricao) por considerar o timestamp leak relevante para LGPD?**
+
+## Drivers da decisão
+
+- **Coerência interna.** Mistura v4/v7 no mesmo codebase é dívida técnica; padrão único reduz carga cognitiva e elimina necessidade de ArchUnit guard duplo.
+- **Cursor pagination ([ADR-0026](0026-paginacao-cursor-opaco-cifrado.md)).** Com v4, `OrderBy(e => e.Id)` em PG ordena aleatoriamente; "próxima página" não tem significado intuitivo. Com v7, "próxima página" = "criados depois" — UX natural sem código adicional.
+- **Performance de I/O em PostgreSQL.** UUID v4 random insere em posições aleatórias do índice B-tree → page splits frequentes, bloat acumulado, throughput degradado em tabelas de alto volume (Inscricao com 50k+ rows por edital × dezenas de editais; outbox; audit; Idempotency cache).
+- **Debugging operacional.** IDs ordenáveis facilitam rastreio temporal em logs (Loki/Tempo) e correlação cross-service.
+- **LGPD.** v7 expõe os primeiros 48 bits como `unix_ts_ms` da criação. Necessário avaliar se isso vaza informação que não estava já disponível.
+
+## Opções consideradas
+
+- **A. v7 universal** — todas entidades usam `Guid.CreateVersion7()`, sem exceção.
+- **B. v7 + override v4 em entidades sensíveis** — Candidato, Inscricao, e futuras entidades com PII alta sobrescrevem o construtor base com `Guid.NewGuid()`.
+- **C. ID dual (secret + público)** — entidades sensíveis carregam dois IDs: PK opaco (v4) para uso interno + slug público (HashId/SipHash) para URLs externas.
+- **D. Manter status quo (v4 universal)** — descartado de antemão por não capturar nenhum benefício do padrão emergente da plataforma.
+
+## Resultado da decisão
+
+**Escolhida:** "A — v7 universal", porque o argumento a favor de exceções para entidades sensíveis (opção B) não se sustenta sob análise:
+
+**O timestamp leak do v7 não cria risco LGPD novo.** Toda entidade já carrega `CreatedAt` (campo de `EntityBase`, audit trail obrigatório por padrão do projeto) — coluna `timestamptz` adjacente que expõe a mesma informação com a mesma precisão (ms). Quem tem acesso ao registro tem ambos. O leak marginal de opacidade ao manter v4 só ajudaria contra um adversário que **já enumera IDs sem acesso ao registro** — cenário que o threat model do projeto rejeita: autorização é Keycloak/JWT + ABAC; IDs nunca foram tokens de autorização.
+
+**v7 mantém entropia suficiente contra brute-force.** RFC 9562 exige mínimo de 32 bits aleatórios; v7 entrega 74 bits (rand_a 12 + rand_b 62), muito acima da margem necessária para resistir adivinhação. v4 tem 122 bits, mas o ganho marginal não tem aplicação no nosso modelo.
+
+**Benefícios de localidade B-tree são reais e mensurados.** Benchmarks independentes em PG 15-18 mostram ~25% redução de footprint do índice e até ~49% mais throughput de insert em volumes não-triviais. Importa especificamente em Inscricao (pico em janelas de candidatura), outbox transacional ([ADR-0004](0004-outbox-transacional-via-wolverine.md)), e Idempotency cache ([ADR-0027](0027-idempotency-key-store-postgresql.md)).
+
+**Tradução EF Core 10 / Npgsql preserva-se intacta.** Npgsql escreve Guid em formato big-endian RFC 9562 no wire protocol (diferente do byte-mangling do `Microsoft.Data.SqlClient`); `OrderBy(e => e.Id)` continua traduzindo para `ORDER BY id` byte-by-byte coerente com `Guid.CompareTo > 0`. A crítica de performance circulada para SQL Server (gist sdrapkin) **não se aplica** ao stack PostgreSQL/Npgsql — daí o time do Npgsql ter adotado v7 como default em sua versão 9.0.
+
+A opção C (ID dual) foi descartada por complexidade desproporcional ao ganho — padrão do Stripe (`cus_…` opaco) faz sentido quando o ID é o token de autorização, que não é nosso caso. Caso surja necessidade futura de slug opaco em URL pública específica (ex.: comprovante de inscrição compartilhável), pode ser introduzido como extensão localizada (campo adicional na entidade) sem alterar o PK.
+
+### Esta ADR não decide
+
+- **Migração de IDs v4 já existentes em produção** — não há produção; mistura v4/v7 em DBs de dev/staging é segura (Postgres uuid order é byte-by-byte canônica; v4 ficam intercalados aleatoriamente entre os v7 cronológicos sem perda de integridade).
+- **Slug opaco para URL pública** — quando surgir endpoint que exponha entidade sensível em link compartilhável, criar slug separado (HashId) sem trocar o PK. Issue dedicada na época.
+- **Sub-millisecond monotonicity** — `Guid.CreateVersion7()` não garante ordering estrito sub-ms (rand_a/rand_b re-randomizam a cada chamada, RFC-compliant). Aceitável: nossas cargas não geram >10k inserts/ms no mesmo nó. Reavaliar se aparecer hot path crítico.
+
+## Consequências
+
+### Positivas
+
+- **Cursor pagination ganha ordering temporal sem código adicional** — clientes que paginam `/api/editais` ou futuros `/api/inscricoes` veem items em ordem cronológica natural.
+- **Performance de inserts** em tabelas de alto volume — Inscricao, outbox, Idempotency cache, audit. Reduz manutenção (REINDEX, VACUUM aggressive) e latência percebida em picos de candidatura.
+- **Coerência interna** — um único padrão de geração de Id em todo o codebase; `Guid.NewGuid()` agora é proibido em código de domínio (fitness test ArchUnit).
+- **Debugging facilitado** — IDs ordenáveis visualmente em logs e traces (correlação Loki/Tempo).
+
+### Negativas
+
+- **Timestamp leak documentado** — IDs revelam aproximadamente o instante de criação (≤1 ms). Documentar explicitamente no Aviso de Privacidade do projeto e no DPIA correspondente. Mitigação: já feito acima (informação já disponível via `CreatedAt`).
+- **Sub-ms monotonicity ausente** — não usar Id como ordenador secundário em algoritmos que exigem ordering estrito sub-ms (não há tal caso hoje).
+- **Predictability ligeiramente reduzida** — 74 bits aleatórios em v7 vs 122 bits em v4. Sem impacto prático para nosso threat model (ver "Resultado da decisão"), mas vale documentar para futuras revisões caso o modelo mude.
+
+### Neutras
+
+- **Mistura v4/v7 em DBs existentes** — durante a transição (após merge desta ADR), entidades já persistidas mantêm IDs v4; novas usam v7. Ordering é estável (Postgres compara byte-by-byte canônico). Sem migração necessária.
+
+## Confirmação
+
+1. **Fitness test solution-wide** — `DominioNaoUsaGuidNewGuidTests` em `tests/Unifesspa.UniPlus.ArchTests/SolutionRules/` varre por regex os arquivos `.cs` de `Kernel`, `Selecao.Domain` e `Ingresso.Domain` falhando o build se encontrar `Guid.NewGuid()`. Permitido em `*.Tests.*` (seeds) e em código fora de domínio (ex.: `Instance` de ProblemDetails em Infrastructure já usa `Guid.CreateVersion7()`, sem regressão). Vive no projeto centralizado `Unifesspa.UniPlus.ArchTests` em vez de duplicado entre os Selecao/Ingresso ArchTests porque a regra cobre o `Kernel` compartilhado.
+2. **Teste regressivo de cursor pagination** — cenário com IDs mistos (v4 antigos manualmente inseridos + v7 novos via factory) navegando cursor paginação; afirmar zero duplicação e zero omissão.
+3. **Code review checklist** — revisor confirma que entidades novas usam `Guid.CreateVersion7()` (ou herdam de `EntityBase` que faz isso). PR template lembra dessa verificação na próxima atualização.
+
+## Mais informações
+
+- [ADR-0026](0026-paginacao-cursor-opaco-cifrado.md) — beneficiária direta da ordenação temporal.
+- [ADR-0031](0031-decoding-de-cursor-opaco-no-boundary-http.md) — discute Guid ordering em Npgsql; agora consistente com decisão deste ADR.
+- [Guid.CreateVersion7 — Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/api/system.guid.createversion7) — API oficial.
+- [RFC 9562 — Universally Unique IDentifiers (UUIDs)](https://datatracker.ietf.org/doc/rfc9562/) — fonte canônica; §5.7 (UUIDv7), §6.2 (timestamp privacy), §8 (security).
+- [PostgreSQL 18 Datatype UUID](https://www.postgresql.org/docs/current/datatype-uuid.html) — `uuidv7()` nativo.
+- [Npgsql EFCore 9.0 Release Notes](https://www.npgsql.org/efcore/release-notes/9.0.html) — adoção de UUID v7 como default.
+- [Npgsql EFCore 10.0 Release Notes](https://www.npgsql.org/efcore/release-notes/10.0.html) — tradução de `Guid.CreateVersion7()` para `uuidv7()` em PG18.
+- [Cybertec — Unexpected downsides of UUID keys in PostgreSQL](https://www.cybertec-postgresql.com/en/unexpected-downsides-of-uuid-keys-in-postgresql/) — análise técnica de bloat e mitigação por v7.
+- [pg-uuidv7-benchmark (mblum.me)](https://mblum.me/posts/pg-uuidv7-benchmark/) — benchmark reproduzível: ~49% mais throughput insert.
+- [Marc Brooker — Fixing UUIDv7 (for database use-cases)](https://brooker.co.za/blog/2025/10/22/uuidv7.html) — perspectiva contrária registrada (correlated leak em sistemas multi-tenant; não aplicável ao nosso caso single-tenant).
+- Issue #311 (uniplus-api) — issue de implementação que carrega esta ADR.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -60,6 +60,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0029](0029-hateoas-level-1-links.md) | HATEOAS Level 1 — `_links` mínimo embutido no recurso | accepted | 2026-05-03 |
 | [0030](0030-openapi-3-1-contract-first-microsoft-aspnetcore-openapi.md) | Geração de OpenAPI 3.1 via `Microsoft.AspNetCore.OpenApi` com pipeline de pós-processamento | accepted | 2026-05-03 |
 | [0031](0031-decoding-de-cursor-opaco-no-boundary-http.md) | Decoding de cursor opaco no boundary HTTP, não em handlers de Application | proposed | 2026-05-04 |
+| [0032](0032-guid-v7-para-identidade-de-entidades.md) | Guid v7 (RFC 9562) como identidade de entidades de domínio | proposed | 2026-05-05 |
 
 ## Como adicionar um novo ADR
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Inscricao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Inscricao.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
 
+using System.Security.Cryptography;
+
 using Enums;
 using Events;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
@@ -53,6 +55,11 @@ public sealed class Inscricao : EntityBase
 
     public void OptarPorListaEspera() => ListaEspera = true;
 
+    // Sufixo de 8 hex chars (32 bits aleatórios) compõe o número humano-legível.
+    // Usa RandomNumberGenerator em vez de Guid v4 porque (a) Guid.NewGuid é
+    // proibido em domínio (ADR-0032 / fitness test) e (b) Guid v7 não serve
+    // aqui — seus primeiros 8 chars são timestamp ms, não random; quem quer
+    // entropia em string curta usa RNG direto.
     private static string GerarNumeroInscricao() =>
-        $"{DateTimeOffset.UtcNow:yyyyMMdd}-{Guid.NewGuid().ToString()[..8].ToUpperInvariant()}";
+        $"{DateTimeOffset.UtcNow:yyyyMMdd}-{RandomNumberGenerator.GetHexString(stringLength: 8, lowercase: false)}";
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/EditalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/EditalRepository.cs
@@ -66,11 +66,11 @@ public sealed class EditalRepository : IEditalRepository
 
         if (afterId is { } cursor)
         {
-            // Keyset coerente server-side (ADR-0026): Npgsql traduz Guid.CompareTo
-            // para o operador uuid > nativo do PG — mesmo comparador que o OrderBy(Id)
-            // acima. Estabilidade da janela independe da versão do Guid (v4 hoje;
-            // quando #311 promover EntityBase.Id para Guid v7, ordering passa a
-            // refletir criação temporal sem alteração nesta consulta).
+            // Keyset coerente server-side (ADR-0026 + ADR-0032): Npgsql traduz
+            // Guid.CompareTo para o operador uuid > nativo do PG — mesmo
+            // comparador que o OrderBy(Id) acima. Com Guid v7 (ADR-0032), a
+            // ordenação por Id reflete criação temporal — clientes recebem
+            // editais em ordem cronológica natural ao paginar.
             query = query.Where(e => e.Id.CompareTo(cursor) > 0);
         }
 

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
@@ -4,7 +4,17 @@ using Events;
 
 public abstract class EntityBase
 {
-    public Guid Id { get; protected init; } = Guid.NewGuid();
+    // UUIDv7 (RFC 9562 §5.7) — 48 bits de unix_ts_ms no prefixo + 74 bits aleatórios.
+    // Adotado em todas as entidades de domínio (ADR-0032). Ganhos:
+    // (a) ordering temporal estável → cursor pagination (ADR-0026) ganha semântica
+    //     "próxima página = criados depois" sem código adicional;
+    // (b) localidade B-tree no Postgres → menos page splits e bloat em tabelas de
+    //     alto volume (Inscricao, outbox, audit);
+    // (c) coerência com o resto do projeto que já usa Guid.CreateVersion7 em
+    //     Instance/traceId de ProblemDetails.
+    // O timestamp leak não cria risco LGPD novo: toda entidade já carrega
+    // CreatedAt como audit trail obrigatório, expondo o mesmo dado.
+    public Guid Id { get; protected init; } = Guid.CreateVersion7();
     public DateTimeOffset CreatedAt { get; protected set; } = DateTimeOffset.UtcNow;
     public DateTimeOffset? UpdatedAt { get; protected set; }
     public bool IsDeleted { get; private set; }

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Events/DomainEventBase.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Events/DomainEventBase.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.Kernel.Domain.Events;
 
 public abstract record DomainEventBase : IDomainEvent
 {
-    public Guid EventId { get; } = Guid.NewGuid();
+    // UUID v7 (ADR-0032) — eventos ganham ordering temporal natural no outbox
+    // e nos consumers, facilitando debug e replay determinístico.
+    public Guid EventId { get; } = Guid.CreateVersion7();
     public DateTimeOffset OccurredOn { get; } = DateTimeOffset.UtcNow;
 }

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/DominioNaoUsaGuidNewGuidTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/DominioNaoUsaGuidNewGuidTests.cs
@@ -1,0 +1,126 @@
+namespace Unifesspa.UniPlus.ArchTests.SolutionRules;
+
+using System.IO;
+using System.Text.RegularExpressions;
+
+using AwesomeAssertions;
+
+/// <summary>
+/// Fitness function da ADR-0032: identidade de entidades de domínio é gerada
+/// via <see cref="System.Guid.CreateVersion7()"/> (UUID v7), nunca
+/// <c>Guid.NewGuid()</c> (v4). Testa por regex em arquivos <c>.cs</c> dos
+/// projetos <c>*.Domain</c> — abordagem por inspeção textual é apropriada
+/// porque ArchUnitNET enxerga dependência de tipo, não chamadas de método
+/// específicas (todas as classes dependem de <c>System.Guid</c> como tipo).
+/// </summary>
+/// <remarks>
+/// Falsos positivos esperáveis e tratados:
+/// - Comentários mencionando <c>Guid.NewGuid()</c> historicamente: filtrar
+///   linhas que começam com <c>//</c> ou que estão dentro de bloco
+///   <c>/* */</c>.
+/// - Arquivos gerados em <c>obj/</c> e <c>bin/</c>: excluídos por path.
+/// </remarks>
+public sealed partial class DominioNaoUsaGuidNewGuidTests
+{
+    [GeneratedRegex(@"\bGuid\.NewGuid\s*\(\s*\)")]
+    private static partial Regex GuidNewGuidPattern();
+
+    [Fact(DisplayName = "ADR-0032: nenhum arquivo .cs em *.Domain chama Guid.NewGuid()")]
+    public void Dominio_NaoChama_GuidNewGuid()
+    {
+        string solutionRoot = LocateSolutionRoot();
+        string[] domainSourceRoots =
+        [
+            Path.Combine(solutionRoot, "src", "shared", "Unifesspa.UniPlus.Kernel"),
+            Path.Combine(solutionRoot, "src", "selecao", "Unifesspa.UniPlus.Selecao.Domain"),
+            Path.Combine(solutionRoot, "src", "ingresso", "Unifesspa.UniPlus.Ingresso.Domain"),
+        ];
+
+        List<string> violations = [];
+
+        foreach (string root in domainSourceRoots)
+        {
+            if (!Directory.Exists(root))
+                continue;
+
+            IEnumerable<string> files = Directory
+                .EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+                .Where(static p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                .Where(static p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+            foreach (string file in files)
+            {
+                string[] lines = File.ReadAllLines(file);
+                bool inBlockComment = false;
+
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    string line = lines[i];
+                    string trimmed = line.TrimStart();
+
+                    // Estado-máquina mínima de comment: rastreia /* ... */ que pode atravessar
+                    // múltiplas linhas. Linha que ABRE e FECHA o bloco (/* foo */) sai do estado
+                    // dentro do mesmo passo. Não trata corner-cases exóticos como "/* dentro de
+                    // string literal" porque arquivos de domínio não fazem parsing-bait.
+                    if (inBlockComment)
+                    {
+                        int closing = line.IndexOf("*/", StringComparison.Ordinal);
+                        if (closing < 0)
+                            continue;
+                        inBlockComment = false;
+                        line = line[(closing + 2)..];
+                        trimmed = line.TrimStart();
+                        if (trimmed.Length == 0)
+                            continue;
+                    }
+
+                    if (trimmed.StartsWith("//", StringComparison.Ordinal))
+                        continue;
+
+                    int blockStart = line.IndexOf("/*", StringComparison.Ordinal);
+                    if (blockStart >= 0)
+                    {
+                        int blockEnd = line.IndexOf("*/", blockStart + 2, StringComparison.Ordinal);
+                        if (blockEnd < 0)
+                        {
+                            inBlockComment = true;
+                            line = line[..blockStart];
+                        }
+                        else
+                        {
+                            // /* ... */ inline na mesma linha — remove o trecho do comment.
+                            line = string.Concat(line.AsSpan(0, blockStart), line.AsSpan(blockEnd + 2));
+                        }
+                    }
+
+                    if (GuidNewGuidPattern().IsMatch(line))
+                    {
+                        string relative = Path.GetRelativePath(solutionRoot, file);
+                        violations.Add($"{relative}:{i + 1}: {lines[i].Trim()}");
+                    }
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "ADR-0032 exige Guid.CreateVersion7() em entidades de domínio para ordenação temporal e localidade B-tree no Postgres. " +
+            "Substitua por Guid.CreateVersion7() ou herde de EntityBase, que faz isso por padrão. " +
+            $"Violações encontradas:\n  - {string.Join("\n  - ", violations)}");
+    }
+
+    private static string LocateSolutionRoot()
+    {
+        // Sobe a partir do AppContext.BaseDirectory até encontrar UniPlus.slnx.
+        // Resiliente a mudanças de target framework e path do bin.
+        string current = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            if (File.Exists(Path.Combine(current, "UniPlus.slnx")))
+                return current;
+            current = Directory.GetParent(current)?.FullName ?? string.Empty;
+        }
+
+        throw new DirectoryNotFoundException(
+            "UniPlus.slnx não encontrado a partir de AppContext.BaseDirectory; estrutura do repositório alterada?");
+    }
+}


### PR DESCRIPTION
## Resumo

Implementa **story #311** — substitui `Guid.NewGuid()` (UUID v4 random) por `Guid.CreateVersion7()` (UUID v7, RFC 9562) em toda entidade de domínio. Decisão documentada na **ADR-0032** (proposed neste PR).

## Por que

A inconsistência foi notada durante o review do PR #310 (cursor pagination): o resto do projeto **já** usava `Guid.CreateVersion7()` em ProblemDetails (`Instance`, `traceId`), mas `EntityBase.Id` ainda usava v4. Migrar agora cristaliza:

1. **Cursor pagination ganha ordering temporal natural** — `OrderBy(e => e.Id)` em PG passa a ordenar cronologicamente, "próxima página = items criados depois" sem código adicional (ADR-0026 beneficiária direta).
2. **Localidade B-tree** — UUID v4 random gera page splits frequentes; v7 prefixa timestamp ms, inserts são appendish. Importante em Inscricao (50k+ rows/edital), outbox transacional, audit, Idempotency cache.
3. **Coerência interna** — um único padrão em todo o codebase.

## Mudanças

- `EntityBase.Id` e `DomainEventBase.EventId` usam `Guid.CreateVersion7()`.
- `Inscricao.GerarNumeroInscricao` troca `Guid.NewGuid()[..8]` por `RandomNumberGenerator.GetHexString(8)` — entropia em sufixo curto não cabe em v7 cujos primeiros 8 chars são timestamp.
- `EditalRepository.ListarPaginadoAsync:70` — comentário inline citando ADR-0032 + ADR-0026.
- **Fitness test** novo `DominioNaoUsaGuidNewGuidTests` em `tests/Unifesspa.UniPlus.ArchTests/SolutionRules/` — varre `.cs` de Kernel + *.Domain falhando build se encontrar `Guid.NewGuid()`. Trata comentários de linha e bloco com estado-máquina mínima. Permite em *.Tests.* (seeds).
- **ADR-0032** (proposed) — pesquisa apoiada em RFC 9562, Microsoft Learn, Npgsql 9/10 release notes, PostgreSQL 18 docs, benchmarks pg-uuidv7.
- Índice de ADRs atualizado.

## LGPD

ADR discute timestamp leak (v7 expõe 48 bits de unix_ts_ms). Conclusão: não introduz risco novo no threat model — `CreatedAt` (audit obrigatório) já expõe a mesma informação com a mesma precisão. Argumento desenvolvido na seção "Resultado da decisão" da ADR.

## Plano de teste

- [x] `dotnet build UniPlus.slnx --no-incremental` — 0 warnings, 0 errors
- [x] `dotnet test UniPlus.slnx --no-build` (sem integration) — todos os arch + unit tests passam
- [x] `ListarEditaisEndpointTests` (cursor pagination com IDs v7) — 6/6 passam
- [x] `bash tools/adr-lint/validate.sh` — 32 ADRs limpos
- [x] Fitness test `Dominio_NaoChama_GuidNewGuid` passa (zero violações em domínio)
- [x] Review local pré-commit aprovado (2 importantes do 1º round endereçados antes do commit)

Closes #311