### PR TITLE
chore(infra): adicionar Dependabot para auto-update NuGet + GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,92 @@
+# Dependabot — auto-update de dependências NuGet + GitHub Actions
+#
+# Decisão (issue #366): Dependabot escolhido em vez de Renovate por ser nativo
+# do GitHub (zero setup de App na org) e ter suporte ao `Directory.Packages.props`
+# central usado pelo repo. Schedule semanal segunda 06:00 BRT — antes do daily.
+# Major bumps sempre manuais (sem PR automático) para evitar surpresas em
+# atualizações que exigem migração (Wolverine, EF Core, .NET runtime).
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # NuGet — central management via Directory.Packages.props na raiz
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Belem"
+    open-pull-requests-limit: 5
+    labels:
+      - "chore"
+      - "deps"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      # Trem único do OpenTelemetry — quando uma versão sobe, todas sobem juntas
+      # (alinhamento de SDK + instrumentations + exporter evita incompatibilidade
+      # binária). Inclui o sink Serilog que segue o mesmo wire OTLP.
+      opentelemetry:
+        patterns:
+          - "OpenTelemetry.*"
+          - "Serilog.Sinks.OpenTelemetry"
+      wolverine:
+        patterns:
+          - "WolverineFx*"
+      ef-core:
+        patterns:
+          - "Microsoft.EntityFrameworkCore*"
+          - "Npgsql*"
+      serilog:
+        patterns:
+          - "Serilog*"
+        # Excluir o sink OTel que já vai no group opentelemetry (evita
+        # ambiguidade — se aparecer aqui também, Dependabot agrupa onde matchou
+        # primeiro, gerando comportamento dependente de ordem).
+        exclude-patterns:
+          - "Serilog.Sinks.OpenTelemetry"
+      kafka:
+        patterns:
+          - "Confluent.*"
+          - "Apache.Avro"
+      testing:
+        patterns:
+          - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "Microsoft.AspNetCore.Mvc.Testing"
+          - "AwesomeAssertions"
+          - "NSubstitute"
+          - "Bogus"
+          - "Testcontainers*"
+          - "TngTech.ArchUnitNET*"
+          - "coverlet.collector"
+    ignore:
+      # Major bumps sempre manuais — Wolverine 5→6, EF Core 10→11, .NET 10→11
+      # exigem revisão arquitetural (breaking changes documentados nos release
+      # notes) que não cabe em PR automático.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions — actions/* usadas em ci.yml/publish-images.yml/etc.
+  # Mais raro de mudar; agrupar tudo em PR único reduz ruído.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Belem"
+    open-pull-requests-limit: 2
+    labels:
+      - "chore"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,6 +349,29 @@ Para banir uma nova dependência: criar/atualizar a ADR correspondente, adiciona
 
 ---
 
+## Auto-update de dependências (Dependabot)
+
+O repositório usa **Dependabot** para detectar updates de pacotes NuGet (`Directory.Packages.props` central) e GitHub Actions, configurado em [`.github/dependabot.yml`](.github/dependabot.yml).
+
+### Como funciona
+
+- **Schedule semanal:** segunda 06:00 BRT — antes do daily.
+- **Grouping:** PRs agrupam pacotes do mesmo trem para reduzir ruído (todos `OpenTelemetry.*` num PR só, todos `WolverineFx*` em outro, e assim por diante).
+- **Major bumps são ignorados** pelo bot — versões `X.0.0` exigem revisão arquitetural manual (release notes, breaking changes, ADR se necessário). Quando precisar, o dev abre o PR explicitamente.
+- **Patch e minor** entram automaticamente como PRs com label `chore` + `deps` (ou `chore` + `ci` para Actions).
+
+### Tratamento dos PRs do bot
+
+1. **CI verde primeiro.** Mesmas 5 checagens dos PRs humanos (build/test/coverage, ADR lint, Spectral, forbidden-deps, PR author org member). Se o `NU1902` (vulnerabilidade) aparecer no restore, o bump já está corrigindo — PR é ainda mais prioritário.
+2. **Auto-merge condicional.** Patches sem CVE conhecida podem ser mergeados sem review humano profundo (CI verde basta). Minors merecem leitura rápida do diff de comportamento. Majors **nunca** chegam aqui (ignorados pelo bot).
+3. **Validação local opcional.** Para mudanças sensíveis (Wolverine, EF Core, Npgsql, Serilog), rodar `dotnet test UniPlus.slnx` localmente antes de aprovar.
+
+### Como adicionar um novo grupo
+
+Editar `.github/dependabot.yml` adicionando entrada em `updates[0].groups`. Padrão glob (`*` por sufixo) já cobre famílias inteiras.
+
+---
+
 ## Checklist antes de pedir merge
 
 Complementa os Quality gates acima (verificações de CI automáticas) com higiene de commits e branch — essas são verificações humanas:


### PR DESCRIPTION
## Resumo

Resolve a issue **#366** (criada como follow-up do PR #365 quando introduzimos o primeiro prerelease no `Directory.Packages.props` central). Adiciona configuração Dependabot completa para auto-update de pacotes NuGet e GitHub Actions, com grouping inteligente para reduzir ruído e major bumps sempre manuais.

## Decisão: Dependabot vs Renovate

- **Dependabot ✅** — nativo do GitHub, zero setup de App na org, suporte completo a `Directory.Packages.props` central + `packages.lock.json` em 17 projetos
- **Renovate ❌** — mais flexível mas requer instalação da App na org `unifesspa-edu-br` (decisão de plataforma fora do escopo desta issue)

## Mudanças

### `.github/dependabot.yml` (novo)

**2 ecosystems:** `nuget` (root) + `github-actions` (root)

**Schedule:** semanal, segunda 06:00 BRT (`timezone: America/Belem`) — antes do daily

**Grouping inteligente** para reduzir ruído (1 PR consolidado por trem):

| Grupo | Patterns |
|---|---|
| `opentelemetry` | `OpenTelemetry.*` + `Serilog.Sinks.OpenTelemetry` (trem único) |
| `wolverine` | `WolverineFx*` |
| `ef-core` | `Microsoft.EntityFrameworkCore*` + `Npgsql*` |
| `serilog` | `Serilog*` exceto o sink OTel (já no group `opentelemetry`) |
| `kafka` | `Confluent.*` + `Apache.Avro` |
| `testing` | xunit + AwesomeAssertions + NSubstitute + Testcontainers + ArchUnitNET + coverlet |
| `github-actions-all` | catch-all em 1 PR |

**Major bumps SEMPRE manuais** (`ignore: update-types: [\"version-update:semver-major\"]`) — Wolverine 5→6, EF Core 10→11, .NET 10→11 exigem revisão arquitetural (release notes, breaking changes, ADR se necessário)

**Limites:** `open-pull-requests-limit: 5` (NuGet) + `2` (Actions) — evita inundação

**Labels e commits:** `chore` + `deps` (NuGet) ou `chore` + `ci` (Actions); commit prefix `chore(deps):` / `chore(ci):` (Conventional Commits-friendly conforme [`docs/guia-commits-e-integracao.md`](docs/guia-commits-e-integracao.md))

### `CONTRIBUTING.md`

Nova seção **\"Auto-update de dependências (Dependabot)\"** entre `Dependências proibidas` e `Checklist antes de pedir merge`. Explica:

- Como funciona (schedule, grouping, major bumps)
- Tratamento dos PRs do bot (CI verde primeiro, auto-merge condicional para patches sem CVE, validação local opcional para deps sensíveis)
- Como adicionar um novo grupo

## Validação

\`\`\`bash
python3 -c \"import yaml; yaml.safe_load(open('.github/dependabot.yml'))\"  # OK
\`\`\`

GitHub valida o schema do `dependabot.yml` automaticamente após o merge — se houver erro de sintaxe, aparece em [Insights → Dependency graph → Dependabot](https://github.com/unifesspa-edu-br/uniplus-api/network/updates).

## Próximos passos pós-merge

1. **Esperar primeira execução automática** (próxima segunda 06:00 BRT após merge) — Dependabot abre os PRs agrupados
2. **Calibrar** se algum grupo gerar muito ruído ou ficar isolado por engano
3. **Considerar setup análogo** em `uniplus-web` e `uniplus-developers` (issues separadas se aplicável)

Closes #366