### PR TITLE
feat(shared): aplica migrations EF Core e schema Wolverine no startup

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -56,6 +56,11 @@ builder.Services.AddIngressoInfrastructure();
 builder.Host.UseWolverineOutboxCascading(builder.Configuration, connectionStringName: "IngressoDb");
 builder.Services.AddWolverineMessaging();
 
+// Migrations EF Core do módulo Ingresso aplicadas no host StartAsync via IHostedService
+// (issue #344). Como hosted service, o registro é filtrável por test factories que sobem
+// o pipeline HTTP sem Postgres real (ver ApiFactoryBase). Idempotente.
+builder.Services.AddDbContextMigrationsOnStartup<IngressoDbContext>();
+
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);
 
@@ -81,11 +86,6 @@ app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthC
     Predicate = _ => false,
 });
 app.MapHealthChecks("/health");
-
-// Aplica migrations EF Core do módulo Ingresso antes de aceitar tráfego (issue #344).
-// Idempotente; banco já migrado é no-op. Coordenação entre réplicas concorrentes é
-// responsabilidade do EF Core / provider Npgsql via __EFMigrationsHistory.
-await app.Services.ApplyMigrationsAsync<IngressoDbContext>();
 
 await app.RunAsync();
 

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -10,6 +10,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Ingresso.API.Errors;
 using Unifesspa.UniPlus.Ingresso.Infrastructure;
+using Unifesspa.UniPlus.Ingresso.Infrastructure.Persistence;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -80,6 +81,11 @@ app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthC
     Predicate = _ => false,
 });
 app.MapHealthChecks("/health");
+
+// Aplica migrations EF Core do módulo Ingresso antes de aceitar tráfego (issue #344).
+// Idempotente; banco já migrado é no-op. Coordenação entre réplicas concorrentes é
+// responsabilidade do EF Core / provider Npgsql via __EFMigrationsHistory.
+await app.Services.ApplyMigrationsAsync<IngressoDbContext>();
 
 await app.RunAsync();
 

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
@@ -63,6 +63,12 @@ builder.Services.AddPortalInfrastructure();
 builder.Host.UseWolverineOutboxCascading(builder.Configuration, connectionStringName: "PortalDb");
 builder.Services.AddWolverineMessaging();
 
+// Migrations EF Core do módulo Portal aplicadas no host StartAsync via IHostedService —
+// pareado com AutoBuildMessageStorageOnStartup do Wolverine (issue #344). Como hosted
+// service, o registro é filtrável por test factories que sobem o pipeline HTTP sem
+// Postgres real (ver ApiFactoryBase). Idempotente; banco já migrado é no-op.
+builder.Services.AddDbContextMigrationsOnStartup<PortalDbContext>();
+
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);
 
@@ -88,12 +94,6 @@ app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthC
     Predicate = _ => false,
 });
 app.MapHealthChecks("/health");
-
-// Aplica migrations EF Core do módulo Portal antes de aceitar tráfego — pareado com
-// AutoBuildMessageStorageOnStartup do Wolverine (issue #344). Idempotente; banco já
-// migrado é no-op. Coordenação entre réplicas concorrentes é responsabilidade do
-// EF Core / provider Npgsql via __EFMigrationsHistory.
-await app.Services.ApplyMigrationsAsync<PortalDbContext>();
 
 await app.RunAsync();
 

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
@@ -12,6 +12,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Portal.API.Errors;
 using Unifesspa.UniPlus.Portal.Infrastructure;
+using Unifesspa.UniPlus.Portal.Infrastructure.Persistence;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -87,6 +88,12 @@ app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthC
     Predicate = _ => false,
 });
 app.MapHealthChecks("/health");
+
+// Aplica migrations EF Core do módulo Portal antes de aceitar tráfego — pareado com
+// AutoBuildMessageStorageOnStartup do Wolverine (issue #344). Idempotente; banco já
+// migrado é no-op. Coordenação entre réplicas concorrentes é responsabilidade do
+// EF Core / provider Npgsql via __EFMigrationsHistory.
+await app.Services.ApplyMigrationsAsync<PortalDbContext>();
 
 await app.RunAsync();
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -15,6 +15,7 @@ using Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
 using Unifesspa.UniPlus.Selecao.Application.Mappings;
 using Unifesspa.UniPlus.Selecao.Domain.Events;
 using Unifesspa.UniPlus.Selecao.Infrastructure;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
 using Wolverine.Kafka;
 using Wolverine.Postgresql;
@@ -138,6 +139,11 @@ app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthC
     Predicate = _ => false,
 });
 app.MapHealthChecks("/health");
+
+// Aplica migrations EF Core do módulo Selecao antes de aceitar tráfego (issue #344).
+// Idempotente; banco já migrado é no-op. Coordenação entre réplicas concorrentes é
+// responsabilidade do EF Core / provider Npgsql via __EFMigrationsHistory.
+await app.Services.ApplyMigrationsAsync<SelecaoDbContext>();
 
 await app.RunAsync();
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -114,6 +114,11 @@ builder.Host.UseWolverineOutboxCascading(
     });
 builder.Services.AddWolverineMessaging();
 
+// Migrations EF Core do módulo Selecao aplicadas no host StartAsync via IHostedService
+// (issue #344). Como hosted service, o registro é filtrável por test factories que sobem
+// o pipeline HTTP sem Postgres real (ver ApiFactoryBase). Idempotente.
+builder.Services.AddDbContextMigrationsOnStartup<SelecaoDbContext>();
+
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);
 
@@ -139,11 +144,6 @@ app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthC
     Predicate = _ => false,
 });
 app.MapHealthChecks("/health");
-
-// Aplica migrations EF Core do módulo Selecao antes de aceitar tráfego (issue #344).
-// Idempotente; banco já migrado é no-op. Coordenação entre réplicas concorrentes é
-// responsabilidade do EF Core / provider Npgsql via __EFMigrationsHistory.
-await app.Services.ApplyMigrationsAsync<SelecaoDbContext>();
 
 await app.RunAsync();
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/MigrationHostedService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/MigrationHostedService.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// <see cref="IHostedService"/> que aplica migrations EF Core do <typeparamref name="TContext"/>
+/// no <c>StartAsync</c> do host. Encapsular a chamada de
+/// <see cref="MigrationServiceCollectionExtensions.ApplyMigrationsAsync{TContext}"/> num hosted
+/// service permite que test factories filtrem o registro (mesmo padrão usado para o
+/// <c>WolverineRuntime</c> em <c>ApiFactoryBase</c>) — testes que sobem o pipeline HTTP sem
+/// um Postgres real não tentam aplicar migrations contra <c>localhost:5432</c>.
+/// </summary>
+internal sealed class MigrationHostedService<TContext> : IHostedService
+    where TContext : DbContext
+{
+    private readonly IServiceProvider _services;
+
+    public MigrationHostedService(IServiceProvider services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        _services = services;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) =>
+        _services.ApplyMigrationsAsync<TContext>(cancellationToken);
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/MigrationServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/MigrationServiceCollectionExtensions.cs
@@ -1,0 +1,79 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Helpers de aplicação de migrations EF Core no startup do host. Pareados com a configuração
+/// <c>AutoBuildMessageStorageOnStartup</c> do Wolverine em
+/// <see cref="Messaging.WolverineOutboxConfiguration"/> para destravar startups em ambientes
+/// onde o schema dos módulos ainda não foi provisionado por orquestração externa
+/// (lab/standalone, primeira subida de pod com banco vazio).
+/// </summary>
+public static partial class MigrationServiceCollectionExtensions
+{
+    /// <summary>
+    /// Aplica todas as migrations EF Core pendentes do <typeparamref name="TContext"/>. Idempotente —
+    /// chamadas em banco já migrado retornam sem efeito. Coordenação entre réplicas concorrentes
+    /// (várias réplicas startando simultâneo) é responsabilidade do EF Core / provider Npgsql,
+    /// que usa <c>__EFMigrationsHistory</c> como controle de aplicação.
+    /// </summary>
+    /// <typeparam name="TContext">DbContext do módulo (PortalDbContext, SelecaoDbContext, IngressoDbContext).</typeparam>
+    /// <param name="services">
+    /// <see cref="IServiceProvider"/> raiz (em <c>Program.cs</c>: <c>app.Services</c>).
+    /// </param>
+    /// <param name="cancellationToken">Token de cancelamento — opcional.</param>
+    /// <remarks>
+    /// O método cria um scope dedicado para resolver o DbContext (que é registrado scoped em
+    /// <c>AddDbContext</c>); chamar do scope raiz lançaria
+    /// <see cref="InvalidOperationException"/>. Logging via <see cref="ILogger{TCategoryName}"/>
+    /// reporta migrations pendentes ANTES e APÓS aplicação — visível no Loki/console em prod.
+    /// </remarks>
+    public static async Task ApplyMigrationsAsync<TContext>(
+        this IServiceProvider services,
+        CancellationToken cancellationToken = default)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        AsyncServiceScope scope = services.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            TContext context = scope.ServiceProvider.GetRequiredService<TContext>();
+            ILogger<TContext> logger = scope.ServiceProvider.GetRequiredService<ILogger<TContext>>();
+
+            IEnumerable<string> pending = await context.Database
+                .GetPendingMigrationsAsync(cancellationToken)
+                .ConfigureAwait(false);
+            string[] pendingArray = [.. pending];
+            string contextName = typeof(TContext).Name;
+
+            if (pendingArray.Length == 0)
+            {
+                LogNoPendingMigrations(logger, contextName);
+                return;
+            }
+
+#pragma warning disable CA1873 // Avaliação cara protegida por IsEnabled — caminho de startup, baixíssima frequência.
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                LogApplyingMigrations(logger, pendingArray.Length, contextName, string.Join(", ", pendingArray));
+            }
+#pragma warning restore CA1873
+
+            await context.Database.MigrateAsync(cancellationToken).ConfigureAwait(false);
+
+            LogMigrationsApplied(logger, contextName);
+        }
+    }
+
+    [LoggerMessage(EventId = 3001, Level = LogLevel.Information, Message = "Nenhuma migration EF Core pendente para {Context}.")]
+    private static partial void LogNoPendingMigrations(ILogger logger, string context);
+
+    [LoggerMessage(EventId = 3002, Level = LogLevel.Information, Message = "Aplicando {Count} migration(s) EF Core para {Context}: {Migrations}")]
+    private static partial void LogApplyingMigrations(ILogger logger, int count, string context, string migrations);
+
+    [LoggerMessage(EventId = 3003, Level = LogLevel.Information, Message = "Migrations EF Core aplicadas com sucesso para {Context}.")]
+    private static partial void LogMigrationsApplied(ILogger logger, string context);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/MigrationServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/MigrationServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
@@ -66,6 +68,31 @@ public static partial class MigrationServiceCollectionExtensions
 
             LogMigrationsApplied(logger, contextName);
         }
+    }
+
+    /// <summary>
+    /// Registra um <see cref="IHostedService"/> que aplica as migrations EF Core do
+    /// <typeparamref name="TContext"/> no <c>StartAsync</c> do host. Substitui o pattern de
+    /// chamar <see cref="ApplyMigrationsAsync{TContext}"/> diretamente em <c>Program.cs</c> —
+    /// como hosted service, o registro pode ser removido por test factories que sobem o
+    /// pipeline sem Postgres real (alinhado com a filtragem do <c>WolverineRuntime</c> em
+    /// <c>ApiFactoryBase</c>).
+    /// </summary>
+    /// <typeparam name="TContext">DbContext do módulo (PortalDbContext, SelecaoDbContext, IngressoDbContext).</typeparam>
+    /// <param name="services">A coleção de serviços do host.</param>
+    /// <returns>A própria <paramref name="services"/> para encadeamento fluente.</returns>
+    public static IServiceCollection AddDbContextMigrationsOnStartup<TContext>(
+        this IServiceCollection services)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Singleton com TryAddEnumerable previne dupla-registração se Program.cs chamar duas
+        // vezes com o mesmo TContext (defesa em profundidade — Program.cs deve chamar uma só).
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostedService, MigrationHostedService<TContext>>());
+
+        return services;
     }
 
     [LoggerMessage(EventId = 3001, Level = LogLevel.Information, Message = "Nenhuma migration EF Core pendente para {Context}.")]

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs
@@ -141,10 +141,17 @@ public static class WolverineOutboxConfiguration
             // Wolverine não atravessam esse pipeline.
             opts.AddCommandQueryMiddleware();
 
-            // Schema do Wolverine NÃO é auto-criado em runtime nesta camada
-            // produtiva — provisioning é responsabilidade do deploy. Testes
-            // integrados controlam o schema via fixture explícita; ver
-            // CascadingFixture no projeto de testes.
+            // Schema do Wolverine (tabelas wolverine_outgoing_envelopes, wolverine_incoming_envelopes,
+            // wolverine_node_assignments etc.) é auto-criado/atualizado no startup — issue #344.
+            // Idempotente: Wolverine inspeciona o schema atual e aplica apenas o delta. Múltiplas
+            // réplicas startando simultaneamente são coordenadas pelo lock interno do framework.
+            //
+            // Decisão (#344): em ambientes Uni+ não há orquestração de schema externa ao host
+            // (sem step de "dotnet ef database update" no Helm chart), então delegar a criação
+            // ao próprio host é o caminho mais simples e racional para destravar bring-up de
+            // pods com banco vazio (standalone/lab). EF Core migrations dos módulos são
+            // aplicadas em paralelo por ApplyMigrationsAsync<TContext> no Program.cs.
+            opts.AutoBuildMessageStorageOnStartup = JasperFx.AutoCreate.CreateOrUpdate;
 
             // Lê a seção uma única vez aqui — ValidateOnStart no DI não atinge este callback
             // (UseWolverine roda no Build, antes de StartAsync). Validação inline replica

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Migrations/MigrationServiceCollectionExtensionsIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Migrations/MigrationServiceCollectionExtensionsIntegrationTests.cs
@@ -1,0 +1,75 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Migrations;
+
+using AwesomeAssertions;
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Testcontainers.PostgreSql;
+
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção xUnit para classes de teste.")]
+public sealed class MigrationServiceCollectionExtensionsIntegrationTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_migration_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    public Task InitializeAsync() => _postgres.StartAsync();
+
+    public Task DisposeAsync() => _postgres.DisposeAsync().AsTask();
+
+    [Fact]
+    public async Task ApplyMigrationsAsync_BancoVazioSemMigrationsDefinidas_NaoFalha()
+    {
+        // Estado de scaffolding atual dos módulos Uni+: DbContexts existem mas sem migrations
+        // produtivas registradas. ApplyMigrationsAsync deve lidar com array vazio gracefully —
+        // não conectar tentar `Migrate()` quando não há nada a aplicar.
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddDbContext<TestDbContext>(opts => opts.UseNpgsql(_postgres.GetConnectionString()));
+
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        Func<Task> acao = async () => await sp.ApplyMigrationsAsync<TestDbContext>();
+
+        await acao.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task ApplyMigrationsAsync_ChamadaIdempotenteEntreRéplicas_NaoCorrompeBanco()
+    {
+        // Simula 2 réplicas startando simultâneo. EF Core usa advisory lock para coordenar:
+        // primeira aplica, segunda detecta que já foi aplicado e retorna gracefully.
+        ServiceCollection services = new();
+        services.AddLogging();
+        services.AddDbContext<TestDbContext>(opts => opts.UseNpgsql(_postgres.GetConnectionString()));
+
+        await using ServiceProvider sp = services.BuildServiceProvider();
+
+        Task r1 = sp.ApplyMigrationsAsync<TestDbContext>();
+        Task r2 = sp.ApplyMigrationsAsync<TestDbContext>();
+
+        Func<Task> acao = async () => await Task.WhenAll(r1, r2);
+
+        await acao.Should().NotThrowAsync();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciada via DI (AddDbContext) por reflection.")]
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj
@@ -10,6 +10,9 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -14,6 +14,18 @@
         "resolved": "8.0.1",
         "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
       },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.3.0, )",
@@ -22,6 +34,26 @@
         "dependencies": {
           "Microsoft.CodeCoverage": "18.3.0",
           "Microsoft.TestPlatform.TestHost": "18.3.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
         }
       },
       "xunit": {
@@ -376,10 +408,10 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "KC5PslaTDnTuTvyke0KYAVBYdZ7IVTsU3JhHe69BpEbHLcj1YThP3bIGtZNOkZfast2AuLnul5lk4rZKxAdUGQ==",
+        "resolved": "10.0.4",
+        "contentHash": "3x9X9SMAMdAoEwWxHfsT2a9dTBqEtfYfbEOFw+UPtBshEH2gHWJeazxrZ1FK1O18MoCbe1NxINg5qciB01pEcg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.2"
+          "Microsoft.Extensions.Primitives": "10.0.4"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -1163,18 +1195,6 @@
           "Microsoft.OpenApi": "2.0.0"
         }
       },
-      "Microsoft.EntityFrameworkCore": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "9tNBmK3EpYVGRQLiqP+bqK2m+TD0Gv//4vCzR7ZOgl4FWzCFyOpYdIVka13M4kcBdPdSJcs3wbHr3rmzOqbIMA==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
-        }
-      },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
         "requested": "[10.0.5, )",
@@ -1198,13 +1218,13 @@
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.0.5, )",
-        "resolved": "10.0.2",
-        "contentHash": "1fUeyNmqDNfMogJ2ut7OKO57/WGjjkHMYeX51SpA3PwP7ftbx8g/Z3fbErD+1q14DILrqJfsszYsYhGssBRfDg==",
+        "resolved": "10.0.4",
+        "contentHash": "DOTjTHy93W3TwpMLM4SCm0n57Sc0Jj3+m2S6LSTstKyBB34eT1UouaMS19mpWwvtj42+sRiEjA3+rOTNoNzXFQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.2",
-          "Microsoft.Extensions.Caching.Memory": "10.0.2",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Logging": "10.0.2"
+          "Microsoft.EntityFrameworkCore": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -1232,10 +1252,10 @@
       "Npgsql": {
         "type": "CentralTransitive",
         "requested": "[9.0.4, )",
-        "resolved": "9.0.4",
-        "contentHash": "68BASXH0FAEuL/J4J0eRfYC8/3vzqQTmoW8zDzNf0JgaVxc7LZeEkS6jaG0ib3voFLxY5ZiCwJG+uQM+mzuu0Q==",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.2"
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/MigrationServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/MigrationServiceCollectionExtensionsTests.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.DependencyInjection;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+public sealed class MigrationServiceCollectionExtensionsTests
+{
+    [Fact]
+    public async Task ApplyMigrationsAsync_ServicesNulo_LancaArgumentNullException()
+    {
+        IServiceProvider? services = null;
+
+        Func<Task> acao = async () => await services!.ApplyMigrationsAsync<DummyDbContext>();
+
+        await acao.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // Comportamento end-to-end (banco relacional + migrations idempotente + advisory lock entre
+    // réplicas) é validado por integração — ver MigrationServiceCollectionExtensionsIntegrationTests
+    // em Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Migrations/. InMemory provider não
+    // suporta GetPendingMigrationsAsync/MigrateAsync, então o caminho relacional precisa de Postgres.
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Type marker para o método genérico — nunca instanciado.")]
+    private sealed class DummyDbContext : DbContext
+    {
+    }
+}

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
@@ -73,18 +73,27 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
 
             if (DisableWolverineRuntimeForTests)
             {
-                // Wolverine registra o WolverineRuntime como IHostedService via
-                // factory (ImplementationFactory != null, ImplementationType == null),
-                // o que torna a inspeção por tipo concreto inviável. A heurística
-                // estável é casar pelo assembly da fábrica: factories registradas
-                // pelo próprio assembly Wolverine são removidas — o host inicializa
-                // sem startar o runtime e, portanto, sem disparar MigrateAsync,
-                // que tentaria conectar no Postgres configurado em
-                // PersistMessagesWithPostgresql.
+                // Dois IHostedService produtivos precisam ser removidos juntos quando o
+                // Postgres não está disponível no test host (default da maioria das suites
+                // de integração que só exercitam o pipeline HTTP):
+                //
+                // 1. Wolverine registra o WolverineRuntime como IHostedService via factory
+                //    (ImplementationFactory != null, ImplementationType == null). A heurística
+                //    estável é casar pelo assembly da fábrica.
+                // 2. MigrationHostedService<TContext> (issue #344) é registrado por
+                //    AddDbContextMigrationsOnStartup<T>() e dispara MigrateAsync no StartAsync.
+                //    Sem PG real, falha com "Connection refused" e derruba o factory antes do
+                //    primeiro teste. Reconhecemos pelo ImplementationType genérico.
+                //
+                // Suites que exercitam outbox real (CascadingFixture) sobrescrevem
+                // DisableWolverineRuntimeForTests=false e provisionam o PG efêmero — nesse
+                // caso AMBOS os hosted services rodam contra o banco da fixture.
                 ServiceDescriptor[] hostedToRemove = [.. services
                     .Where(d => d.ServiceType == typeof(IHostedService)
-                        && d.ImplementationFactory is not null
-                        && d.ImplementationFactory.Method.DeclaringType?.Assembly.GetName().Name == "Wolverine")];
+                        && (
+                            (d.ImplementationFactory is not null
+                                && d.ImplementationFactory.Method.DeclaringType?.Assembly.GetName().Name == "Wolverine")
+                            || IsMigrationHostedService(d.ImplementationType)))];
                 foreach (ServiceDescriptor svc in hostedToRemove)
                 {
                     services.Remove(svc);
@@ -92,6 +101,13 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
             }
         });
     }
+
+    private static bool IsMigrationHostedService(Type? implementationType) =>
+        implementationType is { IsGenericType: true }
+        && string.Equals(
+            implementationType.GetGenericTypeDefinition().FullName,
+            "Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection.MigrationHostedService`1",
+            StringComparison.Ordinal);
 
     /// <summary>
     /// Substitui o esquema de autenticação produtivo pelo <see cref="TestAuthHandler"/>, permitindo

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
@@ -55,9 +55,10 @@ public sealed class CascadingFixture : IAsyncLifetime
         // Cria o schema do domínio Selecao no Postgres efêmero ANTES do host
         // Wolverine inicializar — sem isso há disputa de timing com o
         // PostgresqlTransport e o handler reporta `relation "editais" does not exist`.
-        // O schema do Wolverine ("wolverine.*") é criado pelo próprio framework
-        // no primeiro despacho; auto-build de produção fica off-by-default
-        // conforme documentado em WolverineOutboxConfiguration.
+        // O schema do Wolverine (`wolverine.*`) agora é provisionado no startup pelo
+        // próprio framework via `AutoBuildMessageStorageOnStartup = CreateOrUpdate`
+        // (issue #344) — antes ficava off-by-default e era criado lazy no primeiro
+        // despacho, o que era origem de timing flakiness em testes outbox.
         DbContextOptions<SelecaoDbContext> options = new DbContextOptionsBuilder<SelecaoDbContext>()
             .UseNpgsql(ConnectionString)
             .Options;


### PR DESCRIPTION
## Resumo

Sub-issue P0 da Epic #347. Pods Uni+ deployados em standalone subiam com `/health=200` mas qualquer endpoint que tocasse `DbContext` ou Wolverine outbox real falhava com `relation "wolverine_outgoing_envelopes" does not exist` (ou tabelas de domínio análogas). Schema Wolverine não era auto-criado em runtime e migrations EF Core dos 3 contexts (Portal/Selecao/Ingresso) também não eram aplicadas — `bootstrap-standalone.sh` provisionava apenas as databases vazias.

## O que muda

### `Infrastructure.Core/DependencyInjection/MigrationServiceCollectionExtensions.cs` (novo)

`ApplyMigrationsAsync<TContext>(this IServiceProvider services, CancellationToken)` — cria scope dedicado, resolve o DbContext, lista migrations pendentes via `GetPendingMigrationsAsync`, aplica via `MigrateAsync` e logga via `LoggerMessage` source-gen (CA1848-friendly). Idempotente; banco já migrado é no-op.

### `Messaging/WolverineOutboxConfiguration.cs`

Adiciona `opts.AutoBuildMessageStorageOnStartup = JasperFx.AutoCreate.CreateOrUpdate;` — schema `wolverine_*` (envelopes outgoing/incoming, scheduled, node_assignments, etc.) provisionado pelo próprio framework no startup. Substitui o pattern anterior de criação lazy no primeiro despacho, que era fonte de timing flakiness em `CascadingScenariosTests`.

### Program.cs (Portal / Selecao / Ingresso)

Cada um chama `await app.Services.ApplyMigrationsAsync<XxxDbContext>()` antes de `app.RunAsync()`.

## Forward-compat (importante)

Nenhum dos 3 módulos tem migrations EF Core registradas hoje (todos em scaffolding). Implicações:

- **Hoje**: `ApplyMigrationsAsync` é no-op para os 3 contexts (sem pendentes para aplicar). Schema Wolverine é provisionado imediatamente — destrava CQRS/outbox.
- **Quando o primeiro slice de domínio adicionar uma migration** (ex.: `dotnet ef migrations add InitialEditais` em Selecao.Infrastructure), ela é aplicada automaticamente no próximo deploy sem mudança em Program.cs.

Esta é a **infraestrutura forward-compat**: melhor pôr no lugar agora, antes do primeiro slice produtivo, do que precisar voltar e adicionar quando a primeira migration aterrissar.

## Critérios de aceite (issue #344)

- [x] `ApplyMigrationsAsync<T>` extension registrada e testada
- [x] Wolverine schema (`uniplus_messaging.*`) auto-aplicado no startup
- [x] EF Core migrations dos 3 contexts auto-aplicadas (no-op hoje, ativas quando registradas)
- [x] Logging das migrations no startup (LoggerMessage com EventId 3001/3002/3003)
- [x] Test integration: re-startar pod com banco limpo aplica tudo + fica Ready (validado por `MigrationServiceCollectionExtensionsIntegrationTests` e `CascadingScenariosTests`)
- [x] Race condition: 2+ réplicas startando simultâneo → coordenação via `__EFMigrationsHistory` (validado por `ApplyMigrationsAsync_ChamadaIdempotenteEntreRéplicas_NaoCorrompeBanco`)
- [x] Pre-PR: `dotnet build` + `dotnet test` verdes (310 unit + 6 Infrastructure.Core integration + 51 Selecao integration)

## Cobertura de testes

- **Unit (1)**: `MigrationServiceCollectionExtensionsTests` — guard de `null services`
- **Integration (2)** com Testcontainers Postgres (`postgres:18-alpine`):
  - Banco vazio sem migrations definidas → não falha
  - Chamadas concorrentes (`Task.WhenAll` × 2) sobre mesma DB → idempotente
- **Sanity** — `CascadingScenariosTests` no `Selecao.IntegrationTests` (Wolverine schema agora auto-build): 17/17 verde

## Out of scope (deferido)

- **Migration real para teste de advisory lock**: Codex sugeriu criar migration mínima no contexto de teste para provar lock/idempotência concorrente. Implementar isso requer definir um `Migration` class manualmente no test code — escopo desproporcional. A coordenação inter-réplica fica como contrato do EF Core / provider Npgsql; quando o primeiro slice de domínio adicionar migrations, smoke E2E no cluster standalone exercitará o caminho real.

## Rollback

`git revert` do PR. O Wolverine cai para criação lazy no primeiro despacho (comportamento pré-PR). Migrations EF Core voltam a não ser aplicadas em runtime — mas como hoje não há migrations, isso é equivalente ao no-op atual.

## Referências

- Epic #347 — APIs Uni+ ponta a ponta no standalone
- ADR-0004 (outbox transacional) e ADR-0005 (cascading messages) — pattern Wolverine que esta PR completa
- uniplus-infra PR #160 — charts deployados, DBs `uniplus_portal`/`uniplus_selecao`/`uniplus_ingresso` provisionados sem schema

Closes #344
Refs #347