### PR TITLE
docs(adr-0050): promove para accepted após primeiro publish verde

### DIFF
--- a/docs/adrs/0050-registry-ghcr-e-tagging.md
+++ b/docs/adrs/0050-registry-ghcr-e-tagging.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 date: "2026-05-08"
 decision-makers:
   - "Tech Lead"

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -78,7 +78,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0047](0047-confluent-kafka-npgsql-pisos-transitivos-wolverine.md) | `Confluent.Kafka 2.14.0` + `Npgsql 9.0.4` como pisos transitivos do Wolverine 5.32.1 | accepted | 2026-05-05 |
 | [0048](0048-controllers-mvc-public-com-ca1515-suprimido.md) | Controllers MVC em `*.API` devem ser `public`, com CA1515 suprimido por justificativa | accepted | 2026-05-05 |
 | [0049](0049-implementacao-hateoas-edital-resource-links-builder.md) | Implementação de HATEOAS Level 1 em `EditalDto` via `IResourceLinksBuilder<TDto>` na camada API | accepted | 2026-05-06 |
-| [0050](0050-registry-ghcr-e-tagging.md) | GitHub Container Registry e estratégia de tagging das imagens da `uniplus-api` | proposed | 2026-05-08 |
+| [0050](0050-registry-ghcr-e-tagging.md) | GitHub Container Registry e estratégia de tagging das imagens da `uniplus-api` | accepted | 2026-05-08 |
 
 ## Como adicionar um novo ADR
 


### PR DESCRIPTION
## Resumo

Promove ADR-0050 de `proposed` para `accepted` em commit separado, conforme padrão do projeto (precedente: ADR-0049, ADR-0019).

## Evidência

- Tag `v0.1.1` publicou as 3 imagens em `ghcr.io/unifesspa-edu-br/uniplus-api-{selecao,ingresso,portal}` em 2026-05-08T21:32Z
- Smoke estrutural verde nos 3 módulos (`docker create` + `docker inspect User != root` + `docker inspect Entrypoint` + `dotnet --info`)
- Packages com visibilidade `public` (herdada do repo)
- Pull anônimo verificado pós-publish
- Stack `docker compose` validou as 3 APIs em `/health` agregado (200) com Postgres + Kafka + Redis chegáveis

## Mudanças

- `docs/adrs/0050-registry-ghcr-e-tagging.md`: frontmatter `status: "proposed"` → `status: "accepted"`
- `docs/adrs/README.md`: índice da linha 0050 atualizado

## Pareada com

ADR-0020 (web) já está em `accepted` desde antes — paridade restaurada.