### PR TITLE
refactor(crypto): separar guards do construtor de VaultTransitEncryptionService por cenário

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/VaultTransitEncryptionService.cs
@@ -45,15 +45,26 @@ internal sealed partial class VaultTransitEncryptionService : IUniPlusEncryption
         bool hasRole = !string.IsNullOrWhiteSpace(opts.KubernetesRole);
         bool hasToken = !string.IsNullOrWhiteSpace(opts.VaultToken);
 
-        if (hasRole == hasToken)
+        // EncryptionOptionsValidator já enforça exatamente um dos dois quando Provider=vault.
+        // As guardas defensivas abaixo cobrem o fluxo de testes que instancia o serviço
+        // diretamente (sem passar pelo validator), tornando a violação explícita em vez
+        // de um NullReferenceException mais adiante em CreateVaultClient. Mensagens
+        // separadas facilitam o diagnóstico — ambos definidos vs nenhum definido têm
+        // ações corretivas distintas.
+        if (hasRole && hasToken)
         {
-            // EncryptionOptionsValidator já enforça exatamente um dos dois quando Provider=vault.
-            // Esta guarda defensiva cobre o fluxo de testes que instancia o serviço diretamente
-            // (sem passar pelo validator), tornando a violação explícita em vez de um
-            // NullReferenceException mais adiante em CreateVaultClient.
             throw new InvalidOperationException(
-                "UniPlus:Encryption: exatamente um entre KubernetesRole e VaultToken deve estar definido " +
-                "quando Provider = 'vault'. Ver EncryptionOptionsValidator e docs/guia-config-cifragem.md.");
+                "UniPlus:Encryption: KubernetesRole e VaultToken são mutuamente exclusivos quando Provider = 'vault'. " +
+                "Em produção use KubernetesRole; em testes/dev use VaultToken. " +
+                "Ver EncryptionOptionsValidator e docs/guia-config-cifragem.md.");
+        }
+
+        if (!hasRole && !hasToken)
+        {
+            throw new InvalidOperationException(
+                "UniPlus:Encryption: nem KubernetesRole nem VaultToken estão definidos quando Provider = 'vault'. " +
+                "Configure UNIPLUS__ENCRYPTION__KUBERNETESROLE (produção) ou UNIPLUS__ENCRYPTION__VAULTTOKEN (testes/dev). " +
+                "Ver EncryptionOptionsValidator e docs/guia-config-cifragem.md.");
         }
 
         _vaultAddress = opts.VaultAddress;

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/VaultTransitEncryptionServiceConstructorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/VaultTransitEncryptionServiceConstructorTests.cs
@@ -50,7 +50,7 @@ public sealed class VaultTransitEncryptionServiceConstructorTests : IDisposable
     }
 
     [Fact]
-    public void Construtor_SemRoleNemToken_DeveLancarInvalidOperationException()
+    public void Construtor_SemRoleNemToken_DeveLancarComMensagemDeConfiguracaoAusente()
     {
         EncryptionOptions opts = new()
         {
@@ -63,11 +63,11 @@ public sealed class VaultTransitEncryptionServiceConstructorTests : IDisposable
         Action ato = () => CriarServico(opts);
 
         ato.Should().Throw<InvalidOperationException>()
-            .WithMessage("*exatamente um*");
+            .WithMessage("*nem KubernetesRole nem VaultToken*Configure UNIPLUS__ENCRYPTION__KUBERNETESROLE*");
     }
 
     [Fact]
-    public void Construtor_ComRoleEToken_DeveLancarInvalidOperationException()
+    public void Construtor_ComRoleEToken_DeveLancarComMensagemDeExclusividade()
     {
         EncryptionOptions opts = new()
         {
@@ -81,7 +81,7 @@ public sealed class VaultTransitEncryptionServiceConstructorTests : IDisposable
         Action ato = () => CriarServico(opts);
 
         ato.Should().Throw<InvalidOperationException>()
-            .WithMessage("*exatamente um*");
+            .WithMessage("*mutuamente exclusivos*Em produção use KubernetesRole*");
     }
 
     [Fact]
@@ -150,6 +150,10 @@ public sealed class VaultTransitEncryptionServiceConstructorTests : IDisposable
     [Fact]
     public void Construtor_RoleConfiguradaEJwtPresente_DeveCriarServicoSemLancar()
     {
+        // VaultAddress aqui é não-resolvível de propósito: VaultClient (VaultSharp) é
+        // lazy — só faz handshake na primeira chamada de EncryptAsync/DecryptAsync.
+        // Por isso o construtor não tenta tráfego de rede e não lança em endereços
+        // sem DNS válido. Round-trip real fica em IntegrationTests com Testcontainers Vault.
         EncryptionOptions opts = new()
         {
             Provider = "vault",


### PR DESCRIPTION
Closes #404

## Contexto

Follow-up dos achados S1 + S2 da revisão retroativa do PR #403. Refinos pequenos sem mudança de comportamento observável; melhoram diagnóstico operacional e legibilidade do test suite.

## O que muda

### S1 — Split do guard `hasRole == hasToken` em 2 guards distintos

`VaultTransitEncryptionService.cs:45-65` consolidava dois cenários inválidos diferentes (ambos auth methods definidos vs nenhum definido) numa única mensagem "exatamente um deve estar definido". Cada cenário tem ação corretiva específica:

- **Ambos definidos**: remover um (em prod, manter `KubernetesRole`; em dev/CI, `VaultToken`).
- **Nenhum definido**: configurar uma das duas env vars.

Agora cada um lança com mensagem própria que cita as env vars (`UNIPLUS__ENCRYPTION__KUBERNETESROLE` / `UNIPLUS__ENCRYPTION__VAULTTOKEN`), eliminando o passo extra de o operador inferir o cenário a partir do estado da config.

### S2 — Comentário inline em `Construtor_RoleConfiguradaEJwtPresente_DeveCriarServicoSemLancar`

O teste usa `VaultAddress = \"http://vault:8200\"` (não-resolvível) e o construtor não lança. Funciona porque `VaultClient` (VaultSharp) é lazy — só faz handshake na primeira `EncryptAsync`/`DecryptAsync`. Sem essa nota inline, futuro mantenedor pode achar que o construtor faz network I/O e ficar surpreso ao adicionar testes que esperem comportamento síncrono.

### Ajustes nos testes

- Renomeados de `_DeveLancarInvalidOperationException` para nomes que descrevem o **conteúdo** da mensagem esperada:
  - `Construtor_SemRoleNemToken_DeveLancarComMensagemDeConfiguracaoAusente`
  - `Construtor_ComRoleEToken_DeveLancarComMensagemDeExclusividade`
- Trocado `.Where(e => e.Message.Contains(...))` para `.WithMessage(\"*pattern*\")` — assertion mais idiomática que produz mensagem de falha mais clara em CI.

## Validação local

- `dotnet build` — 0 warnings com `TreatWarningsAsErrors`.
- `dotnet test --filter Cryptography` — 46 passed.
- `dotnet test --filter !~IntegrationTests` — 512 passed em `Infrastructure.Core.UnitTests`.

Codex CLI 1 rodada — sem achados bloqueantes; 3 ajustes opcionais (`WithMessage` vs `Where`, texto do comment, validação das env vars) absorvidos antes do push.

## Fora de escopo

S3 do review (eager warmup via `IHostedService`) — issue #405 dedicada por ser mudança arquitetural com impacto em test factories existentes (pattern §23.1).

## Riscos

Mínimos. Backward compatibility: ambos os guards continuam lançando `InvalidOperationException` no mesmo ponto do código; apenas a mensagem fica mais específica. Nenhum teste de integração existente verificava a string exata da mensagem antiga.

## Test plan

- [x] `dotnet build UniPlus.slnx` verde
- [x] `dotnet test UniPlus.slnx --filter \"!~IntegrationTests\"` verde
- [x] Codex CLI absorvido
- [ ] CI 10/10 verde
- [ ] Review humano (jf2s)