### PR TITLE
feat(openapi): pipeline AddOpenApi + transformers Uni+ + ruleset Spectral (#289)

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -30,6 +30,9 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 });
 
 builder.Services.AddEndpointsApiExplorer();
+// OpenAPI 3.1 (ADR-0030) — documento nomeado por módulo + transformers Uni+
+// (info, operation, schema). Spec exposto em /openapi/ingresso.json.
+builder.Services.AddUniPlusOpenApi("ingresso", builder.Configuration);
 
 string connectionString = builder.Configuration.GetConnectionString("IngressoDb")
     ?? throw new InvalidOperationException("Connection string 'IngressoDb' não configurada.");
@@ -65,6 +68,7 @@ app.UseAuthorization();
 app.MapSharedAuthEndpoints();
 app.MapSharedProfileEndpoints();
 app.MapControllers();
+app.MapOpenApi("/openapi/{documentName}.json");
 app.MapHealthChecks("/health");
 
 await app.RunAsync();

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -36,6 +36,9 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 });
 
 builder.Services.AddEndpointsApiExplorer();
+// OpenAPI 3.1 (ADR-0030) — documento nomeado por módulo + transformers Uni+
+// (info, operation, schema). Spec exposto em /openapi/selecao.json.
+builder.Services.AddUniPlusOpenApi("selecao", builder.Configuration);
 
 string connectionString = builder.Configuration.GetConnectionString("SelecaoDb")
     ?? throw new InvalidOperationException("Connection string 'SelecaoDb' não configurada.");
@@ -121,6 +124,7 @@ app.UseAuthorization();
 app.MapSharedAuthEndpoints();
 app.MapSharedProfileEndpoints();
 app.MapControllers();
+app.MapOpenApi("/openapi/{documentName}.json");
 app.MapHealthChecks("/health");
 
 await app.RunAsync();

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/UniPlusOpenApiServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/UniPlusOpenApiServiceCollectionExtensions.cs
@@ -1,0 +1,50 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using OpenApi;
+
+/// <summary>
+/// Registra o pipeline de transformers Uni+ + um documento OpenAPI nomeado
+/// (<paramref name="documentName"/>). Cada módulo chama em seu Program.cs com
+/// seu próprio nome (ex.: <c>"selecao"</c>, <c>"ingresso"</c>); transformers
+/// são reutilizados (<c>TryAddSingleton</c>).
+/// </summary>
+public static class UniPlusOpenApiServiceCollectionExtensions
+{
+    public static IServiceCollection AddUniPlusOpenApi(
+        this IServiceCollection services,
+        string documentName,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(documentName);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services
+            .AddOptions<UniPlusOpenApiOptions>()
+            .Bind(configuration.GetSection(UniPlusOpenApiOptions.SectionName))
+            .Validate(
+                static o => Uri.TryCreate(o.ContactUrl, UriKind.Absolute, out _)
+                    && Uri.TryCreate(o.ProductionServerUrl, UriKind.Absolute, out _)
+                    && Uri.TryCreate(o.StagingServerUrl, UriKind.Absolute, out _),
+                "UniPlus:OpenApi — ContactUrl/ProductionServerUrl/StagingServerUrl precisam ser URIs absolutas.")
+            .ValidateOnStart();
+
+        services.TryAddSingleton<UniPlusInfoTransformer>();
+        services.TryAddSingleton<UniPlusOperationTransformer>();
+        services.TryAddSingleton<UniPlusSchemaTransformer>();
+
+        services.AddOpenApi(documentName, options =>
+        {
+            options.AddDocumentTransformer<UniPlusInfoTransformer>();
+            options.AddOperationTransformer<UniPlusOperationTransformer>();
+            options.AddSchemaTransformer<UniPlusSchemaTransformer>();
+        });
+
+        return services;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusInfoTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusInfoTransformer.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.OpenApi;
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi;
+
+/// <summary>
+/// Document transformer que injeta metadata institucional Uni+ em todos os
+/// documentos OpenAPI gerados (selecao, ingresso, futuros). Aplica info
+/// (title, description, contact, license em pt-BR), servers por ambiente, e
+/// versão de contrato alinhada com ADR-0022 (Contrato REST canônico V1).
+/// </summary>
+public sealed class UniPlusInfoTransformer : IOpenApiDocumentTransformer
+{
+    private readonly UniPlusOpenApiOptions _options;
+
+    public UniPlusInfoTransformer(IOptions<UniPlusOpenApiOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options.Value;
+    }
+
+    public Task TransformAsync(
+        OpenApiDocument document,
+        OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(context);
+
+        string moduleTitle = context.DocumentName switch
+        {
+            "selecao" => "Uni+ — Módulo Seleção",
+            "ingresso" => "Uni+ — Módulo Ingresso",
+            _ => $"Uni+ — {context.DocumentName}",
+        };
+
+        document.Info = new OpenApiInfo
+        {
+            Title = moduleTitle,
+            Version = _options.ContractVersion,
+            Description = "API REST do Sistema Unificado Unifesspa (Uni+). Contrato canônico V1 — "
+                + "ProblemDetails RFC 9457, paginação cursor opaco, vendor MIME versioning. "
+                + "Toda string user-facing em pt-BR (ADR-0022).",
+            Contact = new OpenApiContact
+            {
+                Name = _options.ContactName,
+                Email = _options.ContactEmail,
+                Url = new Uri(_options.ContactUrl),
+            },
+            License = new OpenApiLicense
+            {
+                Name = "MIT",
+                Url = new Uri("https://opensource.org/licenses/MIT"),
+            },
+        };
+
+        document.Servers =
+        [
+            new OpenApiServer { Url = _options.ProductionServerUrl, Description = "Produção" },
+            new OpenApiServer { Url = _options.StagingServerUrl, Description = "Homologação" },
+        ];
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusOpenApiOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusOpenApiOptions.cs
@@ -1,0 +1,34 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.OpenApi;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Configuração compartilhada do <c>UniPlusInfoTransformer</c>: dados
+/// institucionais que aparecem em todos os documentos OpenAPI gerados pela
+/// API Uni+ (contact, license, servers). Bind a partir de
+/// <c>UniPlus:OpenApi</c>; defaults sensatos para dev/CI.
+/// </summary>
+[SuppressMessage("Design", "CA1056:URI-like properties should not be strings",
+    Justification = "Properties bound from JSON via IOptions; System.Text.Json não desserializa Uri nativamente. Conversão para Uri acontece no transformer.")]
+public sealed record UniPlusOpenApiOptions
+{
+    public const string SectionName = "UniPlus:OpenApi";
+
+    /// <summary>Email institucional para contato técnico.</summary>
+    public string ContactEmail { get; init; } = "ctic@unifesspa.edu.br";
+
+    /// <summary>Nome do contato exibido no spec.</summary>
+    public string ContactName { get; init; } = "CTIC Unifesspa";
+
+    /// <summary>URL do portal de developers (Milestone C).</summary>
+    public string ContactUrl { get; init; } = "https://developers.uniplus.unifesspa.edu.br";
+
+    /// <summary>Versão do contrato V1 — alinhada com ADR-0022.</summary>
+    public string ContractVersion { get; init; } = "1.0.0";
+
+    /// <summary>URL base de produção; sobrescrever via configuração em deploy.</summary>
+    public string ProductionServerUrl { get; init; } = "https://api.uniplus.unifesspa.edu.br";
+
+    /// <summary>URL base de homologação.</summary>
+    public string StagingServerUrl { get; init; } = "https://api.hml.uniplus.unifesspa.edu.br";
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusOperationTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusOperationTransformer.cs
@@ -42,6 +42,13 @@ public sealed class UniPlusOperationTransformer : IOpenApiOperationTransformer
                     Type = JsonSchemaType.String,
                     MinLength = 1,
                     MaxLength = 255,
+                    // ECMA-262 (JSON Schema) — espelha IdempotencyFilter.IsKeyValid:
+                    // ASCII printable (0x21-0x7E) menos ',' (0x2C) e ';' (0x3B),
+                    // que são separadores em sf-list (draft-ietf-httpapi-idempotency-key).
+                    // Mantém o contrato consistente com a validação de runtime — clientes
+                    // gerados a partir do spec recebem 400 imediato em chave inválida em vez
+                    // de aceitar a chamada e ser rejeitado pelo filter.
+                    Pattern = @"^[\x21-\x2B\x2D-\x3A\x3C-\x7E]+$",
                 },
             });
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusOperationTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusOperationTransformer.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.OpenApi;
+
+using System.Text.Json.Nodes;
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+using Idempotency;
+
+/// <summary>
+/// Operation transformer que injeta metadata Uni+ por operação:
+/// <list type="bullet">
+///   <item><description>Header <c>Idempotency-Key</c> declarado como required quando a action tem <c>[RequiresIdempotencyKey]</c>.</description></item>
+///   <item><description>Extension <c>x-uniplus-idempotent: true</c> em endpoints com idempotência opt-in.</description></item>
+/// </list>
+/// </summary>
+public sealed class UniPlusOperationTransformer : IOpenApiOperationTransformer
+{
+    public Task TransformAsync(
+        OpenApiOperation operation,
+        OpenApiOperationTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(context);
+
+        IList<object> metadata = context.Description.ActionDescriptor.EndpointMetadata;
+
+        bool requiresIdempotency = metadata.OfType<RequiresIdempotencyKeyAttribute>().Any();
+        if (requiresIdempotency)
+        {
+            operation.Parameters ??= [];
+            operation.Parameters.Add(new OpenApiParameter
+            {
+                Name = "Idempotency-Key",
+                In = ParameterLocation.Header,
+                Required = true,
+                Description = "Chave opaca (1-255 ASCII printable, sem ',' ou ';') para retry seguro do comando. "
+                    + "Replay com mesma key + mesmo body retorna response cacheada (ADR-0027).",
+                Schema = new OpenApiSchema
+                {
+                    Type = JsonSchemaType.String,
+                    MinLength = 1,
+                    MaxLength = 255,
+                },
+            });
+
+            operation.Extensions ??= new Dictionary<string, IOpenApiExtension>(StringComparer.Ordinal);
+            operation.Extensions["x-uniplus-idempotent"] = new JsonNodeExtension(JsonValue.Create(true));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusSchemaTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusSchemaTransformer.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.OpenApi;
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+/// <summary>
+/// Schema transformer que aplica invariantes de domínio Uni+ a propriedades
+/// tipadas. Hoje cobre <c>cpf</c> (regex de 11 dígitos + nota PII).
+/// <para>
+/// O <c>code</c> de ProblemDetails NÃO é coberto aqui: o campo vive em
+/// <c>ProblemDetails.Extensions["code"]</c> (<c>[JsonExtensionData]</c>) e
+/// não recebe um <c>JsonPropertyInfo</c> nomeado — o pattern
+/// <c>^[a-z]+(\.[a-z_]+)+$</c> da taxonomia (ADR-0023) é validado a partir
+/// do spec gerado pela rule Spectral <c>uniplus-error-code-format</c>.
+/// </para>
+/// </summary>
+public sealed class UniPlusSchemaTransformer : IOpenApiSchemaTransformer
+{
+    public Task TransformAsync(
+        OpenApiSchema schema,
+        OpenApiSchemaTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(schema);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (schema.Type != JsonSchemaType.String)
+            return Task.CompletedTask;
+
+        string? propertyName = context.JsonPropertyInfo?.Name;
+        if (propertyName is null)
+            return Task.CompletedTask;
+
+        if (string.Equals(propertyName, "cpf", StringComparison.Ordinal))
+        {
+            schema.Pattern = @"^\d{11}$";
+            schema.Description ??= "CPF (apenas dígitos, sem formatação). PII — sempre mascarar em logs ('***.***.***-XX', ADR-0011).";
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusSchemaTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusSchemaTransformer.cs
@@ -24,7 +24,10 @@ public sealed class UniPlusSchemaTransformer : IOpenApiSchemaTransformer
         ArgumentNullException.ThrowIfNull(schema);
         ArgumentNullException.ThrowIfNull(context);
 
-        if (schema.Type != JsonSchemaType.String)
+        // JsonSchemaType é [Flags] — propriedades nullable saem como
+        // String | Null, então comparação por igualdade exata pula schemas
+        // legítimos. HasFlag pega ambos os casos (String puro e String|Null).
+        if (!schema.Type.HasValue || !schema.Type.Value.HasFlag(JsonSchemaType.String))
             return Task.CompletedTask;
 
         string? propertyName = context.JsonPropertyInfo?.Name;

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Confluent.Kafka" />
     <PackageReference Include="VaultSharp" />
     <PackageReference Include="FluentValidation" />

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/OpenApi/UniPlusInfoTransformerTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/OpenApi/UniPlusInfoTransformerTests.cs
@@ -1,0 +1,97 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.OpenApi;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Infrastructure.Core.OpenApi;
+
+public sealed class UniPlusInfoTransformerTests
+{
+    [Theory]
+    [InlineData("selecao", "Uni+ — Módulo Seleção")]
+    [InlineData("ingresso", "Uni+ — Módulo Ingresso")]
+    [InlineData("custom", "Uni+ — custom")]
+    public async Task TransformAsync_Should_AssignTitlePerDocumentName(string documentName, string expectedTitle)
+    {
+        UniPlusInfoTransformer transformer = CreateTransformer();
+        OpenApiDocument document = new();
+        OpenApiDocumentTransformerContext context = CreateContext(documentName);
+
+        await transformer.TransformAsync(document, context, CancellationToken.None);
+
+        document.Info.Should().NotBeNull();
+        document.Info.Title.Should().Be(expectedTitle);
+    }
+
+    [Fact]
+    public async Task TransformAsync_Should_AssignContractVersionFromOptions()
+    {
+        UniPlusInfoTransformer transformer = CreateTransformer(o => o with { ContractVersion = "1.2.3" });
+        OpenApiDocument document = new();
+
+        await transformer.TransformAsync(document, CreateContext("selecao"), CancellationToken.None);
+
+        document.Info!.Version.Should().Be("1.2.3");
+    }
+
+    [Fact]
+    public async Task TransformAsync_Should_AssignContactAndLicense()
+    {
+        UniPlusInfoTransformer transformer = CreateTransformer();
+        OpenApiDocument document = new();
+
+        await transformer.TransformAsync(document, CreateContext("selecao"), CancellationToken.None);
+
+        document.Info!.Contact!.Email.Should().Be("ctic@unifesspa.edu.br");
+        document.Info.Contact.Name.Should().Be("CTIC Unifesspa");
+        document.Info.License!.Name.Should().Be("MIT");
+    }
+
+    [Fact]
+    public async Task TransformAsync_Should_AssignProductionAndStagingServers()
+    {
+        UniPlusInfoTransformer transformer = CreateTransformer();
+        OpenApiDocument document = new();
+
+        await transformer.TransformAsync(document, CreateContext("selecao"), CancellationToken.None);
+
+        document.Servers.Should().HaveCount(2);
+        document.Servers![0].Description.Should().Be("Produção");
+        document.Servers[1].Description.Should().Be("Homologação");
+    }
+
+    [Fact]
+    public async Task TransformAsync_Should_DescribeApiInPortuguese()
+    {
+        UniPlusInfoTransformer transformer = CreateTransformer();
+        OpenApiDocument document = new();
+
+        await transformer.TransformAsync(document, CreateContext("selecao"), CancellationToken.None);
+
+        document.Info!.Description.Should().Contain("Sistema Unificado Unifesspa");
+        document.Info.Description.Should().Contain("pt-BR");
+    }
+
+    private static UniPlusInfoTransformer CreateTransformer(Func<UniPlusOpenApiOptions, UniPlusOpenApiOptions>? configure = null)
+    {
+        UniPlusOpenApiOptions baseOptions = new();
+        UniPlusOpenApiOptions options = configure is null ? baseOptions : configure(baseOptions);
+        return new UniPlusInfoTransformer(Options.Create(options));
+    }
+
+    private static OpenApiDocumentTransformerContext CreateContext(string documentName)
+    {
+        IServiceProvider services = Substitute.For<IServiceProvider>();
+        return new OpenApiDocumentTransformerContext
+        {
+            DocumentName = documentName,
+            ApplicationServices = services,
+            DescriptionGroups = [],
+        };
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/OpenApi/UniPlusOperationTransformerTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/OpenApi/UniPlusOperationTransformerTests.cs
@@ -1,0 +1,86 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.OpenApi;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.OpenApi;
+
+public sealed class UniPlusOperationTransformerTests
+{
+    [Fact]
+    public async Task TransformAsync_Should_AddIdempotencyHeader_WhenActionHasAttribute()
+    {
+        UniPlusOperationTransformer transformer = new();
+        OpenApiOperation operation = new();
+        OpenApiOperationTransformerContext context = CreateContext(metadata: [new RequiresIdempotencyKeyAttribute()]);
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        operation.Parameters.Should().NotBeNull();
+        operation.Parameters.Should().ContainSingle(p =>
+            p.Name == "Idempotency-Key" && p.In == ParameterLocation.Header && p.Required);
+    }
+
+    [Fact]
+    public async Task TransformAsync_Should_AddIdempotentExtension_WhenActionHasAttribute()
+    {
+        UniPlusOperationTransformer transformer = new();
+        OpenApiOperation operation = new();
+        OpenApiOperationTransformerContext context = CreateContext(metadata: [new RequiresIdempotencyKeyAttribute()]);
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        operation.Extensions.Should().ContainKey("x-uniplus-idempotent");
+    }
+
+    [Fact]
+    public async Task TransformAsync_Should_NotMutate_WhenActionLacksAttribute()
+    {
+        UniPlusOperationTransformer transformer = new();
+        OpenApiOperation operation = new();
+        OpenApiOperationTransformerContext context = CreateContext(metadata: []);
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        operation.Parameters.Should().BeNull();
+        operation.Extensions.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TransformAsync_Should_DescribeIdempotencyKeyHeader_InPortuguese()
+    {
+        UniPlusOperationTransformer transformer = new();
+        OpenApiOperation operation = new();
+        OpenApiOperationTransformerContext context = CreateContext(metadata: [new RequiresIdempotencyKeyAttribute()]);
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        IOpenApiParameter? header = operation.Parameters!.SingleOrDefault(p => p.Name == "Idempotency-Key");
+        header.Should().NotBeNull();
+        header!.Description.Should().Contain("Chave opaca").And.Contain("ADR-0027");
+    }
+
+    private static OpenApiOperationTransformerContext CreateContext(IList<object> metadata)
+    {
+        ApiDescription description = new()
+        {
+            ActionDescriptor = new ControllerActionDescriptor
+            {
+                EndpointMetadata = metadata,
+            },
+        };
+
+        return new OpenApiOperationTransformerContext
+        {
+            DocumentName = "selecao",
+            ApplicationServices = NSubstitute.Substitute.For<IServiceProvider>(),
+            Description = description,
+        };
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/OpenApiEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/OpenApiEndpointTests.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests;
+
+using System.Net;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Outbox.Cascading;
+
+/// <summary>
+/// Smoke test do endpoint <c>/openapi/{documentName}.json</c> exposto pelo
+/// pipeline <c>AddUniPlusOpenApi("selecao", ...)</c> em <c>Program.cs</c>.
+/// Garante que o documento gerado em runtime sai com a metadata Uni+ aplicada
+/// pelos transformers (info, servers, contact) e que o spec é JSON válido.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+public sealed class OpenApiEndpointTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public OpenApiEndpointTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /openapi/selecao.json retorna 200 com documento OpenAPI válido e metadata Uni+")]
+    public async Task GetOpenApiDocument_RetornaSpecJsonComMetadataInjetada()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri("/openapi/selecao.json", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+        JsonElement root = doc.RootElement;
+
+        // OpenAPI 3.x — top-level: openapi, info, paths
+        root.GetProperty("openapi").GetString().Should().StartWith("3.");
+        root.GetProperty("info").GetProperty("title").GetString().Should().Be("Uni+ — Módulo Seleção");
+        root.GetProperty("info").GetProperty("version").GetString().Should().Be("1.0.0");
+        root.GetProperty("info").GetProperty("contact").GetProperty("email").GetString()
+            .Should().Be("ctic@unifesspa.edu.br");
+
+        // Servers injetados pelo UniPlusInfoTransformer (Produção, Homologação)
+        JsonElement servers = root.GetProperty("servers");
+        servers.GetArrayLength().Should().Be(2);
+        servers[0].GetProperty("description").GetString().Should().Be("Produção");
+        servers[1].GetProperty("description").GetString().Should().Be("Homologação");
+    }
+}

--- a/tools/spectral/.spectral.yaml
+++ b/tools/spectral/.spectral.yaml
@@ -66,16 +66,18 @@ rules:
               required: ["application/problem+json"]
 
   # --- 3. Code regex (ADR-0023) --------------------------------------------
-  # Aplicada quando ProblemDetails carrega exemplo do code.
+  # Aplicada quando ProblemDetails carrega exemplo do code. Pattern obriga
+  # o prefixo `uniplus.` — taxonomia canônica `uniplus.<modulo>.<codigo>`.
+  # Sem o prefixo a regex genérica permitiria qualquer dotted lowercase.
   uniplus-error-code-format:
-    description: code segue taxonomia ^[a-z]+(\.[a-z_]+)+$
+    description: code segue taxonomia ^uniplus(\.[a-z_]+){2,}$
     message: "code '{{value}}' fora da taxonomia uniplus.<modulo>.<codigo> (ADR-0023)"
     severity: error
     given: $..responses[?(@property.match(/^[45]/))].content["application/problem+json"].schema..properties.code.example
     then:
       function: pattern
       functionOptions:
-        match: "^[a-z]+(\\.[a-z_]+)+$"
+        match: "^uniplus(\\.[a-z_]+){2,}$"
 
   # --- 4. Deprecated requer Sunset (RFC 8594) ------------------------------
   uniplus-deprecated-requires-sunset:

--- a/tools/spectral/.spectral.yaml
+++ b/tools/spectral/.spectral.yaml
@@ -45,14 +45,25 @@ rules:
         notMatch: "\\b(the|and|with|for|this|that|will|please|must)\\b"
 
   # --- 2. ProblemDetails RFC 9457 (ADR-0023) -------------------------------
+  # Targeting the response object (não .content) é proposital: se a resposta
+  # omitir `content` por completo o JSONPath ainda dispara e a validação
+  # de schema falha — caso contrário o `then` só executaria quando .content
+  # já existisse, mascarando o pior cenário.
   uniplus-error-response-uses-problem-details:
     description: Respostas 4xx/5xx devem usar application/problem+json
     message: "Resposta {{property}} não declara application/problem+json — RFC 9457 (ADR-0023)"
     severity: error
-    given: $.paths[*][*].responses[?(@property.match(/^[45]\d\d$/))].content
+    given: $.paths[*][*].responses[?(@property.match(/^[45]\d\d$/))]
     then:
-      field: "application/problem+json"
-      function: truthy
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required: [content]
+          properties:
+            content:
+              type: object
+              required: ["application/problem+json"]
 
   # --- 3. Code regex (ADR-0023) --------------------------------------------
   # Aplicada quando ProblemDetails carrega exemplo do code.
@@ -79,23 +90,39 @@ rules:
         match: "^\\d{4}-\\d{2}-\\d{2}$"
 
   # --- 5. Idempotency-Key required em POSTs marcados ------------------------
+  # JSONPath do Spectral não filtra confiavelmente por extensions x-* no
+  # `given` (jsonpath-plus desserializa keys com hyphen de forma inconsistente).
+  # Solução: aplicar a regra a TODA operação POST e usar JSON Schema
+  # condicional (if/then) — só valida parameters quando a operação tem
+  # x-uniplus-idempotent: true.
   uniplus-idempotent-post-declares-header:
     description: POST com x-uniplus-idempotent declara header Idempotency-Key obrigatório
     message: "POST com x-uniplus-idempotent precisa declarar header Idempotency-Key required (ADR-0027)"
     severity: error
-    given: $.paths[*].post[?(@['x-uniplus-idempotent'] == true)].parameters
+    given: $.paths[*].post
     then:
       function: schema
       functionOptions:
         schema:
-          type: array
-          contains:
+          if:
             type: object
+            required: ["x-uniplus-idempotent"]
             properties:
-              name:
-                const: Idempotency-Key
-              in:
-                const: header
-              required:
+              x-uniplus-idempotent:
                 const: true
-            required: [name, in, required]
+          then:
+            type: object
+            required: [parameters]
+            properties:
+              parameters:
+                type: array
+                contains:
+                  type: object
+                  required: [name, in, required]
+                  properties:
+                    name:
+                      const: Idempotency-Key
+                    in:
+                      const: header
+                    required:
+                      const: true

--- a/tools/spectral/.spectral.yaml
+++ b/tools/spectral/.spectral.yaml
@@ -53,7 +53,9 @@ rules:
     description: Respostas 4xx/5xx devem usar application/problem+json
     message: "Resposta {{property}} não declara application/problem+json — RFC 9457 (ADR-0023)"
     severity: error
-    given: $.paths[*][*].responses[?(@property.match(/^[45]\d\d$/))]
+    # OpenAPI permite tanto códigos exatos (400, 500) quanto ranges (4XX, 5XX);
+    # a regex precisa cobrir os dois para não deixar buracos.
+    given: $.paths[*][*].responses[?(@property.match(/^[45](\d\d|XX)$/i))]
     then:
       function: schema
       functionOptions:
@@ -98,10 +100,13 @@ rules:
   # condicional (if/then) — só valida parameters quando a operação tem
   # x-uniplus-idempotent: true.
   uniplus-idempotent-post-declares-header:
-    description: POST com x-uniplus-idempotent declara header Idempotency-Key obrigatório
-    message: "POST com x-uniplus-idempotent precisa declarar header Idempotency-Key required (ADR-0027)"
+    description: Operação com x-uniplus-idempotent declara header Idempotency-Key obrigatório
+    message: "Operação com x-uniplus-idempotent precisa declarar header Idempotency-Key required (ADR-0027)"
     severity: error
-    given: $.paths[*].post
+    # [RequiresIdempotencyKey] é aplicável a qualquer verb com side-effects
+    # (POST, PUT, PATCH, DELETE). Limitar a `post` deixaria PATCH/DELETE
+    # idempotentes sem cobertura de lint.
+    given: $.paths[*][post,put,patch,delete]
     then:
       function: schema
       functionOptions:

--- a/tools/spectral/.spectral.yaml
+++ b/tools/spectral/.spectral.yaml
@@ -1,0 +1,101 @@
+# Spectral ruleset Uni+ — house style do contrato REST canônico V1.
+#
+# Fundamentos:
+# - ADR-0022 (umbrella V1): pt-BR em strings user-facing, ProblemDetails RFC 9457,
+#   paginação cursor opaco, vendor MIME versioning, idempotência opt-in.
+# - ADR-0023: code regex `^uniplus\.<modulo>\.<codigo>$`.
+# - ADR-0025: body de coleção é array JSON puro.
+# - ADR-0026: cursor com TTL e Link header.
+# - ADR-0028: vendor MIME `application/vnd.uniplus.<resource>.v<N>+json`.
+# - ADR-0030: OpenAPI 3.1 contract-first.
+#
+# Uso:
+#   npx @stoplight/spectral-cli lint --ruleset tools/spectral/.spectral.yaml \
+#     contracts/openapi.selecao.json contracts/openapi.ingresso.json
+#
+# Severidades: error (bloqueia CI), warn (visibilidade), info (informativo).
+
+# `recommended` ativa o conjunto curado pela Stoplight (sem regras pedantes
+# como oas3-valid-media-example que costumam dar falso positivo). Promover
+# para `all` é decisão local de auditoria depois do baseline da Milestone A.
+extends: [[spectral:oas, recommended]]
+formats: [oas3_1]
+documentationUrl: https://developers.uniplus.unifesspa.edu.br/style-guide
+
+rules:
+  # --- 1. pt-BR em descrições user-facing ----------------------------------
+  uniplus-pt-br-info-description:
+    description: info.description deve estar em pt-BR (heurística — ausência de palavras inglesas comuns)
+    message: "info.description parece estar em inglês — toda string user-facing é pt-BR (ADR-0022)"
+    severity: error
+    given: $.info.description
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: "\\b(the|and|with|for|this|that|will|please|must)\\b"
+
+  uniplus-pt-br-operation-summary:
+    description: operations.summary em pt-BR
+    message: "summary parece estar em inglês — usar pt-BR (ADR-0022)"
+    severity: warn
+    given: $.paths[*][get,post,put,patch,delete].summary
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: "\\b(the|and|with|for|this|that|will|please|must)\\b"
+
+  # --- 2. ProblemDetails RFC 9457 (ADR-0023) -------------------------------
+  uniplus-error-response-uses-problem-details:
+    description: Respostas 4xx/5xx devem usar application/problem+json
+    message: "Resposta {{property}} não declara application/problem+json — RFC 9457 (ADR-0023)"
+    severity: error
+    given: $.paths[*][*].responses[?(@property.match(/^[45]\d\d$/))].content
+    then:
+      field: "application/problem+json"
+      function: truthy
+
+  # --- 3. Code regex (ADR-0023) --------------------------------------------
+  # Aplicada quando ProblemDetails carrega exemplo do code.
+  uniplus-error-code-format:
+    description: code segue taxonomia ^[a-z]+(\.[a-z_]+)+$
+    message: "code '{{value}}' fora da taxonomia uniplus.<modulo>.<codigo> (ADR-0023)"
+    severity: error
+    given: $..responses[?(@property.match(/^[45]/))].content["application/problem+json"].schema..properties.code.example
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-z]+(\\.[a-z_]+)+$"
+
+  # --- 4. Deprecated requer Sunset (RFC 8594) ------------------------------
+  uniplus-deprecated-requires-sunset:
+    description: Operação deprecated declara x-sunset com data ISO-8601
+    message: "Operação deprecated sem x-sunset — RFC 8594 exige header Sunset (ADR-0028)"
+    severity: error
+    given: $.paths[*][?(@.deprecated == true)]
+    then:
+      field: x-sunset
+      function: pattern
+      functionOptions:
+        match: "^\\d{4}-\\d{2}-\\d{2}$"
+
+  # --- 5. Idempotency-Key required em POSTs marcados ------------------------
+  uniplus-idempotent-post-declares-header:
+    description: POST com x-uniplus-idempotent declara header Idempotency-Key obrigatório
+    message: "POST com x-uniplus-idempotent precisa declarar header Idempotency-Key required (ADR-0027)"
+    severity: error
+    given: $.paths[*].post[?(@['x-uniplus-idempotent'] == true)].parameters
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: array
+          contains:
+            type: object
+            properties:
+              name:
+                const: Idempotency-Key
+              in:
+                const: header
+              required:
+                const: true
+            required: [name, in, required]


### PR DESCRIPTION
## Resumo

Implementa story **#289** (Milestone A do Epic #259 — Contrato REST canônico V1): pipeline OpenAPI 3.1 baseado em `Microsoft.AspNetCore.OpenApi` 10 + ruleset Spectral house-style.

### O que entra

**Pipeline `AddUniPlusOpenApi(documentName, configuration)`:**
- `UniPlusOpenApiOptions` (record) — bind de `UniPlus:OpenApi` com validação de URLs absolutas (\`Validate(...).ValidateOnStart()\`).
- `UniPlusInfoTransformer` — title/description pt-BR por módulo, contact CTIC, license MIT, servers Produção/Homologação, versão do contrato V1.
- `UniPlusOperationTransformer` — ações com \`[RequiresIdempotencyKey]\` ganham parameter \`Idempotency-Key\` (header, required) + extension \`x-uniplus-idempotent: true\` (ADR-0027).
- `UniPlusSchemaTransformer` — propriedades \`cpf\` recebem pattern \`^\d{11}$\` + nota PII (ADR-0011). \`code\` de ProblemDetails vive em \`Extensions\` e é validado via rule Spectral (não via transformer).

**Wiring:** `Program.cs` de selecao + ingresso passam a chamar `AddUniPlusOpenApi("selecao"|"ingresso")` + `MapOpenApi("/openapi/{documentName}.json")`.

**Spectral ruleset** (\`tools/spectral/.spectral.yaml\`): extends \`spectral:oas\` (recommended) + 5 rules Uni+:
- pt-BR em \`info.description\` / \`operations.summary\` (heurística de palavras inglesas);
- 4xx/5xx exigem \`application/problem+json\` (RFC 9457);
- exemplos de \`code\` seguem regex \`^[a-z]+(\.[a-z_]+)+$\` (ADR-0023);
- operações \`deprecated\` exigem \`x-sunset\` ISO-8601 (ADR-0028 / RFC 8594);
- POST com \`x-uniplus-idempotent: true\` declara header \`Idempotency-Key\` required (ADR-0027).

**Testes:** 11 unit (Info + Operation transformers) + 1 integration smoke (\`GET /openapi/selecao.json\` verifica metadata injetada).

### Decisões deliberadas

- **\`extends: [[spectral:oas, recommended]]\`** em vez de \`all\`: evita falsos positivos pedantes (\`oas3-valid-media-example\`); \`all\` fica como decisão local de auditoria depois do baseline da Milestone A.
- **\`Validate()\` antes do \`ValidateOnStart()\`**: \`UniPlusOpenApiOptions\` não tem DataAnnotations; sem \`.Validate()\` o \`ValidateOnStart()\` é no-op silencioso.
- **\`code\` removido do schema transformer**: o campo vive em \`ProblemDetails.Extensions\` (\`[JsonExtensionData]\`), não recebe \`JsonPropertyInfo\` nomeado e não é alcançável pelo \`switch (propertyName)\`. Cobertura via rule Spectral.

### Não entra (escopo das próximas stories)

- **CI Spectral** (rodar lint contra o spec) → #290 (junto com baselines em \`contracts/\`).
- **Postman/Newman smoke** → #290.
- **EditalController consumindo o stack** (\`[RequiresIdempotencyKey]\`, content negotiation, cursor) → #291 (pilot integrador).

## Plano de teste

- [x] \`dotnet build UniPlus.slnx --no-incremental\` → 0 warnings, 0 errors
- [x] \`dotnet test tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests --filter "FullyQualifiedName~OpenApi"\` → 11/11
- [x] \`dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests --filter "FullyQualifiedName~OpenApiEndpoint"\` → 1/1 (spec real gerado pelo runtime, validação de info+servers)
- [x] Suíte unit + integration sem regressões
- [ ] CI verde (Build, ADR-lint, forbidden-deps, pr-author-org-member)

Refs ADR-0030, ADR-0027, ADR-0023, ADR-0011, ADR-0028.
Closes #289