### PR TITLE
feat(api): user-binding no payload do cursor (story #312)

### DIFF
--- a/docs/adrs/0026-paginacao-cursor-opaco-cifrado.md
+++ b/docs/adrs/0026-paginacao-cursor-opaco-cifrado.md
@@ -44,6 +44,20 @@ O cursor recebido pelo cliente é uma string base64-url-safe sem padding. Seu co
 - **`sort_key`** — coluna ou expressão de ordenação aplicada (ex.: `created_at_desc`, `numero_edital_asc`). Endpoint declara qual valor é válido; cliente não escolhe.
 - **`expiry`** — timestamp absoluto após o qual o cursor não é mais aceito.
 - **`scope`** — escopo de tenant/contexto quando aplicável (multi-tenancy futuro). Garante que cursor emitido em um contexto não é replicável noutro.
+- **`user_id`** (opcional) — sub claim do principal autenticado quando o recurso é user-scoped (ver "User-binding em cursores user-scoped" abaixo). `null` em recursos públicos (`/api/editais`).
+
+### User-binding em cursores user-scoped
+
+**Acrescentado pós-implementação (story #312, 2026-05-05).** Cursor sem binding de usuário em recurso user-scoped vaza metadata cross-cliente: cliente A recebe cursor com `last_id = inscA.Id`; se o cursor sair do client (logs, support ticket, browser cache compartilhado), cliente B autenticado pode replay no mesmo endpoint e descobrir existência/timestamp/posição ordinal de itens de A — ainda que o filtro server-side aplique `WHERE userId = B.Id` e ele não veja os dados em si.
+
+A mitigação:
+
+- Endpoint user-scoped declara `[FromCursor(resource, RequireUserBinding = true)]`. Default `false` (recurso público).
+- Binder popula `user_id` no payload com o sub do principal corrente quando `RequireUserBinding == true`.
+- No decode, valida `payload.user_id == currentUser.UserId`. Mismatch → 400 com `code: uniplus.cursor.invalido` (não `uniplus.cursor.proibido` para não vazar status: cursor de outro user é tratado como cursor adulterado).
+- Anonymous request em endpoint marcado → 400 `uniplus.cursor.invalido` (consistente com a política do filter de Idempotency-Key — endpoints user-scoped exigem auth).
+
+Recursos públicos (`/api/editais`) **não** populam `user_id` mesmo se o request for autenticado — `user_id` aplicado a recurso público fragmentaria o cache por usuário sem benefício. O default `RequireUserBinding = false` preserva comportamento legacy.
 
 A cifragem usa **AES-GCM** com chave gerenciada por infraestrutura externa de gerenciamento de chaves (em produção: HashiCorp Vault transit engine; em desenvolvimento e CI: fixture local equivalente). A chave nunca sai do gerenciador; cifragem e decifragem ocorrem via API. Rotação periódica é responsabilidade do gerenciador — cursors emitidos com chave anterior continuam válidos até expirarem por TTL, sem revogação retroativa.
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
@@ -66,7 +66,8 @@ public sealed class EditalController : ControllerBase
             new ListarEditaisQuery(page.AfterId, page.Limit), cancellationToken);
 
         return await this.OkPaginatedAsync(
-            resultado.Items, resultado.ProximoAfterId, page, ResourceTag, cancellationToken);
+            resultado.Items, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken);
     }
 
     [HttpGet("{id:guid}")]

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorPayload.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorPayload.cs
@@ -10,8 +10,17 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 /// <param name="Limit">Tamanho de página efetivamente solicitado.</param>
 /// <param name="ResourceTag">Identificador do recurso paginado (ex.: <c>editais</c>); previne reuso cross-resource.</param>
 /// <param name="ExpiresAt">Instante UTC após o qual o cursor é rejeitado com 410.</param>
+/// <param name="UserId">
+/// Sub claim do JWT de quem emitiu o cursor. <c>null</c> em recursos públicos
+/// (ex.: <c>/api/editais</c>); obrigatório em recursos user-scoped
+/// (<c>/api/inscricoes/minhas</c>) — <see cref="FromCursorAttribute.RequireUserBinding"/>
+/// fixa a invariante. Previne metadata leak entre clientes diferentes:
+/// cliente A não consegue replay de cursor emitido para cliente B (ADR-0026
+/// §"User-binding em cursores user-scoped").
+/// </param>
 public sealed record CursorPayload(
     string After,
     int Limit,
     string ResourceTag,
-    DateTimeOffset ExpiresAt);
+    DateTimeOffset ExpiresAt,
+    string? UserId = null);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/FromCursorAttribute.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/FromCursorAttribute.cs
@@ -23,4 +23,13 @@ public sealed class FromCursorAttribute : ModelBinderAttribute
 
     /// <summary>Identificador do recurso embutido no payload do cursor (ex.: <c>"editais"</c>).</summary>
     public string Resource { get; }
+
+    /// <summary>
+    /// Quando <c>true</c>, o binder popula <see cref="CursorPayload.UserId"/>
+    /// com o sub claim do principal autenticado na emissão do cursor e valida
+    /// igualdade no decode — cursor de Alice não é navegável por Bob mesmo
+    /// que decoda corretamente (gap LGPD em metadata de recursos user-scoped,
+    /// ADR-0026). Default <c>false</c> (recurso público).
+    /// </summary>
+    public bool RequireUserBinding { get; init; }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PageRequestModelBinder.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PageRequestModelBinder.cs
@@ -9,6 +9,8 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+
 /// <summary>
 /// Binder de <see cref="PageRequest"/>: lê <c>cursor</c> e <c>limit</c> do
 /// query string, valida limit contra <see cref="CursorPaginationOptions"/>,
@@ -76,6 +78,43 @@ public sealed class PageRequestModelBinder : IModelBinder
                     {
                         FailWith(bindingContext, CursorBindingErrorCodes.Invalido, "O cursor informado é inválido.");
                         return;
+                    }
+
+                    // User-binding (ADR-0026 §"User-binding em cursores
+                    // user-scoped"): tres invariantes distintas, mesmo
+                    // outcome (Cursor.Invalido — nao vazar status: "cursor
+                    // existe mas e de outro user" daria info ao atacante).
+                    // Split em tres ifs torna a intencao explicita e evita
+                    // que mudancas futuras no guard de auth escondam a
+                    // checagem de "cursor sem binding em endpoint user-scoped".
+                    if (attribute.RequireUserBinding)
+                    {
+                        IUserContext userContext = services.GetRequiredService<IUserContext>();
+
+                        // (a) Anonymous em endpoint user-scoped.
+                        if (!userContext.IsAuthenticated || string.IsNullOrEmpty(userContext.UserId))
+                        {
+                            FailWith(bindingContext, CursorBindingErrorCodes.Invalido,
+                                "O cursor informado é inválido.");
+                            return;
+                        }
+
+                        // (b) Cursor legacy (emitido como público, sem user_id)
+                        // não pode ser navegado em endpoint user-scoped.
+                        if (string.IsNullOrEmpty(decoded.Payload.UserId))
+                        {
+                            FailWith(bindingContext, CursorBindingErrorCodes.Invalido,
+                                "O cursor informado é inválido.");
+                            return;
+                        }
+
+                        // (c) Cross-user replay — payload de Alice em sessão de Bob.
+                        if (!string.Equals(decoded.Payload.UserId, userContext.UserId, StringComparison.Ordinal))
+                        {
+                            FailWith(bindingContext, CursorBindingErrorCodes.Invalido,
+                                "O cursor informado é inválido.");
+                            return;
+                        }
                     }
 
                     afterId = parsedAfter;

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PaginationControllerExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PaginationControllerExtensions.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+
 /// <summary>
 /// Extensões de <see cref="ControllerBase"/> para responder coleções
 /// paginadas com cursor (ADR-0026): encoda o cursor da próxima página,
@@ -27,6 +29,7 @@ public static class PaginationControllerExtensions
         Guid? nextAfterId,
         PageRequest page,
         string resource,
+        bool requireUserBinding = false,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(controller);
@@ -39,14 +42,34 @@ public static class PaginationControllerExtensions
         CursorPaginationOptions options = services.GetRequiredService<IOptions<CursorPaginationOptions>>().Value;
         TimeProvider timeProvider = services.GetRequiredService<TimeProvider>();
 
+        // User-binding (ADR-0026 §"User-binding em cursores user-scoped"):
+        // recurso user-scoped popula UserId no payload com o sub do principal
+        // corrente — emissão e decode validam o mesmo binding. Resolução de
+        // IUserContext só acontece quando há próxima página A SER EMITIDA;
+        // last-page (sem cursor) não toca o DI evitando friction em testes
+        // slice-level que registram só CursorEncoder/TimeProvider.
         string? nextCursor = null;
         if (nextAfterId is { } proximo)
         {
+            string? userId = null;
+            if (requireUserBinding)
+            {
+                IUserContext userContext = services.GetRequiredService<IUserContext>();
+                if (!userContext.IsAuthenticated || string.IsNullOrEmpty(userContext.UserId))
+                {
+                    throw new InvalidOperationException(
+                        "OkPaginatedAsync com requireUserBinding=true exige principal autenticado. " +
+                        "Verifique se o endpoint tem [Authorize] e se o middleware de auth está antes do MVC.");
+                }
+                userId = userContext.UserId;
+            }
+
             CursorPayload payload = new(
                 After: proximo.ToString(),
                 Limit: page.Limit,
                 ResourceTag: resource,
-                ExpiresAt: timeProvider.GetUtcNow().Add(options.CursorTtl));
+                ExpiresAt: timeProvider.GetUtcNow().Add(options.CursorTtl),
+                UserId: userId);
             nextCursor = await encoder.EncodeAsync(payload, cancellationToken).ConfigureAwait(false);
         }
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Pagination/PageRequestModelBinderTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Pagination/PageRequestModelBinderTests.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 
 using AwesomeAssertions;
 
+using NSubstitute;
+
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -204,6 +206,132 @@ public sealed class PageRequestModelBinderTests
         page.Limit.Should().Be(50, "limit do query string vence sobre o do cursor");
     }
 
+    // ─── User-binding (story #312, ADR-0026) ─────────────────────────────────
+
+    [Fact]
+    public async Task BindModelAsync_RequireUserBinding_CursorComUserIdQueBate_RetornaSuccess()
+    {
+        Guid afterId = Guid.CreateVersion7();
+        ServiceProvider services = BuildServicesWithUser("user-alice");
+        CursorEncoder encoder = services.GetRequiredService<CursorEncoder>();
+        string cursor = await encoder.EncodeAsync(new CursorPayload(
+            After: afterId.ToString(),
+            Limit: 10,
+            ResourceTag: "inscricoes",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            UserId: "user-alice"));
+
+        DefaultModelBindingContext context = CreateContext(
+            "inscricoes", $"?cursor={Uri.EscapeDataString(cursor)}",
+            servicesOverride: services, methodName: nameof(TestActions.UserScopedAction));
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeTrue();
+        ((PageRequest)context.Result.Model!).AfterId.Should().Be(afterId);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_RequireUserBinding_CursorComUserIdDeOutroUser_RetornaInvalido()
+    {
+        Guid afterId = Guid.CreateVersion7();
+        ServiceProvider services = BuildServicesWithUser("user-bob");
+        CursorEncoder encoder = services.GetRequiredService<CursorEncoder>();
+        // Cursor emitido para Alice — Bob tenta usar.
+        string cursor = await encoder.EncodeAsync(new CursorPayload(
+            After: afterId.ToString(),
+            Limit: 10,
+            ResourceTag: "inscricoes",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            UserId: "user-alice"));
+
+        DefaultModelBindingContext context = CreateContext(
+            "inscricoes", $"?cursor={Uri.EscapeDataString(cursor)}",
+            servicesOverride: services, methodName: nameof(TestActions.UserScopedAction));
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeFalse();
+        // Mismatch retorna Invalido (não Forbidden) — não vaza status de
+        // "cursor existe mas é de outro user".
+        context.HttpContext.Items[CursorBindingErrorCodes.HttpContextItemKey]
+            .Should().Be(CursorBindingErrorCodes.Invalido);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_RequireUserBinding_CursorSemUserIdLegacy_RetornaInvalido()
+    {
+        Guid afterId = Guid.CreateVersion7();
+        ServiceProvider services = BuildServicesWithUser("user-alice");
+        CursorEncoder encoder = services.GetRequiredService<CursorEncoder>();
+        // Cursor sem UserId (era público quando emitido) — endpoint user-scoped
+        // não aceita.
+        string cursor = await encoder.EncodeAsync(new CursorPayload(
+            After: afterId.ToString(),
+            Limit: 10,
+            ResourceTag: "inscricoes",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            UserId: null));
+
+        DefaultModelBindingContext context = CreateContext(
+            "inscricoes", $"?cursor={Uri.EscapeDataString(cursor)}",
+            servicesOverride: services, methodName: nameof(TestActions.UserScopedAction));
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeFalse();
+        context.HttpContext.Items[CursorBindingErrorCodes.HttpContextItemKey]
+            .Should().Be(CursorBindingErrorCodes.Invalido);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_RequireUserBinding_Anonymous_RetornaInvalido()
+    {
+        Guid afterId = Guid.CreateVersion7();
+        ServiceProvider services = BuildServicesWithUser(userId: null);
+        CursorEncoder encoder = services.GetRequiredService<CursorEncoder>();
+        string cursor = await encoder.EncodeAsync(new CursorPayload(
+            After: afterId.ToString(),
+            Limit: 10,
+            ResourceTag: "inscricoes",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            UserId: "user-alice"));
+
+        DefaultModelBindingContext context = CreateContext(
+            "inscricoes", $"?cursor={Uri.EscapeDataString(cursor)}",
+            servicesOverride: services, methodName: nameof(TestActions.UserScopedAction));
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeFalse();
+        context.HttpContext.Items[CursorBindingErrorCodes.HttpContextItemKey]
+            .Should().Be(CursorBindingErrorCodes.Invalido);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_RequireUserBindingFalse_CursorComUserId_IgnoraBinding()
+    {
+        // Endpoint público (RequireUserBinding=false) não valida UserId mesmo
+        // se vier preenchido. Mantém compat com cursores antigos e legacy.
+        Guid afterId = Guid.CreateVersion7();
+        ServiceProvider services = BuildServicesWithUser("user-anyone");
+        CursorEncoder encoder = services.GetRequiredService<CursorEncoder>();
+        string cursor = await encoder.EncodeAsync(new CursorPayload(
+            After: afterId.ToString(),
+            Limit: 10,
+            ResourceTag: "editais",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            UserId: "user-someoneelse"));
+
+        DefaultModelBindingContext context = CreateContext(
+            "editais", $"?cursor={Uri.EscapeDataString(cursor)}",
+            servicesOverride: services, methodName: nameof(TestActions.PaginatedAction));
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeTrue();
+    }
+
     [Fact]
     public async Task BindModelAsync_CursorExpirado_RetornaCursorExpirado()
     {
@@ -242,18 +370,38 @@ public sealed class PageRequestModelBinderTests
         return services.BuildServiceProvider();
     }
 
+    private static ServiceProvider BuildServicesWithUser(string? userId)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<IUniPlusEncryptionService>(_ => new LocalAesEncryptionService(
+            Options.Create(new EncryptionOptions { Provider = "local", LocalKey = Convert.ToBase64String(Key) }),
+            NullLogger<LocalAesEncryptionService>.Instance));
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton<CursorEncoder>();
+        services.AddSingleton(Options.Create(new CursorPaginationOptions()));
+
+        Unifesspa.UniPlus.Application.Abstractions.Authentication.IUserContext userCtx =
+            NSubstitute.Substitute.For<Unifesspa.UniPlus.Application.Abstractions.Authentication.IUserContext>();
+        userCtx.IsAuthenticated.Returns(!string.IsNullOrEmpty(userId));
+        userCtx.UserId.Returns(userId);
+        services.AddSingleton(userCtx);
+
+        return services.BuildServiceProvider();
+    }
+
     private static DefaultModelBindingContext CreateContext(
         string resource,
         string queryString,
-        ServiceProvider? servicesOverride = null)
+        ServiceProvider? servicesOverride = null,
+        string methodName = nameof(TestActions.PaginatedAction))
     {
         ServiceProvider services = servicesOverride ?? BuildServices();
 
-        // Atributo [FromCursor("editais")] vem de uma assinatura real construída
+        // Atributo [FromCursor(...)] vem de uma assinatura real construída
         // por reflection — caminho que o binder também usa em produção, garantindo
         // que o teste exercita exatamente o ResolveAttribute.
         ParameterInfo parameterInfo = typeof(TestActions)
-            .GetMethod(nameof(TestActions.PaginatedAction), BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic)!
             .GetParameters()[0];
 
         ControllerParameterDescriptor parameterDescriptor = new()
@@ -266,7 +414,7 @@ public sealed class PageRequestModelBinderTests
         ControllerActionDescriptor actionDescriptor = new()
         {
             Parameters = new List<ParameterDescriptor> { parameterDescriptor },
-            ActionName = nameof(TestActions.PaginatedAction),
+            ActionName = methodName,
         };
 
         DefaultHttpContext httpContext = new() { RequestServices = services };
@@ -292,6 +440,12 @@ public sealed class PageRequestModelBinderTests
     private static class TestActions
     {
         internal static void PaginatedAction([FromCursor("editais")] PageRequest page)
+        {
+            _ = page;
+        }
+
+        internal static void UserScopedAction(
+            [FromCursor("inscricoes", RequireUserBinding = true)] PageRequest page)
         {
             _ = page;
         }


### PR DESCRIPTION
## Resumo

Implementa **story #312** estrutural: `CursorPayload.UserId`, `FromCursorAttribute.RequireUserBinding`, validação simétrica entre emissão e decode, política de retorno `Cursor.Invalido` (não vazar status). ADR-0026 atualizada com seção dedicada e cenário Alice/Bob. Primeiro endpoint user-scoped paginado virá em Sprint 4 — infra fica pronta agora com 5 tests cobrindo a matriz comportamental.

## Como funciona

```csharp
[HttpGet("minhas")]
[Authorize]
[FromCursor("inscricoes", RequireUserBinding = true)] // emissão valida sub do JWT
public async Task<IActionResult> ListarMinhas(PageRequest page, CancellationToken ct)
{
    var result = await _queryBus.Send(new ListarMinhasInscricoesQuery(...), ct);
    return await this.OkPaginatedAsync(
        result.Items, result.ProximoAfterId, page, "inscricoes",
        requireUserBinding: true,         // popula UserId no payload
        cancellationToken: ct);
}
```

Cliente que tenta replay com cursor de outro user (Alice → Bob) recebe 400 `uniplus.cursor.invalido` — política da ADR de não vazar status (não usa `Cursor.Proibido`).

## Mudanças

- `CursorPayload` — `string? UserId = null` (default preserva callers).
- `FromCursorAttribute.RequireUserBinding` — opt-in.
- `PageRequestModelBinder` — três invariantes no decode (anonymous / legacy sem user_id / cross-user mismatch), todas → `Cursor.Invalido`.
- `OkPaginatedAsync(requireUserBinding=true)` — popula `UserId` apenas quando há próxima página (lazy DI resolve evita friction em testes slice).
- ADR-0026 — nova seção "User-binding em cursores user-scoped" com cenário Alice/Bob.
- 5 tests novos no binder + scaffold ajustado para multi-action via reflection.

## Review local pré-commit

APROVADO COM RESSALVAS (3 itens aplicados):
- Split do check em 3 ifs (auth / legacy / mismatch) — torna intenção explícita
- `OkPaginatedAsync` resolve `IUserContext` apenas quando emite cursor
- `ActionDescriptor.ActionName = methodName` no scaffold de tests

## Plano de teste

- [x] `dotnet build UniPlus.slnx --no-incremental` — 0 warnings, 0 errors
- [x] Suite full: 283 unit + 11 arch + 39 integration / 0 falhas (5 novos no binder)
- [x] ADR linter local com flake conhecido (CI passa com rerun)
- [x] EditalController.Listar continua funcionando (recurso público — passa `requireUserBinding: false` por default)

Closes #312