### PR TITLE
test(arch): 3 fitness tests do Contrato REST canônico V1 (#291)

### DIFF
--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
@@ -214,11 +214,16 @@ public sealed partial class ContractV1FitnessTestsTests
     [GeneratedRegex(@"new\s+DomainError\(\s*""([^""]+)""", RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
     private static partial Regex DomainErrorCallRegex();
 
-    // Whitelist de assemblies de produção que podem hospedar IDomainErrorRegistration.
-    // Mantém a regex restrita: stubs em Unifesspa.UniPlus.*.UnitTests/IntegrationTests/ArchTests
-    // não casam (terminam em ".Tests" ou similar) e ficam fora do scan.
+    // Whitelist alinhado com a DI graph que Selecao serve em produção.
+    // Inclui Selecao + cross-cutting (Kernel, Application.Abstractions,
+    // Infrastructure.Core), mas NÃO inclui Ingresso — Selecao.API não
+    // registra IngressoDomainErrorRegistration. Sem essa exclusão, em
+    // execução conjunta com Stage1 (que carrega Ingresso para R1), uma
+    // mesma key registrada apenas em Ingresso mascararia gap de Selecao.
+    // Stubs de testes terminam em ".Tests"/".UnitTests"/"ArchTests" e não
+    // casam com a regex.
     [GeneratedRegex(
-        @"^Unifesspa\.UniPlus\.(Kernel|Application\.Abstractions|Infrastructure\.Core|(Selecao|Ingresso)\.(Domain|Application|Infrastructure|API))$",
+        @"^Unifesspa\.UniPlus\.(Kernel|Application\.Abstractions|Infrastructure\.Core|Selecao\.(Domain|Application|Infrastructure|API))$",
         RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
     private static partial Regex ProductionAssemblyRegex();
 }

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
@@ -145,17 +145,23 @@ public sealed partial class ContractV1FitnessTestsTests
 
     private static HashSet<string> LoadRegisteredCodes()
     {
-        // Varre TODOS os assemblies carregados no AppDomain — uma registration
-        // pode acabar em Application, Application.Abstractions, Kernel ou
-        // qualquer assembly futuro. Hardcodar dois assemblies geraria falsos
-        // orphans quando alguém migrar uma registration para outro lugar.
-        // Toca-os primeiro via typeof().Assembly para garantir carga.
-        _ = typeof(IDomainErrorRegistration).Assembly;
-        _ = typeof(API.Controllers.EditalController).Assembly;
+        // Toca os assemblies de produção primeiro para garantir a carga. Sem
+        // estes "touches" a JIT pode não materializar os assemblies no AppDomain
+        // antes do scan.
+        _ = typeof(IDomainErrorRegistration).Assembly; // Infrastructure.Core: kernel + pagination + idempotency
+        _ = typeof(API.Controllers.EditalController).Assembly; // Selecao.API: SelecaoDomainErrorRegistration
+
+        // Whitelist explícito de assemblies de produção. Filtrar por convenção
+        // de nome em vez de scan amplo evita que stubs de testes (tipo
+        // DomainErrorMappingRegistrationStub das unit tests) sejam contados
+        // como cobertura — garante que F1 valida APENAS registrations que o
+        // host Selecao realmente serve em produção.
+        Regex productionAssembly = ProductionAssemblyRegex();
 
         HashSet<string> codes = new(StringComparer.Ordinal);
         IEnumerable<ReflectionType> registrationTypes = AppDomain.CurrentDomain
             .GetAssemblies()
+            .Where(a => a.GetName().Name is { } name && productionAssembly.IsMatch(name))
             .SelectMany(a =>
             {
                 try { return a.GetTypes(); }
@@ -166,13 +172,17 @@ public sealed partial class ContractV1FitnessTestsTests
 
         foreach (ReflectionType type in registrationTypes)
         {
+            // Suporta ctors internal/private (registrations são `internal sealed`).
+            // Se não há ctor default, falha alto: registrations com dependências
+            // requerem DI activation real — atualizar F1 antes de adicionar.
             ConstructorInfo? ctor = type.GetConstructor(
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                 types: []);
-            if (ctor is null)
-                continue;
+            ctor.Should().NotBeNull(
+                $"registration {type.FullName} precisa de constructor sem parâmetros para ser carregada por F1; "
+                    + "se a classe ganhou dependências de DI, atualizar este teste para usar IServiceProvider real.");
 
-            IDomainErrorRegistration instance = (IDomainErrorRegistration)ctor.Invoke(null);
+            IDomainErrorRegistration instance = (IDomainErrorRegistration)ctor!.Invoke(null);
             foreach (KeyValuePair<string, DomainErrorMapping> mapping in instance.GetMappings())
                 codes.Add(mapping.Key);
         }
@@ -203,4 +213,12 @@ public sealed partial class ContractV1FitnessTestsTests
     /// </remarks>
     [GeneratedRegex(@"new\s+DomainError\(\s*""([^""]+)""", RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
     private static partial Regex DomainErrorCallRegex();
+
+    // Whitelist de assemblies de produção que podem hospedar IDomainErrorRegistration.
+    // Mantém a regex restrita: stubs em Unifesspa.UniPlus.*.UnitTests/IntegrationTests/ArchTests
+    // não casam (terminam em ".Tests" ou similar) e ficam fora do scan.
+    [GeneratedRegex(
+        @"^Unifesspa\.UniPlus\.(Kernel|Application\.Abstractions|Infrastructure\.Core|(Selecao|Ingresso)\.(Domain|Application|Infrastructure|API))$",
+        RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex ProductionAssemblyRegex();
 }

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
@@ -1,0 +1,197 @@
+namespace Unifesspa.UniPlus.Selecao.ArchTests;
+
+using System.IO;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Loader;
+using ArchUnitNET.xUnit;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+using ReflectionAssembly = System.Reflection.Assembly;
+using ReflectionType = System.Type;
+
+/// <summary>
+/// Fitness tests do Contrato REST canônico V1 (issue #291). Três regras:
+/// <list type="number">
+///   <item><description>Cobertura do registry — todo <c>code</c> usado em <c>new DomainError("...", ...)</c>
+///   nas camadas Domain e Application está registrado em algum <see cref="IDomainErrorRegistration"/>.</description></item>
+///   <item><description>Direção de dependência — Selecao.Domain e Selecao.Application não dependem de
+///   <c>Microsoft.AspNetCore.*</c> nem de <c>Selecao.API</c>.</description></item>
+///   <item><description>Controllers — tipos em <c>Selecao.API.Controllers</c> não dependem de
+///   <see cref="DomainError"/> diretamente; mapeamento é responsabilidade do <see cref="IDomainErrorMapper"/>.</description></item>
+/// </list>
+/// </summary>
+public sealed partial class ContractV1FitnessTestsTests
+{
+    private static readonly Architecture ModuleArchitecture = LoadModuleArchitecture();
+
+    [Fact(DisplayName = "F1: codes de DomainError em Domain/Application estão registrados em IDomainErrorRegistration")]
+    public void Codes_DeDomainError_EstaoRegistradosNoMapper()
+    {
+        // Coleta source-side: regex sobre os .cs em Domain + Application.
+        // Análise estática (não-runtime) é proposital: muitos codes ficam dentro
+        // de branches conditionals que nunca executariam num teste sem fixture.
+        IReadOnlySet<string> sourceCodes = ScanSourceForDomainErrorCodes(
+            FindRepoSourceDir("src/selecao/Unifesspa.UniPlus.Selecao.Domain"),
+            FindRepoSourceDir("src/selecao/Unifesspa.UniPlus.Selecao.Application"));
+
+        // Coleta registry-side: instancia todas as IDomainErrorRegistration disponíveis
+        // (selecao + cross-cutting) e agrega as keys.
+        IReadOnlySet<string> registeredCodes = LoadRegisteredCodes();
+
+        IEnumerable<string> orphans = sourceCodes.Except(registeredCodes);
+        orphans.Should().BeEmpty(
+            "todo `new DomainError(\"<code>\", ...)` em Domain/Application precisa ter "
+                + "mapeamento em IDomainErrorRegistration; sem registry o mapper devolve "
+                + "500 genérico em vez do ProblemDetails canônico (ADR-0024).");
+    }
+
+    [Fact(DisplayName = "F2: Selecao.Domain e Selecao.Application não dependem de Microsoft.AspNetCore.* nem de Selecao.API")]
+    public void DomainAplication_NaoDependemDeAspNetCore()
+    {
+        IArchRule domainRule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.Domain(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Microsoft\.AspNetCore(\.|$)")
+            .Because("Domain é puro, sem dependência de framework web (ADR-002).");
+
+        IArchRule applicationRule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.Application(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Microsoft\.AspNetCore(\.|$)")
+            .Because("Application orquestra casos de uso e fala com IBus/IRepo — sem ASP.NET Core.");
+
+        domainRule.Check(ModuleArchitecture);
+        applicationRule.Check(ModuleArchitecture);
+    }
+
+    [Fact(DisplayName = "F3: Controllers não dependem de DomainError diretamente — mapeamento é via IDomainErrorMapper")]
+    public void Controllers_NaoDependemDeDomainErrorDiretamente()
+    {
+        IArchRule rule = Types()
+            .That()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.API\.Controllers(\.|$)")
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .Are(typeof(DomainError))
+            .Because("Controllers chamam result.ToActionResult(mapper) — não constroem ProblemDetails do "
+                + "DomainError manualmente. ADR-0024: mapeamento centralizado preserva taxonomia "
+                + "uniplus.<modulo>.<codigo> e status code consistente entre slices.");
+
+        rule.Check(ModuleArchitecture);
+    }
+
+    private static Architecture LoadModuleArchitecture()
+    {
+        // Kernel é incluído explicitamente para que Are(typeof(DomainError)) em
+        // F3 resolva contra o IType correspondente no grafo arquitetural —
+        // sem o Kernel a regra avaliaria zero dependências e passaria de
+        // forma silenciosa.
+        ReflectionAssembly[] assemblies =
+        [
+            typeof(DomainError).Assembly,
+            typeof(Domain.Entities.Edital).Assembly,
+            typeof(Application.Commands.Editais.CriarEditalCommand).Assembly,
+            typeof(Infrastructure.Persistence.SelecaoDbContext).Assembly,
+            typeof(API.Controllers.EditalController).Assembly,
+        ];
+
+        return new ArchLoader().LoadAssemblies(assemblies).Build();
+    }
+
+    private static HashSet<string> ScanSourceForDomainErrorCodes(params string[] roots)
+    {
+        Regex pattern = DomainErrorCallRegex();
+        HashSet<string> codes = new(StringComparer.Ordinal);
+
+        foreach (string root in roots)
+        {
+            foreach (string file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                    || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+                    continue;
+
+                string content = File.ReadAllText(file);
+                foreach (Match match in pattern.Matches(content))
+                    codes.Add(match.Groups[1].Value);
+            }
+        }
+
+        return codes;
+    }
+
+    private static HashSet<string> LoadRegisteredCodes()
+    {
+        // Varre TODOS os assemblies carregados no AppDomain — uma registration
+        // pode acabar em Application, Application.Abstractions, Kernel ou
+        // qualquer assembly futuro. Hardcodar dois assemblies geraria falsos
+        // orphans quando alguém migrar uma registration para outro lugar.
+        // Toca-os primeiro via typeof().Assembly para garantir carga.
+        _ = typeof(IDomainErrorRegistration).Assembly;
+        _ = typeof(API.Controllers.EditalController).Assembly;
+
+        HashSet<string> codes = new(StringComparer.Ordinal);
+        IEnumerable<ReflectionType> registrationTypes = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .SelectMany(a =>
+            {
+                try { return a.GetTypes(); }
+                catch (ReflectionTypeLoadException ex) { return ex.Types.OfType<ReflectionType>(); }
+            })
+            .Where(t => !t.IsAbstract && !t.IsInterface
+                && typeof(IDomainErrorRegistration).IsAssignableFrom(t));
+
+        foreach (ReflectionType type in registrationTypes)
+        {
+            ConstructorInfo? ctor = type.GetConstructor(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                types: []);
+            if (ctor is null)
+                continue;
+
+            IDomainErrorRegistration instance = (IDomainErrorRegistration)ctor.Invoke(null);
+            foreach (KeyValuePair<string, DomainErrorMapping> mapping in instance.GetMappings())
+                codes.Add(mapping.Key);
+        }
+
+        return codes;
+    }
+
+    private static string FindRepoSourceDir(string relativeFromRepoRoot)
+    {
+        // Sobe da pasta do binário até achar o slnx; combinar com o path relativo
+        // garante portabilidade entre máquinas e CI.
+        string? current = AppContext.BaseDirectory;
+        while (current is not null && !File.Exists(Path.Combine(current, "UniPlus.slnx")))
+            current = Path.GetDirectoryName(current);
+
+        if (current is null)
+            throw new DirectoryNotFoundException("UniPlus.slnx não encontrado a partir de AppContext.BaseDirectory.");
+
+        return Path.Combine(current, relativeFromRepoRoot);
+    }
+
+    /// <remarks>
+    /// Detecta APENAS literais inline na construção <c>new DomainError("CODE", ...)</c>.
+    /// Codes vindos de constantes (<c>const string CodNaoEncontrado = "..."</c>),
+    /// interpolação (<c>$"{prefixo}.NaoEncontrado"</c>) ou concatenação escapam
+    /// à detecção. Convenção obrigatória do projeto: o code é sempre literal
+    /// inline — caso contrário F1 deixa de capturar codes órfãos sem aviso.
+    /// </remarks>
+    [GeneratedRegex(@"new\s+DomainError\(\s*""([^""]+)""", RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex DomainErrorCallRegex();
+}

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
@@ -124,6 +124,8 @@ public sealed partial class ContractV1FitnessTestsTests
     private static HashSet<string> ScanSourceForDomainErrorCodes(params string[] roots)
     {
         Regex pattern = DomainErrorCallRegex();
+        Regex blockComment = BlockCommentRegex();
+        Regex lineComment = LineCommentRegex();
         HashSet<string> codes = new(StringComparer.Ordinal);
 
         foreach (string root in roots)
@@ -134,7 +136,17 @@ public sealed partial class ContractV1FitnessTestsTests
                     || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
                     continue;
 
+                // Striping comments antes do match evita falsos positivos quando
+                // alguém menciona `new DomainError("X", ...)` em XML doc, comentário
+                // de exemplo ou linha `//`. AST-correto exigiria Roslyn — strip
+                // simples cobre os casos reais (block + line comments). String
+                // literais que contenham o padrão exato escapariam inner quotes
+                // como `\"`, fazendo o pattern de F1 capturar `\X\` em vez de `X`,
+                // o que não polui o set de orphans.
                 string content = File.ReadAllText(file);
+                content = blockComment.Replace(content, string.Empty);
+                content = lineComment.Replace(content, string.Empty);
+
                 foreach (Match match in pattern.Matches(content))
                     codes.Add(match.Groups[1].Value);
             }
@@ -213,6 +225,12 @@ public sealed partial class ContractV1FitnessTestsTests
     /// </remarks>
     [GeneratedRegex(@"new\s+DomainError\(\s*""([^""]+)""", RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
     private static partial Regex DomainErrorCallRegex();
+
+    [GeneratedRegex(@"/\*[\s\S]*?\*/", RegexOptions.Compiled, matchTimeoutMilliseconds: 2000)]
+    private static partial Regex BlockCommentRegex();
+
+    [GeneratedRegex(@"//[^\n]*", RegexOptions.Compiled, matchTimeoutMilliseconds: 1000)]
+    private static partial Regex LineCommentRegex();
 
     // Whitelist alinhado com a DI graph que Selecao serve em produção.
     // Inclui Selecao + cross-cutting (Kernel, Application.Abstractions,

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs
@@ -58,13 +58,19 @@ public sealed partial class ContractV1FitnessTestsTests
     [Fact(DisplayName = "F2: Selecao.Domain e Selecao.Application não dependem de Microsoft.AspNetCore.* nem de Selecao.API")]
     public void DomainAplication_NaoDependemDeAspNetCore()
     {
+        // Stage1 R3 já banne dependência transitiva Domain/Application → API
+        // dentro do mesmo módulo, mas duplicar aqui torna F2 self-contained
+        // e o display name fiel ao escopo do teste.
         IArchRule domainRule = Types()
             .That()
             .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.Domain(\.|$)")
             .Should()
             .NotDependOnAnyTypesThat()
             .ResideInNamespaceMatching(@"^Microsoft\.AspNetCore(\.|$)")
-            .Because("Domain é puro, sem dependência de framework web (ADR-002).");
+            .AndShould()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.API(\.|$)")
+            .Because("Domain é puro, sem dependência de framework web nem da camada de transporte (ADR-002).");
 
         IArchRule applicationRule = Types()
             .That()
@@ -72,7 +78,10 @@ public sealed partial class ContractV1FitnessTestsTests
             .Should()
             .NotDependOnAnyTypesThat()
             .ResideInNamespaceMatching(@"^Microsoft\.AspNetCore(\.|$)")
-            .Because("Application orquestra casos de uso e fala com IBus/IRepo — sem ASP.NET Core.");
+            .AndShould()
+            .NotDependOnAnyTypesThat()
+            .ResideInNamespaceMatching(@"^Unifesspa\.UniPlus\.Selecao\.API(\.|$)")
+            .Because("Application orquestra casos de uso via IBus/IRepo — sem ASP.NET Core nem tipos da API.");
 
         domainRule.Check(ModuleArchitecture);
         applicationRule.Check(ModuleArchitecture);


### PR DESCRIPTION
## Resumo

Story **#291** (Milestone A do Epic #259 — Contrato REST canônico V1, último piece): 3 fitness tests ArchUnit gating CI.

### O que entra

`tests/Unifesspa.UniPlus.Selecao.ArchTests/ContractV1FitnessTestsTests.cs` (1 arquivo, 197 linhas, 3 testes):

- **F1 — cobertura do registry**: scan regex `new\\s+DomainError\\(\\s*\"([^\"]+)\"` sobre os \`.cs\` em \`Selecao.Domain\` + \`Selecao.Application\`; cruza com agregação reflexiva de **todos** os \`IDomainErrorRegistration\` carregados no AppDomain (kernel, pagination, idempotency, selecao). Falha CI se um \`new DomainError(\"CODE\", ...)\` não estiver mapeado — sem registry o mapper devolve 500 genérico em vez do ProblemDetails canônico (ADR-0024).

- **F2 — direção de dependência**: \`Selecao.Domain\` e \`Selecao.Application\` não dependem de \`Microsoft.AspNetCore.*\`. Fortalece R3 (Stage1) cobrindo dependências de framework web.

- **F3 — controllers sem DomainError direto**: tipos em \`Selecao.API.Controllers\` não dependem de \`DomainError\`; mapeamento obrigatório via \`IDomainErrorMapper\` em \`result.ToActionResult(mapper)\`. Previne shortcuts inline tipo \`BadRequest(new DomainError(...))\` que burlariam taxonomia.

### Por que apenas 3 fitness tests?

EditalController já consome o stack completo desde stories anteriores:
- **#288** (Feature #282): \`[VendorMediaType(\"edital\", v1)]\` em GETs + cursor pagination com \`[FromCursor(\"editais\")]\`.
- **#286** (Feature #280): \`[RequiresIdempotencyKey]\` em \`POST /editais\` e \`POST /editais/{id}/publicar\`.
- **#311** (Feature #282): IDs Guid v7.
- **Codes da taxonomia**: \`SelecaoDomainErrorRegistration\` já lista \`uniplus.selecao.edital.nao_encontrado\`, \`uniplus.selecao.edital.ja_publicado\`, etc. — todos em conformidade com a regex Spectral \`^uniplus(\\.[a-z_]+){2,}$\` (ADR-0023).
- **Rota canônica**: \`api/editais\` (não \`api/v1/editais\`).

A story #291 fecha o ciclo adicionando os gates de regressão que protegem o que já está em produção contra drift futuro.

### Decisões deliberadas (após review pré-commit)

- **Reflective scan over AppDomain.GetAssemblies()** em vez de assemblies hardcoded — registrations futuras em qualquer assembly são detectadas automaticamente.
- **Kernel assembly explicitamente carregado em \`LoadModuleArchitecture\`** — \`Are(typeof(DomainError))\` resolve no grafo arquitetural; sem isso F3 passaria silenciosamente.
- **Convenção de literais inline documentada na regex** — codes de \`DomainError\` são sempre literais inline; constantes/interpolação escapariam ao scan.

## Plano de teste

- [x] \`dotnet build UniPlus.slnx --no-incremental\` → 0 warnings, 0 errors
- [x] \`dotnet test tests/Unifesspa.UniPlus.Selecao.ArchTests --no-build\` → 6/6 (3 originais Stage1 + 3 novos ContractV1)
- [x] Suíte unit + integration sem regressões
- [ ] CI verde (Build, ADR-lint, forbidden-deps, pr-author-org-member)

Closes #291