### PR TITLE
ci(security): adicionar workflow CodeQL SAST para C# / .NET 10

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,75 @@
+name: CodeQL
+
+# Análise estática de segurança (SAST) do código C# / .NET 10. Resultados
+# alimentam a aba Security do GitHub via upload SARIF do passo `analyze`.
+# Issue #23: adoção de CodeQL como gate inicial não bloqueante (alerta);
+# elevação para required check fica para fase futura quando a baseline de
+# findings estiver triada.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Segunda-feira 03:30 UTC (= 00:30 BRT). Janela noturna de baixo tráfego
+    # nos GitHub Actions runners e fora do horário operacional do time.
+    - cron: '30 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  DOTNET_VERSION: 10.0.x
+  SOLUTION_PATH: UniPlus.slnx
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # build-mode manual em vez de autobuild: o solution file UniPlus.slnx
+          # usa o formato XML novo do .NET, que o autobuild ainda não reconhece
+          # de forma totalmente previsível para .NET 10. Build explícito via
+          # dotnet build é determinístico e segue o mesmo comando do ci.yml.
+          - language: csharp
+            build-mode: manual
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Build .NET solution
+        run: |
+          dotnet restore "$SOLUTION_PATH"
+          dotnet build "$SOLUTION_PATH" \
+            --configuration Release \
+            --no-restore
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,19 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    # paths-ignore evita execução em PRs/pushes docs-only (sem código C#
+    # alterado, CodeQL não acrescenta sinal). O schedule semanal abaixo
+    # cobre drift acidental.
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
   schedule:
     # Segunda-feira 03:30 UTC (= 00:30 BRT). Janela noturna de baixo tráfego
     # nos GitHub Actions runners e fora do horário operacional do time.
@@ -55,6 +66,11 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+          # Cache de packages NuGet chaveado por hash dos .csproj. Reduz
+          # restore frio (~30-60s na árvore atual de ~30 projetos) para
+          # ~5s em cache hit, economizando runner minutes em PRs em rajada.
+          cache: true
+          cache-dependency-path: '**/*.csproj'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,7 +73,7 @@ jobs:
           cache-dependency-path: '**/*.csproj'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -86,6 +86,6 @@ jobs:
             --no-restore
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Resumo

- Adiciona `.github/workflows/codeql.yml` para análise estática (SAST) do código C# / .NET 10 — atende metade da issue #23 (a outra metade é o PR irmão em `uniplus-web` que cobre TypeScript/JavaScript).
- Resultados publicados automaticamente na aba **Security** do repositório via upload SARIF da action `github/codeql-action/analyze`.

## Triggers

- `push` → main
- `pull_request` → main
- `schedule` semanal (segunda 03:30 UTC = 00:30 BRT)
- `workflow_dispatch` (re-run manual)

## Decisões

- **`build-mode: manual`** em vez de `autobuild`: o solution file `UniPlus.slnx` (formato XML novo do .NET) ainda não é totalmente previsível com autobuild. Build explícito via `dotnet restore` + `dotnet build --configuration Release` segue o mesmo comando do `ci.yml` e é determinístico.
- **Permissions mínimas**: `actions:read`, `contents:read`, `security-events:write` — suficiente para upload SARIF, sem privilégios excedentes.
- **Concurrency**: cancela PRs em re-push (alinhado com o `ci.yml`).
- **Gate não bloqueante**: o workflow falha apenas se a action quebrar tecnicamente, não por findings. Promoção a required check fica para fase futura quando a baseline estiver triada (alinhado com critério da issue: "Zero findings high/critical como quality gate (alerta, não bloqueante inicialmente)").

## Plano de teste

- [x] `yamllint` passa (estilo limpo)
- [x] YAML parse válido (Python yaml)
- [ ] CI: workflow será executado neste próprio PR (push → trigger `pull_request`); resultado visível na aba Checks e na aba Security após análise

Refs #23 (não fecha — fechamento manual quando o PR irmão `uniplus-web/feature/23-codeql-sast` também mergear)