### PR TITLE
docs/chore: anotações pós-spike S10 + plano cleanup branches

### DIFF
--- a/docs/spikes/158-s10-relatorio.md
+++ b/docs/spikes/158-s10-relatorio.md
@@ -303,15 +303,15 @@ A nova ADR deixa a estratégia anterior (`PublishDomainEventsFromEntityFramework
 
 ## 7. Próximos passos (não-fazer-sem-aprovação)
 
-> **Estado atual (2026-04-26):** a coluna "Operacionalização" foi acrescentada após o merge desta consolidação para apontar onde cada item está sendo executado. As linhas originais ficam preservadas como snapshot do momento da spike.
+> **Estado atual (2026-05-05):** a coluna "Operacionalização" foi atualizada após a sequência de PRs #166/#167/#168/#172/#173 mergear em `main`. As linhas originais ficam preservadas como snapshot do momento da spike.
 
 | Ação | Aprovação requerida | Operacionalização |
 |---|---|---|
 | Promover `ADR-026` rascunho local em `repositories/uniplus-docs/docs/adrs/ADR-026-...md` | Humana — Tech Lead | **Concluído** — ADR-026 mergeada em `uniplus-docs/main`. |
-| Remover `vendors/nuget-local/` + reverter `nuget.config` para apenas `nuget.org` | Humana (PR específico após ADR-026 aprovada) | Em execução em **#163**. |
-| Remover `Directory.Packages.props` lock em `5.32.1-pr2586` → bump para `5.32.1` oficial | Humana (PR específico) | Em execução em **#163**. |
-| Implementar handlers de produção com cascading na Story `#158` (saída do spike) | Humana — Story re-aberta com escopo do estilo cascading | Recalibrado em duas tasks: **#164** (configuração outbox produtivo) + **#136** (handler de referência `PublicarEditalCommand`). |
-| Refatorar `EntityBase.DomainEvents` para visibilidade reduzida (`internal` + `InternalsVisibleTo`) | Humana — fora do escopo deste spike | Pendente — não há issue aberta; permanece como recomendação futura. |
+| Remover `vendors/nuget-local/` + reverter `nuget.config` para apenas `nuget.org` | Humana (PR específico após ADR-026 aprovada) | **Concluído** — issue #163 fechada via PR #168. |
+| Remover `Directory.Packages.props` lock em `5.32.1-pr2586` → bump para `5.32.1` oficial | Humana (PR específico) | **Concluído** — issue #163 / PR #168. |
+| Implementar handlers de produção com cascading na Story `#158` (saída do spike) | Humana — Story re-aberta com escopo do estilo cascading | **Concluído** — issue #158 fechada (Story do produtivo); #164 fechada via PR #172 (configuração outbox produtivo); #136 fechada via PR #173 (handler de referência `PublicarEditalCommand`). |
+| Refatorar `EntityBase.DomainEvents` para visibilidade reduzida (`internal` + `InternalsVisibleTo`) | Humana — fora do escopo deste spike | Pendente — não há issue aberta; permanece como recomendação futura. PR #166 (`DequeueDomainEvents`) cobre apenas o caminho de drenagem explícita, não a redução de visibilidade. |
 
 ## 8. Anexos
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
@@ -62,6 +62,18 @@ public static class WolverineOutboxConfiguration
     /// .ToPostgresqlQueue("domain-events")</c>). Executado depois das policies
     /// transacionais; pode adicionar publishers, listeners, dead letters etc.
     /// Pode ser nulo se o módulo ainda não tem eventos a rotear.</param>
+    /// <remarks>
+    /// <para><strong>Nota sobre <c>Discovery.IncludeAssembly</c> (issue #198):</strong>
+    /// hoje o consumidor único (<c>Selecao.API/Program.cs</c>) chama
+    /// <c>opts.Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly)</c>
+    /// inline dentro do <paramref name="configureRouting"/>. Quando Ingresso
+    /// ganhar o primeiro handler real do tipo cascading, refatorar este
+    /// helper para receber um parâmetro adicional
+    /// <c>params Type[] applicationMarkers</c> (ou
+    /// <c>IEnumerable&lt;Assembly&gt;</c>) que faça o
+    /// <c>opts.Discovery.IncludeAssembly</c> internamente. Não antecipar a
+    /// abstração agora — YAGNI até existir o segundo consumidor.</para>
+    /// </remarks>
     public static IHostBuilder UseWolverineOutboxCascading(
         this IHostBuilder host,
         IConfiguration configuration,

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
@@ -23,11 +23,37 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
     /// Quando <c>true</c> (default), o factory remove o
     /// <see cref="WolverineRuntime"/> da lista de <see cref="IHostedService"/>
     /// — o host inicializa sem startar o Wolverine, evitando que testes que
-    /// só exercitam o pipeline HTTP precisem de Postgres ou Kafka. Subclasses
-    /// que exercitam a infra produtiva de outbox (PG queue, durable envelopes)
-    /// sobrescrevem para <c>false</c> e provisionam o Postgres efêmero por
-    /// fixture (ver <c>CascadingFixture</c>).
+    /// só exercitam o pipeline HTTP precisem de Postgres ou Kafka.
     /// </summary>
+    /// <remarks>
+    /// <para><strong>Por que remover por default?</strong> A maioria das suítes
+    /// de integração testa o pipeline HTTP (auth, routing, controllers,
+    /// middleware) sem exercitar mensageria. Iniciar o Wolverine dispararia
+    /// <c>MigrateAsync</c> contra o Postgres configurado em
+    /// <c>PersistMessagesWithPostgresql</c> — em ambiente de teste sem PG
+    /// real, isso vira timeout de 30+ segundos por suite, mascarando o erro
+    /// real (não há PG) atrás de mensagens genéricas de connection.</para>
+    ///
+    /// <para><strong>Quando sobrescrever para <c>false</c>?</strong> Suites
+    /// que exercitam a infra produtiva de outbox (PG queue durável,
+    /// envelopes persistidos, cascading messages) precisam do Wolverine
+    /// rodando. Essas suites provisionam um Postgres efêmero por fixture
+    /// (ver <c>CascadingFixture</c> em <c>Selecao.IntegrationTests/Outbox/Cascading/</c>)
+    /// e setam <c>DisableWolverineRuntimeForTests = false</c> na sua
+    /// <see cref="ApiFactoryBase{T}"/>-derivada. <c>CascadingApiFactory</c>
+    /// é o exemplo canônico.</para>
+    ///
+    /// <para><strong>Heurística de remoção e sentinela:</strong> a query no
+    /// método <see cref="ConfigureWebHost"/> usa
+    /// <c>d.ImplementationFactory.Method.DeclaringType?.Assembly.GetName().Name == "Wolverine"</c>
+    /// para identificar o <see cref="IHostedService"/> que o Wolverine registra
+    /// via factory delegate. Refactors internos do JasperFx.Wolverine (renomear
+    /// assembly, migrar para <c>ImplementationType</c>) silenciosamente quebrariam
+    /// este filtro, fazendo o runtime iniciar e timeoutar contra Postgres fake.
+    /// O sentinela <c>WolverineRuntimeRemovalSentinelTests</c> em
+    /// <c>Selecao.IntegrationTests/Hosting/</c> (issue #194) replica EXATAMENTE
+    /// esta query e falha cedo se a heurística regredir.</para>
+    /// </remarks>
     protected virtual bool DisableWolverineRuntimeForTests => true;
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)


### PR DESCRIPTION
## Resumo

Frente 3d do plano backend cleanup. 4 issues do lote #192-206:

- **#193** — \`docs/spikes/158-s10-relatorio.md\` §7 atualizada com PRs concluídos (#168, #172, #173) substituindo "Em execução em #163/#164/#136". Snapshot histórico preservado.
- **#198** — Plano para \`Discovery.IncludeAssembly\` compartilhado documentado em \`<remarks>\` XML do \`WolverineOutboxConfiguration.UseWolverineOutboxCascading\`. YAGNI até Ingresso ganhar segundo handler.
- **#206** — \`ApiFactoryBase.DisableWolverineRuntimeForTests\` ganha docstring de 4 parágrafos (por que remover, quando sobrescrever, heurística, sentinela #194).
- **#203** — Plano de remoção de 12 branches da spike S10 registrado no comment de fechamento da issue. Tip-SHAs preservados, comando proposto, salvaguardas confirmadas. **Execução manual pendente de aprovação humana** (operação destrutiva).

## Test plan

- [x] \`dotnet build UniPlus.slnx --no-incremental -v quiet\` → 0/0
- [x] Mudanças exclusivamente docs/comentários — sem impacto runtime
- [ ] CI verde
- [ ] Codex review (provavelmente usage limit)

Closes #193
Closes #198
Closes #206