### PR TITLE
docs(messaging): documenta span OTel built-in do Wolverine como fonte primária de observabilidade do publish

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToKafkaCascadeHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/EditalPublicadoToKafkaCascadeHandler.cs
@@ -26,13 +26,46 @@ using EditalPublicadoAvro = unifesspa.uniplus.selecao.events.EditalPublicado;
 /// idempotência exigida pela ADR-0014 (consumers deduplicam por <c>EventoId</c>).
 /// </para>
 /// <para>
-/// <b>Observabilidade (issue #427):</b> emite log estruturado <c>LogProjetandoParaKafkaCascade</c>
-/// (EventoId, EditalId, NumeroEdital) antes de retornar o Avro projetado. Permite confirmar
-/// no Loki/Grafana que o evento foi consumido por este cascade handler antes do roteamento
-/// Wolverine → Kafka. O <i>sucesso de entrega ao broker</i> não é logado aqui — Wolverine
-/// despacha assincronamente após este handler retornar; a confirmação definitiva vem da
-/// inspeção do topic (AKHQ) ou de spans do producer no Tempo. Story uniplus-api#427
-/// fornece apenas o sinal estruturado; dashboards/métricas pertencem ao Epic uniplus-infra#240.
+/// <b>Observabilidade do publish para Kafka (issue #427):</b>
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///       <b>Span OTel built-in do Wolverine</b> (fonte primária): cada publish para Kafka
+///       gera um span <c>send</c> com <see cref="System.Diagnostics.ActivityKind.Producer"/>
+///       e atributos OpenTelemetry messaging semantic conventions —
+///       <c>messaging.system=kafka</c>, <c>messaging.destination=kafka://topic/edital_events</c>,
+///       <c>messaging.message_id</c>, <c>messaging.conversation_id</c> (TraceId),
+///       <c>messaging.message_type=unifesspa.uniplus.selecao.events.EditalPublicado</c>,
+///       <c>messaging.message_payload_size_bytes</c>. Disponível no Grafana Tempo via
+///       TraceQL <c>{ name = "send" &amp;&amp; messaging.destination = "kafka://topic/edital_events" }</c>
+///       sem instrumentação adicional. Esta é a confirmação canônica de que o publish foi
+///       enviado ao broker (o span fecha após o ack do producer Kafka).
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Log estruturado emitido por este handler</b> (fonte complementar):
+///       <c>LogProjetandoParaKafkaCascade(EventoId, EditalId, NumeroEdital)</c> em
+///       Information com TraceId/SpanId attachados pelo enricher Serilog. Permite query
+///       LogQL no Loki <c>{k8s_namespace_name="uniplus"} |= "Projetando EditalPublicadoEvent
+///       para Kafka cascade"</c> para alertas baseados em frequência de cascading
+///       (ex.: detectar quedas anômalas no volume de publicações).
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <b>Métricas Prometheus</b> (não disponíveis hoje): Wolverine emite métricas OTel
+///       (counters/histograms) via <c>OpenTelemetry().WithMetrics()</c>, mas o pipeline
+///       <c>otelcol → prometheusremotewrite</c> ainda não está implementado no standalone.
+///       Endereçado pela Feature uniplus-infra#242. Até lá, derivação de SLO/SLI usa
+///       <c>rate({...} |= "...")</c> sobre o log estruturado deste handler.
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// Em incidente, priorizar Tempo (span semantic conventions) sobre o log: o span tem
+/// duração e atributos do broker, o log apenas registra que o cascade handler executou.
 /// </para>
 /// </remarks>
 [SuppressMessage(


### PR DESCRIPTION
## Contexto + transparência

O PR #428 (story #427) entregou log estruturado no `EditalPublicadoToKafkaCascadeHandler` com a justificativa de que "a confirmação de entrega ao broker fica via AKHQ ou spans do producer no Tempo". A AC original da issue pedia "investigar Wolverine 5.x se há `IMessageProcessingObserver` ou hook similar pós-publish" — **eu não fiz essa investigação de fato** e fechei a issue baseado em inferência superficial.

A issue foi reaberta hoje para corrigir esse débito.

## Investigação real (capturada agora)

Trace `0aac89cd8944123988d147a94d5ad34f` no Tempo do standalone, gerado por `POST /api/editais/{id}/publicar`, mostra **14 spans** incluindo:

```
--- send [SPAN_KIND_PRODUCER] ---
  messaging.system = kafka
  messaging.destination = kafka://topic/edital_events
  messaging.message_id = 08deb069-534c-ce8b-b280-1b8fc8fe0000
  messaging.conversation_id = 0aac89cd8944123988d147a94d5ad34f
  messaging.message_type = unifesspa.uniplus.selecao.events.EditalPublicado
  messaging.message_payload_size_bytes = 177
```

Wolverine 5.x **já emite spans OTel built-in** com [OpenTelemetry messaging semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/messaging/messaging-spans.md) — `send` PRODUCER cobre exatamente o gap que motivou abrir #426 e #427.

**O log estruturado adicionado pelo PR #428 é COMPLEMENTAR** (LogQL para alertas de volume), não a observabilidade primária. Diagnóstico de incidente deve usar Tempo, não Loki, porque o span tem duração e atributos do broker.

## Achado secundário (não corrigido aqui)

Métricas Wolverine **não estão no Prometheus** (0 de 1616 metric names contém `wolverine` ou `messaging.`). Wolverine emite métricas via OTel, mas o pipeline `otelcol → prometheusremotewrite` ainda não está implementado — bate exatamente com a Feature uniplus-infra#242. Não é regressão; é gap pré-existente.

Adicionalmente: datasource Prometheus do Grafana retorna **HTTP 502** porque aponta para service inexistente (`platform-observability-prometheus-uniplus-standalone-prometheus` em vez de `platform-observability-pro-prometheus`) — mesmo pattern do bug OTel resolvido em uniplus-infra#237/#238. **Abrirei issue separada** para este.

## Mudança neste PR

Apenas em XmlDoc do handler — **nenhuma alteração funcional**. Reescreve o `<remarks>` listando as 3 fontes de observabilidade na ordem de prioridade real:

1. **Span OTel** (Tempo) — fonte primária, OpenTelemetry semantic conventions
2. **Log estruturado** (Loki) — complementar, LogQL alerts
3. **Métricas Prometheus** — gap conhecido (Feature uniplus-infra#242)

Adiciona instrução explícita: "em incidente, priorizar Tempo sobre o log".

## Validação

- Build limpo (0 warnings/errors)
- Sem mudança funcional → suite não precisa re-rodar (mas roda no CI mesmo assim)

Refs #427