### PR TITLE
feat(shared): registra IMinioClient + IStorageService no DI

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -56,6 +56,7 @@ builder.Host.UseWolverineOutboxCascading(builder.Configuration, connectionString
 builder.Services.AddWolverineMessaging();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
+builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);
 
 WebApplication app = builder.Build();
 

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
@@ -63,6 +63,7 @@ builder.Host.UseWolverineOutboxCascading(builder.Configuration, connectionString
 builder.Services.AddWolverineMessaging();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
+builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);
 
 WebApplication app = builder.Build();
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -114,6 +114,7 @@ builder.Host.UseWolverineOutboxCascading(
 builder.Services.AddWolverineMessaging();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
+builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);
 
 WebApplication app = builder.Build();
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
@@ -1,0 +1,89 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+using Minio;
+
+using Storage;
+
+/// <summary>
+/// Registra <see cref="IMinioClient"/> e <see cref="IStorageService"/> no container DI a partir
+/// da seção <c>Storage</c> do <see cref="IConfiguration"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Padrão alinhado com <see cref="Cors.CorsConfiguration"/> e
+/// <see cref="Authentication.OidcAuthenticationConfiguration"/>: validação leniente em Development,
+/// fail-fast fora de Development quando <c>Storage:Endpoint</c>, <c>Storage:AccessKey</c> ou
+/// <c>Storage:SecretKey</c> estão vazios.
+/// </para>
+/// <para>
+/// <see cref="IMinioClient"/> é registrado como <em>singleton</em> — o cliente mantém um pool
+/// HTTP interno reutilizável entre requests. <see cref="IStorageService"/> é <em>scoped</em> por
+/// request, conforme padrão do projeto para serviços de Infrastructure que abstraem clientes
+/// remotos. <see cref="MinioStorageService"/> é stateless, então scope vs. singleton é
+/// equivalente em runtime — manter scoped preserva a opção de injetar serviços scoped no futuro
+/// (correlation id, user context) sem mudança de contrato.
+/// </para>
+/// </remarks>
+public static class StorageServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registra <see cref="StorageOptions"/>, <see cref="IMinioClient"/> e
+    /// <see cref="IStorageService"/>. Deve ser chamado uma única vez por aplicação,
+    /// junto com os demais <c>AddUniPlus*</c> em <c>Program.cs</c>.
+    /// </summary>
+    /// <param name="services">A coleção de serviços.</param>
+    /// <param name="configuration">Configuração da aplicação (lê seção <c>Storage</c>).</param>
+    /// <param name="environment">Ambiente de hospedagem — controla rigor da validação.</param>
+    /// <returns>A própria <paramref name="services"/> para encadeamento fluente.</returns>
+    /// <exception cref="ArgumentNullException">Algum dos parâmetros é <see langword="null"/>.</exception>
+    public static IServiceCollection AddUniPlusStorage(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        services.AddOptions<StorageOptions>()
+            .Bind(configuration.GetSection(StorageOptions.SectionName))
+            .Validate(
+                options => environment.IsDevelopment()
+                    || (!string.IsNullOrWhiteSpace(options.Endpoint)
+                        && !string.IsNullOrWhiteSpace(options.AccessKey)
+                        && !string.IsNullOrWhiteSpace(options.SecretKey)),
+                "Storage:Endpoint, Storage:AccessKey and Storage:SecretKey must be configured outside Development.")
+            .Validate(
+                options => string.IsNullOrWhiteSpace(options.Endpoint)
+                    || (!options.Endpoint.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                        && !options.Endpoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase)),
+                "Storage:Endpoint must be host:port without scheme — control HTTPS via Storage:UseSSL.")
+            .ValidateOnStart();
+
+        services.AddSingleton<IMinioClient>(sp =>
+        {
+            StorageOptions opts = sp.GetRequiredService<IOptions<StorageOptions>>().Value;
+
+            IMinioClient client = new MinioClient()
+                .WithEndpoint(opts.Endpoint)
+                .WithCredentials(opts.AccessKey, opts.SecretKey)
+                .WithSSL(opts.UseSSL);
+
+            if (!string.IsNullOrWhiteSpace(opts.Region))
+            {
+                client = client.WithRegion(opts.Region);
+            }
+
+            return client.Build();
+        });
+
+        services.AddScoped<IStorageService, MinioStorageService>();
+
+        return services;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/StorageOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/StorageOptions.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Storage;
+
+/// <summary>
+/// Bound options for object storage (S3-compatible — MinIO em todos os ambientes Uni+).
+/// Ligadas via <see cref="DependencyInjection.StorageServiceCollectionExtensions.AddUniPlusStorage"/>.
+/// Fora de Development, <see cref="Endpoint"/>/<see cref="AccessKey"/>/<see cref="SecretKey"/>
+/// devem estar preenchidos — caso contrário, o startup falha. Em Development a validação é leniente
+/// para permitir bring-up parcial sem MinIO local (ex.: rodar API de auth sem subir storage).
+/// </summary>
+public sealed class StorageOptions
+{
+    public const string SectionName = "Storage";
+
+    /// <summary>
+    /// Endpoint MinIO no formato <c>host:port</c> (sem esquema). O esquema é controlado por
+    /// <see cref="UseSSL"/> — combinar HTTPS via flag e não embedar <c>https://</c> aqui.
+    /// </summary>
+    public string Endpoint { get; init; } = string.Empty;
+
+    /// <summary>Access key (S3 access key id). Provida por env var em prod (chart Helm + Vault).</summary>
+    public string AccessKey { get; init; } = string.Empty;
+
+    /// <summary>Secret key (S3 secret access key). Nunca commitar — sempre via env var/Vault.</summary>
+    public string SecretKey { get; init; } = string.Empty;
+
+    /// <summary>Quando <see langword="true"/>, conecta via HTTPS. Default <see langword="false"/>.</summary>
+    public bool UseSSL { get; init; }
+
+    /// <summary>Região S3 (opcional — MinIO usa <c>us-east-1</c> por default e ignora se vazio).</summary>
+    public string? Region { get; init; }
+
+    /// <summary>
+    /// Bucket default por API (ex.: <c>uniplus-documentos</c>). Opcional na camada de DI —
+    /// handlers que dependem dele devem validar a própria obrigatoriedade.
+    /// </summary>
+    public string? BucketName { get; init; }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/MinioCollectionDefinition.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/MinioCollectionDefinition.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Storage;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+[CollectionDefinition(MinioContainerFixture.CollectionName)]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção xUnit: o sufixo 'Collection' identifica a classe como CollectionDefinition.")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x exige que CollectionDefinitions sejam públicas para que o runner as descubra.")]
+public sealed class MinioCollection : ICollectionFixture<MinioContainerFixture>
+{
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Storage;
+
+using System.Text;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+using Unifesspa.UniPlus.Infrastructure.Core.Storage;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+[Collection(MinioContainerFixture.CollectionName)]
+public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioContainerFixture minio)
+{
+    private const string TestBucket = "uniplus-storage-tests";
+
+    private ServiceProvider BuildProvider()
+    {
+        Dictionary<string, string?> config = new()
+        {
+            ["Storage:Endpoint"] = minio.Endpoint,
+            ["Storage:AccessKey"] = MinioContainerFixture.AccessKey,
+            ["Storage:SecretKey"] = MinioContainerFixture.SecretKey,
+        };
+
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(
+            new ConfigurationBuilder().AddInMemoryCollection(config).Build(),
+            new HostingEnvironment { EnvironmentName = Environments.Production });
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task UploadEDownload_RoundTrip_DevePreservarBytes()
+    {
+        await using ServiceProvider sp = BuildProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IStorageService storage = scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        string objectName = $"smoke/round-trip-{Guid.NewGuid():N}.txt";
+        byte[] payload = Encoding.UTF8.GetBytes("conteúdo de smoke — Uni+ #342");
+
+        using (MemoryStream uploadStream = new(payload))
+        {
+            string location = await storage.UploadAsync(
+                TestBucket,
+                objectName,
+                uploadStream,
+                "text/plain; charset=utf-8");
+
+            location.Should().Be($"{TestBucket}/{objectName}");
+        }
+
+        await using Stream downloaded = await storage.DownloadAsync(TestBucket, objectName);
+        using MemoryStream collector = new();
+        await downloaded.CopyToAsync(collector);
+
+        collector.ToArray().Should().Equal(payload);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/StorageServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/StorageServiceCollectionExtensionsTests.cs
@@ -1,0 +1,206 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.DependencyInjection;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Options;
+
+using Minio;
+
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+using Unifesspa.UniPlus.Infrastructure.Core.Storage;
+
+public sealed class StorageServiceCollectionExtensionsTests
+{
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private static HostingEnvironment Env(string name) =>
+        new() { EnvironmentName = name };
+
+    private static Dictionary<string, string?> CompleteConfig() => new()
+    {
+        ["Storage:Endpoint"] = "minio:9000",
+        ["Storage:AccessKey"] = "ak-test",
+        ["Storage:SecretKey"] = "sk-test",
+    };
+
+    [Fact]
+    public void AddUniPlusStorage_ServicesNulo_LancaArgumentNullException()
+    {
+        IServiceCollection? services = null;
+
+        Action acao = () => services!.AddUniPlusStorage(BuildConfig(CompleteConfig()), Env(Environments.Production));
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddUniPlusStorage_ConfigurationNulo_LancaArgumentNullException()
+    {
+        ServiceCollection services = new();
+
+        Action acao = () => services.AddUniPlusStorage(null!, Env(Environments.Production));
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddUniPlusStorage_EnvironmentNulo_LancaArgumentNullException()
+    {
+        ServiceCollection services = new();
+
+        Action acao = () => services.AddUniPlusStorage(BuildConfig(CompleteConfig()), null!);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddUniPlusStorage_ConfigCompleta_ResolveIMinioClient()
+    {
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(CompleteConfig()), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        IMinioClient client = sp.GetRequiredService<IMinioClient>();
+
+        client.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddUniPlusStorage_ConfigCompleta_ResolveIStorageServiceComoMinioStorageService()
+    {
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(CompleteConfig()), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IStorageService storage = scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        storage.Should().BeOfType<MinioStorageService>();
+    }
+
+    [Fact]
+    public void AddUniPlusStorage_IMinioClient_DeveSerSingleton()
+    {
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(CompleteConfig()), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        IMinioClient first = sp.GetRequiredService<IMinioClient>();
+        IMinioClient second = sp.GetRequiredService<IMinioClient>();
+
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void AddUniPlusStorage_IStorageService_DeveSerScopedDistintoEntreScopes()
+    {
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(CompleteConfig()), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        IStorageService a, b;
+        using (IServiceScope scope1 = sp.CreateScope())
+        {
+            a = scope1.ServiceProvider.GetRequiredService<IStorageService>();
+        }
+
+        using (IServiceScope scope2 = sp.CreateScope())
+        {
+            b = scope2.ServiceProvider.GetRequiredService<IStorageService>();
+        }
+
+        b.Should().NotBeSameAs(a);
+    }
+
+    [Theory]
+    [InlineData("Storage:Endpoint")]
+    [InlineData("Storage:AccessKey")]
+    [InlineData("Storage:SecretKey")]
+    public void AddUniPlusStorage_ProductionComCampoFaltando_OptionsValueLancaOptionsValidationException(string keyToOmit)
+    {
+        Dictionary<string, string?> values = new(CompleteConfig());
+        values[keyToOmit] = "";
+
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(values), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Action acao = () => { _ = sp.GetRequiredService<IOptions<StorageOptions>>().Value; };
+
+        acao.Should().Throw<OptionsValidationException>()
+            .WithMessage("*Storage:Endpoint*Storage:AccessKey*Storage:SecretKey*");
+    }
+
+    [Fact]
+    public void AddUniPlusStorage_DevelopmentSemConfig_NaoLancaValidacao()
+    {
+        // Em Development a validação é leniente — bring-up parcial sem MinIO local
+        // permite rodar API de auth/health sem subir storage. Em prod, env vars
+        // do chart (Storage__Endpoint/AccessKey/SecretKey via Vault) atendem.
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(
+            BuildConfig(new Dictionary<string, string?>()),
+            Env(Environments.Development));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Action acao = () => { _ = sp.GetRequiredService<IOptions<StorageOptions>>().Value; };
+
+        acao.Should().NotThrow();
+    }
+
+    [Theory]
+    [InlineData("http://minio:9000")]
+    [InlineData("https://minio:9000")]
+    [InlineData("HTTPS://minio:9000")]
+    public void AddUniPlusStorage_EndpointComScheme_OptionsValueLancaOptionsValidationException(string endpoint)
+    {
+        Dictionary<string, string?> values = new(CompleteConfig())
+        {
+            ["Storage:Endpoint"] = endpoint,
+        };
+
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(values), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Action acao = () => { _ = sp.GetRequiredService<IOptions<StorageOptions>>().Value; };
+
+        acao.Should().Throw<OptionsValidationException>()
+            .WithMessage("*host:port without scheme*");
+    }
+
+    [Fact]
+    public void AddUniPlusStorage_BindingMapeiaTodasAsPropriedades()
+    {
+        Dictionary<string, string?> values = new()
+        {
+            ["Storage:Endpoint"] = "storage.example:9000",
+            ["Storage:AccessKey"] = "ak",
+            ["Storage:SecretKey"] = "sk",
+            ["Storage:UseSSL"] = "true",
+            ["Storage:Region"] = "us-east-1",
+            ["Storage:BucketName"] = "uniplus-documentos",
+        };
+
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(values), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        StorageOptions opts = sp.GetRequiredService<IOptions<StorageOptions>>().Value;
+
+        opts.Endpoint.Should().Be("storage.example:9000");
+        opts.AccessKey.Should().Be("ak");
+        opts.SecretKey.Should().Be("sk");
+        opts.UseSSL.Should().BeTrue();
+        opts.Region.Should().Be("us-east-1");
+        opts.BucketName.Should().Be("uniplus-documentos");
+    }
+}

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/MinioContainerFixture.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/MinioContainerFixture.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+/// <summary>
+/// Sobe um container MinIO via Testcontainers em modo single-node, expondo endpoint, credentials root
+/// e SSL=off para uso em testes de integração. Compartilhada via <c>[Collection("Minio")]</c> — cada
+/// assembly que a usa deve declarar sua própria <c>[CollectionDefinition]</c> com o mesmo nome
+/// (ver padrão <see cref="VaultContainerFixture"/>).
+/// </summary>
+/// <remarks>
+/// A imagem é fixada na mesma RELEASE usada pelo <c>docker-compose.yml</c> e pelo bootstrap
+/// standalone — alinhar a tag aqui com produção evita variações de schema/comportamento entre
+/// testes e runtime.
+/// </remarks>
+public sealed class MinioContainerFixture : IAsyncLifetime
+{
+    public const string Image = "minio/minio:RELEASE.2025-09-07T16-13-09Z";
+    public const string AccessKey = "minioadmin";
+    public const string SecretKey = "minioadmin";
+    public const string CollectionName = "Minio";
+
+    private const ushort ApiPort = 9000;
+    private const ushort ConsolePort = 9001;
+
+    private readonly IContainer _container;
+
+    public MinioContainerFixture()
+    {
+        _container = new ContainerBuilder(Image)
+            .WithPortBinding(ApiPort, true)
+            .WithPortBinding(ConsolePort, true)
+            .WithEnvironment("MINIO_ROOT_USER", AccessKey)
+            .WithEnvironment("MINIO_ROOT_PASSWORD", SecretKey)
+            .WithCommand("server", "/data", "--console-address", $":{ConsolePort}")
+            .WithWaitStrategy(
+                Wait.ForUnixContainer()
+                    .UntilHttpRequestIsSucceeded(r => r
+                        .ForPort(ApiPort)
+                        .ForPath("/minio/health/live")))
+            .Build();
+    }
+
+    /// <summary>Endpoint MinIO no formato <c>host:port</c> (sem esquema). Apto a alimentar <c>Storage:Endpoint</c>.</summary>
+    public string Endpoint =>
+        $"{_container.Hostname}:{_container.GetMappedPublicPort(ApiPort)}";
+
+    public Task InitializeAsync() => _container.StartAsync();
+
+    public async Task DisposeAsync() =>
+        await _container.DisposeAsync().ConfigureAwait(false);
+}


### PR DESCRIPTION
## Resumo

Sub-issue P0 da Epic #347 (APIs Uni+ — comunicação ponta a ponta com deps externas em standalone).

Antes deste PR, `MinioStorageService` injetava `IMinioClient`, mas o cliente nunca era registrado no container DI. Qualquer endpoint que dependesse de `IStorageService` falhava em runtime com:

```
System.InvalidOperationException: Unable to resolve service for type 'IStorageService'
```

Bloqueava upload de documentos (RF03 da inscrição do candidato) em todos os ambientes.

## O que muda

- `AddUniPlusStorage(IConfiguration, IHostEnvironment)` em `Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs`
  - Liga `Storage:` (Endpoint, AccessKey, SecretKey, UseSSL, Region, BucketName)
  - Registra `IMinioClient` singleton (pool HTTP reutilizado)
  - Registra `IStorageService → MinioStorageService` scoped
- `StorageOptions` em `Infrastructure.Core/Storage/StorageOptions.cs`
- Cada `Program.cs` (Portal/Selecao/Ingresso) chama `AddUniPlusStorage` ao lado de `AddCorsConfiguration`

### Validação

Padrão alinhado com `CorsConfiguration` e `OidcAuthenticationConfiguration`:

- **Fora de Development:** `Storage:Endpoint`, `Storage:AccessKey`, `Storage:SecretKey` obrigatórios — startup falha com mensagem clara via `OptionsValidationException` se algum estiver vazio.
- **Em Development:** validação leniente — bring-up parcial sem MinIO local é aceito (rodar API de auth/health sem subir storage).
- **Endpoint com scheme** (`http://`/`https://`): rejeitado no startup — controle de HTTPS é via `Storage:UseSSL`, não embedado na URL.

Compatível com:
- `appsettings.json` (placeholders vazios sobrescritos por env vars `Storage__*`)
- `docker-compose.override.yml` (Storage__Endpoint/AccessKey/SecretKey já presentes)
- charts Helm `apps/uniplus-api-{portal,selecao,ingresso}` (env vars vindas do Vault, ver uniplus-infra/PR #160)

## Critérios de aceite (issue #342)

- [x] `services.AddUniPlusStorage(IConfiguration)` registrado e testado
- [x] Cada `Program.cs` (3) usa o método
- [x] Validação de config faltante com mensagem clara
- [x] Test integration: PUT/GET object via `IStorageService` no MinIO de teste
- [x] Pre-PR: `dotnet build` + `dotnet test` verdes

## Cobertura de testes

**Unit (`Unifesspa.UniPlus.Infrastructure.Core.UnitTests`)** — 15 testes cobrindo:
- Argumentos nulos (services / configuration / environment) → `ArgumentNullException`
- Config completa Production → resolve `IMinioClient` (singleton) + `IStorageService` (scoped distinto entre scopes) como `MinioStorageService`
- Production com Endpoint/AccessKey/SecretKey vazios → `OptionsValidationException`
- Development sem config → não lança (validação leniente)
- Endpoint com scheme `http://`/`https://`/`HTTPS://` → `OptionsValidationException`
- Binding de todas as 6 propriedades

**Integration (`Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests`)** — 1 teste com Testcontainers MinIO:
- `MinioContainerFixture` (em `IntegrationTests.Fixtures/Hosting/`) sobe `minio/minio:RELEASE.2025-09-07T16-13-09Z` (mesma tag do `docker-compose.yml` e do `bootstrap-standalone.sh` no uniplus-infra)
- `UploadEDownload_RoundTrip_DevePreservarBytes` exercita PUT/GET via `IStorageService` end-to-end com bytes reais

Suíte completa do `UniPlus.slnx` continua verde.

## Out of scope (deferido)

- `MinioHealthCheck` no `/health` agregado → issue #345
- Endpoints smoke (`/api/_smoke/storage/upload`) → issue #346
- Validação de formato `host:port` mais estrita (IPv6, hostname patterns) — atual barra os erros mais comuns (scheme prefix); mais detalhe quando necessário

## Rollback

`git revert` do PR. Sem mudança de schema, dados ou contrato externo. `Storage:*` config já existia mas não era lida — reverter retorna ao estado pré-PR.

## Referências

- Epic #347 — APIs Uni+ ponta a ponta no standalone
- uniplus-infra PR #160 — charts Helm com `Storage__*` envs já cabeados
- ADR-008 (OIDC) — padrão de validação por env replicado aqui

Closes #342
Refs #347