### PR TITLE
fix(ci): restringir bypass do gate a bots confiáveis por login

### DIFF
--- a/.github/workflows/pr-author-org-member.yml
+++ b/.github/workflows/pr-author-org-member.yml
@@ -12,21 +12,28 @@ jobs:
     name: PR author is org member
     runs-on: ubuntu-latest
     steps:
-      # Bots conhecidos do GitHub (Dependabot, GitHub Actions, Renovate)
-      # não são "members" no sentido organizacional — não passam pelo endpoint
-      # /collaborators/{login}/permission e nem aparecem em ?affiliation=outside.
-      # São agentes do próprio GitHub, autorizados a abrir PRs com as permissões
-      # do repo via secrets.GITHUB_TOKEN. Bypass explícito + nominal evita
-      # reescrever o gate semanticamente: humanos continuam sendo validados
-      # pela rota normal abaixo.
-      - name: Bypass para bots do GitHub
-        if: github.event.pull_request.user.type == 'Bot'
+      # Bots confiáveis instalados pelo Owner da org (Dependabot, GitHub Actions,
+      # Renovate) não são "members" no sentido organizacional — não passam pelo
+      # endpoint /collaborators/{login}/permission e nem aparecem em
+      # ?affiliation=outside. Operam com o GITHUB_TOKEN do repo, sem vetor de
+      # impersonation externa.
+      #
+      # Importante: whitelist NOMINAL (não `user.type == 'Bot'` genérico) — caso
+      # contrário qualquer GitHub App de terceiros instalado em qualquer momento
+      # passaria o gate. Para incluir um novo bot, adicionar o login aqui após
+      # revisão do Owner.
+      - name: Bypass para bots confiáveis do GitHub
+        if: |
+          github.event.pull_request.user.type == 'Bot' &&
+          contains(fromJSON('["dependabot[bot]", "github-actions[bot]", "renovate[bot]"]'), github.event.pull_request.user.login)
         run: |
-          echo "PR autor ${{ github.event.pull_request.user.login }} é Bot — bypass do gate org-member."
+          echo "PR autor ${{ github.event.pull_request.user.login }} é Bot confiável (whitelist) — bypass do gate org-member."
           exit 0
 
       - name: Validate author is org member with write access
-        if: github.event.pull_request.user.type != 'Bot'
+        if: |
+          github.event.pull_request.user.type != 'Bot' ||
+          !contains(fromJSON('["dependabot[bot]", "github-actions[bot]", "renovate[bot]"]'), github.event.pull_request.user.login)
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Resumo

Backport do fix aplicado em `uniplus-web#372` e `uniplus-docs#119` (Codex P1) para restringir o bypass do gate a bots **confiáveis** por login.

## Problema

O bypass introduzido em `9b0151f` via `user.type == 'Bot'` é genérico — aceita **qualquer** GitHub App instalado no repo, não só Dependabot/GitHub Actions/Renovate. Caso um app de terceiros venha a ser instalado em algum momento, ele bypassaria o gate sem revisão.

## Fix

Whitelist nominal via `contains(fromJSON('[...]'), github.event.pull_request.user.login)`. Para adicionar um bot novo é preciso editar o array, forçando trilha de auditoria explícita.

Bots autorizados hoje:

- `dependabot[bot]`
- `github-actions[bot]`
- `renovate[bot]`

## Conformidade

Mantém os 3 repos (`uniplus-api`, `uniplus-web`, `uniplus-docs`) com workflow textualmente idêntico (verificado via `diff`).

## Validação

PRs irmãos (web e docs) com mesmo patch foram aprovados pelo Codex AI bot — 👍 silente após o fix, 0 threads.

Refs #396
