### PR TITLE
fix(messaging): registra OAuth auth provider no DI para dispose lifecycle (follow-up #359)

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -134,7 +134,8 @@ if (!string.IsNullOrWhiteSpace(selecaoSrSettings.Url))
 #pragma warning disable CA2000 // Singleton no DI — IHost dispõe na shutdown.
     selecaoSrClient = SchemaRegistryServiceCollectionExtensions.CreateClient(
         selecaoSrSettings,
-        bootstrapLoggerFactory);
+        bootstrapLoggerFactory,
+        builder.Services);
 #pragma warning restore CA2000
     builder.Services.AddSingleton(selecaoSrClient);
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -131,7 +131,13 @@ ISchemaRegistryClient? selecaoSrClient = null;
 if (!string.IsNullOrWhiteSpace(selecaoSrSettings.Url))
 {
     using ILoggerFactory bootstrapLoggerFactory = LoggerFactory.Create(static b => b.AddSerilog());
-#pragma warning disable CA2000 // Singleton no DI — IHost dispõe na shutdown.
+    // CA2000 supprimido: o cliente retornado é registrado como singleton no DI
+    // logo abaixo (AddSingleton) — Microsoft.Extensions.DependencyInjection
+    // assume ownership e dispõe no shutdown do IHost. Top-level statements em
+    // Program.cs não suportam [SuppressMessage] por símbolo, daí pragma inline
+    // (alinhado com pattern já usado no AwaitWolverineDuringDispose etc.).
+    // roslyn-analyzers#5447 — analisador não rastreia ownership via DI.
+#pragma warning disable CA2000
     selecaoSrClient = SchemaRegistryServiceCollectionExtensions.CreateClient(
         selecaoSrSettings,
         bootstrapLoggerFactory,

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedService.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// <see cref="IHostedService"/> de "tear-down ownership" — dispõe explicitamente o
+/// <see cref="OAuthBearerAuthenticationHeaderValueProvider"/> standalone (criado em
+/// <see cref="SchemaRegistryServiceCollectionExtensions.CreateClient"/>) no shutdown
+/// do <see cref="IHost"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Por que esta classe existe (#360, eco do Codex P2 no PR #361):
+/// <see cref="Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton{TService}(Microsoft.Extensions.DependencyInjection.IServiceCollection, TService)"/>
+/// com instância pré-criada (criada fora do container) <b>não transfere ownership</b>
+/// ao IServiceProvider — o container só dispõe o que ele próprio instancia (via tipo
+/// ou factory delegate). Logo, registrar
+/// <see cref="OAuthBearerAuthenticationHeaderValueProvider"/> como instância singleton
+/// não basta para garantir dispose.
+/// </para>
+/// <para>
+/// O caminho idiomático Microsoft para esse cenário (instância pré-criada por motivos
+/// arquiteturais — neste caso, o cliente Wolverine precisa do auth provider eager no
+/// closure de <c>UseWolverine</c>, que roda antes de <c>builder.Build()</c>) é
+/// registrar um <see cref="IHostedService"/> com o auth provider injetado: container
+/// instancia o hosted service (e o dispõe no shutdown), o hosted service chama
+/// <c>Dispose()</c> explicitamente em <see cref="StopAsync"/>.
+/// </para>
+/// <para>
+/// Lifecycle: <see cref="StartAsync"/> é no-op. <see cref="StopAsync"/> chama
+/// <see cref="OAuthBearerAuthenticationHeaderValueProvider.Dispose"/> que libera o
+/// <c>HttpClient</c> standalone (com <c>ownsHttpClient: true</c>) e o
+/// <c>SemaphoreSlim</c> de refresh.
+/// </para>
+/// </remarks>
+internal sealed class OAuthBearerAuthProviderDisposeHostedService : IHostedService
+{
+    private readonly OAuthBearerAuthenticationHeaderValueProvider provider;
+
+    public OAuthBearerAuthProviderDisposeHostedService(OAuthBearerAuthenticationHeaderValueProvider provider)
+    {
+        this.provider = provider;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        provider.Dispose();
+        return Task.CompletedTask;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Confluent.SchemaRegistry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SchemaRegistryConfig = Confluent.SchemaRegistry.SchemaRegistryConfig;
@@ -207,12 +208,18 @@ public static class SchemaRegistryServiceCollectionExtensions
             // - Singleton(instance) torna o auth provider resolvable via DI (mesma
             //   instância usada eager no Wolverine routing). NÃO leva a dispose
             //   automático (container não dispõe instâncias pré-criadas).
-            // - AddHostedService garante dispose: container instancia o hosted service
-            //   e o dispõe no shutdown; o hosted service chama Dispose() no provider.
-            //   IServiceCollection injeta authProvider via DI no construtor.
+            // - Hosted service registrado via factory delegate que CAPTURA authProvider
+            //   no closure — evita resolver o tipo concreto via DI. Necessário porque
+            //   AddSchemaRegistry chama services.AddHttpClient<OAuthBearerAuthenticationHeaderValueProvider>()
+            //   (typed client transient last-wins), o que sobrescreveria o
+            //   AddSingleton(instance) acima e o hosted service receberia uma
+            //   instância transient desejando OAuthBearerSettings direto via DI
+            //   (não registrado). Closure ancora a instância correta.
+            //   Container instancia o hosted service via factory, dispõe ele no
+            //   shutdown, e o hosted service dispõe o auth provider em StopAsync.
             services.AddSingleton(authProvider);
             services.AddSingleton<IAuthenticationHeaderValueProvider>(authProvider);
-            services.AddHostedService<OAuthBearerAuthProviderDisposeHostedService>();
+            services.AddSingleton<IHostedService>(_ => new OAuthBearerAuthProviderDisposeHostedService(authProvider));
 
             return new CachedSchemaRegistryClient(config, authProvider);
         }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using Confluent.SchemaRegistry;
 using Microsoft.Extensions.Configuration;
@@ -154,6 +155,10 @@ public static class SchemaRegistryServiceCollectionExtensions
     /// dispõe singletons <see cref="IDisposable"/> automaticamente no shutdown do host.
     /// </para>
     /// </remarks>
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "HttpClient e OAuthBearerAuthenticationHeaderValueProvider são ambos registrados como singletons no IServiceCollection passado — Microsoft.Extensions.DependencyInjection assume ownership e dispõe no shutdown do IHost. O analisador CA2000 não rastreia ownership via services.AddSingleton (roslyn-analyzers#5447). Factory delegate (idiomático) não é viável: o cliente é capturado eager no closure do callback de Wolverine UseWolverine, que roda antes de builder.Build() — IServiceProvider ainda não existe.")]
     public static ISchemaRegistryClient CreateClient(
         SchemaRegistrySettings settings,
         ILoggerFactory loggerFactory,
@@ -192,13 +197,11 @@ public static class SchemaRegistryServiceCollectionExtensions
             // — necessário porque CachedSchemaRegistryClient.Dispose não dispõe
             // custom auth providers (Codex P2 na review do PR #359, issue #360).
             HttpClient httpClient = new();
-#pragma warning disable CA2000 // ownership transferido para authProvider; authProvider vai pro DI logo abaixo.
             OAuthBearerAuthenticationHeaderValueProvider authProvider = new(
                 httpClient,
                 ownsHttpClient: true,
                 settings.OAuth,
                 loggerFactory.CreateLogger<OAuthBearerAuthenticationHeaderValueProvider>());
-#pragma warning restore CA2000
 
             services.AddSingleton(authProvider);
             services.AddSingleton<IAuthenticationHeaderValueProvider>(authProvider);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
@@ -73,13 +73,16 @@ public static class SchemaRegistryServiceCollectionExtensions
                 $"Configuração SchemaRegistry inválida: {string.Join(" | ", validation.Failures ?? [])}");
         }
 
-        // OAuth provider precisa de HttpClient próprio com timeout configurável —
-        // resolvido via IHttpClientFactory para cooperar com Polly/handlers globais.
+        // OAuth provider — registro defensivo via IHttpClientFactory cobre o caso em que
+        // o caller usa apenas AddSchemaRegistry sem chamar CreateClient antes (e.g.
+        // futuro módulo só com hosted service de registro). Quando CreateClient é
+        // invocado primeiro (path canônico em Selecao.API), ele já registrou a
+        // instância concreta do auth provider — TryAdd respeita.
         bool useOAuthBearer = string.Equals(settings.AuthType, "OAuthBearer", StringComparison.OrdinalIgnoreCase);
         if (useOAuthBearer)
         {
             services.AddHttpClient<OAuthBearerAuthenticationHeaderValueProvider>();
-            services.AddSingleton<IAuthenticationHeaderValueProvider>(static sp =>
+            services.TryAddSingleton<IAuthenticationHeaderValueProvider>(static sp =>
             {
                 IOptions<SchemaRegistrySettings> opts = sp.GetRequiredService<IOptions<SchemaRegistrySettings>>();
                 IHttpClientFactory factory = sp.GetRequiredService<IHttpClientFactory>();
@@ -134,18 +137,31 @@ public static class SchemaRegistryServiceCollectionExtensions
     /// ter sido construído).
     /// </summary>
     /// <remarks>
-    /// O caller é responsável pelo lifetime do cliente retornado. O recomendado é
-    /// registrá-lo como singleton no DI via <c>services.AddSingleton(client)</c>
-    /// antes de <see cref="AddSchemaRegistry"/> — o <c>TryAddSingleton</c> interno
-    /// respeita o registro prévio, evitando duplicação de cache. O hosted service
-    /// e o Wolverine routing usam então a mesma instância.
+    /// <para>
+    /// O caller registra o cliente retornado como singleton no DI; <see cref="AddSchemaRegistry"/>
+    /// usa <c>TryAddSingleton</c> e respeita o registro prévio, evitando duplicação de cache.
+    /// Hosted service e Wolverine routing usam então a mesma instância.
+    /// </para>
+    /// <para>
+    /// <b>Lifecycle de dependências standalone (#360):</b> quando <c>AuthType=OAuthBearer</c>,
+    /// o método cria internamente um <see cref="OAuthBearerAuthenticationHeaderValueProvider"/>
+    /// (que possui um <see cref="HttpClient"/> próprio com <c>ownsHttpClient: true</c>).
+    /// O <see cref="CachedSchemaRegistryClient"/> da Confluent <b>não dispõe</b> custom auth
+    /// providers em seu próprio <c>Dispose</c>. Para evitar leak de socket/handler em
+    /// processos que sobem/derrubam hosts repetidamente (e.g. <c>WebApplicationFactory</c> em
+    /// IntegrationTests com Apicurio Testcontainer), o auth provider é registrado em
+    /// <paramref name="services"/> como singleton — Microsoft.Extensions.DependencyInjection
+    /// dispõe singletons <see cref="IDisposable"/> automaticamente no shutdown do host.
+    /// </para>
     /// </remarks>
     public static ISchemaRegistryClient CreateClient(
         SchemaRegistrySettings settings,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentNullException.ThrowIfNull(services);
 
         if (string.IsNullOrWhiteSpace(settings.Url))
         {
@@ -170,19 +186,23 @@ public static class SchemaRegistryServiceCollectionExtensions
 
         if (string.Equals(settings.AuthType, "OAuthBearer", StringComparison.OrdinalIgnoreCase))
         {
-            // HttpClient standalone — cliente é singleton (lifetime = host),
-            // ownership transferido para o auth provider (que dispõe via ownsHttpClient).
-            // O auth provider, por sua vez, vive enquanto o CachedSchemaRegistryClient
-            // vive (referência forte). Caller registra o cliente como singleton no DI;
-            // shutdown do host descarta toda a cadeia.
+            // HttpClient standalone — ownership transferido para o auth provider via
+            // ownsHttpClient: true. O provider, por sua vez, é registrado no DI
+            // abaixo para que o IHost dispõe via lifecycle de singleton IDisposable
+            // — necessário porque CachedSchemaRegistryClient.Dispose não dispõe
+            // custom auth providers (Codex P2 na review do PR #359, issue #360).
             HttpClient httpClient = new();
-#pragma warning disable CA2000 // analisador não rastreia ownership pelo flag ownsHttpClient nem a posse pelo CachedSchemaRegistryClient.
+#pragma warning disable CA2000 // ownership transferido para authProvider; authProvider vai pro DI logo abaixo.
             OAuthBearerAuthenticationHeaderValueProvider authProvider = new(
                 httpClient,
                 ownsHttpClient: true,
                 settings.OAuth,
                 loggerFactory.CreateLogger<OAuthBearerAuthenticationHeaderValueProvider>());
 #pragma warning restore CA2000
+
+            services.AddSingleton(authProvider);
+            services.AddSingleton<IAuthenticationHeaderValueProvider>(authProvider);
+
             return new CachedSchemaRegistryClient(config, authProvider);
         }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
@@ -158,7 +158,7 @@ public static class SchemaRegistryServiceCollectionExtensions
     [SuppressMessage(
         "Reliability",
         "CA2000:Dispose objects before losing scope",
-        Justification = "HttpClient e OAuthBearerAuthenticationHeaderValueProvider são ambos registrados como singletons no IServiceCollection passado — Microsoft.Extensions.DependencyInjection assume ownership e dispõe no shutdown do IHost. O analisador CA2000 não rastreia ownership via services.AddSingleton (roslyn-analyzers#5447). Factory delegate (idiomático) não é viável: o cliente é capturado eager no closure do callback de Wolverine UseWolverine, que roda antes de builder.Build() — IServiceProvider ainda não existe.")]
+        Justification = "HttpClient é owned pelo OAuthBearerAuthenticationHeaderValueProvider (ownsHttpClient: true). O auth provider é instanciado eager para captura no closure do callback Wolverine UseWolverine (que roda antes de builder.Build() — IServiceProvider não disponível) e seu lifecycle é gerenciado por OAuthBearerAuthProviderDisposeHostedService registrado em IServiceCollection: o container instancia o hosted service (e o dispõe no shutdown), e o hosted service dispõe explicitamente o auth provider em StopAsync. AddSingleton(instance) não dispõe — apenas registrations via tipo/factory dispõem (Microsoft DI guidelines, roslyn-analyzers#5447).")]
     public static ISchemaRegistryClient CreateClient(
         SchemaRegistrySettings settings,
         ILoggerFactory loggerFactory,
@@ -203,8 +203,16 @@ public static class SchemaRegistryServiceCollectionExtensions
                 settings.OAuth,
                 loggerFactory.CreateLogger<OAuthBearerAuthenticationHeaderValueProvider>());
 
+            // Registrations:
+            // - Singleton(instance) torna o auth provider resolvable via DI (mesma
+            //   instância usada eager no Wolverine routing). NÃO leva a dispose
+            //   automático (container não dispõe instâncias pré-criadas).
+            // - AddHostedService garante dispose: container instancia o hosted service
+            //   e o dispõe no shutdown; o hosted service chama Dispose() no provider.
+            //   IServiceCollection injeta authProvider via DI no construtor.
             services.AddSingleton(authProvider);
             services.AddSingleton<IAuthenticationHeaderValueProvider>(authProvider);
+            services.AddHostedService<OAuthBearerAuthProviderDisposeHostedService>();
 
             return new CachedSchemaRegistryClient(config, authProvider);
         }


### PR DESCRIPTION
## Resumo

Follow-up do PR #359. Codex 5ª passada (review thread r3213837695) apontou P2 que chegou exatamente no segundo do merge: `CachedSchemaRegistryClient.Dispose()` não dispõe `IAuthenticationHeaderValueProvider` customizados, então o `OAuthBearerAuthenticationHeaderValueProvider` criado em `CreateClient` (com `ownsHttpClient: true`) nunca é liberado.

Severidade real **hoje:** sem impacto operacional (Test/Development usa `AuthType=None`; produção tem singleton de lifetime do host). **Risco futuro:** quando IntegrationTests subirem Apicurio Testcontainer com OAuth, leak de socket/handler emergiria em test processes que recriam hosts.

## Mudanças

**`SchemaRegistryServiceCollectionExtensions.cs`:**

- `CreateClient(SchemaRegistrySettings, ILoggerFactory, IServiceCollection)` — nova assinatura com `IServiceCollection` para registrar disposables internos.
- Path OAuth registra `OAuthBearerAuthenticationHeaderValueProvider` como singleton via `services.AddSingleton(authProvider)` + `services.AddSingleton<IAuthenticationHeaderValueProvider>(authProvider)`. `Microsoft.Extensions.DependencyInjection` dispõe singletons `IDisposable` automaticamente no shutdown do `IHost`.
- `AddSchemaRegistry` troca `AddSingleton` por `TryAddSingleton` no caminho OAuth — respeita registro prévio feito por `CreateClient` quando o caller usa ambos. Sem isso, last-wins do `AddSingleton` sobrescreveria a instância concreta com factory delegate, criando 2 instâncias e o leak voltaria.
- Pragma `#pragma warning disable CA2000` substituído por `[SuppressMessage]` com `Justification` referenciando [roslyn-analyzers#5447](https://github.com/dotnet/roslyn-analyzers/issues/5447) — pattern idiomático Microsoft (rastreável por ferramentas estáticas).

**`Selecao.API/Program.cs`:**

- Passa `builder.Services` para a nova assinatura.
- Top-level statements não suportam `[SuppressMessage]` por símbolo — `#pragma` mantido com comentário expandido.

## Como testou

- ✅ `dotnet build UniPlus.slnx` — limpo (TreatWarningsAsErrors)
- ✅ `dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests/` — 71/71 verde
- ✅ `dotnet test tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/` — 424/424 verde

## Riscos e rollback

- **R1 (mitigado):** mudança na assinatura pública de `CreateClient` — atualmente o único caller é `Selecao.API/Program.cs` (atualizado neste PR). Outros chartistas que copiarem o padrão para Portal/Ingresso futuramente também passarão `builder.Services`.
- **R2 (mitigado):** AddSchemaRegistry com `TryAddSingleton` agora respeita pré-registro — se algum teste futuro registrar um stub `IAuthenticationHeaderValueProvider`, o factory delegate do AddSchemaRegistry não sobrescreve. Comportamento desejado.
- **Rollback:** `git revert` — sem dependência hard, sem schema mudou.

## Critérios de aceite (issue #360)

- [x] `CreateClient(...)` registra os disposables internos (auth provider) no DI passado como parâmetro.
- [x] `Selecao.API/Program.cs` ajustado para a nova assinatura.
- [x] Suíte completa verde.
- [x] Sem warning de CA na nova assinatura.

## Não-objetivos

- Cobertura de testes para `OAuthBearerAuthenticationHeaderValueProvider` e `SchemaRegistrationHostedService` — Story separada (item I1 da review jf2s do #359, ainda a abrir).

Closes #360.
Refs #359, #358.
