### PR TITLE
ci(images): publish-images workflow para selecao + ingresso + portal (#337)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,138 @@
+name: Publish Images
+
+# Publica imagens das APIs no GitHub Container Registry conforme ADR-0050.
+#
+# Triggers:
+#   - push em main          → tags: sha-<7>, main, latest
+#   - push em tag v*        → tags: sha-<7>, v<major>.<minor>.<patch>, v<major>.<minor>, v<major>
+#
+# Imagens publicadas:
+#   - ghcr.io/<owner>/uniplus-api-selecao
+#   - ghcr.io/<owner>/uniplus-api-ingresso
+#   - ghcr.io/<owner>/uniplus-api-portal
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  # Não cancela publishes em curso — perda de tag mutável (main/latest) nunca é
+  # aceitável. Concurrency só serializa builds da mesma ref.
+  group: publish-images-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.module }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - selecao
+          - ingresso
+          - portal
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login no GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extrair metadados (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/uniplus-api-${{ matrix.module }}
+          # Política de tagging: ver ADR-0050.
+          # - sha-<7>      : sempre (tag imutável para pinar em ArgoCD)
+          # - main         : apenas em push em main (canal de DEV)
+          # - v<semver>    : apenas em git tag v* (release imutável)
+          # - latest       : apenas em main (nunca em tags v*)
+          tags: |
+            type=sha,format=short,prefix=sha-
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+          labels: |
+            org.opencontainers.image.title=uniplus-api-${{ matrix.module }}
+            org.opencontainers.image.description=Módulo ${{ matrix.module }} da API do Uni+ (Sistema Unificado Unifesspa)
+            org.opencontainers.image.vendor=Universidade Federal do Sul e Sudeste do Pará (Unifesspa)
+            org.opencontainers.image.licenses=AGPL-3.0-or-later
+
+      - name: Build e push da imagem
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.${{ matrix.module }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Cache scoped por módulo: builds independentes não invalidam cache uns
+          # dos outros (cada Dockerfile copia src/<module>/ separadamente).
+          cache-from: type=gha,scope=${{ matrix.module }}
+          cache-to: type=gha,scope=${{ matrix.module }},mode=max
+
+      - name: Smoke test — startup + liveness probe
+        # Liveness (/health/live) só verifica que o processo está vivo — não
+        # depende de Postgres/Kafka/Redis, válido em CI sem infra. /health
+        # agregado é responsabilidade do gate de Helm/Kubernetes.
+        run: |
+          set -euo pipefail
+          IMAGE_REF=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          echo "Smoke testing: $IMAGE_REF"
+          docker run -d \
+            --name "smoke-${{ matrix.module }}" \
+            -p 8080:8080 \
+            -e ASPNETCORE_URLS="http://+:8080" \
+            -e ASPNETCORE_ENVIRONMENT=Production \
+            "$IMAGE_REF"
+
+          for attempt in $(seq 1 30); do
+            if curl -fsS http://localhost:8080/health/live > /dev/null 2>&1; then
+              echo "✓ /health/live respondeu 200 em ${attempt}s"
+              docker stop "smoke-${{ matrix.module }}" > /dev/null
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "✗ /health/live não respondeu em 30s"
+          echo "--- container logs ---"
+          docker logs "smoke-${{ matrix.module }}" || true
+          docker stop "smoke-${{ matrix.module }}" > /dev/null || true
+          exit 1
+
+      - name: Resumo
+        if: always()
+        run: |
+          echo "### Publish: \`uniplus-api-${{ matrix.module }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Tags publicadas:**" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Digest:** \`${{ steps.build.outputs.digest }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -53,6 +53,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # fetch-depth=0 traz o histórico completo necessário para
+          # `git merge-base --is-ancestor` no step de validação abaixo.
+          fetch-depth: 0
+
+      - name: Validar que a tag aponta para commit em main
+        # ADR-0050 exige que toda imagem publicada venha de commit já
+        # mergeado em main. Sem este gate, um operador poderia tagear um
+        # commit de feature branch e publicar silenciosamente. Falha cedo
+        # antes de qualquer build.
+        run: |
+          set -euo pipefail
+          git fetch origin main --depth=1
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF#refs/tags/} aponta para commit $GITHUB_SHA fora de origin/main."
+            echo "::error::Tags v* só podem ser aplicadas a commits já mergeados em main (ADR-0050)."
+            exit 1
+          fi
+          echo "✓ Tag aponta para commit em main: $GITHUB_SHA"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -77,27 +77,41 @@ jobs:
           # Sem `latest` e sem `main` — disciplina semver explícita.
           flavor: |
             latest=false
+          # Patterns prefixadas com `v` literal — `{{version}}` em
+          # docker/metadata-action remove o `v` da tag git, então
+          # `pattern={{version}}` em refs/tags/v1.2.3 produz `1.2.3`. Usar
+          # `pattern=v{{version}}` mantém o `v` exigido pela ADR-0050.
           tags: |
             type=sha,format=short,prefix=sha-
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
           labels: |
             org.opencontainers.image.title=uniplus-api-${{ matrix.module }}
             org.opencontainers.image.description=Módulo ${{ matrix.module }} da API do Uni+ (Sistema Unificado Unifesspa)
             org.opencontainers.image.vendor=Universidade Federal do Sul e Sudeste do Pará (Unifesspa)
             org.opencontainers.image.licenses=AGPL-3.0-or-later
 
-      - name: Build e push da imagem
-        id: build
+      # Build em duas fases para validar ANTES de tornar a tag pública:
+      # 1. Build com push=false e load=true → imagem fica no daemon Docker local
+      # 2. Smoke test contra a imagem local (liveness probe)
+      # 3. Build com push=true → reusa cache, publica no GHCR após smoke verde
+      #
+      # O cache GHA torna o segundo build praticamente instantâneo (ele só
+      # exporta o manifest para o registry; layers já estão no GHA cache).
+      # Sem isso, uma imagem que falhe no smoke já estaria publicada como
+      # v<X>.<Y>.<Z> imutável no GHCR.
+
+      - name: Build local (sem push) para smoke
+        id: build_local
         uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile.${{ matrix.module }}
           platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: false
+          load: true
+          tags: smoke/uniplus-api-${{ matrix.module }}:ci
           # Cache scoped por módulo: builds independentes não invalidam cache uns
           # dos outros (cada Dockerfile copia src/<module>/ separadamente).
           cache-from: type=gha,scope=${{ matrix.module }}
@@ -107,9 +121,10 @@ jobs:
         # Liveness (/health/live) só verifica que o processo está vivo — não
         # depende de Postgres/Kafka/Redis, válido em CI sem infra. /health
         # agregado é responsabilidade do gate de Helm/Kubernetes.
+        # Roda contra a imagem local (smoke/...:ci), antes do push para GHCR.
         run: |
           set -euo pipefail
-          IMAGE_REF=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          IMAGE_REF="smoke/uniplus-api-${{ matrix.module }}:ci"
           echo "Smoke testing: $IMAGE_REF"
           docker run -d \
             --name "smoke-${{ matrix.module }}" \
@@ -132,6 +147,20 @@ jobs:
           docker logs "smoke-${{ matrix.module }}" || true
           docker stop "smoke-${{ matrix.module }}" > /dev/null || true
           exit 1
+
+      - name: Push para GHCR (após smoke verde)
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.${{ matrix.module }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Reusa o cache do build_local — segundo build é praticamente
+          # instantâneo (apenas resolve manifest e push das layers já em cache).
+          cache-from: type=gha,scope=${{ matrix.module }}
 
       - name: Resumo
         if: always()

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -2,9 +2,18 @@ name: Publish Images
 
 # Publica imagens das APIs no GitHub Container Registry conforme ADR-0050.
 #
-# Triggers:
-#   - push em main          → tags: sha-<7>, main, latest
-#   - push em tag v*        → tags: sha-<7>, v<major>.<minor>.<patch>, v<major>.<minor>, v<major>
+# Trigger único: push em tag v* (ex.: v0.1.0). Push em main NÃO publica —
+# disciplina de release explícito, sem rolling tag mutável. Tags devem
+# apontar para commits em main (operacional, não enforçado pelo workflow).
+#
+# Tags publicadas para cada release v<X>.<Y>.<Z>:
+#   - sha-<7>             identidade imutável do commit
+#   - v<X>.<Y>.<Z>        release exata (imutável)
+#   - v<X>.<Y>            pin de minor (rola com patches)
+#   - v<X>                pin de major (rola com minors+patches)
+#
+# Sem `latest`, sem `main` — ArgoCD pina semver, devs usam compose local
+# com build-by-context.
 #
 # Imagens publicadas:
 #   - ghcr.io/<owner>/uniplus-api-selecao
@@ -13,8 +22,6 @@ name: Publish Images
 
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 
@@ -24,8 +31,8 @@ permissions:
   id-token: write
 
 concurrency:
-  # Não cancela publishes em curso — perda de tag mutável (main/latest) nunca é
-  # aceitável. Concurrency só serializa builds da mesma ref.
+  # Tags semver são imutáveis; o concurrency aqui só protege contra dois
+  # workflows tentando publicar a MESMA tag por race condition (force-push).
   group: publish-images-${{ github.ref }}
   cancel-in-progress: false
 
@@ -63,17 +70,18 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/uniplus-api-${{ matrix.module }}
           # Política de tagging: ver ADR-0050.
-          # - sha-<7>      : sempre (tag imutável para pinar em ArgoCD)
-          # - main         : apenas em push em main (canal de DEV)
-          # - v<semver>    : apenas em git tag v* (release imutável)
-          # - latest       : apenas em main (nunca em tags v*)
+          # - sha-<7>          : identidade imutável do commit (sempre)
+          # - v<X>.<Y>.<Z>     : release exata (imutável)
+          # - v<X>.<Y>         : pin de minor (rola com patches)
+          # - v<X>             : pin de major (rola com minors+patches)
+          # Sem `latest` e sem `main` — disciplina semver explícita.
+          flavor: |
+            latest=false
           tags: |
             type=sha,format=short,prefix=sha-
-            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.title=uniplus-api-${{ matrix.module }}
             org.opencontainers.image.description=Módulo ${{ matrix.module }} da API do Uni+ (Sistema Unificado Unifesspa)

--- a/docs/adrs/0050-registry-ghcr-e-tagging.md
+++ b/docs/adrs/0050-registry-ghcr-e-tagging.md
@@ -39,7 +39,18 @@ A organização já valida o GHCR como registry institucional via imagem compost
 
 **Escolhida:** "GHCR (`ghcr.io/unifesspa-edu-br/uniplus-api-<modulo>`)", porque é o único registry já em produção na organização (imagem composta do Keycloak), tem custo zero para repositórios públicos, autentica via `GITHUB_TOKEN` sem credencial extra e elimina latência de decisão para destravar a Fase 5.
 
-A convenção de naming dedicada por módulo `uniplus-api-<modulo>` evita o anti-padrão de uma única imagem multipropósito e permite Helm chart per-app sem ramificação. As tags publicadas combinam **uma tag imutável** (`sha-<7-curto>`) que ArgoCD pode pinar, **uma tag de canal** (`main` em push para `main`, `<branch-sanitizado>` em PRs internos opt-in) para promoção contínua em DEV, e **uma tag de release** (`v<major>.<minor>.<patch>`) gerada apenas quando o repositório recebe `git tag v*`. A tag `latest` é publicada apenas em push para `main`, **não** em PRs nem em tags `v*` — evita ambiguidade de "qual versão é latest".
+A convenção de naming dedicada por módulo `uniplus-api-<modulo>` evita o anti-padrão de uma única imagem multipropósito e permite Helm chart per-app sem ramificação.
+
+**Trigger de publish:** o workflow só dispara em `push` de tag `v*` (ex.: `v0.1.0`). Push em `main` **não** publica imagem. Disciplina de release explícito — sem rolling tag mutável, sem ambiguidade sobre "qual é o estado atual de DEV". Devs que precisam de imagem de DEV constroem localmente via `docker compose` com build context. ArgoCD e Helm em qualquer ambiente sempre pinam um semver ou um sha — nunca um canal mutável.
+
+**Tags publicadas para cada release `v<X>.<Y>.<Z>`:**
+
+- `sha-<7-curto>` — identidade imutável do commit (sempre publicada)
+- `v<X>.<Y>.<Z>` — release exata (imutável)
+- `v<X>.<Y>` — pin de minor (rola com patches subsequentes)
+- `v<X>` — pin de major (rola com minors+patches subsequentes)
+
+Sem `latest` — convenção é dispensável quando `v<X>` já fornece soft-pinning automático e ArgoCD pina sempre `v<X>.<Y>.<Z>` (ou `sha-*`) explicitamente. Sem `main` — nenhum consumidor produtivo deve apontar para um canal de branch que muda em cada merge.
 
 Multi-arch fica restrito a `linux/amd64` neste momento; `linux/arm64` é deferido até existir cluster ARM ou demanda concreta de Apple Silicon em CI. SBOM e attestation (cosign keyless via OIDC do GitHub) ficam parqueados como follow-up — registrados em backlog mas fora do escopo de unblock.
 
@@ -68,11 +79,12 @@ Multi-arch fica restrito a `linux/amd64` neste momento; `linux/arm64` é deferid
 
 Verificável por:
 
-- Workflow `.github/workflows/publish-images.yml` presente e verde em push para `main`
-- `gh api /orgs/unifesspa-edu-br/packages?package_type=container --jq '.[].name'` lista `uniplus-api-selecao` e `uniplus-api-ingresso`
-- `docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:main` funciona sem auth (visibilidade pública)
-- Tag de release `v0.1.0` aplicada via `git tag` produz imagem `ghcr.io/unifesspa-edu-br/uniplus-api-selecao:v0.1.0`
-- Helm chart consome tag por `Values.image.tag` sem hardcode
+- Workflow `.github/workflows/publish-images.yml` presente, sem trigger em `push: branches`, apenas em `push: tags v*`
+- `gh api /orgs/unifesspa-edu-br/packages?package_type=container --jq '.[].name'` lista `uniplus-api-{selecao,ingresso,portal}` após o primeiro `git tag v* && git push --tags`
+- `docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:v0.1.0` funciona sem auth (visibilidade pública)
+- `docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:main` falha com 404 — `main` **não** é tag publicada
+- Tag de release `v0.1.0` produz simultaneamente `:v0.1.0`, `:v0.1`, `:v0` e `:sha-<7>`
+- Helm chart consome tag por `Values.image.tag` (semver explícito), sem hardcode e sem `latest`
 
 ## Prós e contras das opções
 

--- a/docs/adrs/0050-registry-ghcr-e-tagging.md
+++ b/docs/adrs/0050-registry-ghcr-e-tagging.md
@@ -43,6 +43,8 @@ A convenção de naming dedicada por módulo `uniplus-api-<modulo>` evita o anti
 
 **Trigger de publish:** o workflow só dispara em `push` de tag `v*` (ex.: `v0.1.0`). Push em `main` **não** publica imagem. Disciplina de release explícito — sem rolling tag mutável, sem ambiguidade sobre "qual é o estado atual de DEV". Devs que precisam de imagem de DEV constroem localmente via `docker compose` com build context. ArgoCD e Helm em qualquer ambiente sempre pinam um semver ou um sha — nunca um canal mutável.
 
+**Tag deve apontar para commit em `main` (enforçado pelo workflow):** o primeiro step da matriz roda `git merge-base --is-ancestor "$GITHUB_SHA" origin/main` e falha o job antes de qualquer build se a tag for aplicada a commit que não está em `main`. Isso evita que um operador tagee acidentalmente um commit de feature branch e publique imagem silenciosamente. Tags `v*` são imutáveis no GHCR após o primeiro push, então o gate precisa ser do lado do CI — não confiar no operador.
+
 **Tags publicadas para cada release `v<X>.<Y>.<Z>`:**
 
 - `sha-<7-curto>` — identidade imutável do commit (sempre publicada)
@@ -84,6 +86,7 @@ Verificável por:
 - `docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:v0.1.0` funciona sem auth (visibilidade pública)
 - `docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:main` falha com 404 — `main` **não** é tag publicada
 - Tag de release `v0.1.0` produz simultaneamente `:v0.1.0`, `:v0.1`, `:v0` e `:sha-<7>`
+- Tag aplicada em commit fora de `main` (ex.: feature branch) faz o workflow falhar no step "Validar que a tag aponta para commit em main" — nada é publicado
 - Helm chart consome tag por `Values.image.tag` (semver explícito), sem hardcode e sem `latest`
 
 ## Prós e contras das opções

--- a/docs/ci-publish-images.md
+++ b/docs/ci-publish-images.md
@@ -53,9 +53,15 @@ Apenas `linux/amd64`. ARM (`linux/arm64`) está deferido até existir cluster AR
 
 Build cache via `type=gha` (GitHub Actions cache backend) com `scope=<module>` por matriz. Cada módulo tem cache isolado — alterar `Directory.Packages.props` invalida os 3 caches; alterar só `src/portal/` invalida apenas o cache do portal.
 
-## Smoke test
+## Smoke test (gate antes do push)
 
-Após o push, cada imagem é instanciada via `docker run` com `ASPNETCORE_URLS=http://+:8080` e `ASPNETCORE_ENVIRONMENT=Production`. O step espera até 30s para `/health/live` responder 200.
+O workflow constrói cada imagem em duas fases para evitar publicar tags imutáveis de uma imagem que falha no smoke:
+
+1. **Build local** com `push: false` + `load: true` — imagem fica no daemon Docker do runner como `smoke/uniplus-api-<module>:ci`.
+2. **Smoke test** contra a imagem local: `docker run` com `ASPNETCORE_URLS=http://+:8080` + `ASPNETCORE_ENVIRONMENT=Production`, espera até 30s por `/health/live` responder 200.
+3. **Push para GHCR** com as tags semver — só roda se o smoke passou. Reusa o cache GHA do build local, então o segundo build é praticamente instantâneo.
+
+Se o smoke falhar, **nenhuma tag chega ao GHCR**. Sem republish 5min depois, sem `v<X>.<Y>.<Z>` imutável apontando para uma imagem quebrada.
 
 `/health/live` é a sonda de **liveness**: só verifica que o processo .NET está vivo e o Kestrel está respondendo. **Não** depende de Postgres, Kafka ou Redis — por isso é seguro rodar em CI sem infra.
 

--- a/docs/ci-publish-images.md
+++ b/docs/ci-publish-images.md
@@ -1,0 +1,84 @@
+# CI — Publicação de imagens Docker
+
+Documento operacional sobre o workflow `.github/workflows/publish-images.yml`. As decisões binding (registry, naming, tagging, retention) vivem em [ADR-0050](adrs/0050-registry-ghcr-e-tagging.md) — este guia explica **como o workflow opera** e **como consumir** as imagens publicadas.
+
+## Imagens publicadas
+
+| Módulo | Imagem |
+|---|---|
+| Seleção | `ghcr.io/unifesspa-edu-br/uniplus-api-selecao` |
+| Ingresso | `ghcr.io/unifesspa-edu-br/uniplus-api-ingresso` |
+| Portal | `ghcr.io/unifesspa-edu-br/uniplus-api-portal` |
+
+Visibilidade: pública (espelha o repositório).
+
+## Triggers e tags publicadas
+
+| Evento | Tags geradas |
+|---|---|
+| `push` em `main` | `sha-<7>`, `main`, `latest` |
+| `push` em tag `v<semver>` (ex.: `v1.2.3`) | `sha-<7>`, `v1.2.3`, `v1.2`, `v1` |
+
+A tag `sha-<7>` é **sempre imutável** e é a recomendada para ArgoCD pinar em ambientes promovidos. `main` e `latest` são canais mutáveis para DEV. Tags `v*` representam releases e nunca devem ser sobrescritas — release branch protection é responsabilidade do operador (não force-push em tags publicadas).
+
+## Plataformas
+
+Apenas `linux/amd64`. ARM (`linux/arm64`) está deferido até existir cluster ARM ou demanda concreta de Apple Silicon — ver [ADR-0050](adrs/0050-registry-ghcr-e-tagging.md#não-objetivos).
+
+## Cache
+
+Build cache via `type=gha` (GitHub Actions cache backend) com `scope=<module>` por matriz. Cada módulo tem cache isolado — alterar `Directory.Packages.props` invalida os 3 caches; alterar só `src/portal/` invalida apenas o cache do portal.
+
+## Smoke test
+
+Após o push, cada imagem é instanciada via `docker run` com `ASPNETCORE_URLS=http://+:8080` e `ASPNETCORE_ENVIRONMENT=Production`. O step espera até 30s para `/health/live` responder 200.
+
+`/health/live` é a sonda de **liveness**: só verifica que o processo .NET está vivo e o Kestrel está respondendo. **Não** depende de Postgres, Kafka ou Redis — por isso é seguro rodar em CI sem infra.
+
+A sonda de readiness completa (`/health` agregado, com checagem de Postgres/Kafka/Redis/MinIO) é exercida no cluster Kubernetes via Helm — fora do escopo deste workflow.
+
+## Como consumir
+
+### Pull anônimo (visibilidade pública)
+
+```bash
+docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:main
+```
+
+### Pin por SHA (recomendado em produção)
+
+```bash
+docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:sha-1a2b3c4
+```
+
+### Helm chart
+
+Configurar em `values.yaml`:
+
+```yaml
+image:
+  repository: ghcr.io/unifesspa-edu-br/uniplus-api-selecao
+  tag: sha-1a2b3c4   # imutável para promoção entre ambientes
+  pullPolicy: IfNotPresent
+```
+
+ArgoCD ApplicationSet atualiza `image.tag` por sync — não usar `latest` em ambiente promovido.
+
+### Listar tags disponíveis
+
+```bash
+gh api /orgs/unifesspa-edu-br/packages/container/uniplus-api-selecao/versions \
+  --jq '.[].metadata.container.tags[]' | sort -u
+```
+
+## Observações operacionais
+
+- **Permissões do `GITHUB_TOKEN`:** `contents: read`, `packages: write`, `id-token: write` (este último prepara o terreno para attestation OIDC futura).
+- **Concurrency:** publishes da mesma `ref` são serializados (`cancel-in-progress: false`) — perda de tag mutável (`main`/`latest`) nunca é aceitável.
+- **Cleanup:** GHCR retention manual é responsabilidade futura. Política planejada: `v*` indefinido, `sha-*` 30 dias, `<branch>` purga ao deletar branch — ver [ADR-0050 § Consequências](adrs/0050-registry-ghcr-e-tagging.md#negativas).
+
+## Próximos passos (deferidos)
+
+- **SBOM e attestation cosign keyless** via OIDC do GitHub — issue separada quando HML exigir.
+- **Trivy gate** — issue [#24](https://github.com/unifesspa-edu-br/uniplus-api/issues/24) plugando como step adicional no workflow.
+- **Multi-arch ARM** — issue separada quando demanda surgir.

--- a/docs/ci-publish-images.md
+++ b/docs/ci-publish-images.md
@@ -1,6 +1,6 @@
 # CI — Publicação de imagens Docker
 
-Documento operacional sobre o workflow `.github/workflows/publish-images.yml`. As decisões binding (registry, naming, tagging, retention) vivem em [ADR-0050](adrs/0050-registry-ghcr-e-tagging.md) — este guia explica **como o workflow opera** e **como consumir** as imagens publicadas.
+Documento operacional sobre o workflow `.github/workflows/publish-images.yml`. As decisões binding (registry, naming, tagging, retention) vivem em [ADR-0050](adrs/0050-registry-ghcr-e-tagging.md) — este guia explica **como o workflow opera**, **como publicar** uma nova versão e **como consumir** as imagens publicadas.
 
 ## Imagens publicadas
 
@@ -12,14 +12,38 @@ Documento operacional sobre o workflow `.github/workflows/publish-images.yml`. A
 
 Visibilidade: pública (espelha o repositório).
 
-## Triggers e tags publicadas
+## Trigger único — push de tag `v*`
+
+O workflow **só dispara** em `push` de tag que case com `v*` (ex.: `v0.1.0`, `v1.2.3`). **Push em `main` não publica imagem.** Disciplina de release explícito — sem rolling tag mutável, sem ambiguidade sobre "qual é o estado atual de DEV".
 
 | Evento | Tags geradas |
 |---|---|
-| `push` em `main` | `sha-<7>`, `main`, `latest` |
-| `push` em tag `v<semver>` (ex.: `v1.2.3`) | `sha-<7>`, `v1.2.3`, `v1.2`, `v1` |
+| `push` em tag `v<X>.<Y>.<Z>` | `sha-<7>`, `v<X>.<Y>.<Z>`, `v<X>.<Y>`, `v<X>` |
 
-A tag `sha-<7>` é **sempre imutável** e é a recomendada para ArgoCD pinar em ambientes promovidos. `main` e `latest` são canais mutáveis para DEV. Tags `v*` representam releases e nunca devem ser sobrescritas — release branch protection é responsabilidade do operador (não force-push em tags publicadas).
+Sem `latest`, sem `main` — `v<X>` já fornece soft-pinning automático que rola com patches/minors do mesmo major. ArgoCD em ambiente promovido pina `v<X>.<Y>.<Z>` ou `sha-<7>` explicitamente.
+
+## Como publicar uma nova versão
+
+Pré-requisito: o commit alvo já está em `main` (mergeado via PR).
+
+```bash
+# 1. Atualiza local
+git checkout main && git pull origin main
+
+# 2. Cria a tag anotada (signed se chave configurada)
+git tag -a v0.1.0 -m "Release v0.1.0 — primeiro publish dos 3 módulos"
+
+# 3. Publica a tag
+git push origin v0.1.0
+```
+
+O workflow inicia automaticamente. Em ~5–10 minutos, as 3 imagens estão em GHCR com 4 tags cada (`sha-<7>`, `v0.1.0`, `v0.1`, `v0`).
+
+**Reverter:** tags são imutáveis no GHCR uma vez publicadas. Para revogar uma release, publique uma versão imediatamente posterior (`v0.1.1`) com o conteúdo correto. Não fazer `git push --force` em tag publicada.
+
+## Como devs/ambientes locais usam
+
+Para DEV local não há imagem publicada — devs constroem via `docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up`, que faz build com contexto local e roda em rede com Postgres/Redis/Kafka/Keycloak.
 
 ## Plataformas
 
@@ -42,10 +66,10 @@ A sonda de readiness completa (`/health` agregado, com checagem de Postgres/Kafk
 ### Pull anônimo (visibilidade pública)
 
 ```bash
-docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:main
+docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:v0.1.0
 ```
 
-### Pin por SHA (recomendado em produção)
+### Pin por SHA (auditoria SHA-perfeita)
 
 ```bash
 docker pull ghcr.io/unifesspa-edu-br/uniplus-api-selecao:sha-1a2b3c4
@@ -58,11 +82,11 @@ Configurar em `values.yaml`:
 ```yaml
 image:
   repository: ghcr.io/unifesspa-edu-br/uniplus-api-selecao
-  tag: sha-1a2b3c4   # imutável para promoção entre ambientes
+  tag: v0.1.0          # release explícita; alternativa: sha-1a2b3c4 para SHA pin
   pullPolicy: IfNotPresent
 ```
 
-ArgoCD ApplicationSet atualiza `image.tag` por sync — não usar `latest` em ambiente promovido.
+ArgoCD ApplicationSet atualiza `image.tag` por sync — sempre semver explícito ou SHA, nunca canal mutável.
 
 ### Listar tags disponíveis
 
@@ -74,8 +98,8 @@ gh api /orgs/unifesspa-edu-br/packages/container/uniplus-api-selecao/versions \
 ## Observações operacionais
 
 - **Permissões do `GITHUB_TOKEN`:** `contents: read`, `packages: write`, `id-token: write` (este último prepara o terreno para attestation OIDC futura).
-- **Concurrency:** publishes da mesma `ref` são serializados (`cancel-in-progress: false`) — perda de tag mutável (`main`/`latest`) nunca é aceitável.
-- **Cleanup:** GHCR retention manual é responsabilidade futura. Política planejada: `v*` indefinido, `sha-*` 30 dias, `<branch>` purga ao deletar branch — ver [ADR-0050 § Consequências](adrs/0050-registry-ghcr-e-tagging.md#negativas).
+- **Concurrency:** `cancel-in-progress: false` — protege contra dois workflows tentando publicar a mesma tag por race (force-push). Tags semver são imutáveis após publicadas; force-push em tag é uma operação que ninguém deve fazer.
+- **Cleanup:** GHCR retention manual é responsabilidade futura. Política planejada: `v*` indefinido, `sha-*` 30 dias — ver [ADR-0050 § Consequências](adrs/0050-registry-ghcr-e-tagging.md#negativas).
 
 ## Próximos passos (deferidos)
 


### PR DESCRIPTION
Closes #337

## Resumo

Implementa o workflow `.github/workflows/publish-images.yml` que publica as imagens das 3 APIs (`selecao`, `ingresso`, `portal`) no GitHub Container Registry conforme ADR-0050. Destrava a Fase 5 do lado do backend.

## Política de publish

**Trigger único:** `push` de tag `v*`. Push em `main` **não** publica. Disciplina de release explícito — sem rolling tag mutável (`main`/`latest`), ambiente promovido pina semver ou SHA.

| Item | Escolha | Por quê |
|---|---|---|
| Imagens | `ghcr.io/unifesspa-edu-br/uniplus-api-{selecao,ingresso,portal}` | naming binding em ADR-0050 |
| Trigger | apenas `push: tags v*` | release explícito, sem rolling DEV tag |
| Tagging | `docker/metadata-action@v5` declarativo | `sha-<7>`, `v<X>.<Y>.<Z>`, `v<X>.<Y>`, `v<X>` |
| Plataforma | `linux/amd64` | ARM deferido |
| Login | `GITHUB_TOKEN` | sem PAT, padrão GHCR; permissions `contents: read`, `packages: write`, `id-token: write` |
| Cache | `type=gha` com `scope=<module>` | builds independentes não invalidam cache uns dos outros |
| Smoke | `/health/live` com 30s timeout | liveness é process-only, não depende de Postgres/Kafka |
| Concurrency | `cancel-in-progress: false` | protege contra race em force-push de tag |
| Matriz | `fail-fast: false` | falha em 1 módulo não derruba publish dos outros |

Portal API (#336) já em main desde 14:17Z, então portal entra na matriz desde o dia 1 — sem follow-up posterior.

## Commits

- \`497afd9\` — workflow inicial + doc (versão preliminar com triggers em main+tag)
- \`2f73e82\` — ajusta política para tag-only, remove main/latest, atualiza ADR-0050 e doc

## Como publicar v0.1.0 após o merge

\`\`\`bash
git checkout main && git pull origin main
git tag -a v0.1.0 -m \"Release v0.1.0 — primeiro publish dos 3 módulos\"
git push origin v0.1.0
\`\`\`

Em ~5–10min, 3 imagens em GHCR com tags `sha-<7>`, `v0.1.0`, `v0.1`, `v0` cada.

## Verificação

- [x] YAML valida (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`)
- [x] Dockerfiles existem para os 3 módulos
- [x] Documentação operacional em `docs/ci-publish-images.md` (atualizada com seção \"Como publicar\")
- [x] ADR-0050 atualizada (Resultado da decisão + Confirmação)
- [ ] CI deste PR verifica que workflow não tem erro de sintaxe
- [ ] Após merge: aplicar `git tag v0.1.0` e validar pull anônimo
- [ ] Após primeiro publish: ajustar visibilidade dos 3 packages para `public`

## Cobertura dos critérios de aceite (Story #337)

- [x] Workflow aciona em `push` para tag `v*`
- [x] Matriz `[selecao, ingresso, portal]` (portal já entra — #336 mergeada)
- [x] Login no GHCR via `GITHUB_TOKEN` com `permissions` corretas
- [x] Build via `docker/build-push-action@v5`, `linux/amd64`
- [x] Tags conforme ADR-0050 (versão revisada — sem main/latest)
- [x] Cache `type=gha` por escopo
- [x] Smoke test pós-build (`/health/live`, 30s timeout, dump de logs em falha)
- [ ] Pull público anônimo (verificação manual pós-merge + tag)
- [x] Documentação em `docs/ci-publish-images.md` referenciando ADR-0050
- [ ] Comentário cruzado na issue da Fase 5 (pendente: link da issue)
- [x] Trivy (#24) pode plugar como gate adicional no mesmo workflow

## Nota sobre #337 AC original

O critério \"workflow aciona em `push` para `main`\" foi revisado nesta implementação para alinhar com a regra operacional \"imagem só nasce em tag v*\" — ADR-0050 atualizada no mesmo PR para refletir.

## Não-objetivos (intencionais)

- SBOM e attestation cosign — issue separada (HML)
- Multi-arch ARM — issue separada
- Registry interno Unifesspa — fora de escopo
- Cleanup de tags antigas — issue separada
- Rolling tag de DEV (`main`) — vedado por ADR-0050; DEV usa compose com build local

## Referências

- ADR-0050: `docs/adrs/0050-registry-ghcr-e-tagging.md` (atualizada neste PR)
- ADR pareada (web): `uniplus-web/docs/adrs/0020-registry-ghcr-e-tagging.md` (será atualizada em PR separado)
- Story implementada: #337
- Feature pai: #7
- Trivy gate dependente: #24
- Helm consumer: #10