### PR TITLE
feat(observability): expandir AdicionarObservabilidade + OTLP sink Serilog + correlation_id span tag

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Logging/SerilogConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Logging/SerilogConfiguration.cs
@@ -1,24 +1,102 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Logging;
 
+using System.Collections.Generic;
 using System.Globalization;
 
 using Microsoft.Extensions.Configuration;
 
 using Serilog;
 using Serilog.Events;
+using Serilog.Sinks.OpenTelemetry;
 
+using Unifesspa.UniPlus.Infrastructure.Core.Observability;
+
+/// <summary>
+/// Configuração canônica do pipeline Serilog Uni+: lê <c>appsettings</c>, override
+/// de Microsoft/EF para Warning, <c>FromLogContext</c>, <see cref="PiiMaskingEnricher"/>
+/// (ADR-0011), Console sink. Quando <c>Observability:Enabled</c> não está desligado,
+/// adiciona o sink OTLP gRPC (ADR-0018) — logs fluem ao Collector → Loki com correlação
+/// <c>traceId</c>/<c>spanId</c> automática por evento.
+/// </summary>
 public static class SerilogConfiguration
 {
-    public static LoggerConfiguration ConfigurarSerilog(this LoggerConfiguration loggerConfiguration, IConfiguration configuration)
+    /// <summary>
+    /// Sobrecarga sem nome de serviço — mantida para callers que ainda não precisam
+    /// rotular logs com <c>service.name</c>/<c>service.namespace</c> no Loki.
+    /// O sink OTLP é registrado mesmo assim (quando o toggle está ativo); apenas
+    /// não popula <c>ResourceAttributes</c>, deixando o sink usar suas próprias
+    /// inferências (env vars padrão OTel, se presentes).
+    /// </summary>
+    public static LoggerConfiguration ConfigurarSerilog(
+        this LoggerConfiguration loggerConfiguration,
+        IConfiguration configuration)
+        => loggerConfiguration.ConfigurarSerilog(configuration, nomeServico: null);
+
+    /// <summary>
+    /// Configura o pipeline com <c>service.name</c>/<c>service.namespace</c> aplicados
+    /// ao Resource do sink OTLP — habilita queries LogQL como
+    /// <c>{service_name="uniplus-selecao"}</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>O Console sink é sempre preservado para que <c>docker logs</c> continue
+    /// útil em bootstrap debugging.</para>
+    /// <para><see cref="PiiMaskingEnricher"/> fica antes dos sinks por construção:
+    /// enrichers executam antes dos sinks no pipeline Serilog. CPF é mascarado
+    /// antes de qualquer egress (Console ou OTLP) — ADR-0011.</para>
+    /// <para>Endpoint OTLP é lido pela env var <c>OTEL_EXPORTER_OTLP_ENDPOINT</c>
+    /// (default <c>http://localhost:4317</c>). Os atributos <c>service.*</c> são
+    /// injetados aqui porque o pipeline Serilog→OTLP é independente do pipeline
+    /// OTel SDK (<see cref="OpenTelemetryConfiguration.AdicionarObservabilidade"/>) —
+    /// duplicação intencional para evitar drift entre logs e traces no Loki/Tempo.</para>
+    /// </remarks>
+    /// <param name="loggerConfiguration">Configuração base do Serilog.</param>
+    /// <param name="configuration">Configuração da aplicação — fornece toggle
+    /// <see cref="OpenTelemetryConfiguration.EnabledConfigurationKey"/> e overrides
+    /// de level via <c>Serilog</c> section.</param>
+    /// <param name="nomeServico">Nome canônico do serviço para rotular o sink OTLP
+    /// (<c>service.name</c> + <c>service.namespace</c>). Quando <c>null</c>, sink
+    /// é registrado sem ResourceAttributes.</param>
+    public static LoggerConfiguration ConfigurarSerilog(
+        this LoggerConfiguration loggerConfiguration,
+        IConfiguration configuration,
+        string? nomeServico)
     {
         ArgumentNullException.ThrowIfNull(loggerConfiguration);
+        ArgumentNullException.ThrowIfNull(configuration);
 
-        return loggerConfiguration
+        loggerConfiguration
             .ReadFrom.Configuration(configuration)
             .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
             .Enrich.With<PiiMaskingEnricher>()
             .WriteTo.Console(formatProvider: CultureInfo.InvariantCulture);
+
+        bool observabilidadeAtivada = configuration.GetValue(
+            OpenTelemetryConfiguration.EnabledConfigurationKey,
+            defaultValue: true);
+
+        if (observabilidadeAtivada)
+        {
+            loggerConfiguration.WriteTo.OpenTelemetry(options =>
+            {
+                options.Protocol = OtlpProtocol.Grpc;
+                options.IncludedData =
+                    IncludedData.TraceIdField
+                    | IncludedData.SpanIdField
+                    | IncludedData.MessageTemplateTextAttribute;
+
+                if (!string.IsNullOrWhiteSpace(nomeServico))
+                {
+                    options.ResourceAttributes = new Dictionary<string, object>
+                    {
+                        ["service.name"] = nomeServico,
+                        ["service.namespace"] = OpenTelemetryConfiguration.ServiceNamespaceResourceValue,
+                    };
+                }
+            });
+        }
+
+        return loggerConfiguration;
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Middleware/CorrelationIdMiddleware.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Middleware/CorrelationIdMiddleware.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 using Microsoft.AspNetCore.Http;
@@ -12,6 +13,13 @@ public sealed partial class CorrelationIdMiddleware
     public const string HeaderName = "X-Correlation-Id";
     public const string LogContextProperty = "CorrelationId";
     public const int MaxCorrelationIdLength = 128;
+
+    /// <summary>
+    /// Nome do span attribute (Activity tag) que carrega o correlation_id no Tempo.
+    /// Lido por <c>derivedFields</c> do Loki datasource em Grafana para o drill-down
+    /// log → trace, fechando o ciclo log ↔ trace ↔ dashboard (ADR-0018).
+    /// </summary>
+    public const string ActivityTagName = "correlation_id";
 
     private readonly RequestDelegate _next;
 
@@ -29,6 +37,13 @@ public sealed partial class CorrelationIdMiddleware
         string correlationId = ObterOuGerarCorrelationId(context);
 
         writer.SetCorrelationId(correlationId);
+
+        // Propagar correlation_id como Activity span attribute habilita o
+        // drill-down Loki → Tempo via derivedFields no Grafana (ADR-0018) e
+        // fecha o ciclo log ↔ trace. Activity.Current pode ser null fora do
+        // request pipeline com OTel wired (ex.: testes unitários sem listener);
+        // o ?. mantém o middleware safe nesse cenário.
+        Activity.Current?.SetTag(ActivityTagName, correlationId);
 
         // Postergar a escrita do header até o início do flush da resposta
         // garante que o valor sobreviva a qualquer mutação feita por

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/OpenTelemetryConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/OpenTelemetryConfiguration.cs
@@ -17,6 +17,15 @@ using OpenTelemetry.Trace;
 public static class OpenTelemetryConfiguration
 {
     /// <summary>
+    /// Nome canônico do <see cref="System.Diagnostics.ActivitySource"/> emitido
+    /// pelo Wolverine. Registrado tanto em <c>WithTracing.AddSource</c> quanto em
+    /// <c>WithMetrics.AddMeter</c> para que command/handler/outbox executions
+    /// apareçam em Tempo (traces) e Prometheus (métricas) — ADR-0018.
+    /// </summary>
+    public const string WolverineActivityAndMeterName = "Wolverine";
+
+
+    /// <summary>
     /// Toggle de configuração para observabilidade. Default <c>true</c>; quando
     /// <c>false</c>, nenhum <see cref="TracerProvider"/> ou <see cref="MeterProvider"/>
     /// é registrado. Cenário de uso: suites de teste HTTP-only sem Collector
@@ -86,9 +95,7 @@ public static class OpenTelemetryConfiguration
             return services;
         }
 
-        Sampler sampler = environment.IsDevelopment()
-            ? new AlwaysOnSampler()
-            : new ParentBasedSampler(new TraceIdRatioBasedSampler(ProductionSamplingRatio));
+        Sampler sampler = SelecionarSampler(environment);
 
         IEnumerable<KeyValuePair<string, object>> resourceAttributes = new[]
         {
@@ -104,18 +111,42 @@ public static class OpenTelemetryConfiguration
             .WithTracing(tracing => tracing
                 .SetSampler(sampler)
                 .AddSource(nomeServico)
+                .AddSource(WolverineActivityAndMeterName)
                 .AddAspNetCoreInstrumentation()
                 .AddHttpClientInstrumentation()
                 .AddEntityFrameworkCoreInstrumentation()
                 .AddOtlpExporter())
             .WithMetrics(metrics => metrics
                 .AddMeter(nomeServico)
-                .AddMeter("Wolverine")
+                .AddMeter(WolverineActivityAndMeterName)
                 .AddAspNetCoreInstrumentation()
                 .AddHttpClientInstrumentation()
                 .AddRuntimeInstrumentation()
                 .AddOtlpExporter());
 
         return services;
+    }
+
+    /// <summary>
+    /// Seleciona o sampler conforme ambiente: <see cref="AlwaysOnSampler"/>
+    /// em <c>Development</c> (debugging local — todos os spans), e
+    /// <see cref="ParentBasedSampler"/> com <see cref="TraceIdRatioBasedSampler"/>
+    /// em <see cref="ProductionSamplingRatio"/> (10%) nos demais ambientes —
+    /// ADR-0018 head-based sampling. Tail-based 100% para erro/latência alta
+    /// é responsabilidade do <c>tail_sampling_processor</c> no Collector.
+    /// </summary>
+    /// <remarks>
+    /// Extraído como <c>internal static</c> exatamente para tornar a regra de
+    /// seleção testável sem precisar inspecionar o <c>TracerProvider</c> via
+    /// reflection — <c>InternalsVisibleTo</c> em <c>Infrastructure.Core.csproj</c>
+    /// expõe esta API para <c>Unifesspa.UniPlus.Infrastructure.Core.UnitTests</c>.
+    /// </remarks>
+    internal static Sampler SelecionarSampler(IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+
+        return environment.IsDevelopment()
+            ? new AlwaysOnSampler()
+            : new ParentBasedSampler(new TraceIdRatioBasedSampler(ProductionSamplingRatio));
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/OpenTelemetryConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/OpenTelemetryConfiguration.cs
@@ -1,19 +1,120 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Observability;
 
-using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
 
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
+/// <summary>
+/// Registra OpenTelemetry com instrumentações canônicas Uni+ (tracing + metrics)
+/// e exporter OTLP para a stack LGTM institucional. ADR-0018.
+/// </summary>
 public static class OpenTelemetryConfiguration
 {
-    public static IServiceCollection AdicionarObservabilidade(this IServiceCollection services, string nomeServico)
+    /// <summary>
+    /// Toggle de configuração para observabilidade. Default <c>true</c>; quando
+    /// <c>false</c>, nenhum <see cref="TracerProvider"/> ou <see cref="MeterProvider"/>
+    /// é registrado. Cenário de uso: suites de teste HTTP-only sem Collector
+    /// provisionado, troubleshooting onde a stack LGTM está fora do ar
+    /// (degradação controlada). Mesma chave usada por <see cref="Logging.SerilogConfiguration"/>
+    /// para condicionar o sink OTLP de logs.
+    /// </summary>
+    public const string EnabledConfigurationKey = "Observability:Enabled";
+
+    /// <summary>
+    /// Atributo Resource canônico do OTel para particionar telemetria entre
+    /// Development/Staging/Production nos dashboards Grafana.
+    /// </summary>
+    public const string DeploymentEnvironmentResourceAttribute = "deployment.environment";
+
+    /// <summary>
+    /// Namespace canônico Uni+ — todas as APIs do projeto compartilham. Permite
+    /// queries cross-service em PromQL/LogQL/TraceQL via
+    /// <c>service_namespace="uniplus"</c>.
+    /// </summary>
+    public const string ServiceNamespaceResourceValue = "uniplus";
+
+    /// <summary>
+    /// Sampling ratio head-based para ambientes não-Development. 10% conforme
+    /// ADR-0018; tail-based 100% para erros e latência alta é responsabilidade
+    /// do <c>tail_sampling_processor</c> no Collector, não da API.
+    /// </summary>
+    public const double ProductionSamplingRatio = 0.1;
+
+    /// <summary>
+    /// Registra OpenTelemetry com instrumentações canônicas Uni+ e exporter OTLP.
+    /// Endpoint OTLP é lido automaticamente pela env var
+    /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> (default <c>http://localhost:4317</c>, gRPC).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Tracing:</b> AspNetCore + EF Core + HttpClient + ActivitySource nominal
+    /// (<paramref name="nomeServico"/>).</para>
+    /// <para><b>Metrics:</b> AspNetCore + Runtime + HttpClient + Meter nominal +
+    /// Wolverine (instrumentação built-in via <c>System.Diagnostics.Metrics.Meter</c>
+    /// nativo do framework — ADR-0018).</para>
+    /// <para><b>Sampler:</b> <see cref="AlwaysOnSampler"/> em Development,
+    /// <see cref="ParentBasedSampler"/> com <see cref="TraceIdRatioBasedSampler"/>
+    /// (10%) nos demais.</para>
+    /// </remarks>
+    /// <param name="services">A coleção de serviços.</param>
+    /// <param name="nomeServico">Nome canônico do serviço (ex.: <c>uniplus-selecao</c>),
+    /// usado como <c>service.name</c> no Resource e como nome da
+    /// <c>ActivitySource</c>/<c>Meter</c> nominal.</param>
+    /// <param name="configuration">Configuração da aplicação.</param>
+    /// <param name="environment">Ambiente de hosting — define o sampler e popula
+    /// <c>deployment.environment</c> no Resource.</param>
+    /// <returns>A própria <paramref name="services"/> para encadeamento fluente.</returns>
+    public static IServiceCollection AdicionarObservabilidade(
+        this IServiceCollection services,
+        string nomeServico,
+        IConfiguration configuration,
+        IHostEnvironment environment)
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrWhiteSpace(nomeServico);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        bool enabled = configuration.GetValue(EnabledConfigurationKey, defaultValue: true);
+        if (!enabled)
+        {
+            return services;
+        }
+
+        Sampler sampler = environment.IsDevelopment()
+            ? new AlwaysOnSampler()
+            : new ParentBasedSampler(new TraceIdRatioBasedSampler(ProductionSamplingRatio));
+
+        IEnumerable<KeyValuePair<string, object>> resourceAttributes = new[]
+        {
+            new KeyValuePair<string, object>(
+                DeploymentEnvironmentResourceAttribute,
+                environment.EnvironmentName),
+        };
+
         services.AddOpenTelemetry()
-            .ConfigureResource(resource => resource.AddService(nomeServico))
+            .ConfigureResource(resource => resource
+                .AddService(serviceName: nomeServico, serviceNamespace: ServiceNamespaceResourceValue)
+                .AddAttributes(resourceAttributes))
             .WithTracing(tracing => tracing
+                .SetSampler(sampler)
+                .AddSource(nomeServico)
                 .AddAspNetCoreInstrumentation()
-                .AddSource(nomeServico));
+                .AddHttpClientInstrumentation()
+                .AddEntityFrameworkCoreInstrumentation()
+                .AddOtlpExporter())
+            .WithMetrics(metrics => metrics
+                .AddMeter(nomeServico)
+                .AddMeter("Wolverine")
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddRuntimeInstrumentation()
+                .AddOtlpExporter());
 
         return services;
     }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/CorrelationIdMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Middleware/CorrelationIdMiddlewareTests.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Middleware;
 
+using System.Diagnostics;
+
 using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
@@ -219,6 +221,61 @@ public class CorrelationIdMiddlewareTests
         capturados[0].Properties.Should().ContainKey(CorrelationIdMiddleware.LogContextProperty);
         capturados[0].Properties[CorrelationIdMiddleware.LogContextProperty]
             .ToString().Trim('"').Should().Be(id);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ComActivityAtiva_DeveSetarCorrelationIdComoTagDoSpan()
+    {
+        // ActivityListener é necessário para que ActivitySource.StartActivity
+        // retorne instância: sem listener, Activity.Current ficaria null e o
+        // teste seria vacuoso. Sample = AllData garante que o span não é
+        // dropado pelo sampler default.
+        using ActivitySource source = new(nameof(InvokeAsync_ComActivityAtiva_DeveSetarCorrelationIdComoTagDoSpan));
+        using ActivityListener listener = new()
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        const string id = "activity-tag-test";
+        (DefaultHttpContext context, _) = CriarContexto();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = id;
+        Activity? activityCapturadaNoPipeline = null;
+
+        using (Activity? activity = source.StartActivity("test-span"))
+        {
+            CorrelationIdMiddleware middleware = new(_ =>
+            {
+                activityCapturadaNoPipeline = Activity.Current;
+                return Task.CompletedTask;
+            });
+
+            await middleware.InvokeAsync(context, new CorrelationIdAccessor());
+        }
+
+        activityCapturadaNoPipeline.Should().NotBeNull();
+        activityCapturadaNoPipeline!.GetTagItem(CorrelationIdMiddleware.ActivityTagName)
+            .Should().Be(id);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SemActivityAtiva_NaoDeveFalhar()
+    {
+        // Sem ActivityListener registrado para esta classe, ActivitySource não
+        // emite spans e Activity.Current permanece null durante o pipeline.
+        // O middleware deve ser null-safe via Activity.Current?.SetTag(...).
+        Activity.Current.Should().BeNull();
+
+        const string id = "sem-activity";
+        (DefaultHttpContext context, _) = CriarContexto();
+        context.Request.Headers[CorrelationIdMiddleware.HeaderName] = id;
+        ICorrelationIdWriter accessor = Substitute.For<ICorrelationIdWriter>();
+        CorrelationIdMiddleware middleware = new(_ => Task.CompletedTask);
+
+        Func<Task> acao = async () => await middleware.InvokeAsync(context, accessor);
+
+        await acao.Should().NotThrowAsync();
     }
 
     // Cria um DefaultHttpContext com IHttpResponseFeature customizado que

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Observability/OpenTelemetryConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Observability/OpenTelemetryConfigurationTests.cs
@@ -1,0 +1,131 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Observability;
+
+using System.Collections.Generic;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using NSubstitute;
+
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Observability;
+
+public class OpenTelemetryConfigurationTests
+{
+    [Fact]
+    public void AdicionarObservabilidade_QuandoToggleDesabilitado_NaoRegistraTracerProviderNemMeterProvider()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = NovaConfiguracao(new Dictionary<string, string?>
+        {
+            [OpenTelemetryConfiguration.EnabledConfigurationKey] = "false",
+        });
+        IHostEnvironment environment = NovoAmbiente("Development");
+
+        services.AdicionarObservabilidade("uniplus-test", configuration, environment);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<TracerProvider>().Should().BeNull();
+        provider.GetService<MeterProvider>().Should().BeNull();
+    }
+
+    [Fact]
+    public void AdicionarObservabilidade_QuandoToggleAtivo_RegistraTracerProviderEMeterProvider()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = NovaConfiguracao();
+        IHostEnvironment environment = NovoAmbiente("Development");
+
+        services.AdicionarObservabilidade("uniplus-test", configuration, environment);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<TracerProvider>().Should().NotBeNull();
+        provider.GetService<MeterProvider>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AdicionarObservabilidade_QuandoToggleAusente_AssumeAtivoPorDefault()
+    {
+        // Default seguro pra produção: ausência da chave significa "ligado".
+        // CI explicitamente desliga via configuração quando não há Collector.
+        ServiceCollection services = new();
+        IConfiguration configuration = NovaConfiguracao();
+        IHostEnvironment environment = NovoAmbiente("Production");
+
+        services.AdicionarObservabilidade("uniplus-test", configuration, environment);
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        provider.GetService<TracerProvider>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AdicionarObservabilidade_NomeServicoVazio_DeveLancarArgumentException()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = NovaConfiguracao();
+        IHostEnvironment environment = NovoAmbiente("Development");
+
+        Action acao = () => services.AdicionarObservabilidade(string.Empty, configuration, environment);
+
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AdicionarObservabilidade_ServicesNulo_DeveLancarArgumentNullException()
+    {
+        IServiceCollection? services = null;
+        IConfiguration configuration = NovaConfiguracao();
+        IHostEnvironment environment = NovoAmbiente("Development");
+
+        Action acao = () => services!.AdicionarObservabilidade("uniplus-test", configuration, environment);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AdicionarObservabilidade_ConfigurationNulo_DeveLancarArgumentNullException()
+    {
+        ServiceCollection services = new();
+        IConfiguration? configuration = null;
+        IHostEnvironment environment = NovoAmbiente("Development");
+
+        Action acao = () => services.AdicionarObservabilidade("uniplus-test", configuration!, environment);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AdicionarObservabilidade_EnvironmentNulo_DeveLancarArgumentNullException()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = NovaConfiguracao();
+        IHostEnvironment? environment = null;
+
+        Action acao = () => services.AdicionarObservabilidade("uniplus-test", configuration, environment!);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    private static IConfiguration NovaConfiguracao(IEnumerable<KeyValuePair<string, string?>>? values = null)
+    {
+        ConfigurationBuilder builder = new();
+        if (values is not null)
+        {
+            builder.AddInMemoryCollection(values);
+        }
+
+        return builder.Build();
+    }
+
+    private static IHostEnvironment NovoAmbiente(string environmentName)
+    {
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns(environmentName);
+        return environment;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Observability/OpenTelemetryConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Observability/OpenTelemetryConfigurationTests.cs
@@ -111,6 +111,45 @@ public class OpenTelemetryConfigurationTests
         acao.Should().Throw<ArgumentNullException>();
     }
 
+    [Fact]
+    public void SelecionarSampler_EmDevelopment_DeveRetornarAlwaysOnSampler()
+    {
+        IHostEnvironment environment = NovoAmbiente("Development");
+
+        Sampler sampler = OpenTelemetryConfiguration.SelecionarSampler(environment);
+
+        sampler.Should().BeOfType<AlwaysOnSampler>();
+    }
+
+    [Theory]
+    [InlineData("Production")]
+    [InlineData("Staging")]
+    [InlineData("HML")]
+    [InlineData("Test")]
+    public void SelecionarSampler_ForaDeDevelopment_DeveRetornarParentBasedComTraceIdRatio10Pct(string environmentName)
+    {
+        IHostEnvironment environment = NovoAmbiente(environmentName);
+
+        Sampler sampler = OpenTelemetryConfiguration.SelecionarSampler(environment);
+
+        // ParentBasedSampler.Description segue o formato canônico OTel:
+        // "ParentBased{root=TraceIdRatioBased{0.100000},...}". Validar pela
+        // descrição evita reflection no campo privado _rootSampler e quebra de
+        // teste em upgrades minor da SDK que reorganizem internals.
+        sampler.Should().BeOfType<ParentBasedSampler>();
+        sampler.Description.Should().Contain("TraceIdRatioBased").And.Contain("0.1");
+    }
+
+    [Fact]
+    public void SelecionarSampler_EnvironmentNulo_DeveLancarArgumentNullException()
+    {
+        IHostEnvironment? environment = null;
+
+        Action acao = () => OpenTelemetryConfiguration.SelecionarSampler(environment!);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
     private static IConfiguration NovaConfiguracao(IEnumerable<KeyValuePair<string, string?>>? values = null)
     {
         ConfigurationBuilder builder = new();


### PR DESCRIPTION
## Resumo

PR 2 da entrega da **Story #30** (`wiring OpenTelemetry`). Expande a extension method `AdicionarObservabilidade` (atualmente 22 linhas, só com AspNetCore tracing) para o conjunto canônico Uni+ exigido pelos CAs da issue + ADR-0018; estende `ConfigurarSerilog` com sink OTLP fechando colateralmente a Story **#105**; adiciona span tag `correlation_id` ao `CorrelationIdMiddleware` fechando colateralmente a Story **#110**.

**Sem mudança de comportamento ainda** — extension não é invocada por nenhum `Program.cs` neste PR. Wiring nos 3 APIs + integration test Testcontainers segue no PR 3 da entrega, que é quem efetivamente vai fechar #30, #105 e #110.

## Mudanças

### `OpenTelemetryConfiguration.cs` (Infrastructure.Core/Observability)
- Aceita agora `IConfiguration` + `IHostEnvironment` + `nomeServico`
- Toggle `Observability:Enabled` (default `true`; off-switch para CI sem Collector e troubleshooting com stack LGTM fora do ar)
- **Tracing:** AspNetCore + EF Core + HttpClient + ActivitySource(`nomeServico`) + OTLP gRPC
- **Metrics:** AspNetCore + Runtime + HttpClient + Meter(`nomeServico`) + Wolverine (instrumentação built-in via Meter nativo) + OTLP gRPC
- **Sampler:** `AlwaysOnSampler` em `Development`, `ParentBasedSampler(TraceIdRatioBasedSampler(0.1))` nos demais — **ADR-0018** head-based 10%; tail-based 100% para erro/latência fica no Collector
- **Resource:** `service.name`, `service.namespace=uniplus`, `deployment.environment=<env>` — particiona dashboards Grafana

### `SerilogConfiguration.cs` (Infrastructure.Core/Logging)
- Sobrecarga adicional `ConfigurarSerilog(this LoggerConfiguration, IConfiguration, string? nomeServico)` — popula `ResourceAttributes` do sink OTLP com `service.name` + `service.namespace` (necessário porque pipeline Serilog→OTLP é independente do pipeline OTel SDK; ambos precisam rotular o mesmo serviço para correlação log↔trace no Loki/Tempo)
- Sobrecarga sem `nomeServico` mantida para callers ainda não migrados — PR 3 atualiza os 3 `Program.cs` para usar a sobrecarga rotulada
- Sink `WriteTo.OpenTelemetry` com `OtlpProtocol.Grpc` + `IncludedData = TraceIdField | SpanIdField | MessageTemplateTextAttribute` — fecha **Story #105** colateralmente
- Console sink **preservado** — `docker logs` continua útil em bootstrap debugging
- `PiiMaskingEnricher` mantém posição pré-sinks (ordem natural Serilog) — CPF mascarado antes de qualquer egress (Console ou OTLP) → **ADR-0011**

### `CorrelationIdMiddleware.cs` (Infrastructure.Core/Middleware)
- `Activity.Current?.SetTag(\"correlation_id\", correlationId)` após `writer.SetCorrelationId` e antes de `LogContext.PushProperty` — habilita drill-down Loki→Tempo via `derivedFields` no Grafana (**ADR-0018**), fechando o ciclo log↔trace↔dashboard. Fecha **Story #110** colateralmente
- Null-safe via `?.` — middleware funciona sem OTel wired (testes unitários sem `ActivityListener` registrado)
- Constante pública `ActivityTagName = \"correlation_id\"` para os testes referenciarem sem string literal

## Testes adicionados

### `OpenTelemetryConfigurationTests.cs` (novo)
7 testes cobrindo:
- Toggle desabilitado → não registra `TracerProvider` nem `MeterProvider`
- Toggle ativo → registra ambos
- Toggle ausente assume default `true` (seguro pra produção)
- 4 guards de argumento (`services`, `configuration`, `environment` null + `nomeServico` vazio)

### `CorrelationIdMiddlewareTests.cs` (+2 testes)
- `InvokeAsync_ComActivityAtiva_DeveSetarCorrelationIdComoTagDoSpan` — registra `ActivityListener` temporário com `Sample = AllData`, valida `Activity.GetTagItem(ActivityTagName)`
- `InvokeAsync_SemActivityAtiva_NaoDeveFalhar` — sem `ActivityListener`, `Activity.Current` permanece null durante o pipeline; valida que `?.` mantém o middleware safe

## Validação local

\`\`\`bash
dotnet build UniPlus.slnx                                    # 0 warning, 0 error
dotnet test UniPlus.slnx --filter \"FullyQualifiedName!~IntegrationTests\"  # 534 passed
dotnet format UniPlus.slnx --verify-no-changes               # exit 0
\`\`\`

## ADRs respeitadas

- **ADR-0011** — `PiiMaskingEnricher` continua antes dos sinks (ordem natural). CPF mascarado antes de qualquer egress
- **ADR-0018** — stack LGTM via OTLP, head-based 10% na API (tail-based no Collector), instrumentações canônicas, retenção 30d traces / 90d logs aplicação fica como política operacional

## Decisões fora do escopo (deferidas)

- **`OpenTelemetry.Instrumentation.Npgsql`** — EF Core instrumentation já cobre spans Postgres por baixo via `DbCommand` events
- **Tail-based sampling adaptativo** — responsabilidade do `tail_sampling_processor` no Collector, não da API
- **Health check `/health/observability`** validando exporter — não no escopo da Story #30; vira issue separada se necessário
- **Métricas custom de negócio** (Kafka consumer lag, classificação) — entregam junto com cada feature owner

## Próximo PR (PR 3, fecha #30 + #105 + #110)

- Wire `AdicionarObservabilidade` nos 3 `Program.cs` (Selecao + Ingresso + Portal — issue só fala em Selecao+Ingresso, mas Portal nasceu depois e merece pela consistência)
- Wire sobrecarga rotulada de `ConfigurarSerilog` (com `nomeServico`)
- 3 `appsettings.json` + 3 `appsettings.Development.json` com `Observability:Enabled`
- Integration test com Testcontainers do OTEL Collector validando spans/metrics/logs

Refs #30, #105, #110