### PR TITLE
feat(shared-kernel): adicionar value converters EF Core para Value Objects

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/CpfValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/CpfValueConverter.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+// Mapeia Cpf ↔ string (11 dígitos) no banco. A materialização chama
+// Cpf.Criar com o valor armazenado — invariantes do VO foram garantidos
+// no momento da escrita, mas a revalidação na leitura é deliberada:
+// dado corrompido (alteração manual no banco) falha alto em vez de
+// produzir Cpf inválido silenciosamente.
+public sealed class CpfValueConverter : ValueConverter<Cpf, string>
+{
+    public CpfValueConverter()
+        : base(
+            cpf => cpf.Valor,
+            valor => Cpf.Criar(valor).Value!)
+    {
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/CpfValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/CpfValueConverter.cs
@@ -4,17 +4,16 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
 
-// Mapeia Cpf ↔ string (11 dígitos) no banco. A materialização chama
-// Cpf.Criar com o valor armazenado — invariantes do VO foram garantidos
-// no momento da escrita, mas a revalidação na leitura é deliberada:
-// dado corrompido (alteração manual no banco) falha alto em vez de
-// produzir Cpf inválido silenciosamente.
+// Mapeia Cpf ↔ string (11 dígitos) no banco. A revalidação na leitura é
+// deliberada: dado corrompido (alteração manual no banco) falha alto via
+// InvalidOperationException com contexto, em vez de produzir Cpf inválido
+// ou NRE tardia no primeiro uso da propriedade.
 public sealed class CpfValueConverter : ValueConverter<Cpf, string>
 {
     public CpfValueConverter()
         : base(
             cpf => cpf.Valor,
-            valor => Cpf.Criar(valor).Value!)
+            valor => ValueObjectMaterialization.Reidratar(Cpf.Criar(valor), nameof(Cpf)))
     {
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/EmailValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/EmailValueConverter.cs
@@ -12,7 +12,7 @@ public sealed class EmailValueConverter : ValueConverter<Email, string>
     public EmailValueConverter()
         : base(
             email => email.Valor,
-            valor => Email.Criar(valor).Value!)
+            valor => ValueObjectMaterialization.Reidratar(Email.Criar(valor), nameof(Email)))
     {
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/EmailValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/EmailValueConverter.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+// Mapeia Email ↔ string normalizado em lowercase (regra do VO). Tamanho
+// máximo recomendado pelo schema = 254 chars (limite prático RFC 5321);
+// definido via convenção no ModelBuilder, não aqui no converter.
+public sealed class EmailValueConverter : ValueConverter<Email, string>
+{
+    public EmailValueConverter()
+        : base(
+            email => email.Valor,
+            valor => Email.Criar(valor).Value!)
+    {
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/NomeSocialValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/NomeSocialValueConverter.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+// Mapeia NomeSocial ↔ JSON (jsonb no Postgres) com payload {"nomeCivil","nome"}.
+// JSON foi escolhido em vez de colunas separadas para manter o VO como um
+// único campo do schema, evitando ON UPDATE em duas colunas sempre que o
+// nome muda, e simplificando consultas que recuperem o registro inteiro.
+// Consultas que precisem filtrar por nome civil podem usar operadores jsonb
+// do Postgres (`->'nomeCivil'`) sem custo significativo em volumes do CEPS.
+public sealed class NomeSocialValueConverter : ValueConverter<NomeSocial, string>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public NomeSocialValueConverter()
+        : base(
+            valor => Serializar(valor),
+            json => Desserializar(json))
+    {
+    }
+
+    private static string Serializar(NomeSocial valor)
+    {
+        NomeSocialPayload payload = new(valor.NomeCivil, valor.Nome);
+        return JsonSerializer.Serialize(payload, JsonOptions);
+    }
+
+    private static NomeSocial Desserializar(string json)
+    {
+        NomeSocialPayload? payload = JsonSerializer.Deserialize<NomeSocialPayload>(json, JsonOptions);
+
+        if (payload is null)
+        {
+            throw new InvalidOperationException(
+                "Valor JSON nulo ao desserializar NomeSocial — dado corrompido no banco.");
+        }
+
+        return NomeSocial.Criar(payload.NomeCivil, payload.Nome).Value!;
+    }
+
+    private sealed record NomeSocialPayload(string NomeCivil, string? Nome);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/NomeSocialValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/NomeSocialValueConverter.cs
@@ -44,7 +44,9 @@ public sealed class NomeSocialValueConverter : ValueConverter<NomeSocial, string
                 "Valor JSON nulo ao desserializar NomeSocial — dado corrompido no banco.");
         }
 
-        return NomeSocial.Criar(payload.NomeCivil, payload.Nome).Value!;
+        return ValueObjectMaterialization.Reidratar(
+            NomeSocial.Criar(payload.NomeCivil, payload.Nome),
+            nameof(NomeSocial));
     }
 
     private sealed record NomeSocialPayload(string NomeCivil, string? Nome);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/NotaFinalValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/NotaFinalValueConverter.cs
@@ -12,7 +12,7 @@ public sealed class NotaFinalValueConverter : ValueConverter<NotaFinal, decimal>
     public NotaFinalValueConverter()
         : base(
             nota => nota.Valor,
-            valor => NotaFinal.Criar(valor).Value!)
+            valor => ValueObjectMaterialization.Reidratar(NotaFinal.Criar(valor), nameof(NotaFinal)))
     {
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/NotaFinalValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/NotaFinalValueConverter.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+// Mapeia NotaFinal ↔ decimal. Precisão (9,4) é definida via convenção no
+// ModelBuilder — escala 4 acompanha o arredondamento já aplicado pelo VO
+// em NotaFinal.Criar (Math.Round(valor, 4)).
+public sealed class NotaFinalValueConverter : ValueConverter<NotaFinal, decimal>
+{
+    public NotaFinalValueConverter()
+        : base(
+            nota => nota.Valor,
+            valor => NotaFinal.Criar(valor).Value!)
+    {
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/ValueObjectConventions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/ValueObjectConventions.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+// Convenções de mapeamento dos Value Objects do Kernel para o EF Core.
+// Chamado no override `ConfigureConventions` dos DbContexts dos módulos
+// (Selecao, Ingresso, Portal) para que toda propriedade tipada como
+// Cpf/Email/NomeSocial/NotaFinal receba o converter e as restrições de
+// coluna apropriadas (tipo, tamanho máximo, precisão).
+//
+// IMPORTANTE — incompatível com `OwnsOne` para os mesmos VOs:
+// se um IEntityTypeConfiguration<T> existente mapeia Cpf/Email/NomeSocial
+// via `builder.OwnsOne(c => c.Cpf, ...)`, esse mapeamento deve ser
+// substituído por `builder.Property(c => c.Cpf)` antes de ativar esta
+// convenção no contexto. EF Core não permite o mesmo tipo CLR ser
+// owned-type e scalar-with-converter simultaneamente.
+//
+// Hoje, módulos ainda usam OwnsOne (ex.: CandidatoConfiguration em
+// Selecao). A adoção desta convenção será incremental, módulo a módulo,
+// junto com a migração do schema. Os converters podem ser usados de
+// forma isolada via HasConversion<T>() em IEntityTypeConfiguration sem
+// precisar acionar a convenção global.
+public static class ValueObjectConventions
+{
+    // Limite prático RFC 5321 para endereços de e-mail.
+    private const int EmailMaxLength = 254;
+
+    // Cpf é sempre 11 dígitos após normalização pelo VO. O tipo escolhido
+    // é `varchar(11)` (não `char(11)`) porque Postgres faz padding com
+    // espaços ao recuperar `char(N)`, o que corromperia o valor lido
+    // ("12345678901 " em vez de "12345678901"). `varchar(11)` enforça o
+    // limite sem padding e mantém performance equivalente desde
+    // Postgres 11 (sem diferença de armazenamento).
+    private const int CpfLength = 11;
+
+    // (9,4) acomoda notas até 99.999,9999 com 4 casas de precisão — escala
+    // alinhada ao Math.Round(valor, 4) aplicado no construtor do VO.
+    private const int NotaFinalPrecision = 9;
+    private const int NotaFinalScale = 4;
+
+    public static void ConfigureValueObjectConverters(this ModelConfigurationBuilder configurationBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(configurationBuilder);
+
+        configurationBuilder.Properties<Cpf>()
+            .HaveConversion<CpfValueConverter>()
+            .HaveColumnType($"varchar({CpfLength})")
+            .HaveMaxLength(CpfLength);
+
+        configurationBuilder.Properties<Email>()
+            .HaveConversion<EmailValueConverter>()
+            .HaveMaxLength(EmailMaxLength);
+
+        configurationBuilder.Properties<NomeSocial>()
+            .HaveConversion<NomeSocialValueConverter>()
+            .HaveColumnType("jsonb");
+
+        configurationBuilder.Properties<NotaFinal>()
+            .HaveConversion<NotaFinalValueConverter>()
+            .HavePrecision(NotaFinalPrecision, NotaFinalScale);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/ValueObjectMaterialization.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/ValueObjectMaterialization.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+// Helper compartilhado pelos converters de Value Object.
+//
+// O padrão `Cpf.Criar(x).Value!` em ValueConverters é convidativo, mas
+// usar o forgiving null `!` no caminho de materialização do EF Core gera
+// NullReferenceException tardia (no primeiro uso da propriedade) caso o
+// dado armazenado esteja corrompido — pior diagnóstico do que falhar
+// explicitamente com contexto.
+//
+// Este helper centraliza o fail-fast: ao reidratar um VO, se o Result
+// vier como Failure ou Value null, lançamos InvalidOperationException
+// com o Code do erro e o nome do VO, evidenciando a corrupção no banco.
+internal static class ValueObjectMaterialization
+{
+    public static T Reidratar<T>(Result<T> resultado, string nomeVo) where T : class
+    {
+        ArgumentNullException.ThrowIfNull(resultado);
+
+        if (resultado.IsFailure || resultado.Value is null)
+        {
+            string codigo = resultado.Error?.Code ?? "Desconhecido";
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nomeVo}: {codigo}. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return resultado.Value;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Persistence/Converters/ValueObjectConvertersIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Persistence/Converters/ValueObjectConvertersIntegrationTests.cs
@@ -1,0 +1,262 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Persistence.Converters;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Testcontainers.PostgreSql;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+// Valida que ValueObjectConventions registra os converters corretamente e
+// que o round-trip persist → recuperar preserva os Value Objects do Kernel.
+// Container Postgres real (não in-memory) para garantir que tipos de
+// coluna definidos pela convenção (varchar(11), jsonb, numeric(9,4))
+// sejam aceitos pelo provider Npgsql.
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção xUnit para classes de teste.")]
+public sealed class ValueObjectConvertersIntegrationTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_converters_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    public Task InitializeAsync() => _postgres.StartAsync();
+
+    public Task DisposeAsync() => _postgres.DisposeAsync().AsTask();
+
+    [Fact(DisplayName = "Round-trip — Cpf é persistido como 11 dígitos e recuperado idêntico")]
+    public async Task RoundTrip_Cpf()
+    {
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        Cpf cpf = Cpf.Criar("529.982.247-25").Value!;
+        EntidadeComVOs entidade = EntidadeComVOs.Criar(
+            cpf: cpf,
+            email: Email.Criar("teste@unifesspa.edu.br").Value!,
+            nomeSocial: NomeSocial.Criar("Maria das Dores").Value!,
+            nota: NotaFinal.Criar(7.5m).Value!);
+
+        context.Entidades.Add(entidade);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        EntidadeComVOs lida = await context.Entidades.AsNoTracking().SingleAsync();
+
+        lida.Cpf.Valor.Should().Be("52998224725");
+        lida.Cpf.Should().Be(cpf, "Cpf é record — igualdade por valor (campo Valor)");
+    }
+
+    [Fact(DisplayName = "Round-trip — Email é persistido normalizado em lowercase")]
+    public async Task RoundTrip_Email_NormalizadoEmLowercase()
+    {
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        // VO normaliza para lowercase antes de persistir; o converter
+        // apenas extrai o `.Valor` já normalizado.
+        Email email = Email.Criar("Teste.Mixed@Unifesspa.EDU.BR").Value!;
+        EntidadeComVOs entidade = EntidadeComVOs.Criar(
+            cpf: Cpf.Criar("52998224725").Value!,
+            email: email,
+            nomeSocial: NomeSocial.Criar("Fulano").Value!,
+            nota: NotaFinal.Criar(0m).Value!);
+
+        context.Entidades.Add(entidade);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        EntidadeComVOs lida = await context.Entidades.AsNoTracking().SingleAsync();
+
+        lida.Email.Valor.Should().Be("teste.mixed@unifesspa.edu.br");
+    }
+
+    [Fact(DisplayName = "Round-trip — NomeSocial com nome social preenchido preserva nome civil + nome")]
+    public async Task RoundTrip_NomeSocial_ComNomeSocial()
+    {
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        NomeSocial nomeSocial = NomeSocial.Criar("João Silva", "Joana Silva").Value!;
+        EntidadeComVOs entidade = EntidadeComVOs.Criar(
+            cpf: Cpf.Criar("52998224725").Value!,
+            email: Email.Criar("a@b.com").Value!,
+            nomeSocial: nomeSocial,
+            nota: NotaFinal.Criar(5m).Value!);
+
+        context.Entidades.Add(entidade);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        EntidadeComVOs lida = await context.Entidades.AsNoTracking().SingleAsync();
+
+        lida.NomeSocial.NomeCivil.Should().Be("João Silva");
+        lida.NomeSocial.Nome.Should().Be("Joana Silva");
+        lida.NomeSocial.UsaNomeSocial.Should().BeTrue();
+        lida.NomeSocial.NomeExibicao.Should().Be("Joana Silva");
+    }
+
+    [Fact(DisplayName = "Round-trip — NomeSocial sem nome social preserva null no campo Nome")]
+    public async Task RoundTrip_NomeSocial_SemNomeSocial()
+    {
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        NomeSocial nomeSocial = NomeSocial.Criar("Carlos Pereira").Value!;
+        EntidadeComVOs entidade = EntidadeComVOs.Criar(
+            cpf: Cpf.Criar("52998224725").Value!,
+            email: Email.Criar("a@b.com").Value!,
+            nomeSocial: nomeSocial,
+            nota: NotaFinal.Criar(0m).Value!);
+
+        context.Entidades.Add(entidade);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        EntidadeComVOs lida = await context.Entidades.AsNoTracking().SingleAsync();
+
+        lida.NomeSocial.NomeCivil.Should().Be("Carlos Pereira");
+        lida.NomeSocial.Nome.Should().BeNull();
+        lida.NomeSocial.UsaNomeSocial.Should().BeFalse();
+        lida.NomeSocial.NomeExibicao.Should().Be("Carlos Pereira");
+    }
+
+    [Fact(DisplayName = "Round-trip — NotaFinal preserva precisão decimal 4 casas após round-trip Postgres")]
+    public async Task RoundTrip_NotaFinal()
+    {
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        NotaFinal nota = NotaFinal.Criar(8.7654m).Value!;
+        EntidadeComVOs entidade = EntidadeComVOs.Criar(
+            cpf: Cpf.Criar("52998224725").Value!,
+            email: Email.Criar("a@b.com").Value!,
+            nomeSocial: NomeSocial.Criar("Teste").Value!,
+            nota: nota);
+
+        context.Entidades.Add(entidade);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        EntidadeComVOs lida = await context.Entidades.AsNoTracking().SingleAsync();
+
+        lida.NotaFinal.Valor.Should().Be(8.7654m);
+        lida.NotaFinal.Should().Be(nota);
+    }
+
+    [Fact(DisplayName = "Schema gerado — Cpf é varchar(11), Email max=254, NomeSocial é jsonb, NotaFinal é numeric(9,4)")]
+    public async Task Schema_RespeitaConvencoes()
+    {
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        // Consulta information_schema para confirmar que as convenções foram
+        // aplicadas ao DDL gerado pelo EF Core. Falhas aqui indicam que o
+        // ValueObjectConventions não está sendo invocado pelo DbContext de
+        // produção — sinal direto para os módulos.
+        await using Npgsql.NpgsqlConnection conexao =
+            new(_postgres.GetConnectionString());
+        await conexao.OpenAsync();
+
+        Dictionary<string, (string TipoUdt, int? CharMax, int? NumPrec, int? NumScale)> colunas = await ListarColunasAsync(conexao);
+
+        colunas["cpf"].TipoUdt.Should().Be("varchar");
+        colunas["cpf"].CharMax.Should().Be(11);
+
+        colunas["email"].CharMax.Should().Be(254);
+
+        colunas["nome_social"].TipoUdt.Should().Be("jsonb");
+
+        colunas["nota_final"].NumPrec.Should().Be(9);
+        colunas["nota_final"].NumScale.Should().Be(4);
+    }
+
+    private static async Task<Dictionary<string, (string TipoUdt, int? CharMax, int? NumPrec, int? NumScale)>> ListarColunasAsync(
+        Npgsql.NpgsqlConnection conexao)
+    {
+        const string sql = """
+            SELECT column_name, udt_name, character_maximum_length, numeric_precision, numeric_scale
+              FROM information_schema.columns
+             WHERE table_name = 'entidades_com_vos'
+        """;
+
+        Dictionary<string, (string, int?, int?, int?)> resultado = [];
+        await using Npgsql.NpgsqlCommand cmd = new(sql, conexao);
+        await using Npgsql.NpgsqlDataReader reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            string nome = reader.GetString(0);
+            string tipo = reader.GetString(1);
+            int? charMax = await reader.IsDBNullAsync(2) ? null : reader.GetInt32(2);
+            int? numPrec = await reader.IsDBNullAsync(3) ? null : reader.GetInt32(3);
+            int? numScale = await reader.IsDBNullAsync(4) ? null : reader.GetInt32(4);
+            resultado[nome] = (tipo, charMax, numPrec, numScale);
+        }
+        return resultado;
+    }
+
+    private TestDbContext CriarContext()
+    {
+        DbContextOptionsBuilder<TestDbContext> options = new();
+        options.UseNpgsql(_postgres.GetConnectionString());
+        return new TestDbContext(options.Options);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciada pelo EF Core.")]
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        public DbSet<EntidadeComVOs> Entidades => Set<EntidadeComVOs>();
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+        {
+            base.ConfigureConventions(configurationBuilder);
+            configurationBuilder.ConfigureValueObjectConverters();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<EntidadeComVOs>(b =>
+            {
+                b.ToTable("entidades_com_vos");
+                b.Property<Cpf>(e => e.Cpf).HasColumnName("cpf");
+                b.Property<Email>(e => e.Email).HasColumnName("email");
+                b.Property<NomeSocial>(e => e.NomeSocial).HasColumnName("nome_social");
+                b.Property<NotaFinal>(e => e.NotaFinal).HasColumnName("nota_final");
+            });
+        }
+    }
+
+    // Agregado de teste — herda EntityBase para ganhar Id UUIDv7 e audit;
+    // apenas para validar persistência dos converters.
+    private sealed class EntidadeComVOs : EntityBase
+    {
+        public Cpf Cpf { get; private set; } = default!;
+        public Email Email { get; private set; } = default!;
+        public NomeSocial NomeSocial { get; private set; } = default!;
+        public NotaFinal NotaFinal { get; private set; } = default!;
+
+        private EntidadeComVOs()
+        {
+        }
+
+        public static EntidadeComVOs Criar(Cpf cpf, Email email, NomeSocial nomeSocial, NotaFinal nota) =>
+            new()
+            {
+                Cpf = cpf,
+                Email = email,
+                NomeSocial = nomeSocial,
+                NotaFinal = nota,
+            };
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Persistence/Converters/ValueObjectConvertersIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Persistence/Converters/ValueObjectConvertersIntegrationTests.cs
@@ -151,6 +151,41 @@ public sealed class ValueObjectConvertersIntegrationTests : IAsyncLifetime
         lida.NotaFinal.Should().Be(nota);
     }
 
+    [Fact(DisplayName = "Materialização — dado corrompido no banco (CPF inválido) lança InvalidOperationException com contexto")]
+    public async Task Materializacao_CpfCorrompido_LancaComContexto()
+    {
+        // Simula corrupção: insere bytes válidos para o schema (varchar(11))
+        // mas inválidos para o VO (dígitos verificadores errados). A leitura
+        // via converter deve falhar alto com InvalidOperationException
+        // citando o VO e o código do erro do Result — não NRE silenciosa.
+
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        // Inserção legítima primeiro para garantir que existe um registro.
+        EntidadeComVOs entidade = EntidadeComVOs.Criar(
+            cpf: Cpf.Criar("52998224725").Value!,
+            email: Email.Criar("a@b.com").Value!,
+            nomeSocial: NomeSocial.Criar("Teste").Value!,
+            nota: NotaFinal.Criar(0m).Value!);
+        context.Entidades.Add(entidade);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        // Corrompe a coluna CPF via SQL direto — bypass do converter.
+        await using Npgsql.NpgsqlConnection conexao = new(_postgres.GetConnectionString());
+        await conexao.OpenAsync();
+        await using Npgsql.NpgsqlCommand corromper = new(
+            "UPDATE entidades_com_vos SET cpf = '00000000000'", conexao);
+        await corromper.ExecuteNonQueryAsync();
+
+        Func<Task> leitura = async () => await context.Entidades.AsNoTracking().SingleAsync();
+
+        await leitura.Should().ThrowAsync<InvalidOperationException>()
+            .Where(e => e.Message.Contains(nameof(Cpf), StringComparison.Ordinal)
+                     && e.Message.Contains("Cpf.Invalido", StringComparison.Ordinal));
+    }
+
     [Fact(DisplayName = "Schema gerado — Cpf é varchar(11), Email max=254, NomeSocial é jsonb, NotaFinal é numeric(9,4)")]
     public async Task Schema_RespeitaConvencoes()
     {


### PR DESCRIPTION
## Resumo

Implementa value converters do EF Core para os 4 Value Objects do Kernel (`Cpf`, `Email`, `NomeSocial`, `NotaFinal`) e disponibiliza a extension `ModelConfigurationBuilder.ConfigureValueObjectConverters()` que aplica os converters globalmente a qualquer DbContext que opte por usá-los.

## Mapeamentos

| VO | Coluna | Justificativa |
|---|---|---|
| `Cpf` | `varchar(11)` | Sempre 11 dígitos após normalização; `char(11)` faria padding com espaços no Postgres |
| `Email` | string `max=254` | Limite prático RFC 5321 |
| `NomeSocial` | `jsonb` | Payload `{nomeCivil, nome}` — mantém o VO como campo único do schema |
| `NotaFinal` | `numeric(9,4)` | Precisão alinhada ao `Math.Round(valor, 4)` aplicado no construtor |

## Decisões de design

- **Materialização revalida** via `Criar(valor).Value!` — dado corrompido falha alto em vez de produzir VO inválido silenciosamente.
- **Convenção incompatível com `OwnsOne`** para os mesmos VOs — adoção será incremental por módulo, removendo `OwnsOne` em paralelo. Documentação destacada no topo de `ValueObjectConventions.cs`. Hoje a Seleção ainda usa `OwnsOne` em `CandidatoConfiguration` — esta PR não migra; apenas disponibiliza a infra.
- Os converters individuais (`CpfValueConverter` etc.) podem ser usados **isoladamente** via `HasConversion<T>()` em `IEntityTypeConfiguration` sem acionar a convenção global, dando ao time flexibilidade na migração.

## Testes

6 integration tests em `Infrastructure.Core.IntegrationTests/Persistence/Converters/` usando Testcontainers Postgres 18:

- Round-trip Cpf (11 dígitos, igualdade record)
- Round-trip Email (normalização lowercase preservada)
- Round-trip NomeSocial com nome social preenchido
- Round-trip NomeSocial sem nome social (null preservado)
- Round-trip NotaFinal (4 casas decimais)
- Schema validation: consulta `information_schema.columns` para confirmar `varchar(11)`, `varchar(254)`, `jsonb`, `numeric(9,4)`

## Validação

- [x] `dotnet build -c Debug` — sem warnings (`TreatWarningsAsErrors`)
- [x] `dotnet test --filter "FullyQualifiedName~ValueObjectConvertersIntegrationTests"` — 6/6 ✅ (Testcontainers Postgres real)

Closes #18

## Próximos passos (fora de escopo desta PR)

Migração módulo a módulo de `OwnsOne` → scalar converters. Ordem sugerida: Seleção (Candidato) → Ingresso → Portal. Pode virar uma Story dedicada na Sprint 3.