### PR TITLE
feat(shared): Wolverine + Kafka SASL_SSL + SCRAM via KafkaSettings

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/KafkaSecurity.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/KafkaSecurity.cs
@@ -19,8 +19,22 @@ internal static class KafkaSecurity
             return false;
         }
 
+        // Rejeita inputs numéricos antes de Normalize — Enum.TryParse aceita "999"/"-1"/"1"
+        // e casts os valores como enum sem verificar se mapeiam para nome definido. Pior ainda,
+        // Normalize() strip `-` (para tolerar SCRAM-SHA-512), então "-1" viraria "1" e parseia
+        // para SecurityProtocol.Ssl silenciosamente. A política Uni+ é: SecurityProtocol é
+        // declarado por nome (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL), não por inteiro.
+        if (long.TryParse(raw.Trim(), out _))
+        {
+            return false;
+        }
+
         string normalized = Normalize(raw);
-        return Enum.TryParse(normalized, ignoreCase: true, out protocol);
+
+        // IsDefined garante que só nomes legítimos do enum passem, defesa em profundidade contra
+        // inputs que driblariam o filtro numérico (caracteres unicode, formatações inesperadas).
+        return Enum.TryParse(normalized, ignoreCase: true, out protocol)
+            && Enum.IsDefined(protocol);
     }
 
     public static bool TryParseSaslMechanism(string? raw, out SaslMechanism mechanism)
@@ -31,8 +45,17 @@ internal static class KafkaSecurity
             return false;
         }
 
+        // Mesma proteção de TryParseSecurityProtocol — Mechanism é declarado por nome (PLAIN,
+        // SCRAM-SHA-512 etc.), não por inteiro.
+        if (long.TryParse(raw.Trim(), out _))
+        {
+            return false;
+        }
+
         string normalized = Normalize(raw);
-        return Enum.TryParse(normalized, ignoreCase: true, out mechanism);
+
+        return Enum.TryParse(normalized, ignoreCase: true, out mechanism)
+            && Enum.IsDefined(mechanism);
     }
 
     /// <summary>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/KafkaSecurity.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/KafkaSecurity.cs
@@ -1,0 +1,85 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+
+using Confluent.Kafka;
+
+/// <summary>
+/// Helpers internos para mapear strings de configuração Kafka para os enums
+/// <see cref="Confluent.Kafka.SecurityProtocol"/> e <see cref="Confluent.Kafka.SaslMechanism"/>.
+/// Aceita formas convencionais (<c>SASL_SSL</c>, <c>SCRAM-SHA-512</c>) e PascalCase
+/// (<c>SaslSsl</c>, <c>ScramSha512</c>) — tolera o que vem de variáveis de ambiente
+/// no chart Helm e o que aparece em arquivos <c>appsettings*.json</c>.
+/// </summary>
+internal static class KafkaSecurity
+{
+    public static bool TryParseSecurityProtocol(string? raw, out SecurityProtocol protocol)
+    {
+        protocol = default;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        string normalized = Normalize(raw);
+        return Enum.TryParse(normalized, ignoreCase: true, out protocol);
+    }
+
+    public static bool TryParseSaslMechanism(string? raw, out SaslMechanism mechanism)
+    {
+        mechanism = default;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        string normalized = Normalize(raw);
+        return Enum.TryParse(normalized, ignoreCase: true, out mechanism);
+    }
+
+    /// <summary>
+    /// Aplica <see cref="KafkaSettings"/> ao <see cref="ClientConfig"/> do Confluent.Kafka.
+    /// Idempotente — campos vazios ficam como estavam (ClientConfig defaults).
+    /// </summary>
+    public static void Apply(ClientConfig config, KafkaSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (TryParseSecurityProtocol(settings.SecurityProtocol, out SecurityProtocol protocol))
+        {
+            config.SecurityProtocol = protocol;
+        }
+
+        if (TryParseSaslMechanism(settings.SaslMechanism, out SaslMechanism mechanism))
+        {
+            config.SaslMechanism = mechanism;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.SaslUsername))
+        {
+            config.SaslUsername = settings.SaslUsername;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.SaslPassword))
+        {
+            config.SaslPassword = settings.SaslPassword;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.SslCaLocation))
+        {
+            config.SslCaLocation = settings.SslCaLocation;
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.SslCaPem))
+        {
+            config.SslCaPem = settings.SslCaPem;
+        }
+    }
+
+    /// <summary>
+    /// <c>SASL_SSL</c> → <c>SaslSsl</c>; <c>SCRAM-SHA-512</c> → <c>ScramSha512</c>;
+    /// <c>OAUTHBEARER</c> → <c>OAuthBearer</c> (case-folded depois pelo TryParse ignoreCase).
+    /// </summary>
+    private static string Normalize(string raw) =>
+        raw.Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace("-", string.Empty, StringComparison.Ordinal);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/KafkaSettings.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/KafkaSettings.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+
+/// <summary>
+/// Bound options for the Kafka transport used by Wolverine. Mapeia a seção <c>Kafka:</c> de
+/// <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Configurações suportadas:
+/// </para>
+/// <list type="bullet">
+///   <item><description><b>PLAINTEXT</b> (Development / docker-compose): apenas <see cref="BootstrapServers"/>.</description></item>
+///   <item><description><b>SASL_SSL + SCRAM-SHA-512</b> (standalone, ADR-009 do uniplus-infra):
+///     <see cref="BootstrapServers"/> + <see cref="SecurityProtocol"/>=<c>SaslSsl</c> +
+///     <see cref="SaslMechanism"/>=<c>ScramSha512</c> + <see cref="SaslUsername"/> +
+///     <see cref="SaslPassword"/> + <see cref="SslCaLocation"/> ou <see cref="SslCaPem"/>.</description></item>
+///   <item><description><b>SASL_PLAINTEXT</b> e <b>SSL</b>: também suportados — validação cobre os
+///     pré-requisitos por protocolo.</description></item>
+/// </list>
+/// <para>
+/// Para a lista de valores aceitos consultar
+/// <see cref="Confluent.Kafka.SecurityProtocol"/> e <see cref="Confluent.Kafka.SaslMechanism"/>.
+/// Os valores são lidos como string e convertidos via <see cref="System.Enum.TryParse{TEnum}(string, bool, out TEnum)"/>
+/// (case-insensitive); aceita formas <c>SASL_SSL</c>, <c>SaslSsl</c>, <c>SCRAM-SHA-512</c>,
+/// <c>ScramSha512</c>.
+/// </para>
+/// </remarks>
+public sealed class KafkaSettings
+{
+    public const string SectionName = "Kafka";
+
+    /// <summary>Lista de bootstrap servers (<c>host1:port,host2:port</c>). Vazio desliga o transporte Kafka.</summary>
+    public string BootstrapServers { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Protocolo de segurança (<c>PLAINTEXT</c>, <c>SSL</c>, <c>SASL_PLAINTEXT</c>, <c>SASL_SSL</c>).
+    /// Quando vazio/ausente, o cliente usa <c>PLAINTEXT</c> default — comportamento backward-compat
+    /// de Development com docker-compose.
+    /// </summary>
+    public string? SecurityProtocol { get; init; }
+
+    /// <summary>
+    /// Mecanismo SASL (<c>PLAIN</c>, <c>SCRAM-SHA-256</c>, <c>SCRAM-SHA-512</c>, <c>OAUTHBEARER</c>, <c>GSSAPI</c>).
+    /// Obrigatório quando <see cref="SecurityProtocol"/> envolve SASL.
+    /// </summary>
+    public string? SaslMechanism { get; init; }
+
+    /// <summary>Usuário SASL — obrigatório com SASL_*.</summary>
+    public string? SaslUsername { get; init; }
+
+    /// <summary>Senha SASL — obrigatória com SASL_*. Sempre via env var/Vault.</summary>
+    public string? SaslPassword { get; init; }
+
+    /// <summary>
+    /// Path para o arquivo PEM do CA (ex.: <c>/etc/uniplus-kafka/ca.crt</c>) — obrigatório com SSL ou SASL_SSL,
+    /// a menos que <see cref="SslCaPem"/> esteja preenchido.
+    /// </summary>
+    public string? SslCaLocation { get; init; }
+
+    /// <summary>
+    /// CA PEM inline. Alternativa a <see cref="SslCaLocation"/> — útil quando o cert é injetado
+    /// diretamente via env var em vez de volume mount.
+    /// </summary>
+    public string? SslCaPem { get; init; }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/KafkaSettingsValidator.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/KafkaSettingsValidator.cs
@@ -1,0 +1,123 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validação cross-field de <see cref="KafkaSettings"/>.
+/// </summary>
+/// <remarks>
+/// Garante coerência: campos SASL/SSL preenchidos só fazem sentido sob protocolo correspondente
+/// (rejeita o caso onde credenciais são informadas mas o cliente acabaria em PLAINTEXT, com
+/// risco de "parecer autenticado" sem estar). Para SASL_PLAINTEXT/SASL_SSL, exige mecanismo
+/// + credentials por mecanismo: PLAIN/SCRAM-* requerem usuário+senha; OAUTHBEARER/GSSAPI não
+/// são suportados nesta camada — failure explícita orienta o operador.
+/// </remarks>
+public sealed class KafkaSettingsValidator : IValidateOptions<KafkaSettings>
+{
+    public ValidateOptionsResult Validate(string? name, KafkaSettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        // Bootstrap vazio = transporte desligado (Development sem Kafka). Nada a validar.
+        if (string.IsNullOrWhiteSpace(options.BootstrapServers))
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        List<string> failures = [];
+
+        bool hasAnySaslField =
+            !string.IsNullOrWhiteSpace(options.SaslMechanism)
+            || !string.IsNullOrWhiteSpace(options.SaslUsername)
+            || !string.IsNullOrWhiteSpace(options.SaslPassword);
+
+        bool hasAnySslField =
+            !string.IsNullOrWhiteSpace(options.SslCaLocation)
+            || !string.IsNullOrWhiteSpace(options.SslCaPem);
+
+        Confluent.Kafka.SecurityProtocol protocol = Confluent.Kafka.SecurityProtocol.Plaintext;
+        bool protocolExplicit = !string.IsNullOrWhiteSpace(options.SecurityProtocol);
+
+        if (protocolExplicit
+            && !KafkaSecurity.TryParseSecurityProtocol(options.SecurityProtocol, out protocol))
+        {
+            failures.Add($"Kafka:SecurityProtocol '{options.SecurityProtocol}' inválido. Use PLAINTEXT, SSL, SASL_PLAINTEXT ou SASL_SSL.");
+            return ValidateOptionsResult.Fail(failures);
+        }
+
+        bool requiresSasl = protocol is Confluent.Kafka.SecurityProtocol.SaslPlaintext or Confluent.Kafka.SecurityProtocol.SaslSsl;
+        bool requiresSsl = protocol is Confluent.Kafka.SecurityProtocol.Ssl or Confluent.Kafka.SecurityProtocol.SaslSsl;
+
+        // Coerência: campos SASL preenchidos exigem protocolo SASL_*; idem para SSL.
+        // Sem isso, configurações como SaslUsername="x" + SecurityProtocol=PLAINTEXT
+        // fariam o cliente cair em PLAINTEXT silenciosamente — risco de segurança.
+        if (hasAnySaslField && !requiresSasl)
+        {
+            failures.Add("Kafka:SaslMechanism/SaslUsername/SaslPassword exigem SecurityProtocol=SASL_PLAINTEXT ou SASL_SSL.");
+        }
+
+        if (hasAnySslField && !requiresSsl)
+        {
+            failures.Add("Kafka:SslCaLocation/SslCaPem exigem SecurityProtocol=SSL ou SASL_SSL.");
+        }
+
+        // SslCaLocation e SslCaPem são alternativas — preencher os dois é ambíguo.
+        if (!string.IsNullOrWhiteSpace(options.SslCaLocation)
+            && !string.IsNullOrWhiteSpace(options.SslCaPem))
+        {
+            failures.Add("Kafka:SslCaLocation e Kafka:SslCaPem são mutuamente exclusivos — preencha apenas um.");
+        }
+
+        if (requiresSasl)
+        {
+            if (string.IsNullOrWhiteSpace(options.SaslMechanism))
+            {
+                failures.Add($"Kafka:SaslMechanism é obrigatório com SecurityProtocol={options.SecurityProtocol}.");
+            }
+            else if (!KafkaSecurity.TryParseSaslMechanism(options.SaslMechanism, out Confluent.Kafka.SaslMechanism mechanism))
+            {
+                failures.Add($"Kafka:SaslMechanism '{options.SaslMechanism}' inválido. Use PLAIN, SCRAM-SHA-256 ou SCRAM-SHA-512.");
+            }
+            else
+            {
+                // Por mecanismo: PLAIN e SCRAM-* exigem user+pwd. OAUTHBEARER e GSSAPI ficam fora
+                // do escopo desta camada — operador escolhendo um destes precisa estender o
+                // helper, não cair no caminho user/password silenciosamente.
+                bool requiresUserPassword = mechanism is
+                    Confluent.Kafka.SaslMechanism.Plain
+                    or Confluent.Kafka.SaslMechanism.ScramSha256
+                    or Confluent.Kafka.SaslMechanism.ScramSha512;
+
+                if (!requiresUserPassword)
+                {
+                    failures.Add($"Kafka:SaslMechanism '{options.SaslMechanism}' não é suportado pelo Uni+. Use PLAIN, SCRAM-SHA-256 ou SCRAM-SHA-512.");
+                }
+                else
+                {
+                    if (string.IsNullOrWhiteSpace(options.SaslUsername))
+                    {
+                        failures.Add($"Kafka:SaslUsername é obrigatório com SecurityProtocol={options.SecurityProtocol}.");
+                    }
+
+                    if (string.IsNullOrWhiteSpace(options.SaslPassword))
+                    {
+                        failures.Add($"Kafka:SaslPassword é obrigatório com SecurityProtocol={options.SecurityProtocol}.");
+                    }
+                }
+            }
+        }
+
+        // Política Uni+ standalone (ADR-009 do uniplus-infra): cluster usa CA self-signed,
+        // então CA explícito (location ou PEM) é mandatório quando o transporte é SSL/SASL_SSL.
+        if (requiresSsl
+            && string.IsNullOrWhiteSpace(options.SslCaLocation)
+            && string.IsNullOrWhiteSpace(options.SslCaPem))
+        {
+            failures.Add($"Kafka:SslCaLocation ou Kafka:SslCaPem é obrigatório com SecurityProtocol={options.SecurityProtocol} (política Uni+: CA explícito).");
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
@@ -88,13 +88,17 @@ public static class WolverineOutboxConfiguration
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
         ArgumentException.ThrowIfNullOrWhiteSpace(kafkaConfigSection);
 
-        // Guarda contra a forma legada deste parâmetro (até o #343 era a chave inteira do
-        // bootstrap, p.ex. "Kafka:BootstrapServers"). Bind silencioso de uma chave completa
-        // como seção devolveria um KafkaSettings vazio e desligaria o transporte sem aviso.
-        if (kafkaConfigSection.Contains(':', StringComparison.Ordinal))
+        // Guarda contra a forma legada exata deste parâmetro (até o #343 era a chave inteira do
+        // bootstrap — `"Kafka:BootstrapServers"` — definida na const `DefaultKafkaConfigKey`).
+        // Bind silencioso dessa chave terminal como se fosse o nome de uma seção devolveria um
+        // `KafkaSettings` vazio e desligaria o transporte sem aviso. Restringimos a guarda ao
+        // sufixo `:BootstrapServers` para preservar paths legítimos de seção aninhada
+        // (ex.: `"Messaging:Kafka"`), que `IConfiguration.GetSection` suporta nativamente.
+        if (kafkaConfigSection.EndsWith(":BootstrapServers", StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException(
-                $"kafkaConfigSection '{kafkaConfigSection}' parece um caminho de chave. Passe o nome da seção (ex.: 'Kafka').",
+                $"kafkaConfigSection '{kafkaConfigSection}' parece a forma legada do parâmetro (chave terminal `Kafka:BootstrapServers`). "
+                + "Passe o nome da seção (ex.: 'Kafka' ou 'Messaging:Kafka').",
                 nameof(kafkaConfigSection));
         }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
@@ -1,7 +1,9 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 using Middleware;
 
@@ -26,12 +28,12 @@ public static class WolverineOutboxConfiguration
     public const string PersistenceSchema = "wolverine";
 
     /// <summary>
-    /// Chave em <see cref="IConfiguration"/> de onde o bootstrap servers Kafka é
-    /// lido por padrão. Quando o valor é nulo, vazio ou whitespace, o transporte
-    /// Kafka não é registrado — útil para ambientes locais e testes que só
-    /// exercitam a queue PG.
+    /// Seção em <see cref="IConfiguration"/> de onde <see cref="KafkaSettings"/> é lida
+    /// por padrão. Quando <see cref="KafkaSettings.BootstrapServers"/> é vazio, o transporte
+    /// Kafka não é registrado — útil para ambientes locais e testes que só exercitam a queue PG.
     /// </summary>
-    public const string DefaultKafkaConfigKey = "Kafka:BootstrapServers";
+    public const string DefaultKafkaConfigSection = KafkaSettings.SectionName;
+
 
     /// <summary>
     /// Configura o host com Wolverine + outbox transacional Postgres + (opcional)
@@ -53,10 +55,10 @@ public static class WolverineOutboxConfiguration
     /// <param name="connectionStringName">Nome da connection string em
     /// <see cref="IConfiguration.GetConnectionString"/> (ex.: <c>"SelecaoDb"</c>,
     /// <c>"IngressoDb"</c>).</param>
-    /// <param name="kafkaConfigKey">Chave em <see cref="IConfiguration"/> onde o
-    /// bootstrap servers Kafka é lido. Se ausente/whitespace, o transporte Kafka
-    /// é desligado mantendo a queue PG ativa. Padrão:
-    /// <see cref="DefaultKafkaConfigKey"/>.</param>
+    /// <param name="kafkaConfigSection">Seção em <see cref="IConfiguration"/> ligada a
+    /// <see cref="KafkaSettings"/>. Se <see cref="KafkaSettings.BootstrapServers"/> for vazio,
+    /// o transporte Kafka é desligado mantendo a queue PG ativa. Padrão:
+    /// <see cref="DefaultKafkaConfigSection"/>.</param>
     /// <param name="configureRouting">Callback para roteamento específico do
     /// módulo (ex.: <c>opts.PublishMessage&lt;EditalPublicadoEvent&gt;()
     /// .ToPostgresqlQueue("domain-events")</c>). Executado depois das policies
@@ -78,13 +80,35 @@ public static class WolverineOutboxConfiguration
         this IHostBuilder host,
         IConfiguration configuration,
         string connectionStringName,
-        string kafkaConfigKey = DefaultKafkaConfigKey,
+        string kafkaConfigSection = DefaultKafkaConfigSection,
         Action<WolverineOptions>? configureRouting = null)
     {
         ArgumentNullException.ThrowIfNull(host);
         ArgumentNullException.ThrowIfNull(configuration);
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(kafkaConfigKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kafkaConfigSection);
+
+        // Guarda contra a forma legada deste parâmetro (até o #343 era a chave inteira do
+        // bootstrap, p.ex. "Kafka:BootstrapServers"). Bind silencioso de uma chave completa
+        // como seção devolveria um KafkaSettings vazio e desligaria o transporte sem aviso.
+        if (kafkaConfigSection.Contains(':', StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"kafkaConfigSection '{kafkaConfigSection}' parece um caminho de chave. Passe o nome da seção (ex.: 'Kafka').",
+                nameof(kafkaConfigSection));
+        }
+
+        // Bind + valida KafkaSettings via DI/IOptions. ValidateOnStart roda no host start,
+        // antes de qualquer hosted service consumir o Kafka. Mensagens de validação reportadas
+        // no formato canônico do .NET (OptionsValidationException com lista de campos faltantes).
+        host.ConfigureServices(services =>
+        {
+            services.AddOptions<KafkaSettings>()
+                .Bind(configuration.GetSection(kafkaConfigSection))
+                .ValidateOnStart();
+
+            services.AddSingleton<IValidateOptions<KafkaSettings>, KafkaSettingsValidator>();
+        });
 
         return host.UseWolverine(opts =>
         {
@@ -118,13 +142,47 @@ public static class WolverineOutboxConfiguration
             // integrados controlam o schema via fixture explícita; ver
             // CascadingFixture no projeto de testes.
 
-            string? kafkaBootstrapServers = configuration[kafkaConfigKey];
-            if (!string.IsNullOrWhiteSpace(kafkaBootstrapServers))
+            // Lê a seção uma única vez aqui — ValidateOnStart no DI não atinge este callback
+            // (UseWolverine roda no Build, antes de StartAsync). Validação inline replica
+            // as regras essenciais para falhar antes do AutoProvision tentar conectar com
+            // config inválida; o IValidateOptions registrado acima garante o mesmo erro
+            // padronizado se outro consumidor resolver IOptions<KafkaSettings>.
+            KafkaSettings kafkaSettings = configuration.GetSection(kafkaConfigSection).Get<KafkaSettings>()
+                ?? new KafkaSettings();
+
+            if (string.IsNullOrWhiteSpace(kafkaSettings.BootstrapServers))
             {
-                opts.UseKafka(kafkaBootstrapServers).AutoProvision();
+                configureRouting?.Invoke(opts);
+                return;
             }
+
+            ValidateOptionsResult validation = new KafkaSettingsValidator().Validate(name: null, kafkaSettings);
+            if (validation.Failed)
+            {
+                throw new InvalidOperationException(
+                    $"Configuração Kafka inválida: {string.Join(" | ", validation.Failures ?? [])}");
+            }
+
+            KafkaTransportExpression kafka = opts.UseKafka(kafkaSettings.BootstrapServers);
+
+            // ConfigureClient só quando há sobrescritas a aplicar — evita registrar callback
+            // que mexe em propriedades default do Confluent.Kafka.ClientConfig.
+            if (RequiresClientConfig(kafkaSettings))
+            {
+                kafka = kafka.ConfigureClient(config => KafkaSecurity.Apply(config, kafkaSettings));
+            }
+
+            kafka.AutoProvision();
 
             configureRouting?.Invoke(opts);
         });
     }
+
+    internal static bool RequiresClientConfig(KafkaSettings settings) =>
+        !string.IsNullOrWhiteSpace(settings.SecurityProtocol)
+        || !string.IsNullOrWhiteSpace(settings.SaslMechanism)
+        || !string.IsNullOrWhiteSpace(settings.SaslUsername)
+        || !string.IsNullOrWhiteSpace(settings.SaslPassword)
+        || !string.IsNullOrWhiteSpace(settings.SslCaLocation)
+        || !string.IsNullOrWhiteSpace(settings.SslCaPem);
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/KafkaSecurityTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/KafkaSecurityTests.cs
@@ -29,6 +29,12 @@ public sealed class KafkaSecurityTests
     [InlineData("   ")]
     [InlineData("MTLS")]
     [InlineData("SASL")]
+    // Strings numéricas: Enum.TryParse aceita por default, mas IsDefined garante que só
+    // nomes legítimos do enum passem. Sem isso, "999" parseia para SecurityProtocol)999 e
+    // vaza para ClientConfig, gerando falha tardia em runtime.
+    [InlineData("999")]
+    [InlineData("-1")]
+    [InlineData("100")]
     public void TryParseSecurityProtocol_RejeitaInvalido(string? raw)
     {
         bool ok = KafkaSecurity.TryParseSecurityProtocol(raw, out _);
@@ -56,6 +62,11 @@ public sealed class KafkaSecurityTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("DIGEST-MD5")]
+    // Strings numéricas fora do range nominal são rejeitadas pelo IsDefined (mesmo motivo
+    // documentado em TryParseSecurityProtocol_RejeitaInvalido).
+    [InlineData("999")]
+    [InlineData("-1")]
+    [InlineData("42")]
     public void TryParseSaslMechanism_RejeitaInvalido(string? raw)
     {
         bool ok = KafkaSecurity.TryParseSaslMechanism(raw, out _);

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/KafkaSecurityTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/KafkaSecurityTests.cs
@@ -1,0 +1,119 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging;
+
+using AwesomeAssertions;
+
+using Confluent.Kafka;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+
+public sealed class KafkaSecurityTests
+{
+    [Theory]
+    [InlineData("PLAINTEXT", SecurityProtocol.Plaintext)]
+    [InlineData("Plaintext", SecurityProtocol.Plaintext)]
+    [InlineData("SSL", SecurityProtocol.Ssl)]
+    [InlineData("SASL_SSL", SecurityProtocol.SaslSsl)]
+    [InlineData("SaslSsl", SecurityProtocol.SaslSsl)]
+    [InlineData("sasl_ssl", SecurityProtocol.SaslSsl)]
+    [InlineData("SASL_PLAINTEXT", SecurityProtocol.SaslPlaintext)]
+    public void TryParseSecurityProtocol_AceitaFormasConvencionais(string raw, SecurityProtocol expected)
+    {
+        bool ok = KafkaSecurity.TryParseSecurityProtocol(raw, out SecurityProtocol parsed);
+        ok.Should().BeTrue();
+        parsed.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("MTLS")]
+    [InlineData("SASL")]
+    public void TryParseSecurityProtocol_RejeitaInvalido(string? raw)
+    {
+        bool ok = KafkaSecurity.TryParseSecurityProtocol(raw, out _);
+        ok.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("PLAIN", SaslMechanism.Plain)]
+    [InlineData("Plain", SaslMechanism.Plain)]
+    [InlineData("SCRAM-SHA-256", SaslMechanism.ScramSha256)]
+    [InlineData("ScramSha256", SaslMechanism.ScramSha256)]
+    [InlineData("SCRAM-SHA-512", SaslMechanism.ScramSha512)]
+    [InlineData("ScramSha512", SaslMechanism.ScramSha512)]
+    [InlineData("scram-sha-512", SaslMechanism.ScramSha512)]
+    [InlineData("OAUTHBEARER", SaslMechanism.OAuthBearer)]
+    [InlineData("GSSAPI", SaslMechanism.Gssapi)]
+    public void TryParseSaslMechanism_AceitaFormasConvencionais(string raw, SaslMechanism expected)
+    {
+        bool ok = KafkaSecurity.TryParseSaslMechanism(raw, out SaslMechanism parsed);
+        ok.Should().BeTrue();
+        parsed.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("DIGEST-MD5")]
+    public void TryParseSaslMechanism_RejeitaInvalido(string? raw)
+    {
+        bool ok = KafkaSecurity.TryParseSaslMechanism(raw, out _);
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Apply_SaslSslComScramSha512_PreencheTodosOsCamposNoClientConfig()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+            SaslMechanism = "SCRAM-SHA-512",
+            SaslUsername = "uniplus",
+            SaslPassword = "secret",
+            SslCaLocation = "/etc/uniplus-kafka/ca.crt",
+        };
+
+        ClientConfig config = new();
+        KafkaSecurity.Apply(config, settings);
+
+        config.SecurityProtocol.Should().Be(SecurityProtocol.SaslSsl);
+        config.SaslMechanism.Should().Be(SaslMechanism.ScramSha512);
+        config.SaslUsername.Should().Be("uniplus");
+        config.SaslPassword.Should().Be("secret");
+        config.SslCaLocation.Should().Be("/etc/uniplus-kafka/ca.crt");
+    }
+
+    [Fact]
+    public void Apply_SoBootstrap_NaoMexeEmCamposVazios()
+    {
+        // Em PLAINTEXT (sem nenhum override), Apply é no-op exceto BootstrapServers que
+        // é gerenciado fora. Verifica que campos de SASL/SSL ficam null.
+        KafkaSettings settings = new() { BootstrapServers = "kafka:9092" };
+
+        ClientConfig config = new();
+        KafkaSecurity.Apply(config, settings);
+
+        config.SecurityProtocol.Should().BeNull();
+        config.SaslMechanism.Should().BeNull();
+        config.SaslUsername.Should().BeNullOrEmpty();
+        config.SaslPassword.Should().BeNullOrEmpty();
+    }
+
+    [Fact]
+    public void Apply_SslCaPem_PreencheCampoCorrespondente()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SSL",
+            SslCaPem = "-----BEGIN CERTIFICATE-----\nMIIB...",
+        };
+
+        ClientConfig config = new();
+        KafkaSecurity.Apply(config, settings);
+
+        config.SslCaPem.Should().StartWith("-----BEGIN CERTIFICATE-----");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/KafkaSettingsValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/KafkaSettingsValidatorTests.cs
@@ -1,0 +1,319 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+
+public sealed class KafkaSettingsValidatorTests
+{
+    private static KafkaSettings Bind(Dictionary<string, string?> values)
+    {
+        IConfiguration cfg = new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+        return cfg.GetSection(KafkaSettings.SectionName).Get<KafkaSettings>() ?? new KafkaSettings();
+    }
+
+    [Fact]
+    public void Validate_BootstrapVazio_DeveSerSucesso()
+    {
+        // Transporte desligado em Development sem Kafka — não há o que validar.
+        KafkaSettings settings = new();
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_PlaintextSemSecurity_DeveSerSucesso()
+    {
+        // docker-compose dev: só BootstrapServers, sem SecurityProtocol (PLAINTEXT default).
+        KafkaSettings settings = new() { BootstrapServers = "kafka:9092" };
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("PLAINTEXT")]
+    [InlineData("Plaintext")]
+    [InlineData("plaintext")]
+    public void Validate_SecurityProtocolPlaintext_DeveSerSucesso(string raw)
+    {
+        KafkaSettings settings = new() { BootstrapServers = "kafka:9092", SecurityProtocol = raw };
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_SecurityProtocolInvalido_DeveFalhar()
+    {
+        KafkaSettings settings = new() { BootstrapServers = "kafka:9092", SecurityProtocol = "MTLS" };
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Kafka:SecurityProtocol 'MTLS'");
+    }
+
+    [Theory]
+    [InlineData("SASL_SSL")]
+    [InlineData("SaslSsl")]
+    [InlineData("sasl_ssl")]
+    public void Validate_SaslSslCompleto_DeveSerSucesso(string protocolRaw)
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = protocolRaw,
+            SaslMechanism = "SCRAM-SHA-512",
+            SaslUsername = "uniplus",
+            SaslPassword = "secret",
+            SslCaLocation = "/etc/uniplus-kafka/ca.crt",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_SaslSslSemUsername_DeveFalhar()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+            SaslMechanism = "SCRAM-SHA-512",
+            SaslPassword = "secret",
+            SslCaLocation = "/etc/uniplus-kafka/ca.crt",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Kafka:SaslUsername");
+    }
+
+    [Fact]
+    public void Validate_SaslSslSemPassword_DeveFalhar()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+            SaslMechanism = "SCRAM-SHA-512",
+            SaslUsername = "uniplus",
+            SslCaLocation = "/etc/uniplus-kafka/ca.crt",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Kafka:SaslPassword");
+    }
+
+    [Fact]
+    public void Validate_SaslSslSemMecanismo_DeveFalhar()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+            SaslUsername = "uniplus",
+            SaslPassword = "secret",
+            SslCaLocation = "/etc/uniplus-kafka/ca.crt",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Kafka:SaslMechanism");
+    }
+
+    [Fact]
+    public void Validate_SaslSslMecanismoInvalido_DeveFalhar()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+            SaslMechanism = "DIGEST-MD5",
+            SaslUsername = "u",
+            SaslPassword = "p",
+            SslCaLocation = "/etc/ca.crt",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("'DIGEST-MD5'");
+    }
+
+    [Theory]
+    [InlineData("OAUTHBEARER")]
+    [InlineData("GSSAPI")]
+    public void Validate_SaslSslMecanismoNaoSuportadoPeloUniPlus_DeveFalhar(string mechanism)
+    {
+        // OAUTHBEARER e GSSAPI parseiam no Confluent.Kafka mas não são suportados pelo helper —
+        // operador deve estender o caminho explicitamente, sem cair em fallback inseguro.
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+            SaslMechanism = mechanism,
+            SslCaLocation = "/etc/ca.crt",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("não é suportado pelo Uni+");
+    }
+
+    [Fact]
+    public void Validate_CamposSaslComProtocoloPlaintext_DeveFalhar()
+    {
+        // Risco: SASL_username preenchido com SecurityProtocol vazio → cliente roda PLAINTEXT
+        // mas operador acreditando que está autenticando. Validator precisa cortar isso.
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SaslUsername = "uniplus",
+            SaslPassword = "secret",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("SASL_PLAINTEXT");
+    }
+
+    [Fact]
+    public void Validate_CamposSslComProtocoloPlaintext_DeveFalhar()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SslCaLocation = "/etc/ca.crt",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("SecurityProtocol=SSL");
+    }
+
+    [Fact]
+    public void Validate_CaLocationECaPemSimultaneos_DeveFalhar()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+            SaslMechanism = "SCRAM-SHA-512",
+            SaslUsername = "u",
+            SaslPassword = "p",
+            SslCaLocation = "/etc/ca.crt",
+            SslCaPem = "-----BEGIN CERTIFICATE-----\nMIIB...",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("mutuamente exclusivos");
+    }
+
+    [Fact]
+    public void Validate_SaslSslSemCaLocationENemPem_DeveFalhar()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+            SaslMechanism = "SCRAM-SHA-512",
+            SaslUsername = "u",
+            SaslPassword = "p",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Kafka:SslCaLocation");
+    }
+
+    [Fact]
+    public void Validate_SaslSslComCaPem_DeveSerSucesso()
+    {
+        // SslCaPem é alternativa válida a SslCaLocation.
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+            SaslMechanism = "SCRAM-SHA-512",
+            SaslUsername = "u",
+            SaslPassword = "p",
+            SslCaPem = "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_SaslPlaintextSemCa_DeveSerSucesso()
+    {
+        // SASL_PLAINTEXT não exige CA — apenas SASL.
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_PLAINTEXT",
+            SaslMechanism = "PLAIN",
+            SaslUsername = "u",
+            SaslPassword = "p",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_SslPuroSemCa_DeveFalhar()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SSL",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Kafka:SslCaLocation");
+    }
+
+    [Fact]
+    public void Validate_SaslSslComMultiplosCamposFaltando_DeveAcumularFalhas()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+        };
+
+        ValidateOptionsResult result = new KafkaSettingsValidator().Validate(name: null, settings);
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().HaveCountGreaterThan(1);
+    }
+
+    [Fact]
+    public void Bind_AceitaTodasAsPropriedades()
+    {
+        Dictionary<string, string?> values = new()
+        {
+            ["Kafka:BootstrapServers"] = "k1:9092,k2:9092",
+            ["Kafka:SecurityProtocol"] = "SASL_SSL",
+            ["Kafka:SaslMechanism"] = "SCRAM-SHA-512",
+            ["Kafka:SaslUsername"] = "uniplus-portal",
+            ["Kafka:SaslPassword"] = "p455",
+            ["Kafka:SslCaLocation"] = "/etc/uniplus-kafka/ca.crt",
+            ["Kafka:SslCaPem"] = "-----BEGIN CERTIFICATE-----\nMIIB...",
+        };
+
+        KafkaSettings settings = Bind(values);
+
+        settings.BootstrapServers.Should().Be("k1:9092,k2:9092");
+        settings.SecurityProtocol.Should().Be("SASL_SSL");
+        settings.SaslMechanism.Should().Be("SCRAM-SHA-512");
+        settings.SaslUsername.Should().Be("uniplus-portal");
+        settings.SaslPassword.Should().Be("p455");
+        settings.SslCaLocation.Should().Be("/etc/uniplus-kafka/ca.crt");
+        settings.SslCaPem.Should().StartWith("-----BEGIN CERTIFICATE-----");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineOutboxConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineOutboxConfigurationTests.cs
@@ -1,0 +1,75 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+
+/// <summary>
+/// Cobertura de unit-test do helper de configuração Wolverine — escopo restrito ao que
+/// dá para validar sem subir Postgres/Kafka reais. Testes E2E vivem em
+/// <c>Selecao.IntegrationTests/Outbox/Cascading/</c>.
+/// </summary>
+public sealed class WolverineOutboxConfigurationTests
+{
+    [Fact]
+    public void RequiresClientConfig_SoBootstrap_DeveSerFalse()
+    {
+        // Caminho dev/CI legado: docker-compose com PLAINTEXT, sem nenhum override.
+        // Não pode disparar callback de ConfigureClient — manter exatamente o
+        // comportamento pré-#343.
+        KafkaSettings settings = new() { BootstrapServers = "kafka:9092" };
+        WolverineOutboxConfiguration.RequiresClientConfig(settings).Should().BeFalse();
+    }
+
+    [Fact]
+    public void RequiresClientConfig_VazioCompleto_DeveSerFalse()
+    {
+        KafkaSettings settings = new();
+        WolverineOutboxConfiguration.RequiresClientConfig(settings).Should().BeFalse();
+    }
+
+    [Fact]
+    public void RequiresClientConfig_ComSecurityProtocol_DeveSerTrue()
+    {
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SecurityProtocol = "SASL_SSL",
+        };
+        WolverineOutboxConfiguration.RequiresClientConfig(settings).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RequiresClientConfig_ApenasComSslCa_DeveSerTrue()
+    {
+        // Mesmo sem SecurityProtocol explícito, qualquer override de SSL/SASL implica que o
+        // operador quer customizar o ClientConfig — encaminhar o callback.
+        KafkaSettings settings = new()
+        {
+            BootstrapServers = "kafka:9092",
+            SslCaLocation = "/etc/ca.crt",
+        };
+        WolverineOutboxConfiguration.RequiresClientConfig(settings).Should().BeTrue();
+    }
+
+    [Fact]
+    public void UseWolverineOutboxCascading_KafkaConfigSectionComPath_DeveLancarArgumentException()
+    {
+        // Guarda contra regressão da assinatura legada (kafkaConfigKey="Kafka:BootstrapServers").
+        // Bind silencioso de chave completa como seção devolveria KafkaSettings vazio e
+        // desligaria Kafka sem aviso — preferimos failure clara.
+        IHostBuilder host = Host.CreateDefaultBuilder();
+        IConfiguration cfg = new ConfigurationBuilder().Build();
+
+        Action acao = () => host.UseWolverineOutboxCascading(
+            cfg,
+            connectionStringName: "PortalDb",
+            kafkaConfigSection: "Kafka:BootstrapServers");
+
+        acao.Should().Throw<ArgumentException>()
+            .WithMessage("*kafkaConfigSection*caminho de chave*");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineOutboxConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/WolverineOutboxConfigurationTests.cs
@@ -55,21 +55,52 @@ public sealed class WolverineOutboxConfigurationTests
         WolverineOutboxConfiguration.RequiresClientConfig(settings).Should().BeTrue();
     }
 
-    [Fact]
-    public void UseWolverineOutboxCascading_KafkaConfigSectionComPath_DeveLancarArgumentException()
+    [Theory]
+    [InlineData("Kafka:BootstrapServers")]
+    [InlineData("Messaging:Kafka:BootstrapServers")]
+    [InlineData("kafka:bootstrapservers")]
+    public void UseWolverineOutboxCascading_KafkaConfigSectionComFormaLegada_DeveLancarArgumentException(string legado)
     {
-        // Guarda contra regressão da assinatura legada (kafkaConfigKey="Kafka:BootstrapServers").
-        // Bind silencioso de chave completa como seção devolveria KafkaSettings vazio e
-        // desligaria Kafka sem aviso — preferimos failure clara.
+        // Guarda contra regressão da assinatura legada (`Kafka:BootstrapServers` era o valor da
+        // const `DefaultKafkaConfigKey` antes do #343). Bind silencioso dessa chave terminal como
+        // seção devolveria `KafkaSettings` vazio e desligaria Kafka sem aviso — preferimos failure
+        // clara que orienta a migração.
         IHostBuilder host = Host.CreateDefaultBuilder();
         IConfiguration cfg = new ConfigurationBuilder().Build();
 
         Action acao = () => host.UseWolverineOutboxCascading(
             cfg,
             connectionStringName: "PortalDb",
-            kafkaConfigSection: "Kafka:BootstrapServers");
+            kafkaConfigSection: legado);
 
         acao.Should().Throw<ArgumentException>()
-            .WithMessage("*kafkaConfigSection*caminho de chave*");
+            .WithMessage("*forma legada*");
+    }
+
+    [Theory]
+    [InlineData("Kafka")]
+    [InlineData("Messaging:Kafka")]
+    [InlineData("Modules:Selecao:Kafka")]
+    public void UseWolverineOutboxCascading_KafkaConfigSectionAninhada_DeveAceitarPath(string sectionPath)
+    {
+        // Paths aninhados (`Messaging:Kafka`, `Modules:Selecao:Kafka`) são endereços válidos de
+        // seção em `IConfiguration.GetSection` e devem passar pela guarda. O método pode falhar
+        // depois por falta de connection string, mas NÃO no guard de seção.
+        IHostBuilder host = Host.CreateDefaultBuilder();
+        IConfiguration cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:PortalDb"] = "Host=localhost;Port=5432;Database=x;Username=u;Password=p",
+            })
+            .Build();
+
+        Action acao = () => host.UseWolverineOutboxCascading(
+            cfg,
+            connectionStringName: "PortalDb",
+            kafkaConfigSection: sectionPath);
+
+        // Não levanta a `ArgumentException` da guarda. Pode levantar outras exceções do Wolverine
+        // ao build, fora do escopo deste teste — só verificamos que o guard NÃO disparou.
+        acao.Should().NotThrow<ArgumentException>(because: $"path aninhado '{sectionPath}' é válido para IConfiguration.GetSection");
     }
 }


### PR DESCRIPTION
## Resumo

Sub-issue P0 da Epic #347 (APIs Uni+ — comunicação ponta a ponta com deps externas em standalone).

`UseWolverineOutboxCascading` lia apenas `Kafka:BootstrapServers` — não havia caminho para `SecurityProtocol`/`SaslMechanism`/`SaslUsername`/`SaslPassword`/`SslCaLocation`. Como o cluster standalone Uni+ usa SASL_SSL + SCRAM-SHA-512 (ADR-009 do uniplus-infra), o transporte Kafka ficava desligado em standalone — `kafka.enabled: false` no PR uniplus-infra#160. Eventos cross-módulo não conseguiam publicar.

## O que muda

- **`KafkaSettings`** (`Infrastructure.Core/Messaging/KafkaSettings.cs`) — bound options da seção `Kafka:` (BootstrapServers, SecurityProtocol, SaslMechanism, SaslUsername, SaslPassword, SslCaLocation, SslCaPem)
- **`KafkaSettingsValidator`** (`IValidateOptions<KafkaSettings>`) — coerência cross-field, registrado no DI via `ConfigureServices` dentro do helper
- **`KafkaSecurity`** — helpers de parsing string→enum tolerando formas convencionais (`SASL_SSL`/`SaslSsl`, `SCRAM-SHA-512`/`ScramSha512`) + `Apply(ClientConfig, KafkaSettings)`
- **`WolverineOutboxConfiguration.UseWolverineOutboxCascading`** — agora lê a seção via `IConfiguration.GetSection(kafkaConfigSection).Get<KafkaSettings>()` e aplica `ConfigureClient(c => KafkaSecurity.Apply(c, settings))` quando há overrides de SASL/SSL

### Regras de validação

| Regra | Por quê |
|---|---|
| `BootstrapServers` vazio → transporte Kafka desligado, sem mais validação | Backward compat com Development sem Kafka |
| Campos SASL preenchidos exigem `SecurityProtocol=SASL_PLAINTEXT`/`SASL_SSL` | Corta o risco de "parece autenticado mas é PLAINTEXT" |
| Campos SSL exigem `SecurityProtocol=SSL`/`SASL_SSL` | Coerência |
| `SslCaLocation` e `SslCaPem` mutuamente exclusivos | Ambíguo se os dois preenchidos |
| `SASL_PLAINTEXT`/`SASL_SSL` exigem mecanismo + user + pwd | RFC SASL |
| Mecanismo deve ser `PLAIN` ou `SCRAM-SHA-{256,512}` | OAUTHBEARER/GSSAPI fora de escopo (failure clara orienta operador) |
| `SSL`/`SASL_SSL` exigem CA explícito | Política Uni+: cluster standalone usa CA self-signed |

### Backward compatibility

- **Development com docker-compose (PLAINTEXT)**: só `BootstrapServers` setado → `RequiresClientConfig` retorna false, nenhum callback registrado. Comportamento idêntico ao pré-PR.
- **`Selecao.IntegrationTests/Outbox/Cascading/`** (CascadingFixture com Kafka real via Testcontainers): 51 testes mantém verde.
- **Renomeia parâmetro** `kafkaConfigKey` → `kafkaConfigSection`. Nenhum call site existente passava o param explicitamente. Guard adicional: passar a forma legada (`"Kafka:BootstrapServers"`) lança `ArgumentException` com mensagem orientativa, evitando bind silencioso de seção inválida.

## Critérios de aceite (issue #343)

- [x] `KafkaSettings` registrado via `IConfiguration.GetSection("Kafka")`
- [x] `UseWolverineOutboxCascading` configura SASL_SSL+SCRAM quando declarado
- [x] Validação `IValidateOptions<KafkaSettings>` (SASL exige user+pwd+CA, e mais — ver tabela acima)
- [x] Test: docker-compose continua funcionando (PLAINTEXT) — Selecao.IntegrationTests/Cascading 51/51 verde
- [ ] Test integration: smoke E2E contra Kafka SASL_SSL — **deferido** (ver "Out of scope")
- [x] Pre-PR: `dotnet build` + `dotnet test` verdes (suíte completa: 365 unit + 51 Selecao integration)

## Cobertura de testes

- **`KafkaSecurityTests`** — 21 cases (parse case-insensitive de SecurityProtocol/SaslMechanism, `Apply` no `ClientConfig`)
- **`KafkaSettingsValidatorTests`** — 30 cases cobrindo todas as combinações success/failure (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL × user/pwd/CA presentes/ausentes, mecanismo válido/inválido/não-suportado, fields incoerentes com protocolo, CA dupla)
- **`WolverineOutboxConfigurationTests`** — 5 cases (`RequiresClientConfig` para todos os shapes, guard de section inválida)

## Out of scope (deferido)

- **Integration test contra Kafka SASL_SSL real**: provisionar Kafka via Testcontainers com SCRAM users + cert chain é desproporcional para esta PR. Smoke E2E será feito manualmente no cluster standalone após este merge (issue #347 § "Smoke E2E no cluster standalone"). Próximas PRs (#345 health checks, #346 smoke endpoints) também exercitarão o caminho real.
- **`kafka.enabled: true` em uniplus-infra/environments/standalone**: feito em PR separado no uniplus-infra após este merge.

## Rollback

`git revert` do PR. Sem schema changes. KafkaSettings é puramente bound options — ausência da PR retorna ao bind via `configuration["Kafka:BootstrapServers"]` literal.

## Referências

- Epic #347 — APIs Uni+ ponta a ponta no standalone
- uniplus-infra ADR-009 — Kafka SASL_SSL + SCRAM
- uniplus-infra PR #160 — charts Helm com `Kafka__*` envs preparados (mas `kafka.enabled: false` aguardando este merge)
- uniplus-api PR #349 (#342) — DI MinIO (PR irmão da Epic, mergeará independente)

Closes #343
Refs #347