### PR TITLE
fix(idempotency,pagination): alinhar EncryptionKeyName com chave canonica do Vault Transit

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyOptions.cs
@@ -9,8 +9,15 @@ public sealed record IdempotencyOptions
 {
     public const string SectionName = "UniPlus:Idempotency";
 
-    /// <summary>Nome de chave usada para cifrar response body via IUniPlusEncryptionService.</summary>
-    public const string EncryptionKeyName = "idempotency";
+    /// <summary>
+    /// Nome de chave usada para cifrar response body via IUniPlusEncryptionService.
+    /// Default alinhado com a key canônica provisionada pelo chart
+    /// <c>platform/vault-transit-bootstrap</c> do uniplus-infra (uniplus-infra#219):
+    /// <c>uniplus-idempotency-aesgcm</c>. A policy <c>uniplus-api-transit</c> da
+    /// role <c>uniplus-api</c> só permite update em encrypt/decrypt desta chave
+    /// específica — qualquer nome diferente retorna 403 permission denied.
+    /// </summary>
+    public const string EncryptionKeyName = "uniplus-idempotency-aesgcm";
 
     /// <summary>TTL da entrada do cache. ADR-0027 fixa 24h como teto.</summary>
     public TimeSpan Ttl { get; init; } = TimeSpan.FromHours(24);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorEncoder.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorEncoder.cs
@@ -13,8 +13,17 @@ using Cryptography;
 /// </summary>
 public sealed class CursorEncoder
 {
-    /// <summary>Nome de chave usado para cifrar cursores em <see cref="IUniPlusEncryptionService"/>.</summary>
-    public const string KeyName = "cursor";
+    /// <summary>
+    /// Nome de chave usado para cifrar cursores em <see cref="IUniPlusEncryptionService"/>.
+    /// Default alinhado com a key canônica provisionada pelo chart
+    /// <c>platform/vault-transit-bootstrap</c> do uniplus-infra (uniplus-infra#219):
+    /// <c>uniplus-idempotency-aesgcm</c>. Por enquanto reusa a mesma key da
+    /// Idempotency-Key (escopo pragmático, mesma policy <c>uniplus-api-transit</c>).
+    /// Quando o standalone evoluir para key separation por capability (ex.: dedicar
+    /// uma key <c>uniplus-cursor-aesgcm</c> para pagination), extrair para options
+    /// configurável + key + policy dedicada (follow-up uniplus-infra TBD).
+    /// </summary>
+    public const string KeyName = "uniplus-idempotency-aesgcm";
 
     private static readonly JsonSerializerOptions PayloadJsonOptions = new()
     {


### PR DESCRIPTION
## Contexto

Smoke E2E pós-merge de uniplus-api v0.3.1 (PR #421) + uniplus-infra PRs #234 e #235 (NetworkPolicies bidirecionais) expôs o **terceiro bug** em cascata da cifragem at-rest no standalone: o app retornava 500 com `EncryptionFailureException` raiz `VaultApiException: permission denied` (HTTP 403).

## Diagnóstico

Sequência da cascata, todos os anteriores resolvidos:

1. **uniplus-api#416** (PR #421) — `idempotency_cache` ausente em runtime, 42P01.
2. **uniplus-infra#234** — NetworkPolicy do uniplus-api sem egress 8200 para Vault, Connection refused.
3. **uniplus-infra#235** — NetworkPolicy do Vault sem ingress 8200 da ns `uniplus`, Connection refused do lado server.

Agora tudo alcançável: `curl http://vault.svc:8200/v1/sys/health` do pod retorna 200; `vault write auth/kubernetes/login role=uniplus-api jwt=$JWT` retorna token com policy `uniplus-api-transit`; `vault write transit/encrypt/uniplus-idempotency-aesgcm plaintext=...` retorna 200 com ciphertext.

**Mas** o app .NET chama `transit/encrypt/idempotency` (constante hard-coded em `IdempotencyOptions.EncryptionKeyName = "idempotency"`), enquanto a key real no Vault se chama `uniplus-idempotency-aesgcm` e a policy só permite update nessa key específica. Mismatch → 403.

Mesmo problema em `CursorEncoder.KeyName = "cursor"` — cursor pagination também quebraria assim que fosse exercitada com Vault Transit ativo.

## Fix

Renomeia as 2 constantes para `"uniplus-idempotency-aesgcm"` — alinhamento com a key canônica provisionada por `platform/vault-transit-bootstrap` (uniplus-infra#219). Documentação inline explicita o trade-off de reusar a mesma key para Idempotency e Cursor; key separation por capability fica como follow-up quando o standalone precisar de rotação independente.

## Mudanças

- `IdempotencyOptions.EncryptionKeyName`: `"idempotency"` → `"uniplus-idempotency-aesgcm"`. Comentário XML explica origem da key (chart bootstrap, role+policy) e por que mismatch retorna 403.
- `CursorEncoder.KeyName`: `"cursor"` → `"uniplus-idempotency-aesgcm"`. Comentário documenta o compartilhamento pragmático e o follow-up de key separation.

## Validação

- Build: 0 warnings, 0 errors.
- Suite local: **669 testes verde** (Kernel 99, Application.Abstractions 4, Infrastructure.Core unit 564 + integration 20, Arch x3, Ingresso integration 8, Selecao integration 71).
- Validação manual via `kubectl exec` no pod selecao mostra que `transit/encrypt/uniplus-idempotency-aesgcm` responde 200 — após este PR a app passa a chamar a key correta.

## Validação pós-deploy

Após v0.3.2 publicada e ArgoCD reconciliar:
1. `POST /api/editais` com `Idempotency-Key: <uuid v7>` retorna 201.
2. Log do pod mostra `Vault` 200, sem `EncryptionFailureException`.
3. Audit log do Vault em `kubectl logs -n vault platform-vault-uniplus-standalone-0` mostra `transit/encrypt/uniplus-idempotency-aesgcm` com `client_token` da role `uniplus-api`.

## Follow-ups

- **Key separation** (não-urgente): criar key dedicada `uniplus-cursor-aesgcm` + policy adicional na role `uniplus-api`, tornar nomes configuráveis em options. Abrir issue quando capacity demandar (ex.: rotação cripto independente de cursor vs idempotency).

Closes #422
Refs uniplus-api#400, uniplus-api#402, uniplus-api#404, uniplus-api#405, uniplus-api#416, uniplus-api#421, unifesspa-edu-br/uniplus-infra#219, unifesspa-edu-br/uniplus-infra#234, unifesspa-edu-br/uniplus-infra#235