### PR TITLE
fix(cors): adiciona Idempotency-Key e condicionais HTTP ao Access-Control-Allow-Headers

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cors/CorsConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cors/CorsConfiguration.cs
@@ -17,7 +17,27 @@ public static class CorsConfiguration
     public const string DefaultPolicyName = "DefaultCorsPolicy";
 
     private static readonly string[] DefaultMethods = ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"];
-    private static readonly string[] DefaultHeaders = ["Content-Type", "Authorization", "Accept", "X-Requested-With"];
+
+    // Headers explicitamente declarados no CORS preflight. Lista canônica:
+    // qualquer header novo que o frontend precise enviar deve entrar aqui sob
+    // pena de browsers rejeitarem o preflight (curl/server-to-server não sofre).
+    //
+    // - Content-Type, Authorization, Accept, X-Requested-With: básicos REST.
+    // - Idempotency-Key: header obrigatório em POSTs com [RequiresIdempotencyKey]
+    //   (ADR-0027). Sem este aqui, toda criação via SPA falha "Não foi possível
+    //   conectar ao servidor" antes da request real sair.
+    // - If-Match, If-None-Match: condicionais HTTP (RFC 9110); preventivos para
+    //   ETags do Contrato V1 (ADR-0022).
+    private static readonly string[] DefaultHeaders =
+    [
+        "Content-Type",
+        "Authorization",
+        "Accept",
+        "X-Requested-With",
+        "Idempotency-Key",
+        "If-Match",
+        "If-None-Match",
+    ];
 
     /// <summary>
     /// Binds <see cref="CorsOptions"/> and registers the default CORS policy.

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cors/CorsConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cors/CorsConfigurationTests.cs
@@ -1,0 +1,82 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Cors;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Cors;
+
+using FrameworkCorsOptions = Microsoft.AspNetCore.Cors.Infrastructure.CorsOptions;
+
+public sealed class CorsConfigurationTests
+{
+    [Fact]
+    public void Policy_QuandoAllowAnyHeaderFalso_DeveDeclararIdempotencyKey()
+    {
+        CorsPolicy policy = BuildDefaultPolicy(allowAnyHeader: false);
+
+        policy.Headers.Should().Contain("Idempotency-Key",
+            because: "endpoints com [RequiresIdempotencyKey] dependem desse header no preflight CORS (ADR-0027). " +
+                     "Sem isto na lista, navegadores rejeitam toda criação via SPA antes da request real sair.");
+    }
+
+    [Fact]
+    public void Policy_QuandoAllowAnyHeaderFalso_DeveDeclararCondicionaisHttp()
+    {
+        CorsPolicy policy = BuildDefaultPolicy(allowAnyHeader: false);
+
+        policy.Headers.Should().Contain("If-Match");
+        policy.Headers.Should().Contain("If-None-Match");
+    }
+
+    [Fact]
+    public void Policy_QuandoAllowAnyHeaderFalso_DeveDeclararBasicosRest()
+    {
+        CorsPolicy policy = BuildDefaultPolicy(allowAnyHeader: false);
+
+        policy.Headers.Should().Contain(["Content-Type", "Authorization", "Accept", "X-Requested-With"]);
+    }
+
+    [Fact]
+    public void Policy_QuandoAllowAnyHeaderTrue_PreservaSemantica()
+    {
+        CorsPolicy policy = BuildDefaultPolicy(allowAnyHeader: true);
+
+        policy.Headers.Should().Equal(["*"],
+            because: "AllowAnyHeader=true registra wildcard único na lista (semântica do framework AspNetCore).");
+    }
+
+    private static CorsPolicy BuildDefaultPolicy(bool allowAnyHeader)
+    {
+        Dictionary<string, string?> settings = new()
+        {
+            ["Cors:AllowedOrigins:0"] = "https://selecao.standalone.portaluni.com.br",
+            ["Cors:AllowAnyHeader"] = allowAnyHeader.ToString(),
+        };
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings)
+            .Build();
+
+        IHostEnvironment environment = Substitute.For<IHostEnvironment>();
+        environment.EnvironmentName.Returns("Production");
+
+        ServiceCollection services = new();
+        services.AddSingleton(NullLoggerFactory.Instance);
+        services.AddCorsConfiguration(configuration, environment);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        FrameworkCorsOptions options = provider.GetRequiredService<IOptions<FrameworkCorsOptions>>().Value;
+
+        CorsPolicy? policy = options.GetPolicy(CorsConfiguration.DefaultPolicyName);
+        policy.Should().NotBeNull();
+        return policy!;
+    }
+}


### PR DESCRIPTION
## Contexto

Validação E2E real via UI (Playwright + Chrome em `https://selecao.standalone.portaluni.com.br`) expôs que **todo POST do frontend está quebrado** por CORS preflight. Toast da UI mostra "Não foi possível conectar ao servidor" e console do browser confirma:

```
Access to XMLHttpRequest at 'https://api-selecao.standalone.portaluni.com.br/api/editais'
from origin 'https://selecao.standalone.portaluni.com.br'
has been blocked by CORS policy: Request header field idempotency-key is not allowed by
Access-Control-Allow-Headers in preflight response.
```

A request curl direta (server-to-server, sem origin browser) sempre funcionou — por isso o smoke E2E via curl passou nos PRs anteriores enquanto a UI continuava silenciosamente quebrada.

## Diagnóstico

`src/shared/Unifesspa.UniPlus.Infrastructure.Core/Cors/CorsConfiguration.cs:20`:

```csharp
private static readonly string[] DefaultHeaders = ["Content-Type", "Authorization", "Accept", "X-Requested-With"];
```

`Idempotency-Key` é obrigatório em todos os POSTs com `[RequiresIdempotencyKey]` (ADR-0027). Sem o header na lista do CORS, o browser falha no preflight OPTIONS antes da request real sair.

## Mudanças

- `DefaultHeaders` ganha:
  - `Idempotency-Key` (ADR-0027) — destrava UI imediatamente.
  - `If-Match`, `If-None-Match` (RFC 9110) — preventivos para ETags do Contrato V1 (ADR-0022), evita ciclo similar quando frontend implementar optimistic concurrency.
- Novos testes unitários em `tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Cors/CorsConfigurationTests.cs` (4 cenários):
  - `Idempotency-Key` declarada quando `AllowAnyHeader=false`.
  - Condicionais HTTP (`If-Match`/`If-None-Match`) declaradas.
  - Headers básicos REST mantidos.
  - Semântica `AllowAnyHeader=true` preservada (registra wildcard `*`).

## Validação local

- Build: 0 warnings, 0 errors.
- Suite: 673 testes verde (568 unit `Infrastructure.Core` — 4 a mais que antes, do CorsConfigurationTests novo).

## Validação pós-deploy

1. Após tag v0.3.3 + bump infra + reconcile, abrir `https://selecao.standalone.portaluni.com.br/editais/novo`.
2. Preencher form, clicar "Criar edital".
3. Esperado: HTTP 201 retornado, edital aparece na listagem, toast de sucesso.
4. Console do browser: zero erros CORS.

## Follow-up

Considerar mover `DefaultHeaders` para configuração via `CorsOptions` em PR separado (overridable por environment) caso surjam headers de cliente específicos do candidato (Portal) ou inscrito (Ingresso) que não pertençam ao default global.

Closes #424
Refs uniplus-api#400, uniplus-api#416, uniplus-api#421, uniplus-api#422, uniplus-api#423