### PR TITLE
feat(api): IUserContext.IsAuthenticated + IRequiredUserContext (story #313)

### DIFF
--- a/docs/adrs/0033-icurrentuser-abstraction-via-iusercontext.md
+++ b/docs/adrs/0033-icurrentuser-abstraction-via-iusercontext.md
@@ -1,0 +1,116 @@
+---
+status: "proposed"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0033: `IUserContext` como abstração canônica para acesso ao principal autenticado
+
+## Contexto e enunciado do problema
+
+Endpoints e handlers que precisam do principal autenticado historicamente usariam o anti-pattern:
+
+```csharp
+string userId = User.FindFirstValue("sub")!;
+```
+
+Esse padrão tem três problemas que escalariam com cada novo endpoint user-scoped:
+
+1. **String mágica** — `"sub"` é convenção OIDC (RFC 7519) mas `ClaimTypes.NameIdentifier` é convenção .NET. Dois devs vão divergir; mudança de IdP fica espalhada.
+2. **`!` (null-forgiving) sem garantia** — endpoint anônimo, middleware fora de ordem, ou bug de configuração geram `NullReferenceException` em runtime em vez de erro semântico.
+3. **Acoplamento HTTP em handlers de Application** — `User.FindFirstValue` exige `HttpContext` ou `ClaimsPrincipal`, dependências que Application camada não deveria carregar (Clean Architecture, ADR-0002, fitness test R3 da ADR-0012).
+
+A issue #313 propôs criar `ICurrentUser` + `IRequiredCurrentUser`. Durante a implementação, descobriu-se que **`IUserContext`** já existia em `Application.Abstractions/Authentication/` (introduzido em PRs anteriores) com cobertura idêntica: `UserId`, `Name`, `Email`, `Cpf`, `NomeSocial`, `Roles`, `HasRole`, `GetResourceRoles`. A pergunta passou a ser: criar nova abstração paralela ou consolidar a existente?
+
+## Drivers da decisão
+
+- **Single source of truth para claim mapping.** Tem que existir UM lugar que sabe traduzir tokens OIDC (sub, email, realm_access.roles, resource_access.\*.roles, claims customizadas Uni+ como CPF e Nome Social) para um modelo de domínio limpo. Dois lugares fazendo isso convidam divergência.
+- **Acessibilidade em Application.** Handlers Wolverine, validators FluentValidation, e regras de domínio que precisem do principal devem injetar a abstração diretamente, sem depender de `HttpContext`.
+- **Fail-fast em uso indevido.** Endpoints `[Authorize]` que assumem auth não devem ter `string?` propagando até virar NRE — devem ter contrato não-nullable que falha cedo.
+- **Não duplicar.** Cobertura de testes existente do `HttpUserContext` cobre claim mapping completo (Keycloak realm_access, resource_access, OIDC standard, customizadas Uni+). Recriar no formato `ICurrentUser` perderia esse capital ou exigiria duplicação de testes.
+
+## Opções consideradas
+
+- **A. Consolidar em `IUserContext`** — adicionar `IsAuthenticated` e introduzir `IRequiredUserContext` (variante não-nullable); usar a infra existente.
+- **B. Criar `ICurrentUser`/`IRequiredCurrentUser` como solicitado pela issue #313** — duplicar shape; deprecar `IUserContext`; migrar tudo.
+- **C. Manter status quo (`User.FindFirstValue` direto)** — descartado, é exatamente o anti-pattern que a issue veio resolver.
+
+## Resultado da decisão
+
+**Escolhida:** "A — Consolidar em `IUserContext`", porque é a única opção que respeita a infra de claim mapping já em produção sem reintroduzir débito (duplicação de tests, mismatch de claim policies entre duas implementações, custo de migração de código existente que já consome `IUserContext`).
+
+A nomenclatura `ICurrentUser` proposta na issue era válida mas não trazia benefício técnico; `IUserContext` é equivalente semanticamente e está estabelecida.
+
+### Forma do contrato
+
+`IUserContext` (em `Application.Abstractions/Authentication/`) ganha `bool IsAuthenticated { get; }`:
+
+```csharp
+public interface IUserContext
+{
+    bool IsAuthenticated { get; }     // novo
+    string? UserId { get; }            // sub claim (OIDC) com fallback ClaimTypes.NameIdentifier
+    string? Name { get; }              // ClaimTypes.Name → preferred_username → name
+    string? Email { get; }             // ClaimTypes.Email → email
+    string? Cpf { get; }               // claim Uni+ uniplus.cpf
+    string? NomeSocial { get; }        // claim Uni+ uniplus.nome_social
+    IReadOnlyList<string> Roles { get; }       // realm_access.roles + ClaimTypes.Role
+    bool HasRole(string role);
+    IReadOnlyList<string> GetResourceRoles(string resourceName);  // resource_access.<r>.roles
+}
+```
+
+`IRequiredUserContext` (novo) expõe o subset necessário para handlers/controllers que assumem auth, sem nullables. Implementação `RequiredUserContext` projeta `IUserContext` falhando rápido com `InvalidOperationException` quando `IsAuthenticated == false` ou claim crítica está ausente.
+
+### Implementação e DI
+
+`HttpContextCurrentUser` foi descartado em favor do `HttpUserContext` já existente (`Infrastructure.Core/Authentication/`). DI registra ambos como Scoped na pipeline de auth (`OidcAuthenticationConfiguration`):
+
+```csharp
+services.AddScoped<IUserContext, HttpUserContext>();
+services.AddScoped<IRequiredUserContext>(sp =>
+    new RequiredUserContext(sp.GetRequiredService<IUserContext>()));
+```
+
+### Esta ADR não decide
+
+- Como o claim mapping específico do Keycloak evolui — escopo do `HttpUserContext` (uma classe parcial bem-coberta por testes em `Infrastructure.Core.UnitTests/Authentication/`).
+- Política de deprecação (não há) — não havia código consumindo um `ICurrentUser` que não existia.
+- Como migrar callers que ainda usam `User.FindFirstValue` direto — fitness test ArchUnit (próxima story de hardening) detectará e migrará incrementalmente.
+
+## Consequências
+
+### Positivas
+
+- **Single source of truth** — claim mapping vive em UM ponto (`HttpUserContext`); troca de IdP ou mudança de claim policy é local.
+- **Sem duplicação** — testes existentes do `HttpUserContext` cobrem o caminho; `RequiredUserContext` adiciona apenas testes de fail-fast.
+- **Application camada limpa** — handlers Wolverine injetam `IUserContext` (abstração da camada Application.Abstractions) sem dependência de `HttpContext`.
+- **Fail-fast explícito** — `IRequiredUserContext` em `[Authorize]` endpoints torna NRE em runtime impossível; trocada por `InvalidOperationException` com mensagem útil.
+- **Pronto pra próximas stories** — `IdempotencyFilter` (story #286) já consome `IUserContext.UserId` para `scope`; cursor user-binding (story #312, próxima) consumirá o mesmo.
+
+### Negativas
+
+- **Issue #313 fechada com nomenclatura diferente da proposta original** (`IUserContext` vs `ICurrentUser`). Documentação precisa apontar para o nome real.
+- **`IRequiredUserContext` é projeção, não outro backend** — se algum dia precisarmos de "required mas com fallback de impersonation/test-double", será necessária classe nova. Aceitável: não há requirement hoje.
+
+### Neutras
+
+- Variantes que não usam `IsAuthenticated` continuam funcionando — adicionar a property é backward-compatible para callers que só consomem nullables existentes.
+
+## Confirmação
+
+1. **DI registrado** — `OidcAuthenticationConfiguration.AddOidcAuthentication` registra ambos `IUserContext → HttpUserContext` e `IRequiredUserContext → RequiredUserContext` (proxy).
+2. **Testes unit** — `HttpUserContextTests` ganhou cobertura de `IsAuthenticated` (3 cenários: identity com auth type, anonymous, HttpContext null). `RequiredUserContextTests` cobre fail-fast em todos os accessors.
+3. **Adoção downstream** — `IdempotencyFilter` (story #286, já em main) consome `IUserContext.UserId` para `scope` em vez de extrair claim manualmente. Story #312 (próxima) idem.
+4. **Fitness test futuro** (escopo da story #291) — ArchUnit proibirá `User.FindFirstValue` direto em código de produção fora de `HttpUserContext`.
+
+## Mais informações
+
+- [ADR-0002](0002-clean-architecture-com-quatro-camadas.md) — regra de dependências (Application sem Infrastructure).
+- [ADR-0010](0010-audience-unica-uniplus-em-tokens-oidc.md) — fonte das claims que `HttpUserContext` mapeia.
+- [ADR-0016](0016-keycloak-como-identity-provider.md) — formato Keycloak (realm_access, resource_access).
+- [ADR-0011](0011-mascaramento-de-cpf-em-logs.md) — claim CPF é PII; `HttpUserContext.Cpf` deve seguir mascaramento ao logar.
+- [Ardalis CleanArchitecture template](https://github.com/ardalis/CleanArchitecture) — padrão `ICurrentUserService` análogo (referência inicial da issue #313).
+- [eShopOnContainers](https://github.com/dotnet-architecture/eShopOnContainers) — padrão `IIdentityService` análogo.
+- Issue #313 — issue que motivou a abstração.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -61,6 +61,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0030](0030-openapi-3-1-contract-first-microsoft-aspnetcore-openapi.md) | Geração de OpenAPI 3.1 via `Microsoft.AspNetCore.OpenApi` com pipeline de pós-processamento | accepted | 2026-05-03 |
 | [0031](0031-decoding-de-cursor-opaco-no-boundary-http.md) | Decoding de cursor opaco no boundary HTTP, não em handlers de Application | proposed | 2026-05-04 |
 | [0032](0032-guid-v7-para-identidade-de-entidades.md) | Guid v7 (RFC 9562) como identidade de entidades de domínio | accepted | 2026-05-05 |
+| [0033](0033-icurrentuser-abstraction-via-iusercontext.md) | `IUserContext` como abstração canônica para acesso ao principal autenticado | proposed | 2026-05-05 |
 
 ## Como adicionar um novo ADR
 

--- a/src/shared/Unifesspa.UniPlus.Application.Abstractions/Authentication/IRequiredUserContext.cs
+++ b/src/shared/Unifesspa.UniPlus.Application.Abstractions/Authentication/IRequiredUserContext.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Application.Abstractions.Authentication;
+
+/// <summary>
+/// Variante não-nullable de <see cref="IUserContext"/> para handlers e
+/// controllers protegidos por <c>[Authorize]</c> onde anônimo é estado
+/// impossível. Acessar qualquer propriedade quando
+/// <see cref="IUserContext.IsAuthenticated"/> for <see langword="false"/>
+/// resulta em <see cref="InvalidOperationException"/> — fail-fast em caso de
+/// configuração inconsistente (atributo de auth ausente, middleware fora de
+/// ordem) em vez de <c>NullReferenceException</c> ou silently fallback.
+/// </summary>
+public interface IRequiredUserContext
+{
+    /// <summary>Identificador do principal (sub claim do JWT).</summary>
+    string UserId { get; }
+
+    /// <summary>Display name do usuário.</summary>
+    string Name { get; }
+
+    /// <summary>Email do usuário (do escopo OIDC).</summary>
+    string Email { get; }
+
+    /// <summary>Roles do usuário (realm + resource).</summary>
+    IReadOnlyList<string> Roles { get; }
+
+    /// <summary>Verifica se o usuário tem o role indicado.</summary>
+    bool HasRole(string role);
+}

--- a/src/shared/Unifesspa.UniPlus.Application.Abstractions/Authentication/IUserContext.cs
+++ b/src/shared/Unifesspa.UniPlus.Application.Abstractions/Authentication/IUserContext.cs
@@ -6,6 +6,15 @@ namespace Unifesspa.UniPlus.Application.Abstractions.Authentication;
 public interface IUserContext
 {
     /// <summary>
+    /// Gets a value indicating whether the current request carries an
+    /// authenticated principal (JWT validated, ClaimsIdentity.IsAuthenticated).
+    /// Anonymous requests (no <c>Authorization</c> header, or auth failure)
+    /// return <see langword="false"/> and all other properties default to
+    /// <see langword="null"/>/empty.
+    /// </summary>
+    bool IsAuthenticated { get; }
+
+    /// <summary>
     /// Gets the authenticated user's identifier.
     /// </summary>
     string? UserId { get; }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/HttpUserContext.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/HttpUserContext.cs
@@ -37,6 +37,8 @@ public sealed partial class HttpUserContext : IUserContext
         _roles = new Lazy<IReadOnlyList<string>>(ResolveRoles);
     }
 
+    public bool IsAuthenticated => _user?.Identity?.IsAuthenticated == true;
+
     public string? UserId => GetFirstClaimValue(UserIdClaimCandidates);
 
     public string? Name => GetFirstClaimValue(NameClaimCandidates);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/OidcAuthenticationConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/OidcAuthenticationConfiguration.cs
@@ -76,6 +76,11 @@ public static class OidcAuthenticationConfiguration
 
         services.AddHttpContextAccessor();
         services.AddScoped<IUserContext, HttpUserContext>();
+        // Variante required: lê do mesmo IUserContext mas falha-rápido em
+        // request anônima. Use em handlers/controllers protegidos por
+        // [Authorize] onde anônimo é estado impossível.
+        services.AddScoped<IRequiredUserContext>(sp =>
+            new RequiredUserContext(sp.GetRequiredService<IUserContext>()));
 
         services.AddHttpClient(nameof(OidcDiscoveryHealthCheck));
         services.AddHealthChecks()

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/RequiredUserContext.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/RequiredUserContext.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Authentication;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+
+/// <summary>
+/// Adapter que projeta <see cref="IUserContext"/> em
+/// <see cref="IRequiredUserContext"/>: lê do mesmo backend (HttpContext claims)
+/// mas falha rapidamente com <see cref="InvalidOperationException"/> se o
+/// principal não estiver autenticado, em vez de propagar nullables. Use em
+/// handlers/controllers protegidos por <c>[Authorize]</c>.
+/// </summary>
+internal sealed class RequiredUserContext : IRequiredUserContext
+{
+    private readonly IUserContext _inner;
+
+    public RequiredUserContext(IUserContext inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        _inner = inner;
+    }
+
+    public string UserId => Require(_inner.UserId, nameof(UserId));
+
+    public string Name => Require(_inner.Name, nameof(Name));
+
+    public string Email => Require(_inner.Email, nameof(Email));
+
+    public IReadOnlyList<string> Roles
+    {
+        get
+        {
+            EnsureAuthenticated();
+            return _inner.Roles;
+        }
+    }
+
+    public bool HasRole(string role)
+    {
+        EnsureAuthenticated();
+        return _inner.HasRole(role);
+    }
+
+    private void EnsureAuthenticated()
+    {
+        if (!_inner.IsAuthenticated)
+            throw new InvalidOperationException(
+                "IRequiredUserContext acessado em request anônima. Verifique se o endpoint tem [Authorize] e se o middleware de autenticação está antes do MVC.");
+    }
+
+    private string Require(string? value, string field)
+    {
+        EnsureAuthenticated();
+        // IsNullOrWhiteSpace defensivamente — HttpUserContext já filtra
+        // whitespace na fonte, mas IUserContext custom poderia retornar
+        // " " e isso violaria o contrato semântico de "claim presente".
+        if (string.IsNullOrWhiteSpace(value))
+            throw new InvalidOperationException(
+                $"Claim '{field}' ausente no token JWT validado. Verifique a configuração do IdP e os escopos OIDC solicitados.");
+        return value;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Options;
 using Cryptography;
 using Errors;
 
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
 using Kernel.Results;
 
 /// <summary>
@@ -56,6 +57,7 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
     private readonly IUniPlusEncryptionService _encryption;
     private readonly IDomainErrorMapper _errorMapper;
     private readonly TimeProvider _time;
+    private readonly IUserContext _userContext;
     private readonly IdempotencyOptions _options;
 
     public IdempotencyFilter(
@@ -63,14 +65,21 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
         IUniPlusEncryptionService encryption,
         IDomainErrorMapper errorMapper,
         TimeProvider time,
+        IUserContext userContext,
         IOptions<IdempotencyOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(encryption);
+        ArgumentNullException.ThrowIfNull(errorMapper);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(userContext);
         ArgumentNullException.ThrowIfNull(options);
 
         _store = store;
         _encryption = encryption;
         _errorMapper = errorMapper;
         _time = time;
+        _userContext = userContext;
         _options = options.Value;
     }
 
@@ -115,11 +124,11 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
             return;
         }
 
-        // Resolve principal autenticado ANTES de gastar AES no decode/hash —
-        // endpoint marcado com [RequiresIdempotencyKey] em request anonymous
-        // é inconsistência de configuração: caches anonymous compartilhados
-        // permitem ataques de poisoning entre clientes.
-        string? scope = ResolveScope(httpContext);
+        // Resolve principal via IUserContext (lê claims em UM ÚNICO lugar —
+        // ADR-0033). Endpoint marcado com [RequiresIdempotencyKey] em request
+        // anonymous é inconsistência de configuração: caches anonymous
+        // compartilhados permitem ataques de poisoning entre clientes.
+        string? scope = ResolveScope(_userContext);
         if (scope is null)
         {
             ShortCircuit(context, IdempotencyDomainErrorCodes.PrincipalRequerido,
@@ -388,18 +397,18 @@ public sealed partial class IdempotencyFilter : IAsyncResourceFilter
     }
 
     /// <summary>
-    /// Resolve o scope da chave de cache via sub claim do JWT.
-    /// Retorna <c>null</c> quando não há principal autenticado — sinal para
-    /// rejeitar o request com 401, evitando que clientes anonymous
-    /// compartilhem o mesmo bucket "anonymous" e poluam/colidam keys uns dos
-    /// outros (cache poisoning entre anônimos).
+    /// Resolve o scope da chave de cache via <see cref="IUserContext"/>
+    /// (single source of truth pra claims, ADR-0033). Retorna <c>null</c>
+    /// quando não há principal autenticado — sinal para rejeitar o request
+    /// com 401, evitando que clientes anonymous compartilhem o mesmo bucket
+    /// e poluam/colidam keys uns dos outros (cache poisoning).
     /// </summary>
-    private static string? ResolveScope(HttpContext httpContext)
+    private static string? ResolveScope(IUserContext userContext)
     {
-        string? sub = httpContext.User?.FindFirst("sub")?.Value
-            ?? httpContext.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+        if (!userContext.IsAuthenticated || string.IsNullOrEmpty(userContext.UserId))
+            return null;
 
-        return string.IsNullOrEmpty(sub) ? null : $"user:{sub}";
+        return $"user:{userContext.UserId}";
     }
 
     private static string ResolveEndpoint(ResourceExecutingContext context)

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/HttpUserContextTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/HttpUserContextTests.cs
@@ -177,6 +177,39 @@ public sealed class HttpUserContextTests
         context.GetResourceRoles("uniplus").Should().BeEmpty();
     }
 
+    [Fact]
+    public void IsAuthenticated_Should_ReturnTrue_WhenClaimsIdentityHasAuthenticationType()
+    {
+        // ClaimsIdentity construída com authentication type não-null/não-empty
+        // tem IsAuthenticated == true (.NET BCL).
+        HttpUserContext context = CreateContext(new Claim("sub", "user-1"));
+
+        context.IsAuthenticated.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAuthenticated_Should_ReturnFalse_WhenPrincipalIsAnonymous()
+    {
+        ClaimsIdentity anonymous = new();
+        ClaimsPrincipal principal = new(anonymous);
+        DefaultHttpContext httpContext = new() { User = principal };
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+        HttpUserContext context = new(accessor, NullLogger<HttpUserContext>.Instance);
+
+        context.IsAuthenticated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAuthenticated_Should_ReturnFalse_WhenHttpContextIsNull()
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+        HttpUserContext context = new(accessor, NullLogger<HttpUserContext>.Instance);
+
+        context.IsAuthenticated.Should().BeFalse();
+    }
+
     private static HttpUserContext CreateContext(params Claim[] claims)
     {
         ClaimsIdentity identity = new(claims, "Test");

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/RequiredUserContextTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/RequiredUserContextTests.cs
@@ -1,0 +1,91 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Authentication;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
+
+public sealed class RequiredUserContextTests
+{
+    [Fact]
+    public void UserId_Should_ReturnInner_WhenAuthenticated()
+    {
+        IUserContext inner = Substitute.For<IUserContext>();
+        inner.IsAuthenticated.Returns(true);
+        inner.UserId.Returns("user-42");
+        RequiredUserContext sut = new(inner);
+
+        sut.UserId.Should().Be("user-42");
+    }
+
+    [Fact]
+    public void UserId_Should_Throw_WhenAnonymous()
+    {
+        IUserContext inner = Substitute.For<IUserContext>();
+        inner.IsAuthenticated.Returns(false);
+        RequiredUserContext sut = new(inner);
+
+        FluentActions.Invoking(() => _ = sut.UserId)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*acessado em request anônima*");
+    }
+
+    [Fact]
+    public void UserId_Should_Throw_WhenAuthenticatedButClaimMissing()
+    {
+        IUserContext inner = Substitute.For<IUserContext>();
+        inner.IsAuthenticated.Returns(true);
+        inner.UserId.Returns((string?)null);
+        RequiredUserContext sut = new(inner);
+
+        FluentActions.Invoking(() => _ = sut.UserId)
+            .Should().Throw<InvalidOperationException>()
+            .WithMessage("*Claim 'UserId' ausente*");
+    }
+
+    [Fact]
+    public void Roles_Should_ReturnInner_WhenAuthenticated()
+    {
+        IUserContext inner = Substitute.For<IUserContext>();
+        inner.IsAuthenticated.Returns(true);
+        inner.Roles.Returns(new[] { "admin", "gestor" });
+        RequiredUserContext sut = new(inner);
+
+        sut.Roles.Should().BeEquivalentTo(["admin", "gestor"]);
+    }
+
+    [Fact]
+    public void Roles_Should_Throw_WhenAnonymous()
+    {
+        IUserContext inner = Substitute.For<IUserContext>();
+        inner.IsAuthenticated.Returns(false);
+        RequiredUserContext sut = new(inner);
+
+        FluentActions.Invoking(() => _ = sut.Roles)
+            .Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void HasRole_Should_DelegateToInner_WhenAuthenticated()
+    {
+        IUserContext inner = Substitute.For<IUserContext>();
+        inner.IsAuthenticated.Returns(true);
+        inner.HasRole("admin").Returns(true);
+        RequiredUserContext sut = new(inner);
+
+        sut.HasRole("admin").Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasRole_Should_Throw_WhenAnonymous()
+    {
+        IUserContext inner = Substitute.For<IUserContext>();
+        inner.IsAuthenticated.Returns(false);
+        RequiredUserContext sut = new(inner);
+
+        FluentActions.Invoking(() => sut.HasRole("admin"))
+            .Should().Throw<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
## Resumo

Implementa **story #313** — ICurrentUser abstraction. Durante a implementação descobri que `IUserContext` já existia em `Application.Abstractions/Authentication/` com cobertura idêntica (UserId, Name, Email, Cpf, NomeSocial, Roles, HasRole, GetResourceRoles, claim mapping completo do Keycloak). Decidi **consolidar** nessa abstração em vez de duplicar — **ADR-0033** documenta a decisão honestamente reconhecendo o gap de nomenclatura com a issue original.

## Mudanças

- **`IUserContext.IsAuthenticated`** novo (bool) — `_user?.Identity?.IsAuthenticated == true`.
- **`IRequiredUserContext`** novo — variante não-nullable. `RequiredUserContext` adapter projeta `IUserContext` falhando rápido com `InvalidOperationException` em request anônima ou claim crítica ausente.
- **`OidcAuthenticationConfiguration`** registra ambos como Scoped via factory (single source of truth de claim mapping).
- **`IdempotencyFilter` refatorado** — `ResolveScope` consome `IUserContext.UserId` em vez de extrair claim manualmente. Aproveita o fallback `[ClaimTypes.NameIdentifier, OidcClaims.Sub]` do `HttpUserContext`.
- **`ArgumentNullException.ThrowIfNull`** em todos os parâmetros do construtor de `IdempotencyFilter` (antes faltava em alguns).
- **Testes** — 3 novos em `HttpUserContextTests` (IsAuthenticated) + 7 novos em `RequiredUserContextTests` (fail-fast).
- **ADR-0033** (proposed) documentando consolidação.

## Por que consolidei em vez de criar `ICurrentUser`

A issue #313 propôs `ICurrentUser`/`IRequiredCurrentUser`. `IUserContext` já entregava o mesmo papel semântico, com:
- 51+ tests existentes cobrindo claim mapping (Keycloak realm_access, resource_access, OIDC standard, customizadas Uni+ como CPF/NomeSocial)
- DI já registrado em `OidcAuthenticationConfiguration`
- Já consumido por `MapSharedAuthEndpoints` e `MapSharedProfileEndpoints`

Criar abstração paralela seria duplicação custosa sem benefício técnico. ADR-0033 reconhece o gap de nomenclatura como trade-off aceitável.

## Plano de teste

- [x] `dotnet build UniPlus.slnx --no-incremental` — 0 warnings, 0 errors
- [x] Suite full: 278 unit + 11 arch + 39 integration / 0 falhas
- [x] ADR linter — 33 ADRs OK
- [x] Review local pré-commit aprovado (2 ressalvas aplicadas: ArgumentNullException + IsNullOrWhiteSpace)

Closes #313