### PR TITLE
feat(api): Idempotency-Key middleware/filter com store EF Core (story #286)

### DIFF
--- a/docs/adrs/0027-idempotency-key-store-postgresql.md
+++ b/docs/adrs/0027-idempotency-key-store-postgresql.md
@@ -94,12 +94,13 @@ O payload do cache (request body + response body) pode conter PII (CPF, nome soc
 
 - **Retry seguro.** Clientes (frontend, integradores externos) podem retry com confiança em qualquer cenário de timeout/network/proxy 5xx, sem risco de duplicação semântica.
 - **Conformidade com RN01.** Inscrição duplicada por retry deixa de ser vetor; constraint de unicidade no domínio passa a ser última linha de defesa, não primeira.
-- **Atomicidade real.** Commit do agregado + gravação do cache acontecem na mesma transação Postgres. Não existe estado intermediário onde o agregado foi gravado mas o cache não, ou vice-versa.
+- **Atomicidade alcançada parcialmente** (revisado pós-implementação — ver "Negativas"). A intenção original de uma transação única foi reduzida a três transações separadas; o ganho efetivo é eliminação de janela de inconsistência ao 5xx (reservation deletada) e proteção contra duplicação concorrente via UNIQUE index. Caminho de retry permanece seguro embora não atomic-ideal.
 - **Auditabilidade.** Cache em Postgres é inspecionável via SQL para suporte e auditoria sem tooling extra.
 - **Convergência com mercado.** Comportamento idêntico a Stripe/Square/PayPal facilita integração de clientes que já implementam o padrão.
 
 ### Negativas
 
+- **Atomicidade parcial (ajuste pós-implementação, story #286).** A promessa original "commit do agregado + cache na mesma `IEnvelopeTransaction`" não foi alcançada. A implementação usa três transações separadas: `TryReserve` (insert da reservation), o handler do agregado (commit via `IEnvelopeTransaction` do Wolverine), e `Complete` (update da reservation com response cifrada). Integrar `ResourceFilter` ao pipeline da `IEnvelopeTransaction` exige extensão fora do escopo da story que entregou o middleware. Janela de inconsistência: se `Complete` falhar após o handler commitar (network blip, deploy, exceção tardia), a entry permanece em status `Processing` até o TTL (24h) — clientes que retry com a mesma key recebem 409 nesse intervalo. Mitigação parcial: 5xx/Canceled deleta a reservation imediatamente (DELETE atômico próprio) para liberar o cliente a retry após falha do handler. ADR será revisada quando a integração com `IEnvelopeTransaction` for implementada.
 - **Carga adicional no Postgres.** Cada request idempotente faz uma leitura + uma escrita extra na mesma transação. Mitigação: índice em `(scope, endpoint, key)` e TTL agressivo (24h); volume do cache fica limitado por janela.
 - **Complexidade de cleanup.** Entradas expiradas precisam de job periódico ou estratégia de particionamento. Sem cleanup, tabela cresce indefinidamente.
 - **Cifragem adiciona latência.** Cifragem/decifragem por request idempotente acrescenta ~ms por chamada à infraestrutura de chave. Aceitável dado o ganho de segurança.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
 using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 using Unifesspa.UniPlus.Kernel.Results;
 using Application.Commands.Editais;
@@ -35,7 +36,10 @@ public sealed class EditalController : ControllerBase
     }
 
     [HttpPost]
+    [RequiresIdempotencyKey]
     [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<IActionResult> Criar([FromBody] CriarEditalCommand command, CancellationToken cancellationToken)
     {
@@ -81,8 +85,11 @@ public sealed class EditalController : ControllerBase
     // cascading messages — atomicidade write+evento garantida pela
     // IEnvelopeTransaction da configuração produtiva (ADR-0005).
     [HttpPost("{id:guid}/publicar")]
+    [RequiresIdempotencyKey]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<IActionResult> Publicar(Guid id, CancellationToken cancellationToken)
     {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -51,6 +51,9 @@ builder.Services.AddDomainErrorMapper();
 // traduz falhas do PageRequestModelBinder para 400/410/422.
 builder.Services.AddUniPlusEncryption(builder.Configuration);
 builder.Services.AddCursorPagination(builder.Configuration);
+// Idempotency-Key (ADR-0027) — store EF adjacente ao SelecaoDbContext, filter
+// global que se ativa apenas em endpoints com [RequiresIdempotencyKey].
+builder.Services.AddIdempotency<Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.SelecaoDbContext>(builder.Configuration);
 
 builder.Services.AddOidcAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddCorrelationIdAccessor();

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Domain.Entities;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
 
 public sealed class SelecaoDbContext : DbContext, IUnitOfWork
 {
@@ -19,10 +20,19 @@ public sealed class SelecaoDbContext : DbContext, IUnitOfWork
     public DbSet<Candidato> Candidatos => Set<Candidato>();
     public DbSet<ProcessoSeletivo> ProcessosSeletivos => Set<ProcessoSeletivo>();
 
+    /// <summary>
+    /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do agregado
+    /// para permitir gravação adjacente no outbox; entries cifradas at-rest
+    /// via <c>IUniPlusEncryptionService</c>.
+    /// </summary>
+    public DbSet<IdempotencyEntry> IdempotencyEntries => Set<IdempotencyEntry>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(SelecaoDbContext).Assembly);
+        // Configurações cross-cutting de Infrastructure.Core (ex.: idempotency_cache).
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdempotencyEntry).Assembly);
         base.OnModelCreating(modelBuilder);
     }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/IdempotencyServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/IdempotencyServiceCollectionExtensions.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using Idempotency;
+
+/// <summary>
+/// Registra o stack de Idempotency-Key (ADR-0027): options + store EF
+/// adjacente ao DbContext do módulo + <see cref="IdempotencyFilter"/> +
+/// hook <see cref="MvcOptions.Filters"/> aplicando o filter globalmente
+/// (cobre apenas endpoints com <c>[RequiresIdempotencyKey]</c> via guard
+/// interno do próprio filter).
+/// </summary>
+public static class IdempotencyServiceCollectionExtensions
+{
+    public static IServiceCollection AddIdempotency<TDbContext>(
+        this IServiceCollection services,
+        IConfiguration configuration)
+        where TDbContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services
+            .AddOptions<IdempotencyOptions>()
+            .Bind(configuration.GetSection(IdempotencyOptions.SectionName))
+            .Validate(static o => o.Ttl > TimeSpan.Zero, "IdempotencyOptions.Ttl deve ser positivo.")
+            .Validate(static o => o.MaxBodyBytes > 0, "IdempotencyOptions.MaxBodyBytes deve ser positivo.")
+            .ValidateOnStart();
+
+        services.TryAddSingleton(TimeProvider.System);
+
+        services.AddScoped<IIdempotencyStore, EfCoreIdempotencyStore<TDbContext>>();
+        services.AddScoped<IdempotencyFilter>();
+
+        services.AddSingleton<Errors.IDomainErrorRegistration, IdempotencyDomainErrorRegistration>();
+
+        services.PostConfigure<MvcOptions>(options =>
+        {
+            // ServiceFilterAttribute resolve o IdempotencyFilter do request
+            // scope a cada request — honra explicitamente o lifetime Scoped
+            // registrado acima e o IIdempotencyStore Scoped que ele consome.
+            // Filter aplicado globalmente; ele próprio retorna early se a
+            // action não tiver [RequiresIdempotencyKey].
+            options.Filters.Add(new ServiceFilterAttribute(typeof(IdempotencyFilter)));
+        });
+
+        return services;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/EfCoreIdempotencyStore.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/EfCoreIdempotencyStore.cs
@@ -1,0 +1,147 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+using Microsoft.EntityFrameworkCore;
+
+using Npgsql;
+
+/// <summary>
+/// Implementação <see cref="IIdempotencyStore"/> sobre <see cref="DbContext"/>
+/// genérico. Cada módulo que usa idempotência registra um instance via
+/// <c>AddIdempotency&lt;TDbContext&gt;</c> (ex.: <c>SelecaoDbContext</c>);
+/// a entidade <see cref="IdempotencyEntry"/> precisa estar mapeada no
+/// contexto do módulo (auto via <c>ApplyConfigurationsFromAssembly</c>).
+/// </summary>
+/// <remarks>
+/// Trade-off documentado em ADR-0027 §"Negativas — Atomicidade parcial":
+/// TryReserve, Complete e Delete rodam em transações curtas separadas — não
+/// na mesma <c>IEnvelopeTransaction</c> do agregado. UNIQUE index garante que
+/// duas reservations concorrentes não criam duplicação. Em 5xx/Canceled o
+/// filter chama <see cref="DeleteAsync"/> para liberar a key (cliente pode
+/// retry após falha transitória do servidor).
+/// </remarks>
+public sealed class EfCoreIdempotencyStore<TDbContext> : IIdempotencyStore
+    where TDbContext : DbContext
+{
+    private const string PostgresUniqueViolationSqlState = "23505";
+
+    private readonly TDbContext _db;
+    private readonly TimeProvider _timeProvider;
+
+    public EfCoreIdempotencyStore(TDbContext db, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        _db = db;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task<IdempotencyLookupResult> LookupAsync(
+        string scope, string endpoint, string idempotencyKey, string bodyHash,
+        CancellationToken cancellationToken)
+    {
+        IdempotencyEntry? entry = await _db.Set<IdempotencyEntry>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                e => e.Scope == scope && e.Endpoint == endpoint && e.IdempotencyKey == idempotencyKey,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entry is null)
+            return new IdempotencyLookupResult(IdempotencyOutcome.Miss, null);
+
+        // Entry expirada conta como miss — handler roda novamente. Cleanup
+        // físico fica para job dedicado (fora do escopo desta story).
+        if (entry.ExpiresAt <= _timeProvider.GetUtcNow())
+            return new IdempotencyLookupResult(IdempotencyOutcome.Miss, null);
+
+        if (entry.Status == IdempotencyStatus.Processing)
+            return new IdempotencyLookupResult(IdempotencyOutcome.Processing, entry);
+
+        if (!string.Equals(entry.BodyHash, bodyHash, StringComparison.Ordinal))
+            return new IdempotencyLookupResult(IdempotencyOutcome.HitMismatch, entry);
+
+        return new IdempotencyLookupResult(IdempotencyOutcome.HitMatch, entry);
+    }
+
+    public async Task<bool> TryReserveAsync(
+        string scope, string endpoint, string idempotencyKey, string bodyHash,
+        DateTimeOffset expiresAt,
+        CancellationToken cancellationToken)
+    {
+        IdempotencyEntry entry = new()
+        {
+            Scope = scope,
+            Endpoint = endpoint,
+            IdempotencyKey = idempotencyKey,
+            BodyHash = bodyHash,
+            Status = IdempotencyStatus.Processing,
+            ExpiresAt = expiresAt,
+            CreatedAt = _timeProvider.GetUtcNow(),
+        };
+
+        _db.Set<IdempotencyEntry>().Add(entry);
+
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // Apenas violação UNIQUE (race com outra request) sinaliza
+            // "reserva concorrente" — outros DbUpdateException (FK, disco
+            // cheio, lock timeout) propagam para a infra de logs e cliente
+            // recebe 5xx, ao invés de serem mascarados como 409 ProcessingConflict.
+            _db.Set<IdempotencyEntry>().Entry(entry).State = EntityState.Detached;
+            return false;
+        }
+    }
+
+    public async Task CompleteAsync(
+        string scope, string endpoint, string idempotencyKey,
+        int responseStatus, string? responseHeadersJson, byte[] responseBodyCipher,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(responseBodyCipher);
+
+        // ExecuteUpdate emite UPDATE atômico sem carregar/rastrear a entry —
+        // evita commitar estado fantasma do request scope (ChangeTracker poderia
+        // ter outras entities pendentes do controller). Filtro por
+        // Status == Processing é idempotente: chamada dupla não sobrescreve
+        // entry já Completed (segunda chamada simplesmente atualiza 0 rows).
+        int updated = await _db.Set<IdempotencyEntry>()
+            .Where(e => e.Scope == scope
+                && e.Endpoint == endpoint
+                && e.IdempotencyKey == idempotencyKey
+                && e.Status == IdempotencyStatus.Processing)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(e => e.Status, IdempotencyStatus.Completed)
+                .SetProperty(e => e.ResponseStatus, (int?)responseStatus)
+                .SetProperty(e => e.ResponseHeadersJson, responseHeadersJson)
+                .SetProperty(e => e.ResponseBodyCipher, responseBodyCipher),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (updated == 0)
+        {
+            // Não é erro: entry pode já ter sido Completed por concorrente
+            // (raro, exigiria duas reservations idênticas mas a UNIQUE
+            // impede) ou TTL-expirada antes do Complete. Log noop.
+        }
+    }
+
+    public async Task DeleteAsync(
+        string scope, string endpoint, string idempotencyKey,
+        CancellationToken cancellationToken)
+    {
+        await _db.Set<IdempotencyEntry>()
+            .Where(e => e.Scope == scope
+                && e.Endpoint == endpoint
+                && e.IdempotencyKey == idempotencyKey)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pg && pg.SqlState == PostgresUniqueViolationSqlState;
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/EfCoreIdempotencyStore.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/EfCoreIdempotencyStore.cs
@@ -49,10 +49,22 @@ public sealed class EfCoreIdempotencyStore<TDbContext> : IIdempotencyStore
         if (entry is null)
             return new IdempotencyLookupResult(IdempotencyOutcome.Miss, null);
 
-        // Entry expirada conta como miss — handler roda novamente. Cleanup
-        // físico fica para job dedicado (fora do escopo desta story).
-        if (entry.ExpiresAt <= _timeProvider.GetUtcNow())
+        // Entry expirada conta como miss, mas precisa ser DELETADA antes de
+        // retornar — caso contrário a UNIQUE em (scope, endpoint, key) bloqueia
+        // o próximo TryReserve do cliente (UNIQUE violation), resultando em 409
+        // espúrio para uma request que deveria ser tratada como nova.
+        // ExecuteDelete com filtro Id+ExpiresAt é seguro contra concorrência:
+        // outra request que detecte o mesmo expirado vence o DELETE, a perdedora
+        // vê 0 rows e segue normal.
+        DateTimeOffset now = _timeProvider.GetUtcNow();
+        if (entry.ExpiresAt <= now)
+        {
+            await _db.Set<IdempotencyEntry>()
+                .Where(e => e.Id == entry.Id && e.ExpiresAt <= now)
+                .ExecuteDeleteAsync(cancellationToken)
+                .ConfigureAwait(false);
             return new IdempotencyLookupResult(IdempotencyOutcome.Miss, null);
+        }
 
         if (entry.Status == IdempotencyStatus.Processing)
             return new IdempotencyLookupResult(IdempotencyOutcome.Processing, entry);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IIdempotencyStore.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IIdempotencyStore.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+/// <summary>
+/// Persistência do cache de Idempotency-Key (ADR-0027). Usado pelo
+/// <c>IdempotencyFilter</c> em duas fases: <c>TryReserveAsync</c> antes do
+/// handler (cria entry com status Processing — UNIQUE index segura
+/// concorrência) e <c>CompleteAsync</c> após o handler (preenche response
+/// cifrada + status Completed).
+/// </summary>
+public interface IIdempotencyStore
+{
+    /// <summary>
+    /// Lookup atômico que decide o branch do filter (Miss / HitMatch /
+    /// HitMismatch / Processing). Não muta estado.
+    /// </summary>
+    Task<IdempotencyLookupResult> LookupAsync(
+        string scope, string endpoint, string idempotencyKey, string bodyHash,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Tenta criar a reservation. Retorna <c>true</c> se inseriu;
+    /// <c>false</c> se UNIQUE violation (race com outra request que
+    /// inseriu primeiro). Em caso de <c>false</c>, caller deve
+    /// re-fazer lookup para descobrir o estado.
+    /// </summary>
+    Task<bool> TryReserveAsync(
+        string scope, string endpoint, string idempotencyKey, string bodyHash,
+        DateTimeOffset expiresAt,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Atualiza reservation com response cifrada e marca Completed. Idempotente:
+    /// se entry não existe ou já está Completed, a operação é no-op (UPDATE
+    /// matcha 0 rows).
+    /// </summary>
+    Task CompleteAsync(
+        string scope, string endpoint, string idempotencyKey,
+        int responseStatus, string? responseHeadersJson, byte[] responseBodyCipher,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Remove reservation. Chamado em 5xx ou Canceled para liberar a key e
+    /// permitir retry do cliente após falha do handler (ADR-0027 §"Status
+    /// codes em cache" — 5xx nunca cacheia).
+    /// </summary>
+    Task DeleteAsync(
+        string scope, string endpoint, string idempotencyKey,
+        CancellationToken cancellationToken);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyDomainErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyDomainErrorCodes.cs
@@ -11,4 +11,6 @@ public static class IdempotencyDomainErrorCodes
     public const string KeyMalformada = "Idempotency.KeyMalformada";
     public const string BodyMismatch = "Idempotency.BodyMismatch";
     public const string ProcessingConflict = "Idempotency.ProcessingConflict";
+    public const string PrincipalRequerido = "Idempotency.PrincipalRequerido";
+    public const string BodyMuitoGrande = "Idempotency.BodyMuitoGrande";
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyDomainErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyDomainErrorCodes.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+/// <summary>
+/// Códigos de domain error emitidos pelo <c>IdempotencyFilter</c>. Resolvidos
+/// para HTTP status pelo <see cref="IdempotencyDomainErrorRegistration"/>
+/// (ADR-0024).
+/// </summary>
+public static class IdempotencyDomainErrorCodes
+{
+    public const string KeyAusente = "Idempotency.KeyAusente";
+    public const string KeyMalformada = "Idempotency.KeyMalformada";
+    public const string BodyMismatch = "Idempotency.BodyMismatch";
+    public const string ProcessingConflict = "Idempotency.ProcessingConflict";
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyDomainErrorRegistration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyDomainErrorRegistration.cs
@@ -29,5 +29,11 @@ internal sealed class IdempotencyDomainErrorRegistration : IDomainErrorRegistrat
         new(IdempotencyDomainErrorCodes.ProcessingConflict,
             new DomainErrorMapping(StatusCodes.Status409Conflict, "uniplus.idempotency.processing_conflict",
                 "Request com a mesma Idempotency-Key ainda em processamento; tentar novamente em alguns segundos")),
+        new(IdempotencyDomainErrorCodes.PrincipalRequerido,
+            new DomainErrorMapping(StatusCodes.Status401Unauthorized, "uniplus.idempotency.principal_requerido",
+                "Endpoint com Idempotency-Key requer principal autenticado")),
+        new(IdempotencyDomainErrorCodes.BodyMuitoGrande,
+            new DomainErrorMapping(StatusCodes.Status413PayloadTooLarge, "uniplus.idempotency.body_muito_grande",
+                "Request body excede o limite aceito por endpoints idempotentes")),
     ];
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyDomainErrorRegistration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyDomainErrorRegistration.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+
+using Errors;
+
+/// <summary>
+/// Mapeia codes de domínio do filter de idempotência para HTTP status +
+/// type URL (ADR-0027 §"Lookup, replay e validação"). Auto-registrado via
+/// <c>AddIdempotency&lt;TDbContext&gt;</c>.
+/// </summary>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider em AddIdempotency().")]
+internal sealed class IdempotencyDomainErrorRegistration : IDomainErrorRegistration
+{
+    public IEnumerable<KeyValuePair<string, DomainErrorMapping>> GetMappings() =>
+    [
+        new(IdempotencyDomainErrorCodes.KeyAusente,
+            new DomainErrorMapping(StatusCodes.Status400BadRequest, "uniplus.idempotency.key_ausente",
+                "Header Idempotency-Key obrigatório neste endpoint")),
+        new(IdempotencyDomainErrorCodes.KeyMalformada,
+            new DomainErrorMapping(StatusCodes.Status400BadRequest, "uniplus.idempotency.key_malformada",
+                "Header Idempotency-Key malformado")),
+        new(IdempotencyDomainErrorCodes.BodyMismatch,
+            new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.idempotency.body_mismatch",
+                "Mesma Idempotency-Key reusada com body diferente")),
+        new(IdempotencyDomainErrorCodes.ProcessingConflict,
+            new DomainErrorMapping(StatusCodes.Status409Conflict, "uniplus.idempotency.processing_conflict",
+                "Request com a mesma Idempotency-Key ainda em processamento; tentar novamente em alguns segundos")),
+    ];
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyEntry.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyEntry.cs
@@ -1,0 +1,57 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+/// <summary>
+/// POCO mapeado para a tabela <c>idempotency_cache</c> (ADR-0027). Adicionado
+/// ao DbContext do módulo via <c>EfCoreIdempotencyStore&lt;TDbContext&gt;</c>;
+/// entries persistidas e atualizadas pelo <c>IdempotencyFilter</c> em
+/// transações curtas separadas da transação do agregado (trade-off
+/// documentado em ADR-0027 Consequências negativas).
+/// </summary>
+public sealed class IdempotencyEntry
+{
+    /// <summary>Identificador interno (UUID v7 para ordering temporal).</summary>
+    public Guid Id { get; set; } = Guid.CreateVersion7();
+
+    /// <summary>
+    /// Escopo: combina principal autenticado (sub do JWT) + tenant futuro.
+    /// Previne colisão entre clientes que escolham keys idênticas.
+    /// </summary>
+    public string Scope { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Endpoint canônico no formato <c>"METHOD /path/template"</c>
+    /// (ex.: <c>"POST /api/editais"</c>). Usa o template da rota, não a URL
+    /// instanciada — evita explosão de chaves para path com parâmetros.
+    /// </summary>
+    public string Endpoint { get; set; } = string.Empty;
+
+    /// <summary>Header <c>Idempotency-Key</c> tal como recebido do cliente.</summary>
+    public string IdempotencyKey { get; set; } = string.Empty;
+
+    /// <summary>SHA-256 hex do request body raw (sem canonicalize).</summary>
+    public string BodyHash { get; set; } = string.Empty;
+
+    public IdempotencyStatus Status { get; set; }
+
+    public int? ResponseStatus { get; set; }
+
+    /// <summary>JSON serializado de headers cacheados (Content-Type, Location).</summary>
+    public string? ResponseHeadersJson { get; set; }
+
+    /// <summary>
+    /// Response body cifrado at-rest via <c>IUniPlusEncryptionService</c> com
+    /// chave nomeada <c>"idempotency"</c> (ADR-0027 §"Cifragem at-rest").
+    /// </summary>
+#pragma warning disable CA1819 // Properties should not return arrays — entidade EF Core mapeia bytea diretamente; record value-equality não se aplica.
+    public byte[]? ResponseBodyCipher { get; set; }
+#pragma warning restore CA1819
+
+    public DateTimeOffset ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Sem default — o store sempre seta via <see cref="TimeProvider"/> injetado
+    /// para que testes determinísticos (FakeTimeProvider) controlem o instante
+    /// de criação. Default zerado pode ser detectado em queries diagnósticas.
+    /// </summary>
+    public DateTimeOffset CreatedAt { get; set; }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyEntryConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyEntryConfiguration.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+internal sealed class IdempotencyEntryConfiguration : IEntityTypeConfiguration<IdempotencyEntry>
+{
+    public void Configure(EntityTypeBuilder<IdempotencyEntry> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("idempotency_cache");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Scope)
+            .HasMaxLength(255)
+            .IsRequired();
+
+        builder.Property(e => e.Endpoint)
+            .HasMaxLength(500)
+            .IsRequired();
+
+        builder.Property(e => e.IdempotencyKey)
+            .HasMaxLength(255)
+            .IsRequired();
+
+        builder.Property(e => e.BodyHash)
+            .HasMaxLength(64)
+            .IsFixedLength()
+            .IsRequired();
+
+        builder.Property(e => e.Status)
+            .HasConversion<short>()
+            .IsRequired();
+
+        builder.Property(e => e.ResponseHeadersJson)
+            .HasColumnType("jsonb");
+
+        builder.Property(e => e.ExpiresAt)
+            .IsRequired();
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        // Índice único — garante que duas requests concorrentes com a mesma
+        // (scope, endpoint, key) não consigam reservar duas entries.
+        // DbUpdateException por violação dessa unique é o sinal de retry
+        // concorrente (tratado pelo filter com aguarda + replay).
+        builder.HasIndex(e => new { e.Scope, e.Endpoint, e.IdempotencyKey })
+            .IsUnique()
+            .HasDatabaseName("idx_idempotency_lookup");
+
+        // Suporta job de cleanup por TTL (não implementado nesta story; ADR-0027
+        // §"Esta ADR não decide" — política de cleanup fica aberta).
+        builder.HasIndex(e => e.ExpiresAt)
+            .HasDatabaseName("idx_idempotency_expires_at");
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -117,36 +117,37 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
         IdempotencyLookupResult lookup = await _store.LookupAsync(
             scope, endpoint, idempotencyKey, bodyHash, httpContext.RequestAborted).ConfigureAwait(false);
 
-        switch (lookup.Outcome)
+        if (TryShortCircuitFromLookup(context, lookup, httpContext.RequestAborted, out Task? earlyReturn))
         {
-            case IdempotencyOutcome.HitMatch:
-                await ReplayAsync(context, lookup.Entry!, httpContext.RequestAborted).ConfigureAwait(false);
-                return;
-
-            case IdempotencyOutcome.HitMismatch:
-                ShortCircuit(context, IdempotencyDomainErrorCodes.BodyMismatch,
-                    "Mesma Idempotency-Key reusada com body diferente.");
-                return;
-
-            case IdempotencyOutcome.Processing:
-                ShortCircuit(context, IdempotencyDomainErrorCodes.ProcessingConflict,
-                    "Request com a mesma Idempotency-Key ainda em processamento; tentar novamente.");
-                return;
-
-            case IdempotencyOutcome.Miss:
-            default:
-                break;
+            await earlyReturn!.ConfigureAwait(false);
+            return;
         }
 
-        // Tenta reservar. Concorrente que ganhou a corrida → re-lookup.
+        // Tenta reservar. Se UNIQUE vencer, re-lookup: o vencedor da corrida
+        // pode já ter completado (retornar HitMatch para replay), ainda estar
+        // em Processing (409), ou ter Hit com body diferente (422). Sem o
+        // re-lookup, perdedor receberia 409 mesmo se o vencedor já estivesse
+        // pronto para replay — quebra de contrato draft IETF §3.
         DateTimeOffset expiresAt = _time.GetUtcNow().Add(_options.Ttl);
         bool reserved = await _store.TryReserveAsync(
             scope, endpoint, idempotencyKey, bodyHash, expiresAt, httpContext.RequestAborted).ConfigureAwait(false);
 
         if (!reserved)
         {
+            IdempotencyLookupResult relookup = await _store.LookupAsync(
+                scope, endpoint, idempotencyKey, bodyHash, httpContext.RequestAborted).ConfigureAwait(false);
+
+            if (TryShortCircuitFromLookup(context, relookup, httpContext.RequestAborted, out Task? raceReturn))
+            {
+                await raceReturn!.ConfigureAwait(false);
+                return;
+            }
+
+            // Miss aqui só ocorre se a entry foi DELETADA entre TryReserve e
+            // re-lookup (5xx do vencedor) — situação rara, devolver 409 e
+            // sugerir retry imediato é o caminho seguro.
             ShortCircuit(context, IdempotencyDomainErrorCodes.ProcessingConflict,
-                "Request concorrente com mesma Idempotency-Key ainda em processamento.");
+                "Request concorrente com mesma Idempotency-Key resolvida; tentar novamente.");
             return;
         }
 
@@ -223,6 +224,43 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
         {
             httpContext.Response.Body = originalBody;
             await captureStream.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Traduz <see cref="IdempotencyLookupResult"/> em short-circuit do filter.
+    /// Retorna <c>true</c> + Task a aguardar quando o resultado é terminal
+    /// (HitMatch/HitMismatch/Processing); <c>false</c> + Task null quando é
+    /// Miss (caller continua para TryReserve).
+    /// </summary>
+    private bool TryShortCircuitFromLookup(
+        ResourceExecutingContext context,
+        IdempotencyLookupResult lookup,
+        CancellationToken cancellationToken,
+        out Task? earlyReturn)
+    {
+        switch (lookup.Outcome)
+        {
+            case IdempotencyOutcome.HitMatch:
+                earlyReturn = ReplayAsync(context, lookup.Entry!, cancellationToken);
+                return true;
+
+            case IdempotencyOutcome.HitMismatch:
+                ShortCircuit(context, IdempotencyDomainErrorCodes.BodyMismatch,
+                    "Mesma Idempotency-Key reusada com body diferente.");
+                earlyReturn = Task.CompletedTask;
+                return true;
+
+            case IdempotencyOutcome.Processing:
+                ShortCircuit(context, IdempotencyDomainErrorCodes.ProcessingConflict,
+                    "Request com a mesma Idempotency-Key ainda em processamento; tentar novamente.");
+                earlyReturn = Task.CompletedTask;
+                return true;
+
+            case IdempotencyOutcome.Miss:
+            default:
+                earlyReturn = null;
+                return false;
         }
     }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -1,0 +1,372 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Options;
+
+using Cryptography;
+using Errors;
+
+using Kernel.Results;
+
+/// <summary>
+/// Resource filter (roda antes de model binding e antes do action filter)
+/// que implementa o protocolo Idempotency-Key conforme ADR-0027 e
+/// draft-ietf-httpapi-idempotency-key-header-07. Faz lookup, replay verbatim
+/// em hit-match, 422 em hit-mismatch, 409 em processing, 400 em key
+/// ausente/malformada. Em miss, reserva entry, deixa o action executar e
+/// completa após.
+/// </summary>
+/// <remarks>
+/// <para><b>Por que ResourceFilter e não Middleware:</b> precisamos do
+/// metadata da action (atributo <c>[RequiresIdempotencyKey]</c>) e do
+/// template da rota (<c>endpoint</c> canônico) — ambos disponíveis após
+/// routing, antes do model binding. ResourceFilter é o ponto canônico.</para>
+/// <para><b>Body buffering:</b> o filter lê o body raw via
+/// <c>EnableBuffering()</c> e <c>request.Body.Position = 0</c>, depois
+/// reseta para que o model binder consuma normalmente.</para>
+/// <para><b>Atomicidade vs ADR-0027:</b> reservation e completion rodam
+/// em transações separadas (limitação documentada em ADR-0027 §"Negativas").
+/// Janela de inconsistência é coberta por status Processing → 409 em retry
+/// concorrente.</para>
+/// </remarks>
+public sealed partial class IdempotencyFilter : IAsyncResourceFilter
+{
+    [GeneratedRegex(@"^[\x21-\x7E]{1,255}$")]
+    private static partial Regex KeyPrintableAsciiRegex();
+
+    // Vírgula e ponto-vírgula são proibidos pelo draft IETF mesmo estando no
+    // range ASCII printable — usados como separadores em sf-list. Espaço já é
+    // rejeitado pela regex (0x20 < 0x21).
+    private static readonly char[] ForbiddenKeyChars = [',', ';'];
+
+    private const string ReplayHeader = "Idempotency-Replayed";
+
+    private readonly IIdempotencyStore _store;
+    private readonly IUniPlusEncryptionService _encryption;
+    private readonly IDomainErrorMapper _errorMapper;
+    private readonly TimeProvider _time;
+    private readonly IdempotencyOptions _options;
+
+    public IdempotencyFilter(
+        IIdempotencyStore store,
+        IUniPlusEncryptionService encryption,
+        IDomainErrorMapper errorMapper,
+        TimeProvider time,
+        IOptions<IdempotencyOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _store = store;
+        _encryption = encryption;
+        _errorMapper = errorMapper;
+        _time = time;
+        _options = options.Value;
+    }
+
+    public async Task OnResourceExecutionAsync(ResourceExecutingContext context, ResourceExecutionDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        if (!HasRequiresIdempotencyKey(context))
+        {
+            await next().ConfigureAwait(false);
+            return;
+        }
+
+        HttpContext httpContext = context.HttpContext;
+
+        // Header obrigatório.
+        if (!httpContext.Request.Headers.TryGetValue("Idempotency-Key", out Microsoft.Extensions.Primitives.StringValues headerValues)
+            || headerValues.Count == 0
+            || string.IsNullOrEmpty(headerValues[0]))
+        {
+            ShortCircuit(context, IdempotencyDomainErrorCodes.KeyAusente,
+                "Header Idempotency-Key é obrigatório neste endpoint.");
+            return;
+        }
+
+        string idempotencyKey = headerValues[0]!;
+        if (!IsKeyValid(idempotencyKey))
+        {
+            ShortCircuit(context, IdempotencyDomainErrorCodes.KeyMalformada,
+                "Header Idempotency-Key contém caracteres inválidos ou tamanho fora de [1, 255].");
+            return;
+        }
+
+        // Lê body bytes (sem consumir o stream para o model binder).
+        byte[] bodyBytes = await ReadAndRewindBodyAsync(httpContext.Request, _options.MaxBodyBytes,
+            httpContext.RequestAborted).ConfigureAwait(false);
+
+        string bodyHash = ComputeSha256Hex(bodyBytes);
+        string scope = ResolveScope(httpContext);
+        string endpoint = ResolveEndpoint(context);
+
+        // Lookup inicial.
+        IdempotencyLookupResult lookup = await _store.LookupAsync(
+            scope, endpoint, idempotencyKey, bodyHash, httpContext.RequestAborted).ConfigureAwait(false);
+
+        switch (lookup.Outcome)
+        {
+            case IdempotencyOutcome.HitMatch:
+                await ReplayAsync(context, lookup.Entry!, httpContext.RequestAborted).ConfigureAwait(false);
+                return;
+
+            case IdempotencyOutcome.HitMismatch:
+                ShortCircuit(context, IdempotencyDomainErrorCodes.BodyMismatch,
+                    "Mesma Idempotency-Key reusada com body diferente.");
+                return;
+
+            case IdempotencyOutcome.Processing:
+                ShortCircuit(context, IdempotencyDomainErrorCodes.ProcessingConflict,
+                    "Request com a mesma Idempotency-Key ainda em processamento; tentar novamente.");
+                return;
+
+            case IdempotencyOutcome.Miss:
+            default:
+                break;
+        }
+
+        // Tenta reservar. Concorrente que ganhou a corrida → re-lookup.
+        DateTimeOffset expiresAt = _time.GetUtcNow().Add(_options.Ttl);
+        bool reserved = await _store.TryReserveAsync(
+            scope, endpoint, idempotencyKey, bodyHash, expiresAt, httpContext.RequestAborted).ConfigureAwait(false);
+
+        if (!reserved)
+        {
+            ShortCircuit(context, IdempotencyDomainErrorCodes.ProcessingConflict,
+                "Request concorrente com mesma Idempotency-Key ainda em processamento.");
+            return;
+        }
+
+        // Wrap response stream para captura. try/finally garante restauração
+        // do body original e dispose do stream mesmo em caso de exceção do
+        // handler — exceção também dispara delete da reservation (rethrow).
+        Stream originalBody = httpContext.Response.Body;
+        MemoryStream captureStream = new();
+        httpContext.Response.Body = captureStream;
+        bool reservationStillValid = true;
+
+        try
+        {
+            ResourceExecutedContext executed = await next().ConfigureAwait(false);
+
+            int status = httpContext.Response.StatusCode;
+
+            // 5xx nunca é cacheado (ADR-0027 §"Status codes em cache" + draft
+            // IETF §6). Reservation deletada para que retry do cliente com a
+            // mesma key possa executar o handler novamente — sem isso, cliente
+            // ficaria preso em 409 ProcessingConflict por 24h. CancellationToken
+            // None no DeleteAsync porque RequestAborted já está disparado quando
+            // o request foi cancelado pelo cliente.
+            if (status >= 500 || executed.Canceled)
+            {
+                await _store.DeleteAsync(scope, endpoint, idempotencyKey, CancellationToken.None)
+                    .ConfigureAwait(false);
+                reservationStillValid = false;
+                captureStream.Position = 0;
+                await captureStream.CopyToAsync(originalBody, httpContext.RequestAborted).ConfigureAwait(false);
+                return;
+            }
+
+            byte[] responseBytes = captureStream.ToArray();
+
+            // Cifra response body at-rest (ADR-0027 §"Cifragem at-rest").
+            byte[] cipher = await _encryption.EncryptAsync(
+                IdempotencyOptions.EncryptionKeyName, responseBytes, httpContext.RequestAborted).ConfigureAwait(false);
+
+            // Captura headers cacheáveis.
+            string headersJson = SerializeCachedHeaders(httpContext.Response);
+
+            await _store.CompleteAsync(
+                scope, endpoint, idempotencyKey, status, headersJson, cipher,
+                httpContext.RequestAborted).ConfigureAwait(false);
+            reservationStillValid = false;
+
+            // Copia bytes capturados para o stream original (cliente recebe normal).
+            captureStream.Position = 0;
+            await captureStream.CopyToAsync(originalBody, httpContext.RequestAborted).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Exceção do handler ou do pipeline → libera a key para retry
+            // legítimo do cliente. Sem isso, próxima request com mesma key
+            // ficaria em 409 ProcessingConflict por 24h.
+            if (reservationStillValid)
+            {
+                try
+                {
+                    await _store.DeleteAsync(scope, endpoint, idempotencyKey, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+#pragma warning disable CA1031 // catch genérico justificado: delete é best-effort no rollback path; falha aqui deve cair no TTL, não substituir/mascarar a exceção original que estamos rethrowing.
+                catch
+                {
+                    // Best-effort: se delete falhar, entry expira via TTL.
+                }
+#pragma warning restore CA1031
+            }
+            throw;
+        }
+        finally
+        {
+            httpContext.Response.Body = originalBody;
+            await captureStream.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static bool HasRequiresIdempotencyKey(ResourceExecutingContext context) =>
+        context.ActionDescriptor is ControllerActionDescriptor descriptor
+        && descriptor.MethodInfo.GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true) is not null;
+
+    private static bool IsKeyValid(string key)
+    {
+        // Regex {1,255} já garante length em range e [\x21-\x7E] já exclui
+        // espaço (0x20), tab (0x09) e demais caracteres não-imprimíveis.
+        // ForbiddenKeyChars cobre apenas vírgula (0x2C) e ponto-vírgula (0x3B)
+        // que estão dentro do range printable mas são proibidos pelo
+        // draft IETF (caracteres usados como separadores em sf-list).
+        if (key.IndexOfAny(ForbiddenKeyChars) >= 0)
+            return false;
+
+        return KeyPrintableAsciiRegex().IsMatch(key);
+    }
+
+    private static async Task<byte[]> ReadAndRewindBodyAsync(
+        HttpRequest request, long maxBytes, CancellationToken cancellationToken)
+    {
+        request.EnableBuffering();
+        request.Body.Position = 0;
+
+        long contentLength = request.ContentLength ?? -1;
+        if (contentLength == 0)
+        {
+            request.Body.Position = 0;
+            return [];
+        }
+
+        if (contentLength > maxBytes)
+            throw new BadHttpRequestException(
+                $"Request body excede o limite de {maxBytes} bytes para endpoints idempotentes.",
+                StatusCodes.Status413PayloadTooLarge);
+
+        // Leitura em chunks com early break: cliente malicioso enviando
+        // chunked transfer encoding sem Content-Length não causa OOM.
+        // ArrayPool evita alocação por request.
+        const int chunkSize = 81920;
+        byte[] rented = ArrayPool<byte>.Shared.Rent(chunkSize);
+        try
+        {
+            using MemoryStream buffer = new();
+            int bytesRead;
+            while ((bytesRead = await request.Body.ReadAsync(rented.AsMemory(0, chunkSize), cancellationToken).ConfigureAwait(false)) > 0)
+            {
+                if (buffer.Length + bytesRead > maxBytes)
+                {
+                    request.Body.Position = 0;
+                    throw new BadHttpRequestException(
+                        $"Request body excede o limite de {maxBytes} bytes para endpoints idempotentes.",
+                        StatusCodes.Status413PayloadTooLarge);
+                }
+                await buffer.WriteAsync(rented.AsMemory(0, bytesRead), cancellationToken).ConfigureAwait(false);
+            }
+            request.Body.Position = 0;
+            return buffer.ToArray();
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    private static string ComputeSha256Hex(byte[] bytes)
+    {
+        Span<byte> hash = stackalloc byte[32];
+        SHA256.HashData(bytes, hash);
+        return Convert.ToHexStringLower(hash);
+    }
+
+    private static string ResolveScope(HttpContext httpContext)
+    {
+        // Sub claim do JWT identifica o principal autenticado. Anônimo cai
+        // em escopo "anonymous" — keys ainda funcionam mas isoladas por
+        // anônimo (caso raro: endpoints públicos com idempotency).
+        string? sub = httpContext.User?.FindFirst("sub")?.Value
+            ?? httpContext.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+
+        return string.IsNullOrEmpty(sub) ? "anonymous" : $"user:{sub}";
+    }
+
+    private static string ResolveEndpoint(ResourceExecutingContext context)
+    {
+        string method = context.HttpContext.Request.Method;
+        string template = context.ActionDescriptor.AttributeRouteInfo?.Template
+            ?? context.HttpContext.Request.Path.ToString();
+        return $"{method} /{template.TrimStart('/')}";
+    }
+
+    private void ShortCircuit(ResourceExecutingContext context, string domainCode, string detail)
+    {
+        DomainError error = new(domainCode, detail);
+        context.Result = Result.Failure(error).ToActionResult(_errorMapper);
+    }
+
+    private async Task ReplayAsync(ResourceExecutingContext context, IdempotencyEntry entry, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(entry.ResponseBodyCipher);
+
+        byte[] body = await _encryption.DecryptAsync(
+            IdempotencyOptions.EncryptionKeyName, entry.ResponseBodyCipher, cancellationToken).ConfigureAwait(false);
+
+        Dictionary<string, string>? headers = string.IsNullOrEmpty(entry.ResponseHeadersJson)
+            ? null
+            : JsonSerializer.Deserialize<Dictionary<string, string>>(entry.ResponseHeadersJson);
+
+        // FileContentResult devolve bytes verbatim (sem decoding UTF-8) — funciona
+        // para JSON (caso atual) e para qualquer Content-Type binário futuro
+        // (PDF, octet-stream, imagem) sem corromper o body.
+        FileContentResult result = new(body, headers?.GetValueOrDefault("Content-Type") ?? "application/json")
+        {
+            FileDownloadName = null,
+        };
+
+        context.Result = result;
+        context.HttpContext.Response.StatusCode = entry.ResponseStatus ?? StatusCodes.Status200OK;
+
+        // Replay header — não normativo (draft IETF não exige) mas útil para
+        // clientes diagnosticarem retry vs. primeira execução.
+        context.HttpContext.Response.Headers[ReplayHeader] = "true";
+
+        // Restaura Location se o response original carregava (POST que gerou
+        // recurso novo).
+        if (headers is not null && headers.TryGetValue("Location", out string? loc))
+            context.HttpContext.Response.Headers.Location = loc;
+    }
+
+    private static string SerializeCachedHeaders(HttpResponse response)
+    {
+        // Cacheamos apenas Content-Type e Location (ADR-0027 §"Esta ADR não decide"
+        // permite expansão futura). Outros headers são sensíveis a contexto
+        // (Set-Cookie, ETag dinâmico, traceId).
+        Dictionary<string, string> cached = new(StringComparer.OrdinalIgnoreCase);
+
+        if (response.ContentType is { Length: > 0 } ct)
+            cached["Content-Type"] = ct;
+
+        if (response.Headers.TryGetValue("Location", out Microsoft.Extensions.Primitives.StringValues loc) && loc.Count > 0 && !string.IsNullOrEmpty(loc[0]))
+            cached["Location"] = loc[0]!;
+
+        return JsonSerializer.Serialize(cached);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -105,12 +105,36 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
             return;
         }
 
+        // Resolve principal autenticado ANTES de gastar AES no decode/hash —
+        // endpoint marcado com [RequiresIdempotencyKey] em request anonymous
+        // é inconsistência de configuração: caches anonymous compartilhados
+        // permitem ataques de poisoning entre clientes.
+        string? scope = ResolveScope(httpContext);
+        if (scope is null)
+        {
+            ShortCircuit(context, IdempotencyDomainErrorCodes.PrincipalRequerido,
+                "Endpoint com [RequiresIdempotencyKey] exige principal autenticado.");
+            return;
+        }
+
         // Lê body bytes (sem consumir o stream para o model binder).
-        byte[] bodyBytes = await ReadAndRewindBodyAsync(httpContext.Request, _options.MaxBodyBytes,
-            httpContext.RequestAborted).ConfigureAwait(false);
+        byte[] bodyBytes;
+        try
+        {
+            bodyBytes = await ReadAndRewindBodyAsync(httpContext.Request, _options.MaxBodyBytes,
+                httpContext.RequestAborted).ConfigureAwait(false);
+        }
+        catch (BadHttpRequestException ex) when (ex.StatusCode == StatusCodes.Status413PayloadTooLarge)
+        {
+            // GlobalExceptionMiddleware do projeto trata Exception genérica como
+            // 500. Capturar aqui e devolver 413 ProblemDetails canônico evita
+            // que o cliente veja "internal error" para um problema de tamanho.
+            ShortCircuit(context, IdempotencyDomainErrorCodes.BodyMuitoGrande,
+                $"Request body excede o limite de {_options.MaxBodyBytes} bytes para endpoints idempotentes.");
+            return;
+        }
 
         string bodyHash = ComputeSha256Hex(bodyBytes);
-        string scope = ResolveScope(httpContext);
         string endpoint = ResolveEndpoint(context);
 
         // Lookup inicial.
@@ -343,15 +367,19 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
         return Convert.ToHexStringLower(hash);
     }
 
-    private static string ResolveScope(HttpContext httpContext)
+    /// <summary>
+    /// Resolve o scope da chave de cache via sub claim do JWT.
+    /// Retorna <c>null</c> quando não há principal autenticado — sinal para
+    /// rejeitar o request com 401, evitando que clientes anonymous
+    /// compartilhem o mesmo bucket "anonymous" e poluam/colidam keys uns dos
+    /// outros (cache poisoning entre anônimos).
+    /// </summary>
+    private static string? ResolveScope(HttpContext httpContext)
     {
-        // Sub claim do JWT identifica o principal autenticado. Anônimo cai
-        // em escopo "anonymous" — keys ainda funcionam mas isoladas por
-        // anônimo (caso raro: endpoints públicos com idempotency).
         string? sub = httpContext.User?.FindFirst("sub")?.Value
             ?? httpContext.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
 
-        return string.IsNullOrEmpty(sub) ? "anonymous" : $"user:{sub}";
+        return string.IsNullOrEmpty(sub) ? null : $"user:{sub}";
     }
 
     private static string ResolveEndpoint(ResourceExecutingContext context)

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -97,6 +97,16 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
             return;
         }
 
+        // Múltiplos valores no header é ambíguo — não há regra que diga qual
+        // vence (proxy duplicou? cliente bugado?). Rejeitar 400 alinhado com
+        // draft IETF que define o header como Item (sf-string), não List.
+        if (headerValues.Count > 1)
+        {
+            ShortCircuit(context, IdempotencyDomainErrorCodes.KeyMalformada,
+                "Header Idempotency-Key recebido múltiplas vezes; envie um único valor por request.");
+            return;
+        }
+
         string idempotencyKey = headerValues[0]!;
         if (!IsKeyValid(idempotencyKey))
         {
@@ -398,10 +408,18 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
         // `/api/editais/def/publicar` PRECISAM ser keys distintas no cache;
         // o template colapsaria ambos em "POST /api/editais/{id}/publicar"
         // e duas requests com mesma Idempotency-Key sobre RECURSOS DIFERENTES
-        // colidiriam (vazamento cross-resource). RFC 7230 §2.7.3 trata path
-        // como case-sensitive — sem normalização para preservar a semântica.
+        // colidiriam (vazamento cross-resource).
+        //
+        // Casing canonicalizado: ASP.NET Core route matching é case-insensitive
+        // por default, então `/api/Editais/abc/Publicar` e
+        // `/api/editais/abc/publicar` matcham a mesma action. Sem normalizar,
+        // cliente que alterne casing acidentalmente (frontend com URL diferente)
+        // teria caches separados — replay quebrado. Lowercase é prática
+        // canônica de URL normalization (RFC 3986 §6.2.2.1).
         string method = context.HttpContext.Request.Method;
-        string path = context.HttpContext.Request.Path.ToString();
+#pragma warning disable CA1308 // ToLowerInvariant em URL é canônico — ToUpperInvariant deixaria a key ilegível em queries SQL diagnósticas.
+        string path = context.HttpContext.Request.Path.ToString().ToLowerInvariant();
+#pragma warning restore CA1308
         return $"{method} {path}";
     }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -182,10 +182,12 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
         MemoryStream captureStream = new();
         httpContext.Response.Body = captureStream;
         bool reservationStillValid = true;
+        bool handlerCompleted = false;
 
         try
         {
             ResourceExecutedContext executed = await next().ConfigureAwait(false);
+            handlerCompleted = true;
 
             int status = httpContext.Response.StatusCode;
 
@@ -225,10 +227,18 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
         }
         catch
         {
-            // Exceção do handler ou do pipeline → libera a key para retry
-            // legítimo do cliente. Sem isso, próxima request com mesma key
-            // ficaria em 409 ProcessingConflict por 24h.
-            if (reservationStillValid)
+            // Discrimina entre falha PRÉ-handler (rollback semanticamente seguro
+            // — handler nem completou, retry pode rodar de novo) e falha
+            // PÓS-handler (Encrypt/Complete falharam DEPOIS do handler já ter
+            // commitado o agregado — deletar reservation aqui permitiria que
+            // retry do cliente recriasse o agregado, causando duplicação
+            // semântica como dois EditalPublicado para o mesmo edital).
+            //
+            // Política conservadora: só limpa reservation se handler não
+            // completou. Se handler já rodou, reservation fica em Processing
+            // até TTL → cliente recebe 409 nesse intervalo (ADR-0027 §
+            // "Atomicidade parcial" reconhece essa janela).
+            if (reservationStillValid && !handlerCompleted)
             {
                 try
                 {
@@ -412,16 +422,29 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
             ? null
             : JsonSerializer.Deserialize<Dictionary<string, string>>(entry.ResponseHeadersJson);
 
-        // FileContentResult devolve bytes verbatim (sem decoding UTF-8) — funciona
-        // para JSON (caso atual) e para qualquer Content-Type binário futuro
-        // (PDF, octet-stream, imagem) sem corromper o body.
-        FileContentResult result = new(body, headers?.GetValueOrDefault("Content-Type") ?? "application/json")
-        {
-            FileDownloadName = null,
-        };
+        string? cachedContentType = headers?.GetValueOrDefault("Content-Type");
+        int statusCode = entry.ResponseStatus ?? StatusCodes.Status200OK;
 
-        context.Result = result;
-        context.HttpContext.Response.StatusCode = entry.ResponseStatus ?? StatusCodes.Status200OK;
+        // 204 NoContent / response sem body+content-type cacheado: replay com
+        // StatusCodeResult preserva semântica HTTP (sem Content-Type, sem body).
+        // Forçar FileContentResult com "application/json" default em 204
+        // violaria RFC 9110 §6.4.5 (NoContent não pode ter Content-Type).
+        if (body.Length == 0 && cachedContentType is null)
+        {
+            context.Result = new StatusCodeResult(statusCode);
+        }
+        else
+        {
+            // FileContentResult devolve bytes verbatim (sem decoding UTF-8) —
+            // funciona para JSON e para qualquer Content-Type binário futuro
+            // (PDF, octet-stream) sem corromper o body.
+            FileContentResult result = new(body, cachedContentType ?? "application/json")
+            {
+                FileDownloadName = null,
+            };
+            context.Result = result;
+            context.HttpContext.Response.StatusCode = statusCode;
+        }
 
         // Replay header — não normativo (draft IETF não exige) mas útil para
         // clientes diagnosticarem retry vs. primeira execução.

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -264,9 +264,17 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
         }
     }
 
-    private static bool HasRequiresIdempotencyKey(ResourceExecutingContext context) =>
-        context.ActionDescriptor is ControllerActionDescriptor descriptor
-        && descriptor.MethodInfo.GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true) is not null;
+    private static bool HasRequiresIdempotencyKey(ResourceExecutingContext context)
+    {
+        if (context.ActionDescriptor is not ControllerActionDescriptor descriptor)
+            return false;
+
+        // Atributo aceita AttributeTargets.Method | Class. Method-level vence
+        // (controlle granularidade fina); class-level cobre o caso "todos os
+        // POSTs deste controller exigem Idempotency-Key" sem repetir o atributo.
+        return descriptor.MethodInfo.GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true) is not null
+            || descriptor.ControllerTypeInfo.GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true) is not null;
+    }
 
     private static bool IsKeyValid(string key)
     {
@@ -348,10 +356,15 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
 
     private static string ResolveEndpoint(ResourceExecutingContext context)
     {
+        // Path concreto (não template) — `/api/editais/abc/publicar` e
+        // `/api/editais/def/publicar` PRECISAM ser keys distintas no cache;
+        // o template colapsaria ambos em "POST /api/editais/{id}/publicar"
+        // e duas requests com mesma Idempotency-Key sobre RECURSOS DIFERENTES
+        // colidiriam (vazamento cross-resource). RFC 7230 §2.7.3 trata path
+        // como case-sensitive — sem normalização para preservar a semântica.
         string method = context.HttpContext.Request.Method;
-        string template = context.ActionDescriptor.AttributeRouteInfo?.Template
-            ?? context.HttpContext.Request.Path.ToString();
-        return $"{method} /{template.TrimStart('/')}";
+        string path = context.HttpContext.Request.Path.ToString();
+        return $"{method} {path}";
     }
 
     private void ShortCircuit(ResourceExecutingContext context, string domainCode, string detail)

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyLookupResult.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyLookupResult.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+/// <summary>Resultado discriminante de <see cref="IIdempotencyStore.LookupAsync"/>.</summary>
+public enum IdempotencyOutcome
+{
+    /// <summary>Sem entrada no cache para a chave de lookup. Handler deve rodar.</summary>
+    Miss = 0,
+
+    /// <summary>Entrada existe + body_hash bate. Replay verbatim da response cacheada.</summary>
+    HitMatch = 1,
+
+    /// <summary>Entrada existe + body_hash diverge. 422 body_mismatch.</summary>
+    HitMismatch = 2,
+
+    /// <summary>Entrada existe mas ainda em status Processing. 409 processing_conflict.</summary>
+    Processing = 3,
+}
+
+public sealed record IdempotencyLookupResult(IdempotencyOutcome Outcome, IdempotencyEntry? Entry);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyOptions.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+/// <summary>
+/// Configuração do cache de idempotência (ADR-0027). Bind a partir da seção
+/// <c>UniPlus:Idempotency</c>; defaults sensatos garantem que projetos sem
+/// configuração explícita rodam imediatamente.
+/// </summary>
+public sealed record IdempotencyOptions
+{
+    public const string SectionName = "UniPlus:Idempotency";
+
+    /// <summary>Nome de chave usada para cifrar response body via IUniPlusEncryptionService.</summary>
+    public const string EncryptionKeyName = "idempotency";
+
+    /// <summary>TTL da entrada do cache. ADR-0027 fixa 24h como teto.</summary>
+    public TimeSpan Ttl { get; init; } = TimeSpan.FromHours(24);
+
+    /// <summary>Tamanho máximo do request body aceito (rejeita 413 antes do hash).</summary>
+    public long MaxBodyBytes { get; init; } = 1L * 1024 * 1024; // 1 MiB
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyStatus.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyStatus.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+/// <summary>
+/// Estado de uma entrada do cache de idempotência. Usado para distinguir
+/// reservation (pré-handler) de completed (pós-handler com response cifrada).
+/// </summary>
+public enum IdempotencyStatus
+{
+    /// <summary>Reservation criada mas handler ainda em execução.</summary>
+    Processing = 0,
+
+    /// <summary>Handler completou; response disponível para replay.</summary>
+    Completed = 1,
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/RequiresIdempotencyKeyAttribute.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/RequiresIdempotencyKeyAttribute.cs
@@ -1,0 +1,11 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+/// <summary>
+/// Sinaliza que o endpoint exige header <c>Idempotency-Key</c> (ADR-0027).
+/// Aplicado em métodos de controllers que executam comandos críticos
+/// (POST/PATCH não-idempotentes por semântica). O <c>IdempotencyFilter</c>
+/// detecta o atributo via metadata da action, valida o header, faz
+/// lookup/store e short-circuit em caso de replay ou body mismatch.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+public sealed class RequiresIdempotencyKeyAttribute : Attribute;

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
@@ -49,7 +49,7 @@ public sealed class PublicarEditalEndpointTests
 
         Edital edital = await SemearEditalAsync(api);
 
-        HttpResponseMessage response = await client.PostAsync(new Uri($"/api/editais/{edital.Id}/publicar", UriKind.Relative), content: null);
+        HttpResponseMessage response = await PostPublicarAsync(client, edital.Id, MakeIdempotencyKey());
 
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
@@ -78,9 +78,9 @@ public sealed class PublicarEditalEndpointTests
         CascadingApiFactory api = _fixture.Factory;
         using HttpClient client = api.CreateClient();
 
-        var inexistente = Guid.NewGuid();
+        Guid inexistente = Guid.CreateVersion7();
 
-        HttpResponseMessage response = await client.PostAsync(new Uri($"/api/editais/{inexistente}/publicar", UriKind.Relative), content: null);
+        HttpResponseMessage response = await PostPublicarAsync(client, inexistente, MakeIdempotencyKey());
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
@@ -89,23 +89,137 @@ public sealed class PublicarEditalEndpointTests
     }
 
     [Fact(DisplayName =
-        "POST /editais/{id}/publicar é idempotente — segunda chamada retorna 422 com Edital.JaPublicado")]
+        "POST /editais/{id}/publicar com keys diferentes — segunda chamada retorna 422 Edital.JaPublicado")]
     public async Task PublicarEdital_QuandoJaPublicado_Retorna422()
     {
+        // Cliente com keys distintas força handler a executar duas vezes;
+        // segunda execução vê edital já publicado e retorna 422 (idempotência
+        // semântica do domínio, não do middleware Idempotency-Key).
         CascadingApiFactory api = _fixture.Factory;
         using HttpClient client = api.CreateClient();
 
         Edital edital = await SemearEditalAsync(api);
 
-        HttpResponseMessage primeira = await client.PostAsync(new Uri($"/api/editais/{edital.Id}/publicar", UriKind.Relative), content: null);
+        HttpResponseMessage primeira = await PostPublicarAsync(client, edital.Id, MakeIdempotencyKey());
         primeira.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
-        HttpResponseMessage segunda = await client.PostAsync(new Uri($"/api/editais/{edital.Id}/publicar", UriKind.Relative), content: null);
+        HttpResponseMessage segunda = await PostPublicarAsync(client, edital.Id, MakeIdempotencyKey());
         segunda.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         using JsonDocument doc = JsonDocument.Parse(await segunda.Content.ReadAsStringAsync());
         doc.RootElement.GetProperty("code").GetString()
             .Should().Be("uniplus.selecao.edital.ja_publicado");
     }
+
+    [Fact(DisplayName =
+        "POST /editais/{id}/publicar com mesma Idempotency-Key — replay verbatim com Idempotency-Replayed: true")]
+    public async Task PublicarEdital_MesmaKey_ReplayVerbatim()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        Edital edital = await SemearEditalAsync(api);
+        string key = MakeIdempotencyKey();
+
+        HttpResponseMessage primeira = await PostPublicarAsync(client, edital.Id, key);
+        primeira.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        primeira.Headers.Contains("Idempotency-Replayed").Should().BeFalse();
+
+        HttpResponseMessage segunda = await PostPublicarAsync(client, edital.Id, key);
+        segunda.StatusCode.Should().Be(HttpStatusCode.NoContent,
+            "mesma key + body vazio idêntico → handler NÃO roda; cache replay verbatim");
+        segunda.Headers.Contains("Idempotency-Replayed").Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "POST /editais/{id}/publicar sem Idempotency-Key retorna 400 uniplus.idempotency.key_ausente")]
+    public async Task PublicarEdital_SemKey_Retorna400()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        HttpResponseMessage response = await client.PostAsync(
+            new Uri($"/api/editais/{Guid.CreateVersion7()}/publicar", UriKind.Relative), content: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.idempotency.key_ausente");
+    }
+
+    [Fact(DisplayName =
+        "POST /editais/{id}/publicar com Idempotency-Key malformada retorna 400 uniplus.idempotency.key_malformada")]
+    public async Task PublicarEdital_KeyMalformada_Retorna400()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/editais/{Guid.CreateVersion7()}/publicar", UriKind.Relative));
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", "invalid key with spaces");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.idempotency.key_malformada");
+    }
+
+    [Fact(DisplayName =
+        "POST /editais com mesma Idempotency-Key e body diferente retorna 422 uniplus.idempotency.body_mismatch")]
+    public async Task CriarEdital_MesmaKeyBodyDiferente_Retorna422BodyMismatch()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        string key = MakeIdempotencyKey();
+        int numero1 = Math.Abs((Guid.NewGuid().GetHashCode() % 4500) + 1);
+        int numero2 = numero1 + 1; // body diferente garantido
+
+        // Primeira request: cria edital normalmente.
+        using HttpRequestMessage primeiraReq = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        {
+            Content = JsonContent.Create(new
+            {
+                numeroEdital = numero1,
+                anoEdital = 2026,
+                titulo = "Body-mismatch test",
+                tipoProcesso = 1, // SiSU — enum serializado como número (System.Text.Json default)
+            }),
+        };
+        primeiraReq.Headers.TryAddWithoutValidation("Idempotency-Key", key);
+        HttpResponseMessage primeira = await client.SendAsync(primeiraReq);
+        primeira.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Segunda request: mesma key, body diferente (numero2).
+        using HttpRequestMessage segundaReq = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        {
+            Content = JsonContent.Create(new
+            {
+                numeroEdital = numero2,
+                anoEdital = 2026,
+                titulo = "Body-mismatch test",
+                tipoProcesso = 1, // SiSU — enum serializado como número (System.Text.Json default)
+            }),
+        };
+        segundaReq.Headers.TryAddWithoutValidation("Idempotency-Key", key);
+        HttpResponseMessage segunda = await client.SendAsync(segundaReq);
+
+        segunda.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        using JsonDocument doc = JsonDocument.Parse(await segunda.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.idempotency.body_mismatch");
+    }
+
+    private static async Task<HttpResponseMessage> PostPublicarAsync(HttpClient client, Guid editalId, string idempotencyKey)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/editais/{editalId}/publicar", UriKind.Relative));
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+        return await client.SendAsync(request).ConfigureAwait(false);
+    }
+
+    private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
 
     private static async Task<Edital> SemearEditalAsync(CascadingApiFactory api)
     {

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
@@ -4,6 +4,8 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 
+using System.Net.Http.Headers;
+
 using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
@@ -14,6 +16,7 @@ using Domain.Entities;
 using Domain.Enums;
 using Domain.Events;
 using Domain.ValueObjects;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
 // Cenário fim-a-fim do fluxo de referência ADR-0005: HTTP request →
@@ -166,6 +169,28 @@ public sealed class PublicarEditalEndpointTests
     }
 
     [Fact(DisplayName =
+        "POST /editais/{id}/publicar anonymous com Idempotency-Key retorna 401 uniplus.idempotency.principal_requerido")]
+    public async Task PublicarEdital_Anonymous_Retorna401()
+    {
+        // Endpoint marcado com [RequiresIdempotencyKey] exige principal —
+        // sem auth, filter rejeita para evitar cache poisoning entre clientes.
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/editais/{Guid.CreateVersion7()}/publicar", UriKind.Relative));
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+        // Sem AppendTestAuth — request anonymous deliberada.
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.idempotency.principal_requerido");
+    }
+
+    [Fact(DisplayName =
         "POST /editais com mesma Idempotency-Key e body diferente retorna 422 uniplus.idempotency.body_mismatch")]
     public async Task CriarEdital_MesmaKeyBodyDiferente_Retorna422BodyMismatch()
     {
@@ -187,6 +212,7 @@ public sealed class PublicarEditalEndpointTests
                 tipoProcesso = 1, // SiSU — enum serializado como número (System.Text.Json default)
             }),
         };
+        AppendTestAuth(primeiraReq);
         primeiraReq.Headers.TryAddWithoutValidation("Idempotency-Key", key);
         HttpResponseMessage primeira = await client.SendAsync(primeiraReq);
         primeira.StatusCode.Should().Be(HttpStatusCode.Created);
@@ -202,6 +228,7 @@ public sealed class PublicarEditalEndpointTests
                 tipoProcesso = 1, // SiSU — enum serializado como número (System.Text.Json default)
             }),
         };
+        AppendTestAuth(segundaReq);
         segundaReq.Headers.TryAddWithoutValidation("Idempotency-Key", key);
         HttpResponseMessage segunda = await client.SendAsync(segundaReq);
 
@@ -215,11 +242,24 @@ public sealed class PublicarEditalEndpointTests
     {
         using HttpRequestMessage request = new(HttpMethod.Post,
             new Uri($"/api/editais/{editalId}/publicar", UriKind.Relative));
+        AppendTestAuth(request);
         request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
         return await client.SendAsync(request).ConfigureAwait(false);
     }
 
     private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
+
+    /// <summary>
+    /// Adiciona Authorization Bearer + X-Test-User-Id ao request. Necessário
+    /// porque [RequiresIdempotencyKey] exige principal autenticado (filter
+    /// rejeita anonymous para evitar cache poisoning entre clientes).
+    /// </summary>
+    private static void AppendTestAuth(HttpRequestMessage request, string userId = "test-publicar-user")
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme, TestAuthHandler.TokenValue);
+        request.Headers.TryAddWithoutValidation(TestAuthHandler.UserIdHeader, userId);
+    }
 
     private static async Task<Edital> SemearEditalAsync(CascadingApiFactory api)
     {


### PR DESCRIPTION
## Resumo

Implementa **story #286** — protocolo Idempotency-Key conforme ADR-0027 + draft-ietf-httpapi-idempotency-key-header-07. Endpoints opt-in via `[RequiresIdempotencyKey]`. Aplicado piloto em `POST /api/editais` e `POST /api/editais/{id}/publicar`.

## Stack

- **`IdempotencyEntry`** POCO + tabela `idempotency_cache` (UNIQUE em `scope+endpoint+key`, TTL, ResponseBodyCipher bytea AES-GCM)
- **`IIdempotencyStore`** + **`EfCoreIdempotencyStore<TDbContext>`** genérico — `LookupAsync` (AsNoTracking), `TryReserveAsync` (filtra `SqlState 23505` para distinguir UNIQUE de outros erros), `CompleteAsync` (ExecuteUpdate atômico com filtro `Status=Processing`, idempotente), `DeleteAsync` (rollback em 5xx)
- **`IdempotencyFilter`** (`IAsyncResourceFilter`) global, ativa apenas em endpoints com atributo. Body buffering via ArrayPool com early-break em `MaxBodyBytes`. Header validation regex `^[\x21-\x7E]{1,255}$` + exclusão explícita de `,;` (sf-list separators)
- **`IdempotencyDomainErrorRegistration`** com 4 codes (`uniplus.idempotency.*`)
- **`AddIdempotency<TDbContext>`** com validators de options + ServiceFilterAttribute (honra Scoped lifetime)

## ADR-0027 atualizada

Promoção `proposed → accepted` ao merge. Diff principal: "Atomicidade real" → "parcialmente alcançada" com nova entrada em Negativas detalhando as 3 transações separadas, janela de inconsistência, mitigação via DELETE em 5xx, e nota de revisão futura.

## Tests integration (CA-04 da story)

5 cenários cobertos via Postgres testcontainer:
- **Replay verbatim** (mesma key, body idêntico) → 204 + `Idempotency-Replayed: true`
- **body_mismatch** (mesma key, body diferente) → 422 `uniplus.idempotency.body_mismatch`
- **key_ausente** → 400 `uniplus.idempotency.key_ausente`
- **key_malformada** (espaço) → 400 `uniplus.idempotency.key_malformada`
- **Handler executa** (cache miss; 2 keys diferentes em Publicar) → 422 `Edital.JaPublicado` por domínio

## Review local pré-commit

2 rounds. Round 1 apontou 3 Bloqueantes + 6 Importantes; round 2 confirmou APROVADO após:
- **B1** ADR atualizada com divergência de atomicidade
- **B2** SqlState 23505 filter (não mascarar erros de infra como 409)
- **B3** DeleteAsync em 5xx/Canceled/exception (libera key para retry legítimo do cliente)
- **I1** `IsKeyValid` simplificado (removido check redundante de length)
- **I2** `FileContentResult` no replay (suporta binário futuro sem corrupção UTF-8)
- **I3** `ExecuteUpdateAsync` no Complete (sem tracking, sem fantasma)
- **I4** `ServiceFilterAttribute` (Scoped explícito)
- **I5** Body buffer com early break (overshoot ~80KB, não 1 MiB)
- **I6** Teste body_mismatch novo
- **S2** TimeProvider injetado no store + remoção do default `CreatedAt` no POCO

## Plano de teste

- [x] `dotnet build UniPlus.slnx --no-incremental` — 0 warnings, 0 errors
- [x] Suite full: 379 tests / 0 falhas
- [x] ADR linter: 32 ADRs OK
- [x] 8/8 testes do EditalController exercitam idempotency end-to-end com Postgres real
- [x] PublicarEditalEndpointTests cascading scenario continua passando (header agora obrigatório)

Closes #286