### PR TITLE
feat(shared): health checks Postgres+Redis+MinIO+Kafka + Redis DI

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -63,6 +63,11 @@ builder.Services.AddDbContextMigrationsOnStartup<IngressoDbContext>();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);
+builder.Services.AddUniPlusCache(builder.Configuration, builder.Environment);
+
+// Health checks agregados: Postgres + Redis + MinIO + Kafka + OIDC. Ver Portal.API/Program.cs
+// para a explicação completa do split /health/live vs /health/ready.
+builder.Services.AddUniPlusHealthChecks(builder.Configuration, connectionStringName: "IngressoDb");
 
 WebApplication app = builder.Build();
 
@@ -84,6 +89,10 @@ app.MapOpenApi("/openapi/{documentName}.json");
 app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
 {
     Predicate = _ => false,
+});
+app.MapHealthChecks("/health/ready", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+{
+    Predicate = h => h.Tags.Contains(HealthChecksServiceCollectionExtensions.ReadyTag),
 });
 app.MapHealthChecks("/health");
 

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
@@ -71,6 +71,12 @@ builder.Services.AddDbContextMigrationsOnStartup<PortalDbContext>();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);
+builder.Services.AddUniPlusCache(builder.Configuration, builder.Environment);
+
+// Health checks agregados: Postgres + Redis + MinIO + Kafka + OIDC (já registrado por
+// AddOidcAuthentication acima). Endpoints separados em /health/live (deps-free), /health/ready
+// (todos com tag "ready") e /health (alias retrocompat).
+builder.Services.AddUniPlusHealthChecks(builder.Configuration, connectionStringName: "PortalDb");
 
 WebApplication app = builder.Build();
 
@@ -93,6 +99,14 @@ app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthC
 {
     Predicate = _ => false,
 });
+// Readiness: agrega checks tagueados "ready" (Postgres, Redis, MinIO, Kafka, OIDC).
+// Reflete o estado real das deps externas — Kubernetes deve apontar readinessProbe aqui.
+app.MapHealthChecks("/health/ready", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+{
+    Predicate = h => h.Tags.Contains(HealthChecksServiceCollectionExtensions.ReadyTag),
+});
+// Alias retrocompat: continua expondo /health (sem filtro = todos os checks). Pode ser removido
+// quando todos os clients consumirem /health/live ou /health/ready.
 app.MapHealthChecks("/health");
 
 await app.RunAsync();

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -121,6 +121,11 @@ builder.Services.AddDbContextMigrationsOnStartup<SelecaoDbContext>();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);
+builder.Services.AddUniPlusCache(builder.Configuration, builder.Environment);
+
+// Health checks agregados: Postgres + Redis + MinIO + Kafka + OIDC. Ver Portal.API/Program.cs
+// para a explicação completa do split /health/live vs /health/ready.
+builder.Services.AddUniPlusHealthChecks(builder.Configuration, connectionStringName: "SelecaoDb");
 
 WebApplication app = builder.Build();
 
@@ -142,6 +147,10 @@ app.MapOpenApi("/openapi/{documentName}.json");
 app.MapHealthChecks("/health/live", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
 {
     Predicate = _ => false,
+});
+app.MapHealthChecks("/health/ready", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+{
+    Predicate = h => h.Tags.Contains(HealthChecksServiceCollectionExtensions.ReadyTag),
 });
 app.MapHealthChecks("/health");
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Caching/RedisOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Caching/RedisOptions.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Caching;
+
+/// <summary>
+/// Bound options for Redis cache. Ligadas via
+/// <see cref="DependencyInjection.CacheServiceCollectionExtensions.AddUniPlusCache"/>.
+/// Fora de Development, <see cref="ConnectionString"/> deve estar preenchida — caso contrário,
+/// o startup falha. Em Development a validação é leniente para permitir bring-up parcial sem
+/// Redis local (ex.: rodar API só com pipeline HTTP/auth sem subir cache).
+/// </summary>
+public sealed class RedisOptions
+{
+    public const string SectionName = "Redis";
+
+    /// <summary>
+    /// Connection string no formato <c>StackExchange.Redis</c> — host:port, com opções como
+    /// <c>password</c>, <c>user</c>, <c>ssl</c>, <c>abortConnect</c>. Provida por env var em
+    /// prod (chart Helm + Vault).
+    /// </summary>
+    public string ConnectionString { get; init; } = string.Empty;
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/CacheServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/CacheServiceCollectionExtensions.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+using StackExchange.Redis;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+
+/// <summary>
+/// Registra <see cref="IConnectionMultiplexer"/> e <see cref="ICacheService"/> no container DI
+/// a partir da seção <c>Redis</c> do <see cref="IConfiguration"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Padrão alinhado com <see cref="StorageServiceCollectionExtensions.AddUniPlusStorage"/>:
+/// validação leniente em Development, fail-fast fora quando <c>Redis:ConnectionString</c>
+/// está vazio.
+/// </para>
+/// <para>
+/// <see cref="IConnectionMultiplexer"/> é registrado como <em>singleton</em> — o
+/// <c>StackExchange.Redis</c> mantém um pool TCP interno multi-plexado e é projetado para
+/// reutilização global no processo. <see cref="ICacheService"/> é <em>scoped</em> alinhado
+/// com o pattern dos demais serviços de Infrastructure.
+/// </para>
+/// </remarks>
+public static class CacheServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registra <see cref="RedisOptions"/>, <see cref="IConnectionMultiplexer"/> e
+    /// <see cref="ICacheService"/>. Deve ser chamado uma única vez por aplicação,
+    /// junto com os demais <c>AddUniPlus*</c> em <c>Program.cs</c>.
+    /// </summary>
+    public static IServiceCollection AddUniPlusCache(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        services.AddOptions<RedisOptions>()
+            .Bind(configuration.GetSection(RedisOptions.SectionName))
+            .Validate(
+                options => environment.IsDevelopment()
+                    || !string.IsNullOrWhiteSpace(options.ConnectionString),
+                "Redis:ConnectionString must be configured outside Development.")
+            .ValidateOnStart();
+
+        services.AddSingleton<IConnectionMultiplexer>(sp =>
+        {
+            RedisOptions opts = sp.GetRequiredService<IOptions<RedisOptions>>().Value;
+            return ConnectionMultiplexer.Connect(opts.ConnectionString);
+        });
+
+        services.AddScoped<ICacheService, RedisCacheService>();
+
+        return services;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/HealthChecksServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/HealthChecksServiceCollectionExtensions.cs
@@ -1,0 +1,97 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using Unifesspa.UniPlus.Infrastructure.Core.HealthChecks;
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+
+/// <summary>
+/// Registra health checks agregados para Postgres, Redis, MinIO e Kafka. Pareado com a
+/// configuração existente de <see cref="Authentication.OidcAuthenticationConfiguration"/>
+/// (que já registra <c>OidcDiscoveryHealthCheck</c>) para compor o readiness probe completo
+/// das APIs Uni+.
+/// </summary>
+public static class HealthChecksServiceCollectionExtensions
+{
+    /// <summary>
+    /// Tag canônica usada para filtrar checks que respondem ao readiness probe. Endpoints
+    /// devem usar <c>Predicate = h => h.Tags.Contains(<see cref="ReadyTag"/>)</c> em
+    /// <see cref="Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions"/>.
+    /// </summary>
+    public const string ReadyTag = "ready";
+
+    /// <summary>
+    /// Registra checks para as dependências infra das APIs Uni+ no
+    /// <see cref="IHealthChecksBuilder"/> existente. Cada check é ativado condicionalmente
+    /// pela presença da config correspondente — em Development sem alguma dep, o check é
+    /// simplesmente não registrado em vez de reportar Unhealthy permanente.
+    /// </summary>
+    /// <param name="services">A coleção de serviços.</param>
+    /// <param name="configuration">Configuração da aplicação.</param>
+    /// <param name="connectionStringName">Nome da connection string Postgres (PortalDb,
+    /// SelecaoDb, IngressoDb).</param>
+    /// <returns>A própria <paramref name="services"/> para encadeamento fluente.</returns>
+    /// <remarks>
+    /// <para>
+    /// Pré-requisitos por check:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description><b>Postgres</b>: usa a connection string nominal — ativa quando
+    ///     <c>ConnectionStrings:{connectionStringName}</c> está preenchido.</description></item>
+    ///   <item><description><b>Redis</b>: depende de <see cref="StackExchange.Redis.IConnectionMultiplexer"/>
+    ///     registrado por <see cref="CacheServiceCollectionExtensions.AddUniPlusCache"/>.
+    ///     Ativa quando <c>Redis:ConnectionString</c> está preenchido.</description></item>
+    ///   <item><description><b>MinIO</b>: depende de <see cref="Minio.IMinioClient"/>
+    ///     registrado por <see cref="StorageServiceCollectionExtensions.AddUniPlusStorage"/>.
+    ///     Ativa quando <c>Storage:Endpoint</c> está preenchido.</description></item>
+    ///   <item><description><b>Kafka</b>: depende de <see cref="KafkaSettings"/> bind por
+    ///     <see cref="WolverineOutboxConfiguration.UseWolverineOutboxCascading"/>. Ativa quando
+    ///     <c>Kafka:BootstrapServers</c> está preenchido.</description></item>
+    /// </list>
+    /// </remarks>
+    public static IServiceCollection AddUniPlusHealthChecks(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string connectionStringName)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
+
+        IHealthChecksBuilder hc = services.AddHealthChecks();
+
+        string? pgConn = configuration.GetConnectionString(connectionStringName);
+        if (!string.IsNullOrWhiteSpace(pgConn))
+        {
+            hc.AddCheck(
+                name: "postgres",
+                instance: new PostgresHealthCheck(pgConn),
+                tags: [ReadyTag, "db"]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(configuration[$"{Caching.RedisOptions.SectionName}:{nameof(Caching.RedisOptions.ConnectionString)}"]))
+        {
+            hc.AddCheck<RedisHealthCheck>(
+                name: "redis",
+                tags: [ReadyTag, "cache"]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(configuration[$"{Storage.StorageOptions.SectionName}:{nameof(Storage.StorageOptions.Endpoint)}"]))
+        {
+            hc.AddCheck<MinioHealthCheck>(
+                name: "minio",
+                tags: [ReadyTag, "storage"]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(configuration[$"{KafkaSettings.SectionName}:{nameof(KafkaSettings.BootstrapServers)}"]))
+        {
+            hc.AddCheck<KafkaHealthCheck>(
+                name: "kafka",
+                tags: [ReadyTag, "messaging"]);
+        }
+
+        return services;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/HealthChecks/KafkaHealthCheck.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/HealthChecks/KafkaHealthCheck.cs
@@ -5,14 +5,18 @@ using System.Diagnostics.CodeAnalysis;
 using Confluent.Kafka;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 
 public sealed class KafkaHealthCheck : IHealthCheck
 {
-    private readonly string _bootstrapServers;
+    private readonly KafkaSettings _settings;
 
-    public KafkaHealthCheck(string bootstrapServers)
+    public KafkaHealthCheck(IOptions<KafkaSettings> options)
     {
-        _bootstrapServers = bootstrapServers;
+        ArgumentNullException.ThrowIfNull(options);
+        _settings = options.Value;
     }
 
     [SuppressMessage(
@@ -23,7 +27,14 @@ public sealed class KafkaHealthCheck : IHealthCheck
     {
         try
         {
-            AdminClientConfig config = new() { BootstrapServers = _bootstrapServers };
+            AdminClientConfig config = new() { BootstrapServers = _settings.BootstrapServers };
+
+            // Aplica SecurityProtocol/SaslMechanism/SaslUsername/SaslPassword/SslCa* quando
+            // configurados — necessário em standalone (SASL_SSL + SCRAM-SHA-512). Sem isto, o
+            // health check em standalone tentaria PLAINTEXT contra um broker SASL e reportaria
+            // Unhealthy permanente, mascarando o estado real.
+            KafkaSecurity.Apply(config, _settings);
+
             using IAdminClient adminClient = new AdminClientBuilder(config).Build();
             Metadata metadata = adminClient.GetMetadata(TimeSpan.FromSeconds(5));
             return Task.FromResult(metadata.Brokers.Count > 0

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/HealthChecks/MinioHealthCheck.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/HealthChecks/MinioHealthCheck.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.HealthChecks;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using Minio;
+
+public sealed class MinioHealthCheck : IHealthCheck
+{
+    private readonly IMinioClient _minioClient;
+
+    public MinioHealthCheck(IMinioClient minioClient)
+    {
+        _minioClient = minioClient;
+    }
+
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Health check must isolate downstream failures and report Unhealthy instead of propagating exceptions to the readiness pipeline.")]
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // ListBucketsAsync é a operação mais leve para confirmar conectividade + credentials —
+            // valida endpoint, TLS (se UseSSL), e access/secret key sem depender de bucket
+            // específico existir.
+            await _minioClient.ListBucketsAsync(cancellationToken).ConfigureAwait(false);
+            return HealthCheckResult.Healthy("MinIO está acessível.");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("MinIO inacessível.", ex);
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/HealthChecks/MinioHealthCheckTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/HealthChecks/MinioHealthCheckTests.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.HealthChecks;
+
+using AwesomeAssertions;
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using Minio;
+
+using Unifesspa.UniPlus.Infrastructure.Core.HealthChecks;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+[Collection(MinioContainerFixture.CollectionName)]
+public sealed class MinioHealthCheckTests(MinioContainerFixture minio)
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Caller awaits using on the returned IMinioClient (cast to IAsyncDisposable).")]
+    private static IMinioClient BuildClient(string endpoint, string accessKey, string secretKey) =>
+        new MinioClient()
+            .WithEndpoint(endpoint)
+            .WithCredentials(accessKey, secretKey)
+            .WithSSL(false)
+            .Build();
+
+    [Fact]
+    public async Task CheckHealthAsync_MinioAcessivel_RetornaHealthy()
+    {
+        IMinioClient client = BuildClient(minio.Endpoint, MinioContainerFixture.AccessKey, MinioContainerFixture.SecretKey);
+        using ((IDisposable)client)
+        {
+            MinioHealthCheck check = new(client);
+
+            HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            result.Status.Should().Be(HealthStatus.Healthy);
+            result.Description.Should().Contain("acessível");
+        }
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_MinioInacessivel_RetornaUnhealthy()
+    {
+        // Endpoint inválido (porta 1 — fechada). Confirma que o catch-all do health check
+        // converte exceção em Unhealthy em vez de propagar para o pipeline de readiness.
+        IMinioClient client = BuildClient("127.0.0.1:1", "any", "any");
+        using ((IDisposable)client)
+        {
+            MinioHealthCheck check = new(client);
+
+            HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            result.Status.Should().Be(HealthStatus.Unhealthy);
+            result.Description.Should().Contain("inacessível");
+            result.Exception.Should().NotBeNull();
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/CacheServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/CacheServiceCollectionExtensionsTests.cs
@@ -1,0 +1,100 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.DependencyInjection;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+public sealed class CacheServiceCollectionExtensionsTests
+{
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private static HostingEnvironment Env(string name) =>
+        new() { EnvironmentName = name };
+
+    private static Dictionary<string, string?> CompleteConfig() => new()
+    {
+        ["Redis:ConnectionString"] = "redis:6379",
+    };
+
+    [Fact]
+    public void AddUniPlusCache_ServicesNulo_LancaArgumentNullException()
+    {
+        IServiceCollection? services = null;
+
+        Action acao = () => services!.AddUniPlusCache(BuildConfig(CompleteConfig()), Env(Environments.Production));
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddUniPlusCache_ConfigurationNulo_LancaArgumentNullException()
+    {
+        ServiceCollection services = new();
+
+        Action acao = () => services.AddUniPlusCache(null!, Env(Environments.Production));
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddUniPlusCache_EnvironmentNulo_LancaArgumentNullException()
+    {
+        ServiceCollection services = new();
+
+        Action acao = () => services.AddUniPlusCache(BuildConfig(CompleteConfig()), null!);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddUniPlusCache_ProductionSemConnectionString_OptionsValueLancaOptionsValidationException()
+    {
+        ServiceCollection services = new();
+        services.AddUniPlusCache(BuildConfig(new Dictionary<string, string?>()), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Action acao = () => { _ = sp.GetRequiredService<IOptions<RedisOptions>>().Value; };
+
+        acao.Should().Throw<OptionsValidationException>()
+            .WithMessage("*Redis:ConnectionString*");
+    }
+
+    [Fact]
+    public void AddUniPlusCache_DevelopmentSemConfig_NaoLancaValidacao()
+    {
+        ServiceCollection services = new();
+        services.AddUniPlusCache(BuildConfig(new Dictionary<string, string?>()), Env(Environments.Development));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Action acao = () => { _ = sp.GetRequiredService<IOptions<RedisOptions>>().Value; };
+
+        acao.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AddUniPlusCache_BindingMapeiaConnectionString()
+    {
+        Dictionary<string, string?> values = new()
+        {
+            ["Redis:ConnectionString"] = "redis.example:6379,user=u,password=p",
+        };
+
+        ServiceCollection services = new();
+        services.AddUniPlusCache(BuildConfig(values), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        RedisOptions opts = sp.GetRequiredService<IOptions<RedisOptions>>().Value;
+
+        opts.ConnectionString.Should().Be("redis.example:6379,user=u,password=p");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/HealthChecksServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/HealthChecksServiceCollectionExtensionsTests.cs
@@ -1,0 +1,120 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.DependencyInjection;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+public sealed class HealthChecksServiceCollectionExtensionsTests
+{
+    private static IConfiguration BuildConfig(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    [Fact]
+    public void AddUniPlusHealthChecks_ServicesNulo_LancaArgumentNullException()
+    {
+        IServiceCollection? services = null;
+        Action acao = () => services!.AddUniPlusHealthChecks(BuildConfig([]), "PortalDb");
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddUniPlusHealthChecks_ConfigurationNulo_LancaArgumentNullException()
+    {
+        ServiceCollection services = new();
+        Action acao = () => services.AddUniPlusHealthChecks(null!, "PortalDb");
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddUniPlusHealthChecks_ConnectionStringNameVazio_LancaArgumentException(string raw)
+    {
+        ServiceCollection services = new();
+        Action acao = () => services.AddUniPlusHealthChecks(BuildConfig([]), raw);
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddUniPlusHealthChecks_NenhumaConfig_NaoRegistraNenhumCheck()
+    {
+        // Garante via AddOptions o registro mínimo do pipeline IOptions — necessário porque
+        // AddHealthChecks() não materializa HealthCheckServiceOptions sem AddLogging() ou
+        // contexto IHostBuilder. Em produção, o IHostBuilder cobre isso; nos testes unit,
+        // adicionamos explicitamente.
+        ServiceCollection services = new();
+        services.AddOptions();
+        services.AddUniPlusHealthChecks(BuildConfig([]), "PortalDb");
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        HealthCheckServiceOptions opts = sp.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        opts.Registrations.Select(r => r.Name).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddUniPlusHealthChecks_TodasAsConfigsPresentes_RegistraTodosOsChecks()
+    {
+        Dictionary<string, string?> config = new()
+        {
+            ["ConnectionStrings:PortalDb"] = "Host=pg;Port=5432;Database=x;Username=u;Password=p",
+            ["Redis:ConnectionString"] = "redis:6379",
+            ["Storage:Endpoint"] = "minio:9000",
+            ["Kafka:BootstrapServers"] = "kafka:9092",
+        };
+
+        ServiceCollection services = new();
+        services.AddOptions();
+        services.AddUniPlusHealthChecks(BuildConfig(config), "PortalDb");
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        HealthCheckServiceOptions opts = sp.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        opts.Registrations.Select(r => r.Name).Should().BeEquivalentTo(["postgres", "redis", "minio", "kafka"]);
+    }
+
+    [Fact]
+    public void AddUniPlusHealthChecks_CadaCheckTagueadoComReady()
+    {
+        Dictionary<string, string?> config = new()
+        {
+            ["ConnectionStrings:PortalDb"] = "Host=pg;Port=5432;Database=x;Username=u;Password=p",
+            ["Redis:ConnectionString"] = "redis:6379",
+            ["Storage:Endpoint"] = "minio:9000",
+            ["Kafka:BootstrapServers"] = "kafka:9092",
+        };
+
+        ServiceCollection services = new();
+        services.AddOptions();
+        services.AddUniPlusHealthChecks(BuildConfig(config), "PortalDb");
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        HealthCheckServiceOptions opts = sp.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        // ReadyTag está em todos para que o readiness probe agregue corretamente.
+        opts.Registrations.Should().AllSatisfy(r =>
+            r.Tags.Should().Contain(HealthChecksServiceCollectionExtensions.ReadyTag));
+    }
+
+    [Fact]
+    public void AddUniPlusHealthChecks_ApenasPostgres_RegistraSomentePostgres()
+    {
+        Dictionary<string, string?> config = new()
+        {
+            ["ConnectionStrings:SelecaoDb"] = "Host=pg;Port=5432;Database=x;Username=u;Password=p",
+        };
+
+        ServiceCollection services = new();
+        services.AddUniPlusHealthChecks(BuildConfig(config), "SelecaoDb");
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        HealthCheckServiceOptions opts = sp.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+
+        opts.Registrations.Select(r => r.Name).Should().BeEquivalentTo(["postgres"]);
+    }
+}

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 
 using Authentication;
@@ -56,6 +57,22 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
     /// </remarks>
     protected virtual bool DisableWolverineRuntimeForTests => true;
 
+    /// <summary>
+    /// Nomes dos health checks de infra externa registrados por
+    /// <c>AddUniPlusHealthChecks</c> que são removidos por default em testes — o pipeline
+    /// HTTP típico não tem Postgres/Redis/MinIO/Kafka rodando, e mantê-los gera Unhealthy
+    /// permanente em <c>/health</c>/<c>/health/ready</c>, mascarando o estado real do
+    /// pipeline de auth/routing/controllers que a suite quer validar.
+    /// </summary>
+    /// <remarks>
+    /// Suites que provisionam essas dependências (ex.: <c>CascadingFixture</c> com Postgres
+    /// via Testcontainers) sobrescrevem este conjunto para preservar os checks que sua
+    /// fixture sustenta — tipicamente retornando o conjunto vazio para deixar todos os checks
+    /// ativos.
+    /// </remarks>
+    protected virtual ISet<string> InfraHealthCheckNamesToRemoveForTests { get; } =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "postgres", "redis", "minio", "kafka" };
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
@@ -98,6 +115,26 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
                 {
                     services.Remove(svc);
                 }
+            }
+
+            // Filtro de health checks de infra externa — removidos por default porque a maioria
+            // das suites HTTP-only não tem PG/Redis/MinIO/Kafka rodando. Override
+            // InfraHealthCheckNamesToRemoveForTests => emptyset em fixtures que provisionam
+            // todas as deps. Aplicado via Configure<HealthCheckServiceOptions> que roda na
+            // pipeline de IServiceCollection — a remoção acontece antes do host materializar
+            // o IHealthCheckService.
+            ISet<string> namesToRemove = InfraHealthCheckNamesToRemoveForTests;
+            if (namesToRemove.Count > 0)
+            {
+                services.PostConfigure<HealthCheckServiceOptions>(opts =>
+                {
+                    HealthCheckRegistration[] toRemove = [.. opts.Registrations
+                        .Where(r => namesToRemove.Contains(r.Name))];
+                    foreach (HealthCheckRegistration reg in toRemove)
+                    {
+                        opts.Registrations.Remove(reg);
+                    }
+                });
             }
         });
     }


### PR DESCRIPTION
## Resumo

Sub-issue P1 da Epic #347. Encerra #345 e fecha um **gap latente** identificado durante o #342:

**`IConnectionMultiplexer` e `ICacheService` nunca foram registrados no DI** — `RedisCacheService` e `RedisHealthCheck` (existentes desde antes da Epic) falhariam em runtime ao serem injetados. Espelho do bug que `IMinioClient` tinha pré-#342.

## O que muda

### Pre-req: DI Redis (corrige gap latente)

- **`Caching/RedisOptions.cs`** — bound options da seção `Redis:`
- **`DependencyInjection/CacheServiceCollectionExtensions.cs`** — `AddUniPlusCache(IConfiguration, IHostEnvironment)`:
  - Validação leniente em Development, fail-fast fora (pattern Cors/OIDC/Storage)
  - `IConnectionMultiplexer` singleton (StackExchange.Redis mantém pool TCP multiplexado)
  - `ICacheService` scoped

### Health checks #345

- **`HealthChecks/MinioHealthCheck.cs`** (custom, novo) — `ListBucketsAsync` confirma conectividade + credentials
- **`HealthChecks/KafkaHealthCheck.cs`** refatorado: recebe `IOptions<KafkaSettings>` em vez de bootstrap servers string + `KafkaSecurity.Apply` no `AdminClientConfig`. Sem isto, em standalone (SASL_SSL+SCRAM) o health check tentaria PLAINTEXT contra broker SASL e reportaria Unhealthy permanente.
- **`DependencyInjection/HealthChecksServiceCollectionExtensions.cs`** — `AddUniPlusHealthChecks(IConfiguration, string connectionStringName)`:
  - Registra Postgres+Redis+MinIO+Kafka condicional à presença da config
  - Cada check tagueado `ready` para o readiness probe

### Endpoints `/health/*` em cada `Program.cs`

| Endpoint | Predicate | Uso K8s |
|---|---|---|
| `/health/live` | `_ => false` (deps-free) | livenessProbe — restart loop só se processo travar |
| `/health/ready` | `h.Tags.Contains("ready")` (agg) | readinessProbe — remove pod do service quando deps cair |
| `/health` | sem filtro (alias retrocompat) | manter clients antigos funcionando |

### Test infrastructure

`ApiFactoryBase.InfraHealthCheckNamesToRemoveForTests` (novo override) filtra `postgres`/`redis`/`minio`/`kafka` por default. Sem isto, suites HTTP-only teriam `/health` Unhealthy permanente (mascarando regressões reais no pipeline auth/routing que elas testam). Suites com Testcontainers das deps sobrescrevem para conjunto vazio.

## Critérios de aceite (issue #345)

- [x] `AddUniPlusHealthChecks` extension registra Postgres+Redis+MinIO+Kafka
- [x] Cada `Program.cs` (3) chama o método
- [x] Endpoints separados: `/health/live`, `/health/ready`, `/health`
- [ ] Test integration: derrubar Postgres → readiness vira Unhealthy em 30s — **deferido** (necessitaria Testcontainers PG + restart, smoke E2E manual no cluster cobre isso)
- [ ] Test integration: derrubar Redis → readiness Unhealthy — **deferido** (mesma razão)
- [ ] OpenAPI documenta os 3 paths — **out-of-scope** (paths de health não são modeladas em OpenAPI no projeto; documentado em RUNBOOKS via uniplus-infra)
- [x] Pre-PR: `dotnet build` + `dotnet test` verdes (406 unit + 9 integration + 51 Selecao integration)

## Cobertura de testes

- **Unit (14 cases novos)**:
  - `CacheServiceCollectionExtensionsTests`: null guards × 3, validação Production, leniência Development, binding
  - `HealthChecksServiceCollectionExtensionsTests`: null guards × 3 (Theory), no-config, all-config, ready-tag em todos, only-postgres
- **Integration (2 cases novos)** com Testcontainers MinIO (existing fixture):
  - `MinioHealthCheckTests.CheckHealthAsync_MinioAcessivel_RetornaHealthy`
  - `MinioHealthCheckTests.CheckHealthAsync_MinioInacessivel_RetornaUnhealthy`

## Out of scope

- Smoke E2E completo das deps (PG/Kafka derrubando) → deferido para validação manual no cluster standalone (parte do § "Smoke E2E" da Epic #347)
- `/health/auth` específico para OIDC — ApiFactoryBase filter cobre o caso de teste sem precisar de novo endpoint

## Rollback

`git revert` do PR. Zero schema changes. RedisCacheService e RedisHealthCheck voltam a não funcionar em runtime (estado pré-PR), mas como nenhum endpoint produtivo usa ICacheService ainda, sem impacto operacional imediato.

## Referências

- Epic #347 — APIs Uni+ ponta a ponta no standalone
- ADR-009 do uniplus-infra — Kafka SASL_SSL + SCRAM
- PR #349 (#342) — DI MinIO (registra IMinioClient consumido aqui)
- PR #351 (#343) — KafkaSettings + KafkaSecurity (consumido pelo KafkaHealthCheck refatorado)
- Issue #346 — endpoints smoke E2E (próximo PR, depende deste)

Closes #345
Refs #347