### PR TITLE
feat(messaging): integra Apicurio Schema Registry com Avro e Wolverine (1º caso EditalPublicado)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,9 @@
 
     <!-- Messaging -->
     <PackageVersion Include="Confluent.Kafka" Version="2.14.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry" Version="2.14.0" />
+    <PackageVersion Include="Confluent.SchemaRegistry.Serdes.Avro" Version="2.14.0" />
+    <PackageVersion Include="Apache.Avro" Version="1.12.1" />
 
     <!-- Caching -->
     <PackageVersion Include="StackExchange.Redis" Version="2.12.8" />

--- a/docker/docker-compose.override.example.yml
+++ b/docker/docker-compose.override.example.yml
@@ -10,6 +10,9 @@ services:
       ConnectionStrings__SelecaoDb: "Host=postgres;Port=5432;Database=uniplus_selecao;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
       Redis__ConnectionString: "redis:6379"
       Kafka__BootstrapServers: "kafka:29092"
+      # Schema Registry (Apicurio em modo Confluent-compat) — sufixo /apis/ccompat/v7
+      # é mandatório (Apicurio 3.x). Auth desligada em dev (AuthType=None default).
+      SchemaRegistry__Url: "http://apicurio:8081/apis/ccompat/v7"
       Storage__Endpoint: "minio:9000"
       Storage__AccessKey: "${MINIO_ROOT_USER}"
       Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
@@ -22,6 +25,8 @@ services:
       redis:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      apicurio:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
@@ -41,6 +46,9 @@ services:
       ConnectionStrings__IngressoDb: "Host=postgres;Port=5432;Database=uniplus_ingresso;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}"
       Redis__ConnectionString: "redis:6379"
       Kafka__BootstrapServers: "kafka:29092"
+      # Schema Registry — Ingresso é consumer cross-módulo de eventos Selecao;
+      # SR Url permite recuperar schemas dos eventos publicados.
+      SchemaRegistry__Url: "http://apicurio:8081/apis/ccompat/v7"
       Storage__Endpoint: "minio:9000"
       Storage__AccessKey: "${MINIO_ROOT_USER}"
       Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
@@ -53,6 +61,8 @@ services:
       redis:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      apicurio:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -147,6 +147,31 @@ services:
       retries: 10
       start_period: 60s
 
+  apicurio:
+    # Apicurio Schema Registry — modo Confluent-compat para os clients .NET
+    # (Confluent.SchemaRegistry + Wolverine.Kafka.Serialization). Storage em
+    # memória para dev local — não é durável entre restarts; em standalone/HML/PROD
+    # o Postgres data-host é usado (apps/apicurio-registry chart no uniplus-infra).
+    # Endpoint Confluent-compat: http://localhost:8081/apis/ccompat/v7
+    # Auth desligada em dev (APICURIO_AUTH_ENABLED=false) — APIs locais usam
+    # SchemaRegistry__AuthType=None. ADR-0051.
+    image: apicurio/apicurio-registry:3.2.4
+    restart: unless-stopped
+    environment:
+      QUARKUS_HTTP_PORT: "8081"
+      APICURIO_STORAGE_KIND: "sql"
+      APICURIO_STORAGE_SQL_KIND: "h2"
+      APICURIO_AUTH_ENABLED: "false"
+      QUARKUS_OIDC_ENABLED: "false"
+    ports:
+      - "8081:8081"
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8081 && echo -e 'GET /q/health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && timeout 1 cat <&3 | grep -q '\"UP\"'"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
 volumes:
   postgres_data:
   minio_data:

--- a/docs/adrs/0051-apicurio-schema-registry-avro-wolverine.md
+++ b/docs/adrs/0051-apicurio-schema-registry-avro-wolverine.md
@@ -1,0 +1,142 @@
+---
+status: "accepted"
+date: "2026-05-09"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0051: Apicurio Schema Registry com Avro e Wolverine — schemas no Domain, registro idempotente, OAuth client_credentials
+
+## Contexto e enunciado do problema
+
+A [ADR-0014](0014-kafka-como-bus-assincrono-inter-modulos.md) estabelece Kafka como bus assíncrono inter-módulos do Uni+. A [ADR-0044](0044-roteamento-domain-events-pg-queue-kafka-opcional.md) define que `EditalPublicadoEvent` é roteado para PG queue intra-módulo (sempre) e Kafka cross-módulo (opcional, condicional a `Kafka:BootstrapServers` configurado).
+
+Faltava decidir o **wire format** dos eventos no Kafka. O `uniplus-infra` deployou o Apicurio Schema Registry (chart `apps/apicurio-registry/`, modo Confluent-compat) precisamente para isso. Esta ADR fecha o lado producer (uniplus-api) e estabelece pattern para subsequentes eventos.
+
+Decisões pendentes resolvidas:
+
+1. **Localização dos schemas:** `contracts/events/<modulo>/` (cross-cutting) ou `src/<modulo>/Domain/Events/Schemas/` (local ao bounded context)?
+2. **Forma de codegen:** classes `ISpecificRecord` geradas via tool em build (Avro Tools) ou escritas à mão?
+3. **Auth contra Apicurio:** static credentials, basic, ou OAuth `client_credentials` com Keycloak?
+4. **Quando registrar o schema no Apicurio:** runtime (Confluent serdes lazy) ou startup (idempotente)?
+5. **Cliente HTTP do Schema Registry:** múltiplas instâncias (uma por consumer Wolverine + uma para o hosted service) ou única compartilhada?
+
+## Drivers da decisão
+
+- **Manter Domain puro:** ADR-0002 — Domain depende apenas de SharedKernel; não pode ganhar referência a `Apache.Avro` nem a `Confluent.SchemaRegistry`.
+- **Cross-module sem build-time coupling:** ADR-0014 estabelece que módulos não compartilham assemblies de Domain. Schema Registry resolve isso via `schema-id` no envelope da mensagem — consumer pull do Apicurio em runtime.
+- **Operacional sob falha do Apicurio:** subscribers existentes (`EditalPublicadoEventHandler` na PG queue) precisam continuar funcionando mesmo se Apicurio estiver offline no boot. Hosted service não pode travar `IHost.StartAsync`.
+- **Single source of truth:** drift entre `.avsc` no Git e schema publicado no Apicurio = bug silencioso. Producer e hosted service devem ler do **mesmo** local.
+- **Auth coerente com OIDC clients M2M:** [uniplus-infra#163](https://github.com/unifesspa-edu-br/uniplus-infra/issues/163) já provisionou clients confidenciais `uniplus-api-{portal,selecao,ingresso}` com mappers `aud=apicurio-registry` + `groups=["/users/uniplus"]` precisamente para esse fluxo `client_credentials`.
+
+## Opções consideradas
+
+### 1. Localização dos schemas
+
+- **A. `contracts/events/<modulo>/` (cross-cutting).** Diretório fora dos módulos, simétrico aos baselines OpenAPI em `contracts/openapi.*.json`.
+- **B. `src/<modulo>/Domain/Events/Schemas/` (local ao bounded context).** Schema vive perto do evento de domínio.
+
+**Escolhida: B.** Schemas Avro são parte do contrato de saída do bounded context; vivem com o evento, no Domain. O bind como `<EmbeddedResource>` evita dependência de `Apache.Avro` no Domain — o `.avsc` é só texto.
+
+### 2. Forma de codegen das classes `ISpecificRecord`
+
+- **A. Codegen via Apache.Avro.Tools em build target MSBuild.** Standard. Adiciona complexidade de build (custom target).
+- **B. Classe escrita à mão seguindo `ISpecificRecord`.** Boilerplate ~80 linhas por evento. Schema lido do embedded resource via `Schema.Parse(...)` no static initializer.
+
+**Escolhida: B para o 1º caso.** Custo de boilerplate baixo (1 classe), evita complexidade de codegen no MSBuild para um único subject. Trigger de reavaliação: ≥3 schemas Avro no projeto, considerar codegen automatizado.
+
+### 3. Auth contra Apicurio
+
+- **A. None / desligada.** Apenas em dev local (compose).
+- **B. Basic auth.** Aceitável em lab simples.
+- **C. OAuth `client_credentials` (Bearer JWT) contra Keycloak.** Coerente com clients M2M já provisionados em [uniplus-infra#163](https://github.com/unifesspa-edu-br/uniplus-infra/issues/163) e role mapping em `apps/apicurio-registry/values.yaml`.
+
+**Escolhida: C para standalone/HML/PROD; A para dev.** Suporte a B mantido para casos edge (lab simples).
+
+### 4. Quando registrar o schema
+
+- **A. Runtime (Confluent serdes lazy).** Default da lib — registra no primeiro `Produce`. Race condition possível se múltiplos producers iniciam ao mesmo tempo. Sem schema = sem mensagem.
+- **B. Startup (hosted service idempotente).** Schema disponível no Apicurio antes da primeira mensagem. Race-free. Apicurio offline ≠ host trava (fail-graceful).
+- **C. CLI/script pré-deploy.** Schema fora do ciclo de vida da app. Operacional separado.
+
+**Escolhida: B + A (defesa em profundidade).** Hosted service tenta registrar no startup; se falhar (Apicurio offline), loga warning e segue. O Confluent serdes faz fallback automático em runtime. Cobre os 3 cenários: cluster novo, cluster com Apicurio temporariamente fora, cluster steady-state.
+
+### 5. Cliente HTTP do Schema Registry — múltiplas instâncias ou única
+
+- **A. Múltiplas (default ingenuo).** Cada consumer/producer cria seu cliente. Cache duplicado, possível inconsistência transiente entre caches.
+- **B. Única compartilhada.** Singleton no DI consumido pelo hosted service; mesma instância capturada no closure do `UseWolverineOutboxCascading` para o `SchemaRegistryAvroSerializer`. Single cache, single auth flow.
+
+**Escolhida: B.** Padrão `SchemaRegistryServiceCollectionExtensions.CreateClient(...)` em `Program.cs` cria o cliente uma vez, registra como singleton **antes** de `AddSchemaRegistry()` (que usa `TryAddSingleton` e respeita o registro prévio). O Wolverine routing captura no closure.
+
+## Resultado da decisão
+
+**Pacote completo:** schemas Avro vivem em `src/<modulo>/Domain/Events/Schemas/<Evento>.avsc` como `EmbeddedResource`. Classes `ISpecificRecord` escritas à mão em `src/<modulo>/Infrastructure/Messaging/Avro/<Evento>.cs` no namespace que casa **exatamente** com o do schema (Apache.Avro NET resolve via `Type.GetType("<namespace>.<name>")`). Cascading handler em `Selecao.Infrastructure` mapeia `<Evento>Event` (intra-módulo) para `<Evento>` (Avro, cross-módulo).
+
+Auth via `OAuthBearerAuthenticationHeaderValueProvider` (em `Infrastructure.Core`) que faz `client_credentials` contra Keycloak, cacheia o JWT até `exp - RefreshSkewSeconds`, renova proativamente. `AuthType=None` permite dev local sem auth.
+
+Hosted service `SchemaRegistrationHostedService` (em `Infrastructure.Core`) registra todos os subjects declarados via `AddSchemaRegistry().AddSchema(...)` no startup, **fail-graceful**: erro de auth/network loga warning e retorna. Confluent serdes lida com fallback em runtime.
+
+Cliente `ISchemaRegistryClient` é singleton único, criado em `Program.cs`, compartilhado entre hosted service (DI) e routing Wolverine (closure).
+
+**Convenções de naming**:
+
+- Schema namespace: `unifesspa.uniplus.<modulo>.events` (lowercase). Casa com o C# namespace da classe Avro — Apache.Avro NET é case-sensitive.
+- Schema name: `<Evento>` (sem suffix `Avro`).
+- Topic Kafka: `<dominio>_events` (snake_case, ADR-0014).
+- Subject SR: `<topic>-value` (Confluent SR convention).
+- Compatibility default: `BACKWARD`.
+
+**Estado atual** (snake-case Avro):
+
+```text
+src/selecao/Selecao.Domain/Events/Schemas/EditalPublicado.avsc  ─── namespace=unifesspa.uniplus.selecao.events, name=EditalPublicado
+src/selecao/Selecao.Infrastructure/Messaging/Avro/EditalPublicado.cs  ─── namespace casa com schema
+src/selecao/Selecao.Infrastructure/Messaging/EditalPublicadoToAvroMapper.cs
+src/selecao/Selecao.Infrastructure/Messaging/EditalPublicadoToKafkaCascadeHandler.cs
+```
+
+**Resource name canônico:** `Unifesspa.UniPlus.Selecao.Domain.Events.Schemas.EditalPublicado.avsc` (assembly + path no .csproj). Lido pelo hosted service via `Assembly.GetManifestResourceStream(...)`.
+
+## Consequências
+
+### Positivas
+
+- **Domain puro:** sem dep de Avro lib (apenas embedded resource).
+- **Cross-module sem coupling:** Ingresso futuro consume sem referenciar `Selecao.Domain` — pull do Apicurio.
+- **Compatibility enforced:** Apicurio rejeita mudanças que quebram BACKWARD; schema evolution é validada por mecanismo externo.
+- **Operacional resiliente:** Apicurio offline no boot não trava o host; runtime Confluent recupera quando o Apicurio volta.
+- **Configurável por env:** mesmo binário roda dev (sem auth), lab (basic), standalone/HML/PROD (OAuth) sem code change.
+- **Wire format Confluent:** consumers em qualquer linguagem (Java, Python, Go) funcionam pelo padrão `[magic][schema-id][payload]`.
+
+### Negativas
+
+- **Dois assemblies para 1 evento:** `EditalPublicadoEvent` (Domain) + `EditalPublicado` (Avro) com mapper trivial. Pode parecer ruído mas mantém Clean Architecture.
+- **Namespace lowercase em C#:** classes Avro fogem da convenção PascalCase para casar com schema namespace. CA1707 suprimido na classe (justificado).
+- **Boilerplate `ISpecificRecord` à mão:** ~80 linhas por evento. Aceitável para 1 caso; reavaliar codegen com 3+ schemas.
+- **2 caches no client (mitigado):** ao seguir o padrão de single client em `Program.cs` o cache é único; se algum dev futuro registrar um cliente novo, ficam dois.
+
+### Neutras
+
+- **Schema evolution policy formal não definida nesta ADR.** BACKWARD é o default Confluent — adequada para o caminho "consumers leem dados antigos com schema novo". FORWARD ou FULL serão decisão por subject quando houver caso real.
+- **Ingresso ainda não consume.** Routing existe, mas o evento `EditalPublicado` em Kafka não tem subscriber cross-módulo até "chamada de vagas" entrar em escopo.
+
+## Confirmação
+
+- `src/selecao/Selecao.Domain/Events/Schemas/EditalPublicado.avsc` é embedded resource (verificável via `dotnet build` + `unzip -l Selecao.Domain.dll`).
+- `Selecao.API/Program.cs` cria singleton `ISchemaRegistryClient` antes de `AddSchemaRegistry()`; Wolverine routing usa a mesma instância no closure.
+- Smoke unit tests em `tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Messaging/EditalPublicadoAvroTests.cs` cobrem schema parse + mapping + round-trip Avro binary (`SpecificDefaultWriter` ↔ `SpecificDefaultReader`).
+- `tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/SchemaRegistrySettingsValidatorTests.cs` cobre coerência de auth (None/Basic/OAuthBearer + cross-field).
+- `docker-compose.yml` ganhou serviço `apicurio` em modo Confluent-compat para smoke local; `docker-compose.override.yml` injeta `SchemaRegistry__Url=http://apicurio:8081/apis/ccompat/v7` nas APIs.
+
+## Mais informações
+
+- ADR-0014 — Kafka como bus assíncrono inter-módulos (regra "cross-module via Kafka apenas")
+- ADR-0044 — Roteamento de domain events PG queue + Kafka opcional (callback de routing onde se conecta o Avro serializer)
+- ADR-0005 — Cascading messages (mecanismo via qual o `EditalPublicado` Avro é encadeado a partir do `EditalPublicadoEvent`)
+- [uniplus-infra#163](https://github.com/unifesspa-edu-br/uniplus-infra/issues/163) — clients OIDC `uniplus-api-{portal,selecao,ingresso}` no realm
+- [uniplus-infra#152](https://github.com/unifesspa-edu-br/uniplus-infra/issues/152) — chart Apicurio Registry standalone
+- [Apicurio Registry — Confluent compat](https://www.apicur.io/registry/docs/apicurio-registry/3.x/getting-started/assembly-using-the-registry-client.html)
+- [Confluent .NET — Schema Registry serdes](https://github.com/confluentinc/confluent-kafka-dotnet/wiki/Schema-Registry)
+- [JasperFx Wolverine — Kafka transport, Schema Registry serializers](https://wolverinefx.io/guide/messaging/transports/kafka.html)
+- `docs/guia-apicurio-schema-registry.md` — guia operacional com troubleshooting
+- Origem: issue [#358](https://github.com/unifesspa-edu-br/uniplus-api/issues/358) — Story "Integração Apicurio Schema Registry"

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -79,6 +79,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0048](0048-controllers-mvc-public-com-ca1515-suprimido.md) | Controllers MVC em `*.API` devem ser `public`, com CA1515 suprimido por justificativa | accepted | 2026-05-05 |
 | [0049](0049-implementacao-hateoas-edital-resource-links-builder.md) | Implementação de HATEOAS Level 1 em `EditalDto` via `IResourceLinksBuilder<TDto>` na camada API | accepted | 2026-05-06 |
 | [0050](0050-registry-ghcr-e-tagging.md) | GitHub Container Registry e estratégia de tagging das imagens da `uniplus-api` | accepted | 2026-05-08 |
+| [0051](0051-apicurio-schema-registry-avro-wolverine.md) | Apicurio Schema Registry com Avro e Wolverine — schemas no Domain, registro idempotente, OAuth client_credentials | accepted | 2026-05-09 |
 
 ## Como adicionar um novo ADR
 

--- a/docs/guia-apicurio-schema-registry.md
+++ b/docs/guia-apicurio-schema-registry.md
@@ -1,0 +1,202 @@
+# Guia operacional — Apicurio Schema Registry no uniplus-api
+
+> **Audiência:** desenvolvedores e operadores do uniplus-api.  
+> **Pré-requisitos:** [ADR-0051](adrs/0051-apicurio-schema-registry-avro-wolverine.md) (decisões binding) +
+> [ADR-0044](adrs/0044-roteamento-domain-events-pg-queue-kafka-opcional.md) (routing PG queue/Kafka) +
+> RUNBOOKS §15 do `uniplus-infra` (Apicurio chart deploy + recuperação de `client_secret`).
+
+## O que é
+
+[Apicurio Schema Registry](https://www.apicur.io/registry/) é o **registro central de schemas Avro** dos eventos cross-módulo do Uni+. Em standalone roda em
+`schema-registry.standalone.portaluni.com.br` (chart `apps/apicurio-registry/` no `uniplus-infra`), em **modo Confluent-compat** — o cliente .NET (`Confluent.SchemaRegistry`) usa o endpoint `/apis/ccompat/v7` exatamente como contra um Confluent Schema Registry vanilla.
+
+**Por que Schema Registry:** garante compatibilidade entre producer e consumer. Ao invés de cada serviço carregar seu `.avsc` local e quebrar quando o outro evolui, o producer registra o schema no Apicurio e embute o `schema-id` no envelope da mensagem. Consumers recuperam o schema do Registry via `schema-id`, deserializam, e o servidor enforce regras de compatibility (default Uni+: **BACKWARD** — schemas novos podem ler dados antigos).
+
+## Arquitetura
+
+```
+┌──────────────────┐         ┌────────────────────┐
+│ Selecao.API      │  Kafka  │ Apicurio Registry  │
+│                  │ -------→│ (uniplus-infra)    │
+│ - PG queue       │         │ Confluent-compat   │
+│ - Kafka producer │ ←-------│ /apis/ccompat/v7   │
+│   (Avro serdes)  │  HTTPS  │                    │
+└──────┬───────────┘         └─────────┬──────────┘
+       │                               ▲
+       │                               │
+       │ Schema embedded               │ Schema fetch
+       │ resource (Domain)             │ por schema-id
+       │                               │
+       │                     ┌─────────┴──────────┐
+       │                     │ Ingresso.API       │
+       │                     │ (consumer futuro)  │
+       │                     └────────────────────┘
+       ▼
+┌──────────────────────────────────┐
+│ Selecao.Domain                   │
+│ Events/Schemas/EditalPublicado.avsc │
+└──────────────────────────────────┘
+```
+
+**Single source of truth:** o `.avsc` vive como **embedded resource** em `Selecao.Domain`. A classe `unifesspa.uniplus.selecao.events.EditalPublicado` (`Selecao.Infrastructure`) e o `SchemaRegistrationHostedService` (`Infrastructure.Core`) leem o mesmo recurso via reflection — não há cópia em outro arquivo.
+
+## Wiring no Program.cs
+
+```csharp
+// 1) Settings + cliente único (compartilhado entre hosted service e Wolverine).
+SchemaRegistrySettings selecaoSrSettings = builder.Configuration
+    .GetSection(SchemaRegistrySettings.SectionName)
+    .Get<SchemaRegistrySettings>() ?? new SchemaRegistrySettings();
+
+ISchemaRegistryClient? selecaoSrClient = null;
+if (!string.IsNullOrWhiteSpace(selecaoSrSettings.Url))
+{
+    using ILoggerFactory bootstrapLoggerFactory = LoggerFactory.Create(b => b.AddSerilog());
+    selecaoSrClient = SchemaRegistryServiceCollectionExtensions.CreateClient(
+        selecaoSrSettings,
+        bootstrapLoggerFactory);
+    builder.Services.AddSingleton(selecaoSrClient);
+}
+
+// 2) Hosted service idempotente registra subjects no Apicurio no startup.
+builder.Services.AddSchemaRegistry(builder.Configuration)
+    .AddSchema(
+        subject: "edital_events-value",
+        schemaResourceName: unifesspa.uniplus.selecao.events.EditalPublicado.SchemaResourceName,
+        resourceAssembly: typeof(EditalPublicadoEvent).Assembly);
+
+// 3) Wolverine routing: cascade EditalPublicadoEvent → EditalPublicado (Avro) → Kafka.
+builder.Host.UseWolverineOutboxCascading(builder.Configuration, "SelecaoDb",
+    configureRouting: opts =>
+    {
+        opts.Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly);
+        opts.Discovery.IncludeAssembly(typeof(EditalPublicadoToKafkaCascadeHandler).Assembly);
+
+        opts.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
+        opts.ListenToPostgresqlQueue("domain-events");
+
+        bool kafkaConfigured = !string.IsNullOrWhiteSpace(builder.Configuration["Kafka:BootstrapServers"]);
+        if (kafkaConfigured && selecaoSrClient is not null)
+        {
+            opts.PublishMessage<unifesspa.uniplus.selecao.events.EditalPublicado>()
+                .ToKafkaTopic("edital_events")
+                .DefaultSerializer(new SchemaRegistryAvroSerializer(selecaoSrClient));
+        }
+    });
+```
+
+**Pontos importantes:**
+
+1. **Feature off:** `SchemaRegistry:Url` vazio → cliente não é construído, hosted service não é registrado, routing Avro é skippado. APIs sobem sem Apicurio (dev local sem o serviço).
+2. **Cliente único:** o singleton no DI é a mesma instância capturada no closure do callback Wolverine. Evita 2 caches.
+3. **Cascade:** o handler `EditalPublicadoToKafkaCascadeHandler` (em `Selecao.Infrastructure`) projeta o evento de domínio (`EditalPublicadoEvent`, intra-módulo) em `EditalPublicado` (Avro, cross-módulo). Application/Domain ficam puros — não conhecem `Apache.Avro`.
+4. **Outbox cascade:** o `EditalPublicado` (Avro) é instalado no outbox **dentro** da transação do listener da PG queue. Se o publish para Kafka falhar, o Wolverine retenta a partir do outbox (at-least-once). Consumers cross-módulo deduplicam por `EventId` (UUID v7).
+
+## Configuração — modos de auth
+
+### Dev local (compose)
+
+```yaml
+SchemaRegistry__Url: "http://apicurio:8081/apis/ccompat/v7"
+# AuthType padrão = None — Apicurio compose tem auth desligada.
+```
+
+### Standalone / HML / PROD (OIDC client_credentials contra Keycloak)
+
+```yaml
+SchemaRegistry__Url: "https://schema-registry.standalone.portaluni.com.br/apis/ccompat/v7"
+SchemaRegistry__AuthType: "OAuthBearer"
+SchemaRegistry__OAuth__TokenEndpoint: "https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token"
+SchemaRegistry__OAuth__ClientId: "uniplus-api-selecao"  # ou portal/ingresso
+SchemaRegistry__OAuth__ClientSecret: "${OIDC_CLIENT_SECRET}"  # via ESO 5 → Vault
+```
+
+O `OIDC_CLIENT_SECRET` chega via `ExternalSecret` do chart Helm da API (`apps/uniplus-api-selecao/templates/externalsecret.yaml` ESO 5 no `uniplus-infra`), que sintetiza um Secret K8s a partir de `secret/standalone/keycloak/clients/uniplus-api-selecao` no Vault. RUNBOOKS §15.6 do `uniplus-infra` documenta a recuperação inicial via `kcadm.sh`.
+
+### Basic auth (lab simples)
+
+```yaml
+SchemaRegistry__Url: "http://schema-registry-lab/apis/ccompat/v7"
+SchemaRegistry__AuthType: "Basic"
+SchemaRegistry__BasicAuthUserInfo: "admin:${APICURIO_BASIC_AUTH_PASSWORD}"
+```
+
+## Comportamento operacional
+
+### Startup
+
+1. `SchemaRegistrySettingsValidator` (registrado via `IValidateOptions` + `ValidateOnStart`) verifica coerência da config — falha imediata em `IHost.StartAsync` se algo está inconsistente (e.g. `AuthType=OAuthBearer` sem `ClientSecret`).
+2. `SchemaRegistrationHostedService` itera sobre todas as `SchemaRegistration`s no DI, lê o `.avsc` do embedded resource e chama `RegisterSchemaAsync(subject, schema, normalize=true)` — **idempotente:** Apicurio retorna o mesmo `schema-id` para schemas equivalentes.
+3. Se Apicurio estiver offline, o hosted service **loga warning** e **retorna** — host segue subindo. O `SchemaRegistryAvroSerializer` da Confluent tenta novamente em runtime na primeira mensagem.
+
+### Producer
+
+- Wolverine entrega a mensagem ao transport Kafka conforme `PublishMessage<T>().ToKafkaTopic(...)`.
+- O `SchemaRegistryAvroSerializer` consulta o `ISchemaRegistryClient` (cache local em RAM), obtém ou registra o `schema-id`, e empacota:
+
+```
+[magic byte: 0x00] [schema-id: 4 bytes BE] [payload Avro binary]
+```
+
+- Schema-id local é cacheado — chamadas subsequentes não batem na rede.
+
+### Consumer
+
+- Recebe o envelope, lê `schema-id`, faz `GetSchemaAsync(schemaId)` (cache local). Deserializa o payload conforme schema retornado.
+- **Sem dependência** do assembly do producer: o consumer pode estar em outra linguagem (Java, Python) ou outro módulo .NET (Ingresso) sem referenciar `Selecao.Domain`.
+
+### Compatibility check
+
+- Apicurio aplica a regra de compatibility configurada por subject (default global do chart Uni+: **BACKWARD**).
+- Quando o producer registra um schema novo (evolução), Apicurio compara com a versão anterior. Incompatível → 409 Conflict, hosted service loga error e segue (host não trava). Producer continua tentando registrar em runtime (Confluent serdes loga e retenta).
+
+## Adicionando um novo evento
+
+Padrão concreto. Para acrescentar `InscricaoCriadaEvent` (módulo Selecao):
+
+1. **Schema:** crie `src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/Schemas/InscricaoCriada.avsc` — namespace = `unifesspa.uniplus.selecao.events`, name = `InscricaoCriada`. Já é embedded resource (csproj tem `*.avsc`).
+2. **Classe Avro:** `src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/Avro/InscricaoCriada.cs` — namespace `unifesspa.uniplus.selecao.events` (case-sensitive, casa com schema), implementa `ISpecificRecord`, propriedades batem com fields do schema.
+3. **Mapper:** `Selecao.Infrastructure/Messaging/InscricaoCriadaToAvroMapper.cs` — função pura `InscricaoCriadaEvent → unifesspa.uniplus.selecao.events.InscricaoCriada`.
+4. **Cascade handler:** classe estática que retorna o Avro a partir do evento (Wolverine descobre via `IncludeAssembly`).
+5. **Routing:** em `Program.cs`, adicione `opts.PublishMessage<unifesspa.uniplus.selecao.events.InscricaoCriada>().ToKafkaTopic("inscricao_events").DefaultSerializer(new SchemaRegistryAvroSerializer(selecaoSrClient));`
+6. **Registro:** adicione `.AddSchema("inscricao_events-value", InscricaoCriada.SchemaResourceName, typeof(InscricaoCriadaEvent).Assembly)` na chain de `AddSchemaRegistry`.
+
+## Troubleshooting
+
+| Sintoma | Causa provável | Resolução |
+|---|---|---|
+| API trava em `StartAsync` com erro de bind | `SchemaRegistrySettingsValidator` falhou | Logs mostram a falha exata. Conferir env vars `SchemaRegistry__*` |
+| Hosted service loga `Falha ao registrar schema Avro no startup` | Apicurio offline, auth inválida, ou DNS não resolve | Logs incluem o subject; Apicurio side: `kubectl logs deploy/apicurio-registry`. Após Apicurio voltar, registro tenta novamente em runtime |
+| Producer falha com `SchemaRegistryException: Schema being registered is incompatible` | Mudança no `.avsc` quebra BACKWARD compatibility | Re-pensar evolução — campos novos devem ter default; remoção exige etapa intermediária |
+| Consumer recebe `AvroException: Unable to find type 'unifesspa...EditalPublicado'` | Namespace do `.avsc` não casa com namespace da classe C# | Apache.Avro NET resolve via `Type.GetType("&lt;ns&gt;.&lt;name&gt;")` — namespace lowercase é mandatório quando o schema usa lowercase |
+| Token endpoint retorna 401 | Vault não populado ou client_secret rotacionado | RUNBOOKS §15.6 do `uniplus-infra` — re-recuperar via `kcadm.sh get clients/$CID/client-secret` |
+| Wolverine envia `byte[]` JSON em vez de Avro | `selecaoSrClient` é `null` (URL vazia) ou Kafka não configurado | Conferir `SchemaRegistry__Url` + `Kafka__BootstrapServers` ambos populados |
+
+## Compose local — smoke
+
+```bash
+# Sobe Apicurio (e Kafka, Postgres, etc)
+docker compose -f docker/docker-compose.yml up -d apicurio kafka postgres
+
+# Health
+curl http://localhost:8081/q/health/ready
+
+# Sobe APIs em dev
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d --build selecao-api
+
+# Inspeciona o schema registrado
+curl http://localhost:8081/apis/ccompat/v7/subjects/edital_events-value/versions/latest
+
+# Publica via endpoint (cria + publica edital → cascade dispara → Avro vai para Kafka)
+curl -X POST http://localhost:5202/api/editais ...
+```
+
+## Referências
+
+- ADR-0051 — Apicurio Schema Registry: Avro + Wolverine (decisões binding)
+- ADR-0014 — Kafka como bus assíncrono inter-módulos
+- ADR-0044 — Roteamento de domain events (PG queue + Kafka opcional)
+- [Confluent .NET Schema Registry docs](https://github.com/confluentinc/confluent-kafka-dotnet/wiki/Schema-Registry)
+- [Apicurio Registry docs — Confluent compat mode](https://www.apicur.io/registry/docs/apicurio-registry/3.x/getting-started/assembly-using-the-registry-client.html)
+- `uniplus-infra/apps/apicurio-registry/values.yaml` — chart Helm + role mapping `/users/uniplus → sr-developer`
+- `uniplus-infra/docs/RUNBOOKS.md §15` — operação Apicurio standalone

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
@@ -32,39 +32,10 @@
           "Serilog.Sinks.File": "7.0.0"
         }
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -977,7 +948,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1016,6 +989,16 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
       "Confluent.Kafka": {
         "type": "CentralTransitive",
         "requested": "[2.14.0, )",
@@ -1023,6 +1006,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
@@ -37,39 +37,10 @@
           "Npgsql": "10.0.2"
         }
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -982,7 +953,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1011,6 +984,16 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
       "Confluent.Kafka": {
         "type": "CentralTransitive",
         "requested": "[2.14.0, )",
@@ -1018,6 +1001,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {

--- a/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
@@ -32,39 +32,10 @@
           "Serilog.Sinks.File": "7.0.0"
         }
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -977,7 +948,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1016,6 +989,16 @@
           "Unifesspa.UniPlus.Portal.Domain": "[1.0.0, )"
         }
       },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
       "Confluent.Kafka": {
         "type": "CentralTransitive",
         "requested": "[2.14.0, )",
@@ -1023,6 +1006,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
@@ -37,39 +37,10 @@
           "Npgsql": "10.0.2"
         }
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -982,7 +953,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1011,6 +984,16 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
       "Confluent.Kafka": {
         "type": "CentralTransitive",
         "requested": "[2.14.0, )",
@@ -1018,6 +1001,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -92,14 +92,39 @@ SchemaRegistrySettings selecaoSrSettings = builder.Configuration
 // ADR-0051 estabelece que mensagens em tópicos cross-módulo do Uni+ vão sempre
 // como Avro com schema-id no envelope. Sem SR, o publishing seria silenciosamente
 // desligado — consumers cross-módulo parariam de receber sem qualquer erro no
-// boot. Falha imediata orientando o operador é o correto.
+// boot. Falha imediata orientando o operador é o correto em ambientes produtivos.
+//
+// Test factories (CascadingFixture e similares) sobem Wolverine com Kafka real
+// mas sem SR para testar cascading puro — em ASPNETCORE_ENVIRONMENT=Test/Development
+// degradamos para warning ao invés de exceção, mantendo o fail-fast para
+// Production/Staging/Standalone onde a config real do operador rege.
 bool kafkaEnabledForBuilder = !string.IsNullOrWhiteSpace(builder.Configuration["Kafka:BootstrapServers"]);
-if (kafkaEnabledForBuilder && string.IsNullOrWhiteSpace(selecaoSrSettings.Url))
+bool srMissing = string.IsNullOrWhiteSpace(selecaoSrSettings.Url);
+if (kafkaEnabledForBuilder && srMissing)
 {
-    throw new InvalidOperationException(
-        "Configuração inválida: Kafka:BootstrapServers populado mas SchemaRegistry:Url vazio. "
-        + "ADR-0051 exige Schema Registry para todo publishing cross-módulo. "
-        + "Configure SchemaRegistry:Url (ou desligue Kafka apagando Kafka:BootstrapServers).");
+    bool isProductiveEnvironment =
+        !builder.Environment.IsDevelopment()
+        && !string.Equals(builder.Environment.EnvironmentName, "Test", StringComparison.OrdinalIgnoreCase);
+
+    if (isProductiveEnvironment)
+    {
+        throw new InvalidOperationException(
+            "Configuração inválida: Kafka:BootstrapServers populado mas SchemaRegistry:Url vazio em "
+            + $"ASPNETCORE_ENVIRONMENT={builder.Environment.EnvironmentName}. "
+            + "ADR-0051 exige Schema Registry para todo publishing cross-módulo em ambientes produtivos. "
+            + "Configure SchemaRegistry:Url (ou desligue Kafka apagando Kafka:BootstrapServers).");
+    }
+
+    using ILoggerFactory missingSrLoggerFactory = LoggerFactory.Create(static b => b.AddSerilog());
+    Microsoft.Extensions.Logging.ILogger missingSrLogger = missingSrLoggerFactory.CreateLogger("Selecao.API.Bootstrap");
+#pragma warning disable CA1848 // Bootstrap logging — fora do hot path; LoggerMessage source generator overkill aqui.
+#pragma warning disable CA2254 // Mensagem fixa após format de string interpolada — sem placeholders dinâmicos.
+    missingSrLogger.LogWarning(
+        "Kafka habilitado sem Schema Registry em ambiente {Env} — publishing Avro cross-módulo desligado. "
+        + "Esperado em test factory que isola cascading puro; sinal de bug em ambiente produtivo (ADR-0051).",
+        builder.Environment.EnvironmentName);
+#pragma warning restore CA2254
+#pragma warning restore CA1848
 }
 
 ISchemaRegistryClient? selecaoSrClient = null;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -88,6 +88,20 @@ SchemaRegistrySettings selecaoSrSettings = builder.Configuration
     .GetSection(SchemaRegistrySettings.SectionName)
     .Get<SchemaRegistrySettings>() ?? new SchemaRegistrySettings();
 
+// Invariante operacional: Kafka habilitado exige Schema Registry configurado.
+// ADR-0051 estabelece que mensagens em tópicos cross-módulo do Uni+ vão sempre
+// como Avro com schema-id no envelope. Sem SR, o publishing seria silenciosamente
+// desligado — consumers cross-módulo parariam de receber sem qualquer erro no
+// boot. Falha imediata orientando o operador é o correto.
+bool kafkaEnabledForBuilder = !string.IsNullOrWhiteSpace(builder.Configuration["Kafka:BootstrapServers"]);
+if (kafkaEnabledForBuilder && string.IsNullOrWhiteSpace(selecaoSrSettings.Url))
+{
+    throw new InvalidOperationException(
+        "Configuração inválida: Kafka:BootstrapServers populado mas SchemaRegistry:Url vazio. "
+        + "ADR-0051 exige Schema Registry para todo publishing cross-módulo. "
+        + "Configure SchemaRegistry:Url (ou desligue Kafka apagando Kafka:BootstrapServers).");
+}
+
 ISchemaRegistryClient? selecaoSrClient = null;
 if (!string.IsNullOrWhiteSpace(selecaoSrSettings.Url))
 {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -1,5 +1,7 @@
 using Serilog;
 
+using Confluent.SchemaRegistry;
+
 using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
 using Unifesspa.UniPlus.Infrastructure.Core.Cors;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
@@ -7,6 +9,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 using Unifesspa.UniPlus.Infrastructure.Core.Logging;
 using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Infrastructure.Core.Smoke;
@@ -16,9 +19,11 @@ using Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
 using Unifesspa.UniPlus.Selecao.Application.Mappings;
 using Unifesspa.UniPlus.Selecao.Domain.Events;
 using Unifesspa.UniPlus.Selecao.Infrastructure;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
 using Wolverine.Kafka;
+using Wolverine.Kafka.Serialization;
 using Wolverine.Postgresql;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -74,6 +79,33 @@ builder.Services.AddSelecaoApplication();
 // InMemoryCollection sem precisar re-registrar o DbContext.
 builder.Services.AddSelecaoInfrastructure();
 
+// Schema Registry (ADR-0051) — feature off quando SchemaRegistry:Url está vazio.
+// Cliente único reutilizado pelo hosted service (registro idempotente no startup)
+// e pelo Wolverine routing (SchemaRegistryAvroSerializer no producer Kafka).
+// Singleton registrado ANTES do AddSchemaRegistry para que o TryAddSingleton
+// interno respeite a instância pré-criada e não duplique cache.
+SchemaRegistrySettings selecaoSrSettings = builder.Configuration
+    .GetSection(SchemaRegistrySettings.SectionName)
+    .Get<SchemaRegistrySettings>() ?? new SchemaRegistrySettings();
+
+ISchemaRegistryClient? selecaoSrClient = null;
+if (!string.IsNullOrWhiteSpace(selecaoSrSettings.Url))
+{
+    using ILoggerFactory bootstrapLoggerFactory = LoggerFactory.Create(static b => b.AddSerilog());
+#pragma warning disable CA2000 // Singleton no DI — IHost dispõe na shutdown.
+    selecaoSrClient = SchemaRegistryServiceCollectionExtensions.CreateClient(
+        selecaoSrSettings,
+        bootstrapLoggerFactory);
+#pragma warning restore CA2000
+    builder.Services.AddSingleton(selecaoSrClient);
+}
+
+builder.Services.AddSchemaRegistry(builder.Configuration)
+    .AddSchema(
+        subject: "edital_events-value",
+        schemaResourceName: unifesspa.uniplus.selecao.events.EditalPublicado.SchemaResourceName,
+        resourceAssembly: typeof(EditalPublicadoEvent).Assembly);
+
 // Wolverine como backbone CQRS/messaging com outbox transacional —
 // ver ADR-0003, ADR-0004 e ADR-0005.
 //
@@ -87,8 +119,10 @@ builder.Services.AddSelecaoInfrastructure();
 //   - PublishDomainEventsFromEntityFrameworkCore NÃO é chamado (ADR-0005):
 //     drenagem de EntityBase.DomainEvents via cascading messages no
 //     retorno do handler (IEnumerable<object>), não pelo scraper EF.
-//   - Routing de EditalPublicadoEvent: PG queue "domain-events" +
-//     tópico Kafka "edital_events" quando bootstrap configurado.
+//   - Routing de EditalPublicadoEvent: PG queue "domain-events" intra-módulo;
+//     o cascading handler EditalPublicadoToKafkaCascadeHandler (Selecao.Infrastructure)
+//     projeta para EditalPublicadoAvro, que é roteado ao tópico Kafka
+//     "edital_events" com Confluent SR Avro serializer (ADR-0051).
 //
 // A leitura de connection string e Kafka bootstrap acontece dentro do
 // callback de UseWolverine no startup do host. Em testes integrados,
@@ -101,16 +135,24 @@ builder.Host.UseWolverineOutboxCascading(
     configureRouting: opts =>
     {
         // Wolverine escaneia o entry assembly (Selecao.API) por padrão; handlers
-        // produtivos vivem em Selecao.Application — incluir explicitamente para
-        // que PublicarEditalCommandHandler (e futuros) sejam descobertos.
+        // produtivos vivem em Selecao.Application e Selecao.Infrastructure —
+        // incluir explicitamente para que PublicarEditalCommandHandler e o
+        // cascading EditalPublicadoToKafkaCascadeHandler sejam descobertos.
         opts.Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly);
+        opts.Discovery.IncludeAssembly(typeof(EditalPublicadoToKafkaCascadeHandler).Assembly);
 
         opts.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
         opts.ListenToPostgresqlQueue("domain-events");
 
-        if (!string.IsNullOrWhiteSpace(builder.Configuration["Kafka:BootstrapServers"]))
+        bool kafkaConfigured = !string.IsNullOrWhiteSpace(builder.Configuration["Kafka:BootstrapServers"]);
+        if (kafkaConfigured && selecaoSrClient is not null)
         {
-            opts.PublishMessage<EditalPublicadoEvent>().ToKafkaTopic("edital_events");
+            // Kafka habilitado + Schema Registry disponível: produz Avro com schema-id
+            // no envelope (Confluent wire format). Consumers cross-módulo recuperam o
+            // schema do Apicurio via schema-id, sem dependência do assembly Selecao.Domain.
+            opts.PublishMessage<unifesspa.uniplus.selecao.events.EditalPublicado>()
+                .ToKafkaTopic("edital_events")
+                .DefaultSerializer(new SchemaRegistryAvroSerializer(selecaoSrClient));
         }
     });
 builder.Services.AddWolverineMessaging();

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
@@ -53,39 +53,10 @@
           "WolverineFx.RDBMS": "5.32.1"
         }
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -998,7 +969,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1040,11 +1013,23 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.14.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
         }
       },
       "Confluent.Kafka": {
@@ -1054,6 +1039,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation.DependencyInjectionExtensions": {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/Schemas/EditalPublicado.avsc
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/Schemas/EditalPublicado.avsc
@@ -1,0 +1,31 @@
+{
+  "type": "record",
+  "namespace": "unifesspa.uniplus.selecao.events",
+  "name": "EditalPublicado",
+  "doc": "Evento Avro emitido quando um Edital atinge o estado Publicado. Subject Confluent SR: edital_events-value. Compatibilidade default: BACKWARD.",
+  "fields": [
+    {
+      "name": "EventId",
+      "type": "string",
+      "doc": "UUID v7 do evento (rastreabilidade fim-a-fim, idempotência cross-consumer)."
+    },
+    {
+      "name": "OccurredOn",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Instante de emissão UTC em milissegundos desde a epoch Unix."
+    },
+    {
+      "name": "EditalId",
+      "type": "string",
+      "doc": "UUID v7 do agregado Edital (chave estável cross-módulo)."
+    },
+    {
+      "name": "NumeroEdital",
+      "type": "string",
+      "doc": "Identificador humano do edital, e.g. \"001/2026\"."
+    }
+  ]
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Unifesspa.UniPlus.Selecao.Domain.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Unifesspa.UniPlus.Selecao.Domain.csproj
@@ -4,4 +4,18 @@
     <ProjectReference Include="..\..\shared\Unifesspa.UniPlus.Kernel\Unifesspa.UniPlus.Kernel.csproj" />
   </ItemGroup>
 
+  <!--
+    Schemas Avro de eventos de domínio (ADR-0051).
+    Embedded resource consumido em runtime por:
+    - SchemaRegistrationHostedService (registra subjects no Apicurio no startup)
+    - Classes ISpecificRecord em Selecao.Infrastructure (Schema.Parse via manifest)
+
+    Domain não depende de Apache.Avro nem de qualquer cliente Schema Registry —
+    o .avsc é apenas texto carregado por consumidores externos via reflection
+    no assembly. Mantém a regra "Domain → SharedKernel apenas".
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="Events\Schemas\*.avsc" />
+  </ItemGroup>
+
 </Project>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/Avro/EditalPublicado.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/Avro/EditalPublicado.cs
@@ -1,0 +1,120 @@
+// O namespace abaixo não é PascalCase porque deve casar exatamente com o
+// `namespace` declarado no schema Avro (Apache.Avro NET resolve a classe via
+// reflection usando <namespace>.<name> qualificado). Manter alinhado com
+// `Events/Schemas/EditalPublicado.avsc` em Selecao.Domain.
+#pragma warning disable CA1050 // Declare types in namespaces — namespace declarado, mas em lowercase.
+namespace unifesspa.uniplus.selecao.events;
+#pragma warning restore CA1050
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using global::Avro;
+using global::Avro.Specific;
+using EditalPublicadoEvent = Unifesspa.UniPlus.Selecao.Domain.Events.EditalPublicadoEvent;
+
+/// <summary>
+/// Wire-form Avro do <see cref="EditalPublicadoEvent"/> para publicação em Kafka via
+/// Confluent Schema Registry (Apicurio em modo Confluent-compat).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Classe escrita à mão (não codegen) seguindo a interface <c>ISpecificRecord</c> do
+/// Apache Avro 1.12. <b>Namespace e nome devem casar exatamente</b> com o declarado em
+/// <c>Events/Schemas/EditalPublicado.avsc</c> (Selecao.Domain) — Apache.Avro NET usa
+/// reflection (<c>Type.GetType("&lt;namespace&gt;.&lt;name&gt;")</c>) na desserialização
+/// para instanciar o tipo. Drift = <c>Avro.AvroException: Unable to find type</c>
+/// no consumer.
+/// </para>
+/// <para>
+/// O schema é carregado uma única vez do embedded resource em
+/// <see cref="EditalPublicadoEvent"/>'s assembly (Selecao.Domain) — single source of
+/// truth, evita drift entre o JSON publicado no Apicurio e a forma serializada.
+/// </para>
+/// <para>
+/// Mapeamento <see cref="EditalPublicadoEvent"/> → <see cref="EditalPublicado"/> fica em
+/// <c>Selecao.Infrastructure.Messaging.EditalPublicadoToAvroMapper</c> e é executado
+/// pelo cascading handler <c>EditalPublicadoToKafkaCascadeHandler</c> ao consumir o
+/// evento da PG queue intra-módulo. Consumidores cross-módulo recuperam o schema do
+/// Apicurio via schema-id no envelope da mensagem — não dependem deste assembly.
+/// </para>
+/// </remarks>
+[SuppressMessage(
+    "Naming",
+    "CA1707:Identifiers should not contain underscores",
+    Justification = "Namespace lowercase exigido pelo binding Apache.Avro NET (precisa casar com 'namespace' do .avsc).")]
+[SuppressMessage(
+    "Naming",
+    "CA1300:Specify MessageBoxOptions",
+    Justification = "False positive — atributo aplicável a UI; classe é POCO de mensagem.")]
+public sealed class EditalPublicado : ISpecificRecord
+{
+    public const string SchemaResourceName = "Unifesspa.UniPlus.Selecao.Domain.Events.Schemas.EditalPublicado.avsc";
+
+    private static readonly Lazy<Schema> SchemaInstance = new(LoadSchemaFromDomainAssembly);
+
+    /// <summary>Schema Avro carregado do embedded resource em Selecao.Domain.</summary>
+    public static Schema AvroSchema => SchemaInstance.Value;
+
+    /// <inheritdoc />
+    public Schema Schema => AvroSchema;
+
+    /// <summary>UUID v7 do evento (rastreabilidade fim-a-fim, idempotência cross-consumer).</summary>
+    public string EventId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Instante de emissão UTC. O schema declara <c>{type:long, logicalType:timestamp-millis}</c>;
+    /// Apache.Avro converte automaticamente entre <see cref="DateTime"/> (logical) e
+    /// <see cref="long"/> (base, ms desde epoch Unix) na serialização.
+    /// </summary>
+    public DateTime OccurredOn { get; set; }
+
+    /// <summary>UUID v7 do agregado Edital (chave estável cross-módulo).</summary>
+    public string EditalId { get; set; } = string.Empty;
+
+    /// <summary>Identificador humano do edital, e.g. "001/2026".</summary>
+    public string NumeroEdital { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public object Get(int fieldPos) => fieldPos switch
+    {
+        0 => EventId,
+        1 => OccurredOn,
+        2 => EditalId,
+        3 => NumeroEdital,
+        _ => throw new AvroRuntimeException($"Posição de campo inválida em EditalPublicado.Get: {fieldPos}"),
+    };
+
+    /// <inheritdoc />
+    public void Put(int fieldPos, object fieldValue)
+    {
+        switch (fieldPos)
+        {
+            case 0:
+                EventId = (string)fieldValue;
+                break;
+            case 1:
+                OccurredOn = (DateTime)fieldValue;
+                break;
+            case 2:
+                EditalId = (string)fieldValue;
+                break;
+            case 3:
+                NumeroEdital = (string)fieldValue;
+                break;
+            default:
+                throw new AvroRuntimeException($"Posição de campo inválida em EditalPublicado.Put: {fieldPos}");
+        }
+    }
+
+    private static Schema LoadSchemaFromDomainAssembly()
+    {
+        System.Reflection.Assembly asm = typeof(EditalPublicadoEvent).Assembly;
+        using Stream? stream = asm.GetManifestResourceStream(SchemaResourceName)
+            ?? throw new InvalidOperationException(
+                $"Schema Avro '{SchemaResourceName}' não encontrado como embedded resource em '{asm.FullName}'. " +
+                "Verifique que o arquivo está em Selecao.Domain/Events/Schemas/ e que o csproj inclui <EmbeddedResource Include=\"Events\\Schemas\\*.avsc\" />.");
+        using StreamReader reader = new(stream);
+        return Schema.Parse(reader.ReadToEnd());
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToAvroMapper.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToAvroMapper.cs
@@ -1,0 +1,34 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
+
+using System;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using EditalPublicadoAvro = unifesspa.uniplus.selecao.events.EditalPublicado;
+
+/// <summary>
+/// Conversão entre <see cref="EditalPublicadoEvent"/> (record interno do Domain) e
+/// <see cref="EditalPublicadoAvro"/> (forma wire publicada em Kafka via Confluent SR).
+/// </summary>
+/// <remarks>
+/// Mapping puro sem efeitos colaterais. Posicionado em Infrastructure para não infectar
+/// Domain/Application com dependência de Apache.Avro. Executado pelo cascading handler
+/// <c>EditalPublicadoToKafkaCascadeHandler</c> que dispara quando o evento é consumido
+/// na PG queue intra-módulo (ADR-0044).
+/// </remarks>
+public static class EditalPublicadoToAvroMapper
+{
+    public static EditalPublicadoAvro ToAvro(EditalPublicadoEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        return new EditalPublicadoAvro
+        {
+            EventId = evt.EventId.ToString(),
+            // Apache.Avro com logicalType=timestamp-millis espera DateTime; o serializer
+            // converte para long (ms desde epoch Unix UTC) automaticamente. UtcDateTime
+            // garante Kind=Utc — Apache.Avro arredonda truncando frações de ms.
+            OccurredOn = evt.OccurredOn.UtcDateTime,
+            EditalId = evt.EditalId.ToString(),
+            NumeroEdital = evt.NumeroEdital,
+        };
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToKafkaCascadeHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToKafkaCascadeHandler.cs
@@ -1,0 +1,34 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
+
+using System.Diagnostics.CodeAnalysis;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using EditalPublicadoAvro = unifesspa.uniplus.selecao.events.EditalPublicado;
+
+/// <summary>
+/// Handler convention-based do Wolverine que projeta <see cref="EditalPublicadoEvent"/>
+/// (intra-módulo, PG queue) em <see cref="EditalPublicadoAvro"/> (cross-módulo, Kafka)
+/// via cascading message.
+/// </summary>
+/// <remarks>
+/// Quando o evento é consumido da PG queue <c>domain-events</c> (ADR-0044), Wolverine
+/// dispara todos os handlers com assinatura compatível em paralelo —
+/// <c>EditalPublicadoEventHandler</c> (logging, em Application) e este cascade handler
+/// (em Infrastructure). O retorno deste handler é tratado como mensagem encadeada e
+/// roteada conforme as regras de <c>PublishMessage&lt;EditalPublicadoAvro&gt;()</c> em
+/// <c>Program.cs</c> (Kafka topic <c>edital_events</c> com serializer Confluent SR Avro).
+/// <para>
+/// O envelope Avro é instalado no outbox dentro da transação do listener da PG queue —
+/// se o publish para Kafka falhar, o Wolverine retenta a partir do outbox, garantindo
+/// at-least-once para o consumidor cross-módulo. A duplicação eventual é tratada pela
+/// idempotência exigida pela ADR-0014 (consumers deduplicam por <c>EventId</c>).
+/// </para>
+/// </remarks>
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção do projeto: handlers de cascade de eventos terminam em Handler, ver EditalPublicadoEventHandler.")]
+public sealed class EditalPublicadoToKafkaCascadeHandler
+{
+    public static EditalPublicadoAvro Handle(EditalPublicadoEvent @event)
+        => EditalPublicadoToAvroMapper.ToAvro(@event);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Unifesspa.UniPlus.Selecao.Infrastructure.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Unifesspa.UniPlus.Selecao.Infrastructure.csproj
@@ -4,6 +4,20 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <!--
+      Apache.Avro: dependência de runtime para os tipos Avro gerados em
+      Messaging/Avro/ (ISpecificRecord). Schema é carregado em Schema.Parse
+      a partir do embedded resource em Selecao.Domain (sem duplicação).
+      ADR-0051: schemas Avro vivem no Domain como recurso; classes ISpecificRecord
+      ficam em Infrastructure para não infectar Domain com dep de Avro.
+    -->
+    <PackageReference Include="Apache.Avro" />
+    <!--
+      Confluent.SchemaRegistry.Serdes.Avro: trazido pela dependência transitiva
+      do Wolverine.Kafka.Serialization.SchemaRegistryAvroSerializer, mas declarado
+      explicitamente para clareza do contrato de produção/consumo Avro.
+    -->
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
@@ -2,6 +2,27 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Apache.Avro": {
+        "type": "Direct",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "Direct",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[10.0.5, )",
@@ -37,39 +58,10 @@
           "Npgsql": "10.0.2"
         }
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -982,7 +974,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1028,6 +1022,17 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
         }
       },
       "FluentValidation": {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProvider.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProvider.cs
@@ -165,7 +165,14 @@ public sealed partial class OAuthBearerAuthenticationHeaderValueProvider
                     + $"ClientId={settings.ClientId}.");
             }
 
+            // 5xx do token endpoint é transitivo — Keycloak sob carga, restart em curso.
+            // Marca explicitamente HttpRequestError.ConnectionError para que o
+            // SchemaRegistrationHostedService trate via fail-graceful (ConnectionError/
+            // NameResolutionError são os casos transientes filtrados). Sem o enum value
+            // explícito, HttpRequestError fica Unknown e o catch propaga, travando
+            // startup em incidente transitivo do Keycloak (boot avoidable failure).
             throw new HttpRequestException(
+                HttpRequestError.ConnectionError,
                 $"OAuth client_credentials para Schema Registry falhou com status transiente {status}. "
                 + $"ClientId={settings.ClientId}.");
         }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProvider.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProvider.cs
@@ -1,0 +1,207 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.SchemaRegistry;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// <see cref="IAuthenticationHeaderValueProvider"/> que obtém um access_token via OAuth
+/// <c>client_credentials</c> contra o Keycloak realm <c>uniplus</c> e injeta como
+/// <c>Authorization: Bearer &lt;jwt&gt;</c> em todos os requests do Schema Registry client.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Cacheia o JWT em memória até <c>exp - RefreshSkewSeconds</c>; renova proativamente
+/// para evitar 401 em chamadas concorrentes que peguem token quase expirado. O parsing do
+/// <c>exp</c> é feito sobre o <c>expires_in</c> da response do token endpoint
+/// (em segundos), não sobre o claim do JWT — independe de a presença do <c>exp</c> no
+/// payload (Keycloak sempre retorna <c>expires_in</c>).
+/// </para>
+/// <para>
+/// Renovações concorrentes são serializadas via <see cref="SemaphoreSlim"/> — apenas um
+/// thread chama o token endpoint por vez, os demais reutilizam o token recém-obtido.
+/// </para>
+/// <para>
+/// Falha ao obter token escala como exceção via <see cref="HttpRequestException"/>; o
+/// <c>CachedSchemaRegistryClient</c> trata como erro de chamada (não como auth failure
+/// silencioso). Logging inclui o <c>ClientId</c> mas nunca o secret.
+/// </para>
+/// </remarks>
+public sealed partial class OAuthBearerAuthenticationHeaderValueProvider
+    : IAuthenticationHeaderValueProvider, IDisposable
+{
+    private readonly HttpClient httpClient;
+    private readonly bool ownsHttpClient;
+    private readonly OAuthBearerSettings settings;
+    private readonly ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger;
+    private readonly SemaphoreSlim refreshLock = new(initialCount: 1, maxCount: 1);
+
+    private string? cachedToken;
+    private DateTimeOffset cachedTokenExpiresAt;
+    private bool disposed;
+
+    /// <summary>
+    /// Construtor padrão para uso via DI (<c>IHttpClientFactory</c> + <c>AddHttpClient</c>):
+    /// o <see cref="HttpClient"/> é gerenciado pelo factory, não disposto aqui.
+    /// </summary>
+    public OAuthBearerAuthenticationHeaderValueProvider(
+        HttpClient httpClient,
+        OAuthBearerSettings settings,
+        ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger)
+        : this(httpClient, ownsHttpClient: false, settings, logger)
+    {
+    }
+
+    /// <summary>
+    /// Construtor usado pelo bootstrap standalone (<c>SchemaRegistryServiceCollectionExtensions.CreateClient</c>)
+    /// quando o <see cref="HttpClient"/> é criado fora do <c>IHttpClientFactory</c> —
+    /// nesse caso o provider assume <i>ownership</i> e disposa o cliente em <see cref="Dispose"/>.
+    /// </summary>
+    internal OAuthBearerAuthenticationHeaderValueProvider(
+        HttpClient httpClient,
+        bool ownsHttpClient,
+        OAuthBearerSettings settings,
+        ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this.httpClient = httpClient;
+        this.ownsHttpClient = ownsHttpClient;
+        this.settings = settings;
+        this.logger = logger;
+        this.httpClient.Timeout = TimeSpan.FromMilliseconds(settings.RequestTimeoutMs);
+    }
+
+    public AuthenticationHeaderValue GetAuthenticationHeader()
+    {
+        // Confluent.SchemaRegistry chama esta API sincronamente; bloqueamos no token cache
+        // ou na renovação. O cliente HTTP roda em background no Schema Registry, então o
+        // bloqueio aqui é raro (só na primeira chamada e a cada janela de refresh).
+        string token = GetOrRefreshTokenAsync(CancellationToken.None).GetAwaiter().GetResult();
+        return new AuthenticationHeaderValue("Bearer", token);
+    }
+
+    private async Task<string> GetOrRefreshTokenAsync(CancellationToken cancellationToken)
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        TimeSpan skew = TimeSpan.FromSeconds(settings.RefreshSkewSeconds);
+
+        if (cachedToken is not null && now < cachedTokenExpiresAt - skew)
+        {
+            return cachedToken;
+        }
+
+        await refreshLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Re-check após acquire — outro thread pode ter renovado enquanto esperávamos.
+            now = DateTimeOffset.UtcNow;
+            if (cachedToken is not null && now < cachedTokenExpiresAt - skew)
+            {
+                return cachedToken;
+            }
+
+            TokenEndpointResponse response = await RequestTokenAsync(cancellationToken).ConfigureAwait(false);
+
+            cachedToken = response.AccessToken;
+            cachedTokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(response.ExpiresInSeconds);
+
+            LogTokenRefreshed(logger, settings.ClientId, response.ExpiresInSeconds);
+
+            return cachedToken;
+        }
+        finally
+        {
+            refreshLock.Release();
+        }
+    }
+
+    private async Task<TokenEndpointResponse> RequestTokenAsync(CancellationToken cancellationToken)
+    {
+        List<KeyValuePair<string, string>> form =
+        [
+            new("grant_type", "client_credentials"),
+            new("client_id", settings.ClientId),
+            new("client_secret", settings.ClientSecret),
+        ];
+
+        if (!string.IsNullOrWhiteSpace(settings.Scope))
+        {
+            form.Add(new("scope", settings.Scope));
+        }
+
+        using FormUrlEncodedContent content = new(form);
+        using HttpResponseMessage response = await httpClient
+            .PostAsync(new Uri(settings.TokenEndpoint), content, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            LogTokenRequestFailed(logger, settings.ClientId, (int)response.StatusCode, body);
+            throw new HttpRequestException(
+                $"OAuth client_credentials para Schema Registry falhou. ClientId={settings.ClientId} Status={(int)response.StatusCode}.");
+        }
+
+        TokenEndpointResponse? parsed = await response.Content
+            .ReadFromJsonAsync<TokenEndpointResponse>(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (parsed is null
+            || string.IsNullOrWhiteSpace(parsed.AccessToken)
+            || parsed.ExpiresInSeconds <= 0)
+        {
+            throw new InvalidOperationException(
+                $"Resposta do token endpoint inválida. ClientId={settings.ClientId}.");
+        }
+
+        return parsed;
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        refreshLock.Dispose();
+        if (ownsHttpClient)
+        {
+            httpClient.Dispose();
+        }
+
+        disposed = true;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "SchemaRegistry OAuth token renovado. ClientId={ClientId} ExpiresInSeconds={ExpiresInSeconds}")]
+    private static partial void LogTokenRefreshed(ILogger logger, string clientId, int expiresInSeconds);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "SchemaRegistry OAuth token endpoint falhou. ClientId={ClientId} Status={Status} Body={Body}")]
+    private static partial void LogTokenRequestFailed(ILogger logger, string clientId, int status, string body);
+
+    private sealed record TokenEndpointResponse
+    {
+        [JsonPropertyName("access_token")]
+        public string AccessToken { get; init; } = string.Empty;
+
+        [JsonPropertyName("expires_in")]
+        public int ExpiresInSeconds { get; init; }
+
+        [JsonPropertyName("token_type")]
+        public string TokenType { get; init; } = string.Empty;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProvider.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProvider.cs
@@ -147,9 +147,27 @@ public sealed partial class OAuthBearerAuthenticationHeaderValueProvider
         if (!response.IsSuccessStatusCode)
         {
             string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            LogTokenRequestFailed(logger, settings.ClientId, (int)response.StatusCode, body);
+            int status = (int)response.StatusCode;
+            LogTokenRequestFailed(logger, settings.ClientId, status, body);
+
+            // 4xx = falha determinística (client_id/client_secret incorretos, scope inválido,
+            // realm errado, client desabilitado). Propagar como InvalidOperationException
+            // para que o consumidor (e.g. SchemaRegistrationHostedService) NÃO trate
+            // como transiente — release com config ruim deve travar StartAsync.
+            //
+            // 5xx = falha possivelmente transiente (Keycloak sob carga, restart em curso) —
+            // mantém HttpRequestException para fallback fail-graceful no caminho startup.
+            if (status >= 400 && status < 500)
+            {
+                throw new InvalidOperationException(
+                    $"OAuth client_credentials para Schema Registry recebeu status determinístico {status} "
+                    + "(config inválida — verifique ClientId/ClientSecret/TokenEndpoint/Scope no realm). "
+                    + $"ClientId={settings.ClientId}.");
+            }
+
             throw new HttpRequestException(
-                $"OAuth client_credentials para Schema Registry falhou. ClientId={settings.ClientId} Status={(int)response.StatusCode}.");
+                $"OAuth client_credentials para Schema Registry falhou com status transiente {status}. "
+                + $"ClientId={settings.ClientId}.");
         }
 
         TokenEndpointResponse? parsed = await response.Content

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistration.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+using System;
+using System.IO;
+using System.Reflection;
+
+/// <summary>
+/// Descreve um schema Avro a registrar no Schema Registry no startup da API.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Cada módulo (Selecao, Ingresso, ...) registra suas instâncias via
+/// <c>AddSchemaRegistry().AddSchema(...)</c>. O hosted service
+/// <c>SchemaRegistrationHostedService</c> lê todas as instâncias registradas no DI e
+/// faz <c>RegisterSchemaAsync</c> idempotente para cada uma — Apicurio retorna o mesmo
+/// ID se o schema já existe (BACKWARD compatibility check enforced server-side quando
+/// configurado no chart).
+/// </para>
+/// <para>
+/// O <see cref="Subject"/> segue a convenção Confluent SR <c>&lt;topic&gt;-value</c>
+/// (e <c>&lt;topic&gt;-key</c> quando o producer também serializar a key).
+/// </para>
+/// </remarks>
+/// <param name="Subject">Subject Confluent SR (e.g. <c>edital_events-value</c>).</param>
+/// <param name="SchemaResourceName">
+/// Nome canônico do embedded resource (e.g.
+/// <c>Unifesspa.UniPlus.Selecao.Domain.Events.Schemas.EditalPublicado.avsc</c>).
+/// </param>
+/// <param name="ResourceAssembly">
+/// Assembly que contém o embedded resource — tipicamente o <c>.Domain</c> do módulo.
+/// </param>
+public sealed record SchemaRegistration(
+    string Subject,
+    string SchemaResourceName,
+    Assembly ResourceAssembly)
+{
+    /// <summary>
+    /// Lê o conteúdo do schema do embedded resource. Pode lançar
+    /// <see cref="InvalidOperationException"/> se o resource não for encontrado —
+    /// indica problema de empacotamento do assembly de Domain (csproj sem
+    /// <c>&lt;EmbeddedResource&gt;</c> ou nome de resource desalinhado).
+    /// </summary>
+    public string ReadSchemaContent()
+    {
+        using Stream? stream = ResourceAssembly.GetManifestResourceStream(SchemaResourceName)
+            ?? throw new InvalidOperationException(
+                $"Schema Avro '{SchemaResourceName}' não encontrado como embedded resource em '{ResourceAssembly.FullName}'.");
+        using StreamReader reader = new(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrationHostedService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrationHostedService.cs
@@ -16,16 +16,26 @@ using Microsoft.Extensions.Logging;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Fail-graceful seletivo:</b> apenas falhas <i>transientes</i> (Apicurio offline,
-/// DNS lookup falhou, timeout do HttpClient — capturadas como
-/// <see cref="HttpRequestException"/>, <see cref="SocketException"/> ou
-/// <see cref="TaskCanceledException"/>) são silenciadas — o host segue subindo e o
-/// producer Wolverine retenta em runtime via Confluent serdes. Falhas
-/// <b>determinísticas</b> (<c>SchemaRegistryException</c> = auth 401/403,
-/// conflict 409, malformed 422; <see cref="InvalidOperationException"/> de embedded
-/// resource ausente; <c>AvroException</c> de schema inválido) <b>propagam e travam
-/// StartAsync</b> — release ruim não pode rodar em modo "degraded but accepting
-/// traffic". Sem o filtro, schemas com bug real entram em loop runtime de "fail to
+/// <b>Fail-graceful seletivo:</b> apenas falhas transientes inspecionadas via
+/// <see cref="HttpRequestException.HttpRequestError"/> (<c>ConnectionError</c> =
+/// Apicurio offline / connection refused; <c>NameResolutionError</c> = DNS
+/// resolução falhou) + <see cref="SocketException"/> + timeout
+/// (<see cref="TaskCanceledException"/> com <see cref="TimeoutException"/> inner)
+/// são silenciadas — host segue subindo, Confluent serdes retenta em runtime
+/// quando o Registry voltar.
+/// </para>
+/// <para>
+/// <b>Falhas determinísticas propagam e travam <c>StartAsync</c>:</b>
+/// </para>
+/// <list type="bullet">
+/// <item><description><c>SchemaRegistryException</c> — auth 401/403, conflict 409, malformed 422</description></item>
+/// <item><description><see cref="HttpRequestException"/> com <c>SecureConnectionError</c> (TLS chain inválida), <c>HttpProtocolError</c>, <c>UserAuthenticationError</c> (cliente cert), <c>InvalidResponse</c>, <c>ProxyTunnelError</c></description></item>
+/// <item><description><see cref="InvalidOperationException"/> — embedded resource ausente, OAuth 4xx (config inválida)</description></item>
+/// <item><description><c>AvroException</c> — schema sintaticamente inválido</description></item>
+/// </list>
+/// <para>
+/// Release com config ruim não pode rodar em modo "degraded but accepting traffic" —
+/// sem o filtro, schemas/auth com bug real entram em loop runtime de "fail to
 /// publish" e mensagens durables se acumulam silenciosamente no outbox.
 /// </para>
 /// <para>
@@ -91,10 +101,19 @@ public sealed partial class SchemaRegistrationHostedService : IHostedService
 
                 LogSchemaRegistered(logger, registration.Subject, schemaId);
             }
-            // Fail-graceful **apenas** para falhas transientes — Apicurio offline,
-            // DNS lookup falhou, timeout do HttpClient. Confluent serdes faz retry
-            // em runtime quando o Registry voltar.
-            catch (HttpRequestException ex)
+            // Fail-graceful **apenas** para falhas transientes via inspeção do
+            // HttpRequestError — Apicurio offline (ConnectionError) ou DNS não
+            // resolveu (NameResolutionError). Confluent serdes faz retry em runtime
+            // quando o Registry voltar.
+            //
+            // Demais variantes (SecureConnectionError de TLS chain inválida,
+            // HttpProtocolError, UserAuthenticationError de cliente cert ausente,
+            // InvalidResponse, ProxyTunnelError) são determinísticas — propagam e
+            // travam StartAsync. Release com config TLS/proxy/cert ruim não pode
+            // rodar silenciosamente em modo "degraded but accepting traffic".
+            catch (HttpRequestException ex) when (
+                ex.HttpRequestError == HttpRequestError.ConnectionError
+                || ex.HttpRequestError == HttpRequestError.NameResolutionError)
             {
                 LogSchemaRegistrationTransientFailure(logger, registration.Subject, ex);
             }
@@ -107,9 +126,9 @@ public sealed partial class SchemaRegistrationHostedService : IHostedService
                 LogSchemaRegistrationTransientFailure(logger, registration.Subject, ex);
             }
             // Falhas determinísticas (SchemaRegistryException = auth/conflict/malformed,
-            // InvalidOperationException = embedded resource ausente, AvroException =
-            // schema sintaticamente inválido) propagam e travam StartAsync — release
-            // ruim não pode rodar em modo "degraded but accepting traffic".
+            // HttpRequestException com error codes não-recuperáveis, InvalidOperationException
+            // = embedded resource ausente, AvroException = schema sintaticamente inválido)
+            // propagam e travam StartAsync.
         }
     }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrationHostedService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrationHostedService.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
 
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.SchemaRegistry;
@@ -14,12 +16,17 @@ using Microsoft.Extensions.Logging;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Comportamento fail-graceful:</b> se o Schema Registry estiver offline ou retornar
-/// erro de auth no boot, o serviço loga warning/error e <b>retorna</b> — o host segue
-/// subindo. O producer Wolverine vai tentar registrar o schema novamente em runtime na
-/// primeira mensagem (Confluent serdes faz isso transparentemente). Sem isso, o host
-/// trava em <c>StartAsync</c> sempre que o Apicurio reinicia, o que é inaceitável em
-/// produção.
+/// <b>Fail-graceful seletivo:</b> apenas falhas <i>transientes</i> (Apicurio offline,
+/// DNS lookup falhou, timeout do HttpClient — capturadas como
+/// <see cref="HttpRequestException"/>, <see cref="SocketException"/> ou
+/// <see cref="TaskCanceledException"/>) são silenciadas — o host segue subindo e o
+/// producer Wolverine retenta em runtime via Confluent serdes. Falhas
+/// <b>determinísticas</b> (<c>SchemaRegistryException</c> = auth 401/403,
+/// conflict 409, malformed 422; <see cref="InvalidOperationException"/> de embedded
+/// resource ausente; <c>AvroException</c> de schema inválido) <b>propagam e travam
+/// StartAsync</b> — release ruim não pode rodar em modo "degraded but accepting
+/// traffic". Sem o filtro, schemas com bug real entram em loop runtime de "fail to
+/// publish" e mensagens durables se acumulam silenciosamente no outbox.
 /// </para>
 /// <para>
 /// <b>Idempotência:</b> Apicurio aceita registrar o mesmo schema (byte-equal) múltiplas
@@ -84,12 +91,25 @@ public sealed partial class SchemaRegistrationHostedService : IHostedService
 
                 LogSchemaRegistered(logger, registration.Subject, schemaId);
             }
-#pragma warning disable CA1031 // Do not catch general exception types — fail-graceful por design (ver doc da classe).
-            catch (Exception ex)
+            // Fail-graceful **apenas** para falhas transientes — Apicurio offline,
+            // DNS lookup falhou, timeout do HttpClient. Confluent serdes faz retry
+            // em runtime quando o Registry voltar.
+            catch (HttpRequestException ex)
             {
-                LogSchemaRegistrationFailed(logger, registration.Subject, ex);
+                LogSchemaRegistrationTransientFailure(logger, registration.Subject, ex);
             }
-#pragma warning restore CA1031
+            catch (SocketException ex)
+            {
+                LogSchemaRegistrationTransientFailure(logger, registration.Subject, ex);
+            }
+            catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException || ex.CancellationToken == default)
+            {
+                LogSchemaRegistrationTransientFailure(logger, registration.Subject, ex);
+            }
+            // Falhas determinísticas (SchemaRegistryException = auth/conflict/malformed,
+            // InvalidOperationException = embedded resource ausente, AvroException =
+            // schema sintaticamente inválido) propagam e travam StartAsync — release
+            // ruim não pode rodar em modo "degraded but accepting traffic".
         }
     }
 
@@ -112,6 +132,6 @@ public sealed partial class SchemaRegistrationHostedService : IHostedService
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Falha ao registrar schema Avro no startup (continuando com host degradado — registro tentará novamente em runtime). Subject={Subject}")]
-    private static partial void LogSchemaRegistrationFailed(ILogger logger, string subject, Exception exception);
+        Message = "Falha transiente ao registrar schema Avro no startup (continuando com host degradado — registro tentará novamente em runtime via Confluent serdes). Subject={Subject}")]
+    private static partial void LogSchemaRegistrationTransientFailure(ILogger logger, string subject, Exception exception);
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrationHostedService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrationHostedService.cs
@@ -1,0 +1,117 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.SchemaRegistry;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Hosted service idempotente que registra os schemas Avro conhecidos do módulo no
+/// Schema Registry (Apicurio) durante o startup do host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Comportamento fail-graceful:</b> se o Schema Registry estiver offline ou retornar
+/// erro de auth no boot, o serviço loga warning/error e <b>retorna</b> — o host segue
+/// subindo. O producer Wolverine vai tentar registrar o schema novamente em runtime na
+/// primeira mensagem (Confluent serdes faz isso transparentemente). Sem isso, o host
+/// trava em <c>StartAsync</c> sempre que o Apicurio reinicia, o que é inaceitável em
+/// produção.
+/// </para>
+/// <para>
+/// <b>Idempotência:</b> Apicurio aceita registrar o mesmo schema (byte-equal) múltiplas
+/// vezes — retorna o mesmo schema-id. Mudança de schema dispara o compatibility check
+/// configurado (default BACKWARD); incompatibilidade falha o registro com 409 Conflict
+/// e o serviço propaga via log error (não trava boot).
+/// </para>
+/// <para>
+/// <b>Filtro de assemblies:</b> escaneia <see cref="SchemaRegistration"/>s registradas
+/// no DI por <c>AddSchemaRegistry().AddSchema(...)</c>. Múltiplos módulos podem registrar
+/// schemas no mesmo host sem conflito — cada módulo declara apenas seus subjects.
+/// </para>
+/// <para>
+/// Posicionado <b>após</b> o <c>StartHostedService</c> do Wolverine no pipeline para que
+/// o serviço de mensageria já esteja inicializado quando publicarmos. Ordem importa só
+/// para o caminho feliz (boot subsequente após Apicurio online); fail-graceful resolve
+/// o resto.
+/// </para>
+/// </remarks>
+public sealed partial class SchemaRegistrationHostedService : IHostedService
+{
+    private readonly ISchemaRegistryClient schemaRegistryClient;
+    private readonly IReadOnlyCollection<SchemaRegistration> registrations;
+    private readonly ILogger<SchemaRegistrationHostedService> logger;
+
+    public SchemaRegistrationHostedService(
+        ISchemaRegistryClient schemaRegistryClient,
+        IEnumerable<SchemaRegistration> registrations,
+        ILogger<SchemaRegistrationHostedService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(schemaRegistryClient);
+        ArgumentNullException.ThrowIfNull(registrations);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this.schemaRegistryClient = schemaRegistryClient;
+        this.registrations = [.. registrations];
+        this.logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (registrations.Count == 0)
+        {
+            LogNoSchemasRegistered(logger);
+            return;
+        }
+
+        LogRegisteringSchemas(logger, registrations.Count);
+
+        foreach (SchemaRegistration registration in registrations)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                string schemaContent = registration.ReadSchemaContent();
+                Schema schema = new(schemaContent, SchemaType.Avro);
+
+                int schemaId = await schemaRegistryClient
+                    .RegisterSchemaAsync(registration.Subject, schema, normalize: true)
+                    .ConfigureAwait(false);
+
+                LogSchemaRegistered(logger, registration.Subject, schemaId);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types — fail-graceful por design (ver doc da classe).
+            catch (Exception ex)
+            {
+                LogSchemaRegistrationFailed(logger, registration.Subject, ex);
+            }
+#pragma warning restore CA1031
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Nenhum schema Avro a registrar no Schema Registry — feature off ou módulo sem eventos cross-module.")]
+    private static partial void LogNoSchemasRegistered(ILogger logger);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Registrando {Count} schema(s) Avro no Schema Registry no startup.")]
+    private static partial void LogRegisteringSchemas(ILogger logger, int count);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Schema Avro registrado/confirmado. Subject={Subject} SchemaId={SchemaId}")]
+    private static partial void LogSchemaRegistered(ILogger logger, string subject, int schemaId);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Falha ao registrar schema Avro no startup (continuando com host degradado — registro tentará novamente em runtime). Subject={Subject}")]
+    private static partial void LogSchemaRegistrationFailed(ILogger logger, string subject, Exception exception);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
@@ -1,0 +1,233 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+using System;
+using System.Net.Http;
+using Confluent.SchemaRegistry;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SchemaRegistryConfig = Confluent.SchemaRegistry.SchemaRegistryConfig;
+
+/// <summary>
+/// Extensões DI para o cliente Confluent Schema Registry (Apicurio).
+/// </summary>
+/// <remarks>
+/// <para>
+/// API canônica:
+/// </para>
+/// <code>
+/// builder.Services.AddSchemaRegistry(builder.Configuration)
+///     .AddSchema("edital_events-value", typeof(EditalPublicadoEvent).Assembly);
+/// </code>
+/// <para>
+/// Comportamento "feature-off": quando <c>SchemaRegistry:Url</c> está vazio em
+/// <c>IConfiguration</c>, nada é registrado no DI — APIs sem dependência de schema
+/// registry continuam subindo sem erro, e tentativas de resolver
+/// <see cref="ISchemaRegistryClient"/> falham fail-fast com
+/// <see cref="InvalidOperationException"/>.
+/// </para>
+/// </remarks>
+public static class SchemaRegistryServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registra <see cref="ISchemaRegistryClient"/> (Confluent
+    /// <c>CachedSchemaRegistryClient</c>) + autenticação configurada +
+    /// hosted service idempotente de registro de schemas no startup.
+    /// </summary>
+    public static SchemaRegistryBuilder AddSchemaRegistry(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        services.AddOptions<SchemaRegistrySettings>()
+            .Bind(configuration.GetSection(SchemaRegistrySettings.SectionName))
+            .ValidateOnStart();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<SchemaRegistrySettings>, SchemaRegistrySettingsValidator>());
+
+        SchemaRegistrySettings settings = configuration
+            .GetSection(SchemaRegistrySettings.SectionName)
+            .Get<SchemaRegistrySettings>()
+            ?? new SchemaRegistrySettings();
+
+        // Feature-off path: URL vazia significa sem Schema Registry. Não registramos
+        // ISchemaRegistryClient — quem depender vai falhar fail-fast no DI resolution
+        // com mensagem clara, melhor do que comportamento silencioso.
+        if (string.IsNullOrWhiteSpace(settings.Url))
+        {
+            return new SchemaRegistryBuilder(services, schemaRegistryEnabled: false);
+        }
+
+        // Validação inline cobre o caminho de criação dos clients abaixo —
+        // ValidateOnStart só roda em IHost.StartAsync.
+        ValidateOptionsResult validation = new SchemaRegistrySettingsValidator()
+            .Validate(name: null, settings);
+        if (validation.Failed)
+        {
+            throw new InvalidOperationException(
+                $"Configuração SchemaRegistry inválida: {string.Join(" | ", validation.Failures ?? [])}");
+        }
+
+        // OAuth provider precisa de HttpClient próprio com timeout configurável —
+        // resolvido via IHttpClientFactory para cooperar com Polly/handlers globais.
+        bool useOAuthBearer = string.Equals(settings.AuthType, "OAuthBearer", StringComparison.OrdinalIgnoreCase);
+        if (useOAuthBearer)
+        {
+            services.AddHttpClient<OAuthBearerAuthenticationHeaderValueProvider>();
+            services.AddSingleton<IAuthenticationHeaderValueProvider>(static sp =>
+            {
+                IOptions<SchemaRegistrySettings> opts = sp.GetRequiredService<IOptions<SchemaRegistrySettings>>();
+                IHttpClientFactory factory = sp.GetRequiredService<IHttpClientFactory>();
+                ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger = sp
+                    .GetRequiredService<ILogger<OAuthBearerAuthenticationHeaderValueProvider>>();
+                HttpClient client = factory.CreateClient(nameof(OAuthBearerAuthenticationHeaderValueProvider));
+                return new OAuthBearerAuthenticationHeaderValueProvider(
+                    client,
+                    opts.Value.OAuth,
+                    logger);
+            });
+        }
+
+        services.TryAddSingleton<ISchemaRegistryClient>(sp =>
+        {
+            IOptions<SchemaRegistrySettings> opts = sp.GetRequiredService<IOptions<SchemaRegistrySettings>>();
+            SchemaRegistrySettings current = opts.Value;
+
+            SchemaRegistryConfig config = new()
+            {
+                Url = current.Url,
+                MaxCachedSchemas = current.MaxCachedSchemas,
+                RequestTimeoutMs = current.RequestTimeoutMs,
+            };
+
+            if (string.Equals(current.AuthType, "Basic", StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrWhiteSpace(current.BasicAuthUserInfo))
+            {
+                config.BasicAuthCredentialsSource = AuthCredentialsSource.UserInfo;
+                config.BasicAuthUserInfo = current.BasicAuthUserInfo;
+            }
+
+            if (useOAuthBearer)
+            {
+                IAuthenticationHeaderValueProvider authProvider = sp
+                    .GetRequiredService<IAuthenticationHeaderValueProvider>();
+                return new CachedSchemaRegistryClient(config, authProvider);
+            }
+
+            return new CachedSchemaRegistryClient(config);
+        });
+
+        services.AddHostedService<SchemaRegistrationHostedService>();
+
+        return new SchemaRegistryBuilder(services, schemaRegistryEnabled: true);
+    }
+
+    /// <summary>
+    /// Cria uma instância standalone de <see cref="ISchemaRegistryClient"/> usando
+    /// <see cref="SchemaRegistrySettings"/> diretamente — útil para o callback de
+    /// configuração do Wolverine (que roda antes do <see cref="IServiceProvider"/>
+    /// ter sido construído).
+    /// </summary>
+    /// <remarks>
+    /// O caller é responsável pelo lifetime do cliente retornado. O recomendado é
+    /// registrá-lo como singleton no DI via <c>services.AddSingleton(client)</c>
+    /// antes de <see cref="AddSchemaRegistry"/> — o <c>TryAddSingleton</c> interno
+    /// respeita o registro prévio, evitando duplicação de cache. O hosted service
+    /// e o Wolverine routing usam então a mesma instância.
+    /// </remarks>
+    public static ISchemaRegistryClient CreateClient(
+        SchemaRegistrySettings settings,
+        ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        if (string.IsNullOrWhiteSpace(settings.Url))
+        {
+            throw new InvalidOperationException(
+                "SchemaRegistry:Url está vazia — chamando CreateClient sem feature ativa.");
+        }
+
+        SchemaRegistryConfig config = new()
+        {
+            Url = settings.Url,
+            MaxCachedSchemas = settings.MaxCachedSchemas,
+            RequestTimeoutMs = settings.RequestTimeoutMs,
+        };
+
+        if (string.Equals(settings.AuthType, "Basic", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(settings.BasicAuthUserInfo))
+        {
+            config.BasicAuthCredentialsSource = AuthCredentialsSource.UserInfo;
+            config.BasicAuthUserInfo = settings.BasicAuthUserInfo;
+            return new CachedSchemaRegistryClient(config);
+        }
+
+        if (string.Equals(settings.AuthType, "OAuthBearer", StringComparison.OrdinalIgnoreCase))
+        {
+            // HttpClient standalone — cliente é singleton (lifetime = host),
+            // ownership transferido para o auth provider (que dispõe via ownsHttpClient).
+            // O auth provider, por sua vez, vive enquanto o CachedSchemaRegistryClient
+            // vive (referência forte). Caller registra o cliente como singleton no DI;
+            // shutdown do host descarta toda a cadeia.
+            HttpClient httpClient = new();
+#pragma warning disable CA2000 // analisador não rastreia ownership pelo flag ownsHttpClient nem a posse pelo CachedSchemaRegistryClient.
+            OAuthBearerAuthenticationHeaderValueProvider authProvider = new(
+                httpClient,
+                ownsHttpClient: true,
+                settings.OAuth,
+                loggerFactory.CreateLogger<OAuthBearerAuthenticationHeaderValueProvider>());
+#pragma warning restore CA2000
+            return new CachedSchemaRegistryClient(config, authProvider);
+        }
+
+        return new CachedSchemaRegistryClient(config);
+    }
+}
+
+/// <summary>
+/// Builder fluente para registrar <see cref="SchemaRegistration"/>s do módulo após
+/// <see cref="SchemaRegistryServiceCollectionExtensions.AddSchemaRegistry"/>.
+/// </summary>
+public sealed class SchemaRegistryBuilder
+{
+    private readonly IServiceCollection services;
+    private readonly bool schemaRegistryEnabled;
+
+    internal SchemaRegistryBuilder(IServiceCollection services, bool schemaRegistryEnabled)
+    {
+        this.services = services;
+        this.schemaRegistryEnabled = schemaRegistryEnabled;
+    }
+
+    /// <summary>
+    /// Adiciona um schema Avro a ser registrado/confirmado no Schema Registry no startup.
+    /// </summary>
+    /// <param name="subject">Subject Confluent SR (e.g. <c>edital_events-value</c>).</param>
+    /// <param name="schemaResourceName">Nome canônico do embedded resource.</param>
+    /// <param name="resourceAssembly">Assembly que contém o resource.</param>
+    public SchemaRegistryBuilder AddSchema(
+        string subject,
+        string schemaResourceName,
+        System.Reflection.Assembly resourceAssembly)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaResourceName);
+        ArgumentNullException.ThrowIfNull(resourceAssembly);
+
+        if (!schemaRegistryEnabled)
+        {
+            // Feature-off: não registra a SchemaRegistration no DI — o hosted service
+            // não foi adicionado, e o cliente também não. AddSchema vira no-op.
+            return this;
+        }
+
+        services.AddSingleton(new SchemaRegistration(subject, schemaResourceName, resourceAssembly));
+        return this;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrySettings.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrySettings.cs
@@ -1,0 +1,128 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Bound options para o cliente Confluent Schema Registry (Apicurio em modo Confluent-compat).
+/// Mapeia a seção <c>SchemaRegistry:</c> de
+/// <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Modos de autenticação suportados:
+/// </para>
+/// <list type="bullet">
+///   <item><description><b>None</b> (Development / docker-compose sem auth): apenas <see cref="Url"/>.</description></item>
+///   <item><description><b>Basic</b> (Apicurio com basic auth, dev/lab simples):
+///     <see cref="Url"/> + <see cref="AuthType"/>=<c>Basic</c> + <see cref="BasicAuthUserInfo"/>=<c>user:password</c>.</description></item>
+///   <item><description><b>OAuthBearer</b> (standalone/HML/Prod com Apicurio OIDC, ADR-0051):
+///     <see cref="Url"/> + <see cref="AuthType"/>=<c>OAuthBearer</c> + <see cref="OAuth"/> populado
+///     (token endpoint do Keycloak <c>/protocol/openid-connect/token</c>,
+///     <c>uniplus-api-{portal,selecao,ingresso}</c> client + secret no Vault).</description></item>
+/// </list>
+/// <para>
+/// Quando <see cref="Url"/> está vazio, o cliente Schema Registry e o hosted service
+/// de registro inicial não são registrados — comportamento de "feature off" útil em
+/// dev local quando o Apicurio não está rodando.
+/// </para>
+/// </remarks>
+[SuppressMessage(
+    "Design",
+    "CA1056:URI-like properties should not be strings",
+    Justification = "Bound options via IConfiguration — System.Text.Json não desserializa Uri nativamente. Validação de formato em SchemaRegistrySettingsValidator.")]
+public sealed class SchemaRegistrySettings
+{
+    public const string SectionName = "SchemaRegistry";
+
+    /// <summary>
+    /// URL base do Schema Registry. Para Apicurio em modo Confluent-compat,
+    /// inclui o sufixo <c>/apis/ccompat/v7</c>
+    /// (ex.: <c>https://schema-registry.standalone.portaluni.com.br/apis/ccompat/v7</c>).
+    /// Vazio desliga a feature.
+    /// </summary>
+    public string Url { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Tipo de autenticação. Valores aceitos (case-insensitive):
+    /// <c>None</c>, <c>Basic</c>, <c>OAuthBearer</c>. Default <c>None</c>.
+    /// </summary>
+    public string AuthType { get; init; } = "None";
+
+    /// <summary>
+    /// Credenciais Basic no formato <c>user:password</c>. Obrigatório quando
+    /// <see cref="AuthType"/>=<c>Basic</c>. Sempre via env var/Vault — nunca em arquivo Git.
+    /// </summary>
+    public string? BasicAuthUserInfo { get; init; }
+
+    /// <summary>
+    /// Configuração OAuth client_credentials. Obrigatória quando
+    /// <see cref="AuthType"/>=<c>OAuthBearer</c>.
+    /// </summary>
+    public OAuthBearerSettings OAuth { get; init; } = new();
+
+    /// <summary>
+    /// Timeout HTTP por request ao Schema Registry (default 30s). Apicurio standalone
+    /// pode demorar em primeira chamada (carrega cache + valida JWT contra Keycloak).
+    /// </summary>
+    public int RequestTimeoutMs { get; init; } = 30_000;
+
+    /// <summary>
+    /// Tamanho do cache local de schemas no <c>CachedSchemaRegistryClient</c>
+    /// (default 1000). Cobre todos os subjects do Uni+ com folga.
+    /// </summary>
+    public int MaxCachedSchemas { get; init; } = 1000;
+}
+
+/// <summary>
+/// Configuração OAuth client_credentials para autenticação contra o Apicurio Registry.
+/// </summary>
+/// <remarks>
+/// O cliente cacheia o bearer JWT obtido do <see cref="TokenEndpoint"/> e o renova
+/// proativamente antes da expiração (skew configurável). Detalhes em
+/// <c>OAuthBearerAuthenticationHeaderValueProvider</c>.
+/// </remarks>
+[SuppressMessage(
+    "Design",
+    "CA1056:URI-like properties should not be strings",
+    Justification = "Bound options via IConfiguration — String para token endpoint padrão entre options do Uni+. Validação em SchemaRegistrySettingsValidator.")]
+public sealed class OAuthBearerSettings
+{
+    /// <summary>
+    /// Endpoint <c>/protocol/openid-connect/token</c> do Keycloak realm <c>uniplus</c>
+    /// (ex.: <c>https://standalone.portaluni.com.br/auth/realms/uniplus/protocol/openid-connect/token</c>).
+    /// </summary>
+    public string TokenEndpoint { get; init; } = string.Empty;
+
+    /// <summary>
+    /// <c>client_id</c> do confidential client M2M no realm. Para uniplus-api,
+    /// um de <c>uniplus-api-portal</c>, <c>uniplus-api-selecao</c>, <c>uniplus-api-ingresso</c>
+    /// (issue uniplus-infra#163).
+    /// </summary>
+    public string ClientId { get; init; } = string.Empty;
+
+    /// <summary>
+    /// <c>client_secret</c> custodiado em Vault em
+    /// <c>secret/standalone/keycloak/clients/uniplus-api-{portal,selecao,ingresso}</c>
+    /// (RUNBOOKS §15.6 do uniplus-infra) e injetado via env var
+    /// <c>SchemaRegistry__OAuth__ClientSecret</c> pelo ESO 5 dos charts API.
+    /// </summary>
+    public string ClientSecret { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Escopo OAuth opcional (ex.: <c>openid</c>). Default vazio — Keycloak emite
+    /// access_token sem scope explícito quando o request omite o parâmetro.
+    /// </summary>
+    public string? Scope { get; init; }
+
+    /// <summary>
+    /// Margem de segurança em segundos antes do <c>exp</c> do JWT em que o cliente
+    /// renova proativamente (default 30s). Evita 401 em chamadas concorrentes que
+    /// pegam um token quase-expirado.
+    /// </summary>
+    public int RefreshSkewSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// Timeout HTTP do request ao token endpoint (default 10s).
+    /// </summary>
+    public int RequestTimeoutMs { get; init; } = 10_000;
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrySettingsValidator.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistrySettingsValidator.cs
@@ -1,0 +1,126 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+using System;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Validação cross-field de <see cref="SchemaRegistrySettings"/>.
+/// </summary>
+/// <remarks>
+/// Garante coerência entre <c>AuthType</c> e os campos correspondentes:
+/// <c>Basic</c> exige <c>BasicAuthUserInfo</c>; <c>OAuthBearer</c> exige
+/// <c>OAuth.TokenEndpoint</c> + <c>OAuth.ClientId</c> + <c>OAuth.ClientSecret</c>.
+/// Configurações inconsistentes falham no startup com mensagem orientada ao operador,
+/// ao invés de "parecer autenticado" silenciosamente em runtime.
+/// </remarks>
+public sealed class SchemaRegistrySettingsValidator : IValidateOptions<SchemaRegistrySettings>
+{
+    public ValidateOptionsResult Validate(string? name, SchemaRegistrySettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        // URL vazia = feature desligada (Development sem Apicurio). Nada a validar.
+        if (string.IsNullOrWhiteSpace(options.Url))
+        {
+            return ValidateOptionsResult.Success;
+        }
+
+        List<string> failures = [];
+
+        if (!Uri.TryCreate(options.Url, UriKind.Absolute, out Uri? uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            failures.Add($"SchemaRegistry:Url '{options.Url}' inválida. Use HTTP/HTTPS absolutas.");
+            return ValidateOptionsResult.Fail(failures);
+        }
+
+        string authType = (options.AuthType ?? string.Empty).Trim();
+        bool authIsNone = authType.Length == 0
+            || authType.Equals("None", StringComparison.OrdinalIgnoreCase);
+        bool authIsBasic = authType.Equals("Basic", StringComparison.OrdinalIgnoreCase);
+        bool authIsOAuthBearer = authType.Equals("OAuthBearer", StringComparison.OrdinalIgnoreCase);
+
+        if (!(authIsNone || authIsBasic || authIsOAuthBearer))
+        {
+            failures.Add($"SchemaRegistry:AuthType '{options.AuthType}' inválido. Use None, Basic ou OAuthBearer.");
+            return ValidateOptionsResult.Fail(failures);
+        }
+
+        bool hasBasicField = !string.IsNullOrWhiteSpace(options.BasicAuthUserInfo);
+        bool hasOAuthField =
+            !string.IsNullOrWhiteSpace(options.OAuth.TokenEndpoint)
+            || !string.IsNullOrWhiteSpace(options.OAuth.ClientId)
+            || !string.IsNullOrWhiteSpace(options.OAuth.ClientSecret);
+
+        // Coerência: campos preenchidos exigem AuthType correspondente — evita
+        // BasicAuthUserInfo="user:pwd" ficar inerte porque AuthType=None foi default.
+        if (hasBasicField && !authIsBasic)
+        {
+            failures.Add("SchemaRegistry:BasicAuthUserInfo só faz sentido com AuthType=Basic.");
+        }
+
+        if (hasOAuthField && !authIsOAuthBearer)
+        {
+            failures.Add("SchemaRegistry:OAuth:* só faz sentido com AuthType=OAuthBearer.");
+        }
+
+        if (authIsBasic)
+        {
+            if (string.IsNullOrWhiteSpace(options.BasicAuthUserInfo))
+            {
+                failures.Add("SchemaRegistry:BasicAuthUserInfo é obrigatório com AuthType=Basic.");
+            }
+            else if (!options.BasicAuthUserInfo.Contains(':', StringComparison.Ordinal))
+            {
+                failures.Add("SchemaRegistry:BasicAuthUserInfo deve estar no formato 'user:password'.");
+            }
+        }
+
+        if (authIsOAuthBearer)
+        {
+            if (string.IsNullOrWhiteSpace(options.OAuth.TokenEndpoint))
+            {
+                failures.Add("SchemaRegistry:OAuth:TokenEndpoint é obrigatório com AuthType=OAuthBearer.");
+            }
+            else if (!Uri.TryCreate(options.OAuth.TokenEndpoint, UriKind.Absolute, out Uri? tokenUri)
+                     || (tokenUri.Scheme != Uri.UriSchemeHttp && tokenUri.Scheme != Uri.UriSchemeHttps))
+            {
+                failures.Add($"SchemaRegistry:OAuth:TokenEndpoint '{options.OAuth.TokenEndpoint}' inválido. Use HTTP/HTTPS absoluta.");
+            }
+
+            if (string.IsNullOrWhiteSpace(options.OAuth.ClientId))
+            {
+                failures.Add("SchemaRegistry:OAuth:ClientId é obrigatório com AuthType=OAuthBearer.");
+            }
+
+            if (string.IsNullOrWhiteSpace(options.OAuth.ClientSecret))
+            {
+                failures.Add("SchemaRegistry:OAuth:ClientSecret é obrigatório com AuthType=OAuthBearer (sempre via Vault/env var).");
+            }
+
+            if (options.OAuth.RefreshSkewSeconds < 0)
+            {
+                failures.Add("SchemaRegistry:OAuth:RefreshSkewSeconds não pode ser negativo.");
+            }
+
+            if (options.OAuth.RequestTimeoutMs <= 0)
+            {
+                failures.Add("SchemaRegistry:OAuth:RequestTimeoutMs deve ser positivo.");
+            }
+        }
+
+        if (options.RequestTimeoutMs <= 0)
+        {
+            failures.Add("SchemaRegistry:RequestTimeoutMs deve ser positivo.");
+        }
+
+        if (options.MaxCachedSchemas <= 0)
+        {
+            failures.Add("SchemaRegistry:MaxCachedSchemas deve ser positivo.");
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Confluent.Kafka" />
+    <PackageReference Include="Confluent.SchemaRegistry" />
+    <PackageReference Include="Apache.Avro" />
     <PackageReference Include="VaultSharp" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
@@ -2,6 +2,16 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Apache.Avro": {
+        "type": "Direct",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
       "Confluent.Kafka": {
         "type": "Direct",
         "requested": "[2.14.0, )",
@@ -9,6 +19,17 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "Direct",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
         }
       },
       "FluentValidation": {
@@ -177,39 +198,10 @@
           "WolverineFx.RDBMS": "5.32.1"
         }
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -1121,6 +1113,17 @@
       },
       "unifesspa.uniplus.kernel": {
         "type": "Project"
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
+        }
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -64,39 +64,10 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -1088,7 +1059,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1192,11 +1165,23 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.14.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
         }
       },
       "Confluent.Kafka": {
@@ -1206,6 +1191,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -73,15 +73,6 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
         "resolved": "2.6.2",
@@ -91,26 +82,6 @@
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -1117,7 +1088,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1151,6 +1124,16 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
       "Confluent.Kafka": {
         "type": "CentralTransitive",
         "requested": "[2.14.0, )",
@@ -1158,6 +1141,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/SchemaRegistrySettingsValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/SchemaRegistrySettingsValidatorTests.cs
@@ -1,0 +1,220 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.SchemaRegistry;
+
+using AwesomeAssertions;
+using Microsoft.Extensions.Options;
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+public sealed class SchemaRegistrySettingsValidatorTests
+{
+    [Fact]
+    public void Validate_UrlVazia_DeveSerSucesso()
+    {
+        // Feature off em Development sem Apicurio — nada a validar.
+        SchemaRegistrySettings settings = new();
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("ftp://schema-registry/")]
+    [InlineData("not-a-url")]
+    [InlineData("//missing-scheme")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Design",
+        "CA1054:URI-like parameters should not be strings",
+        Justification = "Test theory parameter — entrada por InlineData; bind via IConfiguration usa string sempre.")]
+    public void Validate_UrlNaoHttpHttps_DeveFalhar(string url)
+    {
+        SchemaRegistrySettings settings = new() { Url = url };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("SchemaRegistry:Url", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_AuthTypeInvalido_DeveFalhar()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "http://localhost:8081",
+            AuthType = "MTLS",
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("AuthType", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("None")]
+    [InlineData("none")]
+    [InlineData("")]
+    public void Validate_AuthTypeNoneSemCampos_DeveSerSucesso(string authType)
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "http://localhost:8081",
+            AuthType = authType,
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_BasicSemUserInfo_DeveFalhar()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "http://localhost:8081",
+            AuthType = "Basic",
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("BasicAuthUserInfo", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_BasicComUserInfoSemColon_DeveFalhar()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "http://localhost:8081",
+            AuthType = "Basic",
+            BasicAuthUserInfo = "userwithoutcolon",
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("user:password", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_BasicCompleto_DeveSerSucesso()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "http://localhost:8081",
+            AuthType = "Basic",
+            BasicAuthUserInfo = "admin:s3cr3t",
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_OAuthBearerSemTokenEndpoint_DeveFalhar()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "https://schema-registry/apis/ccompat/v7",
+            AuthType = "OAuthBearer",
+            OAuth = new OAuthBearerSettings
+            {
+                ClientId = "uniplus-api-selecao",
+                ClientSecret = "secret",
+            },
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("OAuth:TokenEndpoint", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_OAuthBearerSemClientId_DeveFalhar()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "https://schema-registry/apis/ccompat/v7",
+            AuthType = "OAuthBearer",
+            OAuth = new OAuthBearerSettings
+            {
+                TokenEndpoint = "https://kc/realms/uniplus/protocol/openid-connect/token",
+                ClientSecret = "secret",
+            },
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("OAuth:ClientId", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_OAuthBearerSemClientSecret_DeveFalhar()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "https://schema-registry/apis/ccompat/v7",
+            AuthType = "OAuthBearer",
+            OAuth = new OAuthBearerSettings
+            {
+                TokenEndpoint = "https://kc/realms/uniplus/protocol/openid-connect/token",
+                ClientId = "uniplus-api-selecao",
+            },
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("OAuth:ClientSecret", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_OAuthBearerCompleto_DeveSerSucesso()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "https://schema-registry/apis/ccompat/v7",
+            AuthType = "OAuthBearer",
+            OAuth = new OAuthBearerSettings
+            {
+                TokenEndpoint = "https://kc/realms/uniplus/protocol/openid-connect/token",
+                ClientId = "uniplus-api-selecao",
+                ClientSecret = "very-secret",
+            },
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_BasicAuthFieldComAuthTypeNone_DeveFalhar()
+    {
+        // Coerência: BasicAuthUserInfo preenchido mas AuthType=None faz config
+        // ficar inerte silenciosamente — falha explícita orienta o operador.
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "http://localhost:8081",
+            AuthType = "None",
+            BasicAuthUserInfo = "user:pwd",
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("BasicAuthUserInfo só faz sentido", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_OAuthFieldComAuthTypeBasic_DeveFalhar()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "http://localhost:8081",
+            AuthType = "Basic",
+            BasicAuthUserInfo = "user:pwd",
+            OAuth = new OAuthBearerSettings
+            {
+                ClientId = "stale-config",
+            },
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("OAuth:* só faz sentido", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Validate_RequestTimeoutNaoPositivo_DeveFalhar()
+    {
+        SchemaRegistrySettings settings = new()
+        {
+            Url = "http://localhost:8081",
+            RequestTimeoutMs = 0,
+        };
+        ValidateOptionsResult result = new SchemaRegistrySettingsValidator().Validate(name: null, settings);
+        result.Succeeded.Should().BeFalse();
+        result.Failures.Should().Contain(f => f.Contains("RequestTimeoutMs", StringComparison.Ordinal));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
@@ -61,15 +61,6 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
@@ -82,26 +73,6 @@
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -1073,7 +1044,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1096,6 +1069,16 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
       "Confluent.Kafka": {
         "type": "CentralTransitive",
         "requested": "[2.14.0, )",
@@ -1103,6 +1086,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
@@ -64,39 +64,10 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -1088,7 +1059,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1167,11 +1140,23 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.14.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
         }
       },
       "Confluent.Kafka": {
@@ -1181,6 +1166,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
@@ -52,15 +52,6 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
         "resolved": "2.6.2",
@@ -70,26 +61,6 @@
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -1096,7 +1067,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1155,6 +1128,16 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
       "Confluent.Kafka": {
         "type": "CentralTransitive",
         "requested": "[2.14.0, )",
@@ -1162,6 +1145,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
@@ -69,15 +69,6 @@
           "xunit.core": "[2.9.3]"
         }
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
         "resolved": "2.6.2",
@@ -87,26 +78,6 @@
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -1094,7 +1065,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1117,6 +1090,16 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
       "Confluent.Kafka": {
         "type": "CentralTransitive",
         "requested": "[2.14.0, )",
@@ -1124,6 +1107,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
@@ -64,39 +64,10 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -1088,7 +1059,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1167,11 +1140,23 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.14.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
         }
       },
       "Confluent.Kafka": {
@@ -1181,6 +1166,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Messaging/EditalPublicadoAvroTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Messaging/EditalPublicadoAvroTests.cs
@@ -1,0 +1,142 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Messaging;
+
+using System;
+using System.IO;
+using AwesomeAssertions;
+using Avro.IO;
+using Avro.Specific;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
+using EditalPublicadoAvro = unifesspa.uniplus.selecao.events.EditalPublicado;
+
+/// <summary>
+/// Smoke unit tests para o pipeline Avro de <see cref="EditalPublicadoEvent"/>:
+/// schema parse, mapping puro <c>Event → Avro</c> e round-trip Avro binary
+/// (serialize → deserialize) usando <see cref="SpecificDefaultWriter"/> /
+/// <see cref="SpecificDefaultReader"/>.
+/// </summary>
+/// <remarks>
+/// Não toca rede nem Schema Registry — exercita apenas a camada de wire form.
+/// O caminho cross-process com Confluent SR (header magic byte + schema id +
+/// payload) é testado em integração quando o ambiente fornece Apicurio
+/// (compose local ou cluster standalone).
+/// </remarks>
+[Trait("Category", "Unit")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1859:Use concrete types when possible for improved performance",
+    Justification = "Testes do contrato ISpecificRecord — uso da interface é intencional para verificar a implementação dinâmica do Apache.Avro.")]
+public sealed class EditalPublicadoAvroTests
+{
+    [Fact(DisplayName = "Schema é carregado do embedded resource em Selecao.Domain")]
+    public void Schema_DeveSerCarregadoDoEmbeddedResource()
+    {
+        global::Avro.Schema schema = EditalPublicadoAvro.AvroSchema;
+
+        schema.Should().NotBeNull();
+        schema.Tag.Should().Be(global::Avro.Schema.Type.Record);
+
+        global::Avro.RecordSchema schemaRecord = (global::Avro.RecordSchema)schema;
+        schemaRecord.Name.Should().Be("EditalPublicado");
+        schemaRecord.Namespace.Should().Be("unifesspa.uniplus.selecao.events");
+        schemaRecord.Fields.Select(f => f.Name).Should().BeEquivalentTo(
+            ["EventId", "OccurredOn", "EditalId", "NumeroEdital"]);
+    }
+
+    [Fact(DisplayName = "Mapper Event → Avro preserva todos os campos")]
+    public void Mapper_DeveMaperearTodosOsCampos()
+    {
+        EditalPublicadoEvent evt = new(
+            EditalId: Guid.CreateVersion7(),
+            NumeroEdital: "001/2026");
+
+        EditalPublicadoAvro avro = EditalPublicadoToAvroMapper.ToAvro(evt);
+
+        avro.EventId.Should().Be(evt.EventId.ToString());
+        avro.OccurredOn.Should().Be(evt.OccurredOn.UtcDateTime);
+        avro.EditalId.Should().Be(evt.EditalId.ToString());
+        avro.NumeroEdital.Should().Be(evt.NumeroEdital);
+    }
+
+    [Fact(DisplayName = "Mapper rejeita null")]
+    public void Mapper_NullEvent_DeveLancarArgumentNull()
+    {
+        Action act = () => EditalPublicadoToAvroMapper.ToAvro(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "Round-trip Avro binary preserva todos os campos")]
+    public void RoundTrip_DevePreservarCampos()
+    {
+        // Construímos o Avro a partir de um evento real para garantir que o
+        // schema usado na escrita seja exatamente o mesmo carregado do recurso —
+        // qualquer drift entre .avsc e a classe ISpecificRecord falhará aqui.
+        EditalPublicadoEvent evt = new(
+            EditalId: Guid.CreateVersion7(),
+            NumeroEdital: "042/2026");
+
+        EditalPublicadoAvro original = EditalPublicadoToAvroMapper.ToAvro(evt);
+
+        SpecificDefaultWriter writer = new(EditalPublicadoAvro.AvroSchema);
+        using MemoryStream stream = new();
+        BinaryEncoder encoder = new(stream);
+        writer.Write(original, encoder);
+        encoder.Flush();
+
+        stream.Position = 0;
+        SpecificDefaultReader reader = new(EditalPublicadoAvro.AvroSchema, EditalPublicadoAvro.AvroSchema);
+        BinaryDecoder decoder = new(stream);
+        EditalPublicadoAvro? decoded = reader.Read(reuse: default(EditalPublicadoAvro), decoder);
+
+        decoded.Should().NotBeNull();
+        decoded.EventId.Should().Be(original.EventId);
+        // timestamp-millis trunca para ms — original tem ticks (precisão sub-ms),
+        // decoded vem só com ms. Comparar truncado.
+        decoded.OccurredOn.Should().BeCloseTo(original.OccurredOn, TimeSpan.FromMilliseconds(1));
+        decoded.EditalId.Should().Be(original.EditalId);
+        decoded.NumeroEdital.Should().Be(original.NumeroEdital);
+    }
+
+    [Theory(DisplayName = "ISpecificRecord Get por posição retorna campos esperados")]
+    [InlineData(0, "EventId")]
+    [InlineData(1, "OccurredOn")]
+    [InlineData(2, "EditalId")]
+    [InlineData(3, "NumeroEdital")]
+    public void Get_DeveRetornarCampoCorreto(int fieldPos, string expectedFieldName)
+    {
+        EditalPublicadoAvro avro = new()
+        {
+            EventId = "evt-id",
+            OccurredOn = new DateTime(2026, 5, 9, 12, 0, 0, DateTimeKind.Utc),
+            EditalId = "edital-id",
+            NumeroEdital = "001/2026",
+        };
+
+        ISpecificRecord record = (ISpecificRecord)avro;
+        object value = record.Get(fieldPos);
+
+        value.Should().NotBeNull();
+
+        // Cobertura por nome para evitar drift de ordem entre .avsc e Get/Put.
+        global::Avro.RecordSchema schema = (global::Avro.RecordSchema)EditalPublicadoAvro.AvroSchema;
+        schema.Fields[fieldPos].Name.Should().Be(expectedFieldName);
+    }
+
+    [Fact(DisplayName = "ISpecificRecord Get com posição inválida lança AvroRuntimeException")]
+    public void Get_PosicaoInvalida_DeveLancar()
+    {
+        EditalPublicadoAvro avro = new();
+        ISpecificRecord record = (ISpecificRecord)avro;
+        Action act = () => record.Get(99);
+        act.Should().Throw<global::Avro.AvroRuntimeException>();
+    }
+
+    [Fact(DisplayName = "ISpecificRecord Put com posição inválida lança AvroRuntimeException")]
+    public void Put_PosicaoInvalida_DeveLancar()
+    {
+        EditalPublicadoAvro avro = new();
+        ISpecificRecord record = (ISpecificRecord)avro;
+        Action act = () => record.Put(99, "x");
+        act.Should().Throw<global::Avro.AvroRuntimeException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -116,15 +116,6 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
-      "Apache.Avro": {
-        "type": "Transitive",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
         "resolved": "2.6.2",
@@ -142,26 +133,6 @@
         "type": "Transitive",
         "resolved": "8.4.0",
         "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
-      },
-      "Confluent.SchemaRegistry": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
-        "dependencies": {
-          "Confluent.Kafka": "2.14.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "Transitive",
-        "resolved": "2.14.0",
-        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.14.0",
-          "Confluent.SchemaRegistry": "2.14.0"
-        }
       },
       "Confluent.SchemaRegistry.Serdes.Json": {
         "type": "Transitive",
@@ -1168,7 +1139,9 @@
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.0, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
@@ -1233,11 +1206,23 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.14.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
         }
       },
       "Confluent.Kafka": {
@@ -1247,6 +1232,28 @@
         "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
         "dependencies": {
           "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
         }
       },
       "FluentValidation": {


### PR DESCRIPTION
## Resumo

Integra o `EditalPublicadoEvent` (Selecao) ao Apicurio Schema Registry usando Avro como wire format, conforme [ADR-0014](docs/adrs/0014-kafka-como-bus-assincrono-inter-modulos.md) (Kafka como bus inter-módulos) e [ADR-0044](docs/adrs/0044-roteamento-domain-events-pg-queue-kafka-opcional.md) (routing PG queue + Kafka opcional). Primeiro evento cross-módulo do Uni+ a ganhar contrato registrado — pattern definido para os subsequentes.

Pré-requisito mergeado: [uniplus-infra#163](https://github.com/unifesspa-edu-br/uniplus-infra/issues/163) (clients OIDC `uniplus-api-{portal,selecao,ingresso}` com mappers `aud=apicurio-registry` + `groups=[\"/users/uniplus\"]`) + chart Apicurio Registry deployado.

## O que mudou

**Domain (sem dep nova):**
- `Selecao.Domain/Events/Schemas/EditalPublicado.avsc` — schema Avro como `EmbeddedResource` no .csproj. Domain é puro: schema é texto, sem dep de `Apache.Avro`.

**Infrastructure:**
- `Selecao.Infrastructure/Messaging/Avro/EditalPublicado.cs` — classe `ISpecificRecord` no namespace `unifesspa.uniplus.selecao.events` (case-sensitive — Apache.Avro NET resolve via `Type.GetType(\"<ns>.<name>\")`).
- `EditalPublicadoToAvroMapper` + `EditalPublicadoToKafkaCascadeHandler` — projeção Event → Avro via cascading message Wolverine.

**Infrastructure.Core (primitivas reutilizáveis pelos 3 módulos):**
- `SchemaRegistrySettings` + validator com 3 modos auth (None/Basic/OAuthBearer).
- `OAuthBearerAuthenticationHeaderValueProvider` — `client_credentials` contra Keycloak; cache JWT até `exp - RefreshSkewSeconds`; renovação proativa serializada por `SemaphoreSlim`.
- `SchemaRegistrationHostedService` — registra subjects no Apicurio no startup, **idempotente** + **fail-graceful** (offline ≠ trava boot, runtime Confluent serdes faz fallback).
- `SchemaRegistryServiceCollectionExtensions.AddSchemaRegistry()` — DI helper com builder `.AddSchema(...)`. Cliente único compartilhado entre hosted service e Wolverine routing.

**Wiring (Selecao.API/Program.cs):**
\`\`\`csharp
builder.Services.AddSchemaRegistry(builder.Configuration)
    .AddSchema(\"edital_events-value\", EditalPublicado.SchemaResourceName, typeof(EditalPublicadoEvent).Assembly);

opts.PublishMessage<unifesspa.uniplus.selecao.events.EditalPublicado>()
    .ToKafkaTopic(\"edital_events\")
    .DefaultSerializer(new SchemaRegistryAvroSerializer(selecaoSrClient));
\`\`\`

**Compose local:**
- `apicurio` service em modo Confluent-compat (storage H2 in-memory, auth off); endpoint `/apis/ccompat/v7`.
- `selecao-api` + `ingresso-api` ganham `SchemaRegistry__Url=http://apicurio:8081/apis/ccompat/v7` + `depends_on: apicurio`.

**Pacotes (Directory.Packages.props):**
- `Confluent.SchemaRegistry` 2.14.0 + `Confluent.SchemaRegistry.Serdes.Avro` 2.14.0
- `Apache.Avro` 1.12.1 (piso transitivo do Confluent.SchemaRegistry.Serdes.Avro)

## Decisões consolidadas (ADR-0051)

| # | Pergunta | Decisão |
|---|---|---|
| 1 | Onde mora o `.avsc`? | `Domain/Events/Schemas/` como `EmbeddedResource` (alinhado com ADR-0014 \"event catalog no SharedKernel\" — Domain é onde o evento já vive). |
| 2 | Codegen `ISpecificRecord`? | Manual à mão para o 1º caso (~80 linhas). Reavaliar com ≥3 schemas. |
| 3 | Auth contra Apicurio? | OAuth `client_credentials` em standalone/HML/PROD; None em dev; Basic suportado para lab. |
| 4 | Quando registrar schemas? | Hosted service idempotente no startup + fallback runtime Confluent serdes. |
| 5 | Cliente único ou múltiplos? | Único, criado em `Program.cs` antes de `AddSchemaRegistry` — compartilhado via DI singleton e closure Wolverine. |

## Como testou

- ✅ `dotnet build UniPlus.slnx` — limpo (TreatWarningsAsErrors)
- ✅ `dotnet test UniPlus.slnx` — 580+ testes verdes (incluindo `OutboxCascadingMatrixTests`, `OutboxCascadingKafkaTests`, ArchTests)
- ✅ Smoke unit: `SchemaRegistrySettingsValidatorTests` (15 cenários: feature off, URL inválida, AuthType inválido, Basic/OAuthBearer faltando campos, cross-field coherence)
- ✅ Smoke unit: `EditalPublicadoAvroTests` (schema parse + namespace, mapper preserva campos, round-trip Avro binary `SpecificDefaultWriter` ↔ `SpecificDefaultReader`, ISpecificRecord Get/Put)
- ✅ ADR lint: `bash tools/adr-lint/validate.sh` — 53 ADRs, 0 erros
- 📋 Smoke compose (manual, documentado em `docs/guia-apicurio-schema-registry.md`):
  - `docker compose up -d apicurio kafka postgres` → `curl http://localhost:8081/apis/ccompat/v7/subjects` retorna lista
  - Após `selecao-api` start: hosted service registra `edital_events-value`; `curl /subjects/edital_events-value/versions/latest` retorna o `.avsc`
  - POST de edital → cascade dispara → Kafka topic `edital_events` recebe payload Avro com schema-id no header

## Riscos e rollback

- **R1 (mitigado):** Apicurio offline no boot → `SchemaRegistrationHostedService` loga warning e segue. Confluent serdes lazy registra em runtime.
- **R2 (aceito):** classes Avro em namespace lowercase fogem da convenção PascalCase do C# para casar com schema (Apache.Avro NET é case-sensitive). `CA1707` suprimido na classe com justificativa.
- **R3 (aceito):** boilerplate `ISpecificRecord` à mão. Trigger de reavaliação para codegen automatizado: 3+ schemas.
- **R4 (aceito):** dois assemblies para 1 evento (`EditalPublicadoEvent` no Domain + `EditalPublicado` Avro no Infrastructure) com mapper trivial. Mantém Clean Architecture.
- **Rollback:** `git revert` + `helm upgrade` reverte routing. PG queue intra-módulo continua funcionando — só o publishing Kafka volta a JSON default Wolverine. Sem dependência hard de Apicurio para o caminho atual de subscribers (Ingresso ainda não consume).

## Documentação atualizada

- ✅ ADR-0051 — Apicurio Schema Registry: Avro + Wolverine (decisões binding)
- ✅ Guia operacional `docs/guia-apicurio-schema-registry.md` — wiring, modos de auth, troubleshooting, padrão para próximos eventos
- ✅ docs/adrs/README.md (índice atualizado)

## Critérios de aceite (issue #358)

- [x] Schema `EditalPublicado.avsc` em `src/selecao/Selecao.Domain/Events/Schemas/` (decidido em ADR-0051: Domain, alinhado com ADR-0014)
- [x] Configuração `SchemaRegistry__Url` + auth (None/Basic/OAuthBearer) injetada via `IOptions<SchemaRegistrySettings>`
- [x] Wolverine producer integrado com `SchemaRegistryAvroSerializer` que valida + registra schema na publicação
- [-] Wolverine consumer integrado com `AvroDeserializer<T>` — N/A para este PR (consumer cross-módulo é Ingresso futuro; pattern documentado no guia)
- [x] Script de registro inicial idempotente — implementado como `IHostedService` (`SchemaRegistrationHostedService`)
- [x] Topic `edital_events` com schema correto (subject `edital_events-value`)
- [x] Smoke unitário: producer encripta, consumer decripta, round-trip com schema check passa
- [-] Smoke integração local (compose): infra adicionada, smoke documentado em guia (manual; automação fica para `uniplus-infra#99`)
- [x] Documentação `docs/guia-apicurio-schema-registry.md`
- [x] ADR-0051 registra localização dos schemas + estratégia de versionamento (BACKWARD)

## Não-objetivos (por escopo da issue)

- Schemas para outros eventos (`PreInscricaoCriada`, `ResultadoPublicado`, etc.) — Stories separadas, pattern já estabelecido por ADR-0051
- Schema evolution policy formal (FORWARD/FULL) — defer; default BACKWARD do Confluent é adequado para o caminho atual
- Consumer cross-módulo Ingresso (subscriber de `EditalPublicado`) — entra com a Story \"chamada de vagas\"
- Codegen automatizado de classes Avro via MSBuild target — defer até ≥3 schemas

Closes #358