### PR TITLE
chore(adr-lint): integrar markdownlint-cli2 ao validator local (paridade dev↔CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
           node-version: '20'
 
       - name: Markdown lint (markdownlint-cli2)
-        run: npx --yes markdownlint-cli2 'docs/adrs/**/*.md'
+        # Versão pinada em sincronia com tools/adr-lint/validate.sh:
+        # bump exige edição coordenada dos dois para preservar paridade
+        # dev↔CI (script local invoca o mesmo binary).
+        run: npx --yes markdownlint-cli2@0.22.1 'docs/adrs/**/*.md'
 
   spectral:
     name: Spectral lint (OpenAPI baselines)

--- a/tools/adr-lint/validate.sh
+++ b/tools/adr-lint/validate.sh
@@ -119,13 +119,39 @@ MARKDOWNLINT_VERSION="0.22.1"
 if command -v npx >/dev/null 2>&1; then
   echo
   echo "Rodando markdownlint-cli2@${MARKDOWNLINT_VERSION} em $DIR/**/*.md ..."
-  if ! npx --yes "markdownlint-cli2@${MARKDOWNLINT_VERSION}" "$DIR/**/*.md"; then
-    echo
-    echo "ERRO: markdownlint-cli2 reportou violações." >&2
+
+  # Captura combinada de stdout+stderr para diagnosticar a natureza do
+  # exit code != 0 abaixo: violação de lint vs falha de fetch (registry,
+  # auth, network). O `tee` espelha a saída no terminal para o operador
+  # ver progresso enquanto o script processa o resultado.
+  MD_OUTPUT_FILE=$(mktemp)
+  trap 'rm -f "$MD_OUTPUT_FILE"' EXIT
+
+  set +e
+  npx --yes "markdownlint-cli2@${MARKDOWNLINT_VERSION}" "$DIR/**/*.md" 2>&1 \
+    | tee "$MD_OUTPUT_FILE"
+  MD_EXIT="${PIPESTATUS[0]}"
+  set -e
+
+  if [[ "$MD_EXIT" -eq 0 ]]; then
+    echo "markdownlint-cli2: 0 erros."
+  elif grep -qE 'markdownlint-cli2 v[0-9]' "$MD_OUTPUT_FILE"; then
+    # Banner do binary apareceu → ferramenta rodou; exit != 0 = lint real.
+    echo >&2
+    echo "ERRO: markdownlint-cli2 reportou violações de formatação." >&2
     echo "Config: $DIR/.markdownlint-cli2.jsonc" >&2
     exit 1
+  else
+    # Banner ausente → npx falhou ANTES de invocar o binary
+    # (registry HTTP error, auth, network, integrity). Não é violação de
+    # contrato local; emitir aviso para o operador, sem falhar — o gate de
+    # CI ainda protege a main.
+    echo >&2
+    echo "AVISO: npx não conseguiu rodar markdownlint-cli2@${MARKDOWNLINT_VERSION} (exit $MD_EXIT)." >&2
+    echo "       Provável falha de fetch (registry/auth/network), não violação de lint." >&2
+    echo "       O gate de CI ainda valida; tente novamente quando a rede normalizar:" >&2
+    echo "         npx --yes markdownlint-cli2@${MARKDOWNLINT_VERSION} '$DIR/**/*.md'" >&2
   fi
-  echo "markdownlint-cli2: 0 erros."
 else
   echo
   echo "AVISO: npx não encontrado — pulando markdownlint-cli2 local." >&2

--- a/tools/adr-lint/validate.sh
+++ b/tools/adr-lint/validate.sh
@@ -104,4 +104,30 @@ if [[ "$ERRORS" -gt 0 ]]; then
   exit 1
 fi
 
-echo "$COUNT ADR(s) validados sem erros."
+echo "$COUNT ADR(s) validados sem erros (frontmatter MADR 4.0)."
+
+# Markdownlint-cli2 — formatação do markdown (MD032 listas, MD024 siblings,
+# MD041 H1 etc.) regida pelo .markdownlint-cli2.jsonc do diretório de ADRs.
+# CI roda esta mesma versão; rodar localmente garante paridade dev↔CI.
+#
+# Pinar via @VERSION evita drift entre ambientes — bump exige edição
+# coordenada deste script + .github/workflows/ci.yml. Sem npx no PATH,
+# emite aviso em vez de falhar (devs sem Node ainda obtêm validação MADR 4.0
+# via primeira parte deste script; o gate completo fica para o CI).
+MARKDOWNLINT_VERSION="0.22.1"
+
+if command -v npx >/dev/null 2>&1; then
+  echo
+  echo "Rodando markdownlint-cli2@${MARKDOWNLINT_VERSION} em $DIR/**/*.md ..."
+  if ! npx --yes "markdownlint-cli2@${MARKDOWNLINT_VERSION}" "$DIR/**/*.md"; then
+    echo
+    echo "ERRO: markdownlint-cli2 reportou violações." >&2
+    echo "Config: $DIR/.markdownlint-cli2.jsonc" >&2
+    exit 1
+  fi
+  echo "markdownlint-cli2: 0 erros."
+else
+  echo
+  echo "AVISO: npx não encontrado — pulando markdownlint-cli2 local." >&2
+  echo "       O CI ainda roda este gate; instale Node.js para validação dev↔CI paritária." >&2
+fi


### PR DESCRIPTION
## Resumo

Lição capturada na execução do plano backend-followups-cleanup (2026-05-05): o validator local \`tools/adr-lint/validate.sh\` cobria apenas frontmatter MADR 4.0 e estrutura H1/sections, deixando regras de formatação markdown (MD032, MD022, etc.) só no CI. Resultado prático: PR #329 falhou no CI por MD032 que poderia ter sido pego localmente.

## Mudanças

- \`tools/adr-lint/validate.sh\` ganha bloco final invocando \`markdownlint-cli2@0.22.1\` via npx. Falha o script em violações; aviso (não falha) quando npx ausente.
- \`.github/workflows/ci.yml\` com versão pinada (\`@0.22.1\`) — alinhada com o script local. Bump exige edição coordenada dos dois.

## Test plan

- [x] Validação positiva: \`bash tools/adr-lint/validate.sh\` → "48 ADR(s) validados sem erros (MADR 4.0)" + "markdownlint-cli2: 0 erros."
- [x] Prova negativa: remover blank antes de lista em uma ADR → script falha com MD022 + MD032 apontando arquivo+linha.
- [x] Restauração → 0 erros.
- [ ] CI verde nesta branch.