### PR TITLE
docs(adrs): 13 ADRs da spike S10 cascading messages (Frente 2)

### DIFF
--- a/docs/adrs/0036-controllers-mvc-para-negocio-minimal-api-para-shared.md
+++ b/docs/adrs/0036-controllers-mvc-para-negocio-minimal-api-para-shared.md
@@ -1,0 +1,96 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0036: Controllers MVC `[ApiController]` para endpoints de negócio + Minimal API restrita a shared/técnicos
+
+## Contexto e enunciado do problema
+
+A API tem dois shapes possíveis para endpoints HTTP em ASP.NET Core 10: controllers MVC com `[ApiController]` (`EditalController`, futuras `InscricaoController` etc.) ou Minimal API endpoints (`MapGet("/me", ...)`). Cada modelo traz custo cognitivo se misturados sem regra. Sem padrão claro, contribuidores oscilariam entre os dois e a superfície de testes de roteamento + filtros + autorização ficaria inconsistente.
+
+Os PRs #136 (`PublicarEditalCommand` handler) e #173 (`EditalController` cascading fim-a-fim) consolidaram, na prática, um padrão que não estava em ADR. Esta ADR registra a convenção retroativamente.
+
+## Drivers da decisão
+
+- **Versionamento per-resource via vendor MIME** (ADR-0028) — `[VendorMediaType(Resource = "edital", Versions = [1])]` é um filtro `IActionFilter`, exige `[ApiController]`/MVC pipeline. Minimal API não invoca filtros MVC.
+- **Idempotency-Key opt-in** (ADR-0027) — `[RequiresIdempotencyKey]` é também um `IActionFilter`. Mesmo motivo.
+- **Model binding cursor pagination** (ADR-0031) — `[FromCursor]` model binder integra com pipeline MVC, não Minimal API.
+- **Autorização por atributo** — `[Authorize(Policy = "...")]` em controllers MVC é declarativo e auditável; Minimal API requer composição via `RequireAuthorization()` em chains, frágil para review.
+- **Endpoints técnicos compartilhados** (`/api/auth/me`, `/api/profile/me`, `/health`) — sem domínio, sem versionamento, sem idempotency. Minimal API é mais leve aqui.
+
+## Opções consideradas
+
+- **A. Tudo Minimal API.** Consistência única, performance ligeiramente melhor.
+- **B. Tudo controllers MVC.** Consistência única, integração natural com filtros.
+- **C. Híbrido por categoria — MVC para negócio, Minimal API para técnico/shared.**
+
+## Resultado da decisão
+
+**Escolhida:** "C — Híbrido por categoria", porque é a única opção que casa as restrições reais do projeto.
+
+Endpoints de negócio (criação, listagem, transição de estado de agregados) precisam de filtros MVC (vendor MIME, Idempotency-Key, FluentValidation), model binders (cursor pagination), autorização por atributo, e contratos OpenAPI ricos via `[ProducesResponseType]`. Minimal API não suporta esse pacote sem reimplementar. Adotar A custaria reescrever 4-5 mecanismos do contrato V1.
+
+Endpoints shared (auth, profile, health) são triviais, sem versionamento e sem mutação de estado. Adotar B aqui inflaria a superfície (`AuthController`, `ProfileController`, `HealthController` cada um com seu próprio `[ApiController]`) sem benefício — Minimal API expressa essa intenção em 5 linhas.
+
+### Critério canônico
+
+| Endpoint | Modelo | Razão |
+|---|---|---|
+| `EditalController.Listar/Criar/Publicar` | MVC `[ApiController]` | filtros + cursor pagination + Idempotency-Key + vendor MIME |
+| `/api/auth/me` (`MapSharedAuthEndpoints`) | Minimal API | sem domínio, sem versionamento |
+| `/api/profile/me` (`MapSharedProfileEndpoints`) | Minimal API | mesma justificativa |
+| `/health` (`MapHealthChecks`) | Minimal API | infra |
+
+Futuros controllers de negócio (Inscricao, Chamada, Matricula) seguem o pattern do `EditalController`.
+
+## Consequências
+
+### Positivas
+
+- Custo cognitivo reduzido — contribuidor sabe qual modelo usar pelo tipo do endpoint.
+- Reuso completo do contrato V1 (filtros, model binders, atributos OpenAPI) em endpoints de negócio.
+- Endpoints técnicos permanecem leves.
+
+### Negativas
+
+- Dois pipelines no mesmo Program.cs — pequeno custo de orquestração (ambos rodam atrás do mesmo `UseAuthentication/Authorization`).
+- Testes de integração precisam saber qual modelo está sendo testado para escolher entre `EndpointDataSource` (MVC) ou `RequestDelegate` direto (Minimal).
+
+### Neutras
+
+- Decisão pode ser revisitada quando MVC ou Minimal API ganharem features que tornem um deles dominante. Hoje não há horizon disso.
+
+## Confirmação
+
+- `EditalController` em `src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/` segue o pattern (PR #173).
+- `MapSharedAuthEndpoints` e `MapSharedProfileEndpoints` em `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/`/`Profile/`.
+- `ControllersMvcDiscoverySentinelTests` (PR #325, issue #199) protege contra recidiva de controllers `internal sealed` que sairiam silenciosamente do roteamento.
+
+## Prós e contras das opções
+
+### A — Tudo Minimal API
+
+- Bom: consistência única, performance ligeiramente melhor.
+- Ruim: precisa reimplementar filtros, model binders, vendor MIME, Idempotency-Key — 4-5 mecanismos.
+
+### B — Tudo controllers MVC
+
+- Bom: integração natural com filtros, autorização declarativa.
+- Ruim: inflaciona endpoints triviais (auth/profile/health).
+
+### C — Híbrido por categoria
+
+- Bom: encaixa nas restrições do contrato V1 sem reimplementar nada.
+- Ruim: dois pipelines convivendo, teste de integração precisa saber distinguir.
+
+## Mais informações
+
+- [Microsoft Learn — Controller-based APIs vs Minimal APIs (.NET 10)](https://learn.microsoft.com/aspnet/core/fundamentals/apis?view=aspnetcore-10.0)
+- ADR-0027 — Idempotency-Key store PostgreSQL
+- ADR-0028 — Versionamento per-resource via content negotiation
+- ADR-0030 — OpenAPI 3.1 contract-first
+- ADR-0031 — Decoding de cursor opaco no boundary HTTP
+- Origem: PR [#136](https://github.com/unifesspa-edu-br/uniplus-api/pull/136) e [#173](https://github.com/unifesspa-edu-br/uniplus-api/pull/173); issue [#177](https://github.com/unifesspa-edu-br/uniplus-api/issues/177)

--- a/docs/adrs/0037-hosting-minimal-api-vs-startup.md
+++ b/docs/adrs/0037-hosting-minimal-api-vs-startup.md
@@ -1,0 +1,82 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0037: Hosting via `WebApplication.CreateBuilder` (minimal hosting) mantido vs migração para Generic Host + `Startup.cs`
+
+## Contexto e enunciado do problema
+
+Os módulos `Selecao.API` e `Ingresso.API` foram bootstrapped no padrão moderno de hosting do ASP.NET Core 10: `WebApplication.CreateBuilder(args)` + configuração inline em `Program.cs` (top-level statements), sem classe `Startup`. Esse modelo é o default desde .NET 6 e a recomendação ativa do time .NET.
+
+Durante a spike S10 cascading, descobrimos um gap conhecido em [`dotnet/aspnetcore#37680`](https://github.com/dotnet/aspnetcore/issues/37680): overrides de configuração feitos via `IWebHostBuilder.ConfigureAppConfiguration(...)` em `WebApplicationFactory<TEntryPoint>.ConfigureWebHost` **não propagam** para o `WebApplicationBuilder.Configuration` em apps minimal hosting. O test host precisa injetar overrides via env vars (`ConnectionStrings__SelecaoDb`, `Kafka__BootstrapServers`) ou via `ConfigureAppConfiguration` no Generic Host (não adoptado aqui).
+
+A pergunta: o gap justifica migrar para Generic Host + classe `Startup` (modelo legado, que aceita o override via `IWebHostBuilder` corretamente)?
+
+## Drivers da decisão
+
+- **Gap concreto** com workaround custo-baixo: env vars + helper que lê configuração no callback do `UseWolverine` resolvem 100% do test host.
+- **Custo de migrar é alto**: dois `Program.cs` + dois `Startup.cs` + reescrever DI + revisitar lifecycle de hosted services + retreinar contribuidores em modelo legado.
+- **Direção do .NET**: Generic Host + Startup é considerado legado pelo time ASP.NET. Migrar contra a maré significa carregar dívida arquitetural por anos.
+- **Test surface**: o workaround (env vars + `DisableParallelization` na collection) tem 1 linha de comentário inline e está coberto por sentinela em CI (issue #197 + #205).
+
+## Opções consideradas
+
+- **A. Migrar para Generic Host + `Startup.cs`.**
+- **B. Manter `WebApplication.CreateBuilder` + workaround env vars no test host.**
+- **C. Híbrido: produção em minimal hosting, test fixture com Generic Host customizado.**
+
+## Resultado da decisão
+
+**Escolhida:** "B — Manter minimal hosting", porque o custo de A é desproporcional ao gap real, e C cria divergência produção-vs-teste que mascararia bugs específicos de hosting.
+
+O gap é um custo arquitetural conhecido e contido — não vaza para domínio nem application. Vive em duas linhas (dois `Program.cs`) + um helper (`UseWolverineOutboxCascading`). O workaround foi documentado nas fixtures, validado por sentinela (issue #197), e o overhead de "lembrar" é amortizado pelo número de contribuidores que vão tocar em test host (raros).
+
+## Consequências
+
+### Positivas
+
+- Mantém-se o pattern moderno alinhado com a direção do .NET.
+- Não há migração custosa, sem janela de instabilidade.
+- Contribuidores leem `Program.cs` linear, sem indireção via classe.
+
+### Negativas
+
+- Test fixtures precisam usar env vars para injetar overrides de configuração — comportamento "diferente" do Generic Host. Documentado em comentários e em ADR para evitar que novos contribuidores tentem `ConfigureAppConfiguration` e percam tempo até descobrir o gap.
+- Dependência de [`dotnet/aspnetcore#37680`](https://github.com/dotnet/aspnetcore/issues/37680) ser resolvido upstream, ou de o workaround continuar válido. Se Microsoft mudar o comportamento e env vars deixarem de funcionar, este ADR vira gatilho para reavaliação.
+
+### Neutras
+
+- O helper `UseWolverineOutboxCascading` que lê configuração no callback é simétrico ao pattern do próprio Wolverine — não é uma adaptação especial só para teste.
+
+## Confirmação
+
+- `Program.cs` de Selecao e Ingresso são top-level statements + `WebApplication.CreateBuilder`.
+- `CascadingFixture` injeta overrides via env vars; `CascadingFixtureConfigurationTests` (issue #197) sentinela a chegada efetiva no `IConfiguration` runtime.
+- `CascadingCollection` mantém `DisableParallelization = true` (issue #179) para garantir que env vars não sejam mutadas concorrentemente entre testes do mesmo processo.
+
+## Prós e contras das opções
+
+### A — Migrar para Generic Host + Startup.cs
+
+- Bom: `IWebHostBuilder.ConfigureAppConfiguration` no test host funciona "out of the box".
+- Ruim: contradiz a direção do .NET; custo alto de migração; perde top-level statements.
+
+### B — Manter minimal hosting (escolhida)
+
+- Bom: pattern moderno; custo de migração zero.
+- Ruim: workaround env vars nos test fixtures.
+
+### C — Híbrido (produção minimal, teste Generic Host)
+
+- Bom: resolve o gap em teste sem mudar produção.
+- Ruim: divergência produção/teste; fixture custom complexa; mascara bugs específicos de minimal hosting.
+
+## Mais informações
+
+- [Microsoft Learn — App startup (.NET 10)](https://learn.microsoft.com/aspnet/core/fundamentals/host/web-host?view=aspnetcore-10.0)
+- [`dotnet/aspnetcore#37680`](https://github.com/dotnet/aspnetcore/issues/37680) — `WebApplicationFactory.ConfigureWebHost` não propaga
+- ADR-0038 — Override de configuração em testes via env vars
+- Origem: spike S10 cascading; issue [#178](https://github.com/unifesspa-edu-br/uniplus-api/issues/178); PR [#172](https://github.com/unifesspa-edu-br/uniplus-api/pull/172)

--- a/docs/adrs/0038-override-configuracao-em-testes-via-env-vars.md
+++ b/docs/adrs/0038-override-configuracao-em-testes-via-env-vars.md
@@ -1,0 +1,81 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0038: Override de configuração em testes integrados via env vars + `DisableParallelization` na collection
+
+## Contexto e enunciado do problema
+
+Test fixtures de integração que startam o `WebApplicationFactory<Program>` produtivo precisam injetar valores específicos no `IConfiguration` runtime (connection string do testcontainer Postgres, `Kafka:BootstrapServers` em whitespace para desligar transporte). O caminho idiomático seria `IWebHostBuilder.ConfigureAppConfiguration` em `WebApplicationFactory.ConfigureWebHost`. Esse caminho não funciona para apps minimal hosting (`WebApplication.CreateBuilder`) — gap conhecido em [`dotnet/aspnetcore#37680`](https://github.com/dotnet/aspnetcore/issues/37680) (ver ADR-0037 para a decisão de não migrar).
+
+A pergunta: qual mecanismo de override usar?
+
+## Drivers da decisão
+
+- **Aderência ao runtime real**: o override precisa chegar em `WebApplicationBuilder.Configuration` exatamente como em produção, não em um wrapper de teste.
+- **Cross-suite isolation**: env vars são por processo, não por suite. Se uma suite seta uma env var e outra suite paralela espera o appsettings default, há interleave.
+- **Compat cross-runtime**: `Environment.SetEnvironmentVariable(name, string.Empty)` em runtimes < .NET 9 apaga a variável (em vez de definir como vazia), regredindo para o appsettings.
+
+## Opções consideradas
+
+- **A. `Environment.SetEnvironmentVariable` na fixture + `DisableParallelization=true` na collection.**
+- **B. Reflection sobre `WebApplicationBuilder.Configuration` para injetar `InMemoryCollection`.**
+- **C. Custom `WebApplicationFactory` que substitui `IConfiguration` inteiro.**
+
+## Resultado da decisão
+
+**Escolhida:** "A — env vars + `DisableParallelization=true` na collection que precisa do override".
+
+Env vars são lidas pelo `WebApplicationBuilder` na construção (via `EnvironmentVariablesConfigurationProvider`) sem precisar de nenhum hook customizado. O custo é o cuidado com cross-suite — mitigado por aplicar `[CollectionDefinition(DisableParallelization = true)]` apenas na collection que de fato seta env vars (`CascadingCollection`). Outras collections continuam paralelizando normalmente.
+
+Para o caso `Kafka:BootstrapServers`, o helper produtivo desliga o transporte quando `IsNullOrWhiteSpace`. A fixture seta um espaço (whitespace) em vez de string vazia: em runtimes anteriores a .NET 9, `SetEnvironmentVariable(name, string.Empty)` apaga a variável (regredindo para o appsettings que tem `localhost:9092`); um espaço cobre os dois cenários sem regressão cross-runtime.
+
+## Consequências
+
+### Positivas
+
+- Override chega em `IConfiguration` runtime via path padrão (sem reflection, sem wrapper).
+- Protegido contra cross-suite interleave por `DisableParallelization` localizado.
+- Comportamento idêntico cross-runtime via whitespace para "vazio".
+
+### Negativas
+
+- Suites na mesma collection não paralelizam — perda de tempo de CI quando há muitos facts. Mitigado: a `CascadingCollection` só agrupa testes que precisam do PG efêmero compartilhado (10+ facts hoje).
+- Fixture precisa restaurar env vars previas em `DisposeAsync` para não vazar entre runs do mesmo processo (pytest-watch, dotnet watch test). Captura prévia + try/catch foi reforçada em PR #327 (issue #195).
+
+### Neutras
+
+- A decisão pode ser revertida sem custo se o gap upstream for resolvido — basta substituir `SetEnvironmentVariable` por `ConfigureAppConfiguration` na fixture.
+
+## Confirmação
+
+- `CascadingFixture.InitializeAsync` em `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/` seta `ConnectionStrings__SelecaoDb` e `Kafka__BootstrapServers`.
+- `CascadingCollection` aplica `[CollectionDefinition(DisableParallelization = true)]`.
+- `CascadingFixtureConfigurationTests` (PR #327, issue #197) sentinela que a configuração efetiva chegou correta.
+- Captura prévia + restore em catch implementados no PR #327 (issue #195).
+
+## Prós e contras das opções
+
+### A — env vars + DisableParallelization (escolhida)
+
+- Bom: padrão idiomático para apps minimal hosting; sem reflection; restore deterministico.
+- Ruim: `DisableParallelization` reduz throughput de testes paralelizáveis.
+
+### B — Reflection sobre `WebApplicationBuilder.Configuration`
+
+- Bom: não depende de env vars; cada fixture isolada.
+- Ruim: reflection é frágil contra refactors do .NET; perde-se simetria com produção.
+
+### C — Custom `WebApplicationFactory` que substitui `IConfiguration` inteiro
+
+- Bom: escopo total; sem cross-suite leak.
+- Ruim: divergência produção/teste alta; reescreve provider chain.
+
+## Mais informações
+
+- ADR-0037 — Hosting minimal API mantido
+- [`dotnet/aspnetcore#37680`](https://github.com/dotnet/aspnetcore/issues/37680)
+- Origem: spike S10 cascading commit `bf052ad`; issue [#179](https://github.com/unifesspa-edu-br/uniplus-api/issues/179); PR [#172](https://github.com/unifesspa-edu-br/uniplus-api/pull/172)

--- a/docs/adrs/0039-provisioning-schema-wolverine-via-deploy.md
+++ b/docs/adrs/0039-provisioning-schema-wolverine-via-deploy.md
@@ -12,6 +12,7 @@ decision-makers:
 Wolverine 5.32.1 com `PersistMessagesWithPostgresql` cria as tabelas `wolverine.outbox`, `wolverine.envelopes`, `wolverine.dead_letters` etc. Por default, `WolverineOptions.AutoBuildMessageStorageOnStartup` está ligado — o framework cria o schema na primeira inicialização do host.
 
 Em produção, runtime auto-create traz problemas:
+
 - Risco de race quando dois pods iniciam simultaneamente.
 - DDL sem revisão prévia em PR.
 - Ausência de auditoria de migrations da messageria.

--- a/docs/adrs/0039-provisioning-schema-wolverine-via-deploy.md
+++ b/docs/adrs/0039-provisioning-schema-wolverine-via-deploy.md
@@ -1,0 +1,88 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0039: Provisioning do schema Wolverine como responsabilidade do deploy, não auto-create em runtime
+
+## Contexto e enunciado do problema
+
+Wolverine 5.32.1 com `PersistMessagesWithPostgresql` cria as tabelas `wolverine.outbox`, `wolverine.envelopes`, `wolverine.dead_letters` etc. Por default, `WolverineOptions.AutoBuildMessageStorageOnStartup` está ligado — o framework cria o schema na primeira inicialização do host.
+
+Em produção, runtime auto-create traz problemas:
+- Risco de race quando dois pods iniciam simultaneamente.
+- DDL sem revisão prévia em PR.
+- Ausência de auditoria de migrations da messageria.
+- Permissions: usuário runtime precisaria de `CREATE TABLE`, ampliando blast radius LGPD.
+
+A pergunta: como provisionar o schema Wolverine?
+
+## Drivers da decisão
+
+- **Imutabilidade de runtime**: o pod produtivo deveria ter permissões mínimas (CRUD em tabelas existentes), não DDL.
+- **Auditabilidade**: changes no schema da messageria devem passar pelo mesmo pipeline de PR + review que o schema do domínio.
+- **Determinismo**: ambientes (dev, staging, prod) devem ter o mesmo schema validado, não cada um criando seu próprio na primeira inicialização.
+
+## Opções consideradas
+
+- **A. `AutoBuildMessageStorageOnStartup = true` (default Wolverine).**
+- **B. Desligar auto-build em produção; provisionar via `dotnet wolverine db-apply` no pipeline ou step do deploy.**
+- **C. Migration assembly EF Core dedicado para o schema Wolverine.**
+
+## Resultado da decisão
+
+**Escolhida:** "B — auto-build desligado em produção, provisioning como step explícito do deploy".
+
+`WolverineOutboxConfiguration.UseWolverineOutboxCascading` configura `PersistMessagesWithPostgresql(connectionString, schema: "wolverine")` mas **não** chama `AutoBuildMessageStorageOnStartup()`. Em produção, o operador roda `dotnet wolverine db-apply` (ferramenta CLI do JasperFx) como step do pipeline antes de subir o pod, similar a `dotnet ef database update`.
+
+Em testes integrados, a `CascadingFixture` usa `EnsureCreatedAsync` no Postgres efêmero — isso é OK porque (a) o banco existe só para o test run, (b) o usuário do testcontainer tem DDL, (c) a alternativa (rodar `dotnet wolverine db-apply` na fixture) seria custo desproporcional para test ergonomics.
+
+## Consequências
+
+### Positivas
+
+- Pod runtime tem permissões CRUD-only no schema `wolverine.*` — superfície LGPD reduzida.
+- Schema changes passam por PR + review.
+- Determinismo cross-environment.
+- Sem risco de race em deploys multi-pod.
+
+### Negativas
+
+- Step adicional no pipeline de deploy. Mitigação: documentar no playbook operacional.
+- Dev local precisa rodar o comando uma vez antes de iniciar a API. Mitigação: adicionar ao `make dev` / docker-compose entrypoint.
+
+### Neutras
+
+- Decisão pode ser revisitada quando Wolverine introduzir migrations versionadas (parecidas com EF Core). Hoje o `db-apply` é idempotente mas não rastreia versões.
+
+## Confirmação
+
+- `WolverineOutboxConfiguration.UseWolverineOutboxCascading` em `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/` **NÃO** chama `AutoBuildMessageStorageOnStartup`.
+- Comentário inline na linha do `PersistMessagesWithPostgresql` documenta a decisão e aponta para o ADR.
+- Em testes integrados, `CascadingFixture.InitializeAsync` provisiona via `EnsureCreatedAsync` (escopo: Postgres efêmero do testcontainer).
+
+## Prós e contras das opções
+
+### A — Auto-build em runtime
+
+- Bom: zero step no deploy; primeira inicialização auto-resolve.
+- Ruim: pod precisa de DDL; race em multi-pod; sem auditoria.
+
+### B — `dotnet wolverine db-apply` no pipeline (escolhida)
+
+- Bom: pod com permissões mínimas; auditável; determinístico.
+- Ruim: step manual a documentar.
+
+### C — Migration EF Core dedicado
+
+- Bom: integra com o pipeline EF Core do domínio.
+- Ruim: dupla manutenção (schema do Wolverine evolui independente das entidades do domínio); não é o caminho recomendado pelo JasperFx.
+
+## Mais informações
+
+- [JasperFx Wolverine — Database operations CLI](https://wolverinefx.io/guide/durability/postgresql.html)
+- ADR-0040 — Helper `UseWolverineOutboxCascading`
+- ADR-0026 — Outbox transacional via Wolverine
+- Origem: spike S10 cascading; issue [#180](https://github.com/unifesspa-edu-br/uniplus-api/issues/180); PR [#172](https://github.com/unifesspa-edu-br/uniplus-api/pull/172)

--- a/docs/adrs/0040-helper-wolverine-outbox-cascading-canonico.md
+++ b/docs/adrs/0040-helper-wolverine-outbox-cascading-canonico.md
@@ -1,0 +1,93 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0040: `WolverineOutboxConfiguration.UseWolverineOutboxCascading` como ponto canônico de configuração
+
+## Contexto e enunciado do problema
+
+Cada módulo (`Selecao.API`, `Ingresso.API`) precisa configurar o mesmo conjunto de invariantes Wolverine: persistência outbox em PostgreSQL no schema `wolverine`, atomicidade write+evento via `UseEntityFrameworkCoreTransactions`, durable outbox em todos os endpoints, middleware Command+Query, schema NÃO auto-criado em runtime (ADR-0039), Kafka opcional, roteamento específico do módulo via callback.
+
+Sem helper, cada `Program.cs` repetiria 30+ linhas de configuração idênticas — e qualquer drift entre módulos vira bug oculto (um módulo persiste outbox, outro não; um habilita Kafka, outro não).
+
+## Drivers da decisão
+
+- **Invariantes compartilhadas**: persistência, atomicidade, durabilidade, middleware são iguais em todos os módulos.
+- **Customização específica**: cada módulo tem seu próprio routing (`PublishMessage<EditalPublicadoEvent>`, futuros eventos do Ingresso).
+- **Test surface**: a fixture cascading reusa o mesmo helper que produção — divergência produção/teste mascara bugs específicos de configuração.
+
+## Opções consideradas
+
+- **A. Configuração inline em cada `Program.cs`.**
+- **B. Helper estático `UseWolverineOutboxCascading(this IHostBuilder, IConfiguration, string connectionStringName, ...)` em `Infrastructure.Core/Messaging/`.**
+- **C. Builder fluente `new WolverineOutboxBuilder(...).WithKafka(...).WithRouting(...)`.**
+
+## Resultado da decisão
+
+**Escolhida:** "B — Helper estático no `Infrastructure.Core/Messaging/`", porque centraliza as invariantes em um único ponto sem inflar com builder pattern desnecessário. Cada módulo passa a connection string name + um callback `configureRouting` que recebe `WolverineOptions` para eventos específicos.
+
+Assinatura:
+
+```csharp
+public static IHostBuilder UseWolverineOutboxCascading(
+    this IHostBuilder host,
+    IConfiguration configuration,
+    string connectionStringName,
+    string kafkaConfigKey = DefaultKafkaConfigKey,
+    Action<WolverineOptions>? configureRouting = null)
+```
+
+Connection string e Kafka bootstrap são lidos lazy dentro do callback de `UseWolverine`, no startup do host — momento em que os providers de configuração já materializaram (env vars, appsettings). Esse padrão é compatível com o test fixture que injeta override via env var (ADR-0038).
+
+## Consequências
+
+### Positivas
+
+- Drift entre módulos é estruturalmente impossível — todos passam pelo mesmo helper.
+- Test fixture reusa o helper produtivo (`CascadingApiFactory` herda essa configuração via `Program.cs` real).
+- Mudanças nas invariantes (ex.: novo middleware obrigatório, política de retry) propagam para todos os módulos via uma única edição.
+
+### Negativas
+
+- Helper precisa expor parâmetros suficientes para cobrir variações reais sem virar god-object. Mitigado por design: connection string name + Kafka key + routing callback são os três únicos eixos de variação.
+- Adicionar nova invariante exige mudança no helper, que afeta todos os módulos. Aceitável — mudanças em invariantes deveriam mesmo passar por revisão cross-módulo.
+
+### Neutras
+
+- Helper hoje vive em `Infrastructure.Core` (compartilhado entre módulos). Decisão consciente de manter código compartilhado sob `shared/`.
+
+## Confirmação
+
+- `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs` — implementação canônica.
+- `Selecao.API/Program.cs` consome o helper com routing específico (`PublishMessage<EditalPublicadoEvent>`).
+- `Ingresso.API/Program.cs` consome o helper sem routing por enquanto (não há eventos cross-módulo do Ingresso ainda).
+- `WolverineRuntimeRemovalSentinelTests` (issue #194) usa o mesmo helper para validar invariantes do registro de IHostedService.
+
+## Prós e contras das opções
+
+### A — Configuração inline em cada Program.cs
+
+- Bom: zero indireção, código local.
+- Ruim: 30+ linhas duplicadas; drift entre módulos vira bug silencioso.
+
+### B — Helper estático (escolhida)
+
+- Bom: invariantes centralizadas; custom via callback.
+- Ruim: helper precisa balancear flexibilidade vs simplicidade.
+
+### C — Builder fluente
+
+- Bom: descobrível via IntelliSense; chainable.
+- Ruim: overengineering para 3 eixos de variação; test surface maior.
+
+## Mais informações
+
+- [JasperFx Wolverine — Outbox + EF Core](https://wolverinefx.io/guide/durability/efcore.html)
+- ADR-0026 — Outbox transacional via Wolverine
+- ADR-0038 — Override de configuração em testes
+- ADR-0039 — Provisioning do schema via deploy
+- ADR-0044 — Roteamento produtivo de domain events (per-módulo)
+- Origem: PR [#172](https://github.com/unifesspa-edu-br/uniplus-api/pull/172); issue [#181](https://github.com/unifesspa-edu-br/uniplus-api/issues/181)

--- a/docs/adrs/0041-padrao-retorno-handlers-wolverine-cascading.md
+++ b/docs/adrs/0041-padrao-retorno-handlers-wolverine-cascading.md
@@ -1,0 +1,108 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0041: Padrão de retorno `(Result, IEnumerable<object>)` em handlers Wolverine que mutam agregados
+
+## Contexto e enunciado do problema
+
+Handlers Wolverine que mutam agregados precisam (a) retornar um `Result` para o caller via `ICommandBus.Send<Result>` (sucesso/falha tipada) E (b) drenar `EntityBase.DomainEvents` para o bus de cascading messages, que o Wolverine persiste no outbox dentro da mesma transação do `SaveChanges` (atomicidade write+evento — ADR-0026).
+
+Ingenuamente, isso parece exigir dispatch manual: o handler chama `_commandBus.Publish(@event)` para cada evento drenado. Esse caminho falha — o `Publish` abre nova transação fora do `IEnvelopeTransaction` ativo, perdendo atomicidade.
+
+A solução existe na Wolverine 5.32.1: cascading messages via tupla nativa de retorno. Primeira posição vira a resposta tipada do `InvokeAsync<TResponse>`, segunda é capturada por `CaptureCascadingMessages` e persistida no outbox dentro da `IEnvelopeTransaction` da política `AutoApplyTransactions` + `EnrollDbContextInTransaction`.
+
+## Drivers da decisão
+
+- **Atomicidade**: write+evento na mesma transação ou nada — invariante crítico do outbox.
+- **Tipagem do response**: `ICommandBus.Send<Result<Guid>>` precisa receber `Result<Guid>` no chamador, não `object`.
+- **Drenagem explícita** (ADR-0026): `EntityBase.DomainEvents` é populada pelo agregado durante a operação; o handler deve drenar via `DequeueDomainEvents()` antes de retornar.
+- **Sem dispatcher manual**: chamar `_commandBus.Publish(...)` quebra atomicidade.
+
+## Opções consideradas
+
+- **A. Handler retorna apenas `Result`; eventos drenados via dispatcher manual.**
+- **B. Handler retorna tupla `(Result, IEnumerable<object>)`; Wolverine captura cascading.**
+- **C. Handler retorna `Result`; scraper EF Core (`PublishDomainEventsFromEntityFrameworkCore`) drena `EntityBase.DomainEvents` ao final do `SaveChanges`.**
+
+## Resultado da decisão
+
+**Escolhida:** "B — tupla `(Result, IEnumerable<object>)`", porque é a única opção que cumpre simultaneamente atomicidade + tipagem + drenagem explícita.
+
+Forma canônica do handler (slice de referência: `PublicarEditalCommandHandler` em `src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/`):
+
+```csharp
+public static async Task<(Result, IEnumerable<object>)> Handle(
+    PublicarEditalCommand command,
+    IEditalRepository repository,
+    IUnitOfWork unitOfWork,
+    CancellationToken cancellationToken)
+{
+    Edital? edital = await repository.ObterPorIdAsync(command.Id, cancellationToken);
+    if (edital is null)
+        return (Result.Failure(EditalErrors.NaoEncontrado), []);
+
+    Result<Edital> publicarResult = edital.Publicar();
+    if (publicarResult.IsFailure)
+        return (Result.Failure(publicarResult.Error!), []);
+
+    await unitOfWork.SaveChangesAsync(cancellationToken);
+
+    return (Result.Success(), edital.DequeueDomainEvents().Cast<object>());
+}
+```
+
+`DequeueDomainEvents` (ADR-0034 wrap imutável; ADR-0026 drenagem explícita) tira snapshot + limpa a coleção atomicamente. O `Cast<object>()` é necessário porque o tipo cascading do Wolverine é `IEnumerable<object>`, não `IEnumerable<IDomainEvent>`.
+
+A opção C foi explicitamente rejeitada na ADR-0026 — `PublishDomainEventsFromEntityFrameworkCore<EntityBase>` está desligado por configuração no `WolverineOutboxConfiguration`. Razão: o scraper EF lê eventos no final da transação SQL, momento em que mensagens de capabilities (sagas, processadores) já podem ter sido despachadas ignorando esses eventos. A drenagem explícita pelo handler é a fonte única.
+
+## Consequências
+
+### Positivas
+
+- Atomicidade write+evento garantida pelo `IEnvelopeTransaction` ativo.
+- Tipagem preservada: `ICommandBus.Send<Result<Guid>>` continua tipado.
+- Drenagem visível no código do handler — review humano vê os eventos sendo emitidos.
+- `Cast<object>()` é o único custo técnico — uma chamada O(n) no final.
+
+### Negativas
+
+- Handler que muta agregado mas não retorna `IEnumerable<object>` deixa eventos órfãos. Mitigação: revisar PR de novos handlers cascading; padrão documentado em CLAUDE.md do `uniplus-api`.
+- Tupla 2-arity tem custo cognitivo para devs vindos de MediatR (que usa `IRequestHandler<TRequest, TResponse>` mono-aridade).
+
+### Neutras
+
+- A decisão pode ser revisitada quando Wolverine introduzir um wrapper tipo `IDomainResult<T>` que combine os dois canais. Hoje o tuple é o idiomatic.
+
+## Confirmação
+
+- `PublicarEditalCommandHandler` em `Selecao.Application/Commands/Editais/` segue o pattern.
+- `EditalPublicadoSubscriberHandler` (test handler em `tests/.../Outbox/Cascading/`) consome o evento drenado.
+- `PublicarEditalEndpointTests` valida cascading fim-a-fim (PR #173, ADR-0026).
+
+## Prós e contras das opções
+
+### A — `Result` + dispatcher manual
+
+- Bom: sintaxe simples.
+- Ruim: quebra atomicidade write+evento.
+
+### B — Tupla `(Result, IEnumerable<object>)` (escolhida)
+
+- Bom: atomicidade + tipagem + drenagem explícita.
+- Ruim: tuple 2-arity custa cognitivo.
+
+### C — `Result` + scraper EF
+
+- Bom: handler mais simples (sem segundo retorno).
+- Ruim: timing do scraper é depois do dispatch de capabilities; eventos podem ser perdidos.
+
+## Mais informações
+
+- [JasperFx Wolverine — Cascading Messages](https://wolverinefx.io/guide/handlers/cascading.html)
+- ADR-0026 — Outbox transacional via Wolverine
+- ADR-0034 — DequeueDomainEvents (wrap imutável)
+- Origem: spike S10 cascading; PR [#173](https://github.com/unifesspa-edu-br/uniplus-api/pull/173); issue [#182](https://github.com/unifesspa-edu-br/uniplus-api/issues/182)

--- a/docs/adrs/0042-application-nao-depende-diretamente-de-dbcontext.md
+++ b/docs/adrs/0042-application-nao-depende-diretamente-de-dbcontext.md
@@ -1,0 +1,97 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0042: Application layer não depende diretamente de DbContext — sempre via repository + Unit of Work
+
+## Contexto e enunciado do problema
+
+Exemplos canônicos do JasperFx Wolverine no guia de EF Core sugerem injetar `DbContext` direto no handler:
+
+```csharp
+public static async Task Handle(
+    SomeCommand cmd,
+    AppDbContext db,            // ← Wolverine resolve via DI
+    CancellationToken ct)
+{
+    var entity = await db.Entities.FindAsync(...);
+    // mutate
+    await db.SaveChangesAsync(ct);
+}
+```
+
+Esse padrão é tentador (zero indireção, EF features visíveis) mas **viola Clean Architecture** (ADR-0002): `DbContext` é uma classe de Infrastructure, e Application layer não pode depender de Infrastructure.
+
+A pergunta: aderir ao exemplo do framework ou manter Clean Architecture?
+
+## Drivers da decisão
+
+- **ADR-0002 — Clean Architecture obrigatória**: Application → Domain + SharedKernel; nunca Infrastructure.
+- **Fitness test R3 do contrato V1** (PR #319): regra arquitetural detecta dependências Application → Infrastructure e falha o build.
+- **Test surface**: handler que injeta `DbContext` precisa de PG real ou InMemory provider; handler que injeta `IRepository` aceita NSubstitute mock — testável em unit, não só em integration.
+- **Ergonomics**: o exemplo do Wolverine economiza ~3 linhas; a manutenibilidade longo prazo paga isso muitas vezes.
+
+## Opções consideradas
+
+- **A. Aderir ao exemplo Wolverine — DbContext direto no handler.**
+- **B. Application depende de `IEditalRepository` + `IUnitOfWork`; Infrastructure implementa via EF Core.**
+- **C. Híbrido — `DbContext` direto em queries simples (read-only); repository em commands.**
+
+## Resultado da decisão
+
+**Escolhida:** "B — repository + Unit of Work em todos os handlers que tocam persistência".
+
+`Selecao.Application/Commands/Editais/PublicarEditalCommandHandler` injeta `IEditalRepository` (interface em `Selecao.Domain/Interfaces/`) + `IUnitOfWork` (em `Application.Abstractions/Interfaces/`). Implementações vivem em `Selecao.Infrastructure/Persistence/Repositories/`.
+
+A regra arquitetural R3 (fitness test em `Selecao.ArchTests`) protege contra recidiva — se algum handler em `Selecao.Application` adicionar `using Microsoft.EntityFrameworkCore` ou referenciar `SelecaoDbContext`, o build falha.
+
+A opção C foi rejeitada porque introduz divergência: para o reviewer, ler "este é query, OK depender direto de DbContext, mas aquele é command" exige memorizar a regra. B é uma única convenção universal.
+
+## Consequências
+
+### Positivas
+
+- Application unit-testável com mocks (NSubstitute) — não precisa de PG ou InMemory provider.
+- Mudança de provider (Postgres → outro RDBMS, ou Marten) afeta só Infrastructure.
+- Fitness test R3 protege contra recidiva.
+
+### Negativas
+
+- Handler tem 1 indireção a mais que o exemplo Wolverine — leitura inicial demora um beat extra.
+- Repository pode virar "anti-pattern" se ganhar métodos de query específicos demais. Mitigação: queries complexas vão para `IQueryHandler` Wolverine, não inflar o repository.
+
+### Neutras
+
+- A decisão é consistente com ADR-0002 e R3 — esta ADR formaliza retroativamente o que a fitness test já garante.
+
+## Confirmação
+
+- `PublicarEditalCommandHandler` em `Selecao.Application/Commands/Editais/` injeta `IEditalRepository` + `IUnitOfWork`.
+- Fitness test R3 (PR #319) detecta dependências Application → Infrastructure.
+- `IEditalRepository` em `Selecao.Domain/Interfaces/`; `EditalRepository` em `Selecao.Infrastructure/Persistence/Repositories/`.
+
+## Prós e contras das opções
+
+### A — DbContext direto
+
+- Bom: zero indireção; EF features completas.
+- Ruim: viola Clean Architecture; não unit-testável; trava troca de provider.
+
+### B — Repository + UoW (escolhida)
+
+- Bom: Clean Architecture preservada; unit-testável; flexibilidade de provider.
+- Ruim: 1 indireção a mais.
+
+### C — Híbrido
+
+- Bom: ergonomia em queries simples.
+- Ruim: divergência de pattern entre handlers; reviewer precisa memorizar a regra.
+
+## Mais informações
+
+- ADR-0002 — Clean Architecture obrigatória
+- Fitness test R3 — Application não depende de Infrastructure (PR [#319](https://github.com/unifesspa-edu-br/uniplus-api/pull/319))
+- Origem: PR [#173](https://github.com/unifesspa-edu-br/uniplus-api/pull/173); issue [#183](https://github.com/unifesspa-edu-br/uniplus-api/issues/183)

--- a/docs/adrs/0043-discovery-explicito-application-via-includeassembly.md
+++ b/docs/adrs/0043-discovery-explicito-application-via-includeassembly.md
@@ -1,0 +1,96 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0043: Discovery explícito da Application layer no Wolverine via `Discovery.IncludeAssembly`
+
+## Contexto e enunciado do problema
+
+Wolverine descobre handlers escaneando (a) o entry assembly do host e (b) qualquer assembly marcado com `[assembly: WolverineModule<T>]`. O entry assembly é `Selecao.API` (o `Program.cs`), mas os handlers produtivos vivem em `Selecao.Application` — assembly que `Selecao.API` referencia mas que, sem instrução explícita, não entra no scan do Wolverine.
+
+Sem inclusão, o Wolverine inicializa sem registrar `PublicarEditalCommandHandler` e o caller `_commandBus.Send<Result>(new PublicarEditalCommand(...))` lança em runtime "no handler found".
+
+A pergunta: como instruir o Wolverine a escanear `Selecao.Application`?
+
+## Drivers da decisão
+
+- **Clareza no startup**: a configuração do Wolverine deve ser auditável em um único ponto (`Program.cs` / helper compartilhado).
+- **Sem mágica de classpath**: contribuidor lendo o código deve entender de onde os handlers vêm sem precisar conhecer convenções implícitas do Wolverine.
+- **Modularidade**: cada módulo decide quais assemblies seus.
+
+## Opções consideradas
+
+- **A. `[assembly: WolverineModule<DiscoveryExtension>]` em Selecao.Application; classe `DiscoveryExtension : IWolverineExtension` chama `IncludeAssembly`.**
+- **B. `opts.Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly)` no callback de `UseWolverineOutboxCascading` (em `Program.cs`).**
+- **C. Marker interface `IApplicationAssemblyMarker` + reflection para listar assemblies referenciados.**
+
+## Resultado da decisão
+
+**Escolhida:** "B — `IncludeAssembly` explícito no callback, com tipo âncora **public** do assembly de Application".
+
+`Selecao.API/Program.cs` chama:
+
+```csharp
+builder.Host.UseWolverineOutboxCascading(
+    builder.Configuration,
+    connectionStringName: "SelecaoDb",
+    configureRouting: opts =>
+    {
+        opts.Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly);
+        // ...routing específico...
+    });
+```
+
+`PublicarEditalCommand` é o command público âncora — qualquer tipo public do assembly serviria, mas usar um command real torna explícita a relação "este assembly contém handlers de comandos".
+
+Opção A seria viável mas adiciona uma classe extra em Application só para discovery, sem benefício sobre B. A foi adoptada nos testes (`CascadingTestDiscoveryExtension`) onde test handlers vivem no assembly de teste (não referenciado pelo Program.cs produtivo) e o `[assembly: WolverineModule<T>]` é a única forma de incluí-los.
+
+Opção C é overengineering — reflection genérica vs uma linha explícita.
+
+## Consequências
+
+### Positivas
+
+- Discovery é uma linha visível no callback do helper. Auditável.
+- Sem dependência de convenção — quem lê o código sabe de onde vêm os handlers.
+- Pattern uniforme: cada módulo `*.API` chama `IncludeAssembly` no seu callback.
+
+### Negativas
+
+- Adicionar novo assembly Application (ex.: `Selecao.Application.Sagas`) exige edição do `Program.cs` — fricção mínima.
+- Tipo âncora (`PublicarEditalCommand`) precisa permanecer público. Hoje é convenção do projeto que commands sejam públicos (ver ADR-0048 para controllers).
+
+### Neutras
+
+- Quando Ingresso ganhar primeiro handler, o ADR-0040 nota o trigger para refatorar o helper aceitando `params Type[] applicationMarkers` — YAGNI até segundo consumidor (issue #198).
+
+## Confirmação
+
+- `Selecao.API/Program.cs` linha 98 chama `opts.Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly)`.
+- `CascadingTestDiscoveryExtension` em `tests/.../Outbox/Cascading/` usa Opção A (test handlers no assembly de teste).
+
+## Prós e contras das opções
+
+### A — `[assembly: WolverineModule<T>]`
+
+- Bom: descoberta automática quando o assembly é carregado; padrão idiomático Wolverine.
+- Ruim: classe extra só pra discovery; menos visível em review.
+
+### B — `IncludeAssembly` explícito no callback (escolhida)
+
+- Bom: visível no Program.cs; sem classe extra.
+- Ruim: adicionar assembly novo exige edição manual.
+
+### C — Marker interface + reflection
+
+- Bom: zero edição manual.
+- Ruim: overengineering; dificulta debug; comportamento mágico.
+
+## Mais informações
+
+- [JasperFx Wolverine — Handler Discovery](https://wolverinefx.io/guide/handlers/discovery.html)
+- ADR-0040 — Helper `UseWolverineOutboxCascading` (trigger para parametrizar IncludeAssembly)
+- Origem: PR [#173](https://github.com/unifesspa-edu-br/uniplus-api/pull/173); issue [#184](https://github.com/unifesspa-edu-br/uniplus-api/issues/184)

--- a/docs/adrs/0044-roteamento-domain-events-pg-queue-kafka-opcional.md
+++ b/docs/adrs/0044-roteamento-domain-events-pg-queue-kafka-opcional.md
@@ -12,6 +12,7 @@ decision-makers:
 `EditalPublicadoEvent` é drenado do agregado via cascading messages (ADR-0041) e cai no outbox. A pergunta seguinte: para onde o Wolverine entrega esses eventos?
 
 Possibilidades:
+
 - **Listener interno PG queue** (`ToPostgresqlQueue`) — entrega in-process via mesma instância Wolverine; baixíssimo overhead; ideal para subscribers do mesmo módulo (auditoria, logging, projection).
 - **Tópico Kafka** (`ToKafkaTopic`) — entrega cross-process, durável, persistente; necessário para integração cross-módulo ou consumidores externos.
 - **Sem rota** — evento fica no outbox sem subscriber, criando lixo.

--- a/docs/adrs/0044-roteamento-domain-events-pg-queue-kafka-opcional.md
+++ b/docs/adrs/0044-roteamento-domain-events-pg-queue-kafka-opcional.md
@@ -1,0 +1,103 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0044: Roteamento produtivo de domain events — queue PostgreSQL interna + tópico Kafka opcional
+
+## Contexto e enunciado do problema
+
+`EditalPublicadoEvent` é drenado do agregado via cascading messages (ADR-0041) e cai no outbox. A pergunta seguinte: para onde o Wolverine entrega esses eventos?
+
+Possibilidades:
+- **Listener interno PG queue** (`ToPostgresqlQueue`) — entrega in-process via mesma instância Wolverine; baixíssimo overhead; ideal para subscribers do mesmo módulo (auditoria, logging, projection).
+- **Tópico Kafka** (`ToKafkaTopic`) — entrega cross-process, durável, persistente; necessário para integração cross-módulo ou consumidores externos.
+- **Sem rota** — evento fica no outbox sem subscriber, criando lixo.
+
+A pergunta: qual a estratégia padrão?
+
+## Drivers da decisão
+
+- **Subscribers intra-módulo existem hoje** (`EditalPublicadoEventHandler` de logging em `Selecao.Application`). Precisam de PG queue.
+- **Cross-módulo ainda não existe** (Ingresso não consome `EditalPublicadoEvent`), mas existirá quando "chamada de vagas" for implementada. Precisa de Kafka.
+- **Ambiente sem Kafka**: dev local sem broker; CI sem Kafka container; HML pode rodar sem Kafka enquanto Ingresso não consumir. Forçar Kafka faz Wolverine entrar em retry indefinido.
+- **YAGNI**: eventos sem subscriber real não devem ser roteados para Kafka apenas por simetria.
+
+## Opções consideradas
+
+- **A. Sempre rotear para PG queue + Kafka.**
+- **B. PG queue sempre; Kafka opcional condicionado a `Kafka:BootstrapServers` configurado.**
+- **C. Sem roteamento default — cada evento decide caso a caso.**
+
+## Resultado da decisão
+
+**Escolhida:** "B — PG queue sempre, Kafka opcional condicional".
+
+`Selecao.API/Program.cs` configura no callback de `UseWolverineOutboxCascading`:
+
+```csharp
+opts.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
+opts.ListenToPostgresqlQueue("domain-events");
+
+if (!string.IsNullOrWhiteSpace(builder.Configuration["Kafka:BootstrapServers"]))
+{
+    opts.PublishMessage<EditalPublicadoEvent>().ToKafkaTopic("edital_events");
+}
+```
+
+PG queue é unconditional: o subscriber intra-módulo precisa do evento para auditoria/logging em todo ambiente. Kafka é condicional a configuração — quando `Kafka:BootstrapServers` está vazio (dev local sem broker, test fixture, deploy HML pré-Ingresso), Wolverine não tenta abrir transport Kafka.
+
+`Helper UseWolverineOutboxCascading` faz o `opts.UseKafka(...).AutoProvision()` quando `Kafka:BootstrapServers` está populado — auto-provision dos tópicos é OK em ambiente de produção controlado.
+
+## Consequências
+
+### Positivas
+
+- Subscribers intra-módulo funcionam em todos os ambientes (incluindo CI).
+- Kafka pode ser ligado/desligado por configuração — switch operacional.
+- Sem retry indefinido contra broker inexistente.
+- Quando Ingresso consumir `EditalPublicadoEvent`, basta apontar `Kafka:BootstrapServers` e o publishing entra automaticamente.
+
+### Negativas
+
+- Eventos roteados para PG queue + Kafka simultaneamente são entregues duplamente para subscribers que escutam em ambos os transports. Hoje esse caso não existe (subscriber intra escuta PG only; subscriber cross-módulo escutará Kafka only). Documentar quando o cenário materializar.
+- Configuração Kafka é via env var/appsettings — não há flag explícita "use kafka yes/no". Mitigado por convenção: deixar `Kafka:BootstrapServers` vazio = desliga.
+
+### Neutras
+
+- A decisão pode ser revisitada se o Wolverine ganhar transports adicionais (RabbitMQ, Service Bus). Hoje só PG e Kafka são considerados.
+
+## Confirmação
+
+- `Selecao.API/Program.cs` configura ambos os routes condicionais.
+- `WolverineOutboxConfiguration.UseWolverineOutboxCascading` faz `UseKafka` apenas quando `Kafka:BootstrapServers` é não-whitespace.
+- `CascadingFixture` força `Kafka__BootstrapServers` em whitespace (issue #197 sentinela).
+- `OutboxCascadingMatrixTests` (V8/V9) cobre cenários sem Kafka; `OutboxCascadingKafkaTests` (V10) cobre com Kafka.
+
+## Prós e contras das opções
+
+### A — Sempre PG + Kafka
+
+- Bom: simetria.
+- Ruim: dev local + CI sem Kafka entram em retry; force-kafka quebra ambientes pré-Ingresso.
+
+### B — PG sempre + Kafka condicional (escolhida)
+
+- Bom: subscribers intra funcionam sempre; Kafka é switch operacional.
+- Ruim: convenção de "vazio desliga" exige documentação.
+
+### C — Sem default
+
+- Bom: explicitude máxima.
+- Ruim: cada evento precisa de roteamento manual; eventos esquecidos viram lixo no outbox.
+
+## Mais informações
+
+- [JasperFx Wolverine — PostgreSQL Transport](https://wolverinefx.io/guide/messaging/transports/postgresql.html)
+- [JasperFx Wolverine — Kafka Transport](https://wolverinefx.io/guide/messaging/transports/kafka.html)
+- ADR-0026 — Outbox transacional via Wolverine
+- ADR-0040 — Helper `UseWolverineOutboxCascading`
+- ADR-0041 — Padrão de retorno cascading
+- Origem: PR [#172](https://github.com/unifesspa-edu-br/uniplus-api/pull/172) e [#173](https://github.com/unifesspa-edu-br/uniplus-api/pull/173); issue [#185](https://github.com/unifesspa-edu-br/uniplus-api/issues/185)

--- a/docs/adrs/0045-test-factory-remove-wolverine-runtime.md
+++ b/docs/adrs/0045-test-factory-remove-wolverine-runtime.md
@@ -1,0 +1,94 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0045: Test factory remove `WolverineRuntime` de `IHostedService` para suítes não-outbox
+
+## Contexto e enunciado do problema
+
+A maioria das suítes de integração (`AuthEndpointsTests`, `OpenApiEndpointTests`, `EditalEndpointTests` etc.) testa o pipeline HTTP sem exercitar mensageria — não precisa de PostgreSQL para outbox nem Kafka para domain events.
+
+Iniciar o Wolverine em test host implicitamente dispara `MigrateAsync` contra o PG configurado em `PersistMessagesWithPostgresql`. Em ambiente de teste sem PG real (fixtures HTTP-only), isso vira timeout de 30+ segundos por suite, mascarando o erro real (não há PG) atrás de mensagens genéricas de connection.
+
+A pergunta: como impedir o Wolverine de iniciar em test hosts que não precisam dele?
+
+## Drivers da decisão
+
+- **Test ergonomics**: timeout de 30s por suite torna iteração local insuportável.
+- **Divergência produção/teste**: a remoção precisa ser cirúrgica — só `WolverineRuntime` (o IHostedService que startup), não os serviços que ele registra (`ICommandBus`, `IQueryBus`).
+- **Heurística estável**: o `WolverineRuntime` é registrado via factory (`ImplementationFactory != null`, `ImplementationType == null`), o que torna inspeção por tipo concreto inviável.
+
+## Opções consideradas
+
+- **A. `DisableWolverineRuntimeForTests = true` por default; suites de outbox sobrescrevem para `false`.**
+- **B. Sem default — cada test factory precisa decidir.**
+- **C. Wolverine "test mode" oficial via API do JasperFx.**
+
+## Resultado da decisão
+
+**Escolhida:** "A — `DisableWolverineRuntimeForTests = true` por default em `ApiFactoryBase<T>`".
+
+`tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs` expõe a propriedade `protected virtual bool DisableWolverineRuntimeForTests => true`. No `ConfigureWebHost`, quando `true`, remove descriptors via:
+
+```csharp
+ServiceDescriptor[] hostedToRemove = [.. services
+    .Where(d => d.ServiceType == typeof(IHostedService)
+        && d.ImplementationFactory is not null
+        && d.ImplementationFactory.Method.DeclaringType?.Assembly.GetName().Name == "Wolverine")];
+foreach (ServiceDescriptor svc in hostedToRemove)
+    services.Remove(svc);
+```
+
+A heurística casa pelo assembly da factory (`Wolverine`), não pelo tipo concreto. Suites cascading (`CascadingApiFactory`) sobrescrevem para `false` e provisionam PG efêmero por fixture.
+
+A opção C (Wolverine test mode oficial) seria preferível mas o JasperFx não expõe API pública para isso na versão 5.32.1. Quando expuser, este ADR é gatilho para migrar.
+
+## Consequências
+
+### Positivas
+
+- Suites HTTP-only iniciam em segundos, não em 30+.
+- Override sopra simples (`DisableWolverineRuntimeForTests = false`) para suites que precisam.
+- Sentinela `WolverineRuntimeRemovalSentinelTests` (issue #194) protege contra refactor interno do JasperFx que quebre a heurística.
+
+### Negativas
+
+- Heurística depende do nome do assembly Wolverine. Se Wolverine renomear (ex.: `JasperFx.Wolverine`), a heurística vira no-op silencioso. Mitigação: sentinela CI falha cedo se isso acontecer.
+- Suites HTTP-only que injetam `ICommandBus` e tentam enviar comandos vão funcionar até o ponto do envelope — mas nada o consome porque o runtime não roda. Aceitável: testes HTTP-only não devem despachar comandos; se precisarem, sobrescrever a flag.
+
+### Neutras
+
+- A propriedade `DisableWolverineRuntimeForTests` está documentada com `<remarks>` em 4 parágrafos (PR #328, issue #206) explicando porque, quando, heurística e sentinela.
+
+## Confirmação
+
+- `ApiFactoryBase<T>.DisableWolverineRuntimeForTests` em `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs`.
+- `CascadingApiFactory` sobrescreve para `false` (suite cascading).
+- `WolverineRuntimeRemovalSentinelTests` em `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/` espelha a query da heurística.
+
+## Prós e contras das opções
+
+### A — Default `true` + override (escolhida)
+
+- Bom: 90% dos casos via default; opt-out cirúrgico.
+- Ruim: heurística depende de string `"Wolverine"`.
+
+### B — Sem default
+
+- Bom: explicitude.
+- Ruim: cada test factory repete configuração; esquecer = timeout 30s sem causa óbvia.
+
+### C — Test mode oficial
+
+- Bom: API estável do framework.
+- Ruim: não existe na versão 5.32.1.
+
+## Mais informações
+
+- ADR-0040 — Helper `UseWolverineOutboxCascading`
+- Issue [#194](https://github.com/unifesspa-edu-br/uniplus-api/issues/194) — sentinela da heurística (PR [#325](https://github.com/unifesspa-edu-br/uniplus-api/pull/325))
+- Issue [#206](https://github.com/unifesspa-edu-br/uniplus-api/issues/206) — docstring expandida (PR [#328](https://github.com/unifesspa-edu-br/uniplus-api/pull/328))
+- Origem: PR [#172](https://github.com/unifesspa-edu-br/uniplus-api/pull/172); issue [#187](https://github.com/unifesspa-edu-br/uniplus-api/issues/187)

--- a/docs/adrs/0046-validacao-de-regras-sem-excecao-result-failure.md
+++ b/docs/adrs/0046-validacao-de-regras-sem-excecao-result-failure.md
@@ -1,0 +1,106 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0046: Validação de regras de negócio sem exceção — `Result.Failure(DomainError)` para fluxo esperado
+
+## Contexto e enunciado do problema
+
+Handlers e métodos de domínio precisam sinalizar falhas previsíveis (entidade não encontrada, transição de estado inválida, regra de negócio violada). Há dois caminhos possíveis:
+
+- **Exceção**: `throw new EditalNaoEncontradoException(id)`. Capturada por middleware global que mapeia para HTTP 404.
+- **Result pattern**: `return Result.Failure(EditalErrors.NaoEncontrado)`. Caller verifica `IsFailure` e mapeia via `IDomainErrorMapper`.
+
+A pergunta: qual o default?
+
+## Drivers da decisão
+
+- **Performance**: exceções têm custo de stack unwinding (~10-100µs); `Result` é uma struct/record, custo zero.
+- **Explicitude**: `Task<Result>` sinaliza no tipo do método "isso pode falhar"; `Task<T>` pode lançar mas o tipo não diz.
+- **Pipeline previsível**: handlers Wolverine usam middleware que inspeciona retorno; com Result, middleware loga falha estruturada sem custar exception.
+- **Reservar exceção para o inesperado**: `GlobalExceptionMiddleware` (em `Infrastructure.Core/Middleware/`) captura tudo que escapa — esse caminho deveria ser raro, não comum.
+
+## Opções consideradas
+
+- **A. Exceções para tudo (transição inválida lança).**
+- **B. `Result.Failure(DomainError)` para fluxo esperado; exceções para falhas inesperadas (DB indisponível, bug).**
+- **C. Híbrido por caso — handler decide.**
+
+## Resultado da decisão
+
+**Escolhida:** "B — Result para fluxo esperado, exceção para inesperado".
+
+Slice canônico (`PublicarEditalCommandHandler`):
+
+```csharp
+public static async Task<(Result, IEnumerable<object>)> Handle(...)
+{
+    Edital? edital = await repository.ObterPorIdAsync(...);
+    if (edital is null)
+        return (Result.Failure(EditalErrors.NaoEncontrado), []);
+
+    Result<Edital> publicarResult = edital.Publicar();
+    if (publicarResult.IsFailure)
+        return (Result.Failure(publicarResult.Error!), []);
+
+    // ...
+}
+```
+
+Controller MVC mapeia `Result` para HTTP via extension `result.ToActionResult(_mapper)` que consulta `IDomainErrorMapper` (ADR-0024) e retorna `application/problem+json` (RFC 9457, ADR-0023). Códigos canônicos:
+
+- `uniplus.selecao.edital.nao_encontrado` → 404
+- `uniplus.selecao.edital.ja_publicado` → 422
+
+Falhas inesperadas (DbUpdateException, NullReferenceException de bug) sobem para `GlobalExceptionMiddleware` que retorna `uniplus.internal.unexpected` 500. Esse caminho é o exception fallback, não o canal regular.
+
+## Consequências
+
+### Positivas
+
+- Performance: custo zero em fluxos esperados (sem stack unwinding).
+- Pipeline middleware Wolverine pode logar falhas tipadas sem catch.
+- Tipo do método assinala "pode falhar" via `Result<T>` no retorno.
+
+### Negativas
+
+- Caller obrigado a verificar `IsFailure` antes de acessar `.Value` — disciplina sobre tipo. C#  expressões de pattern matching ajudam.
+- Curva de aprendizado para devs vindos de stacks java-style com exceções para "esperado".
+
+### Neutras
+
+- A decisão é consistente com ADR-0024 (mapeamento DomainError → HTTP) e ADR-0023 (RFC 9457). Esta ADR formaliza retroativamente o uso obrigatório do Result pattern para regras de negócio.
+
+## Confirmação
+
+- `Selecao.Application/Commands/Editais/PublicarEditalCommandHandler` segue o pattern.
+- `EditalErrors` em `Selecao.Domain/Errors/` declara códigos canônicos.
+- `SelecaoDomainErrorRegistration` em `Selecao.API/Errors/` mapeia para HTTP.
+- Testes `PublicarEditalEndpointTests` validam 404 (`uniplus.selecao.edital.nao_encontrado`) e 422 (`uniplus.selecao.edital.ja_publicado`).
+- `GlobalExceptionMiddleware` em `Infrastructure.Core/Middleware/` captura exceções inesperadas.
+
+## Prós e contras das opções
+
+### A — Exceções para tudo
+
+- Bom: estilo C# legado/java; imediato.
+- Ruim: stack unwinding caro; tipo do método não declara falha; pipeline Wolverine custa wrap.
+
+### B — Result para esperado, exceção para inesperado (escolhida)
+
+- Bom: performance + explicitude + pipeline limpo.
+- Ruim: disciplina sobre IsFailure.
+
+### C — Híbrido caso a caso
+
+- Bom: máxima flexibilidade.
+- Ruim: convenção viola — reviewer precisa inferir; bugs por inconsistência.
+
+## Mais informações
+
+- ADR-0023 — ProblemDetails RFC 9457 canônico
+- ADR-0024 — Mapeamento DomainError → HTTP
+- Origem: PR [#173](https://github.com/unifesspa-edu-br/uniplus-api/pull/173); issue [#188](https://github.com/unifesspa-edu-br/uniplus-api/issues/188)

--- a/docs/adrs/0047-confluent-kafka-npgsql-pisos-transitivos-wolverine.md
+++ b/docs/adrs/0047-confluent-kafka-npgsql-pisos-transitivos-wolverine.md
@@ -1,0 +1,88 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0047: `Confluent.Kafka 2.14.0` + `Npgsql 9.0.4` como pisos transitivos do Wolverine 5.32.1
+
+## Contexto e enunciado do problema
+
+Após o de-vendor do Wolverine (PR #168) e a adoção do `WolverineFx.Postgresql` + `WolverineFx.Kafka` 5.32.1 oficiais (PR #172), o `Directory.Packages.props` passou a depender transitivamente de:
+
+- `Confluent.Kafka 2.14.0` (provém de `WolverineFx.Kafka`)
+- `Npgsql 9.0.4` (provém de `WolverineFx.Postgresql` + `Microsoft.EntityFrameworkCore`)
+
+Esses pacotes não foram escolhidos independentemente — vieram em pacote arquitetural com a decisão de usar Wolverine. Sem ADR documentando isso, futuros bumps de Confluent.Kafka ou Npgsql parecem opção independente, quando na verdade são dependência arquitetural da escolha Wolverine.
+
+## Drivers da decisão
+
+- **Auditoria**: bumps de pacotes de infra precisam ser rastreáveis a uma decisão arquitetural, não à conveniência local.
+- **Compat**: bump unilateral de `Confluent.Kafka` ou `Npgsql` pode quebrar compatibilidade com a versão Wolverine — só Wolverine atesta.
+- **Documentar restrição**: a próxima vez que alguém ver `<PackageVersion Include="Confluent.Kafka" Version="2.14.0" />` no `Directory.Packages.props`, ADR aponta porque essa versão.
+
+## Opções consideradas
+
+- **A. Documentar pisos transitivos como ADR.**
+- **B. Comentário inline em `Directory.Packages.props`.**
+- **C. Não documentar — rastrear caso a caso.**
+
+## Resultado da decisão
+
+**Escolhida:** "A — ADR documentando pisos transitivos como dependência arquitetural".
+
+Esta ADR registra que:
+
+1. `Confluent.Kafka 2.14.0` e `Npgsql 9.0.4` são **pisos transitivos** do Wolverine 5.32.1.
+2. Bumps unilaterais de qualquer um desses pacotes **devem** vir acompanhados de bump do Wolverine ou de validação explícita de compat.
+3. O matrix de teste S0-S10 da spike #158 valida o conjunto na versão atual; bump no `WolverineFx.Postgresql` ou `WolverineFx.Kafka` deve regerar o matrix.
+
+A opção B (comentário inline em `Directory.Packages.props`) é compatível com A — pode ser feita em PR adicional pequeno, citando esta ADR.
+
+## Consequências
+
+### Positivas
+
+- Bumps futuros de `Confluent.Kafka` ou `Npgsql` ficam visíveis como decisão arquitetural; review consulta este ADR.
+- Aderência ao matrix S0-S10 — não há "pegou e funcionou", há "validado na config X".
+
+### Negativas
+
+- ADR fica em risco de obsolescência — quando Wolverine bumpar, esta ADR precisa de atualização (ou de uma sucessora). Mitigação: nota no rodapé do ADR registra a versão Wolverine atestada e a data.
+
+### Neutras
+
+- A decisão pode ser ampliada quando novos pisos transitivos surgirem (ex.: `MongoDB.Driver` se Wolverine adicionar transport Mongo). Hoje cobre apenas Confluent.Kafka + Npgsql.
+
+## Confirmação
+
+- `Directory.Packages.props` em `repositories/uniplus-api/` declara as versões.
+- `package.lock.json` em cada projeto fixa a versão resolvida.
+- Spike S10 (`docs/spikes/158-relatorio-final.md`) registrou os matrix tests para a config atual.
+
+## Prós e contras das opções
+
+### A — ADR (escolhida)
+
+- Bom: rastreabilidade arquitetural; review consulta documento canônico.
+- Ruim: ADR pode ficar obsoleto se Wolverine bumpar e ninguém atualizar.
+
+### B — Comentário inline em `Directory.Packages.props`
+
+- Bom: mais próximo do código.
+- Ruim: comentário em props file é raramente lido em review de bumps.
+
+### C — Não documentar
+
+- Bom: zero esforço.
+- Ruim: bump unilateral é provável; debug de incompat é caro.
+
+## Mais informações
+
+- [JasperFx Wolverine — Postgresql backend](https://wolverinefx.io/guide/durability/postgresql.html)
+- [JasperFx Wolverine — Kafka transport](https://wolverinefx.io/guide/messaging/transports/kafka.html)
+- ADR-0026 — Outbox transacional via Wolverine
+- ADR-0040 — Helper `UseWolverineOutboxCascading`
+- Origem: PR [#168](https://github.com/unifesspa-edu-br/uniplus-api/pull/168) (de-vendor); PR [#172](https://github.com/unifesspa-edu-br/uniplus-api/pull/172) (5.32.1 oficial); issue [#189](https://github.com/unifesspa-edu-br/uniplus-api/issues/189)
+- **Versão Wolverine atestada nesta ADR:** `WolverineFx.Postgresql 5.32.1` + `WolverineFx.Kafka 5.32.1` (2026-05-05).

--- a/docs/adrs/0048-controllers-mvc-public-com-ca1515-suprimido.md
+++ b/docs/adrs/0048-controllers-mvc-public-com-ca1515-suprimido.md
@@ -1,0 +1,101 @@
+---
+status: "accepted"
+date: "2026-05-05"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0048: Controllers MVC em projetos `*.API` devem ser `public`, com CA1515 suprimido por justificativa
+
+## Contexto e enunciado do problema
+
+ASP.NET Core MVC descobre controllers via `ControllerFeatureProvider.IsController(TypeInfo type)`, que exige `type.IsPublic == true`. Controllers marcados como `internal sealed` (default sugerido pelo analyzer `CA1515` — "Consider making public types internal") ficam silenciosamente fora do roteamento — nenhum endpoint registrado, nenhum diagnóstico claro em runtime. Foi exatamente isso que causou a regressão capturada em #173.
+
+Por outro lado, o analyzer `CA1515` é geralmente saudável — reduz superfície pública desnecessária. Suprimi-lo globalmente perde valor.
+
+A pergunta: como reconciliar a obrigação MVC ("público") com o analyzer geral?
+
+## Drivers da decisão
+
+- **Discovery MVC obrigatória**: controllers precisam ser `public` por contrato do framework.
+- **Auditabilidade**: a supressão deve indicar **por que** está sendo feita, não ser CYA silencioso.
+- **Cobertura de regressão**: além da supressão correta, sentinela de teste que protege contra recidiva.
+
+## Opções consideradas
+
+- **A. `[SuppressMessage("Performance", "CA1515:...")]` inline em cada controller, com justification explicando MVC discovery.**
+- **B. `<NoWarn>CA1515</NoWarn>` no csproj de cada `*.API`.**
+- **C. Suprimir CA1515 globalmente em `.editorconfig`.**
+
+## Resultado da decisão
+
+**Escolhida:** "A — `[SuppressMessage]` inline com `Justification` explicando MVC discovery".
+
+Slice canônico (`EditalController`):
+
+```csharp
+[ApiController]
+[Route("api/editais")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public; sem isso o MVC ignora a classe e nenhum endpoint é registrado.")]
+public sealed class EditalController : ControllerBase
+{
+    // ...
+}
+```
+
+A justificativa explica o porquê — review humano consegue auditar.
+
+A opção B (`<NoWarn>` no csproj) silencia globalmente o analyzer no projeto, perdendo sinal de classes utilitárias `internal` válidas. Opção C agrava: silencia em toda a solution.
+
+A sentinela de discovery MVC (`ControllersMvcDiscoverySentinelTests` em PR #325, issue #199) protege contra recidiva: se algum dev no futuro mudar `public` para `internal`, o teste falha cedo com mensagem direcional.
+
+## Consequências
+
+### Positivas
+
+- Analyzer CA1515 continua ativo para o resto do código — sinal preservado.
+- Justificativa inline é auditável.
+- Sentinela CI protege contra recidiva.
+
+### Negativas
+
+- Boilerplate `[SuppressMessage]` em cada novo controller. Mitigação: pattern consolidado em CLAUDE.md do `uniplus-api`; templates de Stories indicam o snippet.
+- Devs que não conhecem o pattern podem tentar `internal sealed` por reflexo do CA1515 — sentinela falha cedo, mas custa loop dev.
+
+### Neutras
+
+- A decisão é específica para controllers MVC. Outras supressões CA1515 (test factories `internal sealed` que precisam ser `public` para fixture genérica) seguem o mesmo padrão de inline justify.
+
+## Confirmação
+
+- `EditalController` em `src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/` segue o pattern.
+- `ControllersMvcDiscoverySentinelTests` em `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/` protege contra recidiva.
+- ADR-0036 (Controllers MVC vs Minimal API) referencia este ADR para o padrão de declaração.
+
+## Prós e contras das opções
+
+### A — `[SuppressMessage]` inline (escolhida)
+
+- Bom: justificativa auditável; analyzer ativo no resto.
+- Ruim: boilerplate por controller.
+
+### B — `<NoWarn>` no csproj
+
+- Bom: zero boilerplate em controllers.
+- Ruim: silencia globalmente; perde sinal em utilitários internos.
+
+### C — `.editorconfig` global
+
+- Bom: silencia em toda solution.
+- Ruim: perda total do sinal CA1515.
+
+## Mais informações
+
+- [Microsoft Learn — `ControllerFeatureProvider` (.NET 10)](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.controllers.controllerfeatureprovider?view=aspnetcore-10.0)
+- [CA1515 — Consider making public types internal](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1515)
+- ADR-0036 — Controllers MVC para negócio + Minimal API para shared
+- Issue [#199](https://github.com/unifesspa-edu-br/uniplus-api/issues/199) — sentinela controllers MVC discovery (PR [#325](https://github.com/unifesspa-edu-br/uniplus-api/pull/325))
+- Origem: PR [#173](https://github.com/unifesspa-edu-br/uniplus-api/pull/173); issue [#190](https://github.com/unifesspa-edu-br/uniplus-api/issues/190)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -64,6 +64,19 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0033](0033-icurrentuser-abstraction-via-iusercontext.md) | `IUserContext` como abstração canônica para acesso ao principal autenticado | accepted | 2026-05-05 |
 | [0034](0034-problemdetails-em-401-403-via-jwtbearer-events.md) | ProblemDetails RFC 9457 em 401/403 via `JwtBearerEvents.OnChallenge`/`OnForbidden` | accepted | 2026-05-05 |
 | [0035](0035-shared-schemas-cross-module-fitness-test.md) | Schemas duplicados entre baselines OpenAPI — fitness test cross-module no lugar de `$ref` multi-arquivo | accepted | 2026-05-05 |
+| [0036](0036-controllers-mvc-para-negocio-minimal-api-para-shared.md) | Controllers MVC `[ApiController]` para endpoints de negócio + Minimal API restrita a shared/técnicos | accepted | 2026-05-05 |
+| [0037](0037-hosting-minimal-api-vs-startup.md) | Hosting via `WebApplication.CreateBuilder` mantido vs migração para Generic Host + `Startup.cs` | accepted | 2026-05-05 |
+| [0038](0038-override-configuracao-em-testes-via-env-vars.md) | Override de configuração em testes via env vars + `DisableParallelization` na collection | accepted | 2026-05-05 |
+| [0039](0039-provisioning-schema-wolverine-via-deploy.md) | Provisioning do schema Wolverine como responsabilidade do deploy, não auto-create em runtime | accepted | 2026-05-05 |
+| [0040](0040-helper-wolverine-outbox-cascading-canonico.md) | `WolverineOutboxConfiguration.UseWolverineOutboxCascading` como ponto canônico de configuração | accepted | 2026-05-05 |
+| [0041](0041-padrao-retorno-handlers-wolverine-cascading.md) | Padrão de retorno `(Result, IEnumerable<object>)` em handlers Wolverine que mutam agregados | accepted | 2026-05-05 |
+| [0042](0042-application-nao-depende-diretamente-de-dbcontext.md) | Application layer não depende de DbContext — sempre via repository + Unit of Work | accepted | 2026-05-05 |
+| [0043](0043-discovery-explicito-application-via-includeassembly.md) | Discovery explícito da Application layer no Wolverine via `Discovery.IncludeAssembly` | accepted | 2026-05-05 |
+| [0044](0044-roteamento-domain-events-pg-queue-kafka-opcional.md) | Roteamento de domain events: queue PG interna + tópico Kafka opcional | accepted | 2026-05-05 |
+| [0045](0045-test-factory-remove-wolverine-runtime.md) | Test factory remove `WolverineRuntime` de `IHostedService` para suítes não-outbox | accepted | 2026-05-05 |
+| [0046](0046-validacao-de-regras-sem-excecao-result-failure.md) | Validação de regras de negócio sem exceção — `Result.Failure(DomainError)` para fluxo esperado | accepted | 2026-05-05 |
+| [0047](0047-confluent-kafka-npgsql-pisos-transitivos-wolverine.md) | `Confluent.Kafka 2.14.0` + `Npgsql 9.0.4` como pisos transitivos do Wolverine 5.32.1 | accepted | 2026-05-05 |
+| [0048](0048-controllers-mvc-public-com-ca1515-suprimido.md) | Controllers MVC em `*.API` devem ser `public`, com CA1515 suprimido por justificativa | accepted | 2026-05-05 |
 
 ## Como adicionar um novo ADR
 


### PR DESCRIPTION
## Resumo

Frente 2 do plano backend cleanup. **13 decisões já em produção** da spike S10 cascading messages formalizadas como ADRs MADR 4.0 com status **\`accepted\`** (não proposed — são decisões em main).

## Mapeamento issue → ADR

| Issue | ADR | Tema |
|---|---|---|
| #177 | [0036](docs/adrs/0036-controllers-mvc-para-negocio-minimal-api-para-shared.md) | Controllers MVC + Minimal API split por categoria |
| #178 | [0037](docs/adrs/0037-hosting-minimal-api-vs-startup.md) | Hosting via WebApplication.CreateBuilder mantido |
| #179 | [0038](docs/adrs/0038-override-configuracao-em-testes-via-env-vars.md) | Override config em testes via env vars |
| #180 | [0039](docs/adrs/0039-provisioning-schema-wolverine-via-deploy.md) | Schema Wolverine via deploy, não auto-create |
| #181 | [0040](docs/adrs/0040-helper-wolverine-outbox-cascading-canonico.md) | Helper UseWolverineOutboxCascading canônico |
| #182 | [0041](docs/adrs/0041-padrao-retorno-handlers-wolverine-cascading.md) | Padrão (Result, IEnumerable<object>) em handlers |
| #183 | [0042](docs/adrs/0042-application-nao-depende-diretamente-de-dbcontext.md) | Application sem DbContext direto |
| #184 | [0043](docs/adrs/0043-discovery-explicito-application-via-includeassembly.md) | Discovery via IncludeAssembly explícito |
| #185 | [0044](docs/adrs/0044-roteamento-domain-events-pg-queue-kafka-opcional.md) | Routing PG queue + Kafka opcional |
| #187 | [0045](docs/adrs/0045-test-factory-remove-wolverine-runtime.md) | Test factory remove WolverineRuntime |
| #188 | [0046](docs/adrs/0046-validacao-de-regras-sem-excecao-result-failure.md) | Result.Failure para fluxo esperado |
| #189 | [0047](docs/adrs/0047-confluent-kafka-npgsql-pisos-transitivos-wolverine.md) | Confluent.Kafka + Npgsql como pisos |
| #190 | [0048](docs/adrs/0048-controllers-mvc-public-com-ca1515-suprimido.md) | Controllers public com CA1515 suprimido |

## Test plan

- [x] \`bash tools/adr-lint/validate.sh\` → 48 ADRs validados sem erros
- [x] \`dotnet build UniPlus.slnx --no-incremental\` → 0/0 (mudanças exclusivamente docs)
- [x] Cada ADR linka aos PRs públicos (#136, #166, #168, #172, #173, #194/325, #199/325, #206/328) e ADRs anteriores (0023, 0024, 0026, 0028, 0030, 0031, 0034)
- [ ] CI verde

Closes #177
Closes #178
Closes #179
Closes #180
Closes #181
Closes #182
Closes #183
Closes #184
Closes #185
Closes #187
Closes #188
Closes #189
Closes #190