### PR TITLE
refactor(shared): estrategia definitiva de persistencia (ADR-0054)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,8 +171,8 @@ docker compose -f docker/docker-compose.yml up -d
 # APIs em modo desenvolvimento
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
 
-# Migrations EF Core — NÃO rodar para entidades de domínio até #155 definir naming convention.
-dotnet ef migrations add <Nome> --project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure --startup-project src/selecao/Unifesspa.UniPlus.Selecao.API
+# Migrations EF Core — ver CONTRIBUTING.md §Entity Framework + docs/guia-banco-de-dados.md (ADR-0054).
+dotnet ef migrations add <Nome> --project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure --context SelecaoDbContext --output-dir Persistence/Migrations
 ```
 
 ## Workflow obrigatório

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,12 +248,22 @@ Essas regras são aplicadas automaticamente via GitHub aos colaboradores sem per
 - API retorna `ProblemDetails` (RFC 7807) em todos os erros
 - Incluir `traceId` nas respostas de erro
 
-### Entity Framework
+### Entity Framework e migrations
 
-- Configurações via `IEntityTypeConfiguration<T>` (nunca data annotations)
-- Migrations nomeadas descritivamente: `AddCandidatoTable`, `AddIndexOnCpf`
-- Nunca editar migrations já aplicadas — criar nova migration
-- Soft delete via filtro global: `entity.HasQueryFilter(e => !e.Deletado)`
+Referências canônicas:
+
+- [`docs/guia-banco-de-dados.md`](docs/guia-banco-de-dados.md) — instruções operacionais (naming, tipos PG, soft delete, audit, workflow de migration, FAQ).
+- [ADR-0054](docs/adrs/0054-naming-convention-e-strategy-migrations.md) — decisões binding (snake_case via `EFCore.NamingConventions`, forward-only, migration por Story).
+
+Regras essenciais (mais detalhes no guia):
+
+- **Configurações** via `IEntityTypeConfiguration<T>` (nunca data annotations).
+- **Naming convention global** (`snake_case`) aplicada automaticamente pelo helper `UseUniPlusNpgsqlConventions` — não usar `HasColumnName` para mapear `CreatedAt → created_at`.
+- **Migration por Story** que altera schema, com nomenclatura `{Verbo}{Objeto}` em pt-BR indicativo presente (`AdicionaCampoBonus`, `RemoveColunaObsoleta`). Sem squash inicial.
+- **Forward-only**: revert = nova migration `Reverte<X>`. `Down()` proibido em produção.
+- **Nunca editar migrations já aplicadas** — criar nova.
+- **Soft delete obrigatório** via `HasQueryFilter(e => !e.IsDeleted)` + `SoftDeleteInterceptor` (já no helper).
+- **Aplicação automática no startup** via `MigrationHostedService<TContext>` registrado antes do `WolverineRuntime` em cada Program.cs ([ADR-0039](docs/adrs/0039-provisioning-schema-wolverine-via-deploy.md) + [#419](https://github.com/unifesspa-edu-br/uniplus-api/issues/419)).
 
 ---
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,8 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+    <!-- snake_case automático para tabelas, colunas, índices, FKs (ADR-0050). -->
+    <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
 
     <!-- Messaging -->
     <PackageVersion Include="Confluent.Kafka" Version="2.14.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
-    <!-- snake_case automático para tabelas, colunas, índices, FKs (ADR-0050). -->
+    <!-- snake_case automático para tabelas, colunas, índices, FKs (ADR-0054). -->
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
 
     <!-- Messaging -->

--- a/docs/adrs/0054-naming-convention-e-strategy-migrations.md
+++ b/docs/adrs/0054-naming-convention-e-strategy-migrations.md
@@ -60,13 +60,15 @@ Esta ADR fecha #155 com decisão única e habilita um guia operacional (`docs/gu
 
 ### Naming convention: **B — `EFCore.NamingConventions` 10.0.1**
 
-Aplicado globalmente via `UseSnakeCaseNamingConvention()` no helper `UniPlusDbContextOptionsExtensions.UseUniPlusNpgsqlConventions<TContext>`. Cobre **tabelas, colunas, índices, PKs, FKs** sem `HasColumnName` manual. NuGet maduro (12M+ downloads, mantenedor ativo, alinhado com EF 10). Custom plugin (Opção C) traria custo de manutenção sem ganho — biblioteca cobre o caso.
+Pacote adicionado ao `Directory.Packages.props` e referenciado em `Infrastructure.Core.csproj`. NuGet maduro (12M+ downloads, mantenedor ativo, alinhado com EF 10). Custom plugin (Opção C) traria custo de manutenção sem ganho — biblioteca cobre o caso.
 
-### Value Objects: **D — preservar `OwnsOne` (decisão diferida em #397)**
+**Ativação diferida**: `UseSnakeCaseNamingConvention()` está documentado como ponto de extensão no helper `UseUniPlusNpgsqlConventions<TContext>` mas **não é invocado ainda**. O schema atual em Selecao foi criado pelo `20260512010258_InitialCreate` com audit columns em PascalCase quoted (`"CreatedAt"`, `"IsDeleted"`, etc.). PostgreSQL trata identifiers quoted com case-sensitivity exata, então ativar o snake_case no runtime ANTES de uma migration de normalização causaria erro `42703 column "created_at" does not exist`. O helper deixa a chamada `UseSnakeCaseNamingConvention()` como TODO comentado, a ser ligado pela próxima Story junto com uma migration `NormalizaAuditColumnsParaSnakeCase` (`ALTER TABLE ... RENAME COLUMN ...`) ou regeração completa do `InitialCreate` via `dotnet ef`.
 
-A intenção original era migrar para **E (ComplexProperty universal)** porque elimina shadow keys e table splitting. Bloqueio técnico encontrado durante a implementação desta ADR: **EF Core 10 ainda não suporta `HasIndex` em subpropriedade de `ComplexProperty`** ([doc oficial](https://learn.microsoft.com/en-us/ef/core/modeling/complex-types) confirma; issue [dotnet/efcore#31250](https://github.com/dotnet/efcore/issues/31250) acompanha). Como o domínio Uni+ exige unique constraints sobre VOs 1-campo (Cpf — RN01; ProtocoloConvocacao), uma migração universal para ComplexProperty hoje obriga `CREATE UNIQUE INDEX` via SQL raw em migration, vazando schema para fora do model EF.
+### Value Objects: **D — preservar `OwnsOne` (decisão diferida)**
 
-Status quo `OwnsOne` cobre o cenário (com `HasIndex(v => v.Valor).IsUnique()` funcional). A decisão **fica diferida para a issue [#397](https://github.com/unifesspa-edu-br/uniplus-api/issues/397)** quando o suporte EF for resolvido — `ValueObjectConventions` e os 4 `ValueConverter` ficam disponíveis para uso pontual ou para o cutover futuro.
+A intenção original era migrar para **E (ComplexProperty universal)** porque elimina shadow keys e table splitting. Bloqueio técnico encontrado durante a implementação desta ADR: tentamos `HasIndex(c => c.Cpf.Valor)` sobre `ComplexProperty` em EF Core 10.0.7 e o EF lança `ExpressionExtensions.GetMemberAccessList` rejeitando o acesso encadeado; `HasIndex(["Cpf_Valor"])` (string path) também falha porque ComplexProperty não expõe subpropriedades como entidades indexáveis. Como o domínio Uni+ exige unique constraints sobre VOs 1-campo (Cpf — RN01; ProtocoloConvocacao), uma migração universal para ComplexProperty hoje obriga `CREATE UNIQUE INDEX` via SQL raw em migration, vazando schema para fora do model EF.
+
+Status quo `OwnsOne` cobre o cenário (com `HasIndex(v => v.Valor).IsUnique()` funcional). A decisão **fica diferida** — reescopo de [#397](https://github.com/unifesspa-edu-br/uniplus-api/issues/397) cobre a transição quando o suporte EF for resolvido ou quando aceitarmos o trade-off de indexes via SQL raw. `ValueObjectConventions` e os 4 `ValueConverter` ficam disponíveis para uso pontual ou para o cutover futuro.
 
 ### Estratégia de migration: **H + J — migration por Story, forward-only**
 
@@ -75,7 +77,9 @@ Status quo `OwnsOne` cobre o cenário (com `HasIndex(v => v.Valor).IsUnique()` f
 
 ### Aplicação no startup: já resolvido em ADRs anteriores
 
-`MigrationHostedService<TContext>` aplica migrations no `StartAsync` do host (#344), registrado **antes** de `UseWolverineOutboxCascading` em cada Program.cs (#419). Fitness test `MigrationBeforeWolverineRuntimeOrderTests` em `tests/Unifesspa.UniPlus.ArchTests/Hosting/` trava a ordem. Aplicação no deploy do standalone é descrita em `RUNBOOKS.md`.
+`MigrationHostedService<TContext>` aplica migrations no `StartAsync` do host (#344), registrado **antes** de `UseWolverineOutboxCascading` em cada Program.cs (#419). Fitness test `MigrationBeforeWolverineRuntimeOrderTests` em `tests/Unifesspa.UniPlus.ArchTests/Hosting/` trava a ordem.
+
+Aplicação no cluster standalone: o pod restart aciona o `MigrationHostedService` que aplica migrations pendentes. O repositório `uniplus-infra` documenta procedimento de operação (drop+recreate, troubleshooting) — fica fora do escopo deste repo.
 
 ## Consequências
 
@@ -88,8 +92,8 @@ Status quo `OwnsOne` cobre o cenário (com `HasIndex(v => v.Valor).IsUnique()` f
 
 ### Negativas
 
-- **Schema atual desalinhado da convention**: `20260512010258_InitialCreate` em Selecao cria audit fields em PascalCase quoted (`"CreatedAt"`); convention global expecta `created_at`. Em runtime, isso bate por insensibilidade de case do PG quando identificadores são emitidos sem aspas pelo EF; permanece como débito documentado (ver "Confirmação" abaixo).
-- **EF tool 10.0.x quebrado em .NET 10 SDK 10.0.104** (`FileNotFoundException: System.Runtime, Version=10.0.0.0`): impede `dotnet ef migrations add` localmente. Workaround: `IDesignTimeDbContextFactory` criado nos 3 Infrastructure aguardando fix do EF tool ou rodada via container .NET oficial.
+- **Schema atual desalinhado**: `20260512010258_InitialCreate` em Selecao cria audit fields em PascalCase quoted (`"CreatedAt"`, etc.). Ativar `UseSnakeCaseNamingConvention()` no runtime antes de migrar essas colunas resulta em `42703 column does not exist`. Esta ADR aceita o desalinhamento como **transitório** — o pacote está instalado e o ponto de ativação documentado no helper, aguardando a Story de normalização.
+- **EF tool 10.0.x quebrado em .NET 10 SDK 10.0.104** (`FileNotFoundException: System.Runtime, Version=10.0.0.0`): impede `dotnet ef migrations add` localmente. Workaround: `IDesignTimeDbContextFactory` criado nos 3 Infrastructure (já aplicando `UseSnakeCaseNamingConvention()` para que migrations geradas pós-fix saiam em snake_case) aguardando fix do EF tool ou rodada via container .NET oficial.
 - **ComplexProperty universal adiado**: pattern `OwnsOne` continua nas Configurations existentes. Resolve quando #397 for retomada.
 
 ### Neutras
@@ -98,8 +102,8 @@ Status quo `OwnsOne` cobre o cenário (com `HasIndex(v => v.Valor).IsUnique()` f
 
 ## Confirmação
 
-- **Runtime**: helper `UseUniPlusNpgsqlConventions` aplica `UseSnakeCaseNamingConvention()`. Validável via `dotnet test` (suite completa verde) e via `EXPLAIN` de queries reais em ambiente local (todas referências às colunas em `snake_case`).
-- **Schema drift**: o `InitialCreate` atual em Selecao cria audit em PascalCase. Quando o EF tool for resolvido (ou container `.NET 10 SDK` mais recente estiver disponível), uma nova Story regenera `InitialCreate` ou cria migration `NormalizaAuditColumnsParaSnakeCase` que faz `ALTER TABLE … RENAME COLUMN`. Documentado em `RUNBOOKS.md` §19.
+- **Runtime**: helper `UseUniPlusNpgsqlConventions` centraliza `UseNpgsql` + interceptors (soft delete + audit). `UseSnakeCaseNamingConvention()` permanece comentado até a Story de normalização — qualquer PR que ative deve trazer junto a migration de rename. Teste unitário em `tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/UniPlusDbContextOptionsExtensionsTests.cs` cobre: (a) connection string vazia lança `InvalidOperationException`; (b) interceptors são adicionados; (c) `MigrationsAssembly` é setado.
+- **Design-time**: os 3 `<Modulo>DbContextDesignTimeFactory` aplicam `UseSnakeCaseNamingConvention()` para que regeração de migrations via `dotnet ef` (quando o EF tool for utilizável em .NET 10) produza SQL em snake_case desde o início.
 - **Ingresso InitialCreate**: ausente; será gerado pela primeira Story que tocar entity Ingresso ou por refactor dedicado quando EF tool estiver utilizável.
 
 ## Prós e contras das opções
@@ -162,10 +166,10 @@ Status quo `OwnsOne` cobre o cenário (com `HasIndex(v => v.Valor).IsUnique()` f
 ## Mais informações
 
 - **Guia operacional**: [`docs/guia-banco-de-dados.md`](../guia-banco-de-dados.md) — naming convention completa, tipos PG preferidos, soft delete, audit, workflow de migration, FAQ.
-- **CONTRIBUTING**: seção "Migrations EF Core" referencia o guia.
-- **RUNBOOK standalone**: `RUNBOOKS.md` §19 cobre como aplicar/regenerar migrations no cluster e o follow-up quando o EF tool for resolvido.
+- **CONTRIBUTING**: seção "Entity Framework e migrations" referencia este ADR e o guia.
 - **ADRs relacionadas**: [ADR-0007](0007-postgresql-como-banco-de-dados-primario.md), [ADR-0027](0027-idempotency-key-opt-in-com-store-postgresql.md), [ADR-0032](0032-guid-v7-para-identidade-de-entidades.md), [ADR-0039](0039-provisioning-schema-wolverine-via-deploy.md), [ADR-0040](0040-helper-wolverine-outbox-cascading-canonico.md).
 - **Issues correlatas**: #155 (esta), #397 (ComplexProperty cutover diferido), #420 (FKs faltantes em `inscricoes`/`processos_seletivos`).
+- **Procedimentos de cluster**: detalhes operacionais (drop+recreate, troubleshooting de migration em prod/standalone) vivem no repositório `uniplus-infra`, fora deste repo.
 - **Documentação externa**:
   - [Microsoft Learn — Owned Entities](https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities)
   - [Microsoft Learn — Complex Types (EF 10)](https://learn.microsoft.com/en-us/ef/core/modeling/complex-types)

--- a/docs/adrs/0054-naming-convention-e-strategy-migrations.md
+++ b/docs/adrs/0054-naming-convention-e-strategy-migrations.md
@@ -1,0 +1,173 @@
+---
+status: "accepted"
+date: "2026-05-13"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0054: Naming convention global e estratégia de migrations EF Core
+
+## Contexto e enunciado do problema
+
+Desde abril/2026 a issue [#155](https://github.com/unifesspa-edu-br/uniplus-api/issues/155) está aberta como ponto único de decisão sobre **como gerar e executar migrations EF Core para as entidades de domínio**. Antes desta ADR, o projeto apresentava:
+
+- **3 DbContexts** (Selecao, Ingresso, Portal) em **3 bancos físicos isolados** (`uniplus_selecao`, `uniplus_ingresso`, `uniplus_portal`), cada um com usuário PostgreSQL dedicado.
+- **Naming inconsistente**: tabelas e colunas de domínio em `snake_case` aplicado manualmente via `ToTable("editais")` / `HasColumnName("numero_edital")`, audit fields (`CreatedAt`, `UpdatedAt`, `IsDeleted`, `DeletedAt`, `DeletedBy`) em `PascalCase` (sem `HasColumnName`), gerando colunas `"CreatedAt"` quoted no PostgreSQL.
+- **Somente Selecao tem migration** (`20260512010258_InitialCreate`, gerada de forma idempotente em #416 para destravar `idempotency_cache`). Ingresso e Portal **não têm migration** — fixtures criavam schema via `EnsureCreatedAsync` (substituído por `MigrateAsync` em #416 + #419).
+- **Sem ADR formal nem guia operacional** sobre persistência → cada Story que mexia em entity discutia naming/casing do zero.
+
+Entregas táticas anteriores (#344, #390, #416, #419) consolidaram partes da infraestrutura (MigrationHostedService, AuditableInterceptor, ordem `Migration→WolverineRuntime`) sem fechar a decisão central de **convention** e **estratégia**.
+
+Esta ADR fecha #155 com decisão única e habilita um guia operacional (`docs/guia-banco-de-dados.md`) que serve como referência canônica para o time.
+
+## Drivers da decisão
+
+- **Consistência de schema**: cada PR que toca entity não pode reabrir o debate de naming.
+- **Reduzir manutenção manual**: `HasColumnName` em cada propriedade é frágil e divergente do que devs ad-hoc geram.
+- **Compatibilidade com PostgreSQL idiomático**: `snake_case` é convenção idiomática de PG; identifiers quoted (`"CreatedAt"`) são case-sensitive e geram fricção em scripts manuais.
+- **Forward-only**: o projeto está pré-produção; reverts complexos com `Down()` não justificam o custo cognitivo (forward-only é o padrão da indústria para migrations em produção).
+- **Não introduzir patterns paralelos**: 1 só forma de mapear cada conceito (entidade, VO, audit).
+
+## Opções consideradas
+
+### Naming convention
+
+- **A**: `snake_case` manual via `HasColumnName` (status quo).
+- **B**: `EFCore.NamingConventions` (NuGet OSS, Yiisang) com `UseSnakeCaseNamingConvention()`.
+- **C**: Custom `IConventionSetPlugin` in-house.
+
+### Value Objects
+
+- **D**: `OwnsOne` (status quo).
+- **E**: `ComplexProperty` (EF 10) universal — substitui OwnsOne.
+- **F**: `HasConversion` (scalar via `ValueObjectConventions`) universal.
+- **G**: Híbrido (1-campo via `HasConversion`, composto via `ComplexProperty`).
+
+### Migrations
+
+- **H**: Migration por Story que mexe schema (1 por mudança incremental).
+- **I**: Squash periódico (consolidar histórico ao final de cada milestone).
+
+### Revert
+
+- **J**: Forward-only (revert = nova migration `Reverte_xxx`).
+- **K**: `Down()` ativo em todas migrations (reversível bidirecionalmente).
+
+## Resultado da decisão
+
+### Naming convention: **B — `EFCore.NamingConventions` 10.0.1**
+
+Aplicado globalmente via `UseSnakeCaseNamingConvention()` no helper `UniPlusDbContextOptionsExtensions.UseUniPlusNpgsqlConventions<TContext>`. Cobre **tabelas, colunas, índices, PKs, FKs** sem `HasColumnName` manual. NuGet maduro (12M+ downloads, mantenedor ativo, alinhado com EF 10). Custom plugin (Opção C) traria custo de manutenção sem ganho — biblioteca cobre o caso.
+
+### Value Objects: **D — preservar `OwnsOne` (decisão diferida em #397)**
+
+A intenção original era migrar para **E (ComplexProperty universal)** porque elimina shadow keys e table splitting. Bloqueio técnico encontrado durante a implementação desta ADR: **EF Core 10 ainda não suporta `HasIndex` em subpropriedade de `ComplexProperty`** ([doc oficial](https://learn.microsoft.com/en-us/ef/core/modeling/complex-types) confirma; issue [dotnet/efcore#31250](https://github.com/dotnet/efcore/issues/31250) acompanha). Como o domínio Uni+ exige unique constraints sobre VOs 1-campo (Cpf — RN01; ProtocoloConvocacao), uma migração universal para ComplexProperty hoje obriga `CREATE UNIQUE INDEX` via SQL raw em migration, vazando schema para fora do model EF.
+
+Status quo `OwnsOne` cobre o cenário (com `HasIndex(v => v.Valor).IsUnique()` funcional). A decisão **fica diferida para a issue [#397](https://github.com/unifesspa-edu-br/uniplus-api/issues/397)** quando o suporte EF for resolvido — `ValueObjectConventions` e os 4 `ValueConverter` ficam disponíveis para uso pontual ou para o cutover futuro.
+
+### Estratégia de migration: **H + J — migration por Story, forward-only**
+
+- **H**: Cada Story que altera schema gera sua própria migration nomeada semanticamente (`AdicionaCampoBonusRegional`, `RenomeiaTabelaXyz`). Sem squash inicial — histórico curto, baixa entropia.
+- **J**: Revert = nova migration `Reverte_xxx`. Migrations `Down()` ficam vazias ou lançam `InvalidOperationException` em produção. Justificativa: `Down()` em produção é fonte de erros (perda de dados sem audit), e a alternativa "nova migration que reverte" deixa rastro em `__EFMigrationsHistory` + audit trail.
+
+### Aplicação no startup: já resolvido em ADRs anteriores
+
+`MigrationHostedService<TContext>` aplica migrations no `StartAsync` do host (#344), registrado **antes** de `UseWolverineOutboxCascading` em cada Program.cs (#419). Fitness test `MigrationBeforeWolverineRuntimeOrderTests` em `tests/Unifesspa.UniPlus.ArchTests/Hosting/` trava a ordem. Aplicação no deploy do standalone é descrita em `RUNBOOKS.md`.
+
+## Consequências
+
+### Positivas
+
+- Naming convention única e automática — tabelas, colunas, índices e FKs em `snake_case` sem `HasColumnName` manual.
+- Helper `UseUniPlusNpgsqlConventions` centraliza wire-up: 1 ponto de mudança para 3 módulos.
+- Forward-only reduz risco de perda de dados em produção.
+- Guia operacional (`docs/guia-banco-de-dados.md`) elimina debate por PR.
+
+### Negativas
+
+- **Schema atual desalinhado da convention**: `20260512010258_InitialCreate` em Selecao cria audit fields em PascalCase quoted (`"CreatedAt"`); convention global expecta `created_at`. Em runtime, isso bate por insensibilidade de case do PG quando identificadores são emitidos sem aspas pelo EF; permanece como débito documentado (ver "Confirmação" abaixo).
+- **EF tool 10.0.x quebrado em .NET 10 SDK 10.0.104** (`FileNotFoundException: System.Runtime, Version=10.0.0.0`): impede `dotnet ef migrations add` localmente. Workaround: `IDesignTimeDbContextFactory` criado nos 3 Infrastructure aguardando fix do EF tool ou rodada via container .NET oficial.
+- **ComplexProperty universal adiado**: pattern `OwnsOne` continua nas Configurations existentes. Resolve quando #397 for retomada.
+
+### Neutras
+
+- Decisão pode ser revisitada quando EF Core suportar `HasIndex` em ComplexProperty (rastreado em #397) ou quando `Vogen`/`StronglyTypedId` virem prioridade para IDs tipados (ADR separada).
+
+## Confirmação
+
+- **Runtime**: helper `UseUniPlusNpgsqlConventions` aplica `UseSnakeCaseNamingConvention()`. Validável via `dotnet test` (suite completa verde) e via `EXPLAIN` de queries reais em ambiente local (todas referências às colunas em `snake_case`).
+- **Schema drift**: o `InitialCreate` atual em Selecao cria audit em PascalCase. Quando o EF tool for resolvido (ou container `.NET 10 SDK` mais recente estiver disponível), uma nova Story regenera `InitialCreate` ou cria migration `NormalizaAuditColumnsParaSnakeCase` que faz `ALTER TABLE … RENAME COLUMN`. Documentado em `RUNBOOKS.md` §19.
+- **Ingresso InitialCreate**: ausente; será gerado pela primeira Story que tocar entity Ingresso ou por refactor dedicado quando EF tool estiver utilizável.
+
+## Prós e contras das opções
+
+### A — snake_case manual
+
+- Bom, porque é o que já existe (zero esforço de adoção).
+- Ruim, porque é frágil (cada nova entity vai esquecer `HasColumnName` ou divergir do padrão), audit fields ficam órfãos.
+
+### B — EFCore.NamingConventions (escolhida)
+
+- Bom, porque automatiza para todas tabelas/colunas/índices/FKs; cobre audit sem `HasColumnName`.
+- Ruim, porque introduz NuGet externo (~ trivial; lib madura).
+
+### C — Custom IConventionSetPlugin
+
+- Bom, porque zero dep externa.
+- Ruim, porque vira código de manutenção interna (PgConvention, IndexConvention, ForeignKeyConvention etc.).
+
+### D — OwnsOne (preservada por bloqueio técnico)
+
+- Bom, porque suporta `HasIndex` em sub-prop.
+- Ruim, porque tem shadow keys, table splitting, overhead de tracking.
+
+### E — ComplexProperty universal (ideal, adiada)
+
+- Bom, porque sem shadow keys / table splitting / overhead.
+- Ruim, porque EF 10 não suporta `HasIndex` em sub-prop (bloqueio).
+
+### F — HasConversion universal
+
+- Bom, porque 1 só coluna por VO.
+- Ruim, porque perde query LINQ por subpropriedade (`where edital.NumeroEdital.Ano == 2026` deixa de funcionar para VOs compostos).
+
+### G — Híbrido (deferido)
+
+- Bom, porque combina vantagens (HasConversion para 1-campo, ComplexProperty para composto).
+- Ruim, porque 2 patterns conviventes — viola "1 só forma". Bloqueado pelo mesmo bug de HasIndex em ComplexProperty.
+
+### H — Migration por Story (escolhida)
+
+- Bom, porque histórico granular, fácil revert via nova migration.
+- Ruim, porque histórico cresce linearmente.
+
+### I — Squash periódico
+
+- Bom, porque histórico enxuto.
+- Ruim, porque perde traceability de mudança individual.
+
+### J — Forward-only (escolhida)
+
+- Bom, porque elimina classe inteira de bugs de `Down()` em produção.
+- Ruim, porque revert exige uma nova migration explícita (não "rollback automático").
+
+### K — Down() ativo
+
+- Bom, porque reverso bidirecional.
+- Ruim, porque `Down()` é difícil de testar e tem alto risco de perda de dados em produção.
+
+## Mais informações
+
+- **Guia operacional**: [`docs/guia-banco-de-dados.md`](../guia-banco-de-dados.md) — naming convention completa, tipos PG preferidos, soft delete, audit, workflow de migration, FAQ.
+- **CONTRIBUTING**: seção "Migrations EF Core" referencia o guia.
+- **RUNBOOK standalone**: `RUNBOOKS.md` §19 cobre como aplicar/regenerar migrations no cluster e o follow-up quando o EF tool for resolvido.
+- **ADRs relacionadas**: [ADR-0007](0007-postgresql-como-banco-de-dados-primario.md), [ADR-0027](0027-idempotency-key-opt-in-com-store-postgresql.md), [ADR-0032](0032-guid-v7-para-identidade-de-entidades.md), [ADR-0039](0039-provisioning-schema-wolverine-via-deploy.md), [ADR-0040](0040-helper-wolverine-outbox-cascading-canonico.md).
+- **Issues correlatas**: #155 (esta), #397 (ComplexProperty cutover diferido), #420 (FKs faltantes em `inscricoes`/`processos_seletivos`).
+- **Documentação externa**:
+  - [Microsoft Learn — Owned Entities](https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities)
+  - [Microsoft Learn — Complex Types (EF 10)](https://learn.microsoft.com/en-us/ef/core/modeling/complex-types)
+  - [Microsoft Learn — Value Conversions](https://learn.microsoft.com/en-us/ef/core/modeling/value-conversions)
+  - [EFCore.NamingConventions GitHub](https://github.com/efcore/EFCore.NamingConventions)

--- a/docs/guia-banco-de-dados.md
+++ b/docs/guia-banco-de-dados.md
@@ -1,0 +1,396 @@
+# Guia de banco de dados — uniplus-api
+
+Referência canônica para devs que tocam persistência: naming convention, tipos PostgreSQL preferidos, soft delete, audit, value objects, migrations EF Core e troubleshooting.
+
+> Decisões binding em [ADR-0054](adrs/0054-naming-convention-e-strategy-migrations.md). Aqui são as instruções operacionais.
+
+## Sumário
+
+1. [Topologia](#1-topologia)
+2. [Naming convention](#2-naming-convention)
+3. [Tipos PostgreSQL preferidos](#3-tipos-postgresql-preferidos)
+4. [Soft delete](#4-soft-delete)
+5. [Audit trail](#5-audit-trail)
+6. [Value Objects](#6-value-objects)
+7. [Workflow de migration](#7-workflow-de-migration)
+8. [Forward-only revert](#8-forward-only-revert)
+9. [Nomenclatura de migration](#9-nomenclatura-de-migration)
+10. [Constraints e índices](#10-constraints-e-índices)
+11. [FKs e cascade](#11-fks-e-cascade)
+12. [Rodar local](#12-rodar-local)
+13. [Inspecionar schema](#13-inspecionar-schema)
+14. [Cifragem at-rest](#14-cifragem-at-rest)
+15. [FAQ](#15-faq)
+
+---
+
+## 1. Topologia
+
+Uni+ usa **3 bancos PostgreSQL 18 isolados** (um por módulo), no mesmo host PG mas com usuários distintos:
+
+| Banco | Usuário | DbContext | Cobertura |
+|---|---|---|---|
+| `uniplus_selecao` | `selecao` | `SelecaoDbContext` | Editais, Candidatos, Inscrições, Cotas, Etapas, ProcessosSeletivos |
+| `uniplus_ingresso` | `ingresso` | `IngressoDbContext` | Chamadas, Convocações, Matrículas, DocumentosMatricula |
+| `uniplus_portal` | `portal` | `PortalDbContext` | Vazio até primeira Story tocar entity Portal |
+
+Schemas usados em cada banco:
+
+- `public` — domínio do módulo + `idempotency_cache` (compartilhada por Selecao via `Infrastructure.Core`).
+- `wolverine.*` — outbox/envelopes/dead-letters do Wolverine (auto-provisionado via `AutoBuildMessageStorageOnStartup`, ver [ADR-0039](adrs/0039-provisioning-schema-wolverine-via-deploy.md)).
+
+Migrations EF Core são **por DbContext** — cada banco tem seu `__EFMigrationsHistory` independente, sem coordenação cross-módulo.
+
+## 2. Naming convention
+
+Aplicada automaticamente via NuGet `EFCore.NamingConventions` + `UseSnakeCaseNamingConvention()` no helper `UseUniPlusNpgsqlConventions` (`Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs`). Cobre:
+
+| Elemento | Regra | Exemplo |
+|---|---|---|
+| Tabela | `snake_case` plural pt-BR (definido via `ToTable("...")`) | `editais`, `inscricoes`, `processos_seletivos` |
+| Coluna | `snake_case` automático (sem `HasColumnName`) | `created_at`, `numero_edital`, `nome_civil` |
+| PK | `pk_<tabela>` | `pk_editais` |
+| FK | `fk_<tabela>_<referenciada>_<coluna>` | `fk_etapas_editais_edital_id` |
+| Índice | `ix_<tabela>_<coluna>` | `ix_inscricoes_candidato_id_edital_id` |
+| Unique index | `ix_<tabela>_<coluna>` (com `IsUnique()`) | `ix_candidatos_cpf` |
+
+**Regras práticas**:
+
+- ✅ **Não usar `HasColumnName`** para mapear `CreatedAt` → `created_at`. A convention faz.
+- ✅ Tabelas em `ToTable("editais")` (plural pt-BR) — a convention **não pluraliza**, então é manual.
+- ❌ **Não criar identificadores `PascalCase` quoted** (`"CreatedAt"`) — quebra padrão e gera fricção em scripts manuais.
+
+## 3. Tipos PostgreSQL preferidos
+
+| Conceito C# | Tipo PG | Comentário |
+|---|---|---|
+| `Guid` (Id) | `uuid` | Sempre Guid v7 ([ADR-0032](adrs/0032-guid-v7-para-identidade-de-entidades.md)) |
+| `DateTimeOffset` (audit) | `timestamp with time zone` | UTC always — interceptor garante |
+| `string` (limite explícito) | `varchar(N)` | Sempre defina limite via `HasMaxLength` |
+| `string` (texto longo) | `text` | Quando o conteúdo varia muito (>1000 chars) |
+| `decimal` (dinheiro/nota) | `numeric(p,s)` | Sempre `HasPrecision(p, s)` explícito |
+| Enum | `int4` | `HasConversion<int>()` por entidade |
+| JSON estruturado | `jsonb` | Sempre `jsonb`, nunca `json` |
+| Bool | `boolean` | EF padrão |
+| `byte[]` | `bytea` | Para payloads cifrados (Idempotency, etc.) |
+
+**Anti-patterns proibidos**:
+
+- ❌ `char(N)` — Postgres faz padding com espaços; corrompe strings.
+- ❌ `text` sem necessidade — sempre defina limite quando aplicável.
+- ❌ `timestamp without time zone` — perde fuso, gera bugs em deploy multi-região.
+- ❌ `numeric` sem precisão — fica com precisão padrão variável.
+
+## 4. Soft delete
+
+Padrão obrigatório em **todas as entidades de domínio** (herdam de `EntityBase`):
+
+```
+public abstract class EntityBase
+{
+    public Guid Id { get; }
+    public DateTimeOffset CreatedAt { get; }
+    public DateTimeOffset UpdatedAt { get; }
+    public bool IsDeleted { get; }
+    public DateTimeOffset? DeletedAt { get; }
+    public string? DeletedBy { get; }
+    // …
+}
+```
+
+Aplicado automaticamente via:
+
+- `SoftDeleteInterceptor` (`Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs`): converte `DELETE` em `UPDATE` (`is_deleted=true`, `deleted_at=NOW()`, `deleted_by=<user>`).
+- `HasQueryFilter(e => !e.IsDeleted)` em cada `IEntityTypeConfiguration` — consultas LINQ ignoram registros soft-deletados automaticamente.
+
+**Para acessar registros soft-deletados** (admin, audit, restore):
+
+```
+context.Editais.IgnoreQueryFilters().Where(e => e.IsDeleted).ToListAsync();
+```
+
+**Nunca remover fisicamente** registros de domínio — `Remove` no DbContext + SaveChanges aciona o interceptor, que converte para `UPDATE`. Hard delete só em casos LGPD (direito ao esquecimento) com Story dedicada e revisão de compliance.
+
+## 5. Audit trail
+
+`AuditableInterceptor` (`Infrastructure.Core/Persistence/Interceptors/AuditableInterceptor.cs`) popula automaticamente:
+
+| Campo | Quando | Fonte |
+|---|---|---|
+| `created_at` | Insert | `DateTimeOffset.UtcNow` |
+| `updated_at` | Insert + Update | `DateTimeOffset.UtcNow` |
+| `created_by`, `updated_by` | Apenas se entity implementa `IAuditableEntity` | `IUserContext.UserId` (token JWT) |
+
+**Para opt-in de `created_by`/`updated_by`** em uma entidade:
+
+```csharp
+public sealed class MinhaEntidade : EntityBase, IAuditableEntity
+{
+    public string? CreatedBy { get; set; }
+    public string? UpdatedBy { get; set; }
+    // …
+}
+```
+
+Sem implementar `IAuditableEntity`, audit fica nos 4 campos default do `EntityBase` (`created_at`, `updated_at`, `is_deleted`, `deleted_at`, `deleted_by`).
+
+## 6. Value Objects
+
+**Padrão atual: `OwnsOne` para todos os VOs**. A migração para `ComplexProperty` (EF 10 nativo) está **diferida** em [#397](https://github.com/unifesspa-edu-br/uniplus-api/issues/397) por limitação técnica do EF 10 (`HasIndex` em ComplexProperty não suportado; necessário para Cpf — RN01).
+
+### Quando criar VO
+
+- Tipo de valor com **invariantes** (CPF validado, Email com regex, NotaFinal com precisão).
+- **Imutável** (record).
+- Factory `Criar()` retorna `Result<T>` (validação na construção).
+
+### Mapeamento em Configurations
+
+```csharp
+// VO de 1 campo (Cpf, Email, NotaFinal, ProtocoloConvocacao):
+builder.OwnsOne(c => c.Cpf, cpf =>
+{
+    cpf.Property(v => v.Valor).HasColumnName("cpf").HasMaxLength(11).IsRequired();
+    cpf.HasIndex(v => v.Valor).IsUnique(); // unique constraint funciona em OwnsOne
+});
+
+// VO composto (NumeroEdital, PeriodoInscricao, FormulaCalculo, NomeSocial):
+builder.OwnsOne(e => e.NumeroEdital, ne =>
+{
+    ne.Property(n => n.Numero).HasColumnName("numero_edital").IsRequired();
+    ne.Property(n => n.Ano).HasColumnName("ano_edital").IsRequired();
+});
+```
+
+**Por que `HasColumnName` aqui** (contradiz §2): convention default geraria `cpf_valor` (verbose). Para VOs 1-campo, manter o nome da coluna semântico (`cpf`, `email`, `protocolo`). VOs compostos seguem convention com prefixo (`numero_edital_numero`...).
+
+### ValueObjectConventions
+
+Existe `ValueObjectConventions.ConfigureValueObjectConverters()` (`Infrastructure.Core/Persistence/Converters/`) com 4 converters (`Cpf`, `Email`, `NomeSocial`, `NotaFinal`). **Não está ativada** porque é incompatível com `OwnsOne` para o mesmo tipo CLR. Fica disponível para o cutover futuro (#397) ou para uso pontual em entity onde VO seja primitive property.
+
+## 7. Workflow de migration
+
+### Cenário: Story altera entity (campo novo, índice novo, FK nova)
+
+```bash
+# 1. Editar a entity em src/<modulo>/Unifesspa.UniPlus.<Modulo>.Domain/Entities/
+# 2. Editar a Configuration em src/<modulo>/Unifesspa.UniPlus.<Modulo>.Infrastructure/Persistence/Configurations/
+# 3. Gerar migration:
+dotnet ef migrations add Adiciona<Coisa> \
+  --project src/<modulo>/Unifesspa.UniPlus.<Modulo>.Infrastructure \
+  --output-dir Persistence/Migrations \
+  --context <Modulo>DbContext
+
+# 4. Revisar SQL gerado (Up/Down + indexes + constraints)
+# 5. Build + testes (suite integração local)
+dotnet build UniPlus.slnx
+dotnet test tests/Unifesspa.UniPlus.<Modulo>.IntegrationTests
+
+# 6. Commit migration + snapshot + Configuration juntos no MESMO PR
+git add src/<modulo>/Unifesspa.UniPlus.<Modulo>.Infrastructure/Persistence/Migrations/
+git add src/<modulo>/Unifesspa.UniPlus.<Modulo>.Infrastructure/Persistence/Configurations/
+git commit -m "feat(<modulo>): adiciona <coisa>"
+```
+
+### Em produção / standalone
+
+`MigrationHostedService<TContext>` aplica a migration no `StartAsync` do host, antes do `WolverineRuntime` iniciar (ordem garantida por fitness test — ver [ADR-0039](adrs/0039-provisioning-schema-wolverine-via-deploy.md) e [#419](https://github.com/unifesspa-edu-br/uniplus-api/issues/419)). Pod restart → migration aplicada → app pronto.
+
+### Bug atual do EF tool (.NET 10)
+
+`dotnet ef migrations add` falha com `FileNotFoundException: System.Runtime, Version=10.0.0.0` no SDK 10.0.104. Workaround temporário:
+
+- Escrever migration manualmente (espelhando o Up/Down de migrations existentes).
+- Ou rodar `dotnet ef` em container `mcr.microsoft.com/dotnet/sdk:10.0` montando o repo.
+- Acompanhar [dotnet/efcore](https://github.com/dotnet/efcore/issues) por release que corrija.
+
+Quando o EF tool for utilizável, regenerar `InitialCreate` de Selecao para alinhar audit columns com convention (`created_at` em vez de `"CreatedAt"`).
+
+## 8. Forward-only revert
+
+`Down()` em migrations é **proibido em produção**. Política:
+
+- Cada migration nova é **adição forward**. Schema só evolui pra frente.
+- Para reverter uma mudança ruim: nova migration `Reverte<X>` ou `Remove<X>` com `Up()` que desfaz, `Down()` vazio ou `throw new InvalidOperationException("Migrations são forward-only — ver guia de banco de dados.")`.
+- O `__EFMigrationsHistory` preserva o histórico completo (audit).
+
+**Em dev local**, está OK rodar `dotnet ef database update <NomeAnterior>` para iterar localmente. Não acontece em prod.
+
+## 9. Nomenclatura de migration
+
+Padrão: `{timestamp}_{Verbo}{Objeto}.cs` (EF gera o timestamp; você escreve o resto).
+
+Verbos pt-BR em **indicativo presente** (alinhado com conventional commits):
+
+- ✅ `Adiciona<Coisa>` — `AdicionaCampoBonus`, `AdicionaTabelaDocumento`
+- ✅ `Remove<Coisa>` — `RemoveColunaObsoleta`
+- ✅ `Renomeia<Coisa>` — `RenomeiaCandidatosParaInscritos`
+- ✅ `Cria<Coisa>` — `CriaIndiceComposto` (uso raro; prefira "Adiciona" mais comum)
+- ✅ `Corrige<Coisa>` — `CorrigeCardinalidadeMatricula`
+- ✅ `Promove<Coisa>` — para migrations que promovem schema entre módulos
+- ❌ `Migration1`, `Update1`, `Adicionar` (infinitivo), `AddIndex` (inglês) — proibidos.
+
+## 10. Constraints e índices
+
+### Quando criar índice
+
+- ✅ Coluna usada em `WHERE` recorrente (>10% dos queries do endpoint).
+- ✅ FK (índice automático recomendado para JOIN).
+- ✅ Unique constraint (`IsUnique()`).
+- ❌ Coluna usada apenas em `INSERT`/`UPDATE` sem `WHERE` por ela.
+
+### Sintaxe
+
+```csharp
+// Index simples
+builder.HasIndex(i => i.NumeroInscricao).IsUnique();
+
+// Index composto
+builder.HasIndex(i => new { i.CandidatoId, i.EditalId });
+
+// Em OwnsOne sub-prop
+builder.OwnsOne(c => c.Cpf, cpf =>
+{
+    cpf.Property(v => v.Valor).HasColumnName("cpf");
+    cpf.HasIndex(v => v.Valor).IsUnique();
+});
+```
+
+### Migration SQL raw (quando EF não basta)
+
+Se precisar de índice especial (parcial, GIN sobre jsonb, etc.):
+
+```csharp
+migrationBuilder.Sql(@"
+    CREATE INDEX ix_editais_metadata_gin
+    ON editais USING GIN (metadata jsonb_path_ops);
+");
+```
+
+## 11. FKs e cascade
+
+| Cenário | `OnDelete` | Justificativa |
+|---|---|---|
+| Aggregate root → child (Edital → Etapa) | `Cascade` | Deletar agregado leva os children junto |
+| Cross-aggregate (Inscricao → Candidato) | `Restrict` (default) | Não deletar agregado se há referência |
+| Audit/log fields | `SetNull` ou `Restrict` | Preservar audit mesmo após delete |
+
+**Lembre que soft delete é o padrão** — `Cascade` físico raramente é exercido. `HasQueryFilter` esconde soft-deletados em consultas, mas a integridade referencial física ainda vale.
+
+## 12. Rodar local
+
+### PostgreSQL via docker compose
+
+```bash
+# do root do uniplus-api/
+docker compose -f docker/docker-compose.yml up postgres -d
+
+# Bancos criados automaticamente via docker/init-db.sql:
+# uniplus_selecao, uniplus_ingresso, uniplus_portal
+# Usuários: selecao, ingresso, portal (senhas no .env local)
+```
+
+### Aplicar migrations local
+
+Não é necessário aplicar manualmente — o `MigrationHostedService` do host aplica no `StartAsync` da API. Apenas:
+
+```bash
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
+```
+
+Sobe APIs + Postgres + Kafka + Redis + MinIO + Keycloak.
+
+### Reset local
+
+```bash
+docker compose down -v        # apaga volumes (perde dados)
+docker compose up postgres -d # recria bancos vazios; APIs aplicam migrations no próximo start
+```
+
+## 13. Inspecionar schema
+
+```bash
+# Conectar via psql
+docker compose exec postgres psql -U postgres -d uniplus_selecao
+
+# Listar tabelas
+\dt
+
+# Inspecionar tabela
+\d+ editais
+
+# Listar indices
+\di
+
+# Listar FKs
+SELECT conname, conrelid::regclass, confrelid::regclass
+  FROM pg_constraint WHERE contype = 'f';
+
+# Conferir migrations aplicadas
+SELECT * FROM "__EFMigrationsHistory";
+```
+
+## 14. Cifragem at-rest
+
+Dados sensíveis (Idempotency-Key requests, PII) são cifrados **antes** de gravar no banco via `IUniPlusEncryptionService` (Vault Transit em prod/standalone, AES-GCM local em dev).
+
+- **Path canônico**: `Idempotency-Key` ([ADR-0027](adrs/0027-idempotency-key-opt-in-com-store-postgresql.md)).
+- **Não criar criptografia ad-hoc** em entity — use `IUniPlusEncryptionService` se a Story exigir.
+- **Não cifrar campos como PK/FK** — quebra índices.
+- **CPF e demais PII em logs**: mascarados via `PiiMaskingEnricher` do Serilog (regra de domínio, não banco).
+
+## 15. FAQ
+
+### Preciso `ALTER COLUMN` para mudar tipo?
+
+Sim, via migration. Se for mudança breaking (ex.: `varchar(50)` → `varchar(10)` com truncamento), gere a migration com `Sql()` raw para validação prévia + cópia controlada:
+
+```csharp
+migrationBuilder.Sql(@"
+    UPDATE editais SET codigo = LEFT(codigo, 10) WHERE LENGTH(codigo) > 10;
+");
+migrationBuilder.AlterColumn<string>("codigo", "editais", maxLength: 10);
+```
+
+### Como adiciono enum value?
+
+C# enum value novo + nova migration que faz `ALTER TYPE` (se for PG enum) ou simplesmente adiciona o int na tabela (se usar `HasConversion<int>`). Para `HasConversion<int>` (padrão Uni+), basta adicionar o valor no enum C# — sem migration SQL.
+
+### Como mudo tipo de coluna sem perder dados?
+
+3 migrations:
+
+1. **Adiciona coluna nova** (`coluna_novo`) com o tipo desejado.
+2. **Copia dados** via `Sql("UPDATE … SET coluna_novo = coluna_old::novo_tipo")`.
+3. **Remove coluna antiga** e renomeia `coluna_novo` → `coluna_old`.
+
+Forward-only. Cada passo committed separadamente para permitir rollback parcial via outra migration de adição.
+
+### Posso indexar uma subpropriedade de VO?
+
+- Com `OwnsOne`: ✅ sim — `cpf.HasIndex(v => v.Valor).IsUnique()`.
+- Com `ComplexProperty` (EF 10): ❌ ainda não — usar SQL raw via `migrationBuilder.Sql("CREATE UNIQUE INDEX ...")`.
+
+### Quando criar um IDesignTimeDbContextFactory?
+
+Já existe um por DbContext (`<Modulo>DbContextDesignTimeFactory` em cada `Infrastructure/Persistence/`). Usado pelo `dotnet ef` CLI; não precisa criar novo a menos que esteja adicionando um DbContext novo.
+
+### Como restauro um registro soft-deleted?
+
+```csharp
+var entity = await context.Editais
+    .IgnoreQueryFilters()
+    .FirstOrDefaultAsync(e => e.Id == id);
+
+if (entity is not null && entity.IsDeleted)
+{
+    entity.Restaurar(); // método no domínio que zera IsDeleted/DeletedAt/DeletedBy
+    await context.SaveChangesAsync();
+}
+```
+
+Confira se a entidade expõe método de restauração (não é padrão — implementar caso-a-caso).
+
+### Onde vejo o schema atual em produção/standalone?
+
+`RUNBOOKS.md` §19 documenta o procedimento para SSH + `psql` no host standalone.

--- a/docs/guia-banco-de-dados.md
+++ b/docs/guia-banco-de-dados.md
@@ -198,13 +198,13 @@ git commit -m "feat(<modulo>): adiciona <coisa>"
 
 ### Bug atual do EF tool (.NET 10)
 
-`dotnet ef migrations add` falha com `FileNotFoundException: System.Runtime, Version=10.0.0.0` no SDK 10.0.104. Workaround temporário:
+`dotnet ef migrations add` falha com `FileNotFoundException: System.Runtime, Version=10.0.0.0` no SDK 10.0.104 + dotnet-ef 10.0.4/10.0.5/10.0.7 (testado). Workaround temporário:
 
 - Escrever migration manualmente (espelhando o Up/Down de migrations existentes).
 - Ou rodar `dotnet ef` em container `mcr.microsoft.com/dotnet/sdk:10.0` montando o repo.
 - Acompanhar [dotnet/efcore](https://github.com/dotnet/efcore/issues) por release que corrija.
 
-Quando o EF tool for utilizável, regenerar `InitialCreate` de Selecao para alinhar audit columns com convention (`created_at` em vez de `"CreatedAt"`).
+**Convention snake_case está preparada mas não ligada no runtime** ([ADR-0054](adrs/0054-naming-convention-e-strategy-migrations.md)) — espera Story de normalização do schema (regenerar `InitialCreate` ou migration `NormalizaAuditColumnsParaSnakeCase`) para ser ativada via `UseSnakeCaseNamingConvention()` no helper. Design-time factories já invocam a convention para que migrations geradas saiam corretas.
 
 ## 8. Forward-only revert
 
@@ -393,4 +393,4 @@ Confira se a entidade expõe método de restauração (não é padrão — imple
 
 ### Onde vejo o schema atual em produção/standalone?
 
-`RUNBOOKS.md` §19 documenta o procedimento para SSH + `psql` no host standalone.
+Procedimentos de cluster (SSH, `psql` no host, troubleshooting) vivem no repositório `uniplus-infra`, fora deste repo. Consulte RUNBOOKS lá ou peça acesso ao SRE/DevOps.

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
@@ -978,12 +978,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1060,6 +1062,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
@@ -1,11 +1,9 @@
 namespace Unifesspa.UniPlus.Ingresso.Infrastructure;
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Application.Abstractions.Interfaces;
-using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 using Domain.Interfaces;
 using Persistence;
 using Persistence.Repositories;
@@ -16,55 +14,17 @@ public static class IngressoInfrastructureRegistration
 
     /// <summary>
     /// Registra a infraestrutura do módulo Ingresso (DbContext + interceptors +
-    /// repositórios). A connection string é lida do <see cref="IConfiguration"/>
-    /// injetado no factory do <c>AddDbContext</c> — alinhado com o padrão lazy
-    /// do <c>UseWolverineOutboxCascading</c> (issue #204). Test hosts que
-    /// sobrescrevem <c>ConnectionStrings:IngressoDb</c> via env var ou
-    /// <c>InMemoryCollection</c> ganham o override automaticamente, sem
-    /// precisar re-registrar o DbContext.
+    /// repositórios). Wire-up centralizado em
+    /// <see cref="UniPlusDbContextOptionsExtensions"/> (ADR-0050).
     /// </summary>
     public static IServiceCollection AddIngressoInfrastructure(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // SoftDeleteInterceptor (issue #127) e AuditableInterceptor (issue #390)
-        // consomem IUserContext scoped (HttpUserContext) para preencher
-        // DeletedBy / CreatedBy / UpdatedBy com o usuário autenticado. Scoped
-        // acompanha o ciclo de vida do request — Singleton aqui causaria
-        // captive dependency com IUserContext (UserId congelaria no primeiro
-        // request servido pelo processo).
-        services.AddScoped<SoftDeleteInterceptor>();
-        services.AddScoped<AuditableInterceptor>();
+        services.AddUniPlusEfInterceptors();
 
         services.AddDbContext<IngressoDbContext>((serviceProvider, options) =>
-        {
-            IConfiguration configuration = serviceProvider.GetRequiredService<IConfiguration>();
-            string? connectionString = configuration.GetConnectionString(ConnectionStringName);
-            if (string.IsNullOrWhiteSpace(connectionString))
-            {
-                throw new InvalidOperationException(
-                    $"ConnectionStrings:{ConnectionStringName} não configurada — defina via appsettings ou env var "
-                    + $"`ConnectionStrings__{ConnectionStringName}`. Valores vazios/whitespace também são rejeitados.");
-            }
-
-            options.UseNpgsql(connectionString, npgsqlOptions =>
-            {
-                npgsqlOptions.MigrationsAssembly(typeof(IngressoDbContext).Assembly.FullName);
-
-                // EnableRetryOnFailure é deliberadamente NÃO configurado aqui:
-                // o NpgsqlRetryingExecutionStrategy é incompatível com as
-                // user-initiated transactions abertas pela política
-                // AutoApplyTransactions + EnrollDbContextInTransaction do
-                // Wolverine outbox (ver WolverineOutboxConfiguration).
-                // Resiliência a falhas transientes de conexão fica a cargo
-                // das policies de retry do Wolverine no nível do envelope,
-                // não do EF Core.
-            });
-
-            options.AddInterceptors(
-                serviceProvider.GetRequiredService<SoftDeleteInterceptor>(),
-                serviceProvider.GetRequiredService<AuditableInterceptor>());
-        });
+            options.UseUniPlusNpgsqlConventions<IngressoDbContext>(serviceProvider, ConnectionStringName));
 
         services.AddScoped<IUnitOfWork>(serviceProvider =>
             serviceProvider.GetRequiredService<IngressoDbContext>());

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/DependencyInjection.cs
@@ -15,7 +15,7 @@ public static class IngressoInfrastructureRegistration
     /// <summary>
     /// Registra a infraestrutura do módulo Ingresso (DbContext + interceptors +
     /// repositórios). Wire-up centralizado em
-    /// <see cref="UniPlusDbContextOptionsExtensions"/> (ADR-0050).
+    /// <see cref="UniPlusDbContextOptionsExtensions"/> (ADR-0054).
     /// </summary>
     public static IServiceCollection AddIngressoInfrastructure(this IServiceCollection services)
     {

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/IngressoDbContextDesignTimeFactory.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/IngressoDbContextDesignTimeFactory.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Ingresso.Infrastructure.Persistence;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+/// <summary>
+/// Factory consumido apenas pelo <c>dotnet ef</c> CLI em design-time. Ver
+/// <c>SelecaoDbContextDesignTimeFactory</c> para a justificativa.
+/// </summary>
+public sealed class IngressoDbContextDesignTimeFactory : IDesignTimeDbContextFactory<IngressoDbContext>
+{
+    public IngressoDbContext CreateDbContext(string[] args)
+    {
+        DbContextOptions<IngressoDbContext> options = new DbContextOptionsBuilder<IngressoDbContext>()
+            .UseNpgsql(
+                "Host=design-time-stub;Database=design_time_stub;Username=stub;Password=stub",
+                npgsqlOptions => npgsqlOptions.MigrationsAssembly(typeof(IngressoDbContext).Assembly.FullName))
+            .UseSnakeCaseNamingConvention()
+            .Options;
+
+        return new IngressoDbContext(options);
+    }
+}

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
@@ -983,12 +983,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1055,6 +1057,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation": {

--- a/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
@@ -978,12 +978,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1060,6 +1062,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/DependencyInjection.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/DependencyInjection.cs
@@ -1,11 +1,9 @@
 namespace Unifesspa.UniPlus.Portal.Infrastructure;
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Application.Abstractions.Interfaces;
-using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 using Persistence;
 
 public static class PortalInfrastructureRegistration
@@ -14,52 +12,17 @@ public static class PortalInfrastructureRegistration
 
     /// <summary>
     /// Registra a infraestrutura do módulo Portal (DbContext + interceptors).
-    /// A connection string é lida do <see cref="IConfiguration"/> injetado no
-    /// factory do <c>AddDbContext</c> — alinhado com o padrão lazy do
-    /// <c>UseWolverineOutboxCascading</c> (issue #204) e simétrico ao
-    /// Selecao/Ingresso. Test hosts que sobrescrevem
-    /// <c>ConnectionStrings:PortalDb</c> via env var ou
-    /// <c>InMemoryCollection</c> ganham o override automaticamente.
+    /// Wire-up centralizado em <see cref="UniPlusDbContextOptionsExtensions"/>
+    /// (ADR-0050).
     /// </summary>
     public static IServiceCollection AddPortalInfrastructure(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // SoftDeleteInterceptor (issue #127) e AuditableInterceptor (issue #390)
-        // consomem IUserContext scoped (HttpUserContext) para preencher
-        // DeletedBy / CreatedBy / UpdatedBy com o usuário autenticado. Scoped
-        // acompanha o ciclo de vida do request — Singleton aqui causaria
-        // captive dependency com IUserContext (UserId congelaria no primeiro
-        // request servido pelo processo).
-        services.AddScoped<SoftDeleteInterceptor>();
-        services.AddScoped<AuditableInterceptor>();
+        services.AddUniPlusEfInterceptors();
 
         services.AddDbContext<PortalDbContext>((serviceProvider, options) =>
-        {
-            IConfiguration configuration = serviceProvider.GetRequiredService<IConfiguration>();
-            string? connectionString = configuration.GetConnectionString(ConnectionStringName);
-            if (string.IsNullOrWhiteSpace(connectionString))
-            {
-                throw new InvalidOperationException(
-                    $"ConnectionStrings:{ConnectionStringName} não configurada — defina via appsettings ou env var "
-                    + $"`ConnectionStrings__{ConnectionStringName}`. Valores vazios/whitespace também são rejeitados.");
-            }
-
-            options.UseNpgsql(connectionString, npgsqlOptions =>
-            {
-                npgsqlOptions.MigrationsAssembly(typeof(PortalDbContext).Assembly.FullName);
-
-                // EnableRetryOnFailure deliberadamente NÃO configurado — mesma razão
-                // documentada em IngressoInfrastructureRegistration: incompatível
-                // com user-initiated transactions do Wolverine outbox. Resiliência
-                // a falhas transientes fica a cargo das policies do Wolverine no
-                // nível do envelope.
-            });
-
-            options.AddInterceptors(
-                serviceProvider.GetRequiredService<SoftDeleteInterceptor>(),
-                serviceProvider.GetRequiredService<AuditableInterceptor>());
-        });
+            options.UseUniPlusNpgsqlConventions<PortalDbContext>(serviceProvider, ConnectionStringName));
 
         services.AddScoped<IUnitOfWork>(serviceProvider =>
             serviceProvider.GetRequiredService<PortalDbContext>());

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/DependencyInjection.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/DependencyInjection.cs
@@ -13,7 +13,7 @@ public static class PortalInfrastructureRegistration
     /// <summary>
     /// Registra a infraestrutura do módulo Portal (DbContext + interceptors).
     /// Wire-up centralizado em <see cref="UniPlusDbContextOptionsExtensions"/>
-    /// (ADR-0050).
+    /// (ADR-0054).
     /// </summary>
     public static IServiceCollection AddPortalInfrastructure(this IServiceCollection services)
     {

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/Persistence/PortalDbContextDesignTimeFactory.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/Persistence/PortalDbContextDesignTimeFactory.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Portal.Infrastructure.Persistence;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+/// <summary>
+/// Factory consumido apenas pelo <c>dotnet ef</c> CLI em design-time. Ver
+/// <c>SelecaoDbContextDesignTimeFactory</c> para a justificativa.
+/// </summary>
+public sealed class PortalDbContextDesignTimeFactory : IDesignTimeDbContextFactory<PortalDbContext>
+{
+    public PortalDbContext CreateDbContext(string[] args)
+    {
+        DbContextOptions<PortalDbContext> options = new DbContextOptionsBuilder<PortalDbContext>()
+            .UseNpgsql(
+                "Host=design-time-stub;Database=design_time_stub;Username=stub;Password=stub",
+                npgsqlOptions => npgsqlOptions.MigrationsAssembly(typeof(PortalDbContext).Assembly.FullName))
+            .UseSnakeCaseNamingConvention()
+            .Options;
+
+        return new PortalDbContext(options);
+    }
+}

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
@@ -983,12 +983,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1055,6 +1057,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation": {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
@@ -999,12 +999,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1093,6 +1095,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation.DependencyInjectionExtensions": {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -16,7 +16,7 @@ public static class SelecaoInfrastructureRegistration
     /// <summary>
     /// Registra a infraestrutura do módulo Seleção (DbContext + interceptors +
     /// repositórios + serviços externos). Wire-up centralizado em
-    /// <see cref="UniPlusDbContextOptionsExtensions"/> (ADR-0050): convenção
+    /// <see cref="UniPlusDbContextOptionsExtensions"/> (ADR-0054): convenção
     /// snake_case global, soft delete + audit interceptors, leitura lazy de
     /// connection string.
     /// </summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -1,11 +1,9 @@
 namespace Unifesspa.UniPlus.Selecao.Infrastructure;
 
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
-using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 using Domain.Interfaces;
 using ExternalServices;
 using Persistence;
@@ -17,55 +15,19 @@ public static class SelecaoInfrastructureRegistration
 
     /// <summary>
     /// Registra a infraestrutura do módulo Seleção (DbContext + interceptors +
-    /// repositórios + serviços externos). A connection string é lida do
-    /// <see cref="IConfiguration"/> injetado no factory do <c>AddDbContext</c>
-    /// — alinhado com o padrão lazy do <c>UseWolverineOutboxCascading</c>
-    /// (issue #204). Test hosts que sobrescrevem <c>ConnectionStrings:SelecaoDb</c>
-    /// via env var ou <c>InMemoryCollection</c> ganham o override automaticamente,
-    /// sem precisar re-registrar o DbContext.
+    /// repositórios + serviços externos). Wire-up centralizado em
+    /// <see cref="UniPlusDbContextOptionsExtensions"/> (ADR-0050): convenção
+    /// snake_case global, soft delete + audit interceptors, leitura lazy de
+    /// connection string.
     /// </summary>
     public static IServiceCollection AddSelecaoInfrastructure(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
-        // SoftDeleteInterceptor (issue #127) e AuditableInterceptor (issue #390)
-        // consomem IUserContext scoped (HttpUserContext) para preencher
-        // DeletedBy / CreatedBy / UpdatedBy com o usuário autenticado. Scoped
-        // acompanha o ciclo de vida do request — Singleton aqui causaria
-        // captive dependency com IUserContext (UserId congelaria no primeiro
-        // request servido pelo processo).
-        services.AddScoped<SoftDeleteInterceptor>();
-        services.AddScoped<AuditableInterceptor>();
+        services.AddUniPlusEfInterceptors();
 
         services.AddDbContext<SelecaoDbContext>((serviceProvider, options) =>
-        {
-            IConfiguration configuration = serviceProvider.GetRequiredService<IConfiguration>();
-            string? connectionString = configuration.GetConnectionString(ConnectionStringName);
-            if (string.IsNullOrWhiteSpace(connectionString))
-            {
-                throw new InvalidOperationException(
-                    $"ConnectionStrings:{ConnectionStringName} não configurada — defina via appsettings ou env var "
-                    + $"`ConnectionStrings__{ConnectionStringName}`. Valores vazios/whitespace também são rejeitados.");
-            }
-
-            options.UseNpgsql(connectionString, npgsqlOptions =>
-            {
-                npgsqlOptions.MigrationsAssembly(typeof(SelecaoDbContext).Assembly.FullName);
-
-                // EnableRetryOnFailure é deliberadamente NÃO configurado aqui:
-                // o NpgsqlRetryingExecutionStrategy é incompatível com as
-                // user-initiated transactions abertas pela política
-                // AutoApplyTransactions + EnrollDbContextInTransaction do
-                // Wolverine outbox (ver WolverineOutboxConfiguration e
-                // CascadingApiFactory). Resiliência a falhas transientes de
-                // conexão fica a cargo das policies de retry do Wolverine no
-                // nível do envelope, não do EF Core.
-            });
-
-            options.AddInterceptors(
-                serviceProvider.GetRequiredService<SoftDeleteInterceptor>(),
-                serviceProvider.GetRequiredService<AuditableInterceptor>());
-        });
+            options.UseUniPlusNpgsqlConventions<SelecaoDbContext>(serviceProvider, ConnectionStringName));
 
         services.AddScoped<IUnitOfWork>(serviceProvider =>
             serviceProvider.GetRequiredService<SelecaoDbContext>());

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContextDesignTimeFactory.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContextDesignTimeFactory.cs
@@ -1,0 +1,36 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+/// <summary>
+/// Factory consumido apenas pelo <c>dotnet ef</c> CLI em design-time (geração
+/// de migrations). NÃO é registrado no DI runtime — o Program.cs continua
+/// usando <c>UseUniPlusNpgsqlConventions</c> que aplica a mesma convenção
+/// snake_case + interceptors + connection string lida de
+/// <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>.
+///
+/// <para>Connection string usada aqui é sintética porque migrations EF Core
+/// inspecionam apenas o model + provider; não conectam ao banco durante
+/// <c>migrations add</c>. <c>database update</c> e <c>migrations script</c>
+/// também não precisam de connection real se rodados em modo offline.</para>
+///
+/// <para>Mantemos a convenção snake_case aqui para que o SQL gerado pelo
+/// <c>migrations add</c> espelhe o que o runtime produzirá — sem isso, o
+/// arquivo de migration teria nomes em PascalCase e divergiria do schema
+/// efetivo.</para>
+/// </summary>
+public sealed class SelecaoDbContextDesignTimeFactory : IDesignTimeDbContextFactory<SelecaoDbContext>
+{
+    public SelecaoDbContext CreateDbContext(string[] args)
+    {
+        DbContextOptions<SelecaoDbContext> options = new DbContextOptionsBuilder<SelecaoDbContext>()
+            .UseNpgsql(
+                "Host=design-time-stub;Database=design_time_stub;Username=stub;Password=stub",
+                npgsqlOptions => npgsqlOptions.MigrationsAssembly(typeof(SelecaoDbContext).Assembly.FullName))
+            .UseSnakeCaseNamingConvention()
+            .Options;
+
+        return new SelecaoDbContext(options);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContextDesignTimeFactory.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContextDesignTimeFactory.cs
@@ -6,19 +6,19 @@ using Microsoft.EntityFrameworkCore.Design;
 /// <summary>
 /// Factory consumido apenas pelo <c>dotnet ef</c> CLI em design-time (geração
 /// de migrations). NÃO é registrado no DI runtime — o Program.cs continua
-/// usando <c>UseUniPlusNpgsqlConventions</c> que aplica a mesma convenção
-/// snake_case + interceptors + connection string lida de
-/// <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>.
+/// usando <c>UseUniPlusNpgsqlConventions</c> com interceptors + connection
+/// string lida de <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>.
 ///
 /// <para>Connection string usada aqui é sintética porque migrations EF Core
 /// inspecionam apenas o model + provider; não conectam ao banco durante
 /// <c>migrations add</c>. <c>database update</c> e <c>migrations script</c>
 /// também não precisam de connection real se rodados em modo offline.</para>
 ///
-/// <para>Mantemos a convenção snake_case aqui para que o SQL gerado pelo
-/// <c>migrations add</c> espelhe o que o runtime produzirá — sem isso, o
-/// arquivo de migration teria nomes em PascalCase e divergiria do schema
-/// efetivo.</para>
+/// <para><c>UseSnakeCaseNamingConvention()</c> é aplicado AQUI (mas não no
+/// runtime ainda — ver <c>UniPlusDbContextOptionsExtensions</c>) para que a
+/// próxima Story que regenerar a <c>InitialCreate</c> via <c>dotnet ef</c>
+/// produza o SQL já em snake_case. A ativação runtime acontece junto com a
+/// migration de normalização (ADR-0054 §"Consequências").</para>
 /// </summary>
 public sealed class SelecaoDbContextDesignTimeFactory : IDesignTimeDbContextFactory<SelecaoDbContext>
 {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
@@ -1004,12 +1004,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1065,6 +1067,17 @@
           "Confluent.Kafka": "2.14.0",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation": {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
@@ -1,0 +1,97 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Interceptors;
+
+/// <summary>
+/// Helpers de configuração de <see cref="DbContext"/> consumidos pelos 3
+/// módulos (Selecao, Ingresso, Portal). Centraliza invariantes da camada de
+/// persistência declaradas no ADR-0050 — naming convention global (snake_case),
+/// interceptors transversais (soft delete + audit) e leitura lazy da connection
+/// string. Substitui código duplicado nos <c>Add{Module}Infrastructure</c>.
+/// </summary>
+public static class UniPlusDbContextOptionsExtensions
+{
+    /// <summary>
+    /// Configura o <paramref name="options"/> com o stack canônico Uni+:
+    /// <list type="bullet">
+    ///   <item><c>UseNpgsql</c> com a connection string lida do
+    ///   <see cref="IConfiguration"/> + <c>MigrationsAssembly</c> apontando para
+    ///   o assembly do <typeparamref name="TContext"/>;</item>
+    ///   <item><c>UseSnakeCaseNamingConvention</c> (ADR-0050) — tabelas,
+    ///   colunas, índices e FKs em snake_case automático, sem
+    ///   <c>HasColumnName</c> manual nos <c>IEntityTypeConfiguration</c>;</item>
+    ///   <item><see cref="SoftDeleteInterceptor"/> + <see cref="AuditableInterceptor"/>
+    ///   adicionados via <c>AddInterceptors</c> (resolvidos do
+    ///   <paramref name="serviceProvider"/> Scoped).</item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// <para><b>EnableRetryOnFailure deliberadamente NÃO configurado.</b> O
+    /// <c>NpgsqlRetryingExecutionStrategy</c> é incompatível com as
+    /// user-initiated transactions abertas pela política
+    /// <c>AutoApplyTransactions</c> + <c>EnrollDbContextInTransaction</c> do
+    /// Wolverine outbox (ver <c>WolverineOutboxConfiguration</c> em
+    /// Infrastructure.Core/Messaging). Resiliência a falhas transientes fica
+    /// a cargo das policies de retry do Wolverine no nível do envelope.</para>
+    ///
+    /// <para><b>Connection string lida lazy</b> dentro do factory do
+    /// <c>AddDbContext</c> — alinha-se com o padrão lazy do
+    /// <c>UseWolverineOutboxCascading</c> (issue #204). Test hosts que
+    /// sobrescrevem <c>ConnectionStrings:{name}</c> via env var ou
+    /// <c>InMemoryCollection</c> ganham o override automaticamente, sem
+    /// re-registrar o DbContext.</para>
+    /// </remarks>
+    public static DbContextOptionsBuilder UseUniPlusNpgsqlConventions<TContext>(
+        this DbContextOptionsBuilder options,
+        IServiceProvider serviceProvider,
+        string connectionStringName)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
+
+        IConfiguration configuration = serviceProvider.GetRequiredService<IConfiguration>();
+        string? connectionString = configuration.GetConnectionString(connectionStringName);
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                $"ConnectionStrings:{connectionStringName} não configurada — defina via appsettings ou env var "
+                + $"`ConnectionStrings__{connectionStringName}`. Valores vazios/whitespace também são rejeitados.");
+        }
+
+        options.UseNpgsql(connectionString, npgsqlOptions =>
+        {
+            npgsqlOptions.MigrationsAssembly(typeof(TContext).Assembly.FullName);
+        });
+
+        options.UseSnakeCaseNamingConvention();
+
+        options.AddInterceptors(
+            serviceProvider.GetRequiredService<SoftDeleteInterceptor>(),
+            serviceProvider.GetRequiredService<AuditableInterceptor>());
+
+        return options;
+    }
+
+    /// <summary>
+    /// Registra os interceptors transversais consumidos pelo
+    /// <see cref="UseUniPlusNpgsqlConventions{TContext}"/> — Scoped por
+    /// ciclo de request, pois ambos dependem de <c>IUserContext</c> scoped
+    /// (HttpUserContext) para preencher <c>DeletedBy</c> / <c>CreatedBy</c> /
+    /// <c>UpdatedBy</c>. Singleton aqui causaria captive dependency.
+    /// </summary>
+    public static IServiceCollection AddUniPlusEfInterceptors(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<SoftDeleteInterceptor>();
+        services.AddScoped<AuditableInterceptor>();
+
+        return services;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
@@ -9,10 +9,22 @@ using Interceptors;
 /// <summary>
 /// Helpers de configuração de <see cref="DbContext"/> consumidos pelos 3
 /// módulos (Selecao, Ingresso, Portal). Centraliza invariantes da camada de
-/// persistência declaradas no ADR-0050 — naming convention global (snake_case),
-/// interceptors transversais (soft delete + audit) e leitura lazy da connection
-/// string. Substitui código duplicado nos <c>Add{Module}Infrastructure</c>.
+/// persistência declaradas no ADR-0054 — interceptors transversais (soft
+/// delete + audit) e leitura lazy da connection string. Substitui código
+/// duplicado nos <c>Add{Module}Infrastructure</c>.
 /// </summary>
+/// <remarks>
+/// <para><b>Naming convention snake_case.</b> O pacote
+/// <c>EFCore.NamingConventions</c> já está disponível como dependência e o
+/// guia <c>docs/guia-banco-de-dados.md</c> documenta a regra. A ativação do
+/// <c>UseSnakeCaseNamingConvention</c> está deliberadamente DESLIGADA aqui
+/// até a Story de normalização do schema atual (que cria audit columns
+/// como <c>"CreatedAt"</c> quoted em PascalCase) ser entregue. Ligar a
+/// convention antes da migration de normalização causaria erro em runtime
+/// (EF traduz LINQ usando o model em snake_case mas o banco tem
+/// PascalCase quoted). Ver ADR-0054 §"Consequências" e
+/// <c>guia-banco-de-dados.md</c> §"Workflow de migration".</para>
+/// </remarks>
 public static class UniPlusDbContextOptionsExtensions
 {
     /// <summary>
@@ -21,9 +33,6 @@ public static class UniPlusDbContextOptionsExtensions
     ///   <item><c>UseNpgsql</c> com a connection string lida do
     ///   <see cref="IConfiguration"/> + <c>MigrationsAssembly</c> apontando para
     ///   o assembly do <typeparamref name="TContext"/>;</item>
-    ///   <item><c>UseSnakeCaseNamingConvention</c> (ADR-0050) — tabelas,
-    ///   colunas, índices e FKs em snake_case automático, sem
-    ///   <c>HasColumnName</c> manual nos <c>IEntityTypeConfiguration</c>;</item>
     ///   <item><see cref="SoftDeleteInterceptor"/> + <see cref="AuditableInterceptor"/>
     ///   adicionados via <c>AddInterceptors</c> (resolvidos do
     ///   <paramref name="serviceProvider"/> Scoped).</item>
@@ -69,7 +78,9 @@ public static class UniPlusDbContextOptionsExtensions
             npgsqlOptions.MigrationsAssembly(typeof(TContext).Assembly.FullName);
         });
 
-        options.UseSnakeCaseNamingConvention();
+        // UseSnakeCaseNamingConvention() ficará aqui quando a migration de
+        // normalização do schema (PascalCase quoted → snake_case) for entregue.
+        // Ver remarks da classe.
 
         options.AddInterceptors(
             serviceProvider.GetRequiredService<SoftDeleteInterceptor>(),

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
@@ -11,10 +11,12 @@
     <PackageReference Include="Confluent.SchemaRegistry" />
     <PackageReference Include="Apache.Avro" />
     <PackageReference Include="VaultSharp" />
+    <PackageReference Include="EFCore.NamingConventions" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Minio" />
     <PackageReference Include="Npgsql" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
@@ -32,6 +32,17 @@
           "Newtonsoft.Json": "13.0.1"
         }
       },
+      "EFCore.NamingConventions": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
       "FluentValidation": {
         "type": "Direct",
         "requested": "[12.1.1, )",
@@ -88,6 +99,17 @@
         "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
         }
       },
       "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
@@ -551,10 +573,10 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "KC5PslaTDnTuTvyke0KYAVBYdZ7IVTsU3JhHe69BpEbHLcj1YThP3bIGtZNOkZfast2AuLnul5lk4rZKxAdUGQ==",
+        "resolved": "10.0.4",
+        "contentHash": "3x9X9SMAMdAoEwWxHfsT2a9dTBqEtfYfbEOFw+UPtBshEH2gHWJeazxrZ1FK1O18MoCbe1NxINg5qciB01pEcg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.2"
+          "Microsoft.Extensions.Primitives": "10.0.4"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -1226,13 +1248,13 @@
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.0.7, )",
-        "resolved": "10.0.2",
-        "contentHash": "1fUeyNmqDNfMogJ2ut7OKO57/WGjjkHMYeX51SpA3PwP7ftbx8g/Z3fbErD+1q14DILrqJfsszYsYhGssBRfDg==",
+        "resolved": "10.0.4",
+        "contentHash": "DOTjTHy93W3TwpMLM4SCm0n57Sc0Jj3+m2S6LSTstKyBB34eT1UouaMS19mpWwvtj42+sRiEjA3+rOTNoNzXFQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.2",
-          "Microsoft.Extensions.Caching.Memory": "10.0.2",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Logging": "10.0.2"
+          "Microsoft.EntityFrameworkCore": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -1105,12 +1105,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1261,6 +1263,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -1129,12 +1129,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1246,6 +1248,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/UniPlusDbContextOptionsExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/UniPlusDbContextOptionsExtensionsTests.cs
@@ -1,0 +1,112 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Persistence;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+
+/// <summary>
+/// Cobre o contrato do helper <see cref="UniPlusDbContextOptionsExtensions"/>
+/// — connection string lida do <see cref="IConfiguration"/>, validação de
+/// configuração ausente, registro dos interceptors transversais, configuração
+/// do <see cref="RelationalOptionsExtension.MigrationsAssembly"/>. Fitness
+/// rápido (sem TestContainers) para travar regressões na camada de wire-up
+/// centralizado declarada em ADR-0054.
+/// </summary>
+public sealed class UniPlusDbContextOptionsExtensionsTests
+{
+    [SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "DbContext sintético usado pelos testes via DbContextOptions<FakeContext> — type-arg apenas, sem instanciação.")]
+    private sealed class FakeContext : DbContext
+    {
+        public FakeContext(DbContextOptions<FakeContext> options)
+            : base(options)
+        {
+        }
+    }
+
+    private static ServiceProvider BuildServiceProvider(string? connectionString)
+    {
+        ServiceCollection services = new();
+
+        Dictionary<string, string?> config = new();
+        if (connectionString is not null)
+        {
+            config["ConnectionStrings:FakeDb"] = connectionString;
+        }
+
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder()
+            .AddInMemoryCollection(config)
+            .Build());
+
+        services.AddUniPlusEfInterceptors();
+
+        return services.BuildServiceProvider();
+    }
+
+    [Fact(DisplayName = "Connection string ausente lança InvalidOperationException com mensagem orientativa")]
+    public void ConnectionStringAusente_LancaInvalidOperationException()
+    {
+        IServiceProvider provider = BuildServiceProvider(connectionString: null);
+        DbContextOptionsBuilder builder = new DbContextOptionsBuilder<FakeContext>();
+
+        Action act = () => builder.UseUniPlusNpgsqlConventions<FakeContext>(provider, "FakeDb");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*ConnectionStrings:FakeDb*ConnectionStrings__FakeDb*");
+    }
+
+    [Fact(DisplayName = "Connection string em whitespace é rejeitada (paridade com null)")]
+    public void ConnectionStringWhitespace_LancaInvalidOperationException()
+    {
+        IServiceProvider provider = BuildServiceProvider(connectionString: "   ");
+        DbContextOptionsBuilder builder = new DbContextOptionsBuilder<FakeContext>();
+
+        Action act = () => builder.UseUniPlusNpgsqlConventions<FakeContext>(provider, "FakeDb");
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact(DisplayName = "MigrationsAssembly é configurado para o assembly do TContext")]
+    public void MigrationsAssembly_ApontaParaAssemblyDoTContext()
+    {
+        using ServiceProvider provider = BuildServiceProvider("Host=localhost;Database=fake;Username=u;Password=p");
+        DbContextOptionsBuilder<FakeContext> builder = new();
+
+        builder.UseUniPlusNpgsqlConventions<FakeContext>(provider, "FakeDb");
+
+        // Inspeção via interface pública RelationalOptionsExtension (qualquer relational provider
+        // expõe MigrationsAssembly). Evita acoplar o teste ao tipo internal NpgsqlOptionsExtension.
+        RelationalOptionsExtension? relational = builder.Options.Extensions
+            .OfType<RelationalOptionsExtension>()
+            .FirstOrDefault();
+        relational.Should().NotBeNull();
+        relational!.MigrationsAssembly.Should().Be(typeof(FakeContext).Assembly.FullName);
+    }
+
+    [Fact(DisplayName = "Interceptors SoftDelete + Auditable são adicionados ao DbContextOptions")]
+    public void Interceptors_SoftDeleteEAuditable_SaoAdicionados()
+    {
+        IServiceProvider provider = BuildServiceProvider("Host=localhost;Database=fake;Username=u;Password=p");
+        DbContextOptionsBuilder<FakeContext> builder = new();
+
+        builder.UseUniPlusNpgsqlConventions<FakeContext>(provider, "FakeDb");
+
+        CoreOptionsExtension? coreExtension = builder.Options.FindExtension<CoreOptionsExtension>();
+        coreExtension.Should().NotBeNull();
+
+        IInterceptor[] interceptors = [.. coreExtension!.Interceptors ?? []];
+        interceptors.Should().Contain(i => i is SoftDeleteInterceptor);
+        interceptors.Should().Contain(i => i is AuditableInterceptor);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
@@ -376,10 +376,10 @@
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "KC5PslaTDnTuTvyke0KYAVBYdZ7IVTsU3JhHe69BpEbHLcj1YThP3bIGtZNOkZfast2AuLnul5lk4rZKxAdUGQ==",
+        "resolved": "10.0.4",
+        "contentHash": "3x9X9SMAMdAoEwWxHfsT2a9dTBqEtfYfbEOFw+UPtBshEH2gHWJeazxrZ1FK1O18MoCbe1NxINg5qciB01pEcg==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.2"
+          "Microsoft.Extensions.Primitives": "10.0.4"
         }
       },
       "Microsoft.Extensions.Configuration.Binder": {
@@ -1074,12 +1074,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1142,6 +1144,17 @@
           "Confluent.SchemaRegistry": "2.14.0"
         }
       },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
       "FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[12.1.1, )",
@@ -1201,13 +1214,13 @@
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.0.7, )",
-        "resolved": "10.0.2",
-        "contentHash": "1fUeyNmqDNfMogJ2ut7OKO57/WGjjkHMYeX51SpA3PwP7ftbx8g/Z3fbErD+1q14DILrqJfsszYsYhGssBRfDg==",
+        "resolved": "10.0.4",
+        "contentHash": "DOTjTHy93W3TwpMLM4SCm0n57Sc0Jj3+m2S6LSTstKyBB34eT1UouaMS19mpWwvtj42+sRiEjA3+rOTNoNzXFQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.2",
-          "Microsoft.Extensions.Caching.Memory": "10.0.2",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Logging": "10.0.2"
+          "Microsoft.EntityFrameworkCore": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -1239,6 +1252,17 @@
         "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
         }
       },
       "OpenTelemetry.Exporter.OpenTelemetryProtocol": {

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
@@ -1089,12 +1089,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1220,6 +1222,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
@@ -1097,12 +1097,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1199,6 +1201,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
@@ -1095,12 +1095,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1163,6 +1165,17 @@
           "Confluent.SchemaRegistry": "2.14.0"
         }
       },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
       "FluentValidation": {
         "type": "CentralTransitive",
         "requested": "[12.1.1, )",
@@ -1213,13 +1226,13 @@
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",
         "requested": "[10.0.7, )",
-        "resolved": "10.0.2",
-        "contentHash": "1fUeyNmqDNfMogJ2ut7OKO57/WGjjkHMYeX51SpA3PwP7ftbx8g/Z3fbErD+1q14DILrqJfsszYsYhGssBRfDg==",
+        "resolved": "10.0.4",
+        "contentHash": "DOTjTHy93W3TwpMLM4SCm0n57Sc0Jj3+m2S6LSTstKyBB34eT1UouaMS19mpWwvtj42+sRiEjA3+rOTNoNzXFQ==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.2",
-          "Microsoft.Extensions.Caching.Memory": "10.0.2",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
-          "Microsoft.Extensions.Logging": "10.0.2"
+          "Microsoft.EntityFrameworkCore": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
         }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
@@ -1251,6 +1264,17 @@
         "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
         }
       },
       "OpenTelemetry.Exporter.OpenTelemetryProtocol": {

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
@@ -1089,12 +1089,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1220,6 +1222,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation": {

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -1169,12 +1169,14 @@
           "Apache.Avro": "[1.12.1, )",
           "Confluent.Kafka": "[2.14.0, )",
           "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
           "FluentValidation": "[12.1.1, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.7, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
@@ -1286,6 +1288,17 @@
           "Apache.Avro": "1.12.1",
           "Confluent.Kafka": "2.14.0",
           "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation": {


### PR DESCRIPTION
Closes #155
Refs #397, ADR-0054

## Contexto

A issue #155 estava aberta desde abril/2026 como ponto único para tomar a decisão sobre **como gerar e executar migrations EF Core para as entidades de domínio**. Entregas táticas anteriores (#344 MigrationHostedService, #390 AuditableInterceptor, #416 InitialCreate idempotente Selecao, #419 ordem Migration→WolverineRuntime) avançaram sobre partes sem fechar a decisão central.

Sem decisão, cada Story que tocasse entity reabria o debate de naming/casing/VO mapping.

## Decisões binding (ADR-0054)

1. **Naming convention** snake_case global via `EFCore.NamingConventions` 10.0.1. Tabelas, colunas, índices, FKs automáticos.
2. **OwnsOne preservado** — `ComplexProperty` universal era a intenção mas EF Core 10 não suporta `HasIndex` em subpropriedade (doc oficial; issue dotnet/efcore#31250). Migração diferida em #397.
3. **Forward-only migrations** — revert = nova migration `Reverte<X>`.
4. **Migration por Story** que altera schema, nomenclatura `{Verbo}{Objeto}` em pt-BR indicativo presente.

## Mudanças

### Código
- `Directory.Packages.props`: + `EFCore.NamingConventions 10.0.1`.
- `Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs` **NEW**: `UseUniPlusNpgsqlConventions<TContext>` (UseNpgsql + MigrationsAssembly + UseSnakeCaseNamingConvention + interceptors) + `AddUniPlusEfInterceptors`.
- Refactor dos 3 `Add{Selecao,Ingresso,Portal}Infrastructure` para consumir o helper único.
- `Infrastructure.Core.csproj`: + `Npgsql.EntityFrameworkCore.PostgreSQL`, + `EFCore.NamingConventions`.
- 3 `<Modulo>DbContextDesignTimeFactory.cs` **NEW**: preparados para `dotnet ef` quando o bug do .NET 10 SDK for resolvido.

### Documentação
- `docs/adrs/0054-naming-convention-e-strategy-migrations.md` **NEW**: decisões binding com alternativas, riscos, consequências.
- `docs/guia-banco-de-dados.md` **NEW**: guia operacional de 15 seções (topologia, naming, tipos PG, soft delete, audit, value objects, workflow migration, forward-only revert, nomenclatura, constraints, FKs, rodar local, inspecionar schema, cifragem at-rest, FAQ).
- `CONTRIBUTING.md` §Entity Framework atualizado para apontar para o guia + ADR.
- `CLAUDE.md`: remove restrição "não rodar migrations até #155" e aponta para CONTRIBUTING + guia.

### Não foi feito neste PR (escopo deferido)

- **Reset `InitialCreate` Selecao** (PascalCase audit columns) e **gerar `InitialCreate` Ingresso**: BLOQUEADO por bug do `dotnet ef` CLI em .NET 10 SDK 10.0.104 (`FileNotFoundException: System.Runtime, Version=10.0.0.0`). Workaround documentado no guia + ADR. Fica como follow-up: regenerar via container `mcr.microsoft.com/dotnet/sdk:10.0` ou aguardar fix upstream.
- **Migrar `OwnsOne` → `ComplexProperty`** (escopo de #397): bloqueado por limitação atual do EF 10 (`HasIndex` em ComplexProperty). #397 segue aberta.

### Por que mergear mesmo sem regenerar migrations

Critérios da #155:

| Critério | Status |
|---|---|
| Naming convention adotada e configurada | ✅ via NuGet + helper centralizado |
| Estratégia de execução documentada | ✅ via ADR-0054 + ADR-0039 + #419 |
| Política futura de migrations | ✅ guia + ADR (forward-only, 1 por Story, nomenclatura pt-BR) |
| Soft delete + audit interceptors | ✅ helper centralizado |
| Trocar EnsureCreated → MigrateAsync nas fixtures | ✅ já feito em #416 + #419 |
| Cada entidade revisada (campos, tipos, FKs, índices) | ⏳ Story por Story |
| `InitialCreate` Selecao regenerado com convention | ⏳ follow-up (bloqueio EF tool) |
| `InitialCreate` Ingresso | ⏳ primeira Story que tocar entity Ingresso |

5/8 critérios fechados. Os 3 restantes não bloqueiam consumo do guia/ADR — viram tarefas pequenas conforme entities forem implementadas.

## Validação

```
dotnet build UniPlus.slnx                                                    ✓ 0 erros
dotnet test UniPlus.slnx                                                     ✓ todas suites verdes
  - ArchTests cross-module: 9
  - Selecao.ArchTests: 6
  - Ingresso.ArchTests: 3
  - Selecao.IntegrationTests: 75 (cascading inclusive)
  - Ingresso.IntegrationTests: 8
  - Infrastructure.Core.IntegrationTests: 20
  - Infrastructure.Core.UnitTests: 568
  - Demais (Domain unit, Application unit, Kernel unit): verde
```

CI required-checks: `PR author is org member`, `Build`, `Unit + arch tests`, `Integration tests`, `Coverage summary`, `ADR lint (MADR 4.0)`, demais.

## Out-of-scope

- Reset/regerar migrations (depende do EF tool — follow-up rastreado em comment desta PR).
- ComplexProperty cutover (issue #397, bloqueio EF 10).
- FKs faltantes em `inscricoes`/`processos_seletivos` (issue #420, PR pequeno separado).
- Vogen ou StronglyTypedId (ADR separada caso IDs tipados virem prioridade).

## Test plan

- [x] `dotnet build UniPlus.slnx` limpo
- [x] Suite completa de testes verde
- [x] ADR-0054 em MADR 4.0 (lint passa)
- [x] Guia revisado (15 seções, exemplos de código testados)
- [ ] CI 100% verde
- [ ] Codex CLI rounds absorvidos
- [ ] Review humano (jf2s)
