### PR TITLE
ci(api): separar jobs build / test-unit / test-integration / coverage-summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,23 @@ jobs:
       - name: Verificar pacotes proibidos
         run: bash tools/forbidden-deps/check.sh
 
+  # ─────────────────────────────────────────────────────────────────────────
+  # Pipeline build → (test-unit ∥ test-integration) → coverage-summary
+  #
+  # Refatoração da issue #88: o job monolítico anterior ("Build, Test and
+  # Coverage") gerava status check único e pagava setup de Testcontainers
+  # mesmo quando só os unit tests rodavam. A nova divisão entrega:
+  #
+  # - Status checks separados por etapa — falhas mais informativas e
+  #   políticas de branch protection mais granulares
+  # - test-unit e test-integration paralelos — wall-time reduzido
+  # - bin/+obj/ compartilhados via artifact — sem rebuild redundante
+  # ─────────────────────────────────────────────────────────────────────────
+
   build:
-    name: Build, Test and Coverage
+    name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -127,11 +140,128 @@ jobs:
       - name: Build
         run: dotnet build ${{ env.SOLUTION_PATH }} --configuration ${{ env.BUILD_CONFIG }} --no-restore
 
-      - name: Run tests with coverage
+      # bin/ + obj/ contêm tudo o que dotnet test --no-build precisa.
+      # Excluir TestResults/ evita acumular nada de runs anteriores
+      # (não deve existir aqui, mas guarda-corpo barato).
+      - name: Upload build output (bin/ + obj/)
+        uses: actions/upload-artifact@v5
+        with:
+          name: build-output
+          path: |
+            **/bin/${{ env.BUILD_CONFIG }}/**
+            **/obj/**
+            !**/TestResults/**
+          if-no-files-found: error
+          retention-days: 1
+
+  test-unit:
+    name: Unit + arch tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies (lockfile mode)
+        # NuGet packages cache acelera; --locked-mode garante reprodutibilidade
+        # idêntica ao build job (mesmas versões resolvidas).
+        run: dotnet restore ${{ env.SOLUTION_PATH }} --locked-mode
+
+      - name: Download build output
+        uses: actions/download-artifact@v5
+        with:
+          name: build-output
+
+      - name: Run unit + arch tests with coverage
+        # Filtra fora qualquer FullyQualifiedName contendo "IntegrationTests"
+        # — assemblies *.IntegrationTests.dll são carregados mas dotnet test
+        # não executa nenhum método, terminando rapidamente sem custo de Docker.
         run: |
           dotnet test ${{ env.SOLUTION_PATH }} \
             --configuration ${{ env.BUILD_CONFIG }} \
             --no-build \
+            --no-restore \
+            --filter "FullyQualifiedName!~IntegrationTests" \
+            --logger "trx" \
+            --collect:"XPlat Code Coverage" \
+            --settings coverlet.runsettings \
+            --results-directory ${{ env.COVERAGE_DIR }}
+
+      - name: Upload unit coverage
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-unit
+          path: ${{ env.COVERAGE_DIR }}/**/coverage.cobertura.xml
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-results-unit
+          path: ${{ env.COVERAGE_DIR }}/**/*.trx
+          if-no-files-found: warn
+          retention-days: 30
+
+  test-integration:
+    name: Integration tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore dependencies (lockfile mode)
+        run: dotnet restore ${{ env.SOLUTION_PATH }} --locked-mode
+
+      - name: Download build output
+        uses: actions/download-artifact@v5
+        with:
+          name: build-output
+
+      - name: Run integration tests with coverage
+        run: |
+          dotnet test ${{ env.SOLUTION_PATH }} \
+            --configuration ${{ env.BUILD_CONFIG }} \
+            --no-build \
+            --no-restore \
+            --filter "FullyQualifiedName~IntegrationTests" \
             --logger "trx" \
             --collect:"XPlat Code Coverage" \
             --settings coverlet.runsettings \
@@ -153,6 +283,7 @@ jobs:
           out=$(dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests \
             --configuration ${{ env.BUILD_CONFIG }} \
             --no-build \
+            --no-restore \
             --filter "Category=OutboxCapability" \
             --logger "console;verbosity=minimal")
           echo "$out"
@@ -172,6 +303,7 @@ jobs:
           out=$(dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests \
             --configuration ${{ env.BUILD_CONFIG }} \
             --no-build \
+            --no-restore \
             --filter "Category=OutboxCascading" \
             --logger "console;verbosity=minimal")
           echo "$out"
@@ -184,8 +316,63 @@ jobs:
             exit 1
           fi
 
-      - name: Merge coverage reports
+      - name: Upload integration coverage
         if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: coverage-integration
+          path: ${{ env.COVERAGE_DIR }}/**/coverage.cobertura.xml
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload integration test results
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-results-integration
+          path: ${{ env.COVERAGE_DIR }}/**/*.trx
+          if-no-files-found: warn
+          retention-days: 30
+
+  coverage-summary:
+    name: Coverage summary
+    needs: [test-unit, test-integration]
+    # if: always() — quer rodar mesmo se test-* falhar para que o relatório
+    # parcial fique disponível como evidência. Threshold step ainda enforca
+    # falhas reais — esta fase não mascara nada, só agrega.
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore .NET tools (reportgenerator)
+        run: dotnet tool restore
+
+      - name: Download unit coverage
+        uses: actions/download-artifact@v5
+        with:
+          name: coverage-unit
+          path: ${{ env.COVERAGE_DIR }}/unit
+        continue-on-error: true
+
+      - name: Download integration coverage
+        uses: actions/download-artifact@v5
+        with:
+          name: coverage-integration
+          path: ${{ env.COVERAGE_DIR }}/integration
+        continue-on-error: true
+
+      - name: Merge coverage reports
         run: |
           dotnet reportgenerator \
             "-reports:${{ env.COVERAGE_DIR }}/**/coverage.cobertura.xml" \
@@ -215,29 +402,18 @@ jobs:
 
           pct=$(awk "BEGIN{printf \"%.2f\", $line_rate * 100}")
           threshold=${{ env.COVERAGE_THRESHOLD }}
-          echo "Cobertura (Domain + Application): ${pct}% (mínimo: ${threshold}%)"
+          echo "Cobertura agregada (Domain + Application): ${pct}% (mínimo: ${threshold}%)"
 
           if awk "BEGIN{exit !($line_rate * 100 < $threshold)}"; then
             echo "::error::Cobertura ${pct}% abaixo do mínimo exigido (${threshold}%)"
             exit 1
           fi
 
-      - name: Upload coverage reports
+      - name: Upload merged coverage report
         if: always()
         uses: actions/upload-artifact@v5
         with:
           name: coverage-report
-          path: |
-            ${{ env.COVERAGE_DIR }}/**/coverage.cobertura.xml
-            ${{ env.COVERAGE_DIR }}/report/**
+          path: ${{ env.COVERAGE_DIR }}/report/**
           if-no-files-found: error
-          retention-days: 30
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v5
-        with:
-          name: test-results
-          path: ${{ env.COVERAGE_DIR }}/**/*.trx
-          if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,17 +140,25 @@ jobs:
       - name: Build
         run: dotnet build ${{ env.SOLUTION_PATH }} --configuration ${{ env.BUILD_CONFIG }} --no-restore
 
-      # bin/ + obj/ contêm tudo o que dotnet test --no-build precisa.
-      # Excluir TestResults/ evita acumular nada de runs anteriores
-      # (não deve existir aqui, mas guarda-corpo barato).
-      - name: Upload build output (bin/ + obj/)
+      # Empacotar em tar antes do upload preserva a estrutura por projeto
+      # (<projeto>/bin/Release/...) — actions/upload-artifact "rebaseia" globs
+      # iniciados com ** e flatteniza arquivos sob bin/ / obj/ comuns no
+      # download, quebrando dotnet test --no-build --no-restore.
+      # Solução com tar foi adotada em vez de actions/cache porque cache
+      # depende de chave estável e, em PRs com push novo, pode atingir cache
+      # de runs anteriores em vez do build atual; tar via artifact garante
+      # que o exato output do build deste run chega aos test jobs.
+      - name: Pack build output
+        run: |
+          find src tests -type d \( -path '*/bin/${{ env.BUILD_CONFIG }}' -o -name 'obj' \) > build-paths.txt
+          tar -cf build-output.tar -T build-paths.txt
+          ls -lh build-output.tar
+
+      - name: Upload build output
         uses: actions/upload-artifact@v5
         with:
           name: build-output
-          path: |
-            **/bin/${{ env.BUILD_CONFIG }}/**
-            **/obj/**
-            !**/TestResults/**
+          path: build-output.tar
           if-no-files-found: error
           retention-days: 1
 
@@ -188,6 +196,9 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: build-output
+
+      - name: Unpack build output
+        run: tar -xf build-output.tar
 
       - name: Run unit + arch tests with coverage
         # Filtra fora qualquer FullyQualifiedName contendo "IntegrationTests"
@@ -254,6 +265,9 @@ jobs:
         uses: actions/download-artifact@v5
         with:
           name: build-output
+
+      - name: Unpack build output
+        run: tar -xf build-output.tar
 
       - name: Run integration tests with coverage
         run: |


### PR DESCRIPTION
## Resumo

Resolve **#88** — refatora o job monolítico \"Build, Test and Coverage\" em 4 jobs especializados, com paralelismo entre as suítes de teste e artifact compartilhado de `bin/+obj/`.

## Topologia nova

\`\`\`
adr-lint        ┐
spectral        ├── (paralelos, mantidos como estavam)
forbidden-deps  ┘
pr-author-org-member (mantido — workflow separado)

build → upload bin/+obj/ como artifact
  ├──► test-unit         (--no-build --no-restore, filter !~IntegrationTests)
  └──► test-integration  (--no-build --no-restore, filter ~IntegrationTests + sanity Outbox*)
       │ ↓
       ↓ ↓
   coverage-summary  (needs ambos, if: always)
   → merge cobertura + threshold + upload report agregado
\`\`\`

## Mudanças no `ci.yml`

| Job | Antes | Agora |
|---|---|---|
| `adr-lint`, `spectral`, `forbidden-deps` | já separados | inalterados |
| ~~`build`~~ (era \"Build, Test and Coverage\" monolítico) | restore + build + test + sanity + merge + threshold + upload | só restore + build + upload bin/+obj/ |
| `test-unit` (novo) | — | download artifact, `dotnet test --no-build --no-restore --filter \"FullyQualifiedName!~IntegrationTests\"` + upload coverage parcial |
| `test-integration` (novo) | — | download artifact, `dotnet test --no-build --no-restore --filter \"FullyQualifiedName~IntegrationTests\"` + sanity OutboxCapability/OutboxCascading (issue #205) + upload coverage parcial |
| `coverage-summary` (novo) | — | needs `[test-unit, test-integration]`, `if: always()`, download dos 2 coverage parciais, `reportgenerator` merge + threshold step + upload report final |

## Benefícios

- **Status checks separados por etapa** — `build`, `test-unit`, `test-integration`, `coverage-summary` aparecem individualmente no PR. Falha em uma não esconde sucesso/falha das outras
- **Paralelismo `test-unit` + `test-integration`** — wall-time agregado reduzido (test-unit tipicamente ~30s vs test-integration ~3min com Docker do Testcontainers)
- **`bin/+obj/` compartilhados via artifact** — sem rebuild redundante. Cache NuGet (`~/.nuget/packages`) em cada job é hit instantâneo
- **`coverage-summary` com `if: always()`** — relatório parcial fica disponível mesmo se uma suite falhar. Threshold step ainda enforca falha real, sem mascarar
- **Sentinelas OutboxCapability/OutboxCascading** (issue #205) movidos para `test-integration` onde rodam de fato — antes pagavam custo de re-invocar `dotnet test` no job monolítico

## Decisões

- **Threshold mantido em 0%** — escada gradual da issue #21. Subir conforme cobertura real maturar. Não abaixar nunca
- **`--locked-mode` preservado** em todos os 3 restores (build + test-unit + test-integration) — reprodutibilidade idêntica entre jobs
- **Artifact retention escalonado:**
  - `build-output`, `coverage-unit`, `coverage-integration` → **1 dia** (efêmeros entre jobs do mesmo run)
  - `test-results-unit`, `test-results-integration`, `coverage-report` → **30 dias** (auditoria)
- **Concurrency cancel-in-progress** mantido — push novo cancela run anterior em PRs
- **Não adicionei `setup-dotnet@v5` na coverage-summary apenas para ToolRestore?** — adicionei sim, é dependência do `dotnet tool restore` que precisa do SDK. Step explicit + `dotnet tool restore` antes do `dotnet reportgenerator`

## Validação

\`\`\`bash
python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"  # OK
\`\`\`

A validação real do workflow é o próprio CI rodando neste PR. Se houver erro de schema/semântica do GitHub Actions, aparecerá no run desta PR.

## Pós-merge (manual)

- **Atualizar branch protection** (#22) trocando o status check antigo `Build, Test and Coverage` pelos novos:
  - `build`
  - `test-unit`
  - `test-integration`
  - `coverage-summary`

Sem isso, branch protection ficará órfã (referenciando check que não existe mais) e PRs poderão mergear sem aguardar os novos checks. Ação requer admin do repo.

Closes #88