### PR TITLE
feat(crypto): validar EncryptionOptions no boot (fail-fast)

### DIFF
--- a/docs/guia-config-cifragem.md
+++ b/docs/guia-config-cifragem.md
@@ -1,0 +1,77 @@
+# Guia de configuração de cifragem (`UniPlus:Encryption`)
+
+A `uniplus-api` cifra dados sensíveis (cursor de paginação, payload de Idempotency-Key e, futuramente, outros campos do Domínio) por meio de `IUniPlusEncryptionService`. A escolha do provider e suas credenciais entram via configuração `IConfiguration` / variáveis de ambiente, sob a seção `UniPlus:Encryption`.
+
+A combinação de provider + campos dependentes é validada **no boot**. Configurações incoerentes derrubam o pod no startup com mensagem específica, em vez de retornar `500 Internal Server Error` silencioso na primeira requisição que toca cifragem. A validação combinada está em `EncryptionOptionsValidator` (registrado por `AddUniPlusEncryption`).
+
+## Matriz de campos por provider
+
+| Campo | `local` | `vault` | Observação |
+|---|:---:|:---:|---|
+| `Provider` | obrigatório | obrigatório | Valores aceitos: `"local"`, `"vault"` (case-insensitive). |
+| `LocalKey` | **obrigatório** | ignorado | Chave AES-GCM 256 em Base64 (32 bytes após decode). |
+| `VaultAddress` | ignorado | **obrigatório** | URL absoluta `http`/`https`. Em standalone: `http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200`. |
+| `KubernetesRole` | ignorado | obrigatório (produção) | Role Kubernetes auth registrada no Vault. **Mutuamente exclusivo** com `VaultToken`. |
+| `VaultToken` | ignorado | obrigatório (dev/CI) | Token estático para testes de integração — **nunca usar em produção**. **Mutuamente exclusivo** com `KubernetesRole`. |
+| `VaultTransitMount` | ignorado | opcional | Mount do engine `transit`. Default: `"transit"`. |
+| `KubernetesJwtPath` | ignorado | opcional | Path do JWT do Service Account. Default: `/var/run/secrets/kubernetes.io/serviceaccount/token`. |
+
+Quando `Provider=vault`, exatamente um entre `KubernetesRole` e `VaultToken` precisa estar definido. A exclusividade é deliberada: `VaultTransitEncryptionService` cai para `VaultToken` quando o JWT do Service Account não está montado em disco; aceitar ambos definidos abriria janela para um token estático suplantar a identidade de workload em caso de erro operacional no mount do SA.
+
+## Variáveis de ambiente equivalentes
+
+ASP.NET Core mapeia `:` em settings para `__` em env vars:
+
+```bash
+UNIPLUS__ENCRYPTION__PROVIDER=local
+UNIPLUS__ENCRYPTION__LOCALKEY=<base64-32-bytes>
+# ou
+UNIPLUS__ENCRYPTION__PROVIDER=vault
+UNIPLUS__ENCRYPTION__VAULTADDRESS=http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200
+UNIPLUS__ENCRYPTION__KUBERNETESROLE=uniplus-api
+```
+
+## Gerar uma chave local para dev/CI
+
+```bash
+head -c 32 /dev/urandom | base64
+```
+
+A chave gerada nunca deve ser commitada. Em CI vive como segredo do runner; em ambientes Kubernetes, custodiada no Vault em `secret/<env>/uniplus-api/encryption-local` e materializada como Secret K8s via External Secrets Operator.
+
+## Diagnóstico — erros típicos no boot
+
+Cada falha de validação cita o caminho exato da setting que precisa de atenção:
+
+| Sintoma no log | Causa |
+|---|---|
+| `UniPlus:Encryption:LocalKey é obrigatório quando Provider = 'local'` | `Provider=local` (default) mas chave ausente. Provavelmente faltou `ExternalSecret` no chart Helm. |
+| `UniPlus:Encryption:LocalKey não é uma string Base64 válida` | Chave contém caracteres inválidos. Regere com o comando acima. |
+| `UniPlus:Encryption:LocalKey deve ter 32 bytes (256 bits) após decode Base64` | Chave com tamanho errado — AES-GCM-256 exige exatamente 32 bytes. |
+| `UniPlus:Encryption:Provider inválido: '...'` | Valor digitado não está em `{local, vault}`. |
+| `UniPlus:Encryption:VaultAddress é obrigatório quando Provider = 'vault'` | Esqueceu de plugar o endereço do Vault nos values do environment. |
+| `UniPlus:Encryption:VaultAddress inválido: '...' Deve ser uma URL absoluta com scheme http ou https` | Endereço sem scheme ou com scheme inesperado (ex.: `file://`). |
+| `UniPlus:Encryption requer KubernetesRole (produção) ou VaultToken (testes/dev) quando Provider = 'vault'` | Authentication method não configurado. |
+| `UniPlus:Encryption: KubernetesRole e VaultToken são mutuamente exclusivos` | Ambos foram definidos simultaneamente. Em produção, manter apenas `KubernetesRole`. |
+
+## Por que validar no boot
+
+A escolha do `IUniPlusEncryptionService` (`LocalAesEncryptionService` vs `VaultTransitEncryptionService`) é resolvida por factory delegate em `CryptographyServiceCollectionExtensions`. Sem o validator condicional, `Provider=local` sem `LocalKey` só estoura quando o serviço é instanciado pelo DI **na primeira requisição** que toca cifragem (rota de Idempotency-Key, por exemplo). O consumer recebe `500 Internal Server Error` e o operador precisa correlacionar log da API com mudanças de configuração — diagnóstico caro em produção.
+
+O fail-fast no boot transforma esse `500` em um `CrashLoopBackOff` claro: o pod nunca chega a aceitar tráfego com configuração inconsistente.
+
+## Relação com Vault Transit
+
+A trilha Vault Transit em produção depende de:
+
+1. Mount `transit/` + key `uniplus-idempotency-aesgcm` + policy + role K8s auth no Vault (uniplus-infra#219).
+2. Wire-up dos values dos charts `uniplus-api-{portal,selecao,ingresso}` (uniplus-infra#220).
+
+Enquanto o Transit não está disponível em um environment, o provider default `local` permanece adequado para dev/CI desde que a chave esteja presente.
+
+## Referência cruzada
+
+- ADR-0027 — Idempotency-Key (boundary validation completada por este fix).
+- ADR-0010 — Estratégia de segredos via Vault + ESO.
+- Story uniplus-infra#219 — stand-up do Vault Transit no standalone.
+- Story uniplus-infra#220 — wire-up `uniplus-api → Vault Transit`.

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionOptionsValidator.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionOptionsValidator.cs
@@ -1,0 +1,139 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Valida <see cref="EncryptionOptions"/> no boot da aplicação para falhar com mensagem
+/// específica quando a combinação de Provider + campos dependentes está inconsistente
+/// (por exemplo, Provider=local sem LocalKey). Sem este validator a configuração inválida
+/// só estouraria na primeira request que toca cifragem, retornando 500 ao consumer.
+///
+/// Detalhes em <c>docs/guia-config-cifragem.md</c>.
+/// </summary>
+internal sealed class EncryptionOptionsValidator : IValidateOptions<EncryptionOptions>
+{
+    private const int RequiredKeyBytes = 32;
+    private const string GuideHint = "Detalhes em docs/guia-config-cifragem.md.";
+    private static readonly string[] AllowedProviders = ["local", "vault"];
+
+    public ValidateOptionsResult Validate(string? name, EncryptionOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        // Só valida a instância default — projeto não usa named options para cifragem.
+        if (!string.IsNullOrEmpty(name) && name != Options.DefaultName)
+        {
+            return ValidateOptionsResult.Skip;
+        }
+
+        List<string> failures = [];
+
+        string provider = options.Provider?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrEmpty(provider))
+        {
+            failures.Add(
+                $"UniPlus:Encryption:Provider é obrigatório. Valores aceitos: 'local', 'vault'. {GuideHint}");
+        }
+        else if (!IsKnownProvider(provider))
+        {
+            failures.Add(
+                $"UniPlus:Encryption:Provider inválido: '{options.Provider}'. " +
+                $"Valores aceitos: 'local', 'vault'. {GuideHint}");
+        }
+        else if (provider.Equals("local", StringComparison.OrdinalIgnoreCase))
+        {
+            ValidateLocal(options, failures);
+        }
+        else if (provider.Equals("vault", StringComparison.OrdinalIgnoreCase))
+        {
+            ValidateVault(options, failures);
+        }
+
+        return failures.Count == 0
+            ? ValidateOptionsResult.Success
+            : ValidateOptionsResult.Fail(failures);
+    }
+
+    private static bool IsKnownProvider(string provider) =>
+        AllowedProviders.Any(allowed => provider.Equals(allowed, StringComparison.OrdinalIgnoreCase));
+
+    private static void ValidateLocal(EncryptionOptions options, List<string> failures)
+    {
+        if (string.IsNullOrWhiteSpace(options.LocalKey))
+        {
+            failures.Add(
+                "UniPlus:Encryption:LocalKey é obrigatório quando Provider = 'local'. " +
+                "Defina via env var UNIPLUS__ENCRYPTION__LOCALKEY (Base64, 32 bytes). " +
+                "Gere uma chave dev/CI com `head -c 32 /dev/urandom | base64`. " +
+                $"{GuideHint}");
+            return;
+        }
+
+        byte[] keyBytes;
+        try
+        {
+            keyBytes = Convert.FromBase64String(options.LocalKey);
+        }
+        catch (FormatException)
+        {
+            failures.Add(
+                "UniPlus:Encryption:LocalKey não é uma string Base64 válida. " +
+                "Gere uma chave válida com `head -c 32 /dev/urandom | base64`. " +
+                $"{GuideHint}");
+            return;
+        }
+
+        if (keyBytes.Length != RequiredKeyBytes)
+        {
+            failures.Add(
+                $"UniPlus:Encryption:LocalKey deve ter {RequiredKeyBytes} bytes (256 bits) após decode Base64. " +
+                $"Recebido: {keyBytes.Length} bytes. " +
+                $"{GuideHint}");
+        }
+    }
+
+    private static void ValidateVault(EncryptionOptions options, List<string> failures)
+    {
+        if (string.IsNullOrWhiteSpace(options.VaultAddress))
+        {
+            failures.Add(
+                "UniPlus:Encryption:VaultAddress é obrigatório quando Provider = 'vault'. " +
+                "Exemplo: 'http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200'. " +
+                $"{GuideHint}");
+        }
+        else if (!IsAbsoluteHttpUri(options.VaultAddress))
+        {
+            failures.Add(
+                $"UniPlus:Encryption:VaultAddress inválido: '{options.VaultAddress}'. " +
+                "Deve ser uma URL absoluta com scheme http ou https. " +
+                $"{GuideHint}");
+        }
+
+        bool hasKubernetesRole = !string.IsNullOrWhiteSpace(options.KubernetesRole);
+        bool hasVaultToken = !string.IsNullOrWhiteSpace(options.VaultToken);
+
+        if (!hasKubernetesRole && !hasVaultToken)
+        {
+            failures.Add(
+                "UniPlus:Encryption requer KubernetesRole (produção) ou VaultToken (testes/dev) quando Provider = 'vault'. " +
+                "Configure UNIPLUS__ENCRYPTION__KUBERNETESROLE (role K8s auth registrada no Vault) " +
+                "ou UNIPLUS__ENCRYPTION__VAULTTOKEN (apenas para testes de integração — nunca em produção). " +
+                $"{GuideHint}");
+        }
+        else if (hasKubernetesRole && hasVaultToken)
+        {
+            // VaultTransitEncryptionService cai para VaultToken quando o JWT do K8s não existe em disco.
+            // Aceitar ambos definidos abriria janela para um VaultToken estático suplantar a identidade
+            // de workload quando o ServiceAccount estiver mal montado. Operador escolhe um, explicitamente.
+            failures.Add(
+                "UniPlus:Encryption: KubernetesRole e VaultToken são mutuamente exclusivos. " +
+                "Em produção use KubernetesRole; em testes/dev use VaultToken. " +
+                $"{GuideHint}");
+        }
+    }
+
+    private static bool IsAbsoluteHttpUri(string value) =>
+        Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+            && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/CryptographyServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/CryptographyServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 
 using Cryptography;
@@ -30,6 +31,11 @@ public static class CryptographyServiceCollectionExtensions
         {
             optionsBuilder.Configure(configure);
         }
+
+        // Validator condicional Provider × campos dependentes. Composto com ValidateDataAnnotations:
+        // ambos rodam ao materializar IOptions<EncryptionOptions>.Value e ValidateOnStart força no boot.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<EncryptionOptions>, EncryptionOptionsValidator>());
 
         optionsBuilder.ValidateDataAnnotations().ValidateOnStart();
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/CryptographyDiTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/CryptographyDiTests.cs
@@ -1,16 +1,24 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Cryptography;
 
+using System.Security.Cryptography;
+
 using AwesomeAssertions;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 
 public sealed class CryptographyDiTests
 {
-    private static IConfiguration CriarConfig(string provider, string? localKey = null)
+    private static IConfiguration CriarConfig(
+        string provider,
+        string? localKey = null,
+        string? vaultAddress = null,
+        string? kubernetesRole = null,
+        string? vaultToken = null)
     {
         Dictionary<string, string?> values = new()
         {
@@ -22,6 +30,21 @@ public sealed class CryptographyDiTests
             values["UniPlus:Encryption:LocalKey"] = localKey;
         }
 
+        if (vaultAddress is not null)
+        {
+            values["UniPlus:Encryption:VaultAddress"] = vaultAddress;
+        }
+
+        if (kubernetesRole is not null)
+        {
+            values["UniPlus:Encryption:KubernetesRole"] = kubernetesRole;
+        }
+
+        if (vaultToken is not null)
+        {
+            values["UniPlus:Encryption:VaultToken"] = vaultToken;
+        }
+
         return new ConfigurationBuilder()
             .AddInMemoryCollection(values)
             .Build();
@@ -30,7 +53,7 @@ public sealed class CryptographyDiTests
     [Fact]
     public void AddUniPlusEncryption_ProviderLocal_DeveResolverLocalAesEncryptionService()
     {
-        string chaveValida = Convert.ToBase64String(new byte[32]);
+        string chaveValida = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
         ServiceProvider sp = new ServiceCollection()
             .AddLogging()
             .AddUniPlusEncryption(CriarConfig("local", chaveValida))
@@ -42,7 +65,7 @@ public sealed class CryptographyDiTests
     }
 
     [Fact]
-    public void AddUniPlusEncryption_ProviderInvalido_DeveLancarInvalidOperationExceptionAoResolver()
+    public void AddUniPlusEncryption_ProviderInvalido_DeveLancarOptionsValidationExceptionAoResolver()
     {
         ServiceProvider sp = new ServiceCollection()
             .AddLogging()
@@ -51,7 +74,126 @@ public sealed class CryptographyDiTests
 
         Action ato = () => sp.GetRequiredService<IUniPlusEncryptionService>();
 
-        ato.Should().Throw<InvalidOperationException>()
+        ato.Should().Throw<OptionsValidationException>()
             .WithMessage("*'desconhecido'*");
+    }
+
+    // ─── Fail-fast no boot (IStartupValidator) ────────────────────────────────
+
+    [Fact]
+    public void AddUniPlusEncryption_ProviderLocalSemLocalKey_DeveLancarOptionsValidationExceptionNoStart()
+    {
+        ServiceProvider sp = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(CriarConfig("local"))
+            .BuildServiceProvider();
+
+        IStartupValidator startupValidator = sp.GetRequiredService<IStartupValidator>();
+
+        Action ato = () => startupValidator.Validate();
+
+        ato.Should().Throw<OptionsValidationException>()
+            .WithMessage("*UniPlus:Encryption:LocalKey*");
+    }
+
+    [Fact]
+    public void AddUniPlusEncryption_ProviderVaultSemVaultAddress_DeveLancarOptionsValidationExceptionNoStart()
+    {
+        ServiceProvider sp = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(CriarConfig("vault", kubernetesRole: "uniplus-api"))
+            .BuildServiceProvider();
+
+        IStartupValidator startupValidator = sp.GetRequiredService<IStartupValidator>();
+
+        Action ato = () => startupValidator.Validate();
+
+        ato.Should().Throw<OptionsValidationException>()
+            .WithMessage("*UniPlus:Encryption:VaultAddress*");
+    }
+
+    [Fact]
+    public void AddUniPlusEncryption_ProviderLocalComLocalKeyValida_NaoLancaNoStart()
+    {
+        string chaveValida = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        ServiceProvider sp = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(CriarConfig("local", chaveValida))
+            .BuildServiceProvider();
+
+        IStartupValidator startupValidator = sp.GetRequiredService<IStartupValidator>();
+
+        Action ato = () => startupValidator.Validate();
+
+        ato.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AddUniPlusEncryption_ProviderVaultComKubernetesRole_NaoLancaNoStart()
+    {
+        ServiceProvider sp = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(CriarConfig(
+                "vault",
+                vaultAddress: "http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200",
+                kubernetesRole: "uniplus-api"))
+            .BuildServiceProvider();
+
+        IStartupValidator startupValidator = sp.GetRequiredService<IStartupValidator>();
+
+        Action ato = () => startupValidator.Validate();
+
+        ato.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AddUniPlusEncryption_ProviderLocalLocalKeyBase64Invalida_DeveLancarOptionsValidationExceptionNoStart()
+    {
+        ServiceProvider sp = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(CriarConfig("local", localKey: "não-é-base64!"))
+            .BuildServiceProvider();
+
+        IStartupValidator startupValidator = sp.GetRequiredService<IStartupValidator>();
+
+        Action ato = () => startupValidator.Validate();
+
+        ato.Should().Throw<OptionsValidationException>()
+            .WithMessage("*Base64*");
+    }
+
+    [Fact]
+    public void AddUniPlusEncryption_ProviderLocalLocalKeyTamanhoErrado_DeveLancarOptionsValidationExceptionNoStart()
+    {
+        string chave16Bytes = Convert.ToBase64String(new byte[16]);
+        ServiceProvider sp = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(CriarConfig("local", localKey: chave16Bytes))
+            .BuildServiceProvider();
+
+        IStartupValidator startupValidator = sp.GetRequiredService<IStartupValidator>();
+
+        Action ato = () => startupValidator.Validate();
+
+        ato.Should().Throw<OptionsValidationException>()
+            .WithMessage("*32 bytes*");
+    }
+
+    [Fact]
+    public void AddUniPlusEncryption_ProviderVaultSemAuthMethod_DeveLancarOptionsValidationExceptionNoStart()
+    {
+        ServiceProvider sp = new ServiceCollection()
+            .AddLogging()
+            .AddUniPlusEncryption(CriarConfig(
+                "vault",
+                vaultAddress: "http://platform-vault-uniplus-standalone.vault.svc.cluster.local:8200"))
+            .BuildServiceProvider();
+
+        IStartupValidator startupValidator = sp.GetRequiredService<IStartupValidator>();
+
+        Action ato = () => startupValidator.Validate();
+
+        ato.Should().Throw<OptionsValidationException>()
+            .WithMessage("*KubernetesRole*");
     }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/EncryptionOptionsValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/EncryptionOptionsValidatorTests.cs
@@ -1,0 +1,279 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Cryptography;
+
+using System.Security.Cryptography;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+public sealed class EncryptionOptionsValidatorTests
+{
+    private static readonly string ChaveBase64Valida =
+        Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+    private static readonly EncryptionOptionsValidator Sut = new();
+
+    // ─── Provider ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_ProviderNulo_DeveFalhar()
+    {
+        EncryptionOptions opts = new() { Provider = null! };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        resultado.Failures.Should().ContainSingle()
+            .Which.Should().Contain("UniPlus:Encryption:Provider é obrigatório");
+    }
+
+    [Fact]
+    public void Validate_ProviderVazio_DeveFalhar()
+    {
+        EncryptionOptions opts = new() { Provider = "   " };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        resultado.Failures.Should().ContainSingle()
+            .Which.Should().Contain("UniPlus:Encryption:Provider é obrigatório");
+    }
+
+    [Fact]
+    public void Validate_ProviderDesconhecido_DeveFalharListandoValoresAceitos()
+    {
+        EncryptionOptions opts = new() { Provider = "aws" };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        string mensagem = resultado.Failures!.Single();
+        mensagem.Should().Contain("'aws'");
+        mensagem.Should().Contain("'local'");
+        mensagem.Should().Contain("'vault'");
+    }
+
+    [Fact]
+    public void Validate_ProviderEmCaixaAlta_DeveSerCaseInsensitive()
+    {
+        EncryptionOptions opts = new() { Provider = "LOCAL", LocalKey = ChaveBase64Valida };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Succeeded.Should().BeTrue();
+    }
+
+    // ─── Local ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_LocalSemLocalKey_DeveFalharMencionandoPath()
+    {
+        EncryptionOptions opts = new() { Provider = "local", LocalKey = null };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        resultado.Failures.Should().ContainSingle()
+            .Which.Should().Contain("UniPlus:Encryption:LocalKey");
+    }
+
+    [Fact]
+    public void Validate_LocalLocalKeyEmBranco_DeveFalhar()
+    {
+        EncryptionOptions opts = new() { Provider = "local", LocalKey = "   " };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        resultado.Failures.Should().ContainSingle()
+            .Which.Should().Contain("UniPlus:Encryption:LocalKey");
+    }
+
+    [Fact]
+    public void Validate_LocalLocalKeyBase64Invalida_DeveFalharMencionandoBase64()
+    {
+        EncryptionOptions opts = new() { Provider = "local", LocalKey = "não-é-base64!!!" };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        resultado.Failures.Should().ContainSingle()
+            .Which.Should().Contain("Base64");
+    }
+
+    [Fact]
+    public void Validate_LocalLocalKeyComTamanhoErrado_DeveFalharMencionando32Bytes()
+    {
+        string chave16Bytes = Convert.ToBase64String(new byte[16]);
+        EncryptionOptions opts = new() { Provider = "local", LocalKey = chave16Bytes };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        string mensagem = resultado.Failures!.Single();
+        mensagem.Should().Contain("32 bytes");
+        mensagem.Should().Contain("16 bytes");
+    }
+
+    [Fact]
+    public void Validate_LocalLocalKey32BytesValida_DeveSerSuccess()
+    {
+        EncryptionOptions opts = new() { Provider = "local", LocalKey = ChaveBase64Valida };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Succeeded.Should().BeTrue();
+    }
+
+    // ─── Vault ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_VaultSemVaultAddress_DeveFalhar()
+    {
+        EncryptionOptions opts = new()
+        {
+            Provider = "vault",
+            VaultAddress = null,
+            KubernetesRole = "uniplus-api",
+        };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        resultado.Failures.Should().ContainSingle()
+            .Which.Should().Contain("UniPlus:Encryption:VaultAddress");
+    }
+
+    [Fact]
+    public void Validate_VaultComVaultAddressEKubernetesRole_DeveSerSuccess()
+    {
+        EncryptionOptions opts = new()
+        {
+            Provider = "vault",
+            VaultAddress = "http://vault.vault.svc:8200",
+            KubernetesRole = "uniplus-api",
+        };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_VaultComVaultAddressEVaultToken_DeveSerSuccess()
+    {
+        EncryptionOptions opts = new()
+        {
+            Provider = "vault",
+            VaultAddress = "http://127.0.0.1:8200",
+            VaultToken = "hvs.test-only-token",
+        };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Validate_VaultSemRoleNemToken_DeveFalhar()
+    {
+        EncryptionOptions opts = new()
+        {
+            Provider = "vault",
+            VaultAddress = "http://vault.vault.svc:8200",
+            KubernetesRole = null,
+            VaultToken = null,
+        };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        resultado.Failures.Should().ContainSingle()
+            .Which.Should().Contain("KubernetesRole");
+    }
+
+    [Fact]
+    public void Validate_VaultComKubernetesRoleEVaultTokenSimultaneamente_DeveFalhar()
+    {
+        EncryptionOptions opts = new()
+        {
+            Provider = "vault",
+            VaultAddress = "http://vault.vault.svc:8200",
+            KubernetesRole = "uniplus-api",
+            VaultToken = "hvs.dev",
+        };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        string mensagem = resultado.Failures!.Single();
+        mensagem.Should().Contain("mutuamente exclusivos");
+    }
+
+    [Fact]
+    public void Validate_VaultComVaultAddressMalformado_DeveFalhar()
+    {
+        EncryptionOptions opts = new()
+        {
+            Provider = "vault",
+            VaultAddress = "vault.svc:8200",   // sem scheme
+            KubernetesRole = "uniplus-api",
+        };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        string mensagem = resultado.Failures!.Single();
+        mensagem.Should().Contain("UniPlus:Encryption:VaultAddress");
+        mensagem.Should().Contain("URL absoluta");
+    }
+
+    [Fact]
+    public void Validate_VaultComVaultAddressEsquemaFile_DeveFalhar()
+    {
+        EncryptionOptions opts = new()
+        {
+            Provider = "vault",
+            VaultAddress = "file:///etc/vault",
+            KubernetesRole = "uniplus-api",
+        };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        resultado.Failures!.Single().Should().Contain("http ou https");
+    }
+
+    [Fact]
+    public void Validate_VaultSemAddressESemRoleNemToken_DeveAcumularFalhas()
+    {
+        EncryptionOptions opts = new()
+        {
+            Provider = "vault",
+            VaultAddress = null,
+            KubernetesRole = null,
+            VaultToken = null,
+        };
+
+        ValidateOptionsResult resultado = Sut.Validate(Options.DefaultName, opts);
+
+        resultado.Failed.Should().BeTrue();
+        resultado.Failures.Should().HaveCount(2);
+        resultado.Failures!.Should().Contain(f => f.Contains("UniPlus:Encryption:VaultAddress"));
+        resultado.Failures!.Should().Contain(f => f.Contains("KubernetesRole"));
+    }
+
+    // ─── Named options ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_NameDiferenteDoDefault_DeveSkipar()
+    {
+        EncryptionOptions opts = new() { Provider = "local", LocalKey = null };
+
+        ValidateOptionsResult resultado = Sut.Validate(name: "outra-config", opts);
+
+        resultado.Skipped.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Closes #400

## Contexto

`EncryptionOptions` já tinha `[Required]` no `Provider` e `ValidateOnStart()` registrado, mas a consistência condicional entre `Provider` e os campos dependentes não era validada. Configuração inconsistente passava no boot e só estourava `InvalidOperationException` quando o serviço de cifragem era resolvido pelo DI na primeira request que toca cifragem (path Idempotency-Key) — retornando **500 silencioso ao consumer**. No standalone isso se manifestou ao validar smoke E2E da Story #286, porque `environments/standalone/values.yaml` (uniplus-infra) hoje não define `UniPlus__Encryption__Provider` nem `LocalKey`.

## O que muda

Adiciona `IValidateOptions<EncryptionOptions>` (`EncryptionOptionsValidator`) composto com o `ValidateDataAnnotations` já existente, registrado via `TryAddEnumerable<IValidateOptions<T>>` em `AddUniPlusEncryption`. Como `ValidateOnStart()` já estava ativo, qualquer falha do validator agora derruba o app **no startup** em vez de no primeiro request cifrado.

Regras condicionais cobertas:

- `Provider` em `{local, vault}` (case-insensitive); valor desconhecido falha listando os aceitos.
- `Provider=local` ⇒ `LocalKey` obrigatória, 32 bytes (256 bits) após decode Base64. Erros distintos para missing / base64 inválido / tamanho errado.
- `Provider=vault` ⇒ `VaultAddress` como URL **absoluta `http`/`https`** + **exatamente um** entre `KubernetesRole` (produção) e `VaultToken` (testes/dev). Aceitar ambos abriria janela para token estático suplantar identidade de workload quando o ServiceAccount está mal montado — `VaultTransitEncryptionService` cai para token estático quando o JWT do K8s não existe em disco.

Todas as mensagens citam o caminho da setting (`UniPlus:Encryption:*`) e apontam para `docs/guia-config-cifragem.md` para diagnóstico Helm/ESO.

## Cobertura

- 17 unit tests em `EncryptionOptionsValidatorTests` (provider, local, vault, named options skip).
- 7 testes adicionais em `CryptographyDiTests` resolvendo `IStartupValidator` e provando que `OptionsValidationException` é lançada **no startup**, não na primeira request: local sem chave, local com base64 inválida, local com chave de tamanho errado, vault sem address, vault sem auth, provider desconhecido, e caminhos felizes em local e vault.

Validação local:

```
dotnet build UniPlus.slnx                              # 0 warnings, 0 erros
dotnet test UniPlus.slnx --filter "!~IntegrationTests" # 617 passed / 0 failed
```

Codex CLI rodou 3 rodadas (plano + diff + diff pós-fix). P2 sobre `VaultToken/KubernetesRole` simultâneo foi absorvido (exclusividade reforçada). P3 sobre `VaultAddress` non-empty insuficiente também (validação URI absoluta `http/https`).

## Documentação

`docs/guia-config-cifragem.md` em pt-BR com matriz de campos por provider, env vars equivalentes, comando para gerar chave dev/CI, tabela de erros típicos no boot e referências cruzadas com ADR-0027 e Stories uniplus-infra#219 / uniplus-infra#220.

## Fora de escopo

Não muda o default `local` (continua adequado para dev/CI). Não introduz dependências novas. Não toca `LocalAesEncryptionService` nem `VaultTransitEncryptionService` — a validação que esses faziam lazy no construtor continua existindo (defesa em profundidade).

## Relação com correção definitiva no standalone

Este PR é a etapa 1 de 3 da correção da cifragem em produção. As outras duas dependem desta:

- unifesspa-edu-br/uniplus-infra#219 — stand-up do Vault Transit no standalone (mount + key + role K8s auth).
- unifesspa-edu-br/uniplus-infra#220 — wire-up `uniplus-api → Vault Transit` (values + SA + smoke E2E).

## Rollback

Reverter os 2 commits desta branch. Não há migração de dados nem mudança de schema.

## Test plan

- [x] `dotnet build UniPlus.slnx` 0 warnings
- [x] `dotnet test UniPlus.slnx --filter "!~IntegrationTests"` 617 passed
- [x] Codex CLI plan review + diff review aplicados
- [ ] CI verde (PR build / Unit + arch tests / Integration tests / Coverage / PR author org member)
- [ ] Review humano (jf2s)