### PR TITLE
chore(infra): ignorar majors de GitHub Actions no Dependabot (gap pós-#369)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,3 +90,12 @@ updates:
       github-actions-all:
         patterns:
           - "*"
+    ignore:
+      # Major bumps de Actions (checkout v5→v6, setup-node v4→v6, etc.) com
+      # frequência exigem migração de runtime (Node.js version, sintaxe
+      # de inputs deprecada). Tratar como manual evita PRs Dependabot que
+      # quebram silenciosamente todos os workflows num único bump em massa.
+      # Lição aprendida no PR #370 (fechado pelo bot por conflito justamente
+      # quando tentou trazer 7 majors de uma vez).
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Resumo

Fecha gap notado quando o PR #370 (Dependabot github-actions-all) abriu com 7 majors simultâneas — `actions/checkout v5→v6`, `setup-node v4→v6`, `upload-artifact v5→v7`, `docker/setup-buildx@v3→v4`, `docker/login@v3→v4`, `docker/metadata@v5→v6`, `docker/build-push@v5→v7`. Bot fechou o PR sozinho ao detectar conflito com a refatoração do `ci.yml` no #372.

## Causa

O `ignore: semver-major` que adicionei no PR #369 estava aplicado **só** ao ecosystem `nuget`. O ecosystem `github-actions` ficou sem o filtro, então majors de Actions chegavam automaticamente.

## Mudança

Adicionar bloco `ignore` simétrico no ecosystem `github-actions`:

```yaml
ignore:
  - dependency-name: "*"
    update-types: ["version-update:semver-major"]
```

## Por que

Majors de Actions tendem a:

- Trocar Node.js runtime (v20 → v24 em `actions/checkout@v6`)
- Deprecar inputs/outputs antigos
- Mudar sintaxe ou semântica (`actions/upload-artifact@v7` vs v5 tem comportamento diferente em paths/composição)

Bumpar 7 dessas de uma vez quebra silenciosamente todos os workflows. Tratar como manual evita esse risco — quando alguém do time quiser atualizar uma action major específica, abre PR dedicado revisando release notes daquela action.

Patch e minor de Actions continuam vindo automaticamente (são raros e geralmente seguros).