### PR TITLE
test(selecao): sentinelas + cobertura HTTP de Edital (Frente 3a, 4 issues)

### DIFF
--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/ControllersMvcDiscoverySentinelTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/ControllersMvcDiscoverySentinelTests.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Hosting;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+using Infrastructure;
+
+/// <summary>
+/// Sentinela contra recidiva da regressão #173 — controllers MVC marcados
+/// como <c>internal sealed</c> são silenciosamente ignorados pelo
+/// <c>ControllerFeatureProvider</c>, deixando o MVC sem rotas para esses
+/// controllers e nenhum diagnóstico claro em runtime.
+/// </summary>
+/// <remarks>
+/// O guard usa <see cref="EndpointDataSource"/> resolvido pelo test host —
+/// inspeciona os endpoints registrados após pipeline build e asserts que
+/// cada controller esperado tem ao menos uma rota mapeada via
+/// <see cref="ControllerActionDescriptor"/>. Falha cedo com mensagem
+/// orientando a checar o modificador de acesso da classe + supressão de
+/// CA1515 quando aplicável.
+/// </remarks>
+public sealed class ControllersMvcDiscoverySentinelTests : IClassFixture<SelecaoApiFactory>
+{
+    private readonly SelecaoApiFactory _factory;
+
+    public ControllersMvcDiscoverySentinelTests(SelecaoApiFactory factory) => _factory = factory;
+
+    [Theory(DisplayName = "Controller MVC do módulo expõe ao menos uma rota no test host")]
+    [InlineData("EditalController")]
+    public void Controller_RegistrouRotas_NoEndpointDataSource(string controllerName)
+    {
+        // CreateClient força WebApplicationFactory a buildar o test host,
+        // o que faz o pipeline MVC descobrir e mapear endpoints.
+        using HttpClient _ = _factory.CreateClient();
+
+        EndpointDataSource dataSource = _factory.Services.GetRequiredService<EndpointDataSource>();
+
+        IEnumerable<ControllerActionDescriptor> actions = dataSource.Endpoints
+            .Select(static endpoint => endpoint.Metadata.GetMetadata<ControllerActionDescriptor>())
+            .Where(static descriptor => descriptor is not null)
+            .Cast<ControllerActionDescriptor>()
+            .Where(descriptor => string.Equals(
+                descriptor.ControllerTypeInfo.Name, controllerName, StringComparison.Ordinal));
+
+        actions.Should().NotBeEmpty(
+            because: $"{controllerName} deve estar registrado pelo MVC. Recidiva mais provável: o "
+            + "controller virou `internal sealed` (ControllerFeatureProvider só descobre `public`). "
+            + "Conferir modificador de acesso e supressão de CA1515 com a justificativa "
+            + "\"ASP.NET Core ControllerFeatureProvider só descobre controllers public\".");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/WolverineRuntimeRemovalSentinelTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/WolverineRuntimeRemovalSentinelTests.cs
@@ -1,0 +1,88 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Hosting;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+
+/// <summary>
+/// Sentinela da heurística usada em
+/// <c>ApiFactoryBase.ConfigureWebHost</c> (issue #194) para remover o
+/// <c>WolverineRuntime</c> dos hosts de teste com
+/// <c>DisableWolverineRuntimeForTests = true</c>.
+///
+/// A heurística é frágil contra refactors internos do JasperFx.Wolverine:
+/// <code>
+/// d.ServiceType == typeof(IHostedService)
+///     &amp;&amp; d.ImplementationFactory is not null
+///     &amp;&amp; d.ImplementationFactory.Method.DeclaringType?.Assembly.GetName().Name == "Wolverine"
+/// </code>
+///
+/// Quando o Wolverine renomear o assembly (ex.: <c>JasperFx.Wolverine</c>) ou
+/// migrar o registro do runtime para <c>ImplementationType</c> em vez de
+/// factory, a remoção volta a ser silenciosamente no-op — o host inicializa
+/// o runtime real, dispara <c>MigrateAsync</c> contra um Postgres de
+/// referência inválido, e os testes falham por timeout, não pela causa raiz.
+/// Este teste executa a mesma query LINQ que a heurística produtiva e
+/// asserts que ela ainda casa — falha cedo com mensagem orientando a
+/// atualização.
+/// </summary>
+public sealed class WolverineRuntimeRemovalSentinelTests
+{
+    [Fact(DisplayName = "Heurística de remoção do WolverineRuntime ainda casa após UseWolverineOutboxCascading")]
+    public void Heuristica_Casa_AoMenosUm_IHostedService_DoAssemblyWolverine()
+    {
+        // UseWolverineOutboxCascading estende IHostBuilder (legacy host model),
+        // não HostApplicationBuilder — usar Host.CreateDefaultBuilder.
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                // Connection string sintética — UseWolverineOutboxCascading registra
+                // serviços, mas só conecta no banco quando o IHostedService inicia.
+                // Build sem Run não dispara conexão.
+                ["ConnectionStrings:SentinelDb"] =
+                    "Host=sentinel-not-real;Database=fake;Username=u;Password=p",
+                // Desliga Kafka — sem isto Wolverine tentaria iniciar transporte.
+                ["Kafka:BootstrapServers"] = string.Empty,
+            })
+            .Build();
+
+        IHostBuilder hostBuilder = Host.CreateDefaultBuilder()
+            .ConfigureAppConfiguration(b => b.AddConfiguration(configuration));
+
+        hostBuilder.UseWolverineOutboxCascading(
+            configuration,
+            connectionStringName: "SentinelDb");
+
+        // Captura o IServiceCollection efetivo antes do Build — necessário
+        // porque a heurística produtiva inspeciona ServiceDescriptor (metadado
+        // de registro, antes da instância existir), não o tipo da instância
+        // resolvida. Cair no .GetServices<IHostedService>() depois do build
+        // testaria proxy da heurística (assembly do tipo concreto), não a
+        // heurística em si (assembly do método factory).
+        IServiceCollection? capturedServices = null;
+        hostBuilder.ConfigureServices((_, services) => capturedServices = services);
+
+        using IHost host = hostBuilder.Build();
+
+        capturedServices.Should().NotBeNull(
+            "ConfigureServices é chamado durante Build pelo IHostBuilder; se ficou null, o pipeline mudou.");
+
+        // Roda EXATAMENTE a query da heurística (espelho de
+        // tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs).
+        ServiceDescriptor[] hostedFromWolverine = [.. capturedServices!
+            .Where(d => d.ServiceType == typeof(IHostedService)
+                && d.ImplementationFactory is not null
+                && d.ImplementationFactory.Method.DeclaringType?.Assembly.GetName().Name == "Wolverine")];
+
+        hostedFromWolverine.Should().NotBeEmpty(
+            because: "ApiFactoryBase.DisableWolverineRuntimeForTests depende EXATAMENTE desta query "
+            + "para remover WolverineRuntime; se Wolverine renomear o assembly, trocar "
+            + "ImplementationFactory por ImplementationType, ou mover o registro para outro shape, "
+            + "atualizar tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs "
+            + "ANTES que suites com DisableWolverineRuntimeForTests=true falhem por timeout em MigrateAsync.");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalEndpointTests.cs
@@ -1,0 +1,138 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Domain.Entities;
+using Domain.Enums;
+using Domain.ValueObjects;
+using Kernel.Results;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// Cobertura HTTP direta de <c>POST /api/editais</c> (criação) e
+/// <c>GET /api/editais/{id}</c> (consulta) — endpoints que ganharam
+/// roteamento pelo fix de #173 mas não tinham testes HTTP dedicados.
+/// Issue #202.
+/// </summary>
+/// <remarks>
+/// Reusa a <see cref="CascadingFixture"/> para ter Postgres efêmero
+/// disponível, mas os cenários aqui não dependem de cascading messages
+/// (handler de criação não emite domain events além do fluxo já testado
+/// em <see cref="PublicarEditalEndpointTests"/>). Pareada à mesma
+/// collection para evitar paralelismo inválido com PG compartilhado.
+/// </remarks>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+public sealed class EditalEndpointTests
+{
+    private static int _numeroSeedCounter;
+
+    private static int NextNumeroSeed() =>
+        (Interlocked.Increment(ref _numeroSeedCounter) % 9999) + 1;
+
+    private readonly CascadingFixture _fixture;
+
+    public EditalEndpointTests(CascadingFixture fixture) => _fixture = fixture;
+
+    [Fact(DisplayName = "POST /api/editais retorna 201 + Location quando o command é válido")]
+    public async Task CriarEdital_DeveRetornar201()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        int numero = NextNumeroSeed();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        {
+            Content = JsonContent.Create(new
+            {
+                numeroEdital = numero,
+                anoEdital = 2026,
+                titulo = "EditalEndpointTests CriarEdital",
+                tipoProcesso = (int)TipoProcesso.SiSU,
+            }),
+        };
+        AppendTestAuth(request);
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location.Should().NotBeNull(
+            "[ApiController] + CreatedAtAction expõem Location apontando para o recurso criado");
+
+        // O body do POST é o GUID do recurso criado.
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Guid editalId = doc.RootElement.GetGuid();
+        editalId.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact(DisplayName = "GET /api/editais/{id} retorna 200 quando o edital existe")]
+    public async Task ObterEdital_DeveRetornar200_QuandoExiste()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        Edital edital = await SemearEditalAsync(api);
+
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            new Uri($"/api/editais/{edital.Id}", UriKind.Relative));
+        AppendTestAuth(request);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.edital.v1+json"));
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("id").GetGuid().Should().Be(edital.Id);
+    }
+
+    [Fact(DisplayName = "GET /api/editais/{id} retorna 404 quando o edital não existe")]
+    public async Task ObterEdital_DeveRetornar404_QuandoNaoExiste()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        Guid inexistente = Guid.CreateVersion7();
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            new Uri($"/api/editais/{inexistente}", UriKind.Relative));
+        AppendTestAuth(request);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.edital.v1+json"));
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
+
+    private static void AppendTestAuth(HttpRequestMessage request)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme, TestAuthHandler.TokenValue);
+        request.Headers.TryAddWithoutValidation(TestAuthHandler.UserIdHeader, "test-edital-user");
+    }
+
+    private static async Task<Edital> SemearEditalAsync(CascadingApiFactory api)
+    {
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+
+        int numeroSeed = NextNumeroSeed();
+        Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: numeroSeed, ano: 2026);
+        numeroResult.IsSuccess.Should().BeTrue();
+        Edital edital = Edital.Criar(numeroResult.Value!, "EditalEndpointTests seed", TipoProcesso.SiSU);
+        edital.ClearDomainEvents();
+        await db.Editais.AddAsync(edital);
+        await db.SaveChangesAsync();
+        return edital;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
@@ -33,6 +33,16 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 [Trait("Category", "OutboxCascading")]
 public sealed class PublicarEditalEndpointTests
 {
+    // Contador atômico para numeroSeed: garante unicidade dentro do test run
+    // (CascadingFixture é singleton da collection com PG efêmero, então o
+    // contador zera junto com o banco). Substituiu Math.Abs(Guid.NewGuid().GetHashCode() % 9000)
+    // que tinha ~0,01% de chance de colidir com valores hard-coded em outros testes.
+    // Range 1..9999 (NumeroEdital aceita 1..9999); módulo 9999 + 1 evita zero.
+    private static int _numeroSeedCounter;
+
+    private static int NextNumeroSeed() =>
+        (Interlocked.Increment(ref _numeroSeedCounter) % 9999) + 1;
+
     private readonly CascadingFixture _fixture;
 
     public PublicarEditalEndpointTests(CascadingFixture fixture)
@@ -198,8 +208,8 @@ public sealed class PublicarEditalEndpointTests
         using HttpClient client = api.CreateClient();
 
         string key = MakeIdempotencyKey();
-        int numero1 = Math.Abs((Guid.NewGuid().GetHashCode() % 4500) + 1);
-        int numero2 = numero1 + 1; // body diferente garantido
+        int numero1 = NextNumeroSeed();
+        int numero2 = NextNumeroSeed(); // body diferente garantido (incrementos sequenciais)
 
         // Primeira request: cria edital normalmente.
         using HttpRequestMessage primeiraReq = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
@@ -266,10 +276,10 @@ public sealed class PublicarEditalEndpointTests
         await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
         SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
 
-        // Numero estável derivado de NewGuid — Edital.Numero é int (1..9999),
+        // Numero estável via contador atômico — Edital.Numero é int (1..9999),
         // colisão com testes paralelos é evitada pelo CollectionFixture (1
         // fixture por collection, fixture é singleton dentro do test run).
-        int numeroSeed = Math.Abs(Guid.NewGuid().GetHashCode() % 9000) + 1;
+        int numeroSeed = NextNumeroSeed();
         Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: numeroSeed, ano: 2026);
         numeroResult.IsSuccess.Should().BeTrue();
         Edital edital = Edital.Criar(numeroResult.Value!, "PublicarEditalEndpointTests seed", TipoProcesso.SiSU);


### PR DESCRIPTION
## Resumo

Endereça Frente 3a do plano backend-followups-cleanup. Lote de 6 issues (#192-206 escopo testes/sentinelas), absorvidas como:

- **2 issues fechadas com decisão consolidada (sem mudança de código):**
  - [#196](https://github.com/unifesspa-edu-br/uniplus-api/issues/196) — isolamento discovery extension cascading: status quo defensável, trigger de reavaliação documentado no comment de fechamento.
  - [#201](https://github.com/unifesspa-edu-br/uniplus-api/issues/201) — InscricaoController stale (controller não existe no código atual).

- **4 issues implementadas neste PR:**
  - [#194](https://github.com/unifesspa-edu-br/uniplus-api/issues/194) sentinela WolverineRuntime
  - [#199](https://github.com/unifesspa-edu-br/uniplus-api/issues/199) sentinela controllers MVC
  - [#200](https://github.com/unifesspa-edu-br/uniplus-api/issues/200) endurece numeroSeed em PublicarEditalEndpointTests
  - [#202](https://github.com/unifesspa-edu-br/uniplus-api/issues/202) cobre Criar/ObterPorId do EditalController

## Mudanças principais

- **WolverineRuntimeRemovalSentinelTests** — constrói host minimal, captura \`IServiceCollection\` antes do Build via \`ConfigureServices\` callback, roda EXATAMENTE a query da heurística produtiva. Reformulado durante pre-commit review para testar a heurística real (não proxy via \`GetType()\` pós-build).
- **ControllersMvcDiscoverySentinelTests** — Theory inspecionando \`EndpointDataSource\` filtrando \`ControllerActionDescriptor\`. Mensagem aponta recidiva mais provável (\`internal sealed\` quebra ControllerFeatureProvider).
- **PublicarEditalEndpointTests** — \`Interlocked.Increment\` em counter estático cycle 9999, substituindo Math.Abs do hashcode.
- **EditalEndpointTests** (novo) — 3 facts cobrindo POST 201 + GET 200 + GET 404. Reusa CascadingFixture; counter atômico próprio.

## Test plan

- [x] \`dotnet build UniPlus.slnx --no-incremental -v quiet\` → 0/0
- [x] \`dotnet test UniPlus.slnx --no-build\` → 0 falhas (Selecao.IntegrationTests: 46 = 41 anteriores + 5 novos)
- [x] Pre-commit review (feature-dev:code-reviewer): APROVADO com P2 corrigido (sentinel #194)
- [ ] CI verde
- [ ] Codex review (pode estar em usage limit)

Closes #194
Closes #199
Closes #200
Closes #202