### PR TITLE
ci: bypass do gate pr-author-org-member para PRs de bots

### DIFF
--- a/.github/workflows/pr-author-org-member.yml
+++ b/.github/workflows/pr-author-org-member.yml
@@ -12,7 +12,21 @@ jobs:
     name: PR author is org member
     runs-on: ubuntu-latest
     steps:
+      # Bots conhecidos do GitHub (Dependabot, GitHub Actions, Renovate)
+      # não são "members" no sentido organizacional — não passam pelo endpoint
+      # /collaborators/{login}/permission e nem aparecem em ?affiliation=outside.
+      # São agentes do próprio GitHub, autorizados a abrir PRs com as permissões
+      # do repo via secrets.GITHUB_TOKEN. Bypass explícito + nominal evita
+      # reescrever o gate semanticamente: humanos continuam sendo validados
+      # pela rota normal abaixo.
+      - name: Bypass para bots do GitHub
+        if: github.event.pull_request.user.type == 'Bot'
+        run: |
+          echo "PR autor ${{ github.event.pull_request.user.login }} é Bot — bypass do gate org-member."
+          exit 0
+
       - name: Validate author is org member with write access
+        if: github.event.pull_request.user.type != 'Bot'
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Resumo

Destrava PRs do Dependabot (e qualquer bot futuro — github-actions, Renovate) que ficavam bloqueados pelo gate `PR author is org member`. Bots não passam pelo endpoint `/collaborators/{login}/permission` (retorna 404 para bot logins), fazendo o status check obrigatório sempre falhar.

## Mudança

Step novo no início do job que **bypass explícito quando `user.type == 'Bot'`**. Step seguinte ganha condição `if: user.type != 'Bot'` para preservar a validação para humanos.

## Por que bypass + nominal em vez de reescrever o gate

- **Auditoria preservada**: humanos continuam validados pela rota original (permission `write/admin/maintain` + não-outside-collaborator)
- **Bots rastreáveis**: `user.login` aparece no log do bypass step (`dependabot[bot]`, `github-actions[bot]`, etc.)
- **Sem allowlist hardcoded**: `user.type == 'Bot'` é genérico — vale para qualquer bot integration

## Alternativa rejeitada: `--admin` merge para cada PR Dependabot

Anti-pattern que mascara CI failures e quebra histórico de status checks como evidência de aprovação. Bypass explícito do gate é o caminho correto.

## Impacto

Após mergeado, os PRs Dependabot atuais (#371, #373, #374) precisam re-disparar CI (ou rebase em main) para o status `PR author is org member` virar SUCCESS — então conseguem mergear normalmente.