### PR TITLE
feat(crypto): eager warmup de IUniPlusEncryptionService no boot via IHostedService

### DIFF
--- a/docs/guia-config-cifragem.md
+++ b/docs/guia-config-cifragem.md
@@ -39,40 +39,36 @@ head -c 32 /dev/urandom | base64
 
 A chave gerada nunca deve ser commitada. Em CI vive como segredo do runner; em ambientes Kubernetes, custodiada no Vault em `secret/<env>/uniplus-api/encryption-local` e materializada como Secret K8s via External Secrets Operator.
 
-## Diagnóstico — onde o erro estoura
+## Diagnóstico — todos os erros estouram no boot
 
-As validações se dividem em duas categorias com timing distinto:
+Qualquer config inválida derruba o pod com `CrashLoopBackOff` no startup, antes do app aceitar tráfego. Dois mecanismos cooperam para isso:
 
-### Erros no boot (via `EncryptionOptionsValidator` + `ValidateOnStart()`)
+1. **`EncryptionOptionsValidator` + `ValidateOnStart()`** — checa as settings que não dependem de recursos externos (provider conhecido, LocalKey 32 bytes Base64, VaultAddress como URL absoluta http/https, exclusividade KubernetesRole vs VaultToken). Falha → `OptionsValidationException` no `IStartupValidator.Validate()`.
+2. **`EncryptionWarmupHostedService`** — força a resolução do singleton `IUniPlusEncryptionService` no `Host.StartAsync`, propagando qualquer falha do construtor (JWT do ServiceAccount ausente, conteúdo whitespace, `KubernetesJwtPath` em branco) como exceção que aborta o boot.
 
-Configuração de settings que pode ser checada sem tocar em recursos externos. Falha aqui derruba o pod no startup com `OptionsValidationException`, antes de receber tráfego.
+| Sintoma no log | Mecanismo | Causa |
+|---|---|---|
+| `UniPlus:Encryption:LocalKey é obrigatório quando Provider = 'local'` | Validator | `Provider=local` (default) mas chave ausente. Provavelmente faltou `ExternalSecret` no chart Helm. |
+| `UniPlus:Encryption:LocalKey não é uma string Base64 válida` | Validator | Chave contém caracteres inválidos. Regere com o comando acima. |
+| `UniPlus:Encryption:LocalKey deve ter 32 bytes (256 bits) após decode Base64` | Validator | Chave com tamanho errado — AES-GCM-256 exige exatamente 32 bytes. |
+| `UniPlus:Encryption:Provider inválido: '...'` | Validator | Valor digitado não está em `{local, vault}`. |
+| `UniPlus:Encryption:VaultAddress é obrigatório quando Provider = 'vault'` | Validator | Esqueceu de plugar o endereço do Vault nos values do environment. |
+| `UniPlus:Encryption:VaultAddress inválido: '...' Deve ser uma URL absoluta com scheme http ou https` | Validator | Endereço sem scheme ou com scheme inesperado (ex.: `file://`). |
+| `UniPlus:Encryption: KubernetesRole e VaultToken são mutuamente exclusivos` | Validator + construtor | Ambos definidos simultaneamente. Em produção, manter apenas `KubernetesRole`. |
+| `UniPlus:Encryption: nem KubernetesRole nem VaultToken estão definidos` | Validator + construtor | Authentication method não configurado. |
+| `JWT do ServiceAccount não encontrado em '...'` | Warmup hosted service | `Provider=vault` + `KubernetesRole` definido, mas o arquivo do JWT não existe no path configurado. Verificar `automountServiceAccountToken=true` e volume projetado do SA. |
+| `JWT do ServiceAccount em '...' está vazio` | Warmup hosted service | Arquivo presente mas sem conteúdo. O kubelet costuma re-popular automaticamente; verificar logs e estado do volume projetado. |
+| `UniPlus:Encryption:KubernetesJwtPath está vazio` | Warmup hosted service | Path não configurado. Default é `/var/run/secrets/kubernetes.io/serviceaccount/token`; raramente precisa ser override. |
 
-| Sintoma no log | Causa |
-|---|---|
-| `UniPlus:Encryption:LocalKey é obrigatório quando Provider = 'local'` | `Provider=local` (default) mas chave ausente. Provavelmente faltou `ExternalSecret` no chart Helm. |
-| `UniPlus:Encryption:LocalKey não é uma string Base64 válida` | Chave contém caracteres inválidos. Regere com o comando acima. |
-| `UniPlus:Encryption:LocalKey deve ter 32 bytes (256 bits) após decode Base64` | Chave com tamanho errado — AES-GCM-256 exige exatamente 32 bytes. |
-| `UniPlus:Encryption:Provider inválido: '...'` | Valor digitado não está em `{local, vault}`. |
-| `UniPlus:Encryption:VaultAddress é obrigatório quando Provider = 'vault'` | Esqueceu de plugar o endereço do Vault nos values do environment. |
-| `UniPlus:Encryption:VaultAddress inválido: '...' Deve ser uma URL absoluta com scheme http ou https` | Endereço sem scheme ou com scheme inesperado (ex.: `file://`). |
-| `UniPlus:Encryption requer KubernetesRole (produção) ou VaultToken (testes/dev) quando Provider = 'vault'` | Authentication method não configurado. |
-| `UniPlus:Encryption: KubernetesRole e VaultToken são mutuamente exclusivos` | Ambos foram definidos simultaneamente. Em produção, manter apenas `KubernetesRole`. |
+## Por que validar no boot
 
-### Erros na primeira resolução do serviço (via construtor de `VaultTransitEncryptionService`)
+A escolha do `IUniPlusEncryptionService` (`LocalAesEncryptionService` vs `VaultTransitEncryptionService`) é resolvida por factory delegate em `CryptographyServiceCollectionExtensions`. Sem o validator + warmup, `Provider=local` sem `LocalKey` só estouraria quando o serviço é instanciado pelo DI **na primeira requisição** que toca cifragem (rota de Idempotency-Key, por exemplo). O consumer receberia `500 Internal Server Error` e o operador precisaria correlacionar log da API com mudanças de configuração — diagnóstico caro em produção.
 
-Validações que dependem de recursos externos (presença e conteúdo do JWT em disco). `IUniPlusEncryptionService` é registrado como singleton com factory lazy, então o construtor roda no primeiro `GetRequiredService`/`@Inject`. Em apps que tocam cifragem por algum hosted service no startup (Idempotency, cursor, etc.) isso acaba acontecendo cedo o suficiente para virar `CrashLoopBackOff`; em apps que só tocam cifragem em request, o erro aparece na primeira requisição.
+`OptionsValidationException` no `ValidateOnStart` + falha-no-construtor via `EncryptionWarmupHostedService` transformam todos esses cenários em `CrashLoopBackOff` claro: o pod nunca chega a aceitar tráfego com configuração inconsistente.
 
-| Sintoma no log | Causa |
-|---|---|
-| `JWT do ServiceAccount não encontrado em '...'` | `Provider=vault` + `KubernetesRole` definido, mas o arquivo do JWT não existe no path configurado. Verificar `automountServiceAccountToken=true` e volume projetado do SA. |
-| `JWT do ServiceAccount em '...' está vazio` | Arquivo presente mas sem conteúdo. O kubelet costuma re-popular automaticamente; verificar logs e estado do volume projetado. |
-| `UniPlus:Encryption:KubernetesJwtPath está vazio` | Path não configurado. Default é `/var/run/secrets/kubernetes.io/serviceaccount/token`; raramente precisa ser override. |
+## Test factories
 
-## Por que validar antes da primeira requisição cifrada
-
-A escolha do `IUniPlusEncryptionService` (`LocalAesEncryptionService` vs `VaultTransitEncryptionService`) é resolvida por factory delegate em `CryptographyServiceCollectionExtensions`. Sem o validator condicional, `Provider=local` sem `LocalKey` só estouraria quando o serviço é instanciado pelo DI **na primeira requisição** que toca cifragem (rota de Idempotency-Key, por exemplo). O consumer receberia `500 Internal Server Error` e o operador precisaria correlacionar log da API com mudanças de configuração — diagnóstico caro em produção.
-
-O fail-fast via `OptionsValidationException` transforma esse `500` em um `CrashLoopBackOff` claro para os erros de boot acima; e a falha-no-resolve do construtor o transforma em um `CrashLoopBackOff` apenas se o serviço for de fato resolvido cedo (caminho comum quando há hosted services consumindo cifragem). Em todos os cenários, o pod nunca aceita tráfego com configuração inconsistente sem sinalizar.
+`ApiFactoryBase` (em `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/`) carrega `appsettings.Development.json` que já provê `UniPlus:Encryption:LocalKey` para dev/CI. Por isso o warmup hosted service roda normalmente nos integration tests do projeto. Caso uma fixture específica precise mockar o pipeline sem cifragem real (cenário raro), o pattern do `DisableWolverineRuntimeForTests` é o template para criar um filtro análogo via heurística estável de `ImplementationType`.
 
 ## Relação com Vault Transit
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionWarmupHostedService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cryptography/EncryptionWarmupHostedService.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+
+using Microsoft.Extensions.Hosting;
+
+/// <summary>
+/// <see cref="IHostedService"/> que força a resolução do singleton
+/// <see cref="IUniPlusEncryptionService"/> no startup da aplicação.
+///
+/// <para>
+/// O singleton é registrado com factory lazy em
+/// <c>CryptographyServiceCollectionExtensions.AddUniPlusEncryption</c>, então
+/// erros do construtor (JWT do ServiceAccount ausente/vazio,
+/// <c>KubernetesJwtPath</c> em branco, mutex de auth method) só estourariam no
+/// primeiro <c>GetRequiredService&lt;IUniPlusEncryptionService&gt;()</c>. Em
+/// produção, hosted services existentes (Idempotency-Key store, cursor
+/// pagination) tipicamente forçam a resolução cedo o suficiente para o pod
+/// entrar em <c>CrashLoopBackOff</c>, mas isso não é garantido por contrato.
+/// Para apps que só tocam cifragem em request, o erro voltaria ao sintoma
+/// "500 silencioso" que o <c>EncryptionOptionsValidator</c> ataca parcialmente.
+/// </para>
+///
+/// <para>
+/// Este warmup garante <c>CrashLoopBackOff</c> determinístico para qualquer
+/// config inválida de cifragem, complementando o validator (que cobre apenas
+/// settings que podem ser checadas sem tocar recursos externos).
+/// </para>
+///
+/// <para>
+/// Em testes, <c>ApiFactoryBase</c> carrega <c>appsettings.Development.json</c>
+/// que já provê <c>UniPlus:Encryption:LocalKey</c> válida, então o warmup roda
+/// sem mock. Fixtures que precisem mockar o pipeline sem cifragem real (cenário
+/// raro) podem filtrar este hosted service via heurística de
+/// <c>ImplementationType</c>, espelhando o pattern de
+/// <c>MigrationHostedService&lt;TContext&gt;</c> e <c>WolverineRuntime</c>.
+/// </para>
+/// </summary>
+internal sealed class EncryptionWarmupHostedService : IHostedService
+{
+    public EncryptionWarmupHostedService(IUniPlusEncryptionService encryptionService)
+    {
+        // O parâmetro existe para forçar a resolução do singleton via DI durante
+        // a enumeração dos IHostedService no Host.StartAsync — qualquer falha do
+        // construtor do serviço de cifragem dispara aqui, antes do app aceitar
+        // tráfego. ArgumentNullException.ThrowIfNull mantém o contrato explícito.
+        ArgumentNullException.ThrowIfNull(encryptionService);
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/CryptographyServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/CryptographyServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 using Cryptography;
@@ -56,6 +57,17 @@ public static class CryptographyServiceCollectionExtensions
             throw new InvalidOperationException(
                 $"UniPlus:Encryption:Provider inválido: '{opts.Provider}'. Use 'vault' ou 'local'.");
         });
+
+        // Warmup hosted service força a resolução do IUniPlusEncryptionService no
+        // Host.StartAsync — falha do construtor (JWT ausente, mutex auth method)
+        // vira CrashLoopBackOff antes do app aceitar tráfego, em vez de 500 na
+        // primeira request cifrada. Test factories (ApiFactoryBase) carregam
+        // appsettings.Development.json com LocalKey válida e por isso o warmup
+        // roda normalmente em integration tests; fixtures que precisem mockar o
+        // pipeline sem cifragem real podem filtrar via heurística estável de
+        // ImplementationType, mesmo pattern de MigrationHostedService/Wolverine.
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostedService, EncryptionWarmupHostedService>());
 
         return services;
     }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/CryptographyDiTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cryptography/CryptographyDiTests.cs
@@ -6,6 +6,7 @@ using AwesomeAssertions;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
@@ -253,5 +254,67 @@ public sealed class CryptographyDiTests
         Action ato = () => sp.GetRequiredService<IUniPlusEncryptionService>();
 
         ato.Should().NotThrow();
+    }
+
+    // ─── Warmup hosted service (fail-fast no Host.StartAsync) ─────────────────
+
+    private static IHost CriarHostComEncryption(IConfiguration config)
+    {
+        HostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(settings: null);
+        builder.Services.AddLogging();
+        builder.Services.AddUniPlusEncryption(config);
+        return builder.Build();
+    }
+
+    [Fact]
+    public async Task EncryptionWarmupHostedService_ProviderLocalSemLocalKey_StartAsync_DeveLancarOptionsValidationException()
+    {
+        using IHost host = CriarHostComEncryption(CriarConfig("local"));
+
+        Func<Task> ato = () => host.StartAsync();
+
+        await ato.Should().ThrowAsync<OptionsValidationException>()
+            .WithMessage("*UniPlus:Encryption:LocalKey*");
+    }
+
+    [Fact]
+    public async Task EncryptionWarmupHostedService_ProviderVaultKubernetesRoleSemJwtNoDisco_StartAsync_DeveLancarInvalidOperationException()
+    {
+        // EncryptionOptionsValidator passa (KubernetesRole + VaultAddress válidos),
+        // mas o construtor de VaultTransitEncryptionService falha em ReadJwtOrThrow
+        // porque o JWT path não existe. Antes deste PR isso só estouraria no
+        // primeiro GetRequiredService; agora o warmup garante CrashLoopBackOff.
+        string pathInexistente = Path.Combine(Path.GetTempPath(), $"uniplus-warmup-test-{Guid.NewGuid():N}");
+        Dictionary<string, string?> values = new()
+        {
+            ["UniPlus:Encryption:Provider"] = "vault",
+            ["UniPlus:Encryption:VaultAddress"] = "http://vault.vault.svc:8200",
+            ["UniPlus:Encryption:KubernetesRole"] = "uniplus-api",
+            ["UniPlus:Encryption:KubernetesJwtPath"] = pathInexistente,
+        };
+        IConfiguration config = new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+
+        using IHost host = CriarHostComEncryption(config);
+
+        Func<Task> ato = () => host.StartAsync();
+
+        await ato.Should().ThrowAsync<InvalidOperationException>()
+            .Where(e => e.Message.Contains(pathInexistente)
+                && e.Message.Contains("ServiceAccount"));
+    }
+
+    [Fact]
+    public async Task EncryptionWarmupHostedService_ProviderLocalValido_StartAsync_NaoLanca()
+    {
+        string chaveValida = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        using IHost host = CriarHostComEncryption(CriarConfig("local", chaveValida));
+
+        Func<Task> ato = () => host.StartAsync();
+
+        await ato.Should().NotThrowAsync();
+
+        await host.StopAsync();
     }
 }


### PR DESCRIPTION
Closes #405

## Contexto

Após PRs #401 + #403, erros de configuração de cifragem se dividiam em dois caminhos com timing distinto:

1. **`EncryptionOptionsValidator` + `ValidateOnStart()`** → `CrashLoopBackOff` no boot via `OptionsValidationException`. ✅
2. **Construtor de `VaultTransitEncryptionService`** (JWT ausente, whitespace, `KubernetesJwtPath` em branco) → só estourava no **primeiro `GetRequiredService<IUniPlusEncryptionService>()`**. Em produção, hosted services existentes (Idempotency-Key, cursor) tipicamente forçavam o resolve cedo, mas isso **não era garantido por contrato**. Apps que só tocassem cifragem em request voltariam ao "500 silencioso".

## O que muda

Novo `EncryptionWarmupHostedService` registrado via `TryAddEnumerable<IHostedService>` em `AddUniPlusEncryption`. O ASP.NET Core resolve esse hosted service durante `Host.StartAsync`, e a injeção de `IUniPlusEncryptionService` no construtor força a resolução do singleton lazy — qualquer falha do construtor do serviço (`LocalAesEncryptionService` ou `VaultTransitEncryptionService`) propaga antes do app aceitar tráfego.

Garantia agora absoluta: **toda config inválida vira `CrashLoopBackOff` no boot**, independente de quem consome cifragem ou quando.

## Cobertura

- **3 testes novos** em `CryptographyDiTests` usando `Host.CreateEmptyApplicationBuilder()` + `host.StartAsync()`:
  - `EncryptionWarmupHostedService_ProviderLocalSemLocalKey_StartAsync_DeveLancarOptionsValidationException`
  - `EncryptionWarmupHostedService_ProviderVaultKubernetesRoleSemJwtNoDisco_StartAsync_DeveLancarInvalidOperationException`
  - `EncryptionWarmupHostedService_ProviderLocalValido_StartAsync_NaoLanca` (+ `StopAsync` ok)
- **Suite completa verde**: 726 tests incluindo `Selecao.IntegrationTests` (71), `Infrastructure.Core.IntegrationTests` (17), e `Ingresso.IntegrationTests` (8). `appsettings.Development.json` já provê `LocalKey` válida → warmup roda sem mock em integration tests. Pattern §23.1 da skill `issue-driven-implementation` validado empiricamente: não houve regressão em test factories.

## Pattern §23.1 — test factories

`ApiFactoryBase` carrega `appsettings.Development.json` que tem `UniPlus.Encryption.LocalKey` configurada. Por isso o warmup hosted service não precisa de filtro hoje. Fixtures que precisem mockar pipeline sem cifragem real (cenário raro) podem replicar o pattern existente de `DisableWolverineRuntimeForTests` para criar um filtro análogo via heurística estável de `ImplementationType`.

## Documentação

`docs/guia-config-cifragem.md` consolidado: a tabela de \"Diagnóstico\" deixa de separar \"boot vs primeira resolução\" e mostra todos os erros com coluna \"Mecanismo\" indicando se o sintoma vem do `Validator` (settings checáveis) ou do `EncryptionWarmupHostedService` (construtor com I/O). Mensagem unificada: **todos os erros estouram no boot**.

## Codex CLI

1 rodada, 0 P1/P2, 1 P3 absorvido (wording de comentário sobre filter no `ApiFactoryBase` que ainda não existe — ajustei para \"pode filtrar se uma fixture precisar\"). `[SuppressMessage]` IDE0060 redundante removido (`ArgumentNullException.ThrowIfNull` já usa o parâmetro).

## Validação local

```
dotnet build UniPlus.slnx                               # 0 warnings
dotnet test UniPlus.slnx                                # 726 passed / 0 failed
dotnet test --filter \"FullyQualifiedName~Warmup\"        # 3 passed (smoke do feature)
```

## Test plan

- [x] `dotnet build UniPlus.slnx` 0 warnings
- [x] `dotnet test UniPlus.slnx` 726 passed (inclui Integration tests)
- [x] Codex CLI aplicado
- [ ] CI 10/10 verde
- [ ] Review humano (jf2s)