### PR TITLE
fix(messaging): renomeia placeholder EventId para EventoId (colide com LogEvent.EventId)

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToKafkaCascadeHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToKafkaCascadeHandler.cs
@@ -23,11 +23,11 @@ using EditalPublicadoAvro = unifesspa.uniplus.selecao.events.EditalPublicado;
 /// O envelope Avro é instalado no outbox dentro da transação do listener da PG queue —
 /// se o publish para Kafka falhar, o Wolverine retenta a partir do outbox, garantindo
 /// at-least-once para o consumidor cross-módulo. A duplicação eventual é tratada pela
-/// idempotência exigida pela ADR-0014 (consumers deduplicam por <c>EventId</c>).
+/// idempotência exigida pela ADR-0014 (consumers deduplicam por <c>EventoId</c>).
 /// </para>
 /// <para>
 /// <b>Observabilidade (issue #427):</b> emite log estruturado <c>LogProjetandoParaKafkaCascade</c>
-/// (EventId, EditalId, NumeroEdital) antes de retornar o Avro projetado. Permite confirmar
+/// (EventoId, EditalId, NumeroEdital) antes de retornar o Avro projetado. Permite confirmar
 /// no Loki/Grafana que o evento foi consumido por este cascade handler antes do roteamento
 /// Wolverine → Kafka. O <i>sucesso de entrega ao broker</i> não é logado aqui — Wolverine
 /// despacha assincronamente após este handler retornar; a confirmação definitiva vem da
@@ -55,10 +55,10 @@ public sealed partial class EditalPublicadoToKafkaCascadeHandler
 
     [LoggerMessage(
         Level = LogLevel.Information,
-        Message = "Projetando EditalPublicadoEvent para Kafka cascade. EventId={EventId} EditalId={EditalId} NumeroEdital={NumeroEdital}")]
+        Message = "Projetando EditalPublicadoEvent para Kafka cascade. EventoId={EventoId} EditalId={EditalId} NumeroEdital={NumeroEdital}")]
     private static partial void LogProjetandoParaKafkaCascade(
         ILogger logger,
-        Guid eventId,
+        Guid eventoId,
         Guid editalId,
         string numeroEdital);
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalPublicadoToKafkaCascadeHandlerLoggingTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalPublicadoToKafkaCascadeHandlerLoggingTests.cs
@@ -15,7 +15,7 @@ using EditalPublicadoAvro = unifesspa.uniplus.selecao.events.EditalPublicado;
 /// Unit tests do logging estruturado do <see cref="EditalPublicadoToKafkaCascadeHandler"/>
 /// (story uniplus-api#427). Cobre:
 ///   - <c>Handle()</c> projeta o Avro mapeado corretamente (mantém invariante existente).
-///   - <c>Handle()</c> emite log Information com <c>EventId</c>/<c>EditalId</c>/<c>NumeroEdital</c>
+///   - <c>Handle()</c> emite log Information com <c>EventoId</c>/<c>EditalId</c>/<c>NumeroEdital</c>
 ///     como propriedades estruturadas (consultáveis via LogQL no Loki, não só texto).
 ///   - <c>Handle()</c> rejeita <c>@event</c> e <c>logger</c> nulos com
 ///     <see cref="ArgumentNullException"/>.
@@ -39,7 +39,7 @@ public sealed class EditalPublicadoToKafkaCascadeHandlerLoggingTests
         avro.NumeroEdital.Should().Be(numeroEdital);
     }
 
-    [Fact(DisplayName = "Handle emite log Information com EventId/EditalId/NumeroEdital como properties estruturadas")]
+    [Fact(DisplayName = "Handle emite log Information com EventoId/EditalId/NumeroEdital como properties estruturadas")]
     public void Handle_EmiteLogStruturadoAntesDaProjecao()
     {
         Guid editalId = Guid.CreateVersion7();
@@ -53,13 +53,13 @@ public sealed class EditalPublicadoToKafkaCascadeHandlerLoggingTests
             "exatamente uma chamada ao LoggerMessage por execução do Handle");
         EstruturalLogger<EditalPublicadoToKafkaCascadeHandler>.Entrada entrada = logger.Entradas[0];
         entrada.Level.Should().Be(LogLevel.Information);
-        // Property name match do template `Projetando ... EventId={EventId} EditalId={EditalId} NumeroEdital={NumeroEdital}`.
+        // Property name match do template `Projetando ... EventoId={EventoId} EditalId={EditalId} NumeroEdital={NumeroEdital}`.
         // O [LoggerMessage] source generator emite cada placeholder como key
         // estruturado — Loki/Grafana indexa diretamente.
-        entrada.Properties.Should().ContainKey("EventId");
+        entrada.Properties.Should().ContainKey("EventoId");
         entrada.Properties.Should().ContainKey("EditalId");
         entrada.Properties.Should().ContainKey("NumeroEdital");
-        entrada.Properties["EventId"].Should().Be(@event.EventId);
+        entrada.Properties["EventoId"].Should().Be(@event.EventId);
         entrada.Properties["EditalId"].Should().Be(editalId);
         entrada.Properties["NumeroEdital"].Should().Be(numeroEdital);
     }


### PR DESCRIPTION
## Contexto

Smoke E2E real pós-deploy de `v0.3.4` (story #427 entregue) capturou o log estruturado **com problema**:

```
[18:17:07 INF] Projetando EditalPublicadoEvent para Kafka cascade.
  EventId={"Id":1177420331,"Name":"LogProjetandoParaKafkaCascade"}
  EditalId=019e1d68-0acd-7323-94ce-ae57278ed3d0
  NumeroEdital=12345/2026
```

O placeholder `{EventId}` no template `[LoggerMessage]` **colide com a metadata reservada `LogEvent.EventId`** (`Microsoft.Extensions.Logging.EventId` struct, auto-gerada pelo source generator). O formatter resolveu para a metadata em vez do parâmetro `Guid eventId` do método — `EditalId` e `NumeroEdital` aparecem corretos, mas `EventId` renderiza como `{"Id":..., "Name":...}` em vez do Guid v7 do evento.

## Mudança

Renomeia o placeholder + parâmetro do método para `EventoId` (pt-BR alinhado com convenção do projeto, e fora do conflito com a reserved word):

```diff
-Message = "...EventId={EventId} EditalId={EditalId} NumeroEdital={NumeroEdital}"
+Message = "...EventoId={EventoId} EditalId={EditalId} NumeroEdital={NumeroEdital}"
```

E no chamador, continua passando `@event.EventId` (a propriedade do `DomainEventBase` mantém o nome inglês — só o placeholder do log foi adaptado).

Teste estrutural atualizado: `Properties["EventoId"].Should().Be(@event.EventId)`.

## Validação local

- Build limpo (0 warnings)
- Suite completa: **75/75** `Selecao.IntegrationTests` ✅
- Test `Handle_EmiteLogStruturadoAntesDaProjecao` valida property `EventoId` com Guid v7 do evento

## Validação pós-merge esperada

```
[INF] Projetando EditalPublicadoEvent para Kafka cascade.
  EventoId=019e1d68-0acd-7323-94ce-ae57278ed3d0  ← Guid v7 do EditalPublicadoEvent
  EditalId=...
  NumeroEdital=...
```

Refs #427