### PR TITLE
feat(auth): ProblemDetails RFC 9457 em 401/403 via JwtBearer events

### DIFF
--- a/contracts/openapi.ingresso.json
+++ b/contracts/openapi.ingresso.json
@@ -45,7 +45,14 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -70,7 +77,14 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -115,6 +129,44 @@
           "timestamp": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "instance": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -45,7 +45,14 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }
@@ -70,7 +77,14 @@
             }
           },
           "401": {
-            "description": "Unauthorized"
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
         }
       }

--- a/docs/adrs/0034-problemdetails-em-401-403-via-jwtbearer-events.md
+++ b/docs/adrs/0034-problemdetails-em-401-403-via-jwtbearer-events.md
@@ -1,0 +1,102 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0034: ProblemDetails RFC 9457 em 401/403 via `JwtBearerEvents.OnChallenge`/`OnForbidden`
+
+## Contexto e enunciado do problema
+
+[ADR-0023](0023-problemdetails-rfc-9457-canonico-para-todo-erro.md) tornou `application/problem+json` o body canônico de **todo** erro do contrato Uni+. Endpoints de domínio cumpriam o contrato via `Result<T>.ToActionResult(IDomainErrorMapper)`; exceções não tratadas eram convertidas pelo `GlobalExceptionMiddleware`. Ficou descoberto, porém, o caminho mais frequente em produção: **falha de autenticação**.
+
+Endpoints `[Authorize]` (incluindo `/api/auth/me` e `/api/profile/me` no shared kernel, todos os controllers MVC dos módulos) retornavam **401 com body vazio** quando o JWT estava ausente, malformado, expirado ou de issuer/audience inválidos. Razão: o `JwtBearerHandler.HandleChallengeAsync` do ASP.NET Core 10 escreve cabeçalho `WWW-Authenticate`, define status 401 e **finaliza a resposta** antes que `StatusCodePagesMiddleware` ou `ExceptionHandlerMiddleware` (os middlewares que `services.AddProblemDetails()` ativa) tenham chance de agir. Mesma dinâmica para 403 emitido pela `AuthorizationMiddleware` quando o principal está autenticado mas sem permissão.
+
+O Codex P1 do PR #320 sinalizou o débito: o baseline OpenAPI declarava `description: "Unauthorized"` sem `content`, então o linter Spectral aceitava o contrato — mas clientes externos parsing problem+json quebravam ao receber body vazio. Comentário inline em `UniPlusOperationTransformer.cs:84` registrou o follow-up; `contracts/README.md#roadmap` listou-o como item 1.1.
+
+## Drivers da decisão
+
+- **Cumprir ADR-0023 em todos os caminhos de erro do contrato**, sem exceção para auth.
+- **Consistência com clientes gerados** (TypeScript SDK, Postman, Spectral): media type real precisa bater com o declarado no spec.
+- **Não inventar contrato falso no transformer OpenAPI**: o `UniPlusOperationTransformer` só coage `application/json` → `application/problem+json` quando há `content` declarado. Sem solução no runtime, declarar conteúdo no spec geraria divergência runtime/contract.
+- **Reuso entre produção e test host**: o body 401/403 emitido em testes integrados precisa ser byte-equivalente ao de produção, senão regressões passam despercebidas.
+- **LGPD**: nenhum detalhe de validação JWT (claim faltante, valor de token, motivo criptográfico) pode entrar no body — só log estruturado.
+
+## Opções consideradas
+
+- **A. `services.AddProblemDetails()` global, sem hook custom.** Confiar em middlewares default ASP.NET Core para escrever o body em qualquer 4xx/5xx.
+- **B. `JwtBearerEvents.OnChallenge`/`OnForbidden` custom escrevendo via `IProblemDetailsService.WriteAsync`.** Compor handlers que `HandleResponse()` e emitem o body explicitamente.
+- **C. `UseStatusCodePagesWithReExecute("/error/{0}")` + endpoint de erro sintético.** Re-executar o pipeline para status codes não tratados.
+
+## Resultado da decisão
+
+**Escolhida:** "B — `JwtBearerEvents.OnChallenge`/`OnForbidden` custom + `IProblemDetailsService`", porque é a única que efetivamente intercepta o challenge antes da resposta ser finalizada.
+
+[dotnet/aspnetcore#44100](https://github.com/dotnet/aspnetcore/issues/44100) e a documentação oficial confirmam: o `JwtBearerHandler` é um short-circuit selado — `AddProblemDetails` sozinha (Opção A) **não consegue** interceptar challenge, e `UseStatusCodePages` (Opção C) é skipado quando `Response.HasStarted` (que o handler dispara). A única intervenção viável é o evento.
+
+A implementação compõe o evento já existente (`JwtBearerLoggingEvents.WithStructuredLogging`) com o novo `JwtBearerProblemDetailsEvents.WithProblemDetails`, preservando logs estruturados e adicionando o body. O writer compartilhado `AuthenticationProblemDetailsWriter` é usado tanto pela infra produtiva quanto pelo `TestAuthHandler` dos testes integrados — único caminho de produção do payload, zero divergência runtime/test.
+
+`services.AddProblemDetails()` continua registrado: ele provê `IProblemDetailsService` ao DI scope (com `CustomizeProblemDetails` aplicado) que o writer usa via `RequestServices.GetService<IProblemDetailsService>()`. O writer tem fallback manual caso o serviço não esteja registrado — robustez para projetos auxiliares que reusem o helper.
+
+### Type URLs canônicas
+
+| Status | `type` (URL absoluto)                                                       | `code`                            | `title`             |
+| ------ | --------------------------------------------------------------------------- | --------------------------------- | ------------------- |
+| 401    | `https://uniplus.unifesspa.edu.br/errors/uniplus.auth.unauthorized`         | `uniplus.auth.unauthorized`       | `Não autenticado`   |
+| 403    | `https://uniplus.unifesspa.edu.br/errors/uniplus.auth.forbidden`            | `uniplus.auth.forbidden`          | `Acesso negado`     |
+
+Extensions: `code`, `traceId` (extraído do `Activity.Current` ou GUID v7 fallback), `instance` no formato `urn:uuid:<v7>`. Nenhum detalhe da falha de validação JWT é exposto no body.
+
+## Consequências
+
+### Positivas
+
+- Endpoints `[Authorize]` cumprem RFC 9457 sem instrumentação por endpoint — basta declarar `.ProducesProblem(401)` no contrato OpenAPI.
+- Clientes gerados a partir do spec passam a parsear o body corretamente.
+- `UniPlusOperationTransformer` passa a coagir 401/403 para `application/problem+json` consistentemente, eliminando o "follow-up" que pendurava o comportamento.
+- `TestAuthHandler` produz body byte-equivalente ao de produção via `AuthenticationProblemDetailsWriter`, então testes integrados validam o contrato real (pré-existente: status; novo: shape do body).
+
+### Negativas
+
+- O hook custom é mais código a manter do que o caminho default. Mitigação: o hook é uma composição estática isolada (`WithProblemDetails`), sem branch lógica; mudanças futuras de shape passam pelo `AuthenticationProblemDetailsWriter` único.
+- Custo cognitivo: um dev novo pode esperar que `AddProblemDetails()` "funcione" para 401 e descobrir que precisa do hook. Mitigação: comentário inline em `OidcAuthenticationConfiguration` aponta para esta ADR.
+
+### Neutras
+
+- O `UniPlusOperationTransformer` permanece com a lógica defensiva "não inventa content em response vazia": se um endpoint futuro declarar 401 sem `.ProducesProblem`, o spec não mente sobre o body. A regra continua válida.
+
+## Confirmação
+
+- **Testes integrados** (`AuthEndpointsTests`, `ProfileEndpointsTests` em ambos os módulos) verificam status 401 + `Content-Type: application/problem+json` + shape do body (status, type, code, traceId, instance).
+- **Baselines OpenAPI** (`contracts/openapi.{selecao,ingresso}.json`) declaram `application/problem+json` com `$ref ProblemDetails` para os endpoints shared. Drift check em CI falha se o spec gerado divergir.
+- **Spectral** (`uniplus-error-response-uses-problem-details`) valida que toda resposta de erro nos baselines aponta para `application/problem+json`.
+
+## Prós e contras das opções
+
+### A — `AddProblemDetails()` apenas
+
+- Bom, porque é o caminho default documentado pela Microsoft para erros não tratados.
+- Ruim, porque `JwtBearerHandler` short-circuita antes dos middlewares que ele ativa (`StatusCodePagesMiddleware`, `ExceptionHandlerMiddleware`) e o body permanece vazio.
+
+### B — `JwtBearerEvents.OnChallenge`/`OnForbidden` + `IProblemDetailsService`
+
+- Bom, porque é a única intervenção que efetivamente roda antes do response ser finalizado.
+- Bom, porque permite reuso do shape via `AuthenticationProblemDetailsWriter` entre produção e teste.
+- Ruim, porque exige hook explícito por scheme (cada `AddXxxJwt`/scheme adicional precisa do `WithProblemDetails`). Mitigado por compor dentro de `AddOidcAuthentication`.
+
+### C — `UseStatusCodePagesWithReExecute("/error/{0}")`
+
+- Bom em teoria, porque desacopla shape do body do scheme.
+- Ruim, porque `Response.HasStarted == true` quando `JwtBearerHandler` finaliza o challenge, então o middleware de re-execute é skipado — equivalente a A em comportamento.
+- Ruim, porque adiciona endpoint sintético `/error/{statusCode}` ao roteamento, contaminando o spec OpenAPI.
+
+## Mais informações
+
+- [RFC 9457 — Problem Details for HTTP APIs](https://datatracker.ietf.org/doc/html/rfc9457)
+- [Microsoft Learn — Configure JWT bearer authentication (.NET 10)](https://learn.microsoft.com/aspnet/core/security/authentication/configure-jwt-bearer-authentication?view=aspnetcore-10.0)
+- [Microsoft Learn — Handle errors in ASP.NET Core (.NET 10)](https://learn.microsoft.com/aspnet/core/fundamentals/error-handling?view=aspnetcore-10.0#problem-details)
+- [dotnet/aspnetcore#44100 — Write custom authentication failure information to response body](https://github.com/dotnet/aspnetcore/issues/44100)
+- [Andrew Lock — A look behind JwtBearer authentication middleware](https://andrewlock.net/a-look-behind-the-jwt-bearer-authentication-middleware-in-asp-net-core/)
+- [ADR-0023](0023-problemdetails-rfc-9457-canonico-para-todo-erro.md) — ProblemDetails como contrato canônico
+- Origem: follow-up registrado em PR [#320](https://github.com/unifesspa-edu-br/uniplus-api/pull/320) (Codex P1) e [`contracts/README.md#roadmap`](../../contracts/README.md)

--- a/docs/adrs/0034-problemdetails-em-401-403-via-jwtbearer-events.md
+++ b/docs/adrs/0034-problemdetails-em-401-403-via-jwtbearer-events.md
@@ -48,6 +48,10 @@ A implementação compõe o evento já existente (`JwtBearerLoggingEvents.WithSt
 
 Extensions: `code`, `traceId` (extraído do `Activity.Current` ou GUID v7 fallback), `instance` no formato `urn:uuid:<v7>`. Nenhum detalhe da falha de validação JWT é exposto no body.
 
+### Header `WWW-Authenticate` em 401
+
+`HandleResponse()` desliga o caminho default do `JwtBearerHandler`, que normalmente popula `WWW-Authenticate` (RFC 7235 §4.1 e RFC 9110 §11.6.1 exigem o header em toda 401). O `AuthenticationProblemDetailsWriter.WriteUnauthorizedAsync` re-emite `WWW-Authenticate: Bearer` (sem `realm`/`error`/`error_description`) — só o desafio mínimo necessário para conformidade RFC, alinhado com a política de não expor motivo de falha. 403 não recebe o header (não é challenge).
+
 ## Consequências
 
 ### Positivas

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -62,6 +62,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0031](0031-decoding-de-cursor-opaco-no-boundary-http.md) | Decoding de cursor opaco no boundary HTTP, não em handlers de Application | proposed | 2026-05-04 |
 | [0032](0032-guid-v7-para-identidade-de-entidades.md) | Guid v7 (RFC 9562) como identidade de entidades de domínio | accepted | 2026-05-05 |
 | [0033](0033-icurrentuser-abstraction-via-iusercontext.md) | `IUserContext` como abstração canônica para acesso ao principal autenticado | accepted | 2026-05-05 |
+| [0034](0034-problemdetails-em-401-403-via-jwtbearer-events.md) | ProblemDetails RFC 9457 em 401/403 via `JwtBearerEvents.OnChallenge`/`OnForbidden` | accepted | 2026-05-05 |
 
 ## Como adicionar um novo ADR
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/AuthEndpointsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/AuthEndpointsExtensions.cs
@@ -35,7 +35,7 @@ public static class AuthEndpointsExtensions
             .WithSummary("Retorna o usuário autenticado")
             .WithDescription("Retorna informações do usuário extraídas do access token. Requer autenticação.")
             .Produces<AuthenticatedUserResponse>(StatusCodes.Status200OK)
-            .Produces(StatusCodes.Status401Unauthorized);
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         return endpoints;
     }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/AuthenticationProblemDetailsWriter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/AuthenticationProblemDetailsWriter.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 
@@ -35,10 +36,24 @@ public static class AuthenticationProblemDetailsWriter
 
     /// <summary>
     /// Escreve um body 401 problem+json no <paramref name="httpContext"/>.
+    /// Adiciona <c>WWW-Authenticate: Bearer</c> se ausente — RFC 7235 §4.1 e
+    /// RFC 9110 §11.6.1 exigem o header em toda resposta 401.
     /// </summary>
-    public static Task WriteUnauthorizedAsync(HttpContext httpContext) =>
-        WriteAsync(httpContext, StatusCodes.Status401Unauthorized,
+    public static Task WriteUnauthorizedAsync(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        // Sem realm/error/error_description — política Uni+ não expõe motivo
+        // de falha JWT no canal de resposta (LGPD + ADR-0034).
+        if (!httpContext.Response.HasStarted
+            && !httpContext.Response.Headers.ContainsKey(HeaderNames.WWWAuthenticate))
+        {
+            httpContext.Response.Headers.Append(HeaderNames.WWWAuthenticate, "Bearer");
+        }
+
+        return WriteAsync(httpContext, StatusCodes.Status401Unauthorized,
             UnauthorizedCode, UnauthorizedTitle, UnauthorizedDetail);
+    }
 
     /// <summary>
     /// Escreve um body 403 problem+json no <paramref name="httpContext"/>.

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/AuthenticationProblemDetailsWriter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/AuthenticationProblemDetailsWriter.cs
@@ -1,0 +1,104 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Authentication;
+
+using System.Diagnostics;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+
+/// <summary>
+/// Writer compartilhado para respostas <c>application/problem+json</c> originadas
+/// na camada de autenticação/autorização (RFC 9457). Centraliza shape, type URLs e
+/// extensions (<c>code</c>, <c>traceId</c>, <c>instance</c>) para que JwtBearer
+/// (produção) e handlers de teste produzam payloads byte-equivalentes.
+/// </summary>
+public static class AuthenticationProblemDetailsWriter
+{
+    /// <summary>
+    /// Code/title/detail canônicos do 401 emitido pela camada de autenticação.
+    /// </summary>
+    public const string UnauthorizedCode = "uniplus.auth.unauthorized";
+
+    /// <summary>
+    /// Code/title/detail canônicos do 403 emitido pela camada de autorização.
+    /// </summary>
+    public const string ForbiddenCode = "uniplus.auth.forbidden";
+
+    private const string UnauthorizedTitle = "Não autenticado";
+    private const string ForbiddenTitle = "Acesso negado";
+    private const string UnauthorizedDetail =
+        "Requisição requer autenticação válida. Inclua um token Bearer não expirado.";
+    private const string ForbiddenDetail =
+        "Token autenticado, mas sem permissão para acessar este recurso.";
+
+    /// <summary>
+    /// Escreve um body 401 problem+json no <paramref name="httpContext"/>.
+    /// </summary>
+    public static Task WriteUnauthorizedAsync(HttpContext httpContext) =>
+        WriteAsync(httpContext, StatusCodes.Status401Unauthorized,
+            UnauthorizedCode, UnauthorizedTitle, UnauthorizedDetail);
+
+    /// <summary>
+    /// Escreve um body 403 problem+json no <paramref name="httpContext"/>.
+    /// </summary>
+    public static Task WriteForbiddenAsync(HttpContext httpContext) =>
+        WriteAsync(httpContext, StatusCodes.Status403Forbidden,
+            ForbiddenCode, ForbiddenTitle, ForbiddenDetail);
+
+    private static async Task WriteAsync(
+        HttpContext httpContext,
+        int statusCode,
+        string code,
+        string title,
+        string detail)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        if (httpContext.Response.HasStarted)
+            return;
+
+        httpContext.Response.StatusCode = statusCode;
+
+        ProblemDetails problem = new()
+        {
+            Status = statusCode,
+            Type = ProblemDetailsConstants.ErrorsBaseUri + code,
+            Title = title,
+            Detail = detail,
+            Instance = $"urn:uuid:{Guid.CreateVersion7()}",
+        };
+
+        problem.Extensions["code"] = code;
+        problem.Extensions["traceId"] = Activity.Current?.TraceId.ToHexString()
+            ?? Guid.CreateVersion7().ToString("N");
+
+        IProblemDetailsService? service = httpContext.RequestServices
+            .GetService<IProblemDetailsService>();
+
+        if (service is not null)
+        {
+            ProblemDetailsContext problemContext = new()
+            {
+                HttpContext = httpContext,
+                ProblemDetails = problem,
+            };
+
+            if (await service.TryWriteAsync(problemContext).ConfigureAwait(false))
+                return;
+        }
+
+        // Fallback caso AddProblemDetails não tenha sido registrado: escreve
+        // o body manualmente preservando o contrato application/problem+json.
+        // O overload <c>WriteAsJsonAsync&lt;TValue&gt;(response, value, contentType)</c>
+        // é obrigatório aqui — a sobrecarga sem contentType reescreve o header
+        // como "application/json; charset=utf-8" mesmo após Response.ContentType
+        // ter sido setado, quebrando o contrato problem+json.
+        await httpContext.Response.WriteAsJsonAsync(
+                problem,
+                options: (System.Text.Json.JsonSerializerOptions?)null,
+                contentType: "application/problem+json")
+            .ConfigureAwait(false);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/JwtBearerProblemDetailsEvents.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/JwtBearerProblemDetailsEvents.cs
@@ -37,6 +37,10 @@ internal static class JwtBearerProblemDetailsEvents
             if (context.Handled || context.Response.HasStarted)
                 return;
 
+            // HandleResponse desliga o caminho default do JwtBearerHandler,
+            // que normalmente popula WWW-Authenticate. AuthenticationProblemDetailsWriter
+            // re-emite o header (RFC 7235 §4.1 / RFC 9110 §11.6.1 exigem em 401),
+            // alinhado com ADR-0034.
             context.HandleResponse();
             await AuthenticationProblemDetailsWriter
                 .WriteUnauthorizedAsync(context.HttpContext)

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/JwtBearerProblemDetailsEvents.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/JwtBearerProblemDetailsEvents.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Authentication;
+
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+/// <summary>
+/// Composes <see cref="JwtBearerEvents.OnChallenge"/> and
+/// <see cref="JwtBearerEvents.OnForbidden"/> so 401/403 responses carry
+/// <c>application/problem+json</c> bodies (RFC 9457) instead of the
+/// default empty challenge body.
+/// </summary>
+/// <remarks>
+/// The default <see cref="JwtBearerHandler"/> short-circuits the response
+/// before <c>StatusCodePagesMiddleware</c> or <c>ExceptionHandlerMiddleware</c>
+/// can act, so <c>services.AddProblemDetails()</c> alone is not enough.
+/// We hook <c>OnChallenge</c>/<c>OnForbidden</c>, mark the challenge as
+/// handled, and write the body via <see cref="AuthenticationProblemDetailsWriter"/>
+/// so production and test handlers produce byte-equivalent payloads.
+///
+/// Reference: <see href="https://github.com/dotnet/aspnetcore/issues/44100"/>.
+/// </remarks>
+internal static class JwtBearerProblemDetailsEvents
+{
+    /// <summary>
+    /// Wires problem+json writers into the <see cref="JwtBearerEvents.OnChallenge"/>
+    /// and <see cref="JwtBearerEvents.OnForbidden"/> hooks. Existing handlers are
+    /// preserved (composition, not replacement).
+    /// </summary>
+    public static JwtBearerEvents WithProblemDetails(this JwtBearerEvents events)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+
+        Func<JwtBearerChallengeContext, Task> previousChallenge = events.OnChallenge;
+        events.OnChallenge = async context =>
+        {
+            await previousChallenge(context).ConfigureAwait(false);
+
+            if (context.Handled || context.Response.HasStarted)
+                return;
+
+            context.HandleResponse();
+            await AuthenticationProblemDetailsWriter
+                .WriteUnauthorizedAsync(context.HttpContext)
+                .ConfigureAwait(false);
+        };
+
+        Func<ForbiddenContext, Task> previousForbidden = events.OnForbidden;
+        events.OnForbidden = async context =>
+        {
+            await previousForbidden(context).ConfigureAwait(false);
+
+            if (context.Response.HasStarted)
+                return;
+
+            await AuthenticationProblemDetailsWriter
+                .WriteForbiddenAsync(context.HttpContext)
+                .ConfigureAwait(false);
+        };
+
+        return events;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/OidcAuthenticationConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/OidcAuthenticationConfiguration.cs
@@ -70,9 +70,17 @@ public static class OidcAuthenticationConfiguration
                     ClockSkew = auth.ClockSkew,
                 };
 
-                jwtOptions.Events.WithStructuredLogging(
-                    loggerFactory.CreateLogger("Unifesspa.UniPlus.Authentication.JwtBearer"));
+                jwtOptions.Events
+                    .WithStructuredLogging(
+                        loggerFactory.CreateLogger("Unifesspa.UniPlus.Authentication.JwtBearer"))
+                    .WithProblemDetails();
             });
+
+        // IProblemDetailsService disponibiliza `CustomizeProblemDetails` e o
+        // writer único usado pelos hooks de JwtBearer (challenge/forbidden).
+        // Sem este registro, JwtBearerProblemDetailsEvents cai no fallback
+        // manual — funcional, mas sem enriquecimento global.
+        services.AddProblemDetails();
 
         services.AddHttpContextAccessor();
         services.AddScoped<IUserContext, HttpUserContext>();

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusOperationTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusOperationTransformer.cs
@@ -77,11 +77,12 @@ public sealed class UniPlusOperationTransformer : IOpenApiOperationTransformer
             if (kvp.Value is not OpenApiResponse response)
                 continue;
 
-            // Sem content declarado (ex.: JWT challenge 401 que retorna body
-            // vazio), nada para coagir — inventar `application/problem+json`
-            // aqui criaria contrato falso já que o runtime não emite payload.
-            // Endpoints que QUEREM ProblemDetails em 401 precisam de
-            // services.AddProblemDetails() na pipeline (follow-up).
+            // Sem content declarado (raro hoje — JwtBearerProblemDetailsEvents
+            // já emite problem+json em 401/403, e endpoints expressam isso via
+            // .ProducesProblem). Quando ainda assim acontecer, não inventamos
+            // body: escrever `application/problem+json` sobre uma resposta que
+            // o runtime emite vazia geraria contrato falso e clientes
+            // gerados rejeitariam o 401 real.
             if (response.Content is null || response.Content.Count == 0)
                 continue;
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Profile/ProfileEndpointsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Profile/ProfileEndpointsExtensions.cs
@@ -38,7 +38,7 @@ public static class ProfileEndpointsExtensions
             .WithSummary("Retorna o perfil do usuário autenticado")
             .WithDescription("Retorna atributos de identidade e institucionais (CPF, NomeSocial) extraídos do access token. Requer autenticação.")
             .Produces<UserProfileResponse>(StatusCodes.Status200OK)
-            .Produces(StatusCodes.Status401Unauthorized);
+            .ProducesProblem(StatusCodes.Status401Unauthorized);
 
         return endpoints;
     }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/AuthenticationProblemDetailsWriterTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/AuthenticationProblemDetailsWriterTests.cs
@@ -52,6 +52,37 @@ public sealed class AuthenticationProblemDetailsWriterTests
     }
 
     [Fact]
+    public async Task WriteUnauthorizedAsync_Should_Append_WwwAuthenticate_Bearer()
+    {
+        DefaultHttpContext context = CreateHttpContext(includeProblemDetailsService: true);
+
+        await AuthenticationProblemDetailsWriter.WriteUnauthorizedAsync(context);
+
+        context.Response.Headers.WWWAuthenticate.ToString().Should().Be("Bearer");
+    }
+
+    [Fact]
+    public async Task WriteUnauthorizedAsync_Should_Not_Duplicate_WwwAuthenticate_When_Already_Set()
+    {
+        DefaultHttpContext context = CreateHttpContext(includeProblemDetailsService: true);
+        context.Response.Headers.Append("WWW-Authenticate", "Bearer realm=\"uniplus\"");
+
+        await AuthenticationProblemDetailsWriter.WriteUnauthorizedAsync(context);
+
+        context.Response.Headers.WWWAuthenticate.ToString().Should().Be("Bearer realm=\"uniplus\"");
+    }
+
+    [Fact]
+    public async Task WriteForbiddenAsync_Should_Not_Append_WwwAuthenticate()
+    {
+        DefaultHttpContext context = CreateHttpContext(includeProblemDetailsService: true);
+
+        await AuthenticationProblemDetailsWriter.WriteForbiddenAsync(context);
+
+        context.Response.Headers.WWWAuthenticate.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task WriteUnauthorizedAsync_Should_Be_NoOp_When_Response_Has_Started()
     {
         DefaultHttpContext context = CreateHttpContext(includeProblemDetailsService: true);

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/AuthenticationProblemDetailsWriterTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/AuthenticationProblemDetailsWriterTests.cs
@@ -1,0 +1,114 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Authentication;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
+
+public sealed class AuthenticationProblemDetailsWriterTests
+{
+    [Fact]
+    public async Task WriteUnauthorizedAsync_Should_Emit_ProblemJson_With_Canonical_Shape()
+    {
+        DefaultHttpContext context = CreateHttpContext(includeProblemDetailsService: true);
+
+        await AuthenticationProblemDetailsWriter.WriteUnauthorizedAsync(context);
+
+        await AssertProblemDetailsAsync(
+            context,
+            expectedStatus: StatusCodes.Status401Unauthorized,
+            expectedCode: AuthenticationProblemDetailsWriter.UnauthorizedCode);
+    }
+
+    [Fact]
+    public async Task WriteForbiddenAsync_Should_Emit_ProblemJson_With_Canonical_Shape()
+    {
+        DefaultHttpContext context = CreateHttpContext(includeProblemDetailsService: true);
+
+        await AuthenticationProblemDetailsWriter.WriteForbiddenAsync(context);
+
+        await AssertProblemDetailsAsync(
+            context,
+            expectedStatus: StatusCodes.Status403Forbidden,
+            expectedCode: AuthenticationProblemDetailsWriter.ForbiddenCode);
+    }
+
+    [Fact]
+    public async Task WriteUnauthorizedAsync_Fallback_Should_Set_ProblemJson_ContentType()
+    {
+        // Sem IProblemDetailsService no DI — caminho de fallback manual.
+        // Sentinela contra o overload de WriteAsJsonAsync que reescreve
+        // Content-Type para "application/json; charset=utf-8".
+        DefaultHttpContext context = CreateHttpContext(includeProblemDetailsService: false);
+
+        await AuthenticationProblemDetailsWriter.WriteUnauthorizedAsync(context);
+
+        context.Response.ContentType.Should().StartWith("application/problem+json");
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Fact]
+    public async Task WriteUnauthorizedAsync_Should_Be_NoOp_When_Response_Has_Started()
+    {
+        DefaultHttpContext context = CreateHttpContext(includeProblemDetailsService: true);
+        context.Response.StatusCode = StatusCodes.Status200OK;
+        StartedResponseFeature feature = new();
+        context.Features.Set<Microsoft.AspNetCore.Http.Features.IHttpResponseFeature>(feature);
+
+        await AuthenticationProblemDetailsWriter.WriteUnauthorizedAsync(context);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    private static DefaultHttpContext CreateHttpContext(bool includeProblemDetailsService)
+    {
+        ServiceCollection services = new();
+        services.AddOptions();
+        services.AddLogging();
+        if (includeProblemDetailsService)
+            services.AddProblemDetails();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        DefaultHttpContext context = new()
+        {
+            RequestServices = provider,
+        };
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static async Task AssertProblemDetailsAsync(
+        HttpContext context,
+        int expectedStatus,
+        string expectedCode)
+    {
+        context.Response.StatusCode.Should().Be(expectedStatus);
+        context.Response.ContentType.Should().StartWith("application/problem+json");
+
+        context.Response.Body.Position = 0;
+        using JsonDocument doc = await JsonDocument.ParseAsync(context.Response.Body);
+        JsonElement root = doc.RootElement;
+
+        root.GetProperty("status").GetInt32().Should().Be(expectedStatus);
+        root.GetProperty("type").GetString()
+            .Should().Be($"https://uniplus.unifesspa.edu.br/errors/{expectedCode}");
+        root.GetProperty("code").GetString().Should().Be(expectedCode);
+        root.GetProperty("traceId").GetString().Should().NotBeNullOrWhiteSpace();
+        root.GetProperty("instance").GetString().Should().StartWith("urn:uuid:");
+    }
+
+    private sealed class StartedResponseFeature : Microsoft.AspNetCore.Http.Features.IHttpResponseFeature
+    {
+        public int StatusCode { get; set; } = StatusCodes.Status200OK;
+        public string? ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public Stream Body { get; set; } = Stream.Null;
+        public bool HasStarted => true;
+        public void OnStarting(Func<object, Task> callback, object state) { }
+        public void OnCompleted(Func<object, Task> callback, object state) { }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/AuthEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/AuthEndpointsTests.cs
@@ -43,6 +43,8 @@ public sealed class AuthEndpointsTests : IClassFixture<IngressoApiFactory>
     {
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        response.Headers.WwwAuthenticate.Should().NotBeEmpty();
+        response.Headers.WwwAuthenticate.First().Scheme.Should().Be("Bearer");
 
         using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
         JsonElement root = payload.RootElement;

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/AuthEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/AuthEndpointsTests.cs
@@ -17,17 +17,17 @@ public sealed class AuthEndpointsTests : IClassFixture<IngressoApiFactory>
     public AuthEndpointsTests(IngressoApiFactory factory) => _factory = factory;
 
     [Fact]
-    public async Task GetMe_ShouldReturnUnauthorized_WhenRequestDoesNotHaveToken()
+    public async Task GetMe_ShouldReturnProblemDetails_WhenRequestDoesNotHaveToken()
     {
         using HttpClient client = _factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(GetMeUri);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await AssertUnauthorizedProblemDetails(response);
     }
 
     [Fact]
-    public async Task GetMe_ShouldReturnUnauthorized_WhenTokenIsInvalid()
+    public async Task GetMe_ShouldReturnProblemDetails_WhenTokenIsInvalid()
     {
         using HttpClient client = _factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
@@ -36,7 +36,24 @@ public sealed class AuthEndpointsTests : IClassFixture<IngressoApiFactory>
 
         HttpResponseMessage response = await client.GetAsync(GetMeUri);
 
+        await AssertUnauthorizedProblemDetails(response);
+    }
+
+    private static async Task AssertUnauthorizedProblemDetails(HttpResponseMessage response)
+    {
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        JsonElement root = payload.RootElement;
+
+        root.GetProperty("status").GetInt32().Should().Be(401);
+        root.GetProperty("type").GetString()
+            .Should().Be("https://uniplus.unifesspa.edu.br/errors/uniplus.auth.unauthorized");
+        root.GetProperty("title").GetString().Should().Be("Não autenticado");
+        root.GetProperty("code").GetString().Should().Be("uniplus.auth.unauthorized");
+        root.GetProperty("traceId").GetString().Should().NotBeNullOrWhiteSpace();
+        root.GetProperty("instance").GetString().Should().StartWith("urn:uuid:");
     }
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/ProfileEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/ProfileEndpointsTests.cs
@@ -17,13 +17,22 @@ public sealed class ProfileEndpointsTests : IClassFixture<IngressoApiFactory>
     public ProfileEndpointsTests(IngressoApiFactory factory) => _factory = factory;
 
     [Fact]
-    public async Task GetMe_ShouldReturnUnauthorized_WhenRequestDoesNotHaveToken()
+    public async Task GetMe_ShouldReturnProblemDetails_WhenRequestDoesNotHaveToken()
     {
         using HttpClient client = _factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(GetMeUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        JsonElement root = payload.RootElement;
+
+        root.GetProperty("status").GetInt32().Should().Be(401);
+        root.GetProperty("type").GetString()
+            .Should().Be("https://uniplus.unifesspa.edu.br/errors/uniplus.auth.unauthorized");
+        root.GetProperty("code").GetString().Should().Be("uniplus.auth.unauthorized");
     }
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Authentication/TestAuthHandler.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Authentication/TestAuthHandler.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
+using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
+
 /// <summary>
 /// Authentication handler for integration tests. Accepts a fixed bearer token
 /// and builds a <see cref="ClaimsPrincipal"/> from request headers so tests can
@@ -77,6 +79,22 @@ public sealed class TestAuthHandler : AuthenticationHandler<AuthenticationScheme
 
         return Task.FromResult(AuthenticateResult.Success(ticket));
     }
+
+    /// <summary>
+    /// Espelha o body problem+json emitido pelo JwtBearer em produção (ver
+    /// <see cref="AuthenticationProblemDetailsWriter"/>). Sem este override o
+    /// handler base só seta status 401 com body vazio, divergindo do contrato
+    /// real e mascarando regressões em testes de integração.
+    /// </summary>
+    protected override Task HandleChallengeAsync(AuthenticationProperties properties) =>
+        AuthenticationProblemDetailsWriter.WriteUnauthorizedAsync(Context);
+
+    /// <summary>
+    /// Espelha o body problem+json emitido pelo JwtBearer em produção quando a
+    /// AuthorizationMiddleware nega acesso a um principal autenticado.
+    /// </summary>
+    protected override Task HandleForbiddenAsync(AuthenticationProperties properties) =>
+        AuthenticationProblemDetailsWriter.WriteForbiddenAsync(Context);
 
     private string GetHeaderValue(string headerName, string fallbackValue)
     {

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj
@@ -24,4 +24,12 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      TestAuthHandler reutiliza AuthenticationProblemDetailsWriter do código produtivo
+      para emitir o mesmo body problem+json (RFC 9457) em 401/403 dentro do test host.
+    -->
+    <ProjectReference Include="..\..\src\shared\Unifesspa.UniPlus.Infrastructure.Core\Unifesspa.UniPlus.Infrastructure.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/AuthEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/AuthEndpointsTests.cs
@@ -17,17 +17,17 @@ public sealed class AuthEndpointsTests : IClassFixture<SelecaoApiFactory>
     public AuthEndpointsTests(SelecaoApiFactory factory) => _factory = factory;
 
     [Fact]
-    public async Task GetMe_ShouldReturnUnauthorized_WhenRequestDoesNotHaveToken()
+    public async Task GetMe_ShouldReturnProblemDetails_WhenRequestDoesNotHaveToken()
     {
         using HttpClient client = _factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(GetMeUri);
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        await AssertUnauthorizedProblemDetails(response);
     }
 
     [Fact]
-    public async Task GetMe_ShouldReturnUnauthorized_WhenTokenIsInvalid()
+    public async Task GetMe_ShouldReturnProblemDetails_WhenTokenIsInvalid()
     {
         using HttpClient client = _factory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
@@ -36,7 +36,24 @@ public sealed class AuthEndpointsTests : IClassFixture<SelecaoApiFactory>
 
         HttpResponseMessage response = await client.GetAsync(GetMeUri);
 
+        await AssertUnauthorizedProblemDetails(response);
+    }
+
+    private static async Task AssertUnauthorizedProblemDetails(HttpResponseMessage response)
+    {
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        JsonElement root = payload.RootElement;
+
+        root.GetProperty("status").GetInt32().Should().Be(401);
+        root.GetProperty("type").GetString()
+            .Should().Be("https://uniplus.unifesspa.edu.br/errors/uniplus.auth.unauthorized");
+        root.GetProperty("title").GetString().Should().Be("Não autenticado");
+        root.GetProperty("code").GetString().Should().Be("uniplus.auth.unauthorized");
+        root.GetProperty("traceId").GetString().Should().NotBeNullOrWhiteSpace();
+        root.GetProperty("instance").GetString().Should().StartWith("urn:uuid:");
     }
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/AuthEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/AuthEndpointsTests.cs
@@ -43,6 +43,8 @@ public sealed class AuthEndpointsTests : IClassFixture<SelecaoApiFactory>
     {
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+        response.Headers.WwwAuthenticate.Should().NotBeEmpty();
+        response.Headers.WwwAuthenticate.First().Scheme.Should().Be("Bearer");
 
         using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
         JsonElement root = payload.RootElement;

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProfileEndpointsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProfileEndpointsTests.cs
@@ -17,13 +17,22 @@ public sealed class ProfileEndpointsTests : IClassFixture<SelecaoApiFactory>
     public ProfileEndpointsTests(SelecaoApiFactory factory) => _factory = factory;
 
     [Fact]
-    public async Task GetMe_ShouldReturnUnauthorized_WhenRequestDoesNotHaveToken()
+    public async Task GetMe_ShouldReturnProblemDetails_WhenRequestDoesNotHaveToken()
     {
         using HttpClient client = _factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(GetMeUri);
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        using JsonDocument payload = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        JsonElement root = payload.RootElement;
+
+        root.GetProperty("status").GetInt32().Should().Be(401);
+        root.GetProperty("type").GetString()
+            .Should().Be("https://uniplus.unifesspa.edu.br/errors/uniplus.auth.unauthorized");
+        root.GetProperty("code").GetString().Should().Be("uniplus.auth.unauthorized");
     }
 
     [Fact]


### PR DESCRIPTION
## Resumo

Endpoints `[Authorize]` (incluindo `/api/auth/me` e `/api/profile/me`) passam a retornar `application/problem+json` em 401/403, eliminando o débito do PR #320 (Codex P1) e alinhando o caminho de auth com [ADR-0023](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0023-problemdetails-rfc-9457-canonico-para-todo-erro.md).

`JwtBearerHandler` finaliza a resposta antes que `StatusCodePagesMiddleware` ou `ExceptionHandlerMiddleware` rodem, então `services.AddProblemDetails()` sozinho não cobre o challenge — a única intervenção viável é compor `JwtBearerEvents.OnChallenge` e `OnForbidden` chamando `IProblemDetailsService.WriteAsync` (ver [ADR-0034](docs/adrs/0034-problemdetails-em-401-403-via-jwtbearer-events.md) nesta PR e [dotnet/aspnetcore#44100](https://github.com/dotnet/aspnetcore/issues/44100)).

## Mudanças principais

- `AuthenticationProblemDetailsWriter` — writer compartilhado entre produção (JwtBearer) e test host (`TestAuthHandler`), garantindo body byte-equivalente. Type URLs canônicas `uniplus.auth.unauthorized`/`uniplus.auth.forbidden`. Fallback manual com `contentType` explícito (overload de `WriteAsJsonAsync` sem `contentType` reescreve o header — sentinela coberta por unit test).
- `JwtBearerProblemDetailsEvents.WithProblemDetails(events)` — extensão internal que compõe `OnChallenge`/`OnForbidden` preservando handler anterior.
- `OidcAuthenticationConfiguration` — encadeia `WithStructuredLogging().WithProblemDetails()` e registra `services.AddProblemDetails()`.
- `TestAuthHandler` overrides `HandleChallengeAsync`/`HandleForbiddenAsync` chamando o mesmo writer; testes integrados validam o body real.
- `Auth/ProfileEndpointsExtensions` — `.Produces(401)` → `.ProducesProblem(401)`.
- Baselines `contracts/openapi.{selecao,ingresso}.json` regeneradas: 401 dos endpoints shared declara `application/problem+json` com `\$ref ProblemDetails`.
- `ADR-0034` em `accepted` documentando a decisão e alternativas A/B/C.

## Test plan

- [x] `dotnet build UniPlus.slnx --no-incremental -v quiet` → 0 warnings, 0 errors
- [x] `dotnet test UniPlus.slnx --no-build` → 0 falhas (414 testes)
- [x] `bash tools/adr-lint/validate.sh` → 34 ADRs validados
- [x] Spectral lint dos baselines: 0 errors
- [x] Drift check OpenAPI passa nas baselines regeneradas
- [x] Pre-commit code review (feature-dev:code-reviewer): APROVADO com P2 corrigido (fallback path)
- [ ] CI verde
- [ ] Codex review

Closes #321