### PR TITLE
refactor(shared): injetar IUserContext em SoftDeleteInterceptor para audit trail

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
@@ -27,7 +27,11 @@ public static class IngressoInfrastructureRegistration
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddSingleton<SoftDeleteInterceptor>();
+        // SoftDeleteInterceptor consome IUserContext scoped (HttpUserContext)
+        // para preencher DeletedBy com o usuário autenticado (issue #127).
+        // Scoped acompanha o ciclo de vida do request — Singleton aqui causaria
+        // captive dependency com IUserContext.
+        services.AddScoped<SoftDeleteInterceptor>();
         services.AddSingleton<AuditableInterceptor>();
 
         services.AddDbContext<IngressoDbContext>((serviceProvider, options) =>

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/DependencyInjection.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/DependencyInjection.cs
@@ -25,7 +25,11 @@ public static class PortalInfrastructureRegistration
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddSingleton<SoftDeleteInterceptor>();
+        // SoftDeleteInterceptor consome IUserContext scoped (HttpUserContext)
+        // para preencher DeletedBy com o usuário autenticado (issue #127).
+        // Scoped acompanha o ciclo de vida do request — Singleton aqui causaria
+        // captive dependency com IUserContext.
+        services.AddScoped<SoftDeleteInterceptor>();
         services.AddSingleton<AuditableInterceptor>();
 
         services.AddDbContext<PortalDbContext>((serviceProvider, options) =>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -28,7 +28,11 @@ public static class SelecaoInfrastructureRegistration
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        services.AddSingleton<SoftDeleteInterceptor>();
+        // SoftDeleteInterceptor consome IUserContext scoped (HttpUserContext)
+        // para preencher DeletedBy com o usuário autenticado (issue #127).
+        // Scoped acompanha o ciclo de vida do request — Singleton aqui causaria
+        // captive dependency com IUserContext.
+        services.AddScoped<SoftDeleteInterceptor>();
         services.AddSingleton<AuditableInterceptor>();
 
         services.AddDbContext<SelecaoDbContext>((serviceProvider, options) =>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs
@@ -3,10 +3,32 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
 using Kernel.Domain.Entities;
 
+// LGPD audit trail (issue #127): converte DELETE em UPDATE preservando o
+// identificador do usuário responsável em DeletedBy. Em requests autenticados,
+// o IUserContext (sub claim do JWT) é usado; em jobs, migrations e qualquer
+// fluxo sem principal autenticado, cai para "system" como fallback explícito.
+//
+// Registrado como Scoped na DI dos módulos para acompanhar o ciclo de vida
+// scoped do IUserContext (HttpUserContext) e do DbContext — evitar Singleton
+// neste interceptor é deliberado: capturar um IUserContext scoped em um
+// singleton causaria captive dependency e o UserId congelaria no primeiro
+// request servido pelo processo.
 public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
 {
+    private const string SystemUser = "system";
+
+    private readonly IUserContext? _userContext;
+
+    // Construtor sem args preservado para uso em testes que não exigem
+    // IUserContext (cenário equivalente ao fallback "system").
+    public SoftDeleteInterceptor(IUserContext? userContext = null)
+    {
+        _userContext = userContext;
+    }
+
     public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
         DbContextEventData eventData,
         InterceptionResult<int> result,
@@ -32,16 +54,28 @@ public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
         return base.SavingChanges(eventData!, result);
     }
 
-    private static void ConvertDeleteToSoftDelete(DbContext context)
+    private void ConvertDeleteToSoftDelete(DbContext context)
     {
+        string deletedBy = ResolveDeletedBy();
+
         foreach (Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<EntityBase> entry
             in context.ChangeTracker.Entries<EntityBase>())
         {
             if (entry.State == EntityState.Deleted)
             {
                 entry.State = EntityState.Modified;
-                entry.Entity.MarkAsDeleted("system");
+                entry.Entity.MarkAsDeleted(deletedBy);
             }
         }
+    }
+
+    private string ResolveDeletedBy()
+    {
+        if (_userContext is { IsAuthenticated: true, UserId: { Length: > 0 } userId })
+        {
+            return userId;
+        }
+
+        return SystemUser;
     }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
@@ -144,4 +144,26 @@ public sealed class SoftDeleteInterceptorTests
 
         entidade.DeletedBy.Should().Be(SystemUser);
     }
+
+    // Cenário real quando o token validado não traz nem `sub` nem `nameidentifier`
+    // (HttpUserContext.UserId resolve null), mas Identity.IsAuthenticated continua true.
+    // O pattern matching de ResolveDeletedBy depende do null check ocorrer antes do
+    // teste de Length — este caso fixa o contrato.
+    [Fact]
+    public void SavingChanges_DadoUsuarioAutenticadoComUserIdNulo_EntaoDeletedByDeveSerSystem()
+    {
+        IUserContext userContext = Substitute.For<IUserContext>();
+        userContext.IsAuthenticated.Returns(true);
+        userContext.UserId.Returns((string?)null);
+
+        using ContextoTeste contexto = CriarContexto(userContext);
+        EntidadeTeste entidade = new() { Nome = "para excluir" };
+        contexto.Entidades.Add(entidade);
+        contexto.SaveChanges();
+
+        contexto.Entidades.Remove(entidade);
+        contexto.SaveChanges();
+
+        entidade.DeletedBy.Should().Be(SystemUser);
+    }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
@@ -4,11 +4,16 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
 using Kernel.Domain.Entities;
 
 public sealed class SoftDeleteInterceptorTests
 {
+    private const string SystemUser = "system";
+
     private sealed class EntidadeTeste : EntityBase
     {
         public string Nome { get; set; } = string.Empty;
@@ -19,11 +24,27 @@ public sealed class SoftDeleteInterceptorTests
         public DbSet<EntidadeTeste> Entidades { get; set; } = null!;
     }
 
-    private static ContextoTeste CriarContexto() =>
+    private static ContextoTeste CriarContexto(IUserContext? userContext = null) =>
         new(new DbContextOptionsBuilder<ContextoTeste>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .AddInterceptors(new SoftDeleteInterceptor())
+            .AddInterceptors(new SoftDeleteInterceptor(userContext))
             .Options);
+
+    private static IUserContext UsuarioAutenticado(string userId)
+    {
+        IUserContext userContext = Substitute.For<IUserContext>();
+        userContext.IsAuthenticated.Returns(true);
+        userContext.UserId.Returns(userId);
+        return userContext;
+    }
+
+    private static IUserContext UsuarioAnonimo()
+    {
+        IUserContext userContext = Substitute.For<IUserContext>();
+        userContext.IsAuthenticated.Returns(false);
+        userContext.UserId.Returns((string?)null);
+        return userContext;
+    }
 
     [Fact]
     public void SavingChanges_DadoEntityRemovida_EntaoDeveConverterParaModificadaEMarcarComoExcluida()
@@ -38,6 +59,7 @@ public sealed class SoftDeleteInterceptorTests
 
         entidade.IsDeleted.Should().BeTrue();
         entidade.DeletedAt.Should().NotBeNull();
+        entidade.DeletedBy.Should().Be(SystemUser);
         contexto.Entidades.Find(entidade.Id).Should().NotBeNull();
     }
 
@@ -54,6 +76,72 @@ public sealed class SoftDeleteInterceptorTests
 
         entidade.IsDeleted.Should().BeTrue();
         entidade.DeletedAt.Should().NotBeNull();
+        entidade.DeletedBy.Should().Be(SystemUser);
         (await contexto.Entidades.FindAsync(entidade.Id)).Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SavingChanges_DadoUsuarioAutenticado_EntaoDeletedByDeveSerUserId()
+    {
+        IUserContext userContext = UsuarioAutenticado("user-42");
+        using ContextoTeste contexto = CriarContexto(userContext);
+        EntidadeTeste entidade = new() { Nome = "para excluir" };
+        contexto.Entidades.Add(entidade);
+        contexto.SaveChanges();
+
+        contexto.Entidades.Remove(entidade);
+        contexto.SaveChanges();
+
+        entidade.IsDeleted.Should().BeTrue();
+        entidade.DeletedBy.Should().Be("user-42");
+    }
+
+    [Fact]
+    public async Task SavingChangesAsync_DadoUsuarioAutenticado_EntaoDeletedByDeveSerUserId()
+    {
+        IUserContext userContext = UsuarioAutenticado("user-99");
+        await using ContextoTeste contexto = CriarContexto(userContext);
+        EntidadeTeste entidade = new() { Nome = "para excluir" };
+        contexto.Entidades.Add(entidade);
+        await contexto.SaveChangesAsync();
+
+        contexto.Entidades.Remove(entidade);
+        await contexto.SaveChangesAsync();
+
+        entidade.IsDeleted.Should().BeTrue();
+        entidade.DeletedBy.Should().Be("user-99");
+    }
+
+    [Fact]
+    public void SavingChanges_DadoUsuarioNaoAutenticado_EntaoDeletedByDeveSerSystem()
+    {
+        IUserContext userContext = UsuarioAnonimo();
+        using ContextoTeste contexto = CriarContexto(userContext);
+        EntidadeTeste entidade = new() { Nome = "para excluir" };
+        contexto.Entidades.Add(entidade);
+        contexto.SaveChanges();
+
+        contexto.Entidades.Remove(entidade);
+        contexto.SaveChanges();
+
+        entidade.DeletedBy.Should().Be(SystemUser);
+    }
+
+    [Fact]
+    public void SavingChanges_DadoUsuarioAutenticadoComUserIdVazio_EntaoDeletedByDeveSerSystem()
+    {
+        IUserContext userContext = Substitute.For<IUserContext>();
+        userContext.IsAuthenticated.Returns(true);
+        userContext.UserId.Returns(string.Empty);
+
+        using ContextoTeste contexto = CriarContexto(userContext);
+        EntidadeTeste entidade = new() { Nome = "para excluir" };
+        contexto.Entidades.Add(entidade);
+        contexto.SaveChanges();
+
+        contexto.Entidades.Remove(entidade);
+        contexto.SaveChanges();
+
+        entidade.DeletedBy.Should().Be(SystemUser);
     }
 }


### PR DESCRIPTION
## Resumo

- Resolve débito LGPD (issue #127): `SoftDeleteInterceptor` passa a injetar `IUserContext` e preencher `DeletedBy` com o usuário autenticado quando disponível, mantendo `"system"` como fallback para jobs, migrations e requests anônimos.
- Lifetime do interceptor migrado de **Singleton** para **Scoped** nos 3 módulos (Selecao/Ingresso/Portal) para acompanhar o ciclo de vida scoped do `IUserContext` (`HttpUserContext`) e evitar captive dependency.

## Mudanças

- `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs` — refactor para receber `IUserContext?` opcional via DI; `ResolveDeletedBy()` decide entre `UserId` autenticado e fallback `"system"`. Construtor com parâmetro opcional preserva uso direto via `new()` em testes.
- `src/{selecao,ingresso,portal}/.../DependencyInjection.cs` — `AddSingleton<SoftDeleteInterceptor>()` → `AddScoped<SoftDeleteInterceptor>()` (`AuditableInterceptor` permanece Singleton; fora do escopo desta issue).
- `tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs` — 4 cenários novos (autenticado sync/async, não-autenticado, `UserId` vazio) + asserções `DeletedBy` adicionadas aos 2 cenários originais.

## Plano de teste

- [x] `dotnet build UniPlus.slnx` — 0 warnings, 0 errors
- [x] `Infrastructure.Core.UnitTests` — 476/476 passando (inclui 6 cenários do `SoftDeleteInterceptor`)
- [x] Suites unit + arch dos demais projetos verde (Application.Abstractions, Kernel, ArchTests)
- [ ] CI: integration tests Selecao/Ingresso (rodam com Vault + Keycloak + Postgres reais)

Closes #127