### PR TITLE
feat(shared): preencher CreatedBy/UpdatedBy via AuditableInterceptor (opt-in IAuditableEntity)

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
@@ -27,12 +27,14 @@ public static class IngressoInfrastructureRegistration
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // SoftDeleteInterceptor consome IUserContext scoped (HttpUserContext)
-        // para preencher DeletedBy com o usuário autenticado (issue #127).
-        // Scoped acompanha o ciclo de vida do request — Singleton aqui causaria
-        // captive dependency com IUserContext.
+        // SoftDeleteInterceptor (issue #127) e AuditableInterceptor (issue #390)
+        // consomem IUserContext scoped (HttpUserContext) para preencher
+        // DeletedBy / CreatedBy / UpdatedBy com o usuário autenticado. Scoped
+        // acompanha o ciclo de vida do request — Singleton aqui causaria
+        // captive dependency com IUserContext (UserId congelaria no primeiro
+        // request servido pelo processo).
         services.AddScoped<SoftDeleteInterceptor>();
-        services.AddSingleton<AuditableInterceptor>();
+        services.AddScoped<AuditableInterceptor>();
 
         services.AddDbContext<IngressoDbContext>((serviceProvider, options) =>
         {

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/DependencyInjection.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/DependencyInjection.cs
@@ -25,12 +25,14 @@ public static class PortalInfrastructureRegistration
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // SoftDeleteInterceptor consome IUserContext scoped (HttpUserContext)
-        // para preencher DeletedBy com o usuário autenticado (issue #127).
-        // Scoped acompanha o ciclo de vida do request — Singleton aqui causaria
-        // captive dependency com IUserContext.
+        // SoftDeleteInterceptor (issue #127) e AuditableInterceptor (issue #390)
+        // consomem IUserContext scoped (HttpUserContext) para preencher
+        // DeletedBy / CreatedBy / UpdatedBy com o usuário autenticado. Scoped
+        // acompanha o ciclo de vida do request — Singleton aqui causaria
+        // captive dependency com IUserContext (UserId congelaria no primeiro
+        // request servido pelo processo).
         services.AddScoped<SoftDeleteInterceptor>();
-        services.AddSingleton<AuditableInterceptor>();
+        services.AddScoped<AuditableInterceptor>();
 
         services.AddDbContext<PortalDbContext>((serviceProvider, options) =>
         {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -28,12 +28,14 @@ public static class SelecaoInfrastructureRegistration
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // SoftDeleteInterceptor consome IUserContext scoped (HttpUserContext)
-        // para preencher DeletedBy com o usuário autenticado (issue #127).
-        // Scoped acompanha o ciclo de vida do request — Singleton aqui causaria
-        // captive dependency com IUserContext.
+        // SoftDeleteInterceptor (issue #127) e AuditableInterceptor (issue #390)
+        // consomem IUserContext scoped (HttpUserContext) para preencher
+        // DeletedBy / CreatedBy / UpdatedBy com o usuário autenticado. Scoped
+        // acompanha o ciclo de vida do request — Singleton aqui causaria
+        // captive dependency com IUserContext (UserId congelaria no primeiro
+        // request servido pelo processo).
         services.AddScoped<SoftDeleteInterceptor>();
-        services.AddSingleton<AuditableInterceptor>();
+        services.AddScoped<AuditableInterceptor>();
 
         services.AddDbContext<SelecaoDbContext>((serviceProvider, options) =>
         {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/AuditableInterceptor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/AuditableInterceptor.cs
@@ -3,10 +3,35 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
 using Kernel.Domain.Entities;
+using Kernel.Domain.Interfaces;
 
+// Auditoria automática de criação/modificação (issue #390 + ADR-0033):
+//   - Para toda EntityBase: preenche CreatedAt em Added e UpdatedAt em
+//     Modified (comportamento original preservado).
+//   - Para entidades que implementam IAuditableEntity (opt-in): adicionalmente
+//     preenche CreatedBy/UpdatedBy a partir do IUserContext autenticado;
+//     fallback "system" em fluxos sem principal (jobs, migrations).
+//
+// Registrado como Scoped na DI dos módulos (selecao/ingresso/portal) para
+// acompanhar o ciclo de vida scoped do IUserContext (HttpUserContext) e do
+// DbContext — Singleton aqui causaria captive dependency e o UserId
+// congelaria no primeiro request servido pelo processo. Espelha o padrão
+// do SoftDeleteInterceptor pós-#127.
 public sealed class AuditableInterceptor : SaveChangesInterceptor
 {
+    private const string SystemUser = "system";
+
+    private readonly IUserContext? _userContext;
+
+    // Construtor sem args preservado para uso em testes que não exigem
+    // IUserContext (cenário equivalente ao fallback "system").
+    public AuditableInterceptor(IUserContext? userContext = null)
+    {
+        _userContext = userContext;
+    }
+
     public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
         DbContextEventData eventData,
         InterceptionResult<int> result,
@@ -14,7 +39,7 @@ public sealed class AuditableInterceptor : SaveChangesInterceptor
     {
         if (eventData?.Context is not null)
         {
-            ApplyAuditTimestamps(eventData.Context);
+            ApplyAuditFields(eventData.Context);
         }
 
         return base.SavingChangesAsync(eventData!, result, cancellationToken);
@@ -26,29 +51,50 @@ public sealed class AuditableInterceptor : SaveChangesInterceptor
     {
         if (eventData?.Context is not null)
         {
-            ApplyAuditTimestamps(eventData.Context);
+            ApplyAuditFields(eventData.Context);
         }
 
         return base.SavingChanges(eventData!, result);
     }
 
-    private static void ApplyAuditTimestamps(DbContext context)
+    private void ApplyAuditFields(DbContext context)
     {
         DateTimeOffset now = DateTimeOffset.UtcNow;
+        string userBy = ResolveUserBy();
 
         foreach (Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<EntityBase> entry
             in context.ChangeTracker.Entries<EntityBase>())
         {
+            bool isAuditable = entry.Entity is IAuditableEntity;
+
             switch (entry.State)
             {
                 case EntityState.Added:
                     entry.Property(nameof(EntityBase.CreatedAt)).CurrentValue = now;
+                    if (isAuditable)
+                    {
+                        entry.Property(nameof(IAuditableEntity.CreatedBy)).CurrentValue = userBy;
+                    }
                     break;
 
                 case EntityState.Modified:
                     entry.Property(nameof(EntityBase.UpdatedAt)).CurrentValue = now;
+                    if (isAuditable)
+                    {
+                        entry.Property(nameof(IAuditableEntity.UpdatedBy)).CurrentValue = userBy;
+                    }
                     break;
             }
         }
+    }
+
+    private string ResolveUserBy()
+    {
+        if (_userContext is { IsAuthenticated: true, UserId: { Length: > 0 } userId })
+        {
+            return userId;
+        }
+
+        return SystemUser;
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Interfaces/IAuditableEntity.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Interfaces/IAuditableEntity.cs
@@ -1,9 +1,44 @@
 namespace Unifesspa.UniPlus.Kernel.Domain.Interfaces;
 
+/// <summary>
+/// Marca entidades de domínio que registram o usuário responsável por
+/// criação e modificação como parte da auditoria de operações administrativas.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementação é <b>opt-in</b>: aplicar somente em entidades cujas operações
+/// têm semântica de autoria de domínio (avaliação, homologação, interposição
+/// de recurso, decisão administrativa), não em entidades metadata
+/// configuracional como <c>Edital</c>, <c>Cota</c> ou <c>ProcessoSeletivo</c>
+/// — onde o registro estruturado em log (Serilog + <c>PiiMaskingEnricher</c>,
+/// ADR-0011) já cobre o requisito da LGPD art. 37.
+/// </para>
+/// <para>
+/// Quando uma entidade implementa esta interface, o
+/// <c>AuditableInterceptor</c> (issue #390) preenche automaticamente
+/// <see cref="CreatedBy"/> em <c>EntityState.Added</c> e <see cref="UpdatedBy"/>
+/// em <c>EntityState.Modified</c> a partir do <c>IUserContext</c> resolvido
+/// no escopo do request — fallback para <c>"system"</c> em fluxos sem
+/// principal autenticado (jobs, migrations).
+/// </para>
+/// <para>
+/// As propriedades expõem apenas getter; entidades implementadoras devem
+/// declarar setters não-públicos (geralmente <c>private set;</c>) para
+/// permitir que o EF Core/interceptor escreva via reflection sem expor
+/// mutação direta no domínio.
+/// </para>
+/// </remarks>
 public interface IAuditableEntity
 {
+    /// <summary>Instante de criação do registro (UTC).</summary>
     DateTimeOffset CreatedAt { get; }
+
+    /// <summary>Instante da última modificação do registro (UTC), ou <see langword="null"/> se nunca foi modificado.</summary>
     DateTimeOffset? UpdatedAt { get; }
+
+    /// <summary>Identificador (<c>sub</c> do JWT) do usuário responsável pela criação, ou <c>"system"</c> em fluxos sem principal autenticado.</summary>
     string? CreatedBy { get; }
+
+    /// <summary>Identificador (<c>sub</c> do JWT) do usuário responsável pela última modificação, ou <c>"system"</c> em fluxos sem principal autenticado.</summary>
     string? UpdatedBy { get; }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/AuditableInterceptorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/AuditableInterceptorTests.cs
@@ -4,26 +4,60 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
 using Kernel.Domain.Entities;
+using Kernel.Domain.Interfaces;
 
 public sealed class AuditableInterceptorTests
 {
+    private const string SystemUser = "system";
+
     private sealed class EntidadeTeste : EntityBase
     {
         public string Nome { get; set; } = string.Empty;
     }
 
+    // Entidade que implementa IAuditableEntity (opt-in da #390) — exercita o
+    // ramo do interceptor que preenche CreatedBy/UpdatedBy. Setters private
+    // espelham o pattern de entidades reais (EF Core escreve via reflection
+    // sem expor mutação ao domínio).
+    private sealed class EntidadeAuditavel : EntityBase, IAuditableEntity
+    {
+        public string Nome { get; set; } = string.Empty;
+        public string? CreatedBy { get; private set; }
+        public string? UpdatedBy { get; private set; }
+    }
+
     private sealed class ContextoTeste(DbContextOptions<ContextoTeste> options) : DbContext(options)
     {
         public DbSet<EntidadeTeste> Entidades { get; set; } = null!;
+        public DbSet<EntidadeAuditavel> EntidadesAuditaveis { get; set; } = null!;
     }
 
-    private static ContextoTeste CriarContexto() =>
+    private static ContextoTeste CriarContexto(IUserContext? userContext = null, string? dbName = null) =>
         new(new DbContextOptionsBuilder<ContextoTeste>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .AddInterceptors(new AuditableInterceptor())
+            .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString())
+            .AddInterceptors(new AuditableInterceptor(userContext))
             .Options);
+
+    private static IUserContext UsuarioAutenticado(string userId)
+    {
+        IUserContext userContext = Substitute.For<IUserContext>();
+        userContext.IsAuthenticated.Returns(true);
+        userContext.UserId.Returns(userId);
+        return userContext;
+    }
+
+    private static IUserContext UsuarioAnonimo()
+    {
+        IUserContext userContext = Substitute.For<IUserContext>();
+        userContext.IsAuthenticated.Returns(false);
+        userContext.UserId.Returns((string?)null);
+        return userContext;
+    }
 
     [Fact]
     public void SavingChanges_DadoEntityAdicionada_EntaoDeveDefinirCreatedAt()
@@ -81,5 +115,102 @@ public sealed class AuditableInterceptorTests
 
         entidade.UpdatedAt.Should().NotBeNull();
         entidade.UpdatedAt.Should().BeOnOrAfter(antes);
+    }
+
+    // ───── #390: ramos IAuditableEntity (opt-in) ──────────────────────────
+
+    [Fact]
+    public void SavingChanges_DadoIAuditableEntityAddedEUsuarioAutenticado_EntaoCreatedByDeveSerUserId()
+    {
+        IUserContext userContext = UsuarioAutenticado("user-42");
+        using ContextoTeste contexto = CriarContexto(userContext);
+        EntidadeAuditavel entidade = new() { Nome = "novo" };
+
+        contexto.EntidadesAuditaveis.Add(entidade);
+        contexto.SaveChanges();
+
+        entidade.CreatedBy.Should().Be("user-42");
+        entidade.UpdatedBy.Should().BeNull("UpdatedBy só preenchido em Modified");
+    }
+
+    [Fact]
+    public async Task SavingChangesAsync_DadoIAuditableEntityModifiedEUsuarioAutenticado_EntaoUpdatedByDeveSerUserId()
+    {
+        // Compartilha o nome do DB in-memory entre os dois contextos para
+        // simular "mesmo banco, requests distintos". Sem isso cada CriarContexto
+        // gera Guid.NewGuid() e a entidade some entre as chamadas.
+        string dbName = Guid.NewGuid().ToString();
+
+        IUserContext primeiroCriador = UsuarioAutenticado("user-1");
+        await using ContextoTeste contextoCriacao = CriarContexto(primeiroCriador, dbName);
+        EntidadeAuditavel entidade = new() { Nome = "original" };
+        contextoCriacao.EntidadesAuditaveis.Add(entidade);
+        await contextoCriacao.SaveChangesAsync();
+
+        // Reabre o contexto com outro usuário — espelha o padrão de modificação
+        // em request distinto. UpdatedBy = quem modificou; CreatedBy permanece.
+        IUserContext segundoEditor = UsuarioAutenticado("user-99");
+        await using ContextoTeste contextoEdicao = CriarContexto(segundoEditor, dbName);
+        EntidadeAuditavel? alvo = await contextoEdicao.EntidadesAuditaveis.FindAsync(entidade.Id);
+        alvo.Should().NotBeNull("entidade persistida no DB compartilhado deve ser encontrada");
+        alvo!.Nome = "modificado";
+
+        await contextoEdicao.SaveChangesAsync();
+
+        alvo.CreatedBy.Should().Be("user-1");
+        alvo.UpdatedBy.Should().Be("user-99");
+    }
+
+    [Fact]
+    public void SavingChanges_DadoIAuditableEntityEUsuarioNaoAutenticado_EntaoCreatedByDeveSerSystem()
+    {
+        IUserContext userContext = UsuarioAnonimo();
+        using ContextoTeste contexto = CriarContexto(userContext);
+        EntidadeAuditavel entidade = new() { Nome = "job" };
+
+        contexto.EntidadesAuditaveis.Add(entidade);
+        contexto.SaveChanges();
+
+        entidade.CreatedBy.Should().Be(SystemUser);
+    }
+
+    [Fact]
+    public void SavingChanges_DadoIAuditableEntityComUserIdVazio_EntaoCreatedByDeveSerSystem()
+    {
+        // UserId vazio (string.Empty) cai no fallback por causa do
+        // padrão `UserId: { Length: > 0 }` no ResolveUserBy — pin para evitar
+        // regressão se alguém trocar para `is not null`.
+        IUserContext userContext = Substitute.For<IUserContext>();
+        userContext.IsAuthenticated.Returns(true);
+        userContext.UserId.Returns(string.Empty);
+        using ContextoTeste contexto = CriarContexto(userContext);
+        EntidadeAuditavel entidade = new() { Nome = "edge" };
+
+        contexto.EntidadesAuditaveis.Add(entidade);
+        contexto.SaveChanges();
+
+        entidade.CreatedBy.Should().Be(SystemUser);
+    }
+
+    [Fact]
+    public void SavingChanges_DadoEntidadeNaoAuditavel_EntaoCreatedByPermaneceForaDoModelo()
+    {
+        // EntidadeTeste só herda EntityBase, sem IAuditableEntity. O interceptor
+        // não deve tentar tocar em CreatedBy/UpdatedBy (não existem) — apenas
+        // CreatedAt/UpdatedAt continuam funcionando. Sem essa guarda o
+        // interceptor lança em entry.Property("CreatedBy") porque a
+        // propriedade não está no modelo do contexto.
+        IUserContext userContext = UsuarioAutenticado("user-irrelevante");
+        using ContextoTeste contexto = CriarContexto(userContext);
+        EntidadeTeste entidade = new() { Nome = "sem-auditoria" };
+
+        Action acao = () =>
+        {
+            contexto.Entidades.Add(entidade);
+            contexto.SaveChanges();
+        };
+
+        acao.Should().NotThrow();
+        entidade.CreatedAt.Should().BeAfter(DateTimeOffset.UtcNow.AddSeconds(-5));
     }
 }


### PR DESCRIPTION
## Resumo

Implementa a decisão **Opção C** da issue #390: o `AuditableInterceptor` agora preenche `CreatedBy`/`UpdatedBy` para entidades que **opt-in** implementando `IAuditableEntity`. Entidades `EntityBase` "puras" continuam recebendo apenas `CreatedAt`/`UpdatedAt` (comportamento original preservado).

## Padrão espelho do PR #389 (Story #127)

| Componente | SoftDeleteInterceptor (#127) | AuditableInterceptor (#390) |
|---|---|---|
| Constructor | `IUserContext? = null` | `IUserContext? = null` ✅ |
| Fallback | `"system"` | `"system"` ✅ |
| Guard | `IsAuthenticated && UserId.Length > 0` | `IsAuthenticated && UserId.Length > 0` ✅ |
| DI | Scoped (captive dependency) | Scoped (captive dependency) ✅ |
| Trigger | `EntityState.Deleted` | `EntityState.Added` / `Modified` |
| Alvo | `EntityBase.MarkAsDeleted(by)` | `Property("CreatedBy"/"UpdatedBy")` (guarded) |

## Critérios de aceite atendidos

- [x] `IAuditableEntity` ganhou XMLDoc explicando quando implementar
- [x] `AuditableInterceptor` recebe `IUserContext?` opcional; ctor sem args preservado
- [x] Iteração por `EntityBase` entries; ramo `IAuditableEntity` guardado por type check
- [x] Fallback `"system"` em fluxos sem principal autenticado
- [x] `CreatedAt`/`UpdatedAt` continuam funcionando para qualquer `EntityBase`
- [x] DI `Scoped` nos 3 módulos (selecao, ingresso, portal)
- [x] **`EntityBase` NÃO tocado** (decisão deliberada da Opção C)
- [x] 5 novos testes cobrindo todos os cenários da issue
- [x] Cenários originais permanecem verdes
- [x] Sem migração EF Core (deferida para #155)

## Testes

`AuditableInterceptorTests`: **9/9 verdes** (4 originais + 5 novos).

Suite completa: **635/635 verdes** (Application.Abstractions + Kernel + ArchTests + Selecao.ArchTests + Ingresso.ArchTests + Infrastructure.Core).

Codex pre-commit: **APROVADO** sem P0/P1/P2.

## Fora de escopo (issues separadas)

- Fitness test ArchUnitNET enforçando `IAuditableEntity` em operações administrativas — abrir quando primeiro pacote `Operacoes`/`Decisoes` aparecer.
- Migração de entidades existentes para `IAuditableEntity` — decisão de domínio por entidade (`Convocacao.ConvocadoPor`?).

## Riscos

- **EF Core convention**: `entry.Property(nameof(IAuditableEntity.CreatedBy))` requer que a entidade concrete declare a propriedade com getter público (ex.: `public string? CreatedBy { get; private set; }`). Implementação explícita da interface, `Ignore` em configuração ou propriedade computada violariam o contrato — documentado no XMLDoc da interface.

Closes #390
Refs #127
