### PR TITLE
feat(messaging): emite log estruturado no cascade handler Edital -> Kafka

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToKafkaCascadeHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToKafkaCascadeHandler.cs
@@ -1,6 +1,9 @@
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
 
 using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.Logging;
+
 using Unifesspa.UniPlus.Selecao.Domain.Events;
 using EditalPublicadoAvro = unifesspa.uniplus.selecao.events.EditalPublicado;
 
@@ -22,13 +25,40 @@ using EditalPublicadoAvro = unifesspa.uniplus.selecao.events.EditalPublicado;
 /// at-least-once para o consumidor cross-módulo. A duplicação eventual é tratada pela
 /// idempotência exigida pela ADR-0014 (consumers deduplicam por <c>EventId</c>).
 /// </para>
+/// <para>
+/// <b>Observabilidade (issue #427):</b> emite log estruturado <c>LogProjetandoParaKafkaCascade</c>
+/// (EventId, EditalId, NumeroEdital) antes de retornar o Avro projetado. Permite confirmar
+/// no Loki/Grafana que o evento foi consumido por este cascade handler antes do roteamento
+/// Wolverine → Kafka. O <i>sucesso de entrega ao broker</i> não é logado aqui — Wolverine
+/// despacha assincronamente após este handler retornar; a confirmação definitiva vem da
+/// inspeção do topic (AKHQ) ou de spans do producer no Tempo. Story uniplus-api#427
+/// fornece apenas o sinal estruturado; dashboards/métricas pertencem ao Epic uniplus-infra#240.
+/// </para>
 /// </remarks>
 [SuppressMessage(
     "Naming",
     "CA1711:Identifiers should not have incorrect suffix",
     Justification = "Convenção do projeto: handlers de cascade de eventos terminam em Handler, ver EditalPublicadoEventHandler.")]
-public sealed class EditalPublicadoToKafkaCascadeHandler
+public sealed partial class EditalPublicadoToKafkaCascadeHandler
 {
-    public static EditalPublicadoAvro Handle(EditalPublicadoEvent @event)
-        => EditalPublicadoToAvroMapper.ToAvro(@event);
+    public static EditalPublicadoAvro Handle(
+        EditalPublicadoEvent @event,
+        ILogger<EditalPublicadoToKafkaCascadeHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        LogProjetandoParaKafkaCascade(logger, @event.EventId, @event.EditalId, @event.NumeroEdital);
+
+        return EditalPublicadoToAvroMapper.ToAvro(@event);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Projetando EditalPublicadoEvent para Kafka cascade. EventId={EventId} EditalId={EditalId} NumeroEdital={NumeroEdital}")]
+    private static partial void LogProjetandoParaKafkaCascade(
+        ILogger logger,
+        Guid eventId,
+        Guid editalId,
+        string numeroEdital);
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalPublicadoToKafkaCascadeHandlerLoggingTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalPublicadoToKafkaCascadeHandlerLoggingTests.cs
@@ -1,0 +1,133 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Collections.Generic;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
+
+using EditalPublicadoAvro = unifesspa.uniplus.selecao.events.EditalPublicado;
+
+/// <summary>
+/// Unit tests do logging estruturado do <see cref="EditalPublicadoToKafkaCascadeHandler"/>
+/// (story uniplus-api#427). Cobre:
+///   - <c>Handle()</c> projeta o Avro mapeado corretamente (mantém invariante existente).
+///   - <c>Handle()</c> emite log Information com <c>EventId</c>/<c>EditalId</c>/<c>NumeroEdital</c>
+///     como propriedades estruturadas (consultáveis via LogQL no Loki, não só texto).
+///   - <c>Handle()</c> rejeita <c>@event</c> e <c>logger</c> nulos com
+///     <see cref="ArgumentNullException"/>.
+/// </summary>
+[Trait("Category", "OutboxCascadingUnit")]
+public sealed class EditalPublicadoToKafkaCascadeHandlerLoggingTests
+{
+    [Fact(DisplayName = "Handle projeta EditalPublicadoEvent para EditalPublicadoAvro preservando EditalId e NumeroEdital")]
+    public void Handle_RetornaAvroMapeado()
+    {
+        Guid editalId = Guid.CreateVersion7();
+        const string numeroEdital = "42/2026";
+        EditalPublicadoEvent @event = new(editalId, numeroEdital);
+        EstruturalLogger<EditalPublicadoToKafkaCascadeHandler> logger = new();
+
+        EditalPublicadoAvro avro = EditalPublicadoToKafkaCascadeHandler.Handle(@event, logger);
+
+        // Acerto de mapping permanece a invariante; logging entrou junto sem
+        // mudar o contrato cross-module.
+        avro.EditalId.Should().Be(editalId.ToString());
+        avro.NumeroEdital.Should().Be(numeroEdital);
+    }
+
+    [Fact(DisplayName = "Handle emite log Information com EventId/EditalId/NumeroEdital como properties estruturadas")]
+    public void Handle_EmiteLogStruturadoAntesDaProjecao()
+    {
+        Guid editalId = Guid.CreateVersion7();
+        const string numeroEdital = "99/2030";
+        EditalPublicadoEvent @event = new(editalId, numeroEdital);
+        EstruturalLogger<EditalPublicadoToKafkaCascadeHandler> logger = new();
+
+        _ = EditalPublicadoToKafkaCascadeHandler.Handle(@event, logger);
+
+        logger.Entradas.Should().ContainSingle(
+            "exatamente uma chamada ao LoggerMessage por execução do Handle");
+        EstruturalLogger<EditalPublicadoToKafkaCascadeHandler>.Entrada entrada = logger.Entradas[0];
+        entrada.Level.Should().Be(LogLevel.Information);
+        // Property name match do template `Projetando ... EventId={EventId} EditalId={EditalId} NumeroEdital={NumeroEdital}`.
+        // O [LoggerMessage] source generator emite cada placeholder como key
+        // estruturado — Loki/Grafana indexa diretamente.
+        entrada.Properties.Should().ContainKey("EventId");
+        entrada.Properties.Should().ContainKey("EditalId");
+        entrada.Properties.Should().ContainKey("NumeroEdital");
+        entrada.Properties["EventId"].Should().Be(@event.EventId);
+        entrada.Properties["EditalId"].Should().Be(editalId);
+        entrada.Properties["NumeroEdital"].Should().Be(numeroEdital);
+    }
+
+    [Fact(DisplayName = "Handle lança ArgumentNullException com event nulo")]
+    public void Handle_ComEventNulo_LancaArgumentNullException()
+    {
+        EstruturalLogger<EditalPublicadoToKafkaCascadeHandler> logger = new();
+
+        Action act = () => EditalPublicadoToKafkaCascadeHandler.Handle(null!, logger);
+
+        // ArgumentNullException.ThrowIfNull captura o nome do argumento C#
+        // via CallerArgumentExpression — como o parâmetro do handler é
+        // `@event` (palavra-chave escapada), o ParamName preserva o '@'.
+        act.Should().Throw<ArgumentNullException>().WithParameterName("@event");
+        logger.Entradas.Should().BeEmpty("guard de argumento precede a emissão do log");
+    }
+
+    [Fact(DisplayName = "Handle lança ArgumentNullException com logger nulo")]
+    public void Handle_ComLoggerNulo_LancaArgumentNullException()
+    {
+        EditalPublicadoEvent @event = new(Guid.CreateVersion7(), "1/2026");
+
+        Action act = () => EditalPublicadoToKafkaCascadeHandler.Handle(@event, null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    /// <summary>
+    /// Captura mensagem + level + properties estruturadas do <c>ILogger</c>.
+    /// Diferente de um FakeLogger que só guarda a mensagem formatada, este
+    /// preserva o <see cref="IReadOnlyList{KeyValuePair}"/> com as
+    /// propriedades nomeadas que o <c>[LoggerMessage]</c> source generator
+    /// produz — essencial para validar que Loki/Grafana indexa cada campo
+    /// como label estruturado, não como texto livre.
+    /// </summary>
+    internal sealed class EstruturalLogger<T> : ILogger<T>
+    {
+        public List<Entrada> Entradas { get; } = [];
+
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+
+            Dictionary<string, object?> properties = new(StringComparer.Ordinal);
+            if (state is IReadOnlyList<KeyValuePair<string, object?>> kvList)
+            {
+                foreach (KeyValuePair<string, object?> kv in kvList)
+                {
+                    properties[kv.Key] = kv.Value;
+                }
+            }
+
+            Entradas.Add(new Entrada(logLevel, formatter(state, exception), properties));
+        }
+
+        internal sealed record Entrada(
+            LogLevel Level,
+            string Message,
+            IReadOnlyDictionary<string, object?> Properties);
+    }
+}


### PR DESCRIPTION
## Contexto

Validação E2E em 2026-05-12 (smoke pós-`uniplus-api` v0.3.3 + `uniplus-web` v0.2.1) confirmou que o cascading `EditalPublicadoEvent` → `EditalPublicadoToKafkaCascadeHandler` → topic Kafka `edital_events` funciona ponta-a-ponta. Verificação via AKHQ mostrou 2 mensagens persistidas com schema Avro Confluent wire format (schema-id 4).

**Mas a diagnose foi mais difícil do que deveria.** Issue [#426](https://github.com/unifesspa-edu-br/uniplus-api/issues/426) (fechada como falso positivo) documenta o caso real: o handler atual é puro mapper (`EditalPublicadoEvent` → `EditalPublicadoAvro`) sem `ILogger`, sem `[LoggerMessage]`. Nenhum sinal explícito de "evento consumido pelo cascade handler" aparece em Grafana Loki. A confirmação só veio via inspeção direta de offsets do topic no AKHQ.

Em PROD/HML futuros, depender disso é frágil. Para incidente noturno, queremos query LogQL trivial dizendo "este evento foi processado pelo cascade?".

## Mudanças

### `EditalPublicadoToKafkaCascadeHandler` (src/selecao/.../Messaging/)

- `public sealed class` → `public sealed partial class` (para `[LoggerMessage]` source generator).
- Assinatura de `Handle()`: ganha parâmetro `ILogger<EditalPublicadoToKafkaCascadeHandler> logger` (method-level DI via Wolverine, mesmo pattern do `EditalPublicadoEventHandler` em Application).
- `ArgumentNullException.ThrowIfNull` guards para `@event` e `logger`.
- Antes de `return EditalPublicadoToAvroMapper.ToAvro(@event)`: emite log Information `LogProjetandoParaKafkaCascade(EventId, EditalId, NumeroEdital)`.
- `[LoggerMessage]` partial method seguindo CLAUDE.md (CA1848 + `TreatWarningsAsErrors`).
- XmlDoc do `<remarks>` ganha bloco "Observabilidade (issue #427)" explicando trade-off: log emitido **antes** do retorno; sucesso de entrega ao broker **não** é logado (Wolverine despacha assincronamente — confirmação via AKHQ ou spans Tempo).

### `EditalPublicadoToKafkaCascadeHandlerLoggingTests` (novo, tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/)

- Trait `OutboxCascadingUnit` (alinhado com `CascadingHandlerUnitTests.cs` existente — separado do trait `OutboxCapability` que exige container).
- 4 testes:
  - `Handle_RetornaAvroMapeado` — invariante de mapping mantida (EditalId + NumeroEdital).
  - `Handle_EmiteLogStruturadoAntesDaProjecao` — valida que `EventId`/`EditalId`/`NumeroEdital` saem como **properties estruturadas** no `IReadOnlyList<KeyValuePair<string, object?>>` (consultáveis via LogQL no Loki, não só como texto formatado).
  - `Handle_ComEventNulo_LancaArgumentNullException` — guard.
  - `Handle_ComLoggerNulo_LancaArgumentNullException` — guard.
- `EstruturalLogger<T>` interno captura `LogLevel`, mensagem formatada e dicionário de propriedades estruturadas (mais rico que `FakeLogger<T>` existente em `Infrastructure.Core.UnitTests`).

## Fora do escopo

- **Métricas Prometheus** (`uniplus_kafka_publish_total{topic="edital_events",result="success"}`) — pertence à Feature [uniplus-infra#242](https://github.com/unifesspa-edu-br/uniplus-infra/issues/242) (pipeline metrics OTLP → Prometheus).
- **Dashboard Grafana** para visualizar publish — pertence à Feature [uniplus-infra#241](https://github.com/unifesspa-edu-br/uniplus-infra/issues/241).
- **Investigar Wolverine `IMessageProcessingObserver`** (Wolverine 5.x): pesquisa rápida não encontrou hook estável pós-publish que dê broker offset; este PR foca no sinal de **entrada** do cascade (suficiente para diagnose de "fluxo chegou aqui?"). Confirmação de entrega permanece via AKHQ + Tempo span do producer Kafka — documentado no `<remarks>` do handler.
- **Atualizar `configs/uniplus-standalone/13-observability.md`** — arquivo local de operação (não vive em nenhum repo do uniplus), fica como tarefa pessoal pós-merge.

## Validação local

- `dotnet build` → 0 warnings, 0 errors.
- `dotnet test`:
  - Kernel: 99/99 ✅
  - Application.Abstractions: 4/4 ✅
  - Infrastructure.Core unit + integration: 588 ✅
  - ArchTests (uniplus + Selecao + Ingresso): 12/12 ✅
  - Ingresso.IntegrationTests: 8/8 ✅
  - **Selecao.IntegrationTests: 75/75 ✅** (4 a mais — os novos `EditalPublicadoToKafkaCascadeHandlerLoggingTests`)

## Validação pós-merge esperada

Após `uniplus-api` v0.3.4 + bump infra + reconcile ArgoCD:

1. Publicar edital via SPA standalone (`POST /api/editais/{id}/publicar`)
2. No Grafana Explore → datasource Loki:
   ```
   {k8s_namespace_name="uniplus", k8s_container_name="api"} |= "Projetando EditalPublicadoEvent para Kafka cascade"
   ```
3. Esperado: log Information com `EventId`, `EditalId`, `NumeroEdital` como structured properties (consultáveis individualmente com `| line_format`).
4. Botão "Ver trace no Tempo" no painel Loki abre o span correspondente do `PublicarEditalCommand` (TraceId attached via TraceContextEnricher).

## Riscos / Trade-offs

- **Mudança de assinatura** do handler estático (`Handle(@event)` → `Handle(@event, ILogger)`). Risco baixo: Wolverine 5.x faz method-level DI por convenção, e o pattern já existe em `EditalPublicadoEventHandler` (consumido em produção).
- **Performance**: `[LoggerMessage]` source generator avalia `IsEnabled(LogLevel.Information)` antes de tocar nos argumentos — zero alocações quando level off. Hot path do cascade fica idêntico a antes em produção (Info é tipicamente on, então custo é negligível).
- **Backward compat de consumers Kafka**: nenhuma — payload Avro do `EditalPublicadoEvent` não muda. Schema-id 4 do Apicurio permanece.

Closes #427
Refs unifesspa-edu-br/uniplus-infra#240, unifesspa-edu-br/uniplus-infra#241, unifesspa-edu-br/uniplus-infra#242, uniplus-api#426