### PR TITLE
feat(observability): emitir TraceId/SpanId no body do log Console para drill-down Loki↔Tempo (#417)

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Logging/SerilogConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Logging/SerilogConfiguration.cs
@@ -40,8 +40,12 @@ public static class SerilogConfiguration
     /// parsing por humanos durante troubleshooting e mantém a regra <c>TraceId=...</c>
     /// no fim da linha (próxima ao <c>NewLine</c>), padrão amplamente
     /// reconhecido por regex log scrapers.</para>
+    /// <para><strong>Visibilidade:</strong> <c>internal</c> deliberadamente — é detalhe
+    /// de configuração interna; o assembly <c>Unifesspa.UniPlus.Infrastructure.Core.UnitTests</c>
+    /// recebe acesso via <c>InternalsVisibleTo</c> para sentinelas. Pattern consistente
+    /// com <see cref="Middleware.CorrelationIdMiddleware.FormatoValidoPattern"/>.</para>
     /// </remarks>
-    public const string ConsoleOutputTemplate =
+    internal const string ConsoleOutputTemplate =
         "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j} TraceId={TraceId} SpanId={SpanId}{NewLine}{Exception}";
 
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Logging/SerilogConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Logging/SerilogConfiguration.cs
@@ -21,6 +21,31 @@ using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 public static class SerilogConfiguration
 {
     /// <summary>
+    /// Template de saída do <c>WriteTo.Console(...)</c> — inclui <c>TraceId=&lt;hex&gt;</c>
+    /// e <c>SpanId=&lt;hex&gt;</c> no body do log line. Esse formato é contrato com o
+    /// <c>derivedFields</c> do datasource Loki do Grafana
+    /// (<c>uniplus-infra</c> PR #225), cuja regex
+    /// <c>(?:traceID|trace_id|TraceId)["]?[=:]\s*["]?([a-fA-F0-9]{32})</c> captura o
+    /// <c>TraceId</c> e gera o link <em>"Ver trace no Tempo"</em>.
+    /// </summary>
+    /// <remarks>
+    /// <para><strong>Invariante</strong>: qualquer refactor que altere a posição ou
+    /// formato de <c>TraceId=</c> ou <c>SpanId=</c> quebra o drill-down log↔trace no
+    /// Grafana — defeito silencioso (CI verde, smoke visual quebrado). Sentinel test
+    /// em <c>SerilogConfigurationTests.OutputTemplate_DeveConterTraceIdESpanId_*</c>
+    /// trava regressões.</para>
+    /// <para><strong>Posição do <c>{Properties:j}</c>:</strong> precede <c>TraceId</c>/<c>SpanId</c>
+    /// para que as propriedades estruturadas (<c>CorrelationId</c>, <c>ServiceName</c>,
+    /// custom enrichers) saiam em JSON inline antes do par chave-valor textual — facilita
+    /// parsing por humanos durante troubleshooting e mantém a regra <c>TraceId=...</c>
+    /// no fim da linha (próxima ao <c>NewLine</c>), padrão amplamente
+    /// reconhecido por regex log scrapers.</para>
+    /// </remarks>
+    public const string ConsoleOutputTemplate =
+        "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j} TraceId={TraceId} SpanId={SpanId}{NewLine}{Exception}";
+
+
+    /// <summary>
     /// Sobrecarga sem nome de serviço — mantida para callers que ainda não precisam
     /// rotular logs com <c>service.name</c>/<c>service.namespace</c> no Loki.
     /// O sink OTLP é registrado mesmo assim (quando o toggle está ativo); apenas
@@ -69,7 +94,13 @@ public static class SerilogConfiguration
             .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
             .Enrich.FromLogContext()
-            .Enrich.With<PiiMaskingEnricher>();
+            .Enrich.With<PiiMaskingEnricher>()
+            // TraceContextEnricher popula TraceId/SpanId a partir de Activity.Current
+            // (ADR-0018) — invariante para o derivedFields do Loki no Grafana renderizar
+            // o link "Ver trace no Tempo". Registrado APÓS PiiMaskingEnricher (preserva
+            // ordem ADR-0011) e ANTES dos sinks (Console renderiza no outputTemplate;
+            // OTLP popula via IncludedData.TraceIdField independentemente do enricher).
+            .Enrich.With<TraceContextEnricher>();
 
         // ServiceNameEnricher é o segundo componente da ADR-0052: popula a propriedade
         // Serilog `ServiceName` em cada log event, visível em consumidores que não falam
@@ -82,7 +113,9 @@ public static class SerilogConfiguration
             loggerConfiguration.Enrich.With(new ServiceNameEnricher(nomeServico));
         }
 
-        loggerConfiguration.WriteTo.Console(formatProvider: CultureInfo.InvariantCulture);
+        loggerConfiguration.WriteTo.Console(
+            outputTemplate: ConsoleOutputTemplate,
+            formatProvider: CultureInfo.InvariantCulture);
 
         bool observabilidadeAtivada = configuration.GetValue(
             OpenTelemetryConfiguration.EnabledConfigurationKey,

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Logging/TraceContextEnricher.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Logging/TraceContextEnricher.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Logging;
+
+using System.Diagnostics;
+
+using Serilog.Core;
+using Serilog.Events;
+
+/// <summary>
+/// Enricher Serilog que popula <c>TraceId</c> e <c>SpanId</c> em cada
+/// <see cref="LogEvent"/> a partir de <see cref="Activity.Current"/>. Mantém
+/// invariante do pipeline ADR-0018: logs emitidos por sinks textuais (Console,
+/// JSON export) carregam os identificadores W3C do trace ativo, permitindo que
+/// o <c>derivedFields</c> do datasource Loki do Grafana (regex
+/// <c>(?:traceID|trace_id|TraceId)["]?[=:]\s*["]?([a-fA-F0-9]{32})</c>)
+/// reconstrua o link clicável <em>"Ver trace no Tempo"</em>.
+/// </summary>
+/// <remarks>
+/// <para><strong>Por que custom em vez de <c>Serilog.Enrichers.Span</c>?</strong>
+/// Zero dependência adicional, mesmo pattern do
+/// <see cref="ServiceNameEnricher"/> (PR #411 / ADR-0052), e total controle do
+/// formato emitido — alinhado com a regex do derivedFields configurada no
+/// PR <c>uniplus-infra#225</c>.</para>
+/// <para><strong>Comportamento quando <see cref="Activity.Current"/> é null</strong>
+/// (logs antes do <c>app.UseRouting()</c>, ou hosted services sem instrumentação
+/// OTel): emite <c>TraceId</c>/<c>SpanId</c> como string vazia. Output do Console
+/// fica como <c>TraceId= SpanId=</c> — a regex do <c>derivedFields</c> exige
+/// 32 hex chars após o <c>=</c>, então não casa, não gera link
+/// spurious para um trace que não existe. Mantemos as propriedades sempre
+/// presentes (mesmo que vazias) para preservar a estrutura do log JSON em
+/// exportações e evitar que o template Console renderize <c>{TraceId}</c>
+/// literal quando a property estaria ausente.</para>
+/// <para><strong>Ordem do pipeline preservada</strong> (ADR-0011): registrado
+/// APÓS o <see cref="PiiMaskingEnricher"/> e ANTES dos sinks. Os valores
+/// emitidos são opacos (hex hash) sem PII — não exigem masking
+/// — mas a precedence é mantida por consistência da pipeline.</para>
+/// </remarks>
+public sealed class TraceContextEnricher : ILogEventEnricher
+{
+    /// <summary>Nome da propriedade Serilog correspondente ao <c>TraceId</c> W3C.</summary>
+    public const string TraceIdPropertyName = "TraceId";
+
+    /// <summary>Nome da propriedade Serilog correspondente ao <c>SpanId</c> W3C.</summary>
+    public const string SpanIdPropertyName = "SpanId";
+
+    /// <inheritdoc/>
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        ArgumentNullException.ThrowIfNull(logEvent);
+
+        // Pattern do projeto (espelha PiiMaskingEnricher e ServiceNameEnricher):
+        // valores escalares simples são construídos via `new LogEventProperty(...)`
+        // direto, sem passar pelo `propertyFactory` — este existe para destructuring
+        // de objetos complexos (não é o caso de TraceId/SpanId strings opacas).
+        Activity? current = Activity.Current;
+        string traceId = current?.TraceId.ToString() ?? string.Empty;
+        string spanId = current?.SpanId.ToString() ?? string.Empty;
+
+        logEvent.AddOrUpdateProperty(new LogEventProperty(TraceIdPropertyName, new ScalarValue(traceId)));
+        logEvent.AddOrUpdateProperty(new LogEventProperty(SpanIdPropertyName, new ScalarValue(spanId)));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/GrafanaDerivedFields.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/GrafanaDerivedFields.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Logging;
+
+/// <summary>
+/// Constantes que espelham o <c>derivedFields</c> configurado no datasource Loki
+/// do Grafana (<c>uniplus-infra</c> PR #225). Single source of truth para a
+/// regex consumida tanto por <see cref="TraceContextEnricherTests"/> quanto por
+/// <see cref="SerilogConfigurationTests"/> — evita drift entre cópias dispersas
+/// nos testes quando o datasource for atualizado.
+/// </summary>
+/// <remarks>
+/// A verdade canônica desta regex vive no manifesto do datasource em
+/// <c>uniplus-infra</c>. Esta constante é a contraparte C# que documenta a
+/// invariante e permite asserções de contrato; atualizações lá devem propagar
+/// aqui (e o teste <see cref="SerilogConfigurationTests"/>
+/// <c>ConfigurarSerilog_ComActivityAtiva_DeveEmitirLogLineCasandoDerivedFieldsRegex</c>
+/// falha cedo se o contrato regredir).
+/// </remarks>
+internal static class GrafanaDerivedFields
+{
+    /// <summary>
+    /// Regex exata do <c>derivedFields</c> do datasource Loki — captura o
+    /// <c>TraceId</c> hex32 lowercase no body do log entry para o
+    /// link <em>"Ver trace no Tempo"</em>.
+    /// </summary>
+    public const string TraceIdMatcher = @"(?:traceID|trace_id|TraceId)[""]?[=:]\s*[""]?([a-fA-F0-9]{32})";
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/SerilogConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/SerilogConfigurationTests.cs
@@ -1,0 +1,154 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Logging;
+
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting.Display;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Logging;
+using Unifesspa.UniPlus.Infrastructure.Core.Observability;
+
+/// <summary>
+/// Sentinelas do <see cref="SerilogConfiguration"/> — travam o contrato de
+/// formato do Console sink com o <c>derivedFields</c> do datasource Loki no
+/// Grafana (PR <c>uniplus-infra#225</c>). Refactor que altere a posição ou o
+/// formato dos placeholders <c>TraceId</c>/<c>SpanId</c> falha aqui antes de
+/// quebrar silenciosamente o drill-down log↔trace em produção.
+/// </summary>
+public sealed class SerilogConfigurationTests
+{
+    /// <summary>Regex exata configurada no datasource Loki via PR <c>uniplus-infra#225</c>.</summary>
+    private const string DerivedFieldsRegex = @"(?:traceID|trace_id|TraceId)[""]?[=:]\s*[""]?([a-fA-F0-9]{32})";
+
+    // ─── CA-01: sentinela do outputTemplate ────────────────────────────────
+
+    [Fact]
+    public void ConsoleOutputTemplate_DeveConterPlaceholdersTraceIdESpanId()
+    {
+        SerilogConfiguration.ConsoleOutputTemplate.Should().Contain("{TraceId}",
+            "regex do derivedFields exige `TraceId=<hex32>` no body");
+        SerilogConfiguration.ConsoleOutputTemplate.Should().Contain("{SpanId}",
+            "rastreabilidade de span individual no log line");
+    }
+
+    [Fact]
+    public void ConsoleOutputTemplate_DeveTerSeparadorIgualAposTraceId()
+    {
+        // A regex captura o valor APÓS `=` (ou `:`). Validamos o caractere
+        // separador para que refactor que mude `TraceId=` para `TraceId:` em
+        // teste mantenha a invariante coberta — mesma regra para SpanId.
+        SerilogConfiguration.ConsoleOutputTemplate.Should().MatchRegex(
+            @"TraceId\s*[=:]\s*\{TraceId\}",
+            "derivedFields regex busca por TraceId seguido de = ou : antes do hex");
+        SerilogConfiguration.ConsoleOutputTemplate.Should().MatchRegex(
+            @"SpanId\s*[=:]\s*\{SpanId\}");
+    }
+
+    // ─── CA-02/CA-04: pipeline real emite log que casa a regex ─────────────
+
+    [Fact]
+    public void ConfigurarSerilog_ComActivityAtiva_DeveEmitirLogLineCasandoDerivedFieldsRegex()
+    {
+        // Pipeline real Serilog + Activity ativa + sink que captura a STRING
+        // formatada (não a property). Garante que a regex do derivedFields
+        // realmente casa com o body do log line entregue ao stdout.
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Observability:Enabled"] = "false" })
+            .Build();
+
+        using ActivitySource source = new(nameof(ConfigurarSerilog_ComActivityAtiva_DeveEmitirLogLineCasandoDerivedFieldsRegex));
+        using ActivityListener listener = new()
+        {
+            ShouldListenTo = s => s.Name == source.Name,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        CapturingTextSink sink = new(SerilogConfiguration.ConsoleOutputTemplate);
+        Logger logger = new LoggerConfiguration()
+            .ConfigurarSerilog(configuration, UniPlusServiceNames.Selecao)
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        string traceIdEsperado;
+        try
+        {
+            using Activity? activity = source.StartActivity("smoke");
+            activity.Should().NotBeNull();
+            traceIdEsperado = activity!.TraceId.ToString();
+            logger.Information("requisição processada");
+        }
+        finally
+        {
+            logger.Dispose();
+        }
+
+        sink.Linhas.Should().ContainSingle();
+        string linha = sink.Linhas[0];
+        Match match = Regex.Match(linha, DerivedFieldsRegex);
+        match.Success.Should().BeTrue(
+            $"linha gerada `{linha}` deve casar a regex do derivedFields do Loki");
+        match.Groups[1].Value.Should().Be(traceIdEsperado,
+            "captura da regex deve ser exatamente o TraceId do Activity ativo");
+    }
+
+    [Fact]
+    public void ConfigurarSerilog_SemActivity_NaoDeveEmitirLinhaCasandoDerivedFieldsRegex()
+    {
+        // Garante o caso oposto: sem trace ativo, a linha emitida não casa a
+        // regex — derivedFields não vai renderizar link spurious para um trace
+        // que não existe.
+        Activity.Current = null;
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Observability:Enabled"] = "false" })
+            .Build();
+
+        CapturingTextSink sink = new(SerilogConfiguration.ConsoleOutputTemplate);
+        Logger logger = new LoggerConfiguration()
+            .ConfigurarSerilog(configuration, UniPlusServiceNames.Selecao)
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        try
+        {
+            logger.Information("startup pre-routing");
+        }
+        finally
+        {
+            logger.Dispose();
+        }
+
+        sink.Linhas.Should().ContainSingle();
+        Regex.IsMatch(sink.Linhas[0], DerivedFieldsRegex)
+            .Should().BeFalse("string vazia após TraceId= não deve casar 32 hex chars");
+    }
+
+    /// <summary>
+    /// Sink Serilog que renderiza cada evento usando o mesmo
+    /// <see cref="MessageTemplateTextFormatter"/> do <c>WriteTo.Console</c>,
+    /// capturando a STRING entregue ao stdout para assertion textual.
+    /// </summary>
+    private sealed class CapturingTextSink(string outputTemplate) : ILogEventSink
+    {
+        private readonly MessageTemplateTextFormatter _formatter = new(outputTemplate, formatProvider: null);
+
+        public List<string> Linhas { get; } = [];
+
+        public void Emit(LogEvent logEvent)
+        {
+            ArgumentNullException.ThrowIfNull(logEvent);
+            using StringWriter writer = new();
+            _formatter.Format(logEvent, writer);
+            Linhas.Add(writer.ToString().TrimEnd('\r', '\n'));
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/SerilogConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/SerilogConfigurationTests.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Logging;
 
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 
@@ -25,9 +26,6 @@ using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 /// </summary>
 public sealed class SerilogConfigurationTests
 {
-    /// <summary>Regex exata configurada no datasource Loki via PR <c>uniplus-infra#225</c>.</summary>
-    private const string DerivedFieldsRegex = @"(?:traceID|trace_id|TraceId)[""]?[=:]\s*[""]?([a-fA-F0-9]{32})";
-
     // ─── CA-01: sentinela do outputTemplate ────────────────────────────────
 
     [Fact]
@@ -94,7 +92,7 @@ public sealed class SerilogConfigurationTests
 
         sink.Linhas.Should().ContainSingle();
         string linha = sink.Linhas[0];
-        Match match = Regex.Match(linha, DerivedFieldsRegex);
+        Match match = Regex.Match(linha, GrafanaDerivedFields.TraceIdMatcher);
         match.Success.Should().BeTrue(
             $"linha gerada `{linha}` deve casar a regex do derivedFields do Loki");
         match.Groups[1].Value.Should().Be(traceIdEsperado,
@@ -128,7 +126,7 @@ public sealed class SerilogConfigurationTests
         }
 
         sink.Linhas.Should().ContainSingle();
-        Regex.IsMatch(sink.Linhas[0], DerivedFieldsRegex)
+        Regex.IsMatch(sink.Linhas[0], GrafanaDerivedFields.TraceIdMatcher)
             .Should().BeFalse("string vazia após TraceId= não deve casar 32 hex chars");
     }
 
@@ -137,9 +135,17 @@ public sealed class SerilogConfigurationTests
     /// <see cref="MessageTemplateTextFormatter"/> do <c>WriteTo.Console</c>,
     /// capturando a STRING entregue ao stdout para assertion textual.
     /// </summary>
+    /// <remarks>
+    /// Recebe <see cref="CultureInfo.InvariantCulture"/> idêntico ao
+    /// <c>WriteTo.Console(formatProvider: CultureInfo.InvariantCulture)</c> da
+    /// produção em <see cref="SerilogConfiguration.ConfigurarSerilog(LoggerConfiguration, IConfiguration, string?)"/> —
+    /// para que futuras placeholders sensíveis a cultura (decimais, datas) saiam
+    /// formatadas no teste exatamente como em produção.
+    /// </remarks>
     private sealed class CapturingTextSink(string outputTemplate) : ILogEventSink
     {
-        private readonly MessageTemplateTextFormatter _formatter = new(outputTemplate, formatProvider: null);
+        private readonly MessageTemplateTextFormatter _formatter =
+            new(outputTemplate, formatProvider: CultureInfo.InvariantCulture);
 
         public List<string> Linhas { get; } = [];
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/TraceContextEnricherTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/TraceContextEnricherTests.cs
@@ -1,0 +1,171 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Logging;
+
+using System.Diagnostics;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Logging;
+
+public sealed class TraceContextEnricherTests
+{
+    private readonly TraceContextEnricher _enricher = new();
+    private readonly ILogEventPropertyFactory _propertyFactory = Substitute.For<ILogEventPropertyFactory>();
+
+    // ─── CA-02: Activity ativa → TraceId/SpanId hex 32/16 chars no log event ───
+
+    [Fact]
+    public void Enrich_DadoActivityAtiva_DevePopularTraceIdComoHex32()
+    {
+        using ActivitySource source = new(nameof(Enrich_DadoActivityAtiva_DevePopularTraceIdComoHex32));
+        using ActivityListener listener = CriarListenerAllData(source.Name);
+        ActivitySource.AddActivityListener(listener);
+
+        using Activity? activity = source.StartActivity("teste");
+        activity.Should().NotBeNull("ActivityListener com AllData deve permitir criação");
+        LogEvent evento = CriarEventoBasico();
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        string traceId = (string)((ScalarValue)evento.Properties[TraceContextEnricher.TraceIdPropertyName]).Value!;
+        traceId.Should().MatchRegex("^[a-f0-9]{32}$", "Activity.TraceId.ToString() retorna hex32 lowercase");
+        traceId.Should().Be(activity!.TraceId.ToString(), "valor emitido deve bater com TraceId do span ativo");
+    }
+
+    [Fact]
+    public void Enrich_DadoActivityAtiva_DevePopularSpanIdComoHex16()
+    {
+        using ActivitySource source = new(nameof(Enrich_DadoActivityAtiva_DevePopularSpanIdComoHex16));
+        using ActivityListener listener = CriarListenerAllData(source.Name);
+        ActivitySource.AddActivityListener(listener);
+
+        using Activity? activity = source.StartActivity("teste");
+        activity.Should().NotBeNull();
+        LogEvent evento = CriarEventoBasico();
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        string spanId = (string)((ScalarValue)evento.Properties[TraceContextEnricher.SpanIdPropertyName]).Value!;
+        spanId.Should().MatchRegex("^[a-f0-9]{16}$", "Activity.SpanId.ToString() retorna hex16 lowercase");
+        spanId.Should().Be(activity!.SpanId.ToString());
+    }
+
+    [Fact]
+    public void Enrich_DadoActivityAtiva_RegexDoDerivedFieldsDeveCasarOTraceIdEmitido()
+    {
+        // Sentinela do contrato com uniplus-infra PR #225: a regex configurada no
+        // datasource Loki (derivedFields) PRECISA casar com o valor emitido aqui.
+        // Se este teste falhar, o link "Ver trace no Tempo" deixa de renderizar
+        // mesmo com tudo "instalado". Defeito silencioso clássico que justifica
+        // a existência da issue #227 (smoke E2E visual).
+        const string derivedFieldsRegex = @"(?:traceID|trace_id|TraceId)[""]?[=:]\s*[""]?([a-fA-F0-9]{32})";
+
+        using ActivitySource source = new(nameof(Enrich_DadoActivityAtiva_RegexDoDerivedFieldsDeveCasarOTraceIdEmitido));
+        using ActivityListener listener = CriarListenerAllData(source.Name);
+        ActivitySource.AddActivityListener(listener);
+        using Activity? activity = source.StartActivity("teste");
+        LogEvent evento = CriarEventoBasico();
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        string traceId = (string)((ScalarValue)evento.Properties[TraceContextEnricher.TraceIdPropertyName]).Value!;
+        string linhaSimulada = $"[12:34:56 INF] mensagem TraceId={traceId} SpanId=...";
+        System.Text.RegularExpressions.Match match = System.Text.RegularExpressions.Regex.Match(linhaSimulada, derivedFieldsRegex);
+
+        match.Success.Should().BeTrue("derivedFields do Loki deve capturar o TraceId no body do log");
+        match.Groups[1].Value.Should().Be(traceId);
+    }
+
+    // ─── CA-03: Activity null → string vazia, sem casamento spurious ───────
+
+    [Fact]
+    public void Enrich_SemActivity_DeveEmitirTraceIdVazio()
+    {
+        // Listener anterior pode ter deixado Activity.Current setada por outro
+        // teste no mesmo runner — explicitamente garantimos null aqui.
+        Activity.Current = null;
+        LogEvent evento = CriarEventoBasico();
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ((ScalarValue)evento.Properties[TraceContextEnricher.TraceIdPropertyName]).Value
+            .Should().Be(string.Empty);
+        ((ScalarValue)evento.Properties[TraceContextEnricher.SpanIdPropertyName]).Value
+            .Should().Be(string.Empty);
+    }
+
+    [Fact]
+    public void Enrich_SemActivity_RegexDoDerivedFieldsNaoDeveCasarString_Vazia()
+    {
+        // Garantia de não-spurious: quando não há trace, o output `TraceId= SpanId=`
+        // NÃO pode casar a regex hex32 — senão o Grafana renderiza link para um
+        // trace inexistente, pior que não ter link nenhum.
+        const string derivedFieldsRegex = @"(?:traceID|trace_id|TraceId)[""]?[=:]\s*[""]?([a-fA-F0-9]{32})";
+        Activity.Current = null;
+        LogEvent evento = CriarEventoBasico();
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        string traceId = (string)((ScalarValue)evento.Properties[TraceContextEnricher.TraceIdPropertyName]).Value!;
+        string linhaSimulada = $"[12:34:56 INF] startup pre-routing TraceId={traceId} SpanId=";
+        bool casa = System.Text.RegularExpressions.Regex.IsMatch(linhaSimulada, derivedFieldsRegex);
+        casa.Should().BeFalse("string vazia após TraceId= não deve casar 32 hex chars");
+    }
+
+    // ─── AddOrUpdate: re-execução sobrescreve valor anterior ───────────────
+
+    [Fact]
+    public void Enrich_QuandoEventoJaTemTraceId_DeveSobrescreverComValorDoActivityCorrente()
+    {
+        // Cenário hipotético: outro enricher upstream emitiu TraceId de fonte
+        // diferente; o TraceContextEnricher é fonte de verdade do trace W3C ativo.
+        using ActivitySource source = new(nameof(Enrich_QuandoEventoJaTemTraceId_DeveSobrescreverComValorDoActivityCorrente));
+        using ActivityListener listener = CriarListenerAllData(source.Name);
+        ActivitySource.AddActivityListener(listener);
+        using Activity? activity = source.StartActivity("teste");
+        LogEvent evento = CriarEventoComPropriedade(TraceContextEnricher.TraceIdPropertyName, "valor-residual-de-outro-pipeline");
+
+        _enricher.Enrich(evento, _propertyFactory);
+
+        ((ScalarValue)evento.Properties[TraceContextEnricher.TraceIdPropertyName]).Value
+            .Should().Be(activity!.TraceId.ToString());
+    }
+
+    // ─── Guards ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Enrich_LogEventNulo_DeveLancarArgumentNullException()
+    {
+        Action acao = () => _enricher.Enrich(null!, _propertyFactory);
+
+        acao.Should().Throw<ArgumentNullException>();
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private static LogEvent CriarEventoBasico()
+        => CriarEventoComPropriedade("Mensagem", "evento de teste");
+
+    private static LogEvent CriarEventoComPropriedade(string nome, string valor)
+    {
+        MessageTemplate template = new MessageTemplateParser().Parse("template");
+        return new LogEvent(
+            DateTimeOffset.UtcNow,
+            LogEventLevel.Information,
+            exception: null,
+            template,
+            [new LogEventProperty(nome, new ScalarValue(valor))]);
+    }
+
+    private static ActivityListener CriarListenerAllData(string sourceName) => new()
+    {
+        ShouldListenTo = s => s.Name == sourceName,
+        Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData,
+    };
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/TraceContextEnricherTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Logging/TraceContextEnricherTests.cs
@@ -63,8 +63,6 @@ public sealed class TraceContextEnricherTests
         // Se este teste falhar, o link "Ver trace no Tempo" deixa de renderizar
         // mesmo com tudo "instalado". Defeito silencioso clássico que justifica
         // a existência da issue #227 (smoke E2E visual).
-        const string derivedFieldsRegex = @"(?:traceID|trace_id|TraceId)[""]?[=:]\s*[""]?([a-fA-F0-9]{32})";
-
         using ActivitySource source = new(nameof(Enrich_DadoActivityAtiva_RegexDoDerivedFieldsDeveCasarOTraceIdEmitido));
         using ActivityListener listener = CriarListenerAllData(source.Name);
         ActivitySource.AddActivityListener(listener);
@@ -75,7 +73,7 @@ public sealed class TraceContextEnricherTests
 
         string traceId = (string)((ScalarValue)evento.Properties[TraceContextEnricher.TraceIdPropertyName]).Value!;
         string linhaSimulada = $"[12:34:56 INF] mensagem TraceId={traceId} SpanId=...";
-        System.Text.RegularExpressions.Match match = System.Text.RegularExpressions.Regex.Match(linhaSimulada, derivedFieldsRegex);
+        System.Text.RegularExpressions.Match match = System.Text.RegularExpressions.Regex.Match(linhaSimulada, GrafanaDerivedFields.TraceIdMatcher);
 
         match.Success.Should().BeTrue("derivedFields do Loki deve capturar o TraceId no body do log");
         match.Groups[1].Value.Should().Be(traceId);
@@ -105,7 +103,6 @@ public sealed class TraceContextEnricherTests
         // Garantia de não-spurious: quando não há trace, o output `TraceId= SpanId=`
         // NÃO pode casar a regex hex32 — senão o Grafana renderiza link para um
         // trace inexistente, pior que não ter link nenhum.
-        const string derivedFieldsRegex = @"(?:traceID|trace_id|TraceId)[""]?[=:]\s*[""]?([a-fA-F0-9]{32})";
         Activity.Current = null;
         LogEvent evento = CriarEventoBasico();
 
@@ -113,7 +110,7 @@ public sealed class TraceContextEnricherTests
 
         string traceId = (string)((ScalarValue)evento.Properties[TraceContextEnricher.TraceIdPropertyName]).Value!;
         string linhaSimulada = $"[12:34:56 INF] startup pre-routing TraceId={traceId} SpanId=";
-        bool casa = System.Text.RegularExpressions.Regex.IsMatch(linhaSimulada, derivedFieldsRegex);
+        bool casa = System.Text.RegularExpressions.Regex.IsMatch(linhaSimulada, GrafanaDerivedFields.TraceIdMatcher);
         casa.Should().BeFalse("string vazia após TraceId= não deve casar 32 hex chars");
     }
 


### PR DESCRIPTION
## Resumo

Implementa #417 — gap descoberto via smoke direto no ambiente standalone (`https://standalone.portaluni.com.br/grafana/`) em 2026-05-11: a ADR-0052 (PR #411) deixou as propriedades `CorrelationId` e `ServiceName` populadas no LogContext, mas o **outputTemplate default do Serilog Console não inclui `TraceId`/`SpanId`** — então o body do log line emitido ao stdout fica como `[00:41:47 INF] End processing HTTP request after 2.0446ms - 200`, sem o identificador W3C.

Resultado prático: o `derivedFields` do datasource Loki no Grafana (configurado em `uniplus-infra#225` com regex `(?:traceID|trace_id|TraceId)["]?[=:]\s*["]?([a-fA-F0-9]{32})`) **nunca casa**, o botão "Ver trace no Tempo" não renderiza, e o drill-down log↔trace prometido pela ADR-0018 fica invisível na UI mesmo com tudo "instalado".

Este é exatamente o tipo de defeito silencioso que justifica a existência da story #227 (smoke E2E visual): passa em todo CI, só aparece no clique em produção.

## Duas peças simétricas

| Componente | Responsabilidade |
|---|---|
| `TraceContextEnricher` (novo) | Lê `Activity.Current`, popula propriedades Serilog `TraceId`/`SpanId` em cada log event. Quando `Activity.Current` é null, emite string vazia — output `TraceId= SpanId=` não casa hex32, sem link spurious. Pattern espelhado do `ServiceNameEnricher` (ADR-0052), zero dependência adicional. |
| `SerilogConfiguration.ConsoleOutputTemplate` (const) | `[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {Properties:j} TraceId={TraceId} SpanId={SpanId}{NewLine}{Exception}` — formato contratado com a regex do `derivedFields`. `{Properties:j}` à frente preserva `CorrelationId`, `ServiceName` em JSON inline. |

O sink OTLP segue populando `traceId`/`spanId` no wire protocol via `IncludedData.TraceIdField` independentemente do enricher — sem drift entre os dois pipelines.

## Ordem do pipeline preservada (ADR-0011)

```
FromLogContext → PiiMaskingEnricher → TraceContextEnricher → ServiceNameEnricher → sinks
```

PII continua mascarado antes de qualquer egress. `TraceId`/`SpanId` são identificadores opacos sem PII — não exigem masking, mas a precedência é mantida por consistência da pipeline.

## Critérios de aceite

- [x] **CA-01:** `outputTemplate` inclui `{TraceId}` e `{SpanId}` explicitamente (`SerilogConfiguration.ConsoleOutputTemplate`).
- [x] **CA-02:** Com `Activity.Current` ativa, body do log Loki conterá `TraceId=<32 hex>` e `SpanId=<16 hex>` (`TraceContextEnricherTests.Enrich_DadoActivityAtiva_*`).
- [x] **CA-03:** Sem `Activity.Current`, template emite valor vazio (`TraceId= SpanId=`) — não quebra parsing, não casa regex hex32 (`TraceContextEnricherTests.Enrich_SemActivity_*`).
- [x] **CA-04:** Regex exata do `derivedFields` casa a saída gerada (`SerilogConfigurationTests.ConfigurarSerilog_ComActivityAtiva_DeveEmitirLogLineCasandoDerivedFieldsRegex`).
- [x] **CA-05:** Sentinela do `outputTemplate` em uso quando `ConfigurarSerilog(...)` é chamado (`SerilogConfigurationTests.ConsoleOutputTemplate_*`).
- [x] **CA-06:** Documentação no XML doc explica a invariante (refactor que remova quebra drill-down Grafana — defeito silencioso).
- [ ] **CA-07:** Smoke manual no standalone após `uniplus-infra#226` mergeado + Argo sync — pendente fora do escopo desta PR.

## Cobertura

- `TraceContextEnricherTests`: 7 testes (hex format real, AddOrUpdate sobrescreve residuais, regex derivedFields casa output, Activity null emite vazio sem casamento spurious, guard `ArgumentNullException`).
- `SerilogConfigurationTests`: 4 testes (sentinela placeholders, separador `TraceId=`, pipeline real + regex casa, sem Activity não casa).

## Validação local

```
dotnet build UniPlus.slnx                                        → 0 warnings, 0 errors
dotnet test --filter "FullyQualifiedName!~IntegrationTests"     → 683 pass (564 Core + 99 Kernel + 4 App + 12 Arch)
dotnet test Infrastructure.Core.IntegrationTests OpenTelemetry  → 1/1 pass
```

## Dependências

- **Related:** `uniplus-infra#226` (env `OTEL_EXPORTER_OTLP_ENDPOINT` no chart das APIs). Sem #226, esta PR emite `TraceId=` vazio em produção (Activity.Current null porque OTel não está exportando). Ambas precisam estar deployadas para o smoke E2E visual da #227 passar.
- **Related:** `uniplus-infra#227` (smoke E2E visual no Grafana). Esta PR + #226 + Argo sync no standalone fecham os pré-requisitos.
- **Parent:** Feature `#103` (Observabilidade local).

## Test plan

- [ ] Build verde no CI (.NET 10)
- [ ] Unit + arch tests verde (683 testes locais)
- [ ] Integration tests não regridem
- [ ] Codex AI review sem findings P1

## Referências

- ADR-0052 (este repo) — rastreabilidade cross-service (`docs/adrs/0052-*`)
- ADR-0018 (este repo) — OpenTelemetry para instrumentação do backend
- ADR-0011 (este repo) — mascaramento de CPF em logs
- ADR-013 (`uniplus-infra`) — OTel Collector DaemonSet standalone
- PR `uniplus-infra#225` — datasources Loki+Tempo com derivedFields e tracesToLogsV2
- Runbook: `/home/jeferson/configs/uniplus-standalone/13-observability.md`
