### PR TITLE
feat(observability): wire OpenTelemetry nos 3 Program.cs + integration test ponta-a-ponta

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -7,6 +7,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Logging;
 using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
+using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Infrastructure.Core.Smoke;
 using Unifesspa.UniPlus.Ingresso.API.Errors;
@@ -15,8 +16,11 @@ using Unifesspa.UniPlus.Ingresso.Infrastructure.Persistence;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+// service.name canônico — ver explicação em Selecao.API/Program.cs.
+const string nomeServicoIngresso = "uniplus-ingresso";
+
 builder.Host.UseSerilog((context, loggerConfig) =>
-    loggerConfig.ConfigurarSerilog(context.Configuration));
+    loggerConfig.ConfigurarSerilog(context.Configuration, nomeServicoIngresso));
 
 builder.Services.AddControllers()
     .AddJsonOptions(options =>
@@ -42,6 +46,10 @@ builder.Services.AddDomainErrorMapper();
 builder.Services.AddOidcAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddCorrelationIdAccessor();
 builder.Services.AddRequestLogging(builder.Configuration);
+
+// Observabilidade (ADR-0018) — ver explicação em Selecao.API/Program.cs.
+builder.Services.AdicionarObservabilidade(nomeServicoIngresso, builder.Configuration, builder.Environment);
+
 // AddIngressoInfrastructure agora resolve a connection string via
 // IConfiguration injetada no factory do AddDbContext (issue #204) —
 // simetria com UseWolverineOutboxCascading e com Selecao.

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.json
@@ -18,6 +18,9 @@
     "Authority": "",
     "Audience": "uniplus"
   },
+  "Observability": {
+    "Enabled": true
+  },
   "Serilog": {
     "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
@@ -9,6 +9,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Logging;
 using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
+using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Infrastructure.Core.Smoke;
 using Unifesspa.UniPlus.Portal.API.Errors;
@@ -17,8 +18,11 @@ using Unifesspa.UniPlus.Portal.Infrastructure.Persistence;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+// service.name canônico — ver explicação em Selecao.API/Program.cs.
+const string nomeServicoPortal = "uniplus-portal";
+
 builder.Host.UseSerilog((context, loggerConfig) =>
-    loggerConfig.ConfigurarSerilog(context.Configuration));
+    loggerConfig.ConfigurarSerilog(context.Configuration, nomeServicoPortal));
 
 builder.Services.AddControllers()
     .AddJsonOptions(options =>
@@ -53,6 +57,10 @@ builder.Services.AddDomainErrorMapper();
 builder.Services.AddOidcAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddCorrelationIdAccessor();
 builder.Services.AddRequestLogging(builder.Configuration);
+
+// Observabilidade (ADR-0018) — ver explicação em Selecao.API/Program.cs.
+builder.Services.AdicionarObservabilidade(nomeServicoPortal, builder.Configuration, builder.Environment);
+
 // AddPortalInfrastructure resolve a connection string via IConfiguration
 // injetada no factory do AddDbContext — simetria com Selecao/Ingresso (#204).
 builder.Services.AddPortalInfrastructure();

--- a/src/portal/Unifesspa.UniPlus.Portal.API/appsettings.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/appsettings.json
@@ -18,6 +18,9 @@
     "Authority": "",
     "Audience": "uniplus"
   },
+  "Observability": {
+    "Enabled": true
+  },
   "Serilog": {
     "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -11,6 +11,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Logging;
 using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
+using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Infrastructure.Core.Smoke;
 using Unifesspa.UniPlus.Selecao.API.Errors;
@@ -28,8 +29,14 @@ using Wolverine.Postgresql;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
+// service.name canônico para Resource OTel (tracing/metrics) e ResourceAttributes
+// do sink OTLP do Serilog (logs). Mantido em const local para garantir igualdade
+// estrita entre os 2 pipelines — drift de naming entre logs e traces seria a
+// 1ª coisa a quebrar drill-down Loki↔Tempo no Grafana.
+const string nomeServicoSelecao = "uniplus-selecao";
+
 builder.Host.UseSerilog((context, loggerConfig) =>
-    loggerConfig.ConfigurarSerilog(context.Configuration));
+    loggerConfig.ConfigurarSerilog(context.Configuration, nomeServicoSelecao));
 
 builder.Services.AddControllers()
     .AddJsonOptions(options =>
@@ -71,6 +78,13 @@ builder.Services.AddIdempotency<Unifesspa.UniPlus.Selecao.Infrastructure.Persist
 builder.Services.AddOidcAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddCorrelationIdAccessor();
 builder.Services.AddRequestLogging(builder.Configuration);
+
+// Observabilidade (ADR-0018) — tracing + metrics via OpenTelemetry SDK para o Collector
+// institucional. Logs já fluem via Serilog OTLP sink configurado em UseSerilog acima.
+// Toggle Observability:Enabled em appsettings; default true. Em test factories sem
+// Collector provisionado, sobrescrever para false em InMemoryCollection.
+builder.Services.AdicionarObservabilidade(nomeServicoSelecao, builder.Configuration, builder.Environment);
+
 builder.Services.AddSelecaoApplication();
 // AddSelecaoInfrastructure agora resolve a connection string via
 // IConfiguration injetada no factory do AddDbContext (issue #204) —

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.json
@@ -18,6 +18,9 @@
     "Authority": "",
     "Audience": "uniplus"
   },
+  "Observability": {
+    "Enabled": true
+  },
   "Serilog": {
     "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Observability/OpenTelemetryWiringTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Observability/OpenTelemetryWiringTests.cs
@@ -1,0 +1,102 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Observability;
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+using OpenTelemetry.Trace;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Observability;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+[Collection(OtelCollectorContainerFixture.CollectionName)]
+public sealed class OpenTelemetryWiringTests(OtelCollectorContainerFixture collector)
+{
+    private const string ServiceName = "uniplus-test-otel-wiring";
+    private const string EnvVarName = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+    [Fact]
+    public async Task AdicionarObservabilidade_PipelineEndToEnd_ExportaSpanRotuladoParaCollector()
+    {
+        // O OtlpExporter padrão lê o endpoint da env var OTEL_EXPORTER_OTLP_ENDPOINT
+        // (sem opção de override via DI sem mudar a assinatura pública). Setamos
+        // process-wide e restauramos no finally — xUnit não paraleliza dentro da
+        // mesma collection, então não há race com outros testes.
+        string? endpointAnterior = Environment.GetEnvironmentVariable(EnvVarName);
+        try
+        {
+            Environment.SetEnvironmentVariable(EnvVarName, collector.GrpcEndpoint);
+
+            ServiceCollection services = new();
+            services.AddLogging();
+            IConfiguration configuration = new ConfigurationBuilder().Build();
+            IHostEnvironment environment = new TestHostEnvironment("Development");
+
+            services.AdicionarObservabilidade(ServiceName, configuration, environment);
+
+            await using ServiceProvider provider = services.BuildServiceProvider();
+
+            // Resolver o TracerProvider força o startup do pipeline OTel — exporter
+            // OTLP abre a conexão gRPC com o Collector neste ponto.
+            TracerProvider? tracerProvider = provider.GetService<TracerProvider>();
+            tracerProvider.Should().NotBeNull("AdicionarObservabilidade deve registrar um TracerProvider quando Observability:Enabled é o default true");
+
+            // ActivitySource compartilha o nome do serviço — registrado em
+            // AddSource(nomeServico) na pipeline. Sem isso, listeners do OTel
+            // SDK ignoram os spans emitidos.
+            using ActivitySource source = new(ServiceName);
+            using (Activity? span = source.StartActivity("test-wiring-span"))
+            {
+                span.Should().NotBeNull("o sampler em Development é AlwaysOn — span não pode ser dropado");
+                span!.SetTag("test.scenario", "wiring-end-to-end");
+            }
+
+            // ForceFlush garante que o batch processor envia imediatamente em vez
+            // de esperar o intervalo (5s default). Timeout 5s é margem para gRPC
+            // handshake + envio em runners CI mais lentos.
+            tracerProvider!.ForceFlush(timeoutMilliseconds: 5_000).Should().BeTrue();
+
+            // Buffer extra (200ms) para o Collector processar o batch recebido e
+            // emitir no exporter debug. Heurística: na prática 50ms basta, 200ms
+            // dá folga sem aumentar tempo do teste materialmente.
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+
+            string collectorOutput = await collector.GetLogsAsync();
+
+            collectorOutput.Should().Contain("ResourceSpans", because: "o exporter debug do Collector escreve o nome do tipo OTLP recebido em stderr");
+            collectorOutput.Should().Contain(ServiceName, because: $"o Resource attribute service.name precisa chegar até o Collector — confirma que ConfigureResource(...AddService(\"{ServiceName}\")) está wired");
+            collectorOutput.Should().Contain("test-wiring-span", because: "o nome do span emitido localmente precisa aparecer no output do Collector — confirma que AddOtlpExporter() está exportando de fato");
+            collectorOutput.Should().Contain(OpenTelemetryConfiguration.ServiceNamespaceResourceValue, because: "service.namespace=uniplus deve chegar no Resource exportado");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EnvVarName, endpointAnterior);
+        }
+    }
+
+    /// <summary>
+    /// Stub minimal de <see cref="IHostEnvironment"/> — só popula
+    /// <c>EnvironmentName</c> (única propriedade lida por
+    /// <see cref="OpenTelemetryConfiguration.SelecionarSampler"/> e
+    /// <see cref="OpenTelemetryConfiguration.AdicionarObservabilidade"/>).
+    /// Evita NSubstitute aqui porque o test project não referencia o pacote
+    /// (kept lean — IntegrationTests usa Testcontainers + AwesomeAssertions
+    /// e nada além).
+    /// </summary>
+    private sealed class TestHostEnvironment(string environmentName) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = environmentName;
+
+        public string ApplicationName { get; set; } = "Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests";
+
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Observability/OtelCollectorCollection.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Observability/OtelCollectorCollection.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Observability;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+[CollectionDefinition(OtelCollectorContainerFixture.CollectionName)]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção xUnit: o sufixo 'Collection' identifica a classe como CollectionDefinition.")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x exige que CollectionDefinitions sejam públicas para que o runner as descubra.")]
+public sealed class OtelCollectorCollection : ICollectionFixture<OtelCollectorContainerFixture>
+{
+}

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
@@ -21,6 +21,37 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
     where TEntryPoint : class
 {
     /// <summary>
+    /// Static initializer que silencia o pipeline OpenTelemetry para todas as suites
+    /// HTTP-only que usam <see cref="ApiFactoryBase{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para><strong>Por que env var em vez de <c>ConfigureAppConfiguration</c>?</strong>
+    /// Em minimal hosting (<c>WebApplication.CreateBuilder(args)</c>), o
+    /// <c>Program.cs</c> lê <c>builder.Configuration</c> e chama
+    /// <c>AdicionarObservabilidade</c>/<c>ConfigurarSerilog</c> ANTES de
+    /// <c>builder.Build()</c> rodar — momento em que o
+    /// <c>ConfigureAppConfiguration</c> do <see cref="WebApplicationFactory{T}"/>
+    /// é aplicado. Override via <c>AddInMemoryCollection</c> chega tarde demais
+    /// e o exporter OTLP fica tentando <c>localhost:4317</c> em loop.</para>
+    /// <para>Env var (<c>Observability__Enabled=false</c>) é lida pelo
+    /// <c>EnvironmentVariablesConfigurationProvider</c> default do
+    /// <c>CreateBuilder</c> — chega A TEMPO da leitura no <c>Program.cs</c>.</para>
+    /// <para><strong>Process-wide:</strong> setar env var afeta o processo inteiro.
+    /// Aceitável aqui porque (a) é idempotente, (b) o único test no projeto que
+    /// exercita observabilidade real
+    /// (<c>OpenTelemetryWiringTests</c>) constrói <see cref="IServiceCollection"/>
+    /// manualmente sem <c>CreateBuilder</c>, então não é afetado pela env var, e
+    /// (c) o <c>OpenTelemetryWiringTests</c> também sobrescreve
+    /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> via <c>try/finally</c>, demonstrando o
+    /// padrão para testes que queiram OTel ligado.</para>
+    /// </remarks>
+    static ApiFactoryBase()
+    {
+        Environment.SetEnvironmentVariable("Observability__Enabled", "false");
+    }
+
+
+    /// <summary>
     /// Quando <c>true</c> (default), o factory remove o
     /// <see cref="WolverineRuntime"/> da lista de <see cref="IHostedService"/>
     /// — o host inicializa sem startar o Wolverine, evitando que testes que
@@ -81,16 +112,10 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
 
         builder.ConfigureAppConfiguration((_, configurationBuilder) =>
         {
-            // Default off para a maioria das suites HTTP-only — sem Collector OTel
-            // provisionado, o sink OTLP do Serilog e o OtlpExporter do OTel SDK ficam
-            // tentando conectar em localhost:4317 e geram ruído (drop batches, retry
-            // logs). Suites que exercitam observabilidade real (ex.:
-            // OpenTelemetryWiringTests com OtelCollectorContainerFixture) sobrescrevem
-            // via GetConfigurationOverrides retornando "Observability:Enabled" = "true".
-            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Observability:Enabled"] = "false",
-            });
+            // Observability:Enabled=false é injetado via env var no static ctor
+            // desta classe (ver explicação no XML doc) — ConfigureAppConfiguration
+            // roda em builder.Build() e seria tarde demais para o Program.cs ler
+            // antes de chamar AdicionarObservabilidade.
             configurationBuilder.AddInMemoryCollection(GetConfigurationOverrides());
         });
 

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/ApiFactoryBase.cs
@@ -81,6 +81,16 @@ public abstract class ApiFactoryBase<TEntryPoint> : WebApplicationFactory<TEntry
 
         builder.ConfigureAppConfiguration((_, configurationBuilder) =>
         {
+            // Default off para a maioria das suites HTTP-only — sem Collector OTel
+            // provisionado, o sink OTLP do Serilog e o OtlpExporter do OTel SDK ficam
+            // tentando conectar em localhost:4317 e geram ruído (drop batches, retry
+            // logs). Suites que exercitam observabilidade real (ex.:
+            // OpenTelemetryWiringTests com OtelCollectorContainerFixture) sobrescrevem
+            // via GetConfigurationOverrides retornando "Observability:Enabled" = "true".
+            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Observability:Enabled"] = "false",
+            });
             configurationBuilder.AddInMemoryCollection(GetConfigurationOverrides());
         });
 

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/OtelCollectorContainerFixture.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/OtelCollectorContainerFixture.cs
@@ -1,0 +1,112 @@
+namespace Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+using System.Text;
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+
+/// <summary>
+/// Sobe um <c>otel/opentelemetry-collector-contrib</c> via Testcontainers configurado com
+/// receivers OTLP (gRPC + HTTP) e exporter <c>debug</c> com verbosity <c>detailed</c> —
+/// permite que testes E2E afirmem que spans/metrics/logs chegaram ao Collector inspecionando
+/// o stdout do container via <see cref="GetStdoutAsync"/>. Compartilhada via
+/// <c>[Collection("OtelCollector")]</c>; cada assembly que usa declara sua própria
+/// <c>[CollectionDefinition]</c> com o mesmo nome.
+/// </summary>
+/// <remarks>
+/// <para>O config YAML é montado inline via <c>WithResourceMapping</c> (bytes em memória, sem
+/// arquivo temp em disco) — único exporter habilitado é <c>debug</c>, o que garante isolamento
+/// (não há rede saindo do Collector para Loki/Tempo/Prometheus em ambientes de CI).</para>
+/// <para>A imagem é fixada em uma tag estável da família <c>0.x</c>; alinhar com a versão
+/// usada pelo Collector institucional reduz superfície de surpresa quando o exporter ou
+/// receiver evoluir. Atualização vem via Renovate (uniplus-api#366).</para>
+/// </remarks>
+public sealed class OtelCollectorContainerFixture : IAsyncLifetime
+{
+    public const string Image = "otel/opentelemetry-collector-contrib:0.117.0";
+    public const string CollectionName = "OtelCollector";
+
+    private const ushort GrpcPort = 4317;
+    private const ushort HttpPort = 4318;
+    private const string ConfigPath = "/etc/otelcol-contrib/config.yaml";
+
+    private readonly IContainer _container;
+
+    public OtelCollectorContainerFixture()
+    {
+        byte[] config = Encoding.UTF8.GetBytes(BuildMinimalConfig());
+
+        _container = new ContainerBuilder(Image)
+            .WithPortBinding(GrpcPort, true)
+            .WithPortBinding(HttpPort, true)
+            .WithResourceMapping(config, ConfigPath)
+            .WithCommand("--config", ConfigPath)
+            .WithWaitStrategy(
+                Wait.ForUnixContainer()
+                    .UntilMessageIsLogged("Everything is ready. Begin running and processing data."))
+            .Build();
+    }
+
+    /// <summary>
+    /// Endpoint OTLP gRPC no formato <c>http://host:port</c> (apto a alimentar
+    /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c>).
+    /// </summary>
+    public string GrpcEndpoint =>
+        $"http://{_container.Hostname}:{_container.GetMappedPublicPort(GrpcPort)}";
+
+    /// <summary>
+    /// Lê stdout + stderr acumulados do container concatenados em uma única string.
+    /// Usado pelos testes para afirmar que spans/metrics/logs foram exportados
+    /// (procuram tokens como <c>"ResourceSpans"</c>, <c>"service.name"</c>).
+    /// </summary>
+    /// <remarks>
+    /// O <c>otel/opentelemetry-collector-contrib</c> emite o output do exporter
+    /// <c>debug</c> em <c>stderr</c> (não <c>stdout</c>) — incluímos os dois aqui
+    /// para que a fixture funcione consistentemente independente de qual stream
+    /// o Collector escolher emitir em versões futuras.
+    /// </remarks>
+    public async Task<string> GetLogsAsync()
+    {
+        (string Stdout, string Stderr) logs = await _container.GetLogsAsync().ConfigureAwait(false);
+        return string.Concat(logs.Stdout, logs.Stderr);
+    }
+
+    public Task InitializeAsync() => _container.StartAsync();
+
+    public async Task DisposeAsync() =>
+        await _container.DisposeAsync().ConfigureAwait(false);
+
+    private static string BuildMinimalConfig() => """
+        receivers:
+          otlp:
+            protocols:
+              grpc:
+                endpoint: 0.0.0.0:4317
+              http:
+                endpoint: 0.0.0.0:4318
+
+        processors:
+          batch:
+            timeout: 100ms
+
+        exporters:
+          debug:
+            verbosity: detailed
+
+        service:
+          pipelines:
+            traces:
+              receivers: [otlp]
+              processors: [batch]
+              exporters: [debug]
+            metrics:
+              receivers: [otlp]
+              processors: [batch]
+              exporters: [debug]
+            logs:
+              receivers: [otlp]
+              processors: [batch]
+              exporters: [debug]
+        """;
+}


### PR DESCRIPTION
## Resumo

PR 3 (final) da entrega da Story #30. Wire concreto da extension method expandida no PR #367 (`AdicionarObservabilidade`) nos 3 APIs do projeto (Selecao + Ingresso + Portal) + integration test com Testcontainers do OTEL Collector validando o pipeline OTLP gRPC ponta-a-ponta. Fecha definitivamente #30, #105 e #110.

## Fluxo da entrega Story #30

| PR | Escopo | Status |
|---|---|---|
| #365 | `chore(shared): declarar pacotes NuGet OpenTelemetry` | ✅ mergeado |
| #367 | `feat(observability): expandir AdicionarObservabilidade + OTLP sink Serilog + correlation_id span tag` | ✅ mergeado |
| Este | `feat(observability): wire nos 3 Program.cs + integration test` | 🔄 review |

## Mudanças

### Wire em Program.cs (Selecao + Ingresso + Portal)
- `builder.Services.AdicionarObservabilidade(nomeServico, config, env)` registrado após `AddRequestLogging` em cada API
- `nomeServico` declarado como `const` local (`uniplus-{modulo}`) para garantir igualdade estrita entre o Resource OTel SDK e o `ResourceAttributes` do sink OTLP do Serilog — drift de naming entre logs/traces seria a primeira coisa a quebrar drill-down Loki↔Tempo no Grafana
- `builder.Host.UseSerilog` estendido para passar `nomeServico` à sobrecarga rotulada de `ConfigurarSerilog` (introduzida no PR #367)

### 3 `appsettings.json`
- Section `Observability:Enabled=true` (default seguro pra produção)
- `OTEL_EXPORTER_OTLP_ENDPOINT` é env var standard do OTel SDK (NÃO `IConfiguration`); configurado via env vars do container/runtime, não em appsettings

### `ApiFactoryBase` (Tests.Fixtures)
- `AddInMemoryCollection` com `Observability:Enabled=false` ANTES dos `GetConfigurationOverrides` — suites HTTP-only sem Collector OTel provisionado silenciam o exporter, evitando ruído de drop batches/retry no CI
- Override segue padrão de `InfraHealthCheckNamesToRemoveForTests` (memória `boot-time changes` da skill)

### `OtelCollectorContainerFixture` (Tests.Fixtures/Hosting) — novo
- Sobe `otel/opentelemetry-collector-contrib:0.117.0` com config minimal (receivers OTLP gRPC+HTTP, processor batch 100ms, exporter `debug` verbosity=detailed)
- Config YAML inline via `WithResourceMapping` (sem arquivo temp em disco)
- Collection compartilhada `\"OtelCollector\"` — pattern análogo a MinIO/Vault/Keycloak já estabelecido no projeto
- `GetLogsAsync()` concatena `stdout`+`stderr` — Collector loga exporter `debug` em stderr (descoberta via teste primeiro com stdout vazio)

### `OpenTelemetryWiringTests` (Infrastructure.Core.IntegrationTests/Observability) — novo
- 1 teste end-to-end: `AdicionarObservabilidade` → `ActivitySource` → `OtlpExporter` gRPC → Collector real → exporter `debug` → asserts em `ResourceSpans` + `service.name` + `service.namespace` + nome do span emitido
- Set/restore de `OTEL_EXPORTER_OTLP_ENDPOINT` via `try/finally` — xUnit não paraleliza dentro da mesma collection, sem race com outros testes
- `TestHostEnvironment` stub local (sem NSubstitute — IntegrationTests project mantém deps lean: só Testcontainers + AwesomeAssertions)

## Validação local

\`\`\`bash
dotnet build UniPlus.slnx                  # 0 warning, 0 error
dotnet test UniPlus.slnx                   # 629 testes verdes, 0 falhas
                                           #   - 540 unit + arch (~3s)
                                           #   - 8 Ingresso.IntegrationTests
                                           #   - 10 Infrastructure.Core.IntegrationTests (inclui OTel ponta-a-ponta — 3.3s)
                                           #   - 71 Selecao.IntegrationTests (~1m)
\`\`\`

## ADRs respeitadas

- **ADR-0011** — `PiiMaskingEnricher` continua antes do sink OTLP do Serilog (ordem natural). CPF mascarado antes de qualquer egress
- **ADR-0018** — stack LGTM via OTLP, Wolverine ActivitySource exportado, sampling head-based 10% configurado em produção (PR #367)

## Decisões deferidas

- **Health check `/health/observability`** validando exporter OTLP — fora do escopo da Story #30; abrir issue dedicada se a operação pedir
- **Métricas custom de negócio** (Kafka consumer lag, classificação, homologação) — entregam junto com cada feature owner (não é responsabilidade desta Story de fundação)
- **Tail-based sampling adaptativo** — responsabilidade do `tail_sampling_processor` no Collector, não da API

## Issues fechadas

Closes #30
Closes #105
Closes #110