### PR TITLE
ci(security): configurar Trivy para scanning de imagens Docker e deps NuGet

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,144 @@
+name: Trivy
+
+# Varredura de vulnerabilidades (issue #24, ADR-0015 — "Snyk / Trivy"):
+#   1. `trivy fs` — dependências NuGet declaradas + lock files
+#   2. `trivy image` — vulnerabilidades das imagens Docker dos 3 módulos
+#
+# Resultados em SARIF alimentam a aba Security do GitHub via upload-sarif
+# (mesmo padrão do codeql.yml). Initial mode: alerta (não-bloqueante) —
+# severidade CRITICAL/HIGH listada mas exit code zero, permitindo merge
+# enquanto a baseline é triada. Elevação para required check (`exit-code: 1`)
+# fica para fase futura quando triagem inicial estiver completa.
+
+on:
+  push:
+    branches: [main]
+    # paths-ignore evita execução em PRs/pushes docs-only — sem código C# /
+    # Dockerfile alterado o sinal do Trivy é redundante com o schedule.
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
+  schedule:
+    # Sábado 04:00 UTC (= 01:00 BRT). Janela noturna de baixo tráfego no fim
+    # de semana; capta CVEs novos publicados na semana sem requerer push.
+    - cron: '0 4 * * 6'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+concurrency:
+  group: trivy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trivy-fs:
+    name: Trivy filesystem (NuGet + config)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Trivy — fs scan
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          # CRITICAL e HIGH viram alertas no GitHub Security; LOW/MEDIUM
+          # ficam fora do gate inicial para reduzir ruído (alinhado com
+          # política Snyk/Trivy da ADR-0015).
+          severity: CRITICAL,HIGH
+          # Sem `limit-severities-for-sarif: 'true'` o entrypoint da action
+          # ignora `severity` no path SARIF e a aba Security recebe TUDO
+          # (incluindo UNKNOWN/LOW/MEDIUM) — anula o filtro acima.
+          limit-severities-for-sarif: 'true'
+          # exit-code 0: não bloqueia PR; reporta para Security tab.
+          # Quando a baseline estiver triada, mudar para `1` faz virar gate.
+          exit-code: '0'
+          # Skip pastas que não chegam em produção — testes (FsCheck/Bogus)
+          # e docs poluiriam o report sem rodar em runtime.
+          skip-dirs: 'tests,docs'
+          # Habilita download cacheado do DB do Trivy via GHA cache —
+          # primeira execução ~2 min, subsequentes <30s.
+          cache: 'true'
+
+      - name: Upload SARIF (fs)
+        # `if: always()` garante upload mesmo se scan falhar internamente —
+        # importante para auditoria de runs que não geraram resultado.
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-fs.sarif
+          # `category` separa os resultados na aba Security entre os 4 scans
+          # (fs + 3 imagens), evitando que findings sobrescrevam uns aos outros.
+          category: trivy-fs
+
+  trivy-image:
+    name: Trivy image (${{ matrix.module }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mesmos 3 módulos do publish-images.yml. Mantém o set sincronizado
+        # — se um Dockerfile.X novo nascer, atualizar ambos.
+        module:
+          - selecao
+          - ingresso
+          - portal
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build local (sem push)
+        # `cache-from` aponta para o mesmo scope do publish-images.yml; o
+        # cache GHA é isolado por branch, então PRs partem do zero na
+        # primeira execução do branch e subsequentes herdam. Pushes em main
+        # se beneficiam do cache acumulado pelo próprio Trivy ali — não
+        # alimentamos cache aqui (sem `cache-to`) para não competir com o
+        # workflow de publish.
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile.${{ matrix.module }}
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: trivy-scan/uniplus-api-${{ matrix.module }}:ci
+          cache-from: type=gha,scope=${{ matrix.module }}
+
+      - name: Trivy — image scan
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: trivy-scan/uniplus-api-${{ matrix.module }}:ci
+          format: sarif
+          output: trivy-image-${{ matrix.module }}.sarif
+          severity: CRITICAL,HIGH
+          # Mesmo motivo do scan fs: sem este flag, severity é ignorado em
+          # output SARIF.
+          limit-severities-for-sarif: 'true'
+          exit-code: '0'
+          cache: 'true'
+
+      - name: Upload SARIF (image)
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-image-${{ matrix.module }}.sarif
+          category: trivy-image-${{ matrix.module }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -50,7 +50,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Trivy — fs scan
-        uses: aquasecurity/trivy-action@0.35.0
+        # Pin imutável (Codex P1): trivy-action é third-party e teve incidente
+        # de supply chain em março/2026 via retargeting de tag mutável. Para as
+        # actions de orgs auditadas (actions/, docker/, github/) o projeto
+        # mantém pin por major (consistência com codeql.yml e publish-images.yml).
+        # Atualizar este SHA exige PR explícito com diff visível do release notes.
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -124,7 +129,12 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.module }}
 
       - name: Trivy — image scan
-        uses: aquasecurity/trivy-action@0.35.0
+        # Pin imutável (Codex P1): trivy-action é third-party e teve incidente
+        # de supply chain em março/2026 via retargeting de tag mutável. Para as
+        # actions de orgs auditadas (actions/, docker/, github/) o projeto
+        # mantém pin por major (consistência com codeql.yml e publish-images.yml).
+        # Atualizar este SHA exige PR explícito com diff visível do release notes.
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: trivy-scan/uniplus-api-${{ matrix.module }}:ci
           format: sarif


### PR DESCRIPTION
## Resumo

Adiciona workflow `.github/workflows/trivy.yml` com varredura de vulnerabilidades em duas dimensões (ADR-0015 / Snyk-Trivy):

1. **`trivy fs`** — dependências NuGet declaradas + arquivos de configuração.
2. **`trivy image`** — matriz de 3 módulos (selecao, ingresso, portal), espelhando o set do `publish-images.yml`. Build local sem push, scan da imagem resultante.

Resultados em SARIF alimentam a aba **Security** do GitHub via `github/codeql-action/upload-sarif@v4` (mesmo padrão do `codeql.yml`).

## Critérios de aceite atendidos

- [x] Workflow ou job no CI que executa `trivy image` nas imagens Docker buildadas
- [x] Scanning de vulnerabilidades em dependências do projeto (`trivy fs`)
- [x] Resultados em formato SARIF integrados com GitHub Security (Code Scanning)
- [x] Zero CVEs critical como quality gate (alerta, não bloqueante inicialmente)

## Configurações chave

| Item | Valor | Por quê |
|---|---|---|
| `severity` | `CRITICAL,HIGH` | Reduz ruído de baselines longas — alinhado com ADR-0015 |
| `limit-severities-for-sarif` | `'true'` | **Sem isso o filtro `severity` é ignorado no output SARIF** — todas as severidades vazariam para Security tab (Codex P1) |
| `exit-code` | `'0'` | Não-bloqueante inicialmente; eleva para `1` quando baseline triada |
| `skip-dirs` (fs) | `tests,docs` | Exclui FsCheck/Bogus e docs do scan — não chegam em produção |
| Trigger | PR + push main + cron sábado 04:00 UTC + dispatch | `cron` capta CVEs novos sem push |
| `paths-ignore` | `docs/**`, `**.md`, `.github/ISSUE_TEMPLATE/**` | PRs docs-only não disparam |

## Trade-offs aceitos

- **Cache GHA é isolado por branch** (Codex apontou): PRs novos pagam custo de build na primeira run; subsequentes do mesmo branch herdam. Workflow só faz `cache-from`, sem `cache-to`, para não competir com `publish-images.yml`. Tempo esperado: ~3-5 min por imagem na primeira run, <1 min subsequente.
- **Trivy action pinado em `0.35.0`** (atual): bump deste recurso de segurança é mais importante que o status quo em `0.28.0`. Outras actions (`checkout@v5`, `build-push-action@v5`, `setup-buildx-action@v3`) mantidas no major usado no resto do repo (consistência > novidade).

## Codex pre-commit

- **P1 SARIF severity filter**: resolvido com `limit-severities-for-sarif: 'true'`
- **P2 Trivy action version**: bump `0.28.0` → `0.35.0` aplicado
- **P2 docker actions outdated**: deferido — mantém consistência com `publish-images.yml`/`ci.yml` que usam mesmas versões

## Notas operacionais

- Primeira run pode demorar (~5-8 min) — DB do Trivy + build de 3 imagens sem cache prévio. Subsequentes <2 min.
- Findings aparecerão na aba **Security → Code Scanning Alerts** após primeiro merge em `main`. Categorias separadas: `trivy-fs`, `trivy-image-selecao`, `trivy-image-ingresso`, `trivy-image-portal`.

Closes #24
