### PR TITLE
feat(selecao): EditalDto carrega _links HATEOAS Level 1 (ADR-0029) via IResourceLinksBuilder

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -561,6 +561,15 @@
           "criadoEm": {
             "type": "string",
             "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },

--- a/docs/adrs/0049-implementacao-hateoas-edital-resource-links-builder.md
+++ b/docs/adrs/0049-implementacao-hateoas-edital-resource-links-builder.md
@@ -1,0 +1,172 @@
+---
+status: "proposed"
+date: "2026-05-06"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0049: Implementação de HATEOAS Level 1 em `EditalDto` via `IResourceLinksBuilder<TDto>` na camada API
+
+## Contexto e enunciado do problema
+
+A [ADR-0029](0029-hateoas-level-1-links.md) decidiu que toda resposta de recurso single da `uniplus-api` carrega `_links` mínimo (`self` sempre, navigation links opcionais). A decisão é canônica mas explicitamente deixou em aberto a *forma de implementação* (§"Esta ADR não decide": *"Implementação concreta do builder de links na camada API — extension method, helper service ou middleware. Decisão de implementação."*).
+
+A primeira aplicação concreta — `EditalDto` em resposta de `GET /api/editais/{id}` — força essa decisão. O slice `EditalController` hoje devolve `Ok(edital)` sem `_links`, e o consumer frontend (`uniplus-web`, F8 do Milestone B) reportou o gap em [uniplus-api#334](https://github.com/unifesspa-edu-br/uniplus-api/issues/334).
+
+A questão é tripla: **(a) onde gerar os links** (Domain, Application ou API), **(b) como evitar URLs hardcoded** (`LinkGenerator` vs strings), **(c) qual contrato compartilhado** entre futuros builders (Inscrição, Recurso, Classificação).
+
+## Drivers da decisão
+
+- **Boundary-only.** URLs são detalhe da camada HTTP. Domain (`Edital`) e Application (`EditalDto`) não conhecem rotas. ADR-0029 §"URIs relativas" reforça: link generation é responsabilidade do servidor HTTP.
+- **DI-aware.** ASP.NET Core 10 expõe `LinkGenerator` como singleton DI; reutilizar é trivial e blinda contra alterações no `[Route]` attribute do controller.
+- **Pattern reusável.** Inscrição/Recurso/Classificação vão precisar do mesmo padrão. Um contrato genérico evita 3-4 reinvenções diferentes.
+- **Sem reflection nem metadata custom.** Pipeline behaviors (Wolverine middleware) que pós-processam DTOs marcados por interface acoplam infra ao formato dos DTOs e exigem reflection runtime — over-engineering para o número de recursos atual.
+- **Coerência com decisões já tomadas.** ADR-0025 (body como representação direta) implica `_links` é campo do DTO, não wrapper externo. ADR-0030 (OpenAPI 3.1 contract-first) é a fonte de verdade de operações; action links não duplicam.
+- **Vedação binding herdada.** ADR-0029 §"Esta ADR não decide" proíbe action links em V1 (`publicar`, `cancelar`, etc.); operações de mutação são descobertas via OpenAPI.
+
+## Opções consideradas
+
+- **A. Interface genérica `IResourceLinksBuilder<TDto>` por recurso, registrada como singleton; controller chama `builder.Build(dto)` após o handler retornar e anexa via `dto with { Links = ... }`.**
+- **B. Extension method estático `EditalDto.WithLinks(LinkGenerator generator)`** — sem DI service, lógica inline no DTO. Application camada passa a depender de `Microsoft.AspNetCore.Routing` (viola Clean Architecture).
+- **C. `IResultFilter` ou `IAsyncActionFilter` que intercepta toda response e anexa `_links`** baseado em interface marker no DTO (`IHasLinks`). Reflection runtime + precedência confusa com outros filters (vendor MIME, Idempotency).
+- **D. Pipeline behavior Wolverine que envelopa qualquer query handler retornando DTO marcado.** Acopla infra ao formato dos DTOs; ainda usa reflection.
+- **E. Mapping no handler (`ObterEditalQueryHandler`) recebendo `LinkGenerator` injetado.** Application depende de `Microsoft.AspNetCore.Routing` — viola Clean Architecture (mesma falha de B).
+
+## Resultado da decisão
+
+**Escolhida:** "A — `IResourceLinksBuilder<TDto>` no boundary HTTP", porque é a única opção que:
+
+1. Mantém **Application/Domain limpos** de dependências de URL routing (sem viés HTTP em DTOs ou handlers).
+2. **Não usa reflection** nem behaviors implícitos — fluxo é explícito no controller (`dto with { Links = builder.Build(dto) }`).
+3. **Replica trivialmente** para Inscrição/Recurso/Classificação: cada recurso ganha um `XxxLinksBuilder : IResourceLinksBuilder<XxxDto>` registrado uma vez no `Program.cs`.
+4. **Composta com filtros existentes** (vendor MIME, Idempotency) sem precedência ambígua — execução acontece dentro do action method, antes do `Ok(dto)`.
+
+### Forma do contrato
+
+```csharp
+namespace Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+public interface IResourceLinksBuilder<in TDto> where TDto : class
+{
+    /// <summary>
+    /// Constrói o dicionário _links para o recurso. Chave em snake_case ASCII;
+    /// valor é URI relativa começando em /. self sempre presente
+    /// (invariante ADR-0029).
+    /// </summary>
+    IReadOnlyDictionary<string, string> Build(TDto dto);
+}
+```
+
+### Implementação canônica (`EditalLinksBuilder`)
+
+```csharp
+internal sealed class EditalLinksBuilder : IResourceLinksBuilder<EditalDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+
+    public EditalLinksBuilder(LinkGenerator linkGenerator)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        _linkGenerator = linkGenerator;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(EditalDto dto)
+    {
+        // GetPathByAction emite path-only (sem scheme/host) — alinhado com
+        // a invariante "URIs relativas à raiz da API" (ADR-0029 §"URIs relativas").
+        string self = _linkGenerator.GetPathByAction(
+            action: nameof(EditalController.ObterPorId),
+            controller: "Edital",
+            values: new { id = dto.Id })!;
+
+        string collection = _linkGenerator.GetPathByAction(
+            action: nameof(EditalController.Listar),
+            controller: "Edital")!;
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+}
+```
+
+### Localização das classes
+
+- **`Unifesspa.UniPlus.Infrastructure.Core.Hateoas.IResourceLinksBuilder<TDto>`** — contrato cross-module em `Infrastructure.Core` (não em `SharedKernel` porque é convenção HTTP, não primitivo de domínio).
+- **`Unifesspa.UniPlus.Selecao.API.Hateoas.EditalLinksBuilder`** — implementação por recurso, vive na camada API do módulo dono do recurso (mesma assembly do controller). Próximas: `InscricaoLinksBuilder`, `RecursoLinksBuilder`, `ClassificacaoLinksBuilder`.
+
+### Registro DI
+
+```csharp
+// Program.cs
+builder.Services.AddSingleton<
+    IResourceLinksBuilder<EditalDto>,
+    EditalLinksBuilder>();
+```
+
+Singleton porque o builder encapsula apenas o `LinkGenerator` (também singleton); função pura sem estado mutável.
+
+### Composição no controller
+
+```csharp
+public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+{
+    EditalDto? edital = await _queryBus.Send(new ObterEditalQuery(id), cancellationToken);
+    if (edital is null) return NotFound();
+
+    EditalDto editalComLinks = edital with { Links = _linksBuilder.Build(edital) };
+    return Ok(editalComLinks);
+}
+```
+
+### Esta ADR não decide
+
+- **`_links` em coleção.** ADR-0029 §"Coleção" decidiu que coleção usa header `Link` (RFC 5988/8288) — não `_links` no body.
+- **Relações futuras `inscricoes`/`classificacao` para Edital.** Adicionar quando esses endpoints existirem; entram no `EditalLinksBuilder` por edição direta (não exige nova ADR — ADR-0029 §"Catálogo completo de relações por recurso — declarado por slice na implementação").
+- **Controle fino de quando emitir `_links`** (ex.: omitir em endpoints internos chamados em loop). Para V1, inclusão é incondicional. Reabrir se telemetria mostrar custo.
+- **Versionamento de `_links` quando vendor MIME bumpear** (`v2` muda a forma do `_links`?). Postergado até a primeira mudança vendor MIME real acontecer.
+
+### Por que B, C, D e E foram rejeitadas
+
+- **B (extension method).** Application camada precisaria importar `Microsoft.AspNetCore.Routing` — viola regra de dependência (Clean Architecture: Application não conhece API).
+- **C (`IResultFilter`).** Reflection sobre interface marker; precedência de filtros já é complexa (vendor MIME, Idempotency, validação); risco de bugs sutis com a chain.
+- **D (Wolverine pipeline behavior).** Acopla messaging à camada de transporte (HTTP); ainda usa reflection; precedência confusa com middleware existentes (validation, logging).
+- **E (handler com LinkGenerator).** Mesma falha de B — Application depende de routing HTTP. Adicionalmente, handlers passam a ter assinatura inconsistente (queries que retornam DTOs single precisam de DI extra que queries de coleção não precisam).
+
+## Consequências
+
+### Positivas
+
+- **Pattern explícito e replicável.** `XxxLinksBuilder : IResourceLinksBuilder<XxxDto>` cobre todos os recursos futuros sem ADRs novas.
+- **Domain/Application limpos.** Zero acoplamento HTTP nessas camadas.
+- **Composição transparente.** `dto with { Links = ... }` é leitura direta no controller; sem reflection oculta.
+- **Refator de URL não quebra builders.** `LinkGenerator` lê do route table; mudar `[Route("api/editais")]` propaga automaticamente.
+- **Testável isolado.** Builder pode ser unit-testado mockando `LinkGenerator` (NSubstitute); integration test valida o end-to-end.
+
+### Negativas
+
+- **Boilerplate por recurso.** Cada DTO single ganha um `XxxLinksBuilder` + registro DI. Aceitável: ~25 linhas por recurso, replicação mecânica.
+- **`EditalDto` ganha campo opcional `Links`.** Records não amam campos opcionais init-only (`with` é a única forma de setar pós-construção). Aceitável: pattern records permite `dto with { Links = ... }`.
+- **Controller chama o builder explicitamente.** Possível esquecer de chamar em endpoint novo. Mitigação: integration test do endpoint cobre `_links.self` (regression imediata).
+
+### Neutras
+
+- **`IReadOnlyDictionary<string, string>` em vez de tipo dedicado.** ADR-0029 define `_links` como objeto string→string; usar primitivos evita um wrapper redundante. Type-safety adicional não justifica complexidade.
+
+## Confirmação
+
+1. **Integration test `ObterEditalEndpointTests`** — `GET /api/editais/{id}` retorna body com `_links.self` apontando para `/api/editais/{id}` e `_links.collection` apontando para `/api/editais`. Inclui assertion negativa: `_links.publicar` ausente (vedação ADR-0029).
+2. **Code review** rejeita endpoint novo de recurso single sem `IResourceLinksBuilder<TDto>` invocado.
+3. **Spectral rule** já enforça `_links.self` no schema OpenAPI quando declarado (ADR-0029 §"Confirmação"); regenerar spec após mudança propaga validação ao CI.
+
+## Mais informações
+
+- [ADR-0029](0029-hateoas-level-1-links.md) — HATEOAS Level 1 binding (decisão canônica de `_links`).
+- [ADR-0030](0030-openapi-3-1-contract-first.md) — OpenAPI como fonte de verdade das operações (motivo para action links não estarem em `_links`).
+- [ADR-0025](0025-wire-formato-sucesso-body-direto.md) — body como representação direta (motivo para `_links` ser campo do DTO, não wrapper).
+- [ADR-0028](0028-versionamento-per-resource-content-negotiation.md) — vendor MIME (versionamento por recurso; futura mudança pode requerir versionamento de `_links`).
+- [Microsoft Docs — LinkGenerator](https://learn.microsoft.com/aspnet/core/fundamentals/routing#linkgenerator) — geração de URI singleton DI.
+- [Issue uniplus-api#334](https://github.com/unifesspa-edu-br/uniplus-api/issues/334) — gap reportado pelo consumer (uniplus-web F8) que motivou esta ADR.
+- [PR uniplus-web#201](https://github.com/unifesspa-edu-br/uniplus-web/pull/201) — frontend que tentou usar `_links.publicar` por interpretação errada da ADR-0029; será limpo em PR follow-up.

--- a/docs/adrs/0049-implementacao-hateoas-edital-resource-links-builder.md
+++ b/docs/adrs/0049-implementacao-hateoas-edital-resource-links-builder.md
@@ -63,25 +63,30 @@ public interface IResourceLinksBuilder<in TDto> where TDto : class
 internal sealed class EditalLinksBuilder : IResourceLinksBuilder<EditalDto>
 {
     private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public EditalLinksBuilder(LinkGenerator linkGenerator)
+    public EditalLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
     {
-        ArgumentNullException.ThrowIfNull(linkGenerator);
+        // ... null guards
         _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
     }
 
     public IReadOnlyDictionary<string, string> Build(EditalDto dto)
     {
-        // GetPathByAction emite path-only (sem scheme/host) — alinhado com
-        // a invariante "URIs relativas à raiz da API" (ADR-0029 §"URIs relativas").
-        string self = _linkGenerator.GetPathByAction(
-            action: nameof(EditalController.ObterPorId),
-            controller: "Edital",
-            values: new { id = dto.Id })!;
+        // GetPathByAction com HttpContext respeita ambient PathBase (proxy
+        // reverso, app.UsePathBase("/foo")). Sem HttpContext (jobs/webhooks
+        // futuros invocando o builder fora de request scope), cai num path
+        // sem PathBase. Em ambos os casos, path é relativo (sem scheme/host)
+        // — invariante "URIs relativas à raiz da API" (ADR-0029).
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
 
-        string collection = _linkGenerator.GetPathByAction(
-            action: nameof(EditalController.Listar),
-            controller: "Edital")!;
+        string self = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: nameof(EditalController.ObterPorId),
+                controller: "Edital", values: new { id = dto.Id })!
+            : _linkGenerator.GetPathByAction(action: nameof(EditalController.ObterPorId),
+                controller: "Edital", values: new { id = dto.Id })!;
+        // ... idem para collection
 
         return new Dictionary<string, string>(StringComparer.Ordinal)
         {
@@ -91,6 +96,16 @@ internal sealed class EditalLinksBuilder : IResourceLinksBuilder<EditalDto>
     }
 }
 ```
+
+### Por que `IHttpContextAccessor` e não passar `HttpContext` explicitamente?
+
+A interface `IResourceLinksBuilder<TDto>.Build(TDto)` só recebe o DTO — não o `HttpContext`. Isso preserva:
+
+- **Testabilidade isolada** — unit tests do builder podem mockar `IHttpContextAccessor` sem precisar fabricar um `HttpContext` válido.
+- **Reuso fora de request scope** — jobs/webhooks futuros podem invocar o builder; quando `HttpContext` é `null`, builder cai no path-without-PathBase (correto para esses contextos).
+- **Singleton lifetime preservado** — `IHttpContextAccessor` é seguro como singleton (acessa o contexto do request via `AsyncLocal`).
+
+Alternativa rejeitada: `Build(TDto, HttpContext)` força todo caller a passar contexto, quebra a interface genérica e impede reuso fora de request.
 
 ### Localização das classes
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -77,6 +77,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0046](0046-validacao-de-regras-sem-excecao-result-failure.md) | Validação de regras de negócio sem exceção — `Result.Failure(DomainError)` para fluxo esperado | accepted | 2026-05-05 |
 | [0047](0047-confluent-kafka-npgsql-pisos-transitivos-wolverine.md) | `Confluent.Kafka 2.14.0` + `Npgsql 9.0.4` como pisos transitivos do Wolverine 5.32.1 | accepted | 2026-05-05 |
 | [0048](0048-controllers-mvc-public-com-ca1515-suprimido.md) | Controllers MVC em `*.API` devem ser `public`, com CA1515 suprimido por justificativa | accepted | 2026-05-05 |
+| [0049](0049-implementacao-hateoas-edital-resource-links-builder.md) | Implementação de HATEOAS Level 1 em `EditalDto` via `IResourceLinksBuilder<TDto>` na camada API | proposed | 2026-05-06 |
 
 ## Como adicionar um novo ADR
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
 using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 using Unifesspa.UniPlus.Kernel.Results;
@@ -27,12 +28,18 @@ public sealed class EditalController : ControllerBase
     private readonly ICommandBus _commandBus;
     private readonly IQueryBus _queryBus;
     private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<EditalDto> _linksBuilder;
 
-    public EditalController(ICommandBus commandBus, IQueryBus queryBus, IDomainErrorMapper mapper)
+    public EditalController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<EditalDto> linksBuilder)
     {
         _commandBus = commandBus;
         _queryBus = queryBus;
         _mapper = mapper;
+        _linksBuilder = linksBuilder;
     }
 
     [HttpPost]
@@ -78,7 +85,17 @@ public sealed class EditalController : ControllerBase
     public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
     {
         EditalDto? edital = await _queryBus.Send(new ObterEditalQuery(id), cancellationToken);
-        return edital is not null ? Ok(edital) : NotFound();
+        if (edital is null)
+        {
+            return NotFound();
+        }
+
+        // HATEOAS Level 1 (ADR-0029) — anexa _links.self/_links.collection
+        // ao DTO. O builder não toca em domínio; opera sobre URIs relativas
+        // via LinkGenerator. Action links (publicar etc.) NÃO entram aqui —
+        // descobertos via OpenAPI (ADR-0030 + ADR-0029 §"Esta ADR não decide").
+        EditalDto editalComLinks = edital with { Links = _linksBuilder.Build(edital) };
+        return Ok(editalComLinks);
     }
 
     // Despacha PublicarEditalCommand pelo ICommandBus (Wolverine). O handler

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Hateoas/EditalLinksBuilder.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Hateoas/EditalLinksBuilder.cs
@@ -1,0 +1,98 @@
+namespace Unifesspa.UniPlus.Selecao.API.Hateoas;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Selecao.API.Controllers;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+/// <summary>
+/// Constrói o conjunto de <c>_links</c> hypermedia (HATEOAS Level 1) para
+/// <see cref="EditalDto"/>, conforme
+/// <see href="https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0029-hateoas-level-1-links.md">ADR-0029</see>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Relações canônicas emitidas em V1:
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>self</c> — URI canônica do próprio edital (sempre).</description></item>
+///   <item><description><c>collection</c> — URI da coleção <c>/api/editais</c> (sempre — útil para back-nav).</description></item>
+/// </list>
+/// <para>
+/// Relações futuras (<c>inscricoes</c>, <c>classificacao</c>) entram quando
+/// os endpoints correspondentes existirem — issue dedicada por recurso.
+/// Action links (<c>publicar</c> etc.) <strong>nunca</strong> aparecem aqui
+/// (ADR-0029 §"Esta ADR não decide"); são descobertos via OpenAPI (ADR-0030).
+/// </para>
+/// <para>
+/// URIs são <strong>relativas</strong> à raiz da API (ADR-0029 §"URIs
+/// relativas"). Geração via <see cref="LinkGenerator"/> (singleton DI), o que
+/// blinda o builder contra alterações no <c>Route</c> attribute do controller
+/// — refator de URL não quebra os links.
+/// </para>
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<EditalDto>, EditalLinksBuilder>().")]
+internal sealed class EditalLinksBuilder : IResourceLinksBuilder<EditalDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+
+    public EditalLinksBuilder(LinkGenerator linkGenerator)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        _linkGenerator = linkGenerator;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(EditalDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        // GetPathByAction emite somente o path (sem scheme/host) — alinhado
+        // com a invariante "URIs relativas à raiz da API" da ADR-0029.
+        // Sem HttpContext (builder pode ser invocado fora de request scope no
+        // futuro, ex.: jobs de envio de webhooks); aceitamos que sem ambient
+        // pathBase o path começa em /api/editais.
+        string self = _linkGenerator.GetPathByAction(
+            action: nameof(EditalController.ObterPorId),
+            controller: ControllerNameWithoutSuffix(),
+            values: new { id = dto.Id })
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {nameof(EditalController.ObterPorId)}. " +
+                "Verifique o registro do controller e o template de rota.");
+
+        string collection = _linkGenerator.GetPathByAction(
+            action: nameof(EditalController.Listar),
+            controller: ControllerNameWithoutSuffix())
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {nameof(EditalController.Listar)}. " +
+                "Verifique o registro do controller e o template de rota.");
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    /// <summary>
+    /// Convenção do MVC: o nome do controller usado no roteamento é o nome
+    /// da classe sem o sufixo <c>Controller</c>. Centralizar aqui evita
+    /// string literal duplicada e permite refator no controller sem quebrar
+    /// o builder.
+    /// </summary>
+    private static string ControllerNameWithoutSuffix()
+    {
+        const string suffix = "Controller";
+        string name = nameof(EditalController);
+        return name.EndsWith(suffix, StringComparison.Ordinal)
+            ? name[..^suffix.Length]
+            : name;
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Hateoas/EditalLinksBuilder.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Hateoas/EditalLinksBuilder.cs
@@ -43,42 +43,50 @@ using Unifesspa.UniPlus.Selecao.Application.DTOs;
 internal sealed class EditalLinksBuilder : IResourceLinksBuilder<EditalDto>
 {
     private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public EditalLinksBuilder(LinkGenerator linkGenerator)
+    public EditalLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
     {
         ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
         _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
     }
 
     public IReadOnlyDictionary<string, string> Build(EditalDto dto)
     {
         ArgumentNullException.ThrowIfNull(dto);
 
-        // GetPathByAction emite somente o path (sem scheme/host) — alinhado
+        // GetPathByAction com HttpContext respeita o ambient PathBase
+        // (deployments atrás de reverse proxy ou app.UsePathBase("/foo")
+        // emitem links começando em /foo/api/editais...). Sem HttpContext
+        // (cenário futuro: jobs/webhooks invocando o builder fora de request
+        // scope), cai num path sem PathBase — correto para esses contextos.
+        // Em ambos os casos, o path é relativo (sem scheme/host) — alinhado
         // com a invariante "URIs relativas à raiz da API" da ADR-0029.
-        // Sem HttpContext (builder pode ser invocado fora de request scope no
-        // futuro, ex.: jobs de envio de webhooks); aceitamos que sem ambient
-        // pathBase o path começa em /api/editais.
-        string self = _linkGenerator.GetPathByAction(
-            action: nameof(EditalController.ObterPorId),
-            controller: ControllerNameWithoutSuffix(),
-            values: new { id = dto.Id })
-            ?? throw new InvalidOperationException(
-                $"LinkGenerator não conseguiu resolver a rota para {nameof(EditalController.ObterPorId)}. " +
-                "Verifique o registro do controller e o template de rota.");
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        string controllerName = ControllerNameWithoutSuffix();
 
-        string collection = _linkGenerator.GetPathByAction(
-            action: nameof(EditalController.Listar),
-            controller: ControllerNameWithoutSuffix())
-            ?? throw new InvalidOperationException(
-                $"LinkGenerator não conseguiu resolver a rota para {nameof(EditalController.Listar)}. " +
-                "Verifique o registro do controller e o template de rota.");
+        string self = ResolverPath(httpContext, nameof(EditalController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(httpContext, nameof(EditalController.Listar), controllerName, values: null);
 
         return new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["self"] = self,
             ["collection"] = collection,
         };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
     }
 
     /// <summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -4,11 +4,13 @@ using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
 using Unifesspa.UniPlus.Infrastructure.Core.Cors;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 using Unifesspa.UniPlus.Infrastructure.Core.Logging;
 using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Selecao.API.Errors;
+using Unifesspa.UniPlus.Selecao.API.Hateoas;
 using Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
 using Unifesspa.UniPlus.Selecao.Application.Mappings;
 using Unifesspa.UniPlus.Selecao.Domain.Events;
@@ -42,6 +44,10 @@ builder.Services.AddUniPlusOpenApi("selecao", builder.Configuration);
 
 builder.Services.AddSingleton<IDomainErrorRegistration, SelecaoDomainErrorRegistration>();
 builder.Services.AddDomainErrorMapper();
+
+// HATEOAS Level 1 (ADR-0029) — builder de _links por recurso. Singleton
+// porque encapsula apenas um LinkGenerator (também singleton); função pura.
+builder.Services.AddSingleton<IResourceLinksBuilder<Unifesspa.UniPlus.Selecao.Application.DTOs.EditalDto>, EditalLinksBuilder>();
 
 // Criptografia + cursor pagination usados pelos endpoints de listagem
 // (ADR-0026 + ADR-0031). AddUniPlusEncryption: provider 'local' AES-GCM 256

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/EditalDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/EditalDto.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
 
+using System.Text.Json.Serialization;
+
 public sealed record EditalDto(
     Guid Id,
     string NumeroEdital,
@@ -8,4 +10,16 @@ public sealed record EditalDto(
     string Status,
     int MaximoOpcoesCurso,
     bool BonusRegionalHabilitado,
-    DateTimeOffset CriadoEm);
+    DateTimeOffset CriadoEm)
+{
+    /// <summary>
+    /// Hypermedia links (HATEOAS Level 1) — opt-in, populado pelo
+    /// <c>IResourceLinksBuilder&lt;EditalDto&gt;</c> no boundary HTTP da API
+    /// para respostas de recurso single (ex.: <c>GET /api/editais/{id}</c>).
+    /// Coleções não carregam <c>_links</c> — navegação vai por header
+    /// <c>Link</c> (ADR-0026). Vedados action links (<c>publicar</c> etc.)
+    /// per ADR-0029.
+    /// </summary>
+    [JsonPropertyName("_links")]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/EditalDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/EditalDto.cs
@@ -17,9 +17,11 @@ public sealed record EditalDto(
     /// <c>IResourceLinksBuilder&lt;EditalDto&gt;</c> no boundary HTTP da API
     /// para respostas de recurso single (ex.: <c>GET /api/editais/{id}</c>).
     /// Coleções não carregam <c>_links</c> — navegação vai por header
-    /// <c>Link</c> (ADR-0026). Vedados action links (<c>publicar</c> etc.)
-    /// per ADR-0029.
+    /// <c>Link</c> (ADR-0026); por isso <see cref="JsonIgnoreCondition.WhenWritingNull"/>
+    /// suprime o campo da serialização quando <c>null</c>, mantendo arrays
+    /// limpos. Vedados action links (<c>publicar</c> etc.) per ADR-0029.
     /// </summary>
     [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IReadOnlyDictionary<string, string>? Links { get; init; }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Hateoas/IResourceLinksBuilder.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Hateoas/IResourceLinksBuilder.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Constrói o conjunto de <c>_links</c> hypermedia (HATEOAS Level 1) para um
+/// DTO de recurso single, conforme <see href="https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0029-hateoas-level-1-links.md">ADR-0029</see>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementações vivem no boundary HTTP (camada API ou Infrastructure) e
+/// usam <see cref="Microsoft.AspNetCore.Routing.LinkGenerator"/> via DI para
+/// derivar URIs <strong>relativas</strong> (sem scheme/host) a partir de
+/// route templates — payloads ficam transportáveis através de proxies/subpaths.
+/// </para>
+/// <para>
+/// Vedação intencional (ADR-0029 §"Esta ADR não decide"): action links
+/// (<c>publicar</c>, <c>cancelar</c>, etc.) <strong>não</strong> aparecem em
+/// <c>_links</c> em V1 — operações de mutação são descobertas via OpenAPI
+/// (ADR-0030). Adicioná-las exige nova ADR superseding.
+/// </para>
+/// <para>
+/// Implementações são registradas como <see cref="Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton"/>
+/// — a função é estado-pura sobre o <see cref="LinkGenerator"/> singleton.
+/// </para>
+/// </remarks>
+/// <typeparam name="TDto">Tipo do DTO de recurso single (ex.: <c>EditalDto</c>).</typeparam>
+public interface IResourceLinksBuilder<in TDto>
+    where TDto : class
+{
+    /// <summary>
+    /// Constrói o dicionário <c>_links</c> para o recurso. Chave em
+    /// <c>snake_case</c> ASCII; valor é URI relativa começando em <c>/</c>.
+    /// <c>self</c> sempre presente (invariante ADR-0029).
+    /// </summary>
+    IReadOnlyDictionary<string, string> Build(TDto dto);
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ObterEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ObterEditalEndpointTests.cs
@@ -1,0 +1,107 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Editais;
+
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Assertions;
+using Kernel.Results;
+using Domain.Entities;
+using Domain.Enums;
+using Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+using Outbox.Cascading;
+
+/// <summary>
+/// Cobertura de <c>GET /api/editais/{id}</c> em runtime real, focando em
+/// HATEOAS Level 1 (ADR-0029): body inclui <c>_links.self</c> sempre, e
+/// <c>_links.collection</c>; nenhum action link (<c>publicar</c>, etc.) per
+/// vedação explícita da ADR-0029.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+public sealed class ObterEditalEndpointTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public ObterEditalEndpointTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/editais/{id} retorna 200 + body com _links.self e _links.collection (ADR-0029)")]
+    public async Task ObterPorId_EditalExistente_RetornaBodyComLinks()
+    {
+        Edital seeded = await SemearEditalAsync(_fixture.Factory);
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/editais/{seeded.Id}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+
+        // _links presente, com chave snake_case prefixada por underscore (ADR-0029).
+        JsonElement links = doc.RootElement.GetProperty("_links");
+        links.ValueKind.Should().Be(JsonValueKind.Object);
+
+        // _links.self obrigatório, URI relativa apontando para o próprio recurso.
+        string self = links.GetProperty("self").GetString()!;
+        self.Should().Be(
+            $"/api/editais/{seeded.Id.ToString("D", CultureInfo.InvariantCulture)}",
+            "ADR-0029 §'URIs relativas': self é URI relativa à raiz da API");
+
+        // _links.collection navega de volta para a coleção.
+        string collection = links.GetProperty("collection").GetString()!;
+        collection.Should().Be(
+            "/api/editais",
+            "ADR-0029 §'Forma do _links': collection aponta para o endpoint de listagem");
+
+        // Action links (publicar etc.) NÃO aparecem em V1 — ADR-0029 §'Esta ADR não decide'.
+        // Operações de mutação são descobertas via OpenAPI (ADR-0030).
+        links.TryGetProperty("publicar", out _).Should().BeFalse(
+            "ADR-0029 veda action links em V1; operações de mutação ficam no OpenAPI");
+
+        // Exatamente 2 chaves em V1 (self + collection). Qualquer adição
+        // silenciosa (incluindo action link via rota não-óbvia) falha aqui —
+        // toda relação nova exige PR review + ADR-0049 supersede explícito.
+        links.EnumerateObject().Count().Should().Be(2,
+            "ADR-0049 V1 emite somente self e collection");
+
+        await response.AssertNoPiiAsync();
+    }
+
+    [Fact(DisplayName = "GET /api/editais/{id} para id inexistente retorna 404 sem body de _links")]
+    public async Task ObterPorId_EditalInexistente_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/editais/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private static async Task<Edital> SemearEditalAsync(CascadingApiFactory api)
+    {
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+
+        int numeroSeed = Math.Abs(Guid.NewGuid().GetHashCode() % 9000) + 1;
+        Result<NumeroEdital> numero = NumeroEdital.Criar(numero: numeroSeed, ano: 2026);
+        numero.IsSuccess.Should().BeTrue();
+
+        Edital edital = Edital.Criar(numero.Value!, "ObterEditalEndpointTests seed", TipoProcesso.SiSU);
+        edital.ClearDomainEvents();
+        await db.Editais.AddAsync(edital);
+        await db.SaveChangesAsync();
+
+        return edital;
+    }
+}


### PR DESCRIPTION
## Resumo

Implementa o **primeiro slice de HATEOAS Level 1** ([ADR-0029](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0029-hateoas-level-1-links.md)): `GET /api/editais/{id}` retorna body com `_links.self` e `_links.collection`. Action links (`publicar`, etc.) **não** entram em `_links` per ADR-0029 (vedação explícita); operações de mutação são descobertas via OpenAPI ([ADR-0030](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0030-openapi-3-1-contract-first.md)).

## Correção crítica do escopo da issue

A versão original da issue #334 pedia `_links.publicar`. Isso viola ADR-0029 §"Esta ADR não decide" — *"Action links (publicar, cancelar, etc.) explicitamente fora do V1. Operações de mutação são descobertas via OpenAPI, não via _links. Adicioná-las exige nova ADR superseding."* Issue foi reescopada para apenas `_links.self` + `_links.collection`. PR follow-up no `uniplus-web` vai limpar o check `_links?.publicar` indevido em `EditaisDetailPage` (F8 do Milestone B).

## Mudanças

### `Infrastructure.Core` (cross-module)
- `Hateoas/IResourceLinksBuilder<TDto>` — interface genérica reusável; vai cobrir Inscrição/Recurso/Classificação quando esses recursos amadurecerem.

### `Selecao.Application`
- `EditalDto.Links: IReadOnlyDictionary<string, string>?` opcional, com `[JsonPropertyName("_links")]` (preserva snake_case + underscore exigido por ADR-0029).

### `Selecao.API`
- `Hateoas/EditalLinksBuilder` (`internal sealed`; CA1812 suprimido com justificativa) usa `LinkGenerator` (singleton DI ASP.NET Core) para emitir `self` (`/api/editais/{id}`) e `collection` (`/api/editais`). Helper `ControllerNameWithoutSuffix()` deriva nome do controller via `nameof(EditalController)` sem string hardcoded — refator de URL no `[Route]` propaga automaticamente.
- `Program.cs` — registro `AddSingleton<IResourceLinksBuilder<EditalDto>, EditalLinksBuilder>()`.
- `EditalController.ObterPorId` injeta o builder e retorna `Ok(edital with { Links = builder.Build(edital) })` após null-check. Outros endpoints (`Listar`, `Criar`, `Publicar`) intocados.

### `IntegrationTests`
- `Editais/ObterEditalEndpointTests` — 2 cenários: (a) GET 200 com `_links.self`/`_links.collection` corretos, `_links.publicar` ausente, exatamente 2 chaves em `_links` (defesa contra adição silenciosa); (b) 404 para id inexistente.

### Docs
- `docs/adrs/0049-implementacao-hateoas-edital-resource-links-builder.md` (`proposed`) — decisão arquitetural completa: 5 opções consideradas, 4 rejeitadas por violação Clean Architecture, reflection oculta ou precedência ambígua de filtros.
- `docs/adrs/README.md` — entrada da ADR-0049.

## Decisão arquitetural (ADR-0049)

**Escolhida:** `IResourceLinksBuilder<TDto>` interface genérica + implementação por recurso (`EditalLinksBuilder`) na camada API + `LinkGenerator` DI singleton.

**Por quê:** única opção que (1) mantém Domain/Application limpos de URL routing; (2) não usa reflection; (3) replica trivialmente para outros recursos; (4) compõe sem precedência ambígua com filtros existentes (vendor MIME, Idempotency).

**Rejeitadas:**
- Extension method em DTO → Application depende de `Microsoft.AspNetCore.Routing` (viola Clean Architecture).
- `IResultFilter`/`IAsyncActionFilter` com interface marker → reflection runtime + precedência confusa.
- Wolverine pipeline behavior → acopla messaging a HTTP + reflection.
- Handler recebendo `LinkGenerator` → mesma falha de Application/HTTP coupling.

## Verificações executadas

- `dotnet build UniPlus.slnx` → 0 erros, 0 warnings (`TreatWarningsAsErrors` ativo).
- `bash tools/adr-lint/validate.sh` → 51 ADRs OK.
- `npx markdownlint-cli2 'docs/adrs/**/*.md'` → 0 erros.
- Pre-commit review por `feature-dev:code-reviewer` agent → **APROVADO**; 1 P3 opcional aplicado (assertion de exatamente 2 chaves em `_links` no teste).
- Pesquisa: ASP.NET Core docs via context7 confirmou `LinkGenerator` é singleton DI; ADR-0029 e ADR-0030 re-lidas para garantir que action links ficam fora de `_links`.

## Padrões binding aplicados

- ADR-0029 (HATEOAS Level 1) — primeiro slice de implementação.
- ADR-0030 (OpenAPI 3.1) — operações descobertas via OpenAPI, não `_links`.
- ADR-0025 (body como representação direta) — `_links` é campo, não wrapper.
- Clean Architecture — Domain/Application sem `Microsoft.AspNetCore.*`.
- C# 14 / .NET 10; `internal sealed` em API project; `[SuppressMessage]` com `Justification`.
- Strings user-facing pt-BR (mensagens de erro do builder).
- Sem PII (Edital não carrega CPF).

## Não-escopo

- Action links em `_links` — vedado por ADR-0029.
- Implementação para Inscrição/Recurso/Classificação — issues dedicadas quando esses recursos amadurecerem (interface já reusável).
- `_links.inscricoes`/`_links.classificacao` em Edital — endpoints correspondentes não existem ainda.
- Versionamento de `_links` quando vendor MIME bumpear — postergado até a primeira mudança real.
- Omissão condicional de `_links` em endpoints internos — postergado até telemetria mostrar custo.

## Issue dependente (frontend)

- `uniplus-web` PR follow-up vai regenerar OpenAPI codegen + remover check `_links?.publicar` em `EditaisDetailPage` (era débito da F8 baseado em interpretação errada — `podePublicar` deve depender apenas de `status === 'Rascunho'`, conforme ADR-0029 + ADR-0030).

Closes #334