### PR TITLE
refactor(infra): registra migrations antes do WolverineRuntime

### DIFF
--- a/docs/adrs/0039-provisioning-schema-wolverine-via-deploy.md
+++ b/docs/adrs/0039-provisioning-schema-wolverine-via-deploy.md
@@ -101,3 +101,13 @@ Duas evoluções relevantes desde a decisão original:
 3. **`CascadingFixture` mudou de `EnsureCreatedAsync` → `MigrateAsync`** (issue #416). Justificativa: a fixture precisa provisionar o schema do domínio ANTES do host startar para evitar a race com Wolverine outbox (timing histórico documentado em #344/#180). Com migrations EF Core agora registradas (PR #416), `EnsureCreatedAsync` colide com `MigrationHostedService` (42P07 relation already exists). `MigrateAsync` na fixture popula `__EFMigrationsHistory` e o `MigrationHostedService` do host vê banco já migrado e vira no-op. Resultado: dois caminhos chamam `MigrateAsync` (fixture + host), funcionalmente idempotente mas conceitualmente duplicado.
 
 A coabitação fixture↔MigrationHostedService é tática. Follow-up planejado em [issue #419](https://github.com/unifesspa-edu-br/uniplus-api/issues/419): reordenar `Program.cs` para registrar `AddDbContextMigrationsOnStartup` antes de `UseWolverineOutboxCascading` nos 3 módulos (Selecao/Ingresso/Portal) + fitness test garantindo a ordem + remover `MigrateAsync` da fixture, restaurando 1 fonte de verdade para o schema do domínio.
+
+### 2026-05-13 — coabitação resolvida em #419
+
+`Program.cs` dos 3 entry points reordenado: `AddDbContextMigrationsOnStartup<TContext>()` agora precede `UseWolverineOutboxCascading` + `AddWolverineMessaging` em Selecao, Ingresso e Portal. `HostOptions.ServicesStartConcurrently=false` (default) garante que `MigrationHostedService<TContext>` complete `MigrateAsync` antes do `WolverineRuntime` aceitar o primeiro envelope que toque tabelas do módulo.
+
+`CascadingFixture.InitializeAsync` parou de chamar `MigrateAsync` localmente — a fixture confia 100% no host. Comentário inline aponta para a invariante de ordem e para o fitness test.
+
+Fitness test `MigrationBeforeWolverineRuntimeOrderTests` em `tests/Unifesspa.UniPlus.ArchTests/Hosting/` materializa cada `WebApplicationFactory<TEntryPoint>` (Selecao/Ingresso/Portal), captura o `IServiceCollection` antes de qualquer ConfigureTestServices, e verifica que `IsMigrationHostedService` aparece antes de `IsWolverineRuntime` na lista de `IHostedService`. Segundo teórico explicitamente assert que `HostOptions.ServicesStartConcurrently=false`, garantindo que a ordem de registro continua sendo proxy válido da ordem de execução.
+
+Marker `SelecaoApiAssemblyMarker` criado para simetria com `PortalApiAssemblyMarker` e `IngressoApiAssemblyMarker` — usado como type-arg do fitness para evitar ambiguidade de `typeof(Program)` cross-module.

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Program.cs
@@ -56,6 +56,16 @@ builder.Services.AdicionarObservabilidade(nomeServicoIngresso, builder.Configura
 // simetria com UseWolverineOutboxCascading e com Selecao.
 builder.Services.AddIngressoInfrastructure();
 
+// Migrations EF Core do módulo Ingresso aplicadas no host StartAsync via IHostedService
+// (issue #344). Como hosted service, o registro é filtrável por test factories que sobem
+// o pipeline HTTP sem Postgres real (ver ApiFactoryBase). Idempotente.
+//
+// INVARIANTE (#419): registrado antes de UseWolverineOutboxCascading +
+// AddWolverineMessaging — mesma justificativa do Selecao.API. Fitness em
+// tests/Unifesspa.UniPlus.ArchTests/Hosting/MigrationBeforeWolverineRuntimeOrderTests
+// cobre os 3 entry points.
+builder.Services.AddDbContextMigrationsOnStartup<IngressoDbContext>();
+
 // Wolverine como backbone CQRS/messaging com outbox transacional —
 // ver ADR-0003, ADR-0004 e ADR-0005.
 //
@@ -65,11 +75,6 @@ builder.Services.AddIngressoInfrastructure();
 // ganharem destino cross-módulo.
 builder.Host.UseWolverineOutboxCascading(builder.Configuration, connectionStringName: "IngressoDb");
 builder.Services.AddWolverineMessaging();
-
-// Migrations EF Core do módulo Ingresso aplicadas no host StartAsync via IHostedService
-// (issue #344). Como hosted service, o registro é filtrável por test factories que sobem
-// o pipeline HTTP sem Postgres real (ver ApiFactoryBase). Idempotente.
-builder.Services.AddDbContextMigrationsOnStartup<IngressoDbContext>();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
@@ -66,18 +66,23 @@ builder.Services.AdicionarObservabilidade(nomeServicoPortal, builder.Configurati
 // injetada no factory do AddDbContext — simetria com Selecao/Ingresso (#204).
 builder.Services.AddPortalInfrastructure();
 
+// Migrations EF Core do módulo Portal aplicadas no host StartAsync via IHostedService —
+// pareado com AutoBuildMessageStorageOnStartup do Wolverine (issue #344). Como hosted
+// service, o registro é filtrável por test factories que sobem o pipeline HTTP sem
+// Postgres real (ver ApiFactoryBase). Idempotente; banco já migrado é no-op.
+//
+// INVARIANTE (#419): registrado antes de UseWolverineOutboxCascading +
+// AddWolverineMessaging — mesma justificativa do Selecao.API. Fitness em
+// tests/Unifesspa.UniPlus.ArchTests/Hosting/MigrationBeforeWolverineRuntimeOrderTests
+// cobre os 3 entry points.
+builder.Services.AddDbContextMigrationsOnStartup<PortalDbContext>();
+
 // Wolverine como backbone CQRS/messaging com outbox transacional —
 // ver ADR-0003, ADR-0004 e ADR-0005. Esqueleto sem rotas adicionais
 // (não há domain events publicáveis ainda); a Story que introduzir o
 // primeiro caso de uso completa o roteamento.
 builder.Host.UseWolverineOutboxCascading(builder.Configuration, connectionStringName: "PortalDb");
 builder.Services.AddWolverineMessaging();
-
-// Migrations EF Core do módulo Portal aplicadas no host StartAsync via IHostedService —
-// pareado com AutoBuildMessageStorageOnStartup do Wolverine (issue #344). Como hosted
-// service, o registro é filtrável por test factories que sobem o pipeline HTTP sem
-// Postgres real (ver ApiFactoryBase). Idempotente; banco já migrado é no-op.
-builder.Services.AddDbContextMigrationsOnStartup<PortalDbContext>();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/GlobalSuppressions.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/GlobalSuppressions.cs
@@ -10,3 +10,14 @@ using System.Diagnostics.CodeAnalysis;
     Justification = "Program is the entry point referenced by WebApplicationFactory<Program> in integration tests.",
     Scope = "type",
     Target = "~T:Program")]
+
+// SelecaoApiAssemblyMarker é referenciado por carregadores de assembly
+// cross-projeto (ArchUnitNET em Unifesspa.UniPlus.ArchTests, fitness tests
+// que usam WebApplicationFactory<SelecaoApiAssemblyMarker>). Precisa ser
+// public por mesma razão de Program.
+[assembly: SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "SelecaoApiAssemblyMarker é referenciado pelo projeto Unifesspa.UniPlus.ArchTests para load do assembly.",
+    Scope = "type",
+    Target = "~T:Unifesspa.UniPlus.Selecao.API.SelecaoApiAssemblyMarker")]

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -167,6 +167,19 @@ builder.Services.AddSchemaRegistry(builder.Configuration)
         schemaResourceName: unifesspa.uniplus.selecao.events.EditalPublicado.SchemaResourceName,
         resourceAssembly: typeof(EditalPublicadoEvent).Assembly);
 
+// Migrations EF Core do módulo Selecao aplicadas no host StartAsync via IHostedService
+// (issue #344). Como hosted service, o registro é filtrável por test factories que sobem
+// o pipeline HTTP sem Postgres real (ver ApiFactoryBase). Idempotente.
+//
+// INVARIANTE (#419): este registro precede UseWolverineOutboxCascading + AddWolverineMessaging
+// abaixo. HostOptions.ServicesStartConcurrently=false (default) garante que IHostedService
+// inicia sequencialmente na ordem de registro — então MigrationHostedService aplica o
+// schema EF do domínio ANTES do WolverineRuntime aceitar o primeiro envelope cascading,
+// evitando 42P01 em handlers que tocam tabelas do módulo. Fitness test em
+// tests/Unifesspa.UniPlus.ArchTests/Hosting/MigrationBeforeWolverineRuntimeOrderTests
+// trava regressão de ordem nos 3 entry points (Selecao/Ingresso/Portal).
+builder.Services.AddDbContextMigrationsOnStartup<SelecaoDbContext>();
+
 // Wolverine como backbone CQRS/messaging com outbox transacional —
 // ver ADR-0003, ADR-0004 e ADR-0005.
 //
@@ -217,11 +230,6 @@ builder.Host.UseWolverineOutboxCascading(
         }
     });
 builder.Services.AddWolverineMessaging();
-
-// Migrations EF Core do módulo Selecao aplicadas no host StartAsync via IHostedService
-// (issue #344). Como hosted service, o registro é filtrável por test factories que sobem
-// o pipeline HTTP sem Postgres real (ver ApiFactoryBase). Idempotente.
-builder.Services.AddDbContextMigrationsOnStartup<SelecaoDbContext>();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);
 builder.Services.AddUniPlusStorage(builder.Configuration, builder.Environment);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoApiAssemblyMarker.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoApiAssemblyMarker.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Selecao.API;
+
+/// <summary>
+/// Marker type usado por carregadores de assembly (ArchUnitNET, fixtures de
+/// testes) para obter referência inequívoca ao assembly Selecao.API.
+/// Necessário porque o entry point top-level (<c>Program</c>) compartilha
+/// nome com o entry point de outras APIs do mesmo solution e não permite
+/// <c>typeof(Program)</c> sem ambiguidade.
+/// </summary>
+public sealed class SelecaoApiAssemblyMarker
+{
+    private SelecaoApiAssemblyMarker()
+    {
+    }
+}

--- a/tests/Unifesspa.UniPlus.ArchTests/Hosting/MigrationBeforeWolverineRuntimeOrderTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/Hosting/MigrationBeforeWolverineRuntimeOrderTests.cs
@@ -1,0 +1,261 @@
+namespace Unifesspa.UniPlus.ArchTests.Hosting;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Ingresso.API;
+using Unifesspa.UniPlus.Portal.API;
+using Unifesspa.UniPlus.Selecao.API;
+
+/// <summary>
+/// Fitness test (uniplus-api#419) que trava a invariante de ordem dos
+/// <see cref="IHostedService"/> nos 3 entry points (Selecao/Ingresso/Portal):
+/// <c>MigrationHostedService&lt;TContext&gt;</c> precisa ser registrado antes
+/// do <c>WolverineRuntime</c> para que o schema EF do domínio esteja aplicado
+/// quando o Wolverine começar a processar envelopes que tocam tabelas do módulo.
+/// </summary>
+/// <remarks>
+/// <para>A invariante depende de duas premissas conjuntas:
+/// (1) ordem de registro no <see cref="IServiceCollection"/> determina ordem
+/// de Start dos <see cref="IHostedService"/>, e
+/// (2) <see cref="HostOptions.ServicesStartConcurrently"/> permanece <c>false</c>.
+/// O teste verifica ambas explicitamente — sem o segundo assert, uma mudança
+/// futura em <see cref="HostOptions"/> tornaria a ordem de registro insuficiente.</para>
+///
+/// <para>Heurísticas usadas para identificar os hosted services replicam as
+/// queries de <c>ApiFactoryBase</c> (filtro de Migration) e
+/// <c>WolverineRuntimeRemovalSentinelTests</c> (filtro de Wolverine).
+/// Refactor para helper compartilhado é follow-up — não consolidado aqui
+/// para manter o PR focado.</para>
+///
+/// <para>Para evitar a remoção dos hosted services pelo
+/// <c>DisableWolverineRuntimeForTests=true</c> do <c>ApiFactoryBase</c>, o
+/// fitness usa <see cref="WebApplicationFactory{TEntryPoint}"/> direta com
+/// captura do <see cref="IServiceCollection"/> via <c>ConfigureServices</c>
+/// callback — sem passar pelo pipeline de remoção.</para>
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IClassFixture<T> exige tipo público para a fixture compartilhada.")]
+public sealed class MigrationBeforeWolverineRuntimeOrderTests : IClassFixture<MigrationOrderFixture>
+{
+    private readonly MigrationOrderFixture _fixture;
+
+    public MigrationBeforeWolverineRuntimeOrderTests(MigrationOrderFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public static TheoryData<string> EntryPointKeys =>
+        new(MigrationOrderFixture.RegisteredKeys);
+
+    [Theory(DisplayName = "MigrationHostedService precede WolverineRuntime no IServiceCollection (3 entry points)")]
+    [MemberData(nameof(EntryPointKeys))]
+    public void MigrationRegistradaAntesDeWolverineRuntime(string entryPointKey)
+    {
+        IReadOnlyList<ServiceDescriptor> snapshot = _fixture.GetCapturedSnapshot(entryPointKey);
+
+        List<ServiceDescriptor> hostedServices = [..
+            snapshot.Where(d => d.ServiceType == typeof(IHostedService))];
+
+        int migrationIndex = hostedServices.FindIndex(d =>
+            MigrationOrderHeuristics.IsMigrationHostedService(d.ImplementationType));
+        int wolverineIndex = hostedServices.FindIndex(MigrationOrderHeuristics.IsWolverineRuntime);
+
+        migrationIndex.Should().BeGreaterThanOrEqualTo(0,
+            "MigrationHostedService<TContext> precisa estar registrado em Program.cs do entry point " + entryPointKey);
+        wolverineIndex.Should().BeGreaterThanOrEqualTo(0,
+            "WolverineRuntime IHostedService precisa estar registrado em Program.cs do entry point " + entryPointKey);
+        migrationIndex.Should().BeLessThan(
+            wolverineIndex,
+            because: "Schema EF do domínio precisa estar aplicado antes do WolverineRuntime aceitar envelopes "
+                + "que toquem tabelas do módulo (uniplus-api#419). Em Program.cs do entry point "
+                + entryPointKey + ", AddDbContextMigrationsOnStartup<TContext>() precisa preceder UseWolverineOutboxCascading.");
+    }
+
+    [Theory(DisplayName = "HostOptions.ServicesStartConcurrently permanece false (premissa da ordem)")]
+    [MemberData(nameof(EntryPointKeys))]
+    public void HostOptions_ServicesStartConcurrently_FicaFalse(string entryPointKey)
+    {
+        IServiceProvider provider = _fixture.GetCapturedServiceProvider(entryPointKey);
+
+        HostOptions hostOptions = provider.GetRequiredService<IOptions<HostOptions>>().Value;
+
+        hostOptions.ServicesStartConcurrently.Should().BeFalse(
+            because: "MigrationBeforeWolverineRuntimeOrderTests usa ordem de registro do IServiceCollection "
+                + "como proxy de ordem de execução dos IHostedService. Isso só vale se "
+                + "HostOptions.ServicesStartConcurrently=false (default do .NET host). "
+                + "Se ligado, MigrationHostedService e WolverineRuntime começam em paralelo "
+                + "e a invariante de #419 não é mais garantida pela ordem de registro.");
+    }
+}
+
+/// <summary>
+/// Fixture xUnit que materializa as 3 <see cref="WebApplicationFactory{T}"/>
+/// (uma por entry point) uma única vez por test class, preservando o custo de
+/// inicialização do host. As factories são <c>IDisposable</c> via composição
+/// — não há herança custom (evita pattern Dispose(bool) sobre tipo abstrato).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IClassFixture<T> exige tipo público para a fixture compartilhada.")]
+public sealed class MigrationOrderFixture : IDisposable
+{
+    public const string SelecaoKey = "Selecao";
+    public const string IngressoKey = "Ingresso";
+    public const string PortalKey = "Portal";
+
+    public static IReadOnlyCollection<string> RegisteredKeys { get; } =
+        [SelecaoKey, IngressoKey, PortalKey];
+
+    /// <summary>
+    /// Env vars sintéticas aplicadas process-wide via static ctor. Replica o
+    /// pattern do <c>ApiFactoryBase</c> (observabilidade) e dos sentinelas que
+    /// usam <c>Host.CreateDefaultBuilder</c> — em minimal API, overrides via
+    /// <c>ConfigureAppConfiguration</c> chegam tarde demais.
+    /// </summary>
+    static MigrationOrderFixture()
+    {
+        // Connection strings sintéticas — UseWolverineOutboxCascading e
+        // AddDbContextMigrationsOnStartup registram services lazy; a conexão
+        // só seria tentada no IHostedService.StartAsync, que este teste não
+        // dispara (apenas Build do host para capturar IServiceCollection).
+        Environment.SetEnvironmentVariable(
+            "ConnectionStrings__SelecaoDb",
+            "Host=fitness-not-real;Database=fake;Username=u;Password=p");
+        Environment.SetEnvironmentVariable(
+            "ConnectionStrings__IngressoDb",
+            "Host=fitness-not-real;Database=fake;Username=u;Password=p");
+        Environment.SetEnvironmentVariable(
+            "ConnectionStrings__PortalDb",
+            "Host=fitness-not-real;Database=fake;Username=u;Password=p");
+
+        // Desliga Kafka — sem isto Wolverine tenta iniciar transporte.
+        Environment.SetEnvironmentVariable("Kafka__BootstrapServers", " ");
+
+        // OpenTelemetry exporter em loop contra localhost:4317 polui logs do
+        // CI mesmo sem afetar correção. Desliga consistente com ApiFactoryBase.
+        Environment.SetEnvironmentVariable("Observability__Enabled", "false");
+    }
+
+    private readonly CapturingFactory<SelecaoApiAssemblyMarker> _selecaoFactory = new();
+    private readonly CapturingFactory<IngressoApiAssemblyMarker> _ingressoFactory = new();
+    private readonly CapturingFactory<PortalApiAssemblyMarker> _portalFactory = new();
+
+    public IReadOnlyList<ServiceDescriptor> GetCapturedSnapshot(string entryPointKey) => entryPointKey switch
+    {
+        SelecaoKey => _selecaoFactory.CapturedSnapshot,
+        IngressoKey => _ingressoFactory.CapturedSnapshot,
+        PortalKey => _portalFactory.CapturedSnapshot,
+        _ => throw new ArgumentOutOfRangeException(nameof(entryPointKey)),
+    };
+
+    public IServiceProvider GetCapturedServiceProvider(string entryPointKey) => entryPointKey switch
+    {
+        SelecaoKey => _selecaoFactory.Services,
+        IngressoKey => _ingressoFactory.Services,
+        PortalKey => _portalFactory.Services,
+        _ => throw new ArgumentOutOfRangeException(nameof(entryPointKey)),
+    };
+
+    public void Dispose()
+    {
+        _selecaoFactory.Dispose();
+        _ingressoFactory.Dispose();
+        _portalFactory.Dispose();
+    }
+}
+
+/// <summary>
+/// <see cref="WebApplicationFactory{TEntryPoint}"/> mínima que captura o
+/// <see cref="IServiceCollection"/> tal como o Program.cs do módulo o deixa,
+/// antes de qualquer <c>ConfigureTestServices</c> de teste — preserva a ordem
+/// de registro dos <see cref="IHostedService"/>.
+/// </summary>
+internal sealed class CapturingFactory<TEntryPoint> : WebApplicationFactory<TEntryPoint>
+    where TEntryPoint : class
+{
+    private IReadOnlyList<ServiceDescriptor>? _capturedSnapshot;
+
+    /// <summary>
+    /// Snapshot imutável da <see cref="IServiceCollection"/> capturado em
+    /// <c>ConfigureWebHost.ConfigureServices</c> (ANTES de
+    /// <c>ConfigureTestServices</c> remover os hosted services problemáticos
+    /// para permitir Start). Preserva a ordem de registro original do
+    /// Program.cs do módulo.
+    /// </summary>
+    public IReadOnlyList<ServiceDescriptor> CapturedSnapshot =>
+        _capturedSnapshot ?? Materialize();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.UseEnvironment("Development");
+
+        builder.ConfigureServices(services =>
+        {
+            // Snapshot ANTES de ConfigureTestServices — preserva ordem original.
+            _capturedSnapshot = [.. services];
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            // Remove MigrationHostedService e WolverineRuntime para permitir
+            // Start do host sem tentar conectar contra Postgres sintético.
+            // O snapshot acima já guardou a ordem original — esta remoção só
+            // afeta o IServiceProvider materializado por get_Services.
+            ServiceDescriptor[] toRemove = [.. services
+                .Where(d => d.ServiceType == typeof(IHostedService)
+                    && (MigrationOrderHeuristics.IsMigrationHostedService(d.ImplementationType)
+                        || MigrationOrderHeuristics.IsWolverineRuntime(d)))];
+            foreach (ServiceDescriptor descriptor in toRemove)
+            {
+                services.Remove(descriptor);
+            }
+        });
+    }
+
+    private IReadOnlyList<ServiceDescriptor> Materialize()
+    {
+        // Acessar Services força WebApplicationFactory a executar ConfigureWebHost
+        // e Start do host (com os hosted services problemáticos removidos).
+        // Após isso _capturedSnapshot estará preenchido pelo callback acima.
+        _ = Services;
+        return _capturedSnapshot
+            ?? throw new InvalidOperationException(
+                "ConfigureWebHost executou sem preencher _capturedSnapshot — pipeline mudou.");
+    }
+}
+
+internal static class MigrationOrderHeuristics
+{
+    private const string MigrationHostedServiceFullName =
+        "Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection.MigrationHostedService`1";
+
+    private const string WolverineAssemblyName = "Wolverine";
+
+    public static bool IsMigrationHostedService(Type? implementationType) =>
+        implementationType is { IsGenericType: true }
+        && string.Equals(
+            implementationType.GetGenericTypeDefinition().FullName,
+            MigrationHostedServiceFullName,
+            StringComparison.Ordinal);
+
+    public static bool IsWolverineRuntime(ServiceDescriptor descriptor) =>
+        descriptor.ImplementationFactory is not null
+        && string.Equals(
+            descriptor.ImplementationFactory.Method.DeclaringType?.Assembly.GetName().Name,
+            WolverineAssemblyName,
+            StringComparison.Ordinal);
+}

--- a/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="TngTech.ArchUnitNET" />
     <PackageReference Include="TngTech.ArchUnitNET.xUnit" />
   </ItemGroup>

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -14,6 +14,17 @@
         "resolved": "8.0.1",
         "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Hosting": "10.0.7"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.5.1, )",
@@ -190,6 +201,11 @@
         "type": "Transitive",
         "resolved": "2.14.0",
         "contentHash": "jqmYswYUiW9So5lce1Upo/zm5V7p/kWaqnUqkP5Lar1Ekq2yLrORoDCJ1JIiVLD3xdVkavwqW9iFKHBfkTsS7w=="
+      },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -372,11 +388,11 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -389,63 +405,63 @@
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.CommandLine": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "resolved": "10.0.7",
+        "contentHash": "3lNjglxfFxOzI9zG+3HSg/YSGqo//8Fqw6u6iuIamZb4JCorbA3JLaeWOpfKTAPi2UJwaispOXWx14dUqcGz4A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "resolved": "10.0.7",
+        "contentHash": "TWto3imA+mJMLZI+5sbgLiFFoOFNFkizQYNaC5jTuiHKn3diwm1RN7mWDOEZN9kG2bixw7IvgpvtUG5/teSRzA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "resolved": "10.0.7",
+        "contentHash": "qbZLvLsoTdArSloEnSxs21P781YUmwVmHc5NJPQD/ezAreQ7884z+6QfAZVKi86WAZtzx83jK2uC4itxOM44gQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "resolved": "10.0.7",
+        "contentHash": "64dimvyyKk0dbUbrLg/YCv4ugJ4sVz2aXLwfvZwR1EC4tJqW9ru/oVRcXwoJRa2lQGXtYtlpk4maWOeIb48tQw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "resolved": "10.0.7",
+        "contentHash": "YqVIICoIdl0016wkeO2WQS+uEbEXbUhMLKdC5rZNl1X3nu59F+nwaAHdHjq/4OK+Cx31DYmNUSFh+MUot8qSDw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Json": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -463,26 +479,26 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "DHXzj/FKmUDmhzw7AHbMXbNNcgO8Cb9PDbYOUDICjFAdIALy2WbC6pm+dFKiAUNtcYMucZu2iMVw1ef/sdcZFw=="
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
@@ -492,66 +508,66 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "resolved": "10.0.7",
+        "contentHash": "zhgWg/i0ECj5v0jLFBSZHplvc5ygCI91DR4nne+BP4XAKF5ycz0pEKnFiTw8C1jCABJEZsnBZh6pXAvn71kFmw==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+        "resolved": "10.0.7",
+        "contentHash": "NTUspqB+vH9g4wAD6KPOBx01xqYuKXR/cHXm449zpbq1GqfjdAxBmg7eJXrNsPw7SKwIdT2cJ05GxYVvc+lvsA=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "resolved": "10.0.7",
+        "contentHash": "M/vBpfWcschvS2EUeq7cHfscsxabiGTptXwV7GeSueovGiSoNjyo1j5PMcWuOAAQrRW3nRqxZk8NeumrmpzUBg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
-          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Json": "10.0.0",
-          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Diagnostics": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
-          "Microsoft.Extensions.Logging.Console": "10.0.0",
-          "Microsoft.Extensions.Logging.Debug": "10.0.0",
-          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
-          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.7",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Logging.Console": "10.0.7",
+          "Microsoft.Extensions.Logging.Debug": "10.0.7",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.7",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "KrN6TGFwCwqOkLLk/idW/XtDQh+8In+CL9T4M1Dx+5ScsjTq4TlVbal8q532m82UYrMr6RiQJF2HvYCN0QwVsA==",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -566,63 +582,63 @@
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "resolved": "10.0.7",
+        "contentHash": "7BBnoGF37USiu7j434put9mDp7EjdlNDIZsR4vHfC1FbLZeLqiWjgJbeEtF0p59Ryqt8AtraHawf0ZKbe5jibg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Console": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "resolved": "10.0.7",
+        "contentHash": "DA++Es6v6W0HfrOrw+K8WyN6jNnZHp640PDdEvl8yfeVmgflKdn6vSSFvufNUSOuY+M2ZaSUgfY+jUKtNpXcCw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.Debug": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "resolved": "10.0.7",
+        "contentHash": "Y6DSt/JZApunYWKqTtqbdsR6iqAvHx3D0tavbNJ1rnC24MUpF+3XO/VKgFi+9PFqMyvQ2GHBBGb8H3cLSw7rDg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.EventLog": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "resolved": "10.0.7",
+        "contentHash": "1C8eTuxF6BLncNSJ1HCfmaBcjpUSqQDPlBVdYTlet9oldHTPpNh9iatxSJLs8TOqdp/FOpH+nSLdBve7fu9mTQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "System.Diagnostics.EventLog": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "System.Diagnostics.EventLog": "10.0.7"
         }
       },
       "Microsoft.Extensions.Logging.EventSource": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "resolved": "10.0.7",
+        "contentHash": "YWfndnDX1jVMGCN8d5T+rO+BO8sDw6BkYlUk0BYui+WP7+HhlWx8QLdA4yUDjrkGVb3AQxIWWEPVKw5Nnfj5GQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -641,14 +657,14 @@
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -971,8 +987,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
+        "resolved": "10.0.7",
+        "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingFixture.cs
@@ -2,11 +2,7 @@ namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
 
 using System.Diagnostics.CodeAnalysis;
 
-using Microsoft.EntityFrameworkCore;
-
 using Testcontainers.PostgreSql;
-
-using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
 [SuppressMessage(
     "Performance",
@@ -52,31 +48,20 @@ public sealed class CascadingFixture : IAsyncLifetime
     {
         await _postgres.StartAsync().ConfigureAwait(false);
 
-        // Cria o schema do domínio Selecao no Postgres efêmero ANTES do host
-        // Wolverine inicializar — sem isso há disputa de timing com o
-        // PostgresqlTransport e o handler reporta `relation "editais" does not exist`.
-        // O schema do Wolverine (`wolverine.*`) agora é provisionado no startup pelo
-        // próprio framework via `AutoBuildMessageStorageOnStartup = CreateOrUpdate`
-        // (issue #344) — antes ficava off-by-default e era criado lazy no primeiro
-        // despacho, o que era origem de timing flakiness em testes outbox.
+        // Schema do domínio Selecao no Postgres efêmero é provisionado pelo
+        // MigrationHostedService<SelecaoDbContext> registrado no Program.cs
+        // ANTES de UseWolverineOutboxCascading (uniplus-api#419). Como
+        // HostOptions.ServicesStartConcurrently=false (default), o host inicia
+        // hosted services em ordem: Migration aplica __EFMigrationsHistory antes
+        // do WolverineRuntime aceitar qualquer envelope que toque tabelas do
+        // módulo. Esta fixture confia 100% nessa ordem — não chama MigrateAsync
+        // localmente para não duplicar uma fonte de verdade. O fitness test
+        // MigrationBeforeWolverineRuntimeOrderTests em
+        // tests/Unifesspa.UniPlus.ArchTests/Hosting/ trava regressão da ordem.
         //
-        // Usar MigrateAsync (e não EnsureCreatedAsync) garante coabitação com o
-        // MigrationHostedService que o host produtivo carrega no startup
-        // (uniplus-api#416): popular __EFMigrationsHistory aqui faz o
-        // MigrationHostedService achar a migration já aplicada e ser no-op,
-        // evitando colisão 42P07 (relation already exists).
-        //
-        // Esta duplicidade fixture↔MigrationHostedService é tática e está
-        // documentada em ADR-0039 §"Atualizações posteriores". Follow-up
-        // planejado em uniplus-api#419: reordenar IHostedService no
-        // Program.cs (MigrationHostedService antes de UseWolverineOutboxCascading)
-        // + fitness test + remoção desta linha, restaurando 1 fonte de verdade.
-        DbContextOptions<SelecaoDbContext> options = new DbContextOptionsBuilder<SelecaoDbContext>()
-            .UseNpgsql(ConnectionString)
-            .Options;
-
-        await using SelecaoDbContext db = new(options);
-        await db.Database.MigrateAsync().ConfigureAwait(false);
+        // Schema do Wolverine (`wolverine.*`) é provisionado pelo próprio
+        // framework via `AutoBuildMessageStorageOnStartup = CreateOrUpdate`
+        // (issue #344, ADR-0039), independente do schema do domínio.
 
         // Captura todos os valores prévios ANTES de mutar o environment —
         // garantia de restore-em-falha dos dois sets atômicos. Sem isto,


### PR DESCRIPTION
Closes #419
Refs #416, ADR-0039

## Contexto

A partir do PR #416, o schema EF do domínio passou a ser aplicado por `MigrationHostedService<TContext>` (registrado por `AddDbContextMigrationsOnStartup<>`). Em Program.cs dos 3 entry points (Selecao/Ingresso/Portal), esse registro vinha **depois** de `UseWolverineOutboxCascading` + `AddWolverineMessaging`.

Como `HostOptions.ServicesStartConcurrently=false` (default), `IHostedService` startam sequencialmente na ordem de registro → `WolverineRuntime` iniciava primeiro e podia processar envelopes cascading que tocavam tabelas do módulo antes do schema EF existir (race `42P01 relation does not exist`).

`CascadingFixture` mitigava chamando `MigrateAsync` localmente antes do host startar — débito tático documentado em ADR-0039 §"Atualizações posteriores".

## Mudanças

| Arquivo | Mudança |
|---|---|
| `src/selecao/.../Program.cs` | Move `AddDbContextMigrationsOnStartup<SelecaoDbContext>()` antes de `UseWolverineOutboxCascading` + `AddWolverineMessaging`. Comentário cita invariante de #419. |
| `src/ingresso/.../Program.cs` | Idem para `IngressoDbContext`. |
| `src/portal/.../Program.cs` | Idem para `PortalDbContext`. |
| `tests/.../CascadingFixture.cs` | Remove `MigrateAsync` local + bloco `DbContextOptions`. Fixture confia 100% no host. Comentário atualizado. |
| `src/selecao/.../SelecaoApiAssemblyMarker.cs` | **Novo.** Simetria com `Portal/Ingresso` markers — type-arg do fitness sem ambiguidade `typeof(Program)`. |
| `src/selecao/.../GlobalSuppressions.cs` | CA1515 suprimido no marker (mesmo padrão de Portal/Ingresso). |
| `tests/.../ArchTests/Hosting/MigrationBeforeWolverineRuntimeOrderTests.cs` | **Novo.** Fitness com 2 teóricos × 3 entry points = 6 testes. |
| `tests/.../ArchTests.csproj` | Adiciona `Microsoft.AspNetCore.Mvc.Testing`. |
| `docs/adrs/0039-provisioning-schema-wolverine-via-deploy.md` | §"Atualizações posteriores" ganha entrada `2026-05-13 — coabitação resolvida em #419`. |

## Fitness test — invariantes cobertas

Para cada entry point (Selecao/Ingresso/Portal):

1. **Ordem**: `MigrationHostedService<TContext>` aparece antes do `WolverineRuntime` no `IServiceCollection` capturado pelo `WebApplicationFactory<TEntryPoint>`. Snapshot tirado em `ConfigureWebHost.ConfigureServices` ANTES de `ConfigureTestServices` (que remove os hosted services para permitir Start contra Postgres sintético) — preserva ordem original do Program.cs.
2. **Premissa**: `HostOptions.ServicesStartConcurrently == false`. Sem este assert, uma mudança futura em `HostOptions` tornaria a ordem de registro insuficiente para garantir a invariante.

Heurísticas (`IsMigrationHostedService`, `IsWolverineRuntime`) replicam as queries de `ApiFactoryBase` e `WolverineRuntimeRemovalSentinelTests` — refactor para helper compartilhado fica como follow-up (não consolidado neste PR para manter escopo focado).

## Validação local

```
dotnet build UniPlus.slnx                                                                                      ✓ 0 erros
dotnet test tests/Unifesspa.UniPlus.ArchTests                                                                  ✓ 9/9 (3 antigos + 6 novos)
dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests                                                   ✓ 75/75 (CascadingFixture sem MigrateAsync passa)
dotnet test tests/Unifesspa.UniPlus.Ingresso.IntegrationTests                                                  ✓ 8/8
dotnet test tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests                                       ✓ 20/20
dotnet test UniPlus.slnx                                                                                       ✓ todos os projetos
```

## Codex CLI

Plan review aplicado (P1 sobre cobertura de Portal + assert `ServicesStartConcurrently`). Diff review: zero findings.

## Test plan

- [x] `dotnet build UniPlus.slnx` limpo
- [x] Fitness teste passa nos 3 entry points
- [x] `CascadingFixture` sem `MigrateAsync` mantém 75/75 verde
- [x] ADR-0039 §"Atualizações posteriores" atualizada
- [x] CI verde (`PR author is org member`, `Build`, `Unit + arch tests`, `Integration tests`, `Coverage summary`)
- [ ] Review humano (jf2s)

## Out-of-scope

- Refactor das heurísticas `IsMigrationHostedService` / `IsWolverineRuntime` em helper compartilhado entre `ApiFactoryBase`, `WolverineRuntimeRemovalSentinelTests` e o novo fitness. Documentado como follow-up nos comentários do fitness e do PR.
- `AutoBuildMessageStorageOnStartup = CreateOrUpdate` do Wolverine (decisão #344, ADR-0039 vigente).
