### PR TITLE
test(shared-kernel): completar cobertura de testes unitários do Kernel

### DIFF
--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -12,7 +12,7 @@
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <Include>[Unifesspa.UniPlus.*.Domain]*,[Unifesspa.UniPlus.*.Application]*</Include>
+          <Include>[Unifesspa.UniPlus.*.Domain]*,[Unifesspa.UniPlus.*.Application]*,[Unifesspa.UniPlus.Kernel]*</Include>
           <Exclude>[*.Tests]*,[*.ArchTests]*,[*.Integration.Tests]*</Exclude>
           <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
           <ExcludeByFile>**/Migrations/*.cs,**/*.g.cs,**/*.Designer.cs</ExcludeByFile>

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseTests.cs
@@ -109,8 +109,8 @@ public sealed class EntityBaseTests
 
         a.Equals(b).Should().BeFalse("instâncias distintas — igualdade por referência");
         a.Equals(a).Should().BeTrue();
-        a.GetHashCode().Should().NotBe(b.GetHashCode(),
-            "Object.GetHashCode default usa o identity hash do objeto — referências distintas produzem hashes distintos");
+        ReferenceEquals(a, b).Should().BeFalse(
+            "duas instâncias têm referências distintas; assertiva direta evita risco teórico de colisão em GetHashCode");
     }
 
     // RFC 9562 §5.7 — versão fica nos 4 bits altos do byte 6 (offset 7 em string little-endian).

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseTests.cs
@@ -1,0 +1,126 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+
+// Cobre o ciclo de vida básico do EntityBase. A drenagem de domain events
+// fica em EntityBaseDomainEventsTests — esta classe foca em Id, audit e
+// soft delete (ADR-0032 + invariantes da issue #127).
+public sealed class EntityBaseTests
+{
+    [Fact(DisplayName = "Nova entidade nasce com Id UUID v7 (preserva ordering temporal)")]
+    public void NovaEntidade_TemIdUuidV7()
+    {
+        EntidadeDeTeste entidade = new();
+
+        entidade.Id.Should().NotBeEmpty();
+        ExtrairVersao(entidade.Id).Should().Be(7,
+            "EntityBase usa Guid.CreateVersion7 para ganhar ordering temporal (ADR-0032)");
+    }
+
+    [Fact(DisplayName = "Duas entidades criadas em sequência têm Ids distintos")]
+    public void NovaEntidade_IdEhUnico()
+    {
+        EntidadeDeTeste a = new();
+        EntidadeDeTeste b = new();
+
+        a.Id.Should().NotBe(b.Id);
+    }
+
+    [Fact(DisplayName = "CreatedAt é preenchido com UtcNow ±5s no momento da criação")]
+    public void CreatedAt_ProximoDoAgoraUtc()
+    {
+        DateTimeOffset antes = DateTimeOffset.UtcNow;
+
+        EntidadeDeTeste entidade = new();
+
+        DateTimeOffset depois = DateTimeOffset.UtcNow;
+
+        entidade.CreatedAt.Should().BeOnOrAfter(antes.AddSeconds(-5));
+        entidade.CreatedAt.Should().BeOnOrBefore(depois.AddSeconds(5));
+        entidade.CreatedAt.Offset.Should().Be(TimeSpan.Zero,
+            "audit trail é normalizado em UTC");
+    }
+
+    [Fact(DisplayName = "Entidade recém-criada não tem UpdatedAt, IsDeleted, DeletedAt, DeletedBy")]
+    public void NovaEntidade_FlagsDeAuditNaoIniciam()
+    {
+        EntidadeDeTeste entidade = new();
+
+        entidade.UpdatedAt.Should().BeNull();
+        entidade.IsDeleted.Should().BeFalse();
+        entidade.DeletedAt.Should().BeNull();
+        entidade.DeletedBy.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "MarkAsDeleted altera IsDeleted, DeletedAt (UtcNow) e DeletedBy")]
+    public void MarkAsDeleted_AlteraFlagsDeSoftDelete()
+    {
+        EntidadeDeTeste entidade = new();
+        DateTimeOffset antes = DateTimeOffset.UtcNow;
+
+        entidade.MarkAsDeleted("usuario@exemplo.com");
+
+        DateTimeOffset depois = DateTimeOffset.UtcNow;
+
+        entidade.IsDeleted.Should().BeTrue();
+        entidade.DeletedBy.Should().Be("usuario@exemplo.com");
+        entidade.DeletedAt.Should().NotBeNull();
+        entidade.DeletedAt!.Value.Should().BeOnOrAfter(antes.AddSeconds(-1))
+            .And.BeOnOrBefore(depois.AddSeconds(1));
+        entidade.DeletedAt!.Value.Offset.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact(DisplayName = "MarkAsDeleted pode ser chamado mais de uma vez — sobrescreve DeletedBy")]
+    public void MarkAsDeleted_PodeSerChamadoMaisDeUmaVez()
+    {
+        EntidadeDeTeste entidade = new();
+        entidade.MarkAsDeleted("primeiro");
+
+        entidade.MarkAsDeleted("segundo");
+
+        entidade.IsDeleted.Should().BeTrue();
+        entidade.DeletedBy.Should().Be("segundo");
+    }
+
+    [Fact(DisplayName = "DomainEvents inicia como coleção vazia e imutável (não array)")]
+    public void DomainEvents_IniciaVazioEImutavel()
+    {
+        EntidadeDeTeste entidade = new();
+
+        entidade.DomainEvents.Should().BeEmpty();
+        (entidade.DomainEvents is List<Kernel.Domain.Events.IDomainEvent>).Should().BeFalse(
+            "exposição interna usa AsReadOnly — caller não consegue castar para List<T>");
+    }
+
+    [Fact(DisplayName = "EntityBase usa igualdade referencial — não há override Equals/GetHashCode baseado em Id")]
+    public void Igualdade_EhReferencial_NaoBaseadaEmId()
+    {
+        // EntityBase é classe (não record) e não sobrescreve Equals/GetHashCode.
+        // O design atual privilegia identidade gerenciada pelo ChangeTracker do
+        // EF Core; agregados são comparados por referência dentro do escopo do
+        // DbContext. Issue #16 lista "igualdade por Id" como AC, mas o código
+        // não implementa esse contrato hoje — este teste pin documenta o
+        // comportamento real e quebrará se algum dia o design mudar.
+
+        EntidadeDeTeste a = new();
+        EntidadeDeTeste b = new();
+
+        a.Equals(b).Should().BeFalse("instâncias distintas — igualdade por referência");
+        a.Equals(a).Should().BeTrue();
+        a.GetHashCode().Should().NotBe(b.GetHashCode(),
+            "Object.GetHashCode default usa o identity hash do objeto — referências distintas produzem hashes distintos");
+    }
+
+    // RFC 9562 §5.7 — versão fica nos 4 bits altos do byte 6 (offset 7 em string little-endian).
+    private static int ExtrairVersao(Guid id)
+    {
+        byte[] bytes = id.ToByteArray();
+        return (bytes[7] & 0xF0) >> 4;
+    }
+
+    private sealed class EntidadeDeTeste : EntityBase
+    {
+    }
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Events/DomainEventBaseTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Events/DomainEventBaseTests.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.Events;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Domain.Events;
+
+public sealed class DomainEventBaseTests
+{
+    [Fact(DisplayName = "DomainEventBase atribui EventId UUID v7 distinto por instância")]
+    public void EventId_EhUuidV7Unico()
+    {
+        EventoDeTeste a = new("a");
+        EventoDeTeste b = new("b");
+
+        a.EventId.Should().NotBe(b.EventId);
+        ExtrairVersao(a.EventId).Should().Be(7,
+            "DomainEventBase usa Guid.CreateVersion7 para ordering temporal no outbox (ADR-0032)");
+        ExtrairVersao(b.EventId).Should().Be(7);
+    }
+
+    [Fact(DisplayName = "DomainEventBase atribui OccurredOn em UTC próximo de UtcNow")]
+    public void OccurredOn_ProximoUtcNow()
+    {
+        DateTimeOffset antes = DateTimeOffset.UtcNow;
+
+        EventoDeTeste evento = new("x");
+
+        DateTimeOffset depois = DateTimeOffset.UtcNow;
+
+        evento.OccurredOn.Should().BeOnOrAfter(antes.AddSeconds(-5))
+            .And.BeOnOrBefore(depois.AddSeconds(5));
+        evento.OccurredOn.Offset.Should().Be(TimeSpan.Zero,
+            "OccurredOn é normalizado em UTC para serialização determinística");
+    }
+
+    [Fact(DisplayName = "DomainEventBase implementa IDomainEvent")]
+    public void Implementa_IDomainEvent()
+    {
+        EventoDeTeste evento = new("x");
+
+        evento.Should().BeAssignableTo<IDomainEvent>();
+    }
+
+    [Fact(DisplayName = "Records de domain event não colidem por payload — EventId e OccurredOn entram na igualdade record-based")]
+    public void Records_Igualdade_ConsideraEventIdEOccurredOn()
+    {
+        EventoDeTeste a = new("mesmo-payload");
+        EventoDeTeste b = new("mesmo-payload");
+
+        // Records do C# comparam todos os campos sintetizados — EventId e
+        // OccurredOn são auto-properties com inicializador, então entram
+        // na igualdade. Resultado: dois eventos com mesmo payload mas
+        // gerados em momentos distintos são naturalmente desiguais.
+        // Propriedade desejável para deduplicação no outbox.
+        a.Should().NotBe(b);
+        a.EventId.Should().NotBe(b.EventId);
+    }
+
+    private static int ExtrairVersao(Guid id)
+    {
+        byte[] bytes = id.ToByteArray();
+        return (bytes[7] & 0xF0) >> 4;
+    }
+
+    private sealed record EventoDeTeste(string Payload) : DomainEventBase;
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Interfaces/IAuditableEntityContractTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Interfaces/IAuditableEntityContractTests.cs
@@ -1,0 +1,57 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.Interfaces;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+// Contract test via dummy implementation. Padrão acordado em #129
+// (FakeUnitOfWork): se o contrato público da interface mudar, o dummy
+// quebra a compilação e o time vê a breaking change imediatamente.
+public sealed class IAuditableEntityContractTests
+{
+    [Fact(DisplayName = "IAuditableEntity expõe CreatedAt, UpdatedAt, CreatedBy, UpdatedBy via implementação dummy")]
+    public void DummyImplementacao_ExpoePropriedades()
+    {
+        DateTimeOffset agora = DateTimeOffset.UtcNow;
+        DummyAuditavel dummy = new()
+        {
+            CreatedAt = agora,
+            UpdatedAt = agora.AddMinutes(5),
+            CreatedBy = "alice",
+            UpdatedBy = "bob",
+        };
+
+        IAuditableEntity contrato = dummy;
+
+        contrato.CreatedAt.Should().Be(agora);
+        contrato.UpdatedAt.Should().Be(agora.AddMinutes(5));
+        contrato.CreatedBy.Should().Be("alice");
+        contrato.UpdatedBy.Should().Be("bob");
+    }
+
+    [Fact(DisplayName = "IAuditableEntity aceita UpdatedAt/CreatedBy/UpdatedBy nulos no contrato")]
+    public void Propriedades_OpcionaisAceitamNull()
+    {
+        DummyAuditavel dummy = new()
+        {
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = null,
+            CreatedBy = null,
+            UpdatedBy = null,
+        };
+
+        IAuditableEntity contrato = dummy;
+
+        contrato.UpdatedAt.Should().BeNull();
+        contrato.CreatedBy.Should().BeNull();
+        contrato.UpdatedBy.Should().BeNull();
+    }
+
+    private sealed class DummyAuditavel : IAuditableEntity
+    {
+        public DateTimeOffset CreatedAt { get; init; }
+        public DateTimeOffset? UpdatedAt { get; init; }
+        public string? CreatedBy { get; init; }
+        public string? UpdatedBy { get; init; }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Interfaces/IRepositoryContractTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Interfaces/IRepositoryContractTests.cs
@@ -1,0 +1,99 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.Interfaces;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+public sealed class IRepositoryContractTests
+{
+    [Fact(DisplayName = "IRepository<T>.ObterPorIdAsync devolve a entidade armazenada quando o Id existe")]
+    public async Task ObterPorId_RetornaEntidadeArmazenada()
+    {
+        DummyRepository repo = new();
+        EntidadeDeTeste entidade = new();
+        await repo.AdicionarAsync(entidade);
+
+        EntidadeDeTeste? lida = await repo.ObterPorIdAsync(entidade.Id);
+
+        lida.Should().BeSameAs(entidade);
+    }
+
+    [Fact(DisplayName = "IRepository<T>.ObterPorIdAsync retorna null quando o Id não existe")]
+    public async Task ObterPorId_RetornaNullQuandoNaoExiste()
+    {
+        DummyRepository repo = new();
+
+        EntidadeDeTeste? lida = await repo.ObterPorIdAsync(Guid.NewGuid());
+
+        lida.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "IRepository<T>.ObterTodosAsync devolve coleção read-only com as entidades inseridas")]
+    public async Task ObterTodos_RetornaTodasAsEntidades()
+    {
+        DummyRepository repo = new();
+        EntidadeDeTeste a = new();
+        EntidadeDeTeste b = new();
+        await repo.AdicionarAsync(a);
+        await repo.AdicionarAsync(b);
+
+        IReadOnlyList<EntidadeDeTeste> todas = await repo.ObterTodosAsync();
+
+        todas.Should().HaveCount(2)
+            .And.Contain(a)
+            .And.Contain(b);
+    }
+
+    [Fact(DisplayName = "IRepository<T>.Remover apaga a entidade do armazenamento")]
+    public async Task Remover_ApagaEntidade()
+    {
+        DummyRepository repo = new();
+        EntidadeDeTeste entidade = new();
+        await repo.AdicionarAsync(entidade);
+
+        repo.Remover(entidade);
+
+        EntidadeDeTeste? lida = await repo.ObterPorIdAsync(entidade.Id);
+        lida.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "IRepository<T>.Atualizar marca a entidade como modificada (registro de chamada)")]
+    public void Atualizar_RegistraChamada()
+    {
+        DummyRepository repo = new();
+        EntidadeDeTeste entidade = new();
+
+        repo.Atualizar(entidade);
+
+        repo.Atualizados.Should().ContainSingle().Which.Should().BeSameAs(entidade);
+    }
+
+    private sealed class EntidadeDeTeste : EntityBase
+    {
+    }
+
+    private sealed class DummyRepository : IRepository<EntidadeDeTeste>
+    {
+        private readonly Dictionary<Guid, EntidadeDeTeste> _store = [];
+        private readonly List<EntidadeDeTeste> _atualizados = [];
+
+        public IReadOnlyList<EntidadeDeTeste> Atualizados => _atualizados;
+
+        public Task<EntidadeDeTeste?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken = default) =>
+            Task.FromResult(_store.TryGetValue(id, out EntidadeDeTeste? e) ? e : null);
+
+        public Task<IReadOnlyList<EntidadeDeTeste>> ObterTodosAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult<IReadOnlyList<EntidadeDeTeste>>([.. _store.Values]);
+
+        public Task AdicionarAsync(EntidadeDeTeste entity, CancellationToken cancellationToken = default)
+        {
+            _store[entity.Id] = entity;
+            return Task.CompletedTask;
+        }
+
+        public void Atualizar(EntidadeDeTeste entity) => _atualizados.Add(entity);
+
+        public void Remover(EntidadeDeTeste entity) => _store.Remove(entity.Id);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Interfaces/ISoftDeletableContractTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Interfaces/ISoftDeletableContractTests.cs
@@ -1,0 +1,46 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.Interfaces;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+public sealed class ISoftDeletableContractTests
+{
+    [Fact(DisplayName = "ISoftDeletable contrato — dummy começa não deletado")]
+    public void Dummy_IniciaNaoDeletado()
+    {
+        DummySoftDeletable dummy = new();
+        ISoftDeletable contrato = dummy;
+
+        contrato.IsDeleted.Should().BeFalse();
+        contrato.DeletedAt.Should().BeNull();
+        contrato.DeletedBy.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "ISoftDeletable.MarkAsDeleted muta estado para deletado preservando responsável")]
+    public void MarkAsDeleted_AlteraEstado()
+    {
+        DummySoftDeletable dummy = new();
+        ISoftDeletable contrato = dummy;
+
+        contrato.MarkAsDeleted("auditor@exemplo.com");
+
+        contrato.IsDeleted.Should().BeTrue();
+        contrato.DeletedBy.Should().Be("auditor@exemplo.com");
+        contrato.DeletedAt.Should().NotBeNull();
+    }
+
+    private sealed class DummySoftDeletable : ISoftDeletable
+    {
+        public bool IsDeleted { get; private set; }
+        public DateTimeOffset? DeletedAt { get; private set; }
+        public string? DeletedBy { get; private set; }
+
+        public void MarkAsDeleted(string deletedBy)
+        {
+            IsDeleted = true;
+            DeletedAt = DateTimeOffset.UtcNow;
+            DeletedBy = deletedBy;
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/CpfTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/CpfTests.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.ValueObjects;
 using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
-using Results;
+using Unifesspa.UniPlus.Kernel.Results;
 
 public sealed class CpfTests
 {

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/EmailTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/EmailTests.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.ValueObjects;
 using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
-using Results;
+using Unifesspa.UniPlus.Kernel.Results;
 
 public sealed class EmailTests
 {

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/NomeSocialTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/NomeSocialTests.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.ValueObjects;
 using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
-using Results;
+using Unifesspa.UniPlus.Kernel.Results;
 
 public sealed class NomeSocialTests
 {

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/NotaFinalTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/NotaFinalTests.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.ValueObjects;
 using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
-using Results;
+using Unifesspa.UniPlus.Kernel.Results;
 
 public sealed class NotaFinalTests
 {

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Extensions/DateTimeOffsetExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Extensions/DateTimeOffsetExtensionsTests.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Extensions;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Extensions;
+
+public sealed class DateTimeOffsetExtensionsTests
+{
+    // Brasília deixou de ter horário de verão desde 2019 — offset constante -03:00.
+    // Os testes fixam essa premissa: se a legislação voltar a mudar a tzdb a
+    // assertiva quebra e o time fica sabendo que a extensão precisa ser
+    // reavaliada (atualmente delega à tzdb do SO).
+    private static readonly TimeSpan OffsetBrasilia = TimeSpan.FromHours(-3);
+
+    [Fact(DisplayName = "ParaHorarioBrasilia converte UTC para offset -03:00 preservando o instante")]
+    public void ConverteUtcParaBrasilia()
+    {
+        DateTimeOffset utc = new(2026, 5, 10, 18, 30, 0, TimeSpan.Zero);
+
+        DateTimeOffset convertido = utc.ParaHorarioBrasilia();
+
+        convertido.Offset.Should().Be(OffsetBrasilia);
+        convertido.UtcDateTime.Should().Be(utc.UtcDateTime,
+            "conversão de fuso não altera o instante absoluto");
+        convertido.DateTime.Should().Be(new DateTime(2026, 5, 10, 15, 30, 0, DateTimeKind.Unspecified));
+    }
+
+    [Fact(DisplayName = "ParaHorarioBrasilia em data de janeiro (verão astronômico) mantém -03:00 (sem DST desde 2019)")]
+    public void DataDeVerao_NaoAplicaDst()
+    {
+        DateTimeOffset utc = new(2026, 1, 15, 3, 0, 0, TimeSpan.Zero);
+
+        DateTimeOffset convertido = utc.ParaHorarioBrasilia();
+
+        convertido.Offset.Should().Be(OffsetBrasilia,
+            "Brasil revogou horário de verão pelo Decreto 9.772/2019");
+    }
+
+    [Fact(DisplayName = "ParaHorarioBrasilia em DateTimeOffset já em offset distinto preserva o instante")]
+    public void ValorEmOutroOffset_PreservaInstante()
+    {
+        DateTimeOffset emLisboa = new(2026, 5, 10, 21, 30, 0, TimeSpan.FromHours(1));
+
+        DateTimeOffset convertido = emLisboa.ParaHorarioBrasilia();
+
+        convertido.Offset.Should().Be(OffsetBrasilia);
+        convertido.UtcDateTime.Should().Be(emLisboa.UtcDateTime);
+        // 21:30 +01:00 = 20:30 UTC = 17:30 -03:00
+        convertido.DateTime.Should().Be(new DateTime(2026, 5, 10, 17, 30, 0, DateTimeKind.Unspecified));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Extensions/StringExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Extensions;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Extensions;
+
+public sealed class StringExtensionsTests
+{
+    [Theory(DisplayName = "ApenasDigitos remove caracteres não numéricos preservando ordem")]
+    [InlineData("123.456.789-00", "12345678900")]
+    [InlineData("(91) 99999-0000", "91999990000")]
+    [InlineData("abc123def456", "123456")]
+    [InlineData("12345", "12345")]
+    public void RemoveNaoDigitos_PreservaOrdem(string entrada, string esperado)
+    {
+        entrada.ApenasDigitos().Should().Be(esperado);
+    }
+
+    [Theory(DisplayName = "ApenasDigitos para entrada nula, vazia ou só espaços retorna string vazia")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EntradaVaziaOuNula_RetornaVazia(string? entrada)
+    {
+        entrada.ApenasDigitos().Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "ApenasDigitos para entrada sem dígitos retorna string vazia")]
+    public void SemDigitos_RetornaVazia()
+    {
+        "ABC.def-XYZ".ApenasDigitos().Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "ApenasDigitos preserva dígitos Unicode não-ASCII (ex.: árabe-índicos)")]
+    public void DigitosUnicode_TambemSaoConsiderados()
+    {
+        // char.IsDigit considera categoria Unicode Number Decimal Digit (Nd) —
+        // inclui o algarismo árabe-índico ٢ (U+0662). Test pin: assert no
+        // tamanho preciso de 3 garante que uma migração para regex `[0-9]`
+        // (ASCII-only) quebraria este teste, sinalizando a regressão.
+
+        string entrada = "abc1٢3";
+
+        entrada.ApenasDigitos().Should().HaveLength(3,
+            "dígitos ASCII (1, 3) + árabe-índico (٢) — todos retidos");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Results/DomainErrorTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Results/DomainErrorTests.cs
@@ -1,0 +1,45 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Results;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class DomainErrorTests
+{
+    [Fact(DisplayName = "DomainError expõe Code e Message recebidos no construtor")]
+    public void Construtor_ExpoeCodeEMessage()
+    {
+        DomainError erro = new("Edital.NotFound", "Edital não encontrado.");
+
+        erro.Code.Should().Be("Edital.NotFound");
+        erro.Message.Should().Be("Edital não encontrado.");
+    }
+
+    [Fact(DisplayName = "DomainError com mesmo Code e Message é igual por valor")]
+    public void Igualdade_PorValor_QuandoCodeEMessageIguais()
+    {
+        DomainError a = new("Cpf.Invalido", "CPF inválido.");
+        DomainError b = new("Cpf.Invalido", "CPF inválido.");
+
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact(DisplayName = "DomainError com Code diferente é desigual")]
+    public void Desigualdade_QuandoCodeDifere()
+    {
+        DomainError a = new("Cpf.Invalido", "msg");
+        DomainError b = new("Cpf.Vazio", "msg");
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact(DisplayName = "DomainError com Message diferente é desigual")]
+    public void Desigualdade_QuandoMessageDifere()
+    {
+        DomainError a = new("c", "uma mensagem");
+        DomainError b = new("c", "outra mensagem");
+
+        a.Should().NotBe(b);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Results/ResultTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Results/ResultTests.cs
@@ -1,0 +1,129 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Results;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class ResultTests
+{
+    [Fact(DisplayName = "Result.Success — IsSuccess true, IsFailure false, Error null")]
+    public void Success_Estado_Coerente()
+    {
+        Result resultado = Result.Success();
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.IsFailure.Should().BeFalse();
+        resultado.Error.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Result.Failure — IsSuccess false, IsFailure true, Error preservado")]
+    public void Failure_Estado_Coerente()
+    {
+        DomainError erro = new("Teste.Falha", "Mensagem de falha.");
+
+        Result resultado = Result.Failure(erro);
+
+        resultado.IsSuccess.Should().BeFalse();
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error.Should().Be(erro);
+    }
+
+    [Fact(DisplayName = "Result.Failure(null!) — pin do comportamento atual: aceita sem lançar, Error fica null")]
+    public void Failure_ComErroNulo_NaoLancaEDeixaErrorNulo()
+    {
+        // Test pin: a assinatura é não-anulável (Failure(DomainError error)) mas
+        // o construtor privado não valida. Hoje, passar null!? produz um Result
+        // com IsFailure=true e Error=null — comportamento inconsistente.
+        // Se o design adicionar ArgumentNullException ou similar, este teste
+        // quebra e o time revisa intencionalmente.
+
+        Result resultado = Result.Failure(null!);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error.Should().BeNull();
+    }
+}
+
+public sealed class ResultGenericTests
+{
+    [Fact(DisplayName = "Result<T>.Success(value) — Value preservado, Error null")]
+    public void SuccessGenerico_PreservaValor()
+    {
+        Result<int> resultado = Result<int>.Success(42);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.IsFailure.Should().BeFalse();
+        resultado.Value.Should().Be(42);
+        resultado.Error.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Result<T>.Failure(erro) — Error preservado, Value default")]
+    public void FailureGenerico_PreservaErroEMantemValueDefault()
+    {
+        DomainError erro = new("Teste.Erro", "Falhou.");
+
+        Result<int> resultado = Result<int>.Failure(erro);
+
+        resultado.IsSuccess.Should().BeFalse();
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error.Should().Be(erro);
+        resultado.Value.Should().Be(default);
+    }
+
+    [Fact(DisplayName = "Result<T>.Success aceita valor de tipo referência sem normalizar para null")]
+    public void SuccessGenerico_TipoReferencia_PreservaInstancia()
+    {
+        const string valor = "preservado";
+
+        Result<string> resultado = Result<string>.Success(valor);
+
+        resultado.Value.Should().BeSameAs(valor);
+    }
+
+    [Fact(DisplayName = "Match em sucesso — invoca onSuccess com o valor e retorna o resultado")]
+    public void Match_Sucesso_InvocaOnSuccess()
+    {
+        Result<int> resultado = Result<int>.Success(7);
+
+        string saida = resultado.Match(
+            onSuccess: v => $"ok:{v}",
+            onFailure: e => $"err:{e.Code}");
+
+        saida.Should().Be("ok:7");
+    }
+
+    [Fact(DisplayName = "Match em falha — invoca onFailure com o erro e retorna o resultado")]
+    public void Match_Falha_InvocaOnFailure()
+    {
+        DomainError erro = new("X.Y", "boom");
+        Result<int> resultado = Result<int>.Failure(erro);
+
+        string saida = resultado.Match(
+            onSuccess: v => $"ok:{v}",
+            onFailure: e => $"err:{e.Code}");
+
+        saida.Should().Be("err:X.Y");
+    }
+
+    [Fact(DisplayName = "Match com onSuccess nulo lança ArgumentNullException antes de avaliar o resultado")]
+    public void Match_OnSuccessNulo_Lanca()
+    {
+        Result<int> resultado = Result<int>.Success(1);
+
+        Action acao = () => resultado.Match<string>(onSuccess: null!, onFailure: _ => "x");
+
+        acao.Should().Throw<ArgumentNullException>()
+            .WithParameterName("onSuccess");
+    }
+
+    [Fact(DisplayName = "Match com onFailure nulo lança ArgumentNullException antes de avaliar o resultado")]
+    public void Match_OnFailureNulo_Lanca()
+    {
+        Result<int> resultado = Result<int>.Failure(new DomainError("c", "m"));
+
+        Action acao = () => resultado.Match<string>(onSuccess: _ => "x", onFailure: null!);
+
+        acao.Should().Throw<ArgumentNullException>()
+            .WithParameterName("onFailure");
+    }
+}


### PR DESCRIPTION
## Resumo

Completa a cobertura de testes unitários do projeto `Unifesspa.UniPlus.Kernel` conforme os critérios de aceite da Story #16. Os 4 Value Objects já tinham testes; faltavam Result/Error, EntityBase (Id, audit, soft delete), DomainEventBase, marker interfaces (via dummy implementations) e Extensions.

## Cobertura

Medida com `coverlet.runsettings` (escopo expandido para incluir o Kernel — antes só Domain/Application por módulo):

- **Line:** 100% no projeto Kernel
- **Branch:** 96,42% (Cpf 91,7%, demais 100%)

```
Unifesspa.UniPlus.Kernel.Results.Result:                    line=100% branch=100%
Unifesspa.UniPlus.Kernel.Results.Result<T>:                 line=100% branch=100%
Unifesspa.UniPlus.Kernel.Extensions.DateTimeOffsetExtensions: line=100% branch=100%
Unifesspa.UniPlus.Kernel.Extensions.StringExtensions:        line=100% branch=100%
Unifesspa.UniPlus.Kernel.Domain.ValueObjects.Cpf:            line=100% branch=91,7%
Unifesspa.UniPlus.Kernel.Domain.ValueObjects.Email:          line=100% branch=100%
Unifesspa.UniPlus.Kernel.Domain.ValueObjects.NomeSocial:     line=100% branch=100%
Unifesspa.UniPlus.Kernel.Domain.ValueObjects.NotaFinal:      line=100% branch=100%
Unifesspa.UniPlus.Kernel.Domain.Entities.EntityBase:         line=100% branch=100%
```

## Mudanças

### Novos testes (9 arquivos, 99 testes total ao fim)

- `Results/ResultTests.cs` — `Result.Success/Failure`, `Result<T>.Success/Failure/Match`, invariantes de delegate nulo, pin de `Failure(null!)`.
- `Results/DomainErrorTests.cs` — igualdade por valor do record.
- `Domain/Entities/EntityBaseTests.cs` — Id UUIDv7, CreatedAt UTC, soft delete (`MarkAsDeleted`), pin de igualdade referencial.
- `Domain/Events/DomainEventBaseTests.cs` — EventId UUIDv7 único por instância, OccurredOn UTC, contrato `IDomainEvent`, comportamento de igualdade record.
- `Domain/Interfaces/I{Auditable,SoftDeletable,Repository}ContractTests.cs` — dummy implementations + contract tests (padrão acordado em #129).
- `Extensions/DateTimeOffsetExtensionsTests.cs` — conversão UTC↔Brasília (sem DST desde 2019).
- `Extensions/StringExtensionsTests.cs` — `ApenasDigitos` incluindo dígitos Unicode árabe-índicos.

### Mudanças adjacentes

- **`coverlet.runsettings`** — `Include` ganha `[Unifesspa.UniPlus.Kernel]*`. Não há `Threshold`, então é só medição (mantém compatibilidade com CI atual).
- **`Domain/ValueObjects/{Cpf,Email,NomeSocial,NotaFinal}Tests.cs`** — qualifica `using Results;` para `using Unifesspa.UniPlus.Kernel.Results;`. O using relativo dependia de namespace walk-up e era shadowed por qualquer novo sub-namespace `UnitTests.Results` — fragilidade exposta ao adicionar este projeto de testes.

## Notas sobre a issue

A AC mencionava \"igualdade por Id\" no EntityBase, mas o código atual usa igualdade referencial (classe sem override). Adicionei um teste pin documentando esse contrato real — se algum dia o design mudar, o teste quebra propositalmente sinalizando a evolução.

Closes #16

## Test plan

- [x] `dotnet test tests/Unifesspa.UniPlus.Kernel.UnitTests --settings coverlet.runsettings` — 99/99 ✅
- [x] `dotnet build -c Debug` na solution toda — sem regressões
- [x] Cobertura ≥ 90% line e branch para o Kernel