### PR TITLE
fix(ci): trocar smoke runtime por validação estrutural

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -155,11 +155,15 @@ jobs:
           docker create --name "smoke-${{ matrix.module }}" "$IMAGE_REF" >/dev/null
 
           USER_FIELD=$(docker inspect -f '{{.Config.User}}' "smoke-${{ matrix.module }}")
-          if [ -z "$USER_FIELD" ] || [ "$USER_FIELD" = "root" ]; then
-            echo "::error::Imagem roda como root ou USER vazio (got: '$USER_FIELD')"
-            docker rm "smoke-${{ matrix.module }}" >/dev/null
-            exit 1
-          fi
+          # USER pode ser: '' (default root), 'root', 'root:gid', '0' (uid root),
+          # '0:0' / '0:N' (uid root + qualquer gid). Todos significam root.
+          case "$USER_FIELD" in
+            ""|"root"|"root:"*|"0"|"0:"*)
+              echo "::error::Imagem roda como root ou USER não definido (got: '$USER_FIELD')"
+              docker rm "smoke-${{ matrix.module }}" >/dev/null
+              exit 1
+              ;;
+          esac
           echo "✓ Non-root user: $USER_FIELD"
 
           ENTRYPOINT=$(docker inspect -f '{{.Config.Entrypoint}}' "smoke-${{ matrix.module }}")

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -136,36 +136,44 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.module }}
           cache-to: type=gha,scope=${{ matrix.module }},mode=max
 
-      - name: Smoke test — startup + liveness probe
-        # Liveness (/health/live) só verifica que o processo está vivo — não
-        # depende de Postgres/Kafka/Redis, válido em CI sem infra. /health
-        # agregado é responsabilidade do gate de Helm/Kubernetes.
-        # Roda contra a imagem local (smoke/...:ci), antes do push para GHCR.
+      - name: Smoke test — validação estrutural da imagem
+        # Smoke runtime (/health/live) não é viável em CI puro: Wolverine valida
+        # `ConnectionStrings:*Db` ao construir o host, então o app crasha em
+        # startup sem Postgres real. Em vez de prover sidecar Postgres/Kafka/Redis
+        # no workflow (overhead alto, custo cumulativo na matriz), validamos a
+        # estrutura da imagem antes do push:
+        #   - Imagem é loadable (manifest + layers íntegros, `docker create` ok)
+        #   - Roda como usuário não-root (não pode ser '' nem 'root')
+        #   - Entrypoint referencia uma DLL `Unifesspa.UniPlus`
+        #   - Runtime .NET responde a `dotnet --info`
+        # Smoke runtime real é exercido em compose/Helm pós-publish.
         run: |
           set -euo pipefail
           IMAGE_REF="smoke/uniplus-api-${{ matrix.module }}:ci"
-          echo "Smoke testing: $IMAGE_REF"
-          docker run -d \
-            --name "smoke-${{ matrix.module }}" \
-            -p 8080:8080 \
-            -e ASPNETCORE_URLS="http://+:8080" \
-            -e ASPNETCORE_ENVIRONMENT=Production \
-            "$IMAGE_REF"
+          echo "Smoke (structural): $IMAGE_REF"
 
-          for attempt in $(seq 1 30); do
-            if curl -fsS http://localhost:8080/health/live > /dev/null 2>&1; then
-              echo "✓ /health/live respondeu 200 em ${attempt}s"
-              docker stop "smoke-${{ matrix.module }}" > /dev/null
-              exit 0
-            fi
-            sleep 1
-          done
+          docker create --name "smoke-${{ matrix.module }}" "$IMAGE_REF" >/dev/null
 
-          echo "✗ /health/live não respondeu em 30s"
-          echo "--- container logs ---"
-          docker logs "smoke-${{ matrix.module }}" || true
-          docker stop "smoke-${{ matrix.module }}" > /dev/null || true
-          exit 1
+          USER_FIELD=$(docker inspect -f '{{.Config.User}}' "smoke-${{ matrix.module }}")
+          if [ -z "$USER_FIELD" ] || [ "$USER_FIELD" = "root" ]; then
+            echo "::error::Imagem roda como root ou USER vazio (got: '$USER_FIELD')"
+            docker rm "smoke-${{ matrix.module }}" >/dev/null
+            exit 1
+          fi
+          echo "✓ Non-root user: $USER_FIELD"
+
+          ENTRYPOINT=$(docker inspect -f '{{.Config.Entrypoint}}' "smoke-${{ matrix.module }}")
+          if ! echo "$ENTRYPOINT" | grep -qi "Unifesspa.UniPlus"; then
+            echo "::error::Entrypoint não referencia DLL Unifesspa.UniPlus (got: $ENTRYPOINT)"
+            docker rm "smoke-${{ matrix.module }}" >/dev/null
+            exit 1
+          fi
+          echo "✓ Entrypoint: $ENTRYPOINT"
+
+          docker rm "smoke-${{ matrix.module }}" >/dev/null
+
+          docker run --rm --entrypoint /usr/bin/dotnet "$IMAGE_REF" --info | head -3
+          echo "✓ Runtime .NET responde"
 
       - name: Push para GHCR (após smoke verde)
         id: build

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -172,7 +172,12 @@ jobs:
 
           docker rm "smoke-${{ matrix.module }}" >/dev/null
 
-          docker run --rm --entrypoint /usr/bin/dotnet "$IMAGE_REF" --info | head -3
+          # Não pipear `head -N` aqui: com set -euo pipefail, head fechando o
+          # pipe cedo gera SIGPIPE no docker run (exit 141), que pipefail
+          # propaga como falha do step — bloqueia publish mesmo com runtime
+          # saudável. Saída de `dotnet --info` é verbose (~30 linhas) e o
+          # exit code já é o sinal que precisamos. Descartamos stdout.
+          docker run --rm --entrypoint /usr/bin/dotnet "$IMAGE_REF" --info >/dev/null
           echo "✓ Runtime .NET responde"
 
       - name: Push para GHCR (após smoke verde)

--- a/docs/ci-publish-images.md
+++ b/docs/ci-publish-images.md
@@ -58,14 +58,20 @@ Build cache via `type=gha` (GitHub Actions cache backend) com `scope=<module>` p
 O workflow constrói cada imagem em duas fases para evitar publicar tags imutáveis de uma imagem que falha no smoke:
 
 1. **Build local** com `push: false` + `load: true` — imagem fica no daemon Docker do runner como `smoke/uniplus-api-<module>:ci`.
-2. **Smoke test** contra a imagem local: `docker run` com `ASPNETCORE_URLS=http://+:8080` + `ASPNETCORE_ENVIRONMENT=Production`, espera até 30s por `/health/live` responder 200.
-3. **Push para GHCR** com as tags semver — só roda se o smoke passou. Reusa o cache GHA do build local, então o segundo build é praticamente instantâneo.
+2. **Validação estrutural** (sem rodar o app):
+   - `docker create` — manifest + layers íntegros
+   - `docker inspect` confirma `Config.User` ≠ vazio e ≠ `root`
+   - `docker inspect` confirma `Config.Entrypoint` referencia uma DLL `Unifesspa.UniPlus.*`
+   - `dotnet --info` no runtime da imagem (override do entrypoint) — confirma que o runtime .NET 10 está presente e funcional
+3. **Push para GHCR** com as tags semver — só roda se a validação passou. Reusa o cache GHA do build local, então o segundo build é praticamente instantâneo.
 
-Se o smoke falhar, **nenhuma tag chega ao GHCR**. Sem republish 5min depois, sem `v<X>.<Y>.<Z>` imutável apontando para uma imagem quebrada.
+Se a validação falhar, **nenhuma tag chega ao GHCR**.
 
-`/health/live` é a sonda de **liveness**: só verifica que o processo .NET está vivo e o Kestrel está respondendo. **Não** depende de Postgres, Kafka ou Redis — por isso é seguro rodar em CI sem infra.
+### Por que não rodamos `/health/live` em runtime aqui
 
-A sonda de readiness completa (`/health` agregado, com checagem de Postgres/Kafka/Redis/MinIO) é exercida no cluster Kubernetes via Helm — fora do escopo deste workflow.
+A primeira versão do gate tentou `docker run` + curl em `/health/live` e falhou: `Wolverine` valida `ConnectionStrings:*Db` ao construir o host (em `UseWolverineOutboxCascading`), então o app crasha em startup sem um Postgres real ao lado. Para rodar liveness no workflow, seria necessário subir sidecars Postgres + Kafka + Redis em cada entrada da matriz — overhead alto que duplica trabalho que o `docker compose` pós-publish e o Helm em cluster já fazem com infra completa.
+
+A sonda de readiness completa (`/health` agregado, com checagem de Postgres/Kafka/Redis/MinIO) é exercida em compose pós-publish (manualmente ou via deploy de HML) e no cluster Kubernetes via Helm — fora do escopo deste workflow.
 
 ## Como consumir
 


### PR DESCRIPTION
## Resumo

Workflow `publish-images.yml` falhou na primeira execução (tag `v0.1.0`, run [25579729786](https://github.com/unifesspa-edu-br/uniplus-api/actions/runs/25579729786)) porque \`/health/live\` nunca respondeu — \`Wolverine\` valida \`ConnectionStrings:*Db\` em \`UseWolverineOutboxCascading\` e crasha o host antes do Kestrel subir.

## Causa

\`\`\`text
Unhandled exception. System.InvalidOperationException:
Connection string 'PortalDb' não configurada — Wolverine não pode inicializar o outbox.
   at Unifesspa.UniPlus.Infrastructure.Core.Messaging.WolverineOutboxConfiguration
       .UseWolverineOutboxCascading(IHostBuilder, IConfiguration, String, String, Action)
\`\`\`

Os 3 módulos (selecao, ingresso, portal) tiveram a mesma falha — `Postgres` não estava lá.

## Trade-offs avaliados

| Alternativa | Por que descartada |
|---|---|
| Sidecar Postgres+Kafka+Redis no workflow | Overhead na matriz, duplica trabalho que compose+Helm já fazem |
| Stub env vars apontando para `localhost:5432` | Wolverine ainda tenta conectar em startup |
| Code change `--validate-only` flag | Scope creep para uma Story de CI |

## Adotado

Validação estrutural pré-push (sem rodar o app):

- `docker create` — manifest + layers íntegros
- `docker inspect` — `Config.User` ≠ `''` e ≠ `root`
- `docker inspect` — `Config.Entrypoint` contém `Unifesspa.UniPlus.*`
- `dotnet --info` no runtime (override do entrypoint) — confirma .NET 10 presente

Runtime real ficou para `docker compose` pós-publish e Helm em cluster, onde infra completa já está orquestrada.

## Referências

- Run que falhou: [25579729786](https://github.com/unifesspa-edu-br/uniplus-api/actions/runs/25579729786)
- Story original: #337
- ADR-0050 não mencionava smoke como decisão binding — só doc operacional precisava de update