### PR TITLE
refactor: imutabilidade DequeueDomainEvents + IConfiguration nas Infra DI

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -34,16 +34,16 @@ builder.Services.AddEndpointsApiExplorer();
 // (info, operation, schema). Spec exposto em /openapi/ingresso.json.
 builder.Services.AddUniPlusOpenApi("ingresso", builder.Configuration);
 
-string connectionString = builder.Configuration.GetConnectionString("IngressoDb")
-    ?? throw new InvalidOperationException("Connection string 'IngressoDb' não configurada.");
-
 builder.Services.AddSingleton<IDomainErrorRegistration, IngressoDomainErrorRegistration>();
 builder.Services.AddDomainErrorMapper();
 
 builder.Services.AddOidcAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddCorrelationIdAccessor();
 builder.Services.AddRequestLogging(builder.Configuration);
-builder.Services.AddIngressoInfrastructure(connectionString);
+// AddIngressoInfrastructure agora resolve a connection string via
+// IConfiguration injetada no factory do AddDbContext (issue #204) —
+// simetria com UseWolverineOutboxCascading e com Selecao.
+builder.Services.AddIngressoInfrastructure();
 
 // Wolverine como backbone CQRS/messaging com outbox transacional —
 // ver ADR-0003, ADR-0004 e ADR-0005.

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.Ingresso.Infrastructure;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Application.Abstractions.Interfaces;
@@ -11,18 +12,32 @@ using Persistence.Repositories;
 
 public static class IngressoInfrastructureRegistration
 {
-    public static IServiceCollection AddIngressoInfrastructure(
-        this IServiceCollection services,
-        string connectionString)
+    private const string ConnectionStringName = "IngressoDb";
+
+    /// <summary>
+    /// Registra a infraestrutura do módulo Ingresso (DbContext + interceptors +
+    /// repositórios). A connection string é lida do <see cref="IConfiguration"/>
+    /// injetado no factory do <c>AddDbContext</c> — alinhado com o padrão lazy
+    /// do <c>UseWolverineOutboxCascading</c> (issue #204). Test hosts que
+    /// sobrescrevem <c>ConnectionStrings:IngressoDb</c> via env var ou
+    /// <c>InMemoryCollection</c> ganham o override automaticamente, sem
+    /// precisar re-registrar o DbContext.
+    /// </summary>
+    public static IServiceCollection AddIngressoInfrastructure(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
-        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
         services.AddSingleton<SoftDeleteInterceptor>();
         services.AddSingleton<AuditableInterceptor>();
 
         services.AddDbContext<IngressoDbContext>((serviceProvider, options) =>
         {
+            IConfiguration configuration = serviceProvider.GetRequiredService<IConfiguration>();
+            string connectionString = configuration.GetConnectionString(ConnectionStringName)
+                ?? throw new InvalidOperationException(
+                    $"ConnectionStrings:{ConnectionStringName} não configurada — defina via appsettings ou env var "
+                    + $"`ConnectionStrings__{ConnectionStringName}`.");
+
             options.UseNpgsql(connectionString, npgsqlOptions =>
             {
                 npgsqlOptions.MigrationsAssembly(typeof(IngressoDbContext).Assembly.FullName);

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
@@ -33,10 +33,13 @@ public static class IngressoInfrastructureRegistration
         services.AddDbContext<IngressoDbContext>((serviceProvider, options) =>
         {
             IConfiguration configuration = serviceProvider.GetRequiredService<IConfiguration>();
-            string connectionString = configuration.GetConnectionString(ConnectionStringName)
-                ?? throw new InvalidOperationException(
+            string? connectionString = configuration.GetConnectionString(ConnectionStringName);
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new InvalidOperationException(
                     $"ConnectionStrings:{ConnectionStringName} não configurada — defina via appsettings ou env var "
-                    + $"`ConnectionStrings__{ConnectionStringName}`.");
+                    + $"`ConnectionStrings__{ConnectionStringName}`. Valores vazios/whitespace também são rejeitados.");
+            }
 
             options.UseNpgsql(connectionString, npgsqlOptions =>
             {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -40,9 +40,6 @@ builder.Services.AddEndpointsApiExplorer();
 // (info, operation, schema). Spec exposto em /openapi/selecao.json.
 builder.Services.AddUniPlusOpenApi("selecao", builder.Configuration);
 
-string connectionString = builder.Configuration.GetConnectionString("SelecaoDb")
-    ?? throw new InvalidOperationException("Connection string 'SelecaoDb' não configurada.");
-
 builder.Services.AddSingleton<IDomainErrorRegistration, SelecaoDomainErrorRegistration>();
 builder.Services.AddDomainErrorMapper();
 
@@ -62,13 +59,12 @@ builder.Services.AddOidcAuthentication(builder.Configuration, builder.Environmen
 builder.Services.AddCorrelationIdAccessor();
 builder.Services.AddRequestLogging(builder.Configuration);
 builder.Services.AddSelecaoApplication();
-// AddSelecaoInfrastructure é configurado com a connection string lida
-// eagerly do builder.Configuration. Em testes integrados, o
-// CascadingApiFactory remove e re-registra o DbContext apontando para o
-// Postgres efêmero — esta leitura eager fica restrita ao registro do
-// DbContext do módulo, não atinge o backbone Wolverine (que lê via
-// SelecaoOutboxExtension no startup, com IConfiguration final).
-builder.Services.AddSelecaoInfrastructure(connectionString);
+// AddSelecaoInfrastructure agora resolve a connection string via
+// IConfiguration injetada no factory do AddDbContext (issue #204) —
+// simetria com UseWolverineOutboxCascading que já fazia leitura lazy.
+// Test hosts (CascadingApiFactory) podem sobrescrever via env var ou
+// InMemoryCollection sem precisar re-registrar o DbContext.
+builder.Services.AddSelecaoInfrastructure();
 
 // Wolverine como backbone CQRS/messaging com outbox transacional —
 // ver ADR-0003, ADR-0004 e ADR-0005.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.Infrastructure;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
@@ -12,18 +13,32 @@ using Persistence.Repositories;
 
 public static class SelecaoInfrastructureRegistration
 {
-    public static IServiceCollection AddSelecaoInfrastructure(
-        this IServiceCollection services,
-        string connectionString)
+    private const string ConnectionStringName = "SelecaoDb";
+
+    /// <summary>
+    /// Registra a infraestrutura do módulo Seleção (DbContext + interceptors +
+    /// repositórios + serviços externos). A connection string é lida do
+    /// <see cref="IConfiguration"/> injetado no factory do <c>AddDbContext</c>
+    /// — alinhado com o padrão lazy do <c>UseWolverineOutboxCascading</c>
+    /// (issue #204). Test hosts que sobrescrevem <c>ConnectionStrings:SelecaoDb</c>
+    /// via env var ou <c>InMemoryCollection</c> ganham o override automaticamente,
+    /// sem precisar re-registrar o DbContext.
+    /// </summary>
+    public static IServiceCollection AddSelecaoInfrastructure(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
-        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
         services.AddSingleton<SoftDeleteInterceptor>();
         services.AddSingleton<AuditableInterceptor>();
 
         services.AddDbContext<SelecaoDbContext>((serviceProvider, options) =>
         {
+            IConfiguration configuration = serviceProvider.GetRequiredService<IConfiguration>();
+            string connectionString = configuration.GetConnectionString(ConnectionStringName)
+                ?? throw new InvalidOperationException(
+                    $"ConnectionStrings:{ConnectionStringName} não configurada — defina via appsettings ou env var "
+                    + $"`ConnectionStrings__{ConnectionStringName}`.");
+
             options.UseNpgsql(connectionString, npgsqlOptions =>
             {
                 npgsqlOptions.MigrationsAssembly(typeof(SelecaoDbContext).Assembly.FullName);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -34,10 +34,13 @@ public static class SelecaoInfrastructureRegistration
         services.AddDbContext<SelecaoDbContext>((serviceProvider, options) =>
         {
             IConfiguration configuration = serviceProvider.GetRequiredService<IConfiguration>();
-            string connectionString = configuration.GetConnectionString(ConnectionStringName)
-                ?? throw new InvalidOperationException(
+            string? connectionString = configuration.GetConnectionString(ConnectionStringName);
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new InvalidOperationException(
                     $"ConnectionStrings:{ConnectionStringName} não configurada — defina via appsettings ou env var "
-                    + $"`ConnectionStrings__{ConnectionStringName}`.");
+                    + $"`ConnectionStrings__{ConnectionStringName}`. Valores vazios/whitespace também são rejeitados.");
+            }
 
             options.UseNpgsql(connectionString, npgsqlOptions =>
             {

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
@@ -42,10 +42,15 @@ public abstract class EntityBase
     // entidade no mesmo ponto em que o handler os entrega ao bus,
     // evitando republicação acidental se o agregado sobreviver ao escopo
     // do handler (cache, sagas, processadores long-lived).
+    //
+    // Retorno é wrap imutável (Array.AsReadOnly) — simetria com `DomainEvents`,
+    // que também expõe `_domainEvents.AsReadOnly()`. Sem este wrap o caller
+    // poderia castar para `IDomainEvent[]` e mutar o array snapshot, vazando
+    // mutação onde o contrato promete read-only.
     public IReadOnlyCollection<IDomainEvent> DequeueDomainEvents()
     {
         IDomainEvent[] snapshot = [.. _domainEvents];
         _domainEvents.Clear();
-        return snapshot;
+        return Array.AsReadOnly(snapshot);
     }
 }

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseDomainEventsTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseDomainEventsTests.cs
@@ -56,6 +56,24 @@ public sealed class EntityBaseDomainEventsTests
         entidade.DomainEvents.Should().ContainSingle().Which.Should().Be(posterior);
     }
 
+    [Fact(DisplayName = "DequeueDomainEvents retorna ReadOnlyCollection — caller não consegue mutar via cast")]
+    public void DequeueDomainEvents_RetornoEhImutavel_NaoPermiteCastParaArray()
+    {
+        var entidade = new EntidadeDeTeste();
+        entidade.AdicionarEvento(new EventoDeTeste("e1"));
+
+        IReadOnlyCollection<IDomainEvent> drenados = entidade.DequeueDomainEvents();
+
+        // Simetria com `DomainEvents` (que é `_domainEvents.AsReadOnly()`):
+        // o snapshot é wrap imutável, não array mutável tipado como
+        // IReadOnlyCollection. Tentar castar para IDomainEvent[] deve
+        // retornar null — wrap ReadOnlyCollection<T> não é a mesma
+        // referência do array interno.
+        (drenados is IDomainEvent[]).Should().BeFalse(
+            "Array.AsReadOnly produz ReadOnlyCollection<T>, não o array — caller não consegue mutar via cast");
+        (drenados is List<IDomainEvent>).Should().BeFalse();
+    }
+
     [Fact(DisplayName = "ClearDomainEvents continua zerando a coleção sem retornar snapshot")]
     public void ClearDomainEvents_ZeraColecaoSemRetorno()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingApiFactory.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
@@ -61,8 +62,18 @@ public sealed class CascadingApiFactory : ApiFactoryBase<Program>
             services.RemoveAll<IDbContextOptionsConfiguration<SelecaoDbContext>>();
             RemoveAllOptionsConfigurations<DbContextOptions<SelecaoDbContext>>(services);
 
-            services.AddDbContext<SelecaoDbContext>(opts =>
-                opts.UseNpgsql(_connectionString));
+            // Re-registro do DbContext mantém SoftDeleteInterceptor + AuditableInterceptor
+            // simétrico à produção (`SelecaoInfrastructureRegistration.AddSelecaoInfrastructure`).
+            // Sem isto a fixture cascading silenciosamente deixaria os interceptors
+            // de fora — as colunas IsDeleted/DeletedAt/UpdatedAt não seriam preenchidas
+            // automaticamente, mascarando regressões em testes que dependam disso.
+            services.AddDbContext<SelecaoDbContext>((sp, opts) =>
+            {
+                opts.UseNpgsql(_connectionString);
+                opts.AddInterceptors(
+                    sp.GetRequiredService<SoftDeleteInterceptor>(),
+                    sp.GetRequiredService<AuditableInterceptor>());
+            });
 
             services.AddSingleton<DomainEventCollector>();
         });


### PR DESCRIPTION
## Resumo

Frente 3b do plano backend cleanup. 2 issues do lote #192-206:

- **#192** — `DequeueDomainEvents` retorna `ReadOnlyCollection<IDomainEvent>` imutável via `Array.AsReadOnly`, não array mutável tipado como `IReadOnlyCollection`. Simetria com `DomainEvents` que já usava `_domainEvents.AsReadOnly()`.
- **#204** — `AddSelecaoInfrastructure`/`AddIngressoInfrastructure` deixam de receber connection string como parâmetro; resolução lazy via `IConfiguration` no factory do `AddDbContext`. Simetria com `UseWolverineOutboxCascading`.

## Mudanças principais

- `EntityBase.DequeueDomainEvents` retorna `Array.AsReadOnly(snapshot)`. Sentinel novo no `Kernel.UnitTests` valida `(drenados is IDomainEvent[]).Should().BeFalse()`.
- `Selecao/Ingresso.Infrastructure.DependencyInjection` — assinatura sem connection string; resolve `IConfiguration` injetado e lê `ConnectionStrings:{Modulo}Db` no factory. Fail-fast com mensagem indicando env var canônica.
- `Program.cs` (Selecao + Ingresso) — removida leitura eager + variável intermediária.
- `CascadingApiFactory` — re-registro do DbContext mantém `SoftDeleteInterceptor` + `AuditableInterceptor` simétrico à produção (Finding 1 do pre-commit review absorvido).

## Test plan

- [x] \`dotnet build UniPlus.slnx --no-incremental -v quiet\` → 0/0
- [x] \`dotnet test UniPlus.slnx --no-build\` → 0 falhas (415 testes; +1 sentinela imutabilidade no Kernel.UnitTests)
- [x] Pre-commit review (feature-dev:code-reviewer): APROVADO com Finding 1 absorvido
- [ ] CI verde
- [ ] Codex review (provavelmente em usage limit)

Closes #192
Closes #204