### PR TITLE
test(shared): smoke integração do CorrelationIdMiddleware via WebApplicationFactory

### DIFF
--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/CorrelationIdMiddlewareSmokeTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/CorrelationIdMiddlewareSmokeTests.cs
@@ -1,0 +1,118 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Middleware;
+
+using System.Net.Http;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
+
+// Smoke tests do CorrelationIdMiddleware via WebApplicationFactory<Program>
+// (issues #116 / #117). Cobrem o que os 25 testes unitários do middleware
+// (DefaultHttpContext) NÃO conseguem cobrir: ordem de registro em
+// Program.cs, propagação ao longo do pipeline real e comportamento
+// post-OnStarting com a resposta sendo flushada.
+//
+// Cada cenário é uma proteção contra regressão de wiring específica:
+//
+//   CA-03 (gerar): se `AddCorrelationIdMiddleware` for removido do
+//          ServiceCollection ou `UseMiddleware<CorrelationIdMiddleware>`
+//          sair do Program.cs, o header some.
+//   CA-04 (ecoar): se o middleware mover para depois do response start
+//          handler, OnStarting não é chamado e o valor do client é
+//          descartado.
+//   CA-05 (sanitizar): se o regex de validação degradar para algo mais
+//          permissivo (ex.: deixar passar `\r\n`), o teste falha — defesa
+//          contra log injection cross-pipeline.
+public sealed class CorrelationIdMiddlewareSmokeTests : IClassFixture<InfraCoreApiFactory>
+{
+    private static readonly Uri HealthUri = new("/health", UriKind.Relative);
+
+    private readonly InfraCoreApiFactory _factory;
+
+    public CorrelationIdMiddlewareSmokeTests(InfraCoreApiFactory factory) => _factory = factory;
+
+    [Fact(DisplayName = "GET /health sem X-Correlation-Id — resposta contém UUID v4 gerado")]
+    public async Task SemHeader_DeveGerarCorrelationIdUuid()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(HealthUri);
+
+        string correlationId = ExtrairCorrelationId(response);
+        ValidarUuidV4(correlationId);
+    }
+
+    [Fact(DisplayName = "GET /health com X-Correlation-Id válido — resposta ecoa o valor enviado")]
+    public async Task ComHeaderValido_DeveEcoarMesmoValor()
+    {
+        const string idEnviado = "abc-123";
+        using HttpClient client = _factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Get, HealthUri);
+        request.Headers.Add(CorrelationIdMiddleware.HeaderName, idEnviado);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        string correlationId = ExtrairCorrelationId(response);
+        correlationId.Should().Be(idEnviado);
+    }
+
+    [Fact(DisplayName = "GET /health com X-Correlation-Id contendo CRLF — resposta sanitiza com UUID v4 distinto (log injection defense)")]
+    public async Task ComHeaderCrLf_DeveDescartarValorSanitizando()
+    {
+        // O middleware aceita apenas `^[A-Za-z0-9\-_.]{1,128}$`. CRLF cai fora
+        // do alfabeto permitido e dispara o fallback para Guid.NewGuid().
+        //
+        // `TryAddWithoutValidation` é necessário porque o HttpClient valida o
+        // valor do header antes de enviar e rejeita CRLF cliente-side com
+        // FormatException. O TestServer em uso pelo WebApplicationFactory é
+        // mais permissivo do que o Kestrel produtivo nesse aspecto — aceita
+        // o byte e entrega ao middleware, que então valida via regex e cai
+        // para UUID. Em produção, Kestrel rejeitaria com 400; o smoke aqui
+        // garante a defesa de profundidade do middleware em qualquer
+        // transporte que entregue o valor cru.
+        const string idForjado = "abc\r\n[admin] forjado";
+        using HttpClient client = _factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Get, HealthUri);
+
+        // Provar que o header REALMENTE saiu com o valor CRLF antes de afirmar
+        // que o servidor o sanitizou. Sem isso, se uma versão futura do
+        // HttpClient passar a rejeitar CRLF silenciosamente (TryAddWithout-
+        // Validation retorna false), o request sairia sem header e o teste
+        // viraria falso positivo do cenário "sem header → UUID gerado".
+        bool adicionou = request.Headers.TryAddWithoutValidation(CorrelationIdMiddleware.HeaderName, idForjado);
+        adicionou.Should().BeTrue(
+            "TryAddWithoutValidation deve aceitar CRLF; se rejeitar, o smoke não exercita CA-05");
+        request.Headers.GetValues(CorrelationIdMiddleware.HeaderName)
+            .Should().ContainSingle().Which.Should().Be(idForjado,
+                "header precisa carregar o valor CRLF intacto para validar a defesa do middleware");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        string correlationId = ExtrairCorrelationId(response);
+        correlationId.Should().NotBe(idForjado,
+            "CRLF não passa pela regex de validação e o middleware deve gerar um UUID novo");
+        ValidarUuidV4(correlationId);
+    }
+
+    private static string ExtrairCorrelationId(HttpResponseMessage response)
+    {
+        response.Headers.TryGetValues(CorrelationIdMiddleware.HeaderName, out IEnumerable<string>? valores)
+            .Should().BeTrue($"resposta deveria conter o header `{CorrelationIdMiddleware.HeaderName}`");
+        string? correlationId = valores?.FirstOrDefault();
+        correlationId.Should().NotBeNullOrWhiteSpace();
+        return correlationId!;
+    }
+
+    private static void ValidarUuidV4(string correlationId)
+    {
+        Guid.TryParse(correlationId, out Guid parsed).Should().BeTrue(
+            $"correlation id `{correlationId}` deveria ser um UUID parseável");
+        // RFC 9562 §5.4 — versão fica nos 4 bits altos do byte 7 do payload
+        // big-endian. Em .NET 10 `Guid` é little-endian para os primeiros 3
+        // grupos, então o byte físico que carrega a versão é o índice 7 do
+        // ToByteArray() (não o índice 6).
+        byte versionByte = parsed.ToByteArray()[7];
+        int version = (versionByte & 0xF0) >> 4;
+        version.Should().Be(4, "Guid.NewGuid() emite RFC 9562 versão 4 random-based");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/InfraCoreApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/InfraCoreApiFactory.cs
@@ -1,0 +1,46 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Middleware;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+// Fixture canônica para smoke tests do pipeline de middleware shared
+// (issue #117 / #116). Hospeda o Program.cs do Selecao.API porque os
+// 3 módulos (Selecao/Ingresso/Portal) cabeiam o middleware do
+// Infrastructure.Core identicamente — cobrir via Selecao prova o
+// pattern para o caso atual.
+//
+// Risco residual aceito: drift de wiring entre Selecao/Ingresso/Portal
+// não é coberto por este smoke (não há arch test enforçando paridade
+// hoje; CodeQL não prova ordem de middleware). Decisão CA-01 revisitada
+// na issue #117 — quando o custo do drift aparecer, promover para
+// matriz de 3 fixtures (uma por API) ou criar arch test que cabreie a
+// invariante.
+//
+// Herda toda a infraestrutura do ApiFactoryBase:
+//   - Wolverine + MigrationHostedService removidos (sem PG/Kafka reais)
+//   - OpenTelemetry exporter silenciado (env var no static ctor)
+//   - Health checks de infra externa filtrados
+//   - TestAuthHandler plugado (scheme "Test")
+//   - UseEnvironment("Development") — reusa appsettings.Development.json
+//
+// `GetConfigurationOverrides` fornece valores fake para chaves que o
+// Program.cs lê em boot: connection string e Auth metadata. Sem eles,
+// o `WebApplication.CreateBuilder` lançaria InvalidOperationException
+// antes do primeiro request.
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x IClassFixture<T> requires the fixture type to be public.")]
+public sealed class InfraCoreApiFactory : ApiFactoryBase<Program>
+{
+    protected override IEnumerable<KeyValuePair<string, string?>> GetConfigurationOverrides() =>
+    [
+        // Connection string fake — Wolverine + MigrationHostedService já foram
+        // removidos pela ApiFactoryBase, mas a validação inicial em
+        // `AddSelecaoInfrastructure` ainda lê o valor (rejeita whitespace).
+        new("ConnectionStrings:SelecaoDb", "Host=localhost;Port=5432;Database=uniplus_smoke;Username=u;Password=u"),
+        new("Auth:Authority", "http://localhost/test-realm"),
+        new("Auth:Audience", "uniplus"),
+    ];
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/README.md
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/README.md
@@ -1,0 +1,106 @@
+# Smoke tests do pipeline de middleware
+
+Suíte canônica de smoke tests para o pipeline de middleware shared do
+`Infrastructure.Core`. Cobre o que os testes unitários (com
+`DefaultHttpContext`) não conseguem: ordem de registro em `Program.cs`,
+dependências de DI cruzadas e comportamento do servidor HTTP real.
+
+**Origem:** issue [#117](https://github.com/unifesspa-edu-br/uniplus-api/issues/117)
+(Story pai), [#116](https://github.com/unifesspa-edu-br/uniplus-api/issues/116)
+(primeira Task — `CorrelationIdMiddleware`).
+
+## Convenção para adicionar um novo smoke
+
+A `ApiFactoryBase<TEntryPoint>` em `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/`
+faz a maior parte do trabalho — Wolverine, MigrationHostedService,
+OpenTelemetry exporter e health checks de infra externa já são removidos
+ali. Para um middleware novo, geralmente bastam **3 passos** (~20 linhas):
+
+### 1. Reuso da fixture canônica
+
+A fixture `InfraCoreApiFactory` (neste diretório) hospeda o `Program.cs`
+do Selecao.API e fornece os overrides mínimos de configuração. Reusar
+quando o smoke não exigir setup específico:
+
+```csharp
+public sealed class MeuMiddlewareSmokeTests : IClassFixture<InfraCoreApiFactory>
+{
+    private readonly InfraCoreApiFactory _factory;
+
+    public MeuMiddlewareSmokeTests(InfraCoreApiFactory factory) => _factory = factory;
+
+    [Fact]
+    public async Task Cenario_Esperado()
+    {
+        using HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync("/health");
+        // asserts no header / corpo / status code...
+    }
+}
+```
+
+### 2. Fixture especializada (quando precisar de overrides extras)
+
+Se o middleware exigir configuração específica (ex.: feature flag, header
+adicional, scheme de auth diferente), derivar uma fixture nova:
+
+```csharp
+public sealed class RateLimitApiFactory : ApiFactoryBase<Program>
+{
+    protected override IEnumerable<KeyValuePair<string, string?>> GetConfigurationOverrides() =>
+    [
+        new("ConnectionStrings:SelecaoDb", "Host=localhost;Port=5432;Database=u;Username=u;Password=u"),
+        new("Auth:Authority", "http://localhost/test-realm"),
+        new("Auth:Audience", "uniplus"),
+        new("RateLimit:Enabled", "true"),
+        new("RateLimit:RequestsPerMinute", "5"),
+    ];
+}
+```
+
+### 3. Cenários
+
+Cada smoke deve cobrir **proteções de wiring que o unit test não pega**:
+
+- Ordem de registro: middleware está antes/depois do que precisa?
+- DI: o middleware resolve suas dependências no pipeline real?
+- HTTP server: parsing de headers, encoding, content-type — algo que o
+  `DefaultHttpContext` mente?
+
+Use o `CorrelationIdMiddlewareSmokeTests` como template literal: 3 cenários
+(feliz, feliz-com-input, defesa-de-segurança).
+
+## O que NÃO é smoke aqui
+
+- **Testes funcionais de domínio** (Edital, Inscrição, etc.) — esses ficam
+  em `Selecao.IntegrationTests` ou `Ingresso.IntegrationTests`.
+- **Testes que exigem PostgreSQL/Kafka/MinIO reais** — usar `Testcontainers`
+  num `*.IntegrationTests` modular, não aqui.
+- **Testes E2E** com browser/UI — fora do escopo do backend.
+
+## Por que o Selecao.API e não os 3
+
+Os 3 módulos (Selecao/Ingresso/Portal) cabeiam o middleware do
+`Infrastructure.Core` identicamente no `Program.cs`. Smoke contra um
+deles prova o pattern para o caso atual com custo de manutenção mínimo
+(1 fixture, 1 ProjectReference).
+
+**Risco residual aceito:** drift de wiring entre módulos não é
+exercitado por este smoke. Hoje não há arch test enforçando paridade
+da ordem de middleware entre `Selecao`, `Ingresso` e `Portal`, e o
+CodeQL default não prova essa invariante. Mitigações disponíveis se o
+custo do drift aparecer:
+
+- Promover esta suíte a matriz de 3 fixtures (uma por API).
+- Criar arch test em `Unifesspa.UniPlus.ArchTests` cabreando "todos os
+  `Program.cs` chamam `UseMiddleware<CorrelationIdMiddleware>` na mesma
+  posição relativa a `UseAuthentication`/`UseRouting`".
+
+Issue #117 documenta a decisão CA-01 revisitada e mantém esses dois
+caminhos como follow-up explícito.
+
+## Performance esperada
+
+A fixture `InfraCoreApiFactory` sobe em <2s. Cada smoke individual leva
+~5-300ms. Suíte inteira deve fechar em poucos segundos — se passar de 30s
+algo está errado (alguma dep externa real foi reativada).

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj
@@ -13,11 +13,21 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Testcontainers.PostgreSql" />
+    <!-- WebApplicationFactory<Program> para smoke tests do pipeline HTTP
+         (issue #117 / #116). Os outros *.IntegrationTests por módulo já
+         usam o mesmo pacote — versão central via Directory.Packages.props. -->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\shared\Unifesspa.UniPlus.Infrastructure.Core\Unifesspa.UniPlus.Infrastructure.Core.csproj" />
     <ProjectReference Include="..\Unifesspa.UniPlus.IntegrationTests.Fixtures\Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj" />
+    <!-- Selecao.API hospeda o Program.cs usado pelos smoke tests de
+         middleware shared. O middleware do Infrastructure.Core é cabeado
+         identicamente nos 3 Programs (Selecao/Ingresso/Portal); cobrir
+         via Selecao prova o pattern. Drift cross-module é coberto por
+         CodeQL e arch tests, não por este smoke. -->
+    <ProjectReference Include="..\..\src\selecao\Unifesspa.UniPlus.Selecao.API\Unifesspa.UniPlus.Selecao.API.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -14,6 +14,17 @@
         "resolved": "8.0.1",
         "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Hosting": "10.0.7"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[10.0.7, )",
@@ -1156,6 +1167,46 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "unifesspa.uniplus.selecao.api": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.0, )",
+          "WolverineFx.Postgresql": "[5.39.0, )"
+        }
+      },
+      "unifesspa.uniplus.selecao.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Selecao.Domain": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.selecao.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.selecao.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.14.0, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.7, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.7, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )"
+        }
+      },
       "Apache.Avro": {
         "type": "CentralTransitive",
         "requested": "[1.12.1, )",
@@ -1203,6 +1254,16 @@
         "resolved": "12.1.1",
         "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
       },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
         "type": "CentralTransitive",
         "requested": "[10.0.7, )",
@@ -1210,17 +1271,6 @@
         "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
         "dependencies": {
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
-        }
-      },
-      "Microsoft.AspNetCore.Mvc.Testing": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
-        "dependencies": {
-          "Microsoft.AspNetCore.TestHost": "10.0.7",
-          "Microsoft.Extensions.DependencyModel": "10.0.7",
-          "Microsoft.Extensions.Hosting": "10.0.7"
         }
       },
       "Microsoft.AspNetCore.OpenApi": {
@@ -1255,13 +1305,13 @@
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.0.7, )",
-        "resolved": "10.0.4",
-        "contentHash": "DOTjTHy93W3TwpMLM4SCm0n57Sc0Jj3+m2S6LSTstKyBB34eT1UouaMS19mpWwvtj42+sRiEjA3+rOTNoNzXFQ==",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.4",
-          "Microsoft.Extensions.Caching.Memory": "10.0.4",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
-          "Microsoft.Extensions.Logging": "10.0.4"
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {


### PR DESCRIPTION
## Resumo

Implementa Task #116 (Story #117): 3 smoke tests do `CorrelationIdMiddleware` via `WebApplicationFactory<Program>`. Cobrem ordem de registro em `Program.cs`, propagação ao longo do pipeline HTTP real e comportamento post-`OnStarting` — o que os 25 unit tests com `DefaultHttpContext` não conseguem.

## Critérios de aceite atendidos

- **CA-03** ✅ `GET /health` sem `X-Correlation-Id` → resposta contém UUID v4 gerado
- **CA-04** ✅ `GET /health` com `X-Correlation-Id: abc-123` → resposta ecoa o valor
- **CA-05** ✅ `GET /health` com CRLF no header → fallback UUID v4 distinto (log injection defense via regex `^[A-Za-z0-9\-_.]{1,128}$`)
- **CA-07** ✅ Convenção documentada em `README.md` no diretório Middleware/

## Decisões revisitadas (justificadas no commit + README)

| AC original | Decisão aplicada | Por quê |
|---|---|---|
| **CA-01** novo projeto vs reuso | Reuso de `Infrastructure.Core.IntegrationTests` (renomeado de `Infrastructure.Common` no PR #126) + ProjectReference para `Selecao.API` | Projeto JÁ existe pós-refactor #126; ProjectReference 1-way para Selecao.API hospeda `Program` |
| **CA-02** `UseEnvironment("Testing")` | `UseEnvironment("Development")` (default da `ApiFactoryBase`) | Reusa `appsettings.Development.json`; criar `appsettings.Testing.json` sem ROI |
| **CA-07** classe base `MiddlewareSmokeTestBase<TEntryPoint>` | `README.md` de convenção + reuso da `ApiFactoryBase<TEntryPoint>` já existente | A base hipotética seria ~5 helpers `protected static`; `ApiFactoryBase` já entrega 80% |
| **escopo** matriz 3 APIs | Selecao.API como host genérico | Wiring é idêntico nos 3 Programs; promoção para matriz fica como follow-up se drift cross-module aparecer (risco residual documentado) |

## Implementação

### Pre-work no csproj (3 linhas)

- `Microsoft.AspNetCore.Mvc.Testing` package
- `ProjectReference` para `Selecao.API` (necessário para `WebApplicationFactory<Program>`)

### Código novo

- `Middleware/InfraCoreApiFactory.cs` — fixture canônica `: ApiFactoryBase<Program>`. Reusa Wolverine removal + MigrationHostedService removal + OTel silence + health check filter + test auth scheme já em `ApiFactoryBase`.
- `Middleware/CorrelationIdMiddlewareSmokeTests.cs` — 3 `[Fact]` com helpers `ExtrairCorrelationId` + `ValidarUuidV4` (RFC 9562 §5.4 — byte 7 do `ToByteArray()` legacy/mixed-endian).
- `Middleware/README.md` — convenção (CA-07) com 3 seções: reuso da fixture canônica, especialização (quando criar nova fixture), fora de escopo.

## Codex pre-commit

Aplicados 2 findings (P1 + P2):

- **P1 CA-05 false-positive risk**: `TryAddWithoutValidation` retornava `bool` ignorado. Se versão futura do `HttpClient` rejeitar CRLF silenciosamente, request sairia sem header e o teste viraria falso positivo do cenário "sem-header → UUID". Fix: guards `adicionou.Should().BeTrue(...)` + `request.Headers.GetValues(...).Should().ContainSingle().Which.Should().Be(idForjado)`.
- **P2 over-claim cross-module**: README + comentário da fixture afirmavam que "drift cross-module é coberto por CodeQL e arch tests". Não é — não há arch test enforçando paridade de ordem de middleware hoje. Reescrito como risco residual aceito explicitamente, com 2 caminhos de mitigação se aparecer (matriz 3 fixtures ou arch test dedicado).

## Validação

- 3 smoke tests verdes localmente (`/health` responde 503 por OIDC discovery fake → expected; teste foca no header)
- Suite `Infrastructure.Core.IntegrationTests` completa (10/10)
- Suite `Selecao.IntegrationTests` completa (61/61)
- Arch tests verdes
- Build sem warnings (`TreatWarningsAsErrors`)

Closes #116
Refs #117
