### PR TITLE
test(arch): cross-module fitness test para schemas OpenAPI duplicados

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -40,7 +40,7 @@ Os arquivos `contracts/openapi.{selecao,ingresso}.json` são reescritos. **Revis
 
 Itens originalmente listados em #290 que ficam para próximos PRs (mantém este reviewable):
 
-- `contracts/shared.openapi.json` declarando ProblemDetails, Cursor, `_links`, paginação envelopes via `$ref`.
+- ~~`contracts/shared.openapi.json` declarando ProblemDetails, Cursor, `_links`, paginação envelopes via `$ref`.~~ Resolvido por [ADR-0035](../docs/adrs/0035-shared-schemas-cross-module-fitness-test.md): Microsoft.AspNetCore.OpenApi 10 não suporta `$ref` cross-document, e Redocly post-process é desproporcional para 3 schemas duplicados. Em vez disso, `OpenApiSharedSchemasInSyncTests` (`tests/Unifesspa.UniPlus.ArchTests/SolutionRules/`) faz fitness check byte-a-byte dos schemas com mesmo nome em baselines diferentes. Reavaliar quando ≥10 schemas compartilhados, terceiro módulo, ou portal `uniplus-developers` demandar multi-file.
 - `contracts/postman/uniplus-api.postman_collection.json` com cenários smoke (criar edital com Idempotency-Key, listar com cursor, 406 vendor MIME inexistente, 422 validation).
 - Newman em CI rodando contra a API em container — exige docker-compose com Postgres/Kafka/MinIO/Keycloak.
 

--- a/docs/adrs/0035-shared-schemas-cross-module-fitness-test.md
+++ b/docs/adrs/0035-shared-schemas-cross-module-fitness-test.md
@@ -1,0 +1,131 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0035: Schemas duplicados entre baselines OpenAPI — fitness test cross-module no lugar de `$ref` multi-arquivo
+
+## Contexto e enunciado do problema
+
+Os baselines `contracts/openapi.selecao.json` e `contracts/openapi.ingresso.json` (ADR-0030) duplicam schemas idênticos vindos do shared kernel:
+
+- `ProblemDetails` (RFC 9457, ADR-0023)
+- `AuthenticatedUserResponse` (`/api/auth/me`, exposto por `MapSharedAuthEndpoints`)
+- `UserProfileResponse` (`/api/profile/me`, exposto por `MapSharedProfileEndpoints`)
+
+A geração runtime (`Microsoft.AspNetCore.OpenApi` 10) emite cada documento independentemente — a partir das mesmas classes C#, mas serializadas inline em cada spec. O drift check existente (`OpenApiEndpointTests` em cada módulo) protege cada baseline contra divergir do runtime do **mesmo módulo**, mas **não detecta divergência cross-module**: alguém pode mudar `AuthenticatedUserResponse` em código + regenerar só `openapi.selecao.json` e o `openapi.ingresso.json` ficaria stale sem alarme até a próxima rodada de regeneração.
+
+A pergunta: deduplicar via `$ref` cross-document (`shared.openapi.json#/components/schemas/ProblemDetails`) ou aceitar a duplicação inline com gating de drift cross-module?
+
+## Drivers da decisão
+
+- **ADR-0030 invariant:** o runtime é a fonte de verdade do contrato. Qualquer mecanismo de deduplicação não pode quebrar o drift check baseline-vs-runtime.
+- **Custo de tooling:** introduzir `$ref` multi-arquivo exige Redocly CLI (Node.js) ou similar como dep de build/CI. Para 3 schemas duplicados de ~10-30 LOC cada (total ~80 LOC), o ROI é negativo hoje.
+- **Compatibilidade com codegens:** `openapi-generator`, `NSwag`, `Kiota` preferem specs **flat** (sem `$ref` cross-file). Stripe e GitHub publicam **bundled** mesmo autorando multi-file — a multi-file é benefício de autoria, não de consumo.
+- **`Microsoft.AspNetCore.OpenApi` 10:** **não suporta** `$ref` cross-document nativo. `CreateSchemaReferenceId` controla apenas o id intra-document; bugs abertos em [aspnetcore#63090](https://github.com/dotnet/aspnetcore/issues/63090) e [#60164](https://github.com/dotnet/aspnetcore/issues/60164) confirmam que o foco do time é correção de `$ref` intra-document.
+- **Risco real concreto:** divergência cross-module silenciosa, não tamanho do arquivo. O risco é endereçável sem multi-file.
+
+## Opções consideradas
+
+- **A. Aceitar duplicação como tech debt sem ação.** Status quo.
+- **B. Post-processar baselines via Redocly `bundle`/`split` em build step.** Runtime emite inline; pipeline extrai shared schemas e re-injeta `$ref`.
+- **C. Aceitar duplicação inline + adicionar fitness test cross-module verificando byte-equality dos schemas com mesmo nome.** Sem novo tooling.
+- **D. Manter `shared.openapi.json` companion publicado em paralelo (não substitui inline).** Documentação adicional para `uniplus-developers` portal.
+
+## Resultado da decisão
+
+**Escolhida:** "C — fitness test cross-module", porque é a única opção que (1) preserva o runtime-first invariant da ADR-0030 sem mudanças, (2) custa um único arquivo C# de teste sem dependência de Node.js, e (3) detecta exatamente o risco que importa hoje (divergência silenciosa cross-module).
+
+A opção A foi rejeitada porque deixa o risco descoberto. A opção B foi rejeitada por desproporcionalidade — Redocly em CI é a estratégia da indústria quando há ≥10 specs ou ≥dezenas de schemas compartilhados (Stripe, GitHub), não quando há 3. A opção D pode ser somada à C numa iteração futura quando o `uniplus-developers` portal demandar (ver _trigger de reavaliação_ abaixo); ela não substitui a fitness test.
+
+### Forma do contrato
+
+`OpenApiSharedSchemasInSyncTests` em `tests/Unifesspa.UniPlus.ArchTests/SolutionRules/`:
+
+```csharp
+[Fact(DisplayName = "ADR-0035: schemas com mesmo nome em baselines diferentes são byte-equivalentes")]
+public void Schemas_Compartilhados_Devem_Ser_ByteEquivalentes()
+{
+    // 1. Carrega contracts/openapi.{selecao,ingresso}.json
+    // 2. Calcula intersection de nomes em components.schemas
+    // 3. Asserts byte-equivalência com SerializeCanonical (WriteIndented = true)
+    // 4. Mensagem inclui o comando de fix (UPDATE_OPENAPI_BASELINE=1 …)
+}
+```
+
+A intersection é computada dinamicamente — a regra captura schemas adicionais sem mudança de código quando o time mover novos tipos para shared (Cursor envelopes, `_links`, paginated responses).
+
+### Trigger de reavaliação
+
+Promover para opção B (Redocly post-process) quando **ao menos um** dos seguintes acontecer:
+
+- `uniplus-developers` portal entregue e demandando spec multi-file para documentação canônica
+- ≥10 schemas compartilhados entre módulos (limiar de complexidade onde tooling paga o overhead)
+- Integradores externos pedindo formato multi-file
+- Surgir terceiro módulo (ex.: `recursos`, `homologacao`) — multiplicidade quadruplica o risco de drift e provavelmente justifica `$ref` companion
+
+Ao promover, **adicionar** Redocly em build step; **não remover** o fitness test cross-module — ele continua útil como sentinela do `bundle` output.
+
+## Consequências
+
+### Positivas
+
+- Risco de drift cross-module endereçado por uma ferramenta C# nativa, sem aumentar a superfície de tooling do projeto.
+- Mensagem de erro do teste é actionable — aponta o módulo stale e o comando de fix.
+- Regra captura schemas futuros automaticamente (intersection dinâmica).
+- ADR-0030 (runtime-first) permanece intocada — o spec emitido continua sendo a única fonte de verdade.
+
+### Negativas
+
+- A duplicação de bytes nos baselines persiste. Para review humano de PR, schemas idênticos aparecem em dois lugares — ruído visual.
+- Codegens externos não ganham reuso semântico (mas também não perdem nada — eles ignoram `$ref` cross-file de qualquer forma).
+- O fitness test compara apenas componentes registrados em `components.schemas`. Schemas inline em `responses.<status>.content` (caso o runtime regrida no future) não são detectados.
+
+### Neutras
+
+- Decisão é reversível. Promover para Opção B no trigger acima é incremento, não breaking change.
+
+## Confirmação
+
+- `OpenApiSharedSchemasInSyncTests.Schemas_Compartilhados_Devem_Ser_ByteEquivalentes` — 1 fact, roda na pipeline `dotnet test UniPlus.slnx` em CI.
+- Validação por prova negativa durante implementação: alterar manualmente `ProblemDetails.title.type` em um dos baselines fez o teste falhar com mensagem clara.
+- `contracts/README.md#roadmap` atualizado: item "shared.openapi.json com `$ref`" substituído por referência a esta ADR.
+
+## Prós e contras das opções
+
+### A — Aceitar duplicação sem ação
+
+- Bom, porque é zero-cost.
+- Ruim, porque o risco de drift cross-module fica descoberto.
+
+### B — Redocly `bundle`/`split` em CI
+
+- Bom, porque alinha com a estratégia da indústria (Stripe, GitHub) para specs multi-arquivo.
+- Bom, porque emite `shared.openapi.json` consumível pelo portal de devs.
+- Ruim, porque adiciona dep Node.js em CI + step de build + risco de pipeline brittle (reportes de race em [Spectral#2640](https://github.com/stoplightio/spectral/issues/2640)) para um problema que ainda não materializou.
+
+### C — Fitness test cross-module (escolhida)
+
+- Bom, porque é proporcional ao risco real e mantém o runtime-first.
+- Bom, porque captura novos schemas compartilhados sem mudança de código.
+- Ruim, porque não elimina a duplicação visual nos baselines.
+
+### D — `shared.openapi.json` companion publicado em paralelo
+
+- Bom, porque dá documentação centralizada para o portal de devs.
+- Ruim, porque exige sincronização manual ou geração — soma overhead sem resolver o risco de drift sozinho.
+
+Combinável com C numa iteração futura.
+
+## Mais informações
+
+- [ADR-0023 — ProblemDetails RFC 9457 canônico](0023-problemdetails-rfc-9457-canonico-para-todo-erro.md)
+- [ADR-0030 — OpenAPI 3.1 contract-first via Microsoft.AspNetCore.OpenApi](0030-openapi-3-1-contract-first-microsoft-aspnetcore-openapi.md)
+- [Microsoft.AspNetCore.OpenApi customization (.NET 10)](https://learn.microsoft.com/aspnet/core/fundamentals/openapi/customize-openapi?view=aspnetcore-10.0)
+- [aspnetcore#63090 — invalid schema references](https://github.com/dotnet/aspnetcore/issues/63090)
+- [Redocly CLI — bundle/split](https://redocly.com/docs/cli/commands/bundle)
+- [GitHub rest-api-description (Redocly + multi-file → bundled)](https://github.com/github/rest-api-description)
+- [Stripe openapi (publica bundled flat)](https://github.com/stripe/openapi)
+- Origem: follow-up Frente 1.2 do plano `~/.claude/plans/uniplus-api-backend-followups-cleanup.md`; issue [#323](https://github.com/unifesspa-edu-br/uniplus-api/issues/323)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -63,6 +63,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0032](0032-guid-v7-para-identidade-de-entidades.md) | Guid v7 (RFC 9562) como identidade de entidades de domínio | accepted | 2026-05-05 |
 | [0033](0033-icurrentuser-abstraction-via-iusercontext.md) | `IUserContext` como abstração canônica para acesso ao principal autenticado | accepted | 2026-05-05 |
 | [0034](0034-problemdetails-em-401-403-via-jwtbearer-events.md) | ProblemDetails RFC 9457 em 401/403 via `JwtBearerEvents.OnChallenge`/`OnForbidden` | accepted | 2026-05-05 |
+| [0035](0035-shared-schemas-cross-module-fitness-test.md) | Schemas duplicados entre baselines OpenAPI — fitness test cross-module no lugar de `$ref` multi-arquivo | accepted | 2026-05-05 |
 
 ## Como adicionar um novo ADR
 

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/DominioNaoUsaGuidNewGuidTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/DominioNaoUsaGuidNewGuidTests.cs
@@ -5,6 +5,8 @@ using System.Text.RegularExpressions;
 
 using AwesomeAssertions;
 
+using TestSupport;
+
 /// <summary>
 /// Fitness function da ADR-0032: identidade de entidades de domínio é gerada
 /// via <see cref="System.Guid.CreateVersion7()"/> (UUID v7), nunca
@@ -28,7 +30,7 @@ public sealed partial class DominioNaoUsaGuidNewGuidTests
     [Fact(DisplayName = "ADR-0032: nenhum arquivo .cs em *.Domain chama Guid.NewGuid()")]
     public void Dominio_NaoChama_GuidNewGuid()
     {
-        string solutionRoot = LocateSolutionRoot();
+        string solutionRoot = SolutionRootLocator.Locate();
         string[] domainSourceRoots =
         [
             Path.Combine(solutionRoot, "src", "shared", "Unifesspa.UniPlus.Kernel"),
@@ -108,19 +110,4 @@ public sealed partial class DominioNaoUsaGuidNewGuidTests
             $"Violações encontradas:\n  - {string.Join("\n  - ", violations)}");
     }
 
-    private static string LocateSolutionRoot()
-    {
-        // Sobe a partir do AppContext.BaseDirectory até encontrar UniPlus.slnx.
-        // Resiliente a mudanças de target framework e path do bin.
-        string current = AppContext.BaseDirectory;
-        while (!string.IsNullOrEmpty(current))
-        {
-            if (File.Exists(Path.Combine(current, "UniPlus.slnx")))
-                return current;
-            current = Directory.GetParent(current)?.FullName ?? string.Empty;
-        }
-
-        throw new DirectoryNotFoundException(
-            "UniPlus.slnx não encontrado a partir de AppContext.BaseDirectory; estrutura do repositório alterada?");
-    }
 }

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/OpenApiSharedSchemasInSyncTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/OpenApiSharedSchemasInSyncTests.cs
@@ -1,0 +1,115 @@
+namespace Unifesspa.UniPlus.ArchTests.SolutionRules;
+
+using System.IO;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using TestSupport;
+
+/// <summary>
+/// Fitness function da ADR-0035: schemas duplicados entre baselines OpenAPI
+/// dos módulos (<c>contracts/openapi.{selecao,ingresso}.json</c>) devem ser
+/// byte-equivalentes. <c>Microsoft.AspNetCore.OpenApi</c> 10 emite cada
+/// documento independentemente — então é possível regerar um baseline e
+/// esquecer o outro, deixando o contrato cross-module inconsistente sem
+/// alarme do drift check por módulo.
+/// </summary>
+/// <remarks>
+/// Schemas vindos do shared kernel (<c>ProblemDetails</c>,
+/// <c>AuthenticatedUserResponse</c>, <c>UserProfileResponse</c>) são os
+/// candidatos óbvios. A regra captura QUALQUER schema com mesmo nome em
+/// ambos os documentos — extensível por construção: se o time mover mais
+/// tipos para shared, eles passam automaticamente a ser fitness-checked.
+///
+/// Quando este teste falhar:
+/// <list type="number">
+///   <item>Identificar qual schema divergiu (mensagem do teste).</item>
+///   <item>Regerar o baseline do módulo stale:
+///     <c>UPDATE_OPENAPI_BASELINE=1 dotnet test tests/Unifesspa.UniPlus.{Modulo}.IntegrationTests --filter "FullyQualifiedName~SpecRuntime"</c>.</item>
+///   <item>Confirmar via <c>git diff contracts/</c> que a mudança é intencional.</item>
+/// </list>
+/// </remarks>
+public sealed class OpenApiSharedSchemasInSyncTests
+{
+    private static readonly string[] BaselinePaths =
+    [
+        Path.Combine("contracts", "openapi.selecao.json"),
+        Path.Combine("contracts", "openapi.ingresso.json"),
+    ];
+
+    private static readonly JsonSerializerOptions CanonicalOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    [Fact(DisplayName = "ADR-0035: schemas com mesmo nome em baselines diferentes são byte-equivalentes")]
+    public void Schemas_Compartilhados_Devem_Ser_ByteEquivalentes()
+    {
+        string solutionRoot = SolutionRootLocator.Locate();
+        Dictionary<string, JsonElement>[] schemasByModule =
+        [
+            LoadSchemas(Path.Combine(solutionRoot, BaselinePaths[0])),
+            LoadSchemas(Path.Combine(solutionRoot, BaselinePaths[1])),
+        ];
+
+        IEnumerable<string> sharedNames = schemasByModule[0].Keys
+            .Intersect(schemasByModule[1].Keys, StringComparer.Ordinal)
+            .OrderBy(static n => n, StringComparer.Ordinal);
+
+        sharedNames.Should().NotBeEmpty(
+            "ao menos `ProblemDetails` é compartilhado entre os módulos via ADR-0023; ausência aqui sugere regressão da geração OpenAPI.");
+
+        List<string> divergencias = [];
+
+        foreach (string name in sharedNames)
+        {
+            string canonicalSelecao = SerializeCanonical(schemasByModule[0][name]);
+            string canonicalIngresso = SerializeCanonical(schemasByModule[1][name]);
+
+            if (!string.Equals(canonicalSelecao, canonicalIngresso, StringComparison.Ordinal))
+            {
+                divergencias.Add(
+                    $"Schema '{name}' diverge entre selecao e ingresso. "
+                    + "Para sincronizar, rode "
+                    + "`UPDATE_OPENAPI_BASELINE=1 dotnet test tests/Unifesspa.UniPlus.{modulo}.IntegrationTests --filter \"FullyQualifiedName~SpecRuntime\"` "
+                    + "no módulo stale e confira o diff em contracts/.");
+            }
+        }
+
+        divergencias.Should().BeEmpty(
+            because: "schemas duplicados entre baselines violam o contrato cross-module (ADR-0035).");
+    }
+
+    private static Dictionary<string, JsonElement> LoadSchemas(string baselinePath)
+    {
+        File.Exists(baselinePath).Should().BeTrue($"baseline esperado em {baselinePath} não foi encontrado.");
+
+        using JsonDocument doc = JsonDocument.Parse(File.ReadAllText(baselinePath));
+        if (!doc.RootElement.TryGetProperty("components", out JsonElement components)
+            || !components.TryGetProperty("schemas", out JsonElement schemas))
+        {
+            return new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+        }
+
+        Dictionary<string, JsonElement> map = new(StringComparer.Ordinal);
+        foreach (JsonProperty schema in schemas.EnumerateObject())
+        {
+            // JsonElement.Clone() retorna uma cópia independente do JsonDocument
+            // de origem (docs Microsoft: "can be safely stored beyond the lifetime
+            // of the original JsonDocument") — seguro após o using-dispose.
+            map[schema.Name] = schema.Value.Clone();
+        }
+        return map;
+    }
+
+    private static string SerializeCanonical(JsonElement schema)
+    {
+        // Re-serializa com WriteIndented + canonical encoder default — o
+        // mesmo path usado por OpenApiEndpointTests.NormalizeJson, garantindo
+        // diff estável independente de espaços e ordering preservada do
+        // documento de origem (System.Text.Json mantém ordem de inserção).
+        return JsonSerializer.Serialize(schema, CanonicalOptions);
+    }
+
+}

--- a/tests/Unifesspa.UniPlus.ArchTests/TestSupport/SolutionRootLocator.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/TestSupport/SolutionRootLocator.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.ArchTests.TestSupport;
+
+using System.IO;
+
+/// <summary>
+/// Helper compartilhado entre fitness functions solution-level que precisam
+/// resolver caminhos relativos ao repositório (baselines OpenAPI, projetos
+/// de domínio, contracts/). Sobe a partir de <see cref="AppContext.BaseDirectory"/>
+/// procurando <c>UniPlus.slnx</c> — resiliente a mudanças de target framework
+/// e path do bin de teste.
+/// </summary>
+internal static class SolutionRootLocator
+{
+    internal static string Locate()
+    {
+        string current = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(current))
+        {
+            if (File.Exists(Path.Combine(current, "UniPlus.slnx")))
+                return current;
+            current = Directory.GetParent(current)?.FullName ?? string.Empty;
+        }
+
+        throw new DirectoryNotFoundException(
+            "UniPlus.slnx não encontrado a partir de AppContext.BaseDirectory; estrutura do repositório alterada?");
+    }
+}


### PR DESCRIPTION
## Resumo

Endereça follow-up Frente 1.2 do plano backend cleanup. Baselines `contracts/openapi.{selecao,ingresso}.json` duplicam 3 schemas idênticos (`ProblemDetails`, `AuthenticatedUserResponse`, `UserProfileResponse`); o drift check por módulo não detecta divergência cross-module silenciosa.

[ADR-0035](docs/adrs/0035-shared-schemas-cross-module-fitness-test.md) documenta a decisão pela **Opção C — fitness test byte-equality** em vez de Opção B (Redocly multi-file). Microsoft.AspNetCore.OpenApi 10 não suporta `\$ref` cross-document nativo ([aspnetcore#63090](https://github.com/dotnet/aspnetcore/issues/63090), [#60164](https://github.com/dotnet/aspnetcore/issues/60164)), e o ROI de adicionar Redocly em CI para 3 schemas duplicados é negativo. ADR cobre trigger de reavaliação (≥10 schemas, terceiro módulo, portal `uniplus-developers`).

## Mudanças principais

- `OpenApiSharedSchemasInSyncTests` (novo, em ArchTests/SolutionRules) — carrega ambos baselines, intersection de nomes em `components.schemas`, byte-equality via `SerializeCanonical`. Mensagem de erro actionable: aponta o schema divergente e o comando exato `UPDATE_OPENAPI_BASELINE=1 dotnet test ...`.
- `SolutionRootLocator` (novo, em ArchTests/TestSupport) — helper extraído da duplicação preexistente em `DominioNaoUsaGuidNewGuidTests`. Namespace `TestSupport` para evitar shadow do `Unifesspa.UniPlus.Infrastructure`.
- ADR-0035 (`accepted`) + entry em `docs/adrs/README.md`.
- `contracts/README.md` — roadmap atualizado.

## Test plan

- [x] `dotnet build UniPlus.slnx --no-incremental -v quiet` → 0/0
- [x] `dotnet test UniPlus.slnx --no-build` → 0 falhas (415 testes)
- [x] `bash tools/adr-lint/validate.sh` → 35 ADRs validados
- [x] **Prova negativa**: alterar manualmente `ProblemDetails.title.type` em ingresso baseline → fitness test falha com mensagem actionable
- [x] Pre-commit review (feature-dev:code-reviewer): **APROVADO** com C1 (JsonDocument leak no Clone round-trip) e I1 (extração SolutionRootLocator) corrigidos
- [ ] CI verde
- [ ] Codex review

Closes #323