### PR TITLE
fix(openapi): cursor pagination wire format em GET /api/editais (#332)

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -191,22 +191,19 @@
         ],
         "parameters": [
           {
-            "name": "AfterId",
+            "name": "cursor",
             "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
-            "name": "Limit",
+            "name": "limit",
             "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": [
-                "integer",
-                "string"
-              ],
+              "type": "integer",
               "format": "int32"
             }
           }
@@ -214,6 +211,21 @@
         "responses": {
           "200": {
             "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022next\u0022 s\u00F3 quando h\u00E1 pr\u00F3xima p\u00E1gina. Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
             "content": {
               "text/plain": {
                 "schema": {
@@ -281,7 +293,8 @@
               }
             }
           }
-        }
+        },
+        "x-uniplus-paginated": true
       }
     },
     "/api/editais/{id}": {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/UniPlusOpenApiServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/UniPlusOpenApiServiceCollectionExtensions.cs
@@ -36,12 +36,14 @@ public static class UniPlusOpenApiServiceCollectionExtensions
 
         services.TryAddSingleton<UniPlusInfoTransformer>();
         services.TryAddSingleton<UniPlusOperationTransformer>();
+        services.TryAddSingleton<CursorPaginationOperationTransformer>();
         services.TryAddSingleton<UniPlusSchemaTransformer>();
 
         services.AddOpenApi(documentName, options =>
         {
             options.AddDocumentTransformer<UniPlusInfoTransformer>();
             options.AddOperationTransformer<UniPlusOperationTransformer>();
+            options.AddOperationTransformer<CursorPaginationOperationTransformer>();
             options.AddSchemaTransformer<UniPlusSchemaTransformer>();
         });
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/CursorPaginationOperationTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/CursorPaginationOperationTransformer.cs
@@ -1,0 +1,170 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.OpenApi;
+
+using System.Reflection;
+using System.Text.Json.Nodes;
+
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+using Pagination;
+
+/// <summary>
+/// Operation transformer que reconcilia o spec OpenAPI com o contrato wire de
+/// paginação por cursor opaco (ADR-0026). O <see cref="FromCursorAttribute"/>
+/// herda de <c>ModelBinderAttribute</c> com <c>BindingSource = Query</c>, fazendo
+/// o ApiExplorer descrever o tipo <see cref="PageRequest"/> (record com
+/// <c>AfterId</c> + <c>Limit</c>) como query bag — vazando o shape interno
+/// pós-decode em vez do contrato wire (<c>cursor</c> + <c>limit</c>).
+/// <para>
+/// Este transformer detecta operações com <see cref="FromCursorAttribute"/> e:
+/// </para>
+/// <list type="number">
+///   <item><description>Remove os parâmetros vazados <c>AfterId</c> e <c>Limit</c>.</description></item>
+///   <item><description>Adiciona <c>cursor</c> (string, opcional, opaca) e <c>limit</c> (int, opcional) como query params.</description></item>
+///   <item><description>Declara os headers <c>Link</c> (RFC 5988/8288) e <c>X-Page-Size</c> em respostas 200 — espelha o que <c>PaginationControllerExtensions.OkPaginatedAsync</c> de fato emite.</description></item>
+///   <item><description>Marca a operação com a extension <c>x-uniplus-paginated: true</c> para clientes detectarem o pattern.</description></item>
+/// </list>
+/// </summary>
+public sealed class CursorPaginationOperationTransformer : IOpenApiOperationTransformer
+{
+    private const string CursorParam = "cursor";
+    private const string LimitParam = "limit";
+    private const string LinkHeader = "Link";
+    private const string PageSizeHeader = "X-Page-Size";
+    private const string PaginatedExtension = "x-uniplus-paginated";
+    private const string OkStatus = "200";
+
+    private static readonly string[] LeakedPageRequestProperties = ["AfterId", "Limit"];
+
+    public Task TransformAsync(
+        OpenApiOperation operation,
+        OpenApiOperationTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (ResolveCursorAttribute(context) is null)
+            return Task.CompletedTask;
+
+        RemoveLeakedPageRequestParameters(operation);
+        AddWireParameters(operation);
+        DeclareResponseHeaders(operation);
+        MarkAsPaginated(operation);
+
+        return Task.CompletedTask;
+    }
+
+    private static FromCursorAttribute? ResolveCursorAttribute(OpenApiOperationTransformerContext context)
+    {
+        // Espelha a estratégia do PageRequestModelBinder.ResolveAttribute:
+        // ControllerParameterDescriptor.ParameterInfo é o caminho confiável
+        // para chegar ao FromCursorAttribute (BindingInfo.BinderType só guarda
+        // o tipo do binder, não o atributo em si).
+        if (context.Description.ActionDescriptor is not ControllerActionDescriptor descriptor)
+            return null;
+
+        foreach (ParameterDescriptor parameter in descriptor.Parameters)
+        {
+            if (parameter is not ControllerParameterDescriptor controllerParam)
+                continue;
+
+            if (controllerParam.ParameterType != typeof(PageRequest))
+                continue;
+
+            FromCursorAttribute? attribute = controllerParam.ParameterInfo
+                .GetCustomAttribute<FromCursorAttribute>();
+            if (attribute is not null)
+                return attribute;
+        }
+
+        return null;
+    }
+
+    private static void RemoveLeakedPageRequestParameters(OpenApiOperation operation)
+    {
+        if (operation.Parameters is null || operation.Parameters.Count == 0)
+            return;
+
+        // Remove só parâmetros In = Query cujo Name bate exatamente com
+        // propriedades do PageRequest. Mantém qualquer outro query param
+        // explícito do endpoint (ex.: filtros adicionais).
+        operation.Parameters = operation.Parameters
+            .Where(p => !IsLeakedPageRequestProperty(p))
+            .ToList();
+    }
+
+    private static bool IsLeakedPageRequestProperty(IOpenApiParameter parameter) =>
+        parameter.In == ParameterLocation.Query
+            && LeakedPageRequestProperties.Contains(parameter.Name, StringComparer.Ordinal);
+
+    private static void AddWireParameters(OpenApiOperation operation)
+    {
+        operation.Parameters ??= [];
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = CursorParam,
+            In = ParameterLocation.Query,
+            Required = false,
+            Description = "Cursor opaco AES-GCM emitido pelo servidor no header Link da página anterior. "
+                + "Ausente na primeira página. Cliente trata como string opaca — não decodificar (ADR-0026, ADR-0031).",
+            Schema = new OpenApiSchema
+            {
+                Type = JsonSchemaType.String,
+            },
+        });
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = LimitParam,
+            In = ParameterLocation.Query,
+            Required = false,
+            Description = "Tamanho máximo da janela de resultados. Limites configurados em "
+                + "CursorPaginationOptions; valores fora do range retornam 422 com "
+                + "code uniplus.pagination.limit_invalido (ADR-0026).",
+            Schema = new OpenApiSchema
+            {
+                Type = JsonSchemaType.Integer,
+                Format = "int32",
+            },
+        });
+    }
+
+    private static void DeclareResponseHeaders(OpenApiOperation operation)
+    {
+        if (operation.Responses is null)
+            return;
+
+        if (!operation.Responses.TryGetValue(OkStatus, out IOpenApiResponse? response200)
+            || response200 is not OpenApiResponse okResponse)
+            return;
+
+        okResponse.Headers ??= new Dictionary<string, IOpenApiHeader>(StringComparer.Ordinal);
+        okResponse.Headers[LinkHeader] = new OpenApiHeader
+        {
+            Description = "Links de navegação da paginação (RFC 5988/8288). "
+                + "rel=\"self\" sempre presente; rel=\"next\" só quando há próxima página. "
+                + "Cada link carrega o cursor opaco no parâmetro `cursor` (ADR-0026).",
+            Schema = new OpenApiSchema
+            {
+                Type = JsonSchemaType.String,
+            },
+        };
+        okResponse.Headers[PageSizeHeader] = new OpenApiHeader
+        {
+            Description = "Quantidade de itens retornados na página atual (sempre menor ou igual ao limit efetivo).",
+            Schema = new OpenApiSchema
+            {
+                Type = JsonSchemaType.Integer,
+                Format = "int32",
+            },
+        };
+    }
+
+    private static void MarkAsPaginated(OpenApiOperation operation)
+    {
+        operation.Extensions ??= new Dictionary<string, IOpenApiExtension>(StringComparer.Ordinal);
+        operation.Extensions[PaginatedExtension] = new JsonNodeExtension(JsonValue.Create(true));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/OpenApi/CursorPaginationOperationTransformerTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/OpenApi/CursorPaginationOperationTransformerTests.cs
@@ -1,0 +1,213 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.OpenApi;
+
+using System.Reflection;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+using Unifesspa.UniPlus.Infrastructure.Core.OpenApi;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+
+public sealed class CursorPaginationOperationTransformerTests
+{
+    private const string FixtureResource = "editais";
+
+    [Fact(DisplayName = "Action com [FromCursor] remove AfterId/Limit vazados e adiciona cursor/limit como query params")]
+    public async Task TransformAsync_Should_ReplaceLeakedParameters_WithWireParameters()
+    {
+        CursorPaginationOperationTransformer transformer = new();
+        OpenApiOperation operation = OperationWithLeakedPageRequestParameters();
+        OpenApiOperationTransformerContext context = ContextForActionWithCursor();
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        operation.Parameters.Should().NotBeNull();
+        operation.Parameters!.Select(p => p.Name).Should().NotContain(["AfterId", "Limit"]);
+        operation.Parameters.Should().ContainSingle(p =>
+            p.Name == "cursor" && p.In == ParameterLocation.Query && p.Required != true);
+        operation.Parameters.Should().ContainSingle(p =>
+            p.Name == "limit" && p.In == ParameterLocation.Query && p.Required != true);
+    }
+
+    [Fact(DisplayName = "Action com [FromCursor] declara Link (RFC 5988/8288) e X-Page-Size em response 200")]
+    public async Task TransformAsync_Should_DeclareLinkAndPageSizeHeaders_OnOk()
+    {
+        CursorPaginationOperationTransformer transformer = new();
+        OpenApiOperation operation = OperationWith200Response();
+        OpenApiOperationTransformerContext context = ContextForActionWithCursor();
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        IOpenApiResponse response200 = operation.Responses!["200"];
+        OpenApiResponse okResponse = response200.Should().BeOfType<OpenApiResponse>().Subject;
+        okResponse.Headers.Should().NotBeNull();
+
+        IOpenApiHeader linkHeader = okResponse.Headers!["Link"];
+        linkHeader.Description.Should().Contain("RFC 5988/8288").And.Contain("rel=\"next\"");
+        linkHeader.Schema.Should().NotBeNull();
+        linkHeader.Schema!.Type!.Value.HasFlag(JsonSchemaType.String).Should().BeTrue();
+
+        IOpenApiHeader pageSizeHeader = okResponse.Headers["X-Page-Size"];
+        pageSizeHeader.Schema.Should().NotBeNull();
+        pageSizeHeader.Schema!.Type!.Value.HasFlag(JsonSchemaType.Integer).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Action com [FromCursor] marca extension x-uniplus-paginated: true")]
+    public async Task TransformAsync_Should_AddPaginatedExtension()
+    {
+        CursorPaginationOperationTransformer transformer = new();
+        OpenApiOperation operation = new();
+        OpenApiOperationTransformerContext context = ContextForActionWithCursor();
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        operation.Extensions.Should().ContainKey("x-uniplus-paginated");
+    }
+
+    [Fact(DisplayName = "Action sem [FromCursor] não é mutada (não adiciona parâmetros, headers ou extensions)")]
+    public async Task TransformAsync_Should_NotMutate_WhenActionLacksFromCursor()
+    {
+        CursorPaginationOperationTransformer transformer = new();
+        OpenApiOperation operation = new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse(),
+            },
+        };
+        OpenApiOperationTransformerContext context = ContextForActionWithoutCursor();
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        operation.Parameters.Should().BeNull();
+        operation.Extensions.Should().BeNull();
+        OpenApiResponse response200 = operation.Responses["200"].Should().BeOfType<OpenApiResponse>().Subject;
+        response200.Headers.Should().BeNull(
+            "transformer só declara Link/X-Page-Size em endpoints com [FromCursor]");
+    }
+
+    [Fact(DisplayName = "Action com [FromCursor] descreve cursor/limit em pt-BR e referencia ADR-0026")]
+    public async Task TransformAsync_Should_DescribeWireParameters_InPortuguese()
+    {
+        CursorPaginationOperationTransformer transformer = new();
+        OpenApiOperation operation = new();
+        OpenApiOperationTransformerContext context = ContextForActionWithCursor();
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        IOpenApiParameter? cursorParam = operation.Parameters!.SingleOrDefault(p => p.Name == "cursor");
+        cursorParam.Should().NotBeNull();
+        cursorParam!.Description.Should().Contain("opaco").And.Contain("ADR-0026");
+
+        IOpenApiParameter? limitParam = operation.Parameters!.SingleOrDefault(p => p.Name == "limit");
+        limitParam.Should().NotBeNull();
+        limitParam!.Description.Should().Contain("limit_invalido");
+    }
+
+    [Fact(DisplayName = "Action com [FromCursor] preserva outros query params do endpoint (não só remove os vazados)")]
+    public async Task TransformAsync_Should_PreserveOtherQueryParameters()
+    {
+        CursorPaginationOperationTransformer transformer = new();
+        OpenApiOperation operation = new()
+        {
+            Parameters =
+            [
+                new OpenApiParameter { Name = "AfterId", In = ParameterLocation.Query },
+                new OpenApiParameter { Name = "Limit", In = ParameterLocation.Query },
+                new OpenApiParameter { Name = "status", In = ParameterLocation.Query },
+            ],
+        };
+        OpenApiOperationTransformerContext context = ContextForActionWithCursor();
+
+        await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        operation.Parameters!.Select(p => p.Name).Should().Contain("status");
+    }
+
+    [Fact(DisplayName = "Action com [FromCursor] sem response 200 declarado não dispara exceção")]
+    public async Task TransformAsync_Should_NotThrow_WhenResponse200IsAbsent()
+    {
+        CursorPaginationOperationTransformer transformer = new();
+        OpenApiOperation operation = new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["404"] = new OpenApiResponse(),
+            },
+        };
+        OpenApiOperationTransformerContext context = ContextForActionWithCursor();
+
+        Func<Task> act = async () => await transformer.TransformAsync(operation, context, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        operation.Parameters!.Select(p => p.Name).Should().Contain(["cursor", "limit"]);
+    }
+
+    private static OpenApiOperation OperationWithLeakedPageRequestParameters() =>
+        new()
+        {
+            Parameters =
+            [
+                new OpenApiParameter { Name = "AfterId", In = ParameterLocation.Query },
+                new OpenApiParameter { Name = "Limit", In = ParameterLocation.Query },
+            ],
+        };
+
+    private static OpenApiOperation OperationWith200Response() =>
+        new()
+        {
+            Responses = new OpenApiResponses
+            {
+                ["200"] = new OpenApiResponse(),
+            },
+        };
+
+    private static OpenApiOperationTransformerContext ContextForActionWithCursor() =>
+        ContextForAction(typeof(FixtureController).GetMethod(nameof(FixtureController.Listar))!);
+
+    private static OpenApiOperationTransformerContext ContextForActionWithoutCursor() =>
+        ContextForAction(typeof(FixtureController).GetMethod(nameof(FixtureController.SemCursor))!);
+
+    private static OpenApiOperationTransformerContext ContextForAction(MethodInfo methodInfo)
+    {
+        ControllerActionDescriptor descriptor = new()
+        {
+            EndpointMetadata = [],
+            MethodInfo = methodInfo,
+            Parameters = methodInfo.GetParameters()
+                .Select(parameter => (Microsoft.AspNetCore.Mvc.Abstractions.ParameterDescriptor)
+                    new ControllerParameterDescriptor
+                    {
+                        Name = parameter.Name!,
+                        ParameterType = parameter.ParameterType,
+                        ParameterInfo = parameter,
+                    })
+                .ToList(),
+        };
+
+        ApiDescription description = new()
+        {
+            ActionDescriptor = descriptor,
+        };
+
+        return new OpenApiOperationTransformerContext
+        {
+            DocumentName = "selecao",
+            ApplicationServices = NSubstitute.Substitute.For<IServiceProvider>(),
+            Description = description,
+        };
+    }
+
+    private static class FixtureController
+    {
+#pragma warning disable IDE0060 // métodos fixture só servem para reflection
+        public static Task Listar([FromCursor(FixtureResource)] PageRequest page) => Task.CompletedTask;
+
+        public static Task SemCursor(int id) => Task.CompletedTask;
+#pragma warning restore IDE0060
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalEndpointTests.cs
@@ -112,6 +112,37 @@ public sealed class EditalEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    [Fact(DisplayName = "GET /api/editais retorna Link e X-Page-Size headers (RFC 5988/8288, ADR-0026)")]
+    public async Task ListarEditais_DeveExporLinkEXPageSizeHeaders()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        // Garante 2 editais no DB para forçar próxima página com limit=1.
+        await SemearEditalAsync(api);
+        await SemearEditalAsync(api);
+
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            new Uri("/api/editais?limit=1", UriKind.Relative));
+        AppendTestAuth(request);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.edital.v1+json"));
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        response.Headers.TryGetValues("X-Page-Size", out IEnumerable<string>? pageSizeValues).Should().BeTrue(
+            "OkPaginatedAsync popula X-Page-Size com a contagem de itens da página atual (ADR-0026)");
+        pageSizeValues!.Single().Should().Be("1", "limit=1 + ao menos 2 editais semeados garantem 1 item na página");
+
+        response.Headers.TryGetValues("Link", out IEnumerable<string>? linkValues).Should().BeTrue(
+            "OkPaginatedAsync popula Link header (RFC 5988/8288) com rel=\"self\" e — quando há próxima — rel=\"next\"");
+        string linkHeader = linkValues!.Single();
+        linkHeader.Should().Contain("rel=\"self\"");
+        linkHeader.Should().Contain("rel=\"next\"",
+            "ao menos 2 editais existem e limit=1 deve emitir cursor para a próxima página");
+    }
+
     private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
 
     private static void AppendTestAuth(HttpRequestMessage request)


### PR DESCRIPTION
## Resumo

Reconcilia o schema OpenAPI emitido em runtime com o contrato wire fixado pela [ADR-0026](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0026-paginacao-cursor-opaco-cifrado.md). Antes deste PR, `GET /api/editais` declarava `AfterId`/`Limit` (shape interno do `PageRequest` pós-decode) como query params e omitia os headers `Link` (RFC 5988/8288) e `X-Page-Size` que `PaginationControllerExtensions.OkPaginatedAsync` de fato emite. A implementação runtime estava correta — o spec é que vazava.

## Causa raiz

`FromCursorAttribute` herda de `ModelBinderAttribute` com `BindingSource.Query`, então o `ApiExplorer` descreve o tipo `PageRequest` (record com `AfterId` + `Limit`) como query bag — o operation explorer não conhece o `PageRequestModelBinder` que consome `cursor` + `limit` do query string e decoda o cursor opaco AES-GCM.

## Mudanças

1. **Novo `CursorPaginationOperationTransformer`** (`Infrastructure.Core/OpenApi/`) — detecta operações com `[FromCursor]` via `ControllerParameterDescriptor.ParameterInfo` (mesma estratégia do binder), remove os parâmetros vazados, adiciona `cursor`/`limit` como query params com descrições em pt-BR referenciando ADR-0026, declara `Link`/`X-Page-Size` headers em response 200 e marca a operação com `x-uniplus-paginated: true`.
2. **Registro em `AddUniPlusOpenApi`** — em paralelo ao `UniPlusOperationTransformer` existente; escopos disjuntos (idempotency vs cursor pagination), ordem de registro indiferente.
3. **7 unit tests** do transformer cobrindo os 4 cenários BDD da issue (cursor/limit replace AfterId/Limit; Link/X-Page-Size em 200; endpoints sem `[FromCursor]` intactos; extension `x-uniplus-paginated`) + 3 casos defensivos (descrições pt-BR/ADR-0026, preserva outros query params, response 200 ausente sem throw).
4. **Integration test** em `EditalEndpointTests.ListarEditais_DeveExporLinkEXPageSizeHeaders` semeando 2 editais e validando `Link` (com `rel="self"` e `rel="next"`) + `X-Page-Size` em runtime — fechava gap onde o smoke test não validava esses headers.
5. **Baseline regerada** em `contracts/openapi.selecao.json` via `UPDATE_OPENAPI_BASELINE=1`; `Ingresso` não tem endpoints com `[FromCursor]` ainda, baseline preservada.

## Aderência aos critérios de aceite (#332)

- ✅ **CA-01:** Transformer registrado em `AddUniPlusOpenApi`; remove `AfterId`/`Limit` vazados, adiciona `cursor`/`limit`, `Link`/`X-Page-Size`, `x-uniplus-paginated`.
- ✅ **CA-02:** 7 testes em `CursorPaginationOperationTransformerTests` cobrindo os 4 cenários BDD + casos defensivos.
- ✅ **CA-03:** `EditalEndpointTests.ListarEditais_DeveExporLinkEXPageSizeHeaders` valida ambos headers em runtime.
- ✅ **CA-04:** Baseline `contracts/openapi.selecao.json` regerada; diff revisado.
- ✅ **CA-05:** Drift check `OpenApiEndpointTests.SpecRuntime_DeveCasarComBaselineCommitted` verde.
- ✅ **CA-06:** `dotnet build UniPlus.slnx` — 0 warnings, 0 errors.
- ✅ **CA-07:** `OpenApiSharedSchemasInSyncTests` verde.

## Test plan

- [x] `dotnet build UniPlus.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/...csproj` — 308 unit tests aprovados.
- [x] `dotnet test ... --filter Category=OutboxCapability` (Selecao) — 24 integration tests aprovados (incluindo o novo).
- [x] `dotnet test ... --filter "FullyQualifiedName~OpenApiEndpointTests"` (Selecao) — drift check + smoke verdes (2/2).
- [x] `dotnet test ... --filter "FullyQualifiedName~OpenApiEndpointTests"` (Ingresso) — 2/2 verdes (sem endpoints `[FromCursor]`, baseline preservada).
- [x] `OpenApiSharedSchemasInSyncTests` verde.
- [ ] CI verde no PR.
- [ ] Codex review absorvido.

## Não-escopo

- Spectral rule no CI declarado em ADR-0026 §"Tooling" (gap separado, não bloqueante deste fix).
- Migração para Minimal API style com `WithOpenApi()`.

## Referências

- Issue: #332
- ADRs: [ADR-0026](docs/adrs/0026-paginacao-cursor-opaco-cifrado.md), [ADR-0031](docs/adrs/0031-decoding-de-cursor-opaco-no-boundary-http.md), [ADR-0030](docs/adrs/0030-openapi-3-1-contract-first.md)
- RFC 5988 / RFC 8288 — Web Linking
- Detectado durante a Frente 4 do Frontend Milestone B (`uniplus-web` consumer de cursor pagination).

Closes #332