### PR TITLE
test(messaging): cobertura unitária Schema Registry — auth provider + hosted services + dispose service (#362)

### DIFF
--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedServiceTests.cs
@@ -1,0 +1,81 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.SchemaRegistry;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+/// <summary>
+/// Cobertura de <see cref="OAuthBearerAuthProviderDisposeHostedService"/> —
+/// IHostedService responsável por dispor o OAuthBearerAuthenticationHeaderValueProvider
+/// criado eager em CreateClient. Cenários:
+/// <list type="bullet">
+/// <item><description><c>StartAsync</c> é no-op (não toca o provider).</description></item>
+/// <item><description><c>StopAsync</c> chama Dispose explicitamente no provider — libera HttpClient (ownsHttpClient=true) + SemaphoreSlim.</description></item>
+/// </list>
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class OAuthBearerAuthProviderDisposeHostedServiceTests
+{
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Factory: ownership do provider e do HttpClient interno passa ao caller, que dispõe via 'using'.")]
+    private static OAuthBearerAuthenticationHeaderValueProvider CreateProviderOwningHttpClient()
+    {
+        // ownsHttpClient: true para validar que Dispose libera o HttpClient interno.
+        // Settings vazias suficientes — não vamos chamar GetAuthenticationHeader.
+        return new OAuthBearerAuthenticationHeaderValueProvider(
+            httpClient: new HttpClient(),
+            ownsHttpClient: true,
+            settings: new OAuthBearerSettings { ClientId = "x", ClientSecret = "x", TokenEndpoint = "https://x" },
+            logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance);
+    }
+
+    [Fact(DisplayName = "StartAsync é no-op — retorna Task.CompletedTask sem tocar o provider")]
+    public async Task StartAsync_DeveSerNoOp()
+    {
+        using OAuthBearerAuthenticationHeaderValueProvider provider = CreateProviderOwningHttpClient();
+        OAuthBearerAuthProviderDisposeHostedService sut = new(provider);
+
+        Task task = sut.StartAsync(CancellationToken.None);
+
+        task.Should().BeSameAs(Task.CompletedTask);
+        // Provider continua utilizável após StartAsync — não foi disposto.
+        Action probe = () => _ = provider.GetType();
+        probe.Should().NotThrow();
+
+        await Task.CompletedTask;
+    }
+
+    [Fact(DisplayName = "StopAsync dispõe o provider — chamada subsequente lança ObjectDisposed")]
+    public async Task StopAsync_DeveDisporOProvider()
+    {
+        using OAuthBearerAuthenticationHeaderValueProvider provider = CreateProviderOwningHttpClient();
+        OAuthBearerAuthProviderDisposeHostedService sut = new(provider);
+
+        await sut.StopAsync(CancellationToken.None);
+
+        // Após Dispose, GetAuthenticationHeader tenta usar SemaphoreSlim já disposto —
+        // dispara ObjectDisposedException. É a observação confiável de que Dispose foi chamado.
+        Action act = () => _ = provider.GetAuthenticationHeader();
+        act.Should().Throw<System.ObjectDisposedException>();
+    }
+
+    [Fact(DisplayName = "Dispose é idempotente — múltiplas chamadas StopAsync não lançam")]
+    public async Task StopAsync_Multiplo_DeveSerIdempotente()
+    {
+        using OAuthBearerAuthenticationHeaderValueProvider provider = CreateProviderOwningHttpClient();
+        OAuthBearerAuthProviderDisposeHostedService sut = new(provider);
+
+        await sut.StopAsync(CancellationToken.None);
+        Func<Task> act = async () => await sut.StopAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync(
+            because: "OAuthBearerAuthenticationHeaderValueProvider.Dispose tem flag 'disposed' e é idempotente.");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedServiceTests.cs
@@ -2,7 +2,9 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.SchemaRegist
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
@@ -36,10 +38,40 @@ public sealed class OAuthBearerAuthProviderDisposeHostedServiceTests
             logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance);
     }
 
-    [Fact(DisplayName = "StartAsync é no-op — retorna Task.CompletedTask sem tocar o provider")]
+    /// <summary>Cria provider com stub HTTP que responde 200 OK — útil para
+    /// verificar que o provider continua funcional (não disposed) executando
+    /// o caminho real que toca o SemaphoreSlim interno.</summary>
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Factory: ownership do provider passa ao caller (using); HttpClient é owned pelo provider.")]
+    private static OAuthBearerAuthenticationHeaderValueProvider CreateProviderWithStub(StubHttpMessageHandler handler)
+    {
+        string okResponse = JsonSerializer.Serialize(new
+        {
+            access_token = "jwt-test",
+            expires_in = 300,
+            token_type = "Bearer",
+        });
+        handler.EnqueueResponse(HttpStatusCode.OK, okResponse);
+
+        return new OAuthBearerAuthenticationHeaderValueProvider(
+            httpClient: new HttpClient(handler),
+            ownsHttpClient: true,
+            settings: new OAuthBearerSettings
+            {
+                ClientId = "test",
+                ClientSecret = "test",
+                TokenEndpoint = "https://kc.test/token",
+            },
+            logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance);
+    }
+
+    [Fact(DisplayName = "StartAsync é no-op — retorna Task concluída e provider continua funcional")]
     public async Task StartAsync_DeveSerNoOp()
     {
-        using OAuthBearerAuthenticationHeaderValueProvider provider = CreateProviderOwningHttpClient();
+        using StubHttpMessageHandler handler = new();
+        using OAuthBearerAuthenticationHeaderValueProvider provider = CreateProviderWithStub(handler);
         OAuthBearerAuthProviderDisposeHostedService sut = new(provider);
 
         Task task = sut.StartAsync(CancellationToken.None);
@@ -49,11 +81,16 @@ public sealed class OAuthBearerAuthProviderDisposeHostedServiceTests
         // runtimes, então BeSameAs flake-aria. Validar o que importa: já
         // completou síncrono e com sucesso.
         task.IsCompletedSuccessfully.Should().BeTrue(
-            because: "StartAsync é no-op síncrono — deve retornar Task já concluída sem efeito sobre o provider.");
+            because: "StartAsync é no-op síncrono — deve retornar Task já concluída.");
 
-        // Provider continua utilizável após StartAsync — não foi disposto.
-        Action probe = () => _ = provider.GetType();
-        probe.Should().NotThrow();
+        // Operação real que depende do estado não-disposto: GetAuthenticationHeader
+        // entra no caminho de refresh (cache cold), bate no SemaphoreSlim e dispara
+        // o request HTTP. Se StartAsync regredir e chamar Dispose(), esta linha
+        // lança ObjectDisposedException — falha observável (vs GetType() que
+        // sempre passa, mesmo após dispose).
+        Action realCall = () => _ = provider.GetAuthenticationHeader();
+        realCall.Should().NotThrow<ObjectDisposedException>(
+            because: "StartAsync deve ser no-op; provider precisa continuar funcional após StartAsync.");
 
         await Task.CompletedTask;
     }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedServiceTests.cs
@@ -44,7 +44,13 @@ public sealed class OAuthBearerAuthProviderDisposeHostedServiceTests
 
         Task task = sut.StartAsync(CancellationToken.None);
 
-        task.Should().BeSameAs(Task.CompletedTask);
+        // Asserção de comportamento (não de identidade) — Task.CompletedTask
+        // não garante que cada acesso retorna a mesma instância em todos os
+        // runtimes, então BeSameAs flake-aria. Validar o que importa: já
+        // completou síncrono e com sucesso.
+        task.IsCompletedSuccessfully.Should().BeTrue(
+            because: "StartAsync é no-op síncrono — deve retornar Task já concluída sem efeito sobre o provider.");
+
         // Provider continua utilizável após StartAsync — não foi disposto.
         Action probe = () => _ = provider.GetType();
         probe.Should().NotThrow();

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProviderTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProviderTests.cs
@@ -1,0 +1,226 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.SchemaRegistry;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+
+/// <summary>
+/// Cobertura de <see cref="OAuthBearerAuthenticationHeaderValueProvider"/>:
+/// cache de JWT, refresh proativo, distinção 4xx (deterministic — propaga
+/// InvalidOperationException) vs 5xx (transient — HttpRequestException com
+/// HttpRequestError.ConnectionError), serialização de renovações concorrentes via
+/// SemaphoreSlim, ownership de HttpClient.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class OAuthBearerAuthenticationHeaderValueProviderTests
+{
+    private static OAuthBearerSettings DefaultSettings(int refreshSkewSeconds = 30)
+        => new()
+        {
+            TokenEndpoint = "https://kc.test/realms/uniplus/protocol/openid-connect/token",
+            ClientId = "uniplus-api-selecao",
+            ClientSecret = "s3cr3t",
+            RefreshSkewSeconds = refreshSkewSeconds,
+            RequestTimeoutMs = 1_000,
+        };
+
+    private static string TokenResponseJson(string accessToken, int expiresInSeconds)
+        => JsonSerializer.Serialize(new
+        {
+            access_token = accessToken,
+            expires_in = expiresInSeconds,
+            token_type = "Bearer",
+        });
+
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "Factory: HttpClient é owned pelo provider (ownsHttpClient=true); ownership do provider passa ao caller via 'using'.")]
+    private static OAuthBearerAuthenticationHeaderValueProvider CreateProvider(
+        StubHttpMessageHandler handler,
+        OAuthBearerSettings? settings = null)
+    {
+        HttpClient httpClient = new(handler);
+        return new OAuthBearerAuthenticationHeaderValueProvider(
+            httpClient,
+            ownsHttpClient: true,
+            settings ?? DefaultSettings(),
+            NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance);
+    }
+
+    [Fact(DisplayName = "200 OK retorna Bearer header com access_token + cacheia o token")]
+    public void HappyPath_DeveRetornarBearerEcachear()
+    {
+        using StubHttpMessageHandler handler = new();
+        handler.EnqueueResponse(HttpStatusCode.OK, TokenResponseJson("jwt-abc", 300));
+        using OAuthBearerAuthenticationHeaderValueProvider sut = CreateProvider(handler);
+
+        AuthenticationHeaderValue header = sut.GetAuthenticationHeader();
+
+        header.Scheme.Should().Be("Bearer");
+        header.Parameter.Should().Be("jwt-abc");
+        handler.CallCount.Should().Be(1);
+
+        // Forma do request ao token endpoint
+        HttpRequestMessage req = handler.ReceivedRequests[0];
+        req.Method.Should().Be(HttpMethod.Post);
+        req.RequestUri.Should().Be(new Uri("https://kc.test/realms/uniplus/protocol/openid-connect/token"));
+    }
+
+    [Fact(DisplayName = "Cache hit dentro da janela < exp - skew NÃO chama o token endpoint novamente")]
+    public void CacheHit_DeveReusarTokenSemNovaChamada()
+    {
+        using StubHttpMessageHandler handler = new();
+        handler.EnqueueResponse(HttpStatusCode.OK, TokenResponseJson("jwt-cached", 300));
+        using OAuthBearerAuthenticationHeaderValueProvider sut = CreateProvider(handler);
+
+        AuthenticationHeaderValue first = sut.GetAuthenticationHeader();
+        AuthenticationHeaderValue second = sut.GetAuthenticationHeader();
+        AuthenticationHeaderValue third = sut.GetAuthenticationHeader();
+
+        first.Parameter.Should().Be("jwt-cached");
+        second.Parameter.Should().Be("jwt-cached");
+        third.Parameter.Should().Be("jwt-cached");
+        handler.CallCount.Should().Be(1, because: "três chamadas dentro da janela usam o mesmo token.");
+    }
+
+    [Fact(DisplayName = "Refresh proativo após exp - skew chama o token endpoint novamente")]
+    public void RefreshProativo_DeveBuscarNovoToken()
+    {
+        using StubHttpMessageHandler handler = new();
+        // expires_in muito baixo (1s) + skew alto (30s) garante que cache invalida na 2ª chamada.
+        handler.EnqueueResponse(HttpStatusCode.OK, TokenResponseJson("jwt-old", expiresInSeconds: 1));
+        handler.EnqueueResponse(HttpStatusCode.OK, TokenResponseJson("jwt-new", expiresInSeconds: 300));
+        using OAuthBearerAuthenticationHeaderValueProvider sut = CreateProvider(handler);
+
+        AuthenticationHeaderValue first = sut.GetAuthenticationHeader();
+        AuthenticationHeaderValue second = sut.GetAuthenticationHeader();
+
+        first.Parameter.Should().Be("jwt-old");
+        second.Parameter.Should().Be("jwt-new");
+        handler.CallCount.Should().Be(2);
+    }
+
+    [Theory(DisplayName = "4xx no token endpoint propaga InvalidOperationException (deterministic)")]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.NotFound)]
+    public void Status4xx_DevePropagarInvalidOperation(HttpStatusCode status)
+    {
+        using StubHttpMessageHandler handler = new();
+        handler.EnqueueResponse(status, """{"error":"invalid_client"}""");
+        using OAuthBearerAuthenticationHeaderValueProvider sut = CreateProvider(handler);
+
+        Action act = () => sut.GetAuthenticationHeader();
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*determinístico*");
+    }
+
+    [Theory(DisplayName = "5xx no token endpoint propaga HttpRequestException com ConnectionError (transient)")]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public void Status5xx_DevePropagarHttpRequestExceptionTransient(HttpStatusCode status)
+    {
+        using StubHttpMessageHandler handler = new();
+        handler.EnqueueResponse(status, "Server error");
+        using OAuthBearerAuthenticationHeaderValueProvider sut = CreateProvider(handler);
+
+        Action act = () => sut.GetAuthenticationHeader();
+
+        act.Should().Throw<HttpRequestException>()
+            .Which.HttpRequestError.Should().Be(HttpRequestError.ConnectionError,
+                because: "5xx é tratado como transient para que SchemaRegistrationHostedService siga o caminho fail-graceful.");
+    }
+
+    [Fact(DisplayName = "Renovações concorrentes serializam — 1 chamada só ao token endpoint")]
+    public async Task RenovacoesConcorrentes_DeveSerializarChamadas()
+    {
+        using StubHttpMessageHandler handler = new();
+        handler.EnqueueResponse(HttpStatusCode.OK, TokenResponseJson("jwt-shared", 300));
+        using OAuthBearerAuthenticationHeaderValueProvider sut = CreateProvider(handler);
+
+        // 10 threads disputam token cold-cache simultaneamente
+        Task<AuthenticationHeaderValue>[] tasks = Enumerable
+            .Range(0, 10)
+            .Select(_ => Task.Run(sut.GetAuthenticationHeader))
+            .ToArray();
+
+        AuthenticationHeaderValue[] results = await Task.WhenAll(tasks);
+
+        results.Should().AllSatisfy(h =>
+        {
+            h.Scheme.Should().Be("Bearer");
+            h.Parameter.Should().Be("jwt-shared");
+        });
+        handler.CallCount.Should().Be(1,
+            because: "SemaphoreSlim serializa renovações; threads pós-refresh reutilizam o token recém-obtido.");
+    }
+
+    [Fact(DisplayName = "Dispose com ownsHttpClient=true libera SemaphoreSlim — uso subsequente lança")]
+    public void Dispose_OwnsHttpClient_DeveLiberarRecursos()
+    {
+        using StubHttpMessageHandler handler = new();
+        OAuthBearerAuthenticationHeaderValueProvider sut = CreateProvider(handler);
+
+        // Sem chamar GetAuthenticationHeader antes — cache permanece nulo. Após Dispose,
+        // a próxima chamada vai entrar no caminho de refresh (refreshLock.WaitAsync) que
+        // dispara ObjectDisposedException no SemaphoreSlim disposto. Se houvesse token
+        // cached, o fluxo retornaria early sem tocar o semaphore (cache hit).
+        sut.Dispose();
+
+        Action useAfterDispose = () => _ = sut.GetAuthenticationHeader();
+        useAfterDispose.Should().Throw<ObjectDisposedException>(
+            because: "SemaphoreSlim disposed bloqueia uso subsequente.");
+    }
+
+    [Fact(DisplayName = "Dispose com ownsHttpClient=false NÃO dispõe HttpClient externo")]
+    public void Dispose_NotOwnsHttpClient_DevePreservarHttpClient()
+    {
+        using StubHttpMessageHandler handler = new();
+        handler.EnqueueResponse(HttpStatusCode.OK, TokenResponseJson("jwt-1", 300));
+        handler.EnqueueResponse(HttpStatusCode.OK, TokenResponseJson("jwt-2", 300));
+        using HttpClient externalClient = new(handler, disposeHandler: false);
+
+        using (OAuthBearerAuthenticationHeaderValueProvider sut = new(
+            externalClient,
+            settings: DefaultSettings(),
+            logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance))
+        {
+            sut.GetAuthenticationHeader();
+        }
+
+        // HttpClient externo deve continuar utilizável (managed pelo IHttpClientFactory na realidade).
+        Action useExternalAfterProviderDispose = () =>
+        {
+            // Faz uma request direta — handler está acessível, response 200 OK.
+            using HttpResponseMessage _ = externalClient.GetAsync(new Uri("https://kc.test/")).GetAwaiter().GetResult();
+        };
+
+        // Se externalClient tivesse sido disposed, lançaria ObjectDisposedException antes do handler.
+        useExternalAfterProviderDispose.Should().NotThrow<ObjectDisposedException>();
+    }
+
+    [Fact(DisplayName = "Dispose é idempotente — múltiplas chamadas não lançam")]
+    public void Dispose_Multiplo_DeveSerIdempotente()
+    {
+        using StubHttpMessageHandler handler = new();
+        OAuthBearerAuthenticationHeaderValueProvider sut = CreateProvider(handler);
+
+        sut.Dispose();
+        Action act = sut.Dispose;
+
+        act.Should().NotThrow();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/Resources/TestSchema.avsc
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/Resources/TestSchema.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "namespace": "test.unit.schema",
+  "name": "TestSchema",
+  "fields": [
+    {"name": "Id", "type": "string"}
+  ]
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/SchemaRegistrationHostedServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/SchemaRegistrationHostedServiceTests.cs
@@ -1,0 +1,210 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.SchemaRegistry;
+
+using System;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Confluent.SchemaRegistry;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+using SrSchema = Confluent.SchemaRegistry.Schema;
+
+/// <summary>
+/// Cobertura de <see cref="SchemaRegistrationHostedService"/>: registro idempotente,
+/// fail-graceful seletivo (transient via HttpRequestError vs deterministic),
+/// propagação de exceções não-recuperáveis.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class SchemaRegistrationHostedServiceTests
+{
+    private const string SubjectFoo = "foo-events-value";
+    private const string SubjectBar = "bar-events-value";
+    private const string ValidSchemaResource =
+        "Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.SchemaRegistry.Resources.TestSchema.avsc";
+    private const string MissingResource =
+        "Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.SchemaRegistry.Resources.DoesNotExist.avsc";
+
+    private static readonly System.Reflection.Assembly TestAssembly =
+        typeof(SchemaRegistrationHostedServiceTests).Assembly;
+
+    private static SchemaRegistration ValidRegistration(string subject)
+        => new(subject, ValidSchemaResource, TestAssembly);
+
+    private static SchemaRegistration MissingResourceRegistration(string subject)
+        => new(subject, MissingResource, TestAssembly);
+
+    private static SchemaRegistrationHostedService CreateSut(
+        ISchemaRegistryClient client,
+        params SchemaRegistration[] registrations)
+    {
+        return new SchemaRegistrationHostedService(
+            client,
+            registrations,
+            NullLogger<SchemaRegistrationHostedService>.Instance);
+    }
+
+    [Fact(DisplayName = "Sem registrations — StartAsync retorna sem erro e sem chamar o cliente")]
+    public async Task SemRegistrations_DeveLogarENaoLancar()
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        SchemaRegistrationHostedService sut = CreateSut(client);
+
+        Func<Task> act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        await client.DidNotReceiveWithAnyArgs()
+            .RegisterSchemaAsync(default!, default(SrSchema)!, default);
+    }
+
+    [Fact(DisplayName = "1 registration happy path — RegisterSchemaAsync chamado")]
+    public async Task UmaRegistration_HappyPath_DeveRegistrar()
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        client.RegisterSchemaAsync(SubjectFoo, Arg.Any<SrSchema>(), normalize: true)
+            .Returns(Task.FromResult(42));
+
+        SchemaRegistrationHostedService sut = CreateSut(client, ValidRegistration(SubjectFoo));
+
+        await sut.StartAsync(CancellationToken.None);
+
+        await client.Received(1).RegisterSchemaAsync(SubjectFoo, Arg.Any<SrSchema>(), normalize: true);
+    }
+
+    [Fact(DisplayName = "N registrations — todas iteradas")]
+    public async Task NRegistrations_DeveIterarTodas()
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        client.RegisterSchemaAsync(Arg.Any<string>(), Arg.Any<SrSchema>(), normalize: true)
+            .Returns(Task.FromResult(1));
+
+        SchemaRegistrationHostedService sut = CreateSut(
+            client,
+            ValidRegistration(SubjectFoo),
+            ValidRegistration(SubjectBar));
+
+        await sut.StartAsync(CancellationToken.None);
+
+        await client.Received(1).RegisterSchemaAsync(SubjectFoo, Arg.Any<SrSchema>(), normalize: true);
+        await client.Received(1).RegisterSchemaAsync(SubjectBar, Arg.Any<SrSchema>(), normalize: true);
+    }
+
+    [Theory(DisplayName = "HttpRequestError transient (Connection/NameResolution) é silenciado")]
+    [InlineData(HttpRequestError.ConnectionError)]
+    [InlineData(HttpRequestError.NameResolutionError)]
+    public async Task HttpRequestError_Transient_DeveSerSilenciado(HttpRequestError errorType)
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        client.RegisterSchemaAsync(Arg.Any<string>(), Arg.Any<SrSchema>(), normalize: true)
+            .Throws(new HttpRequestException(errorType, "transient"));
+
+        SchemaRegistrationHostedService sut = CreateSut(client, ValidRegistration(SubjectFoo));
+
+        Func<Task> act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync(
+            because: "transient errors deixam o host subir; Confluent serdes retenta em runtime.");
+    }
+
+    [Theory(DisplayName = "HttpRequestError deterministic (TLS/HttpProtocol/etc.) propaga")]
+    [InlineData(HttpRequestError.SecureConnectionError)]
+    [InlineData(HttpRequestError.HttpProtocolError)]
+    [InlineData(HttpRequestError.UserAuthenticationError)]
+    [InlineData(HttpRequestError.InvalidResponse)]
+    [InlineData(HttpRequestError.ProxyTunnelError)]
+    public async Task HttpRequestError_Deterministic_DevePropagar(HttpRequestError errorType)
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        client.RegisterSchemaAsync(Arg.Any<string>(), Arg.Any<SrSchema>(), normalize: true)
+            .Throws(new HttpRequestException(errorType, $"deterministic {errorType}"));
+
+        SchemaRegistrationHostedService sut = CreateSut(client, ValidRegistration(SubjectFoo));
+
+        Func<Task> act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>(
+            because: "release com TLS/proxy/cert ruim deve travar StartAsync — não rodar em modo degraded.");
+    }
+
+    [Fact(DisplayName = "SchemaRegistryException (auth/conflict/malformed) propaga")]
+    public async Task SchemaRegistryException_DevePropagar()
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        client.RegisterSchemaAsync(Arg.Any<string>(), Arg.Any<SrSchema>(), normalize: true)
+            .Throws(new SchemaRegistryException("incompatible", System.Net.HttpStatusCode.Conflict, errorCode: 409));
+
+        SchemaRegistrationHostedService sut = CreateSut(client, ValidRegistration(SubjectFoo));
+
+        Func<Task> act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<SchemaRegistryException>(
+            because: "auth/conflict/malformed schema é deterministic — release não deve subir em modo degraded.");
+    }
+
+    [Fact(DisplayName = "InvalidOperationException (embedded resource ausente) propaga")]
+    public async Task InvalidOperation_ResourceAusente_DevePropagar()
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        SchemaRegistrationHostedService sut = CreateSut(client, MissingResourceRegistration(SubjectFoo));
+
+        Func<Task> act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            because: "embedded resource ausente é bug de empacotamento — release não pode subir.");
+    }
+
+    // Nota: parse sintático Avro NÃO é responsabilidade do hosted service.
+    // O hosted service passa o conteúdo string raw para Confluent.SchemaRegistry.Schema
+    // sem chamar Schema.Parse. O parse acontece no consumer (classe ISpecificRecord),
+    // coberto em EditalPublicadoAvroTests no projeto Selecao.IntegrationTests.
+
+    [Fact(DisplayName = "SocketException é silenciada (transient)")]
+    public async Task SocketException_DeveSerSilenciada()
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        client.RegisterSchemaAsync(Arg.Any<string>(), Arg.Any<SrSchema>(), normalize: true)
+            .Throws(new SocketException((int)SocketError.ConnectionRefused));
+
+        SchemaRegistrationHostedService sut = CreateSut(client, ValidRegistration(SubjectFoo));
+
+        Func<Task> act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact(DisplayName = "TaskCanceledException com TimeoutException inner é silenciada (timeout HttpClient)")]
+    public async Task TaskCanceled_TimeoutInner_DeveSerSilenciada()
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        TaskCanceledException timeout = new("timed out", new TimeoutException());
+        client.RegisterSchemaAsync(Arg.Any<string>(), Arg.Any<SrSchema>(), normalize: true)
+            .Throws(timeout);
+
+        SchemaRegistrationHostedService sut = CreateSut(client, ValidRegistration(SubjectFoo));
+
+        Func<Task> act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact(DisplayName = "TaskCanceledException com cancellation real (não-default) propaga")]
+    public async Task TaskCanceled_CancellationReal_DevePropagar()
+    {
+        ISchemaRegistryClient client = Substitute.For<ISchemaRegistryClient>();
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+        TaskCanceledException canceled = new("operation canceled", innerException: null, cts.Token);
+        client.RegisterSchemaAsync(Arg.Any<string>(), Arg.Any<SrSchema>(), normalize: true)
+            .Throws(canceled);
+
+        SchemaRegistrationHostedService sut = CreateSut(client, ValidRegistration(SubjectFoo));
+
+        Func<Task> act = () => sut.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<TaskCanceledException>(
+            because: "cancellation real é semanticamente diferente de timeout — caller pediu interrupção.");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/StubHttpMessageHandler.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/StubHttpMessageHandler.cs
@@ -1,0 +1,52 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Messaging.SchemaRegistry;
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// HttpMessageHandler em memória que devolve respostas pré-programadas e contabiliza
+/// requests. Substitui IHttpClientFactory/Apicurio real em testes do
+/// OAuthBearerAuthenticationHeaderValueProvider.
+/// </summary>
+internal sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<Func<HttpRequestMessage, HttpResponseMessage>> responses = new();
+
+    public int CallCount { get; private set; }
+
+    public List<HttpRequestMessage> ReceivedRequests { get; } = [];
+
+    public void EnqueueResponse(HttpStatusCode statusCode, string content = "")
+        => responses.Enqueue(_ => new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(content),
+        });
+
+    public void EnqueueResponse(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        => responses.Enqueue(responseFactory);
+
+    public void EnqueueException<T>()
+        where T : Exception, new()
+        => responses.Enqueue(_ => throw new T());
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        CallCount++;
+        ReceivedRequests.Add(request);
+
+        if (responses.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"StubHttpMessageHandler recebeu request #{CallCount} mas a fila de respostas está vazia.");
+        }
+
+        Func<HttpRequestMessage, HttpResponseMessage> factory = responses.Dequeue();
+        return Task.FromResult(factory(request));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests.csproj
@@ -22,6 +22,11 @@
     <ProjectReference Include="..\..\src\shared\Unifesspa.UniPlus.Infrastructure.Core\Unifesspa.UniPlus.Infrastructure.Core.csproj" />
   </ItemGroup>
 
+  <!-- Schemas Avro embedded usados por SchemaRegistrationHostedServiceTests (#362) -->
+  <ItemGroup>
+    <EmbeddedResource Include="Messaging\SchemaRegistry\Resources\*.avsc" />
+  </ItemGroup>
+
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>


### PR DESCRIPTION
## Resumo

Story #362 — endereça o item I1 da review jf2s do PR #359: as 3 classes do Schema Registry com lógica não-trivial (refinada via 5+ rounds de Codex no #359 + #361) ganham cobertura unitária. Sem testes hoje, regressões nesses paths cirúrgicos passariam silenciosas.

## O que mudou

| Arquivo | Cenários |
|---|---|
| `OAuthBearerAuthenticationHeaderValueProviderTests` | ~12 — happy 200, cache hit, refresh proativo, 4xx Theory→InvalidOperationException, 5xx Theory→HttpRequestException com `HttpRequestError.ConnectionError`, 10 threads concorrentes (SemaphoreSlim), Dispose com/sem ownsHttpClient, Dispose idempotente |
| `SchemaRegistrationHostedServiceTests` | ~10 — sem registrations, 1 happy, N iteradas, transient `HttpRequestError` Theory (Connection/NameResolution silenciados), deterministic `HttpRequestError` Theory (SecureConnection/HttpProtocol/UserAuth/InvalidResponse/ProxyTunnel propagam), `SchemaRegistryException` 409 propaga, `InvalidOperationException` resource ausente propaga, `SocketException` silenciada, `TaskCanceledException` com `TimeoutException` inner silenciada vs cancellation real propaga |
| `OAuthBearerAuthProviderDisposeHostedServiceTests` | 3 — StartAsync no-op, StopAsync dispõe (ObjectDisposedException pós), StopAsync idempotente |
| `StubHttpMessageHandler` (test infra) | Fila programável de respostas HTTP, conta requests, sem rede real |
| `Resources/TestSchema.avsc` | Embedded resource Avro válido para os testes do hosted service |

**Total: +33 cenários novos**, suite Infrastructure.Core.UnitTests passa de 424 para 457.

## Decisões

- **Mocking via NSubstitute** — `ISchemaRegistryClient` mockado para tests do hosted service; `HttpMessageHandler` stub para auth provider. Sem dependência de rede ou Apicurio real.
- **Embedded resource Avro real** em vez de stub `SchemaRegistration` (record sealed, não permite herança). `TestSchema.avsc` no test project como `EmbeddedResource` cobre o caminho de leitura via reflection.
- **`AvroException` (schema sintaticamente inválido) não testado** — o hosted service passa o conteúdo string raw para `Confluent.SchemaRegistry.Schema` sem chamar `Schema.Parse`. Parse acontece no consumer (classe `ISpecificRecord`), já coberto em `EditalPublicadoAvroTests` no projeto Selecao.IntegrationTests.

## Como testou

- ✅ `dotnet build UniPlus.slnx` — limpo (TreatWarningsAsErrors)
- ✅ `dotnet test tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/` — 457/457 verde
- ✅ `dotnet test UniPlus.slnx` — full suite verde
- ✅ Sem rede / sem Apicurio real — mocks/stubs apenas

## Critérios de aceite (issue #362)

- [x] `OAuthBearerAuthenticationHeaderValueProviderTests` cobre os 7 cenários originais (e mais 5 via Theory expandidos)
- [x] `SchemaRegistrationHostedServiceTests` cobre 10 dos 11 cenários — `AvroException` removido com justificativa (parse não é responsabilidade do hosted service)
- [x] `OAuthBearerAuthProviderDisposeHostedServiceTests` cobre os 2 cenários + 1 bonus (idempotência)
- [x] Suíte completa verde
- [x] Sem dependência de rede/Apicurio real

## Não-objetivos

- Testes para `SchemaRegistrySettingsValidator` — já cobertos (#359, 15 cenários).
- Testes para `EditalPublicado` Avro / mapper — já cobertos em `EditalPublicadoAvroTests` (#359).
- Smoke E2E real contra Apicurio Testcontainer — Story separada (parte de `uniplus-infra#99`).

Closes #362.
Refs #358, #359, #360, #361.
