### PR TITLE
fix(adr-lint): tornar validator resiliente a set -euo pipefail

### DIFF
--- a/tools/adr-lint/validate.sh
+++ b/tools/adr-lint/validate.sh
@@ -40,7 +40,14 @@ for FILE in "$DIR"/*.md; do
 
   if ! head -1 "$FILE" | grep -q '^---$'; then
     ERR+=("frontmatter YAML ausente (esperado --- na linha 1)")
-  elif ! tail -n +2 "$FILE" | head -n 50 | grep -q '^---$'; then
+  # awk standalone evita falso positivo por SIGPIPE: a versão antiga
+  # `tail | head -n 50 | grep -q` falhava sob `pipefail` em ADRs grandes
+  # porque o `tail` recebia SIGPIPE quando o `grep -q` saía cedo após o match.
+  # `NR<=51` preserva o contrato de sanidade da versão original (frontmatter
+  # MADR 4.0 fica em ~5-10 linhas; 50 é folga) — sem isso, um `---` solto no
+  # corpo de um ADR com frontmatter aberto mas não fechado seria aceito como
+  # delimitador, mascarando o erro real.
+  elif ! awk 'NR==1 && /^---$/{c=1; next} NR<=51 && c==1 && /^---$/{found=1; exit} END{exit found ? 0 : 1}' "$FILE"; then
     ERR+=("frontmatter YAML sem delimitador de fechamento (esperado --- após bloco YAML)")
   fi
 
@@ -52,7 +59,10 @@ for FILE in "$DIR"/*.md; do
     fi
   done
 
-  STATUS=$(printf '%s\n' "$FM" | grep '^status:' | head -1 | sed -E 's/^status:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  # `|| true` evita que o pipeline aborte sob `set -euo pipefail` quando o
+  # campo está ausente — o erro já foi registrado no loop anterior e o script
+  # precisa seguir até o relatório final.
+  STATUS=$(printf '%s\n' "$FM" | { grep '^status:' || true; } | head -1 | sed -E 's/^status:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
   if [[ -n "$STATUS" ]]; then
     if [[ ! "$STATUS" =~ ^(proposed|accepted|rejected|deprecated)$ ]] && \
        [[ ! "$STATUS" =~ ^superseded\ by\ ADR-[0-9]{4}$ ]]; then
@@ -60,7 +70,7 @@ for FILE in "$DIR"/*.md; do
     fi
   fi
 
-  DATE=$(printf '%s\n' "$FM" | grep '^date:' | head -1 | sed -E 's/^date:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  DATE=$(printf '%s\n' "$FM" | { grep '^date:' || true; } | head -1 | sed -E 's/^date:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
   if [[ -n "$DATE" ]] && [[ ! "$DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
     ERR+=("date inválida: '$DATE' (esperado YYYY-MM-DD)")
   fi


### PR DESCRIPTION
## Resumo

Porta os 2 fixes já em produção em `uniplus-web` (commits [`ba159dd`](https://github.com/unifesspa-edu-br/uniplus-web/commit/ba159dd) e [`a5935e4`](https://github.com/unifesspa-edu-br/uniplus-web/commit/a5935e4)) para o `tools/adr-lint/validate.sh` do `uniplus-api`. Os dois bugs vêm da combinação `set -euo pipefail` + pipelines `grep` / `tail|head|grep -q`.

## Bug 1 — STATUS/DATE silenciam summary

`printf | grep | head | sed` falha o pipeline quando o `grep` não encontra match (pipefail propaga exit 1). O script aborta antes de imprimir o relatório.

**Fix:** proteger com `{ grep || true; }`. O erro já é registrado no loop de campos obrigatórios; o `|| true` apenas garante que o pipeline preserve exit 0 e o relatório seja emitido.

## Bug 2 — SIGPIPE em ADRs grandes

`tail -n +2 | head -n 50 | grep -q '^---$'` em ADRs >50 linhas: o `grep -q` matcha e fecha o pipe, `tail` recebe SIGPIPE, pipeline retorna 141, `!` reporta falsamente \"frontmatter sem fechamento\". Flake intermitente — depende do timing do runner.

**Reincidência confirmada hoje** (10/05): PRs #392 (Story #16) e #393 (Story #18) falharam o linter em arquivo byte-idêntico ao main (mesmo blob SHA), passaram no rerun.

**Fix:** substituir o pipeline por `awk` standalone single-pass, imune a `pipefail`. Adicionalmente preserva o contrato de sanidade da versão original (`NR<=51`) — codex pre-commit apontou que o port literal removia a janela de 50 linhas e abria caminho para falsos positivos de \"frontmatter fechado\" em ADRs malformados com `---` solto no corpo.

## Validação manual

Fixtures em `/tmp/fixtures-239/` (não commitadas):

### Cenário 1 — frontmatter sem status/date

```text
FAIL 9998-sem-status-date.md
  - frontmatter sem campo obrigatório: status
  - frontmatter sem campo obrigatório: date
ok   9999-adr-grande.md

Total de erros: 2 em 2 arquivo(s).
exit=1
```

Sem o fix, esse output não chega — o pipeline aborta silenciosamente.

### Cenário 2 — ADR de 5525 linhas

10/10 runs reportam `ok 9999-adr-grande.md` com exit 0. Sem o fix, 0/10 (todos falsos positivos).

### Cenário 3 — sanity NR<=51 preservada

Fixture com frontmatter aberto + `---` solto na linha 60: reporta corretamente `frontmatter YAML sem delimitador de fechamento`. Sem o `NR<=51`, o awk aceitaria o `---` tardio como fechamento e mascararia o erro.

### Cenário 4 — 51 ADRs canônicos

```text
ok   0001-clean-architecture.md
...
ok   0051-apicurio-schema-registry-avro-wolverine.md

51 ADR(s) validados sem erros (frontmatter MADR 4.0).

markdownlint-cli2: 0 erros.
exit=0
```

## Critérios de aceite (issue)

- [x] Reporta `FAIL` + summary mesmo com `status`/`date` ausentes
- [x] Sem falso positivo em ADR ≥ 5000 linhas (10/10 runs)
- [x] 51 ADRs canônicos continuam validando exit 0
- [x] Teste de regressão manual documentado no PR (cenários 1–4 acima)

## Bônus sobre o port do uniplus-web

Codex review pré-commit apontou que o awk do `uniplus-web@a5935e4` removeu a janela de 50 linhas do contrato original. Esta PR preserva o limite via `NR<=51` no awk — pequena melhora sobre o port literal. Posso portar o ajuste de volta ao `uniplus-web` numa PR irmã se quisermos manter os dois sincronizados.

Closes #239