### PR TITLE
test(ci): sanity checks filtros OutboxCapability/Cascading + resilience fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,53 @@ jobs:
             --settings coverlet.runsettings \
             --results-directory ${{ env.COVERAGE_DIR }}
 
+      # Sentinela do filtro AC (issue #205): a suite cascading da Selecao
+      # marca cada teste com [Trait("Category", "OutboxCapability")] +
+      # [Trait("Category", "OutboxCascading")]. Rodar explicitamente cada
+      # filtro garante que (a) ambos os traits permanecem na fonte, e
+      # (b) a suite tem pelo menos a quantidade mínima esperada de testes
+      # — protege contra remoção acidental de uma das marcações.
+      # Equivalente local:
+      #   dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests \
+      #     --filter "Category=OutboxCapability" --no-build
+      - name: Sanity check — Category=OutboxCapability filter has expected coverage
+        run: |
+          set -euo pipefail
+          MIN_TESTS=15
+          out=$(dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests \
+            --configuration ${{ env.BUILD_CONFIG }} \
+            --no-build \
+            --filter "Category=OutboxCapability" \
+            --logger "console;verbosity=minimal")
+          echo "$out"
+          passed=$(echo "$out" | grep -oP 'Aprovado:\s*\K[0-9]+' | head -1 || true)
+          if [ -z "${passed:-}" ]; then
+            passed=$(echo "$out" | grep -oP 'Passed:\s*\K[0-9]+' | head -1 || echo 0)
+          fi
+          if [ "${passed:-0}" -lt "$MIN_TESTS" ]; then
+            echo "::error::Filtro Category=OutboxCapability cobriu $passed testes, mínimo esperado $MIN_TESTS — alguma marcação foi perdida?"
+            exit 1
+          fi
+
+      - name: Sanity check — Category=OutboxCascading filter has expected coverage
+        run: |
+          set -euo pipefail
+          MIN_TESTS=8
+          out=$(dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests \
+            --configuration ${{ env.BUILD_CONFIG }} \
+            --no-build \
+            --filter "Category=OutboxCascading" \
+            --logger "console;verbosity=minimal")
+          echo "$out"
+          passed=$(echo "$out" | grep -oP 'Aprovado:\s*\K[0-9]+' | head -1 || true)
+          if [ -z "${passed:-}" ]; then
+            passed=$(echo "$out" | grep -oP 'Passed:\s*\K[0-9]+' | head -1 || echo 0)
+          fi
+          if [ "${passed:-0}" -lt "$MIN_TESTS" ]; then
+            echo "::error::Filtro Category=OutboxCascading cobriu $passed testes, mínimo esperado $MIN_TESTS — alguma marcação foi perdida?"
+            exit 1
+          fi
+
       - name: Merge coverage reports
         if: always()
         run: |

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
@@ -65,19 +65,37 @@ public sealed class CascadingFixture : IAsyncLifetime
         await using SelecaoDbContext db = new(options);
         await db.Database.EnsureCreatedAsync().ConfigureAwait(false);
 
+        // Captura todos os valores prévios ANTES de mutar o environment —
+        // garantia de restore-em-falha dos dois sets atômicos. Sem isto,
+        // uma exceção entre os dois SetEnvironmentVariable abaixo deixaria
+        // a primeira variável setada para o resto do test run (issue #195).
         _connectionStringEnvVarPrevio = Environment.GetEnvironmentVariable(ConnectionStringEnvVar);
-        Environment.SetEnvironmentVariable(ConnectionStringEnvVar, ConnectionString);
-
         _kafkaEnvVarPrevio = Environment.GetEnvironmentVariable(KafkaBootstrapEnvVar);
-        // Whitespace (espaço) em vez de string.Empty: em runtimes anteriores a
-        // .NET 9, Environment.SetEnvironmentVariable(name, string.Empty) apaga
-        // a variável (em vez de definir como vazia), o que faria o appsettings
-        // voltar a ser consultado e o Wolverine tentar conectar em
-        // localhost:9092. O helper produtivo desliga Kafka via IsNullOrWhiteSpace,
-        // então um espaço cobre os dois cenários sem regressão cross-runtime.
-        Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, " ");
 
-        _factory = new CascadingApiFactory(ConnectionString);
+        try
+        {
+            Environment.SetEnvironmentVariable(ConnectionStringEnvVar, ConnectionString);
+
+            // Whitespace (espaço) em vez de string.Empty: em runtimes anteriores a
+            // .NET 9, Environment.SetEnvironmentVariable(name, string.Empty) apaga
+            // a variável (em vez de definir como vazia), o que faria o appsettings
+            // voltar a ser consultado e o Wolverine tentar conectar em
+            // localhost:9092. O helper produtivo desliga Kafka via IsNullOrWhiteSpace,
+            // então um espaço cobre os dois cenários sem regressão cross-runtime.
+            Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, " ");
+
+            _factory = new CascadingApiFactory(ConnectionString);
+        }
+        catch
+        {
+            // Restore inline antes de relançar — DisposeAsync é chamado por xUnit
+            // mesmo após InitializeAsync falhar, mas só se a fixture chegou a
+            // ser construída. Restaurar aqui torna a fixture resiliente mesmo
+            // em cenários onde xUnit pula o dispose por outro motivo.
+            Environment.SetEnvironmentVariable(ConnectionStringEnvVar, _connectionStringEnvVarPrevio);
+            Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, _kafkaEnvVarPrevio);
+            throw;
+        }
     }
 
     public async Task DisposeAsync()

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixtureConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixtureConfigurationTests.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Sentinela de configuração efetiva da <see cref="CascadingFixture"/>
+/// (issue #197). Valida que o host runtime enxerga:
+/// <list type="bullet">
+///   <item><description>A connection string do Postgres do Testcontainers em
+///   <c>ConnectionStrings:SelecaoDb</c>;</description></item>
+///   <item><description><c>Kafka:BootstrapServers</c> em whitespace, garantindo que
+///   o Wolverine NÃO tente abrir transporte Kafka contra <c>localhost:9092</c>.</description></item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// O teste pega o <see cref="IConfiguration"/> da factory após o build do host —
+/// é o mesmo objeto usado por <c>UseWolverineOutboxCascading</c> e
+/// <c>SelecaoInfrastructureRegistration.AddSelecaoInfrastructure</c>. Se a
+/// configuração efetiva divergir da intenção da fixture, o teste falha cedo
+/// com mensagem direcional.
+/// </remarks>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+public sealed class CascadingFixtureConfigurationTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public CascadingFixtureConfigurationTests(CascadingFixture fixture) => _fixture = fixture;
+
+    [Fact(DisplayName = "IConfiguration efetiva expõe a connection string do testcontainer Postgres")]
+    public void Configuration_ExpoeConnectionStringDoTestcontainer()
+    {
+        IConfiguration configuration = _fixture.Factory.Services.GetRequiredService<IConfiguration>();
+
+        string? connectionString = configuration.GetConnectionString("SelecaoDb");
+
+        connectionString.Should().NotBeNullOrWhiteSpace(
+            because: "ConnectionStrings__SelecaoDb deve ter sido injetada pela fixture via env var; "
+            + "se ficou vazia, AddSelecaoInfrastructure não conseguiria configurar o DbContext.");
+        // Sem expor a connection string completa em logs/asserts — apenas
+        // validar marcadores estruturais (host/Database). PostgreSQL connection
+        // string típica do Testcontainers contém Host=localhost;Port=<random>;Database=uniplus_outbox_cascading.
+        connectionString.Should().Contain("uniplus_outbox_cascading",
+            because: "a fixture cria o testcontainer com WithDatabase(\"uniplus_outbox_cascading\"); "
+            + "se o nome do database divergir, a config efetiva não está vindo do testcontainer.");
+    }
+
+    [Fact(DisplayName = "IConfiguration efetiva mantém Kafka:BootstrapServers em whitespace para desligar o transporte")]
+    public void Configuration_KafkaBootstrapServers_EmWhitespace()
+    {
+        IConfiguration configuration = _fixture.Factory.Services.GetRequiredService<IConfiguration>();
+
+        string? bootstrapServers = configuration["Kafka:BootstrapServers"];
+
+        bootstrapServers.Should().NotBeNull(
+            "a fixture seta a env var explicitamente; null aqui significa que o appsettings.Development venceu.");
+        string.IsNullOrWhiteSpace(bootstrapServers).Should().BeTrue(
+            because: "se Kafka:BootstrapServers tiver valor real (ex.: \"localhost:9092\" do appsettings.Development), "
+            + "o Wolverine inicializaria o transporte Kafka e ficaria em retry indefinido — a fixture não provisiona "
+            + "broker Kafka, então o transporte tem que estar desligado.");
+    }
+}


### PR DESCRIPTION
## Resumo

Frente 3c do plano backend cleanup. 3 issues do lote #192-206:

- **#205** — CI passa a rodar explicitamente \`Category=OutboxCapability\` e \`Category=OutboxCascading\` com mínimo de aprovados (15 / 8). Protege contra remoção acidental de uma das marcações duplas que a suite cascading depende.
- **#195** — \`CascadingFixture.InitializeAsync\` captura env vars prévias antes de mutar o environment + try/catch com restore inline. Resiliente contra falha intermediária entre os Sets.
- **#197** — \`CascadingFixtureConfigurationTests\` (novo) — 2 sentinelas: connection string do testcontainer chega via \`IConfiguration:ConnectionStrings:SelecaoDb\`; \`Kafka:BootstrapServers\` continua em whitespace (não \`localhost:9092\` do appsettings).

## Test plan

- [x] \`dotnet build UniPlus.slnx --no-incremental -v quiet\` → 0/0
- [x] \`dotnet test UniPlus.slnx --no-build\` → 0 falhas (Selecao.IntegrationTests: 48 = 46 + 2 novos)
- [x] OutboxCapability filter: 21 aprovados (>15 mínimo)
- [x] OutboxCascading filter: 10 aprovados (>8 mínimo)
- [x] Pre-commit review (feature-dev:code-reviewer): APROVADO sem findings
- [ ] CI verde com novos sanity checks
- [ ] Codex review

Closes #195
Closes #197
Closes #205