### PR TITLE
chore(ci): workflow para regerar migrations EF Core no runner

### DIFF
--- a/.github/workflows/regen-migrations.yml
+++ b/.github/workflows/regen-migrations.yml
@@ -1,0 +1,158 @@
+name: Regenerar migrations EF Core (manual)
+
+# Workaround para o bug atual do `dotnet ef` em SDK 10.0.x local
+# (FileNotFoundException System.Runtime/Microsoft.Extensions.DependencyInjection.Abstractions
+# em qualquer comando `dotnet ef`, reproduzido em SDK 10.0.104 host e containers
+# sdk:10.0.100 / sdk:10.0). Runner Ubuntu fresh do GitHub Actions tem ambiente
+# limpo onde `dotnet ef migrations add` funciona normalmente.
+#
+# Workflow:
+#  1. checkout em branch alvo
+#  2. ativa UseSnakeCaseNamingConvention() no helper
+#  3. deleta migrations + snapshot atuais (Selecao)
+#  4. roda `dotnet ef migrations add InitialCreate` (Selecao + Ingresso)
+#  5. faz upload das migrations geradas como artifact (revisão manual)
+#  6. opcional: cria PR direto via peter-evans/create-pull-request
+#
+# Trigger: workflow_dispatch. Output: artifact zipado com os arquivos novos.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Nome da branch para o commit das migrations regeneradas"
+        required: true
+        default: "refactor/regenerar-migrations-snake-case"
+      create_pr:
+        description: "Criar PR automaticamente após regenerar?"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  DOTNET_VERSION: 10.0.x
+
+jobs:
+  regen:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore tools (dotnet-ef)
+        run: dotnet tool restore
+
+      - name: Restore NuGet packages
+        run: dotnet restore UniPlus.slnx
+
+      - name: Sanity check — dotnet ef tool funciona neste ambiente?
+        run: |
+          dotnet ef --version
+          dotnet ef migrations list \
+            --project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure \
+            --startup-project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure \
+            --context SelecaoDbContext \
+            --no-build || (echo "::warning::dotnet ef migrations list falhou no runner também — bug é mais profundo" && true)
+
+      - name: Ativar UseSnakeCaseNamingConvention() no helper
+        run: |
+          sed -i 's|// snake_case automático em tabelas.*|options.UseSnakeCaseNamingConvention();|' \
+            src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+          # Verifica que a substituição aconteceu
+          grep -q "options.UseSnakeCaseNamingConvention();" \
+            src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+
+      - name: Deletar migrations existentes do Selecao
+        run: |
+          rm -f \
+            src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260512010258_InitialCreate.cs \
+            src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260512010258_InitialCreate.Designer.cs \
+            src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/SelecaoDbContextModelSnapshot.cs
+
+      - name: Build após mudanças
+        run: dotnet build UniPlus.slnx --nologo
+
+      - name: Regerar InitialCreate Selecao
+        run: |
+          dotnet ef migrations add InitialCreate \
+            --project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure \
+            --startup-project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure \
+            --context SelecaoDbContext \
+            --output-dir Persistence/Migrations \
+            --no-build
+
+      - name: Gerar InitialCreate Ingresso
+        run: |
+          dotnet ef migrations add InitialCreate \
+            --project src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure \
+            --startup-project src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure \
+            --context IngressoDbContext \
+            --output-dir Persistence/Migrations \
+            --no-build
+
+      - name: Mostrar diff resumido
+        run: |
+          git status --short
+          echo "---"
+          git diff --stat
+
+      - name: Upload migrations como artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: migrations-regeneradas
+          path: |
+            src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/
+            src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Migrations/
+            src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+
+      - name: Criar PR (opcional)
+        if: ${{ inputs.create_pr == 'true' }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: ${{ inputs.target_branch }}
+          base: main
+          commit-message: |
+            refactor(persistence): regenera migrations com snake_case (workflow CI)
+
+            Workflow regen-migrations.yml executou `dotnet ef migrations add InitialCreate`
+            no runner Ubuntu (bug do EF tool em SDK 10.0.x local impede regeneração local).
+            UseSnakeCaseNamingConvention() ativado no helper.
+
+            Refs #155
+          title: "refactor(persistence): regenera migrations EF Core com snake_case (via CI)"
+          body: |
+            ## Contexto
+
+            `dotnet ef migrations add` quebra com `FileNotFoundException` em SDK 10.0.104 local
+            (também reproduzido em containers `sdk:10.0.100` e `sdk:10.0`). Workflow rodou
+            no runner Ubuntu fresh para destravar a regeneração.
+
+            ## Mudanças
+
+            - `UseSnakeCaseNamingConvention()` ativado em `UniPlusDbContextOptionsExtensions`.
+            - `InitialCreate` Selecao regenerada (Up/Down + Designer + Snapshot) com snake_case automático.
+            - `InitialCreate` Ingresso criada (era ausente).
+
+            ## Plano de rollout
+
+            - Bancos `uniplus_selecao` e `uniplus_ingresso` no standalone: drop+recreate (pre-prod, sem dados).
+            - Pods reiniciam → `MigrationHostedService` aplica novo schema em snake_case puro.
+            - Smoke E2E confirma cifragem + insert.
+
+            Closes parte do follow-up de #155.
+
+            🤖 Gerado por `.github/workflows/regen-migrations.yml`

--- a/.github/workflows/regen-migrations.yml
+++ b/.github/workflows/regen-migrations.yml
@@ -70,18 +70,50 @@ jobs:
 
       - name: Ativar UseSnakeCaseNamingConvention() no helper
         run: |
-          sed -i 's|// snake_case automático em tabelas.*|options.UseSnakeCaseNamingConvention();|' \
-            src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
-          # Verifica que a substituição aconteceu
+          HELPER=src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+          # Verifica primeiro que a chamada está ausente (estado esperado em main).
+          if grep -q "options.UseSnakeCaseNamingConvention();" "$HELPER"; then
+            echo "::notice::UseSnakeCaseNamingConvention já presente — nada a fazer."
+          else
+            # Substitui o bloco do TODO (2 linhas iniciadas em '// UseSnakeCaseNamingConvention')
+            # pela chamada efetiva, preservando indentação canônica do método.
+            python3 - "$HELPER" <<'PY'
+          import re, sys
+          path = sys.argv[1]
+          content = open(path).read()
+          # Casa o bloco de comentário TODO + linha em branco seguinte (se existir)
+          new = re.sub(
+              r'^(\s*)// UseSnakeCaseNamingConvention\(\) ficará aqui quando a migration de\n\s*// normalização do schema.*?\n(\s*\n)?',
+              r'\1options.UseSnakeCaseNamingConvention();\n\n',
+              content,
+              count=1,
+              flags=re.MULTILINE,
+          )
+          if new == content:
+              print("::error::Padrão TODO não encontrado em UniPlusDbContextOptionsExtensions.cs", file=sys.stderr)
+              sys.exit(1)
+          open(path, 'w').write(new)
+          PY
+          fi
+          # Sanity: chamada efetiva presente
           grep -q "options.UseSnakeCaseNamingConvention();" \
-            src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+            "$HELPER"
 
       - name: Deletar migrations existentes do Selecao
         run: |
-          rm -f \
-            src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260512010258_InitialCreate.cs \
-            src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260512010258_InitialCreate.Designer.cs \
-            src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/SelecaoDbContextModelSnapshot.cs
+          MIGDIR=src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations
+          # Glob protege contra mudanças de timestamp (Codex P2): casa qualquer
+          # *_InitialCreate*.cs já existente, não apenas o ID atual.
+          shopt -s nullglob
+          REMOVED=0
+          for f in "$MIGDIR"/*_InitialCreate*.cs "$MIGDIR"/SelecaoDbContextModelSnapshot.cs; do
+            echo "removing $f"
+            rm -f "$f"
+            REMOVED=$((REMOVED+1))
+          done
+          if [ "$REMOVED" -eq 0 ]; then
+            echo "::warning::Nenhuma migration *_InitialCreate*.cs ou snapshot encontrada — banco pode estar em outro estado."
+          fi
 
       - name: Build após mudanças
         run: dotnet build UniPlus.slnx --nologo

--- a/.github/workflows/regen-migrations.yml
+++ b/.github/workflows/regen-migrations.yml
@@ -46,6 +46,10 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v4
         with:
+          # Pin para main mesmo em workflow_dispatch — base do PR criado abaixo
+          # também é `main`. Sem isso, dispatch de outra branch poderia regenerar
+          # migrations sobre um estado divergente do que será mergeado.
+          ref: main
           fetch-depth: 0
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }}
@@ -99,21 +103,27 @@ jobs:
           grep -q "options.UseSnakeCaseNamingConvention();" \
             "$HELPER"
 
-      - name: Deletar migrations existentes do Selecao
+      - name: Deletar migrations existentes (Selecao + Ingresso)
         run: |
-          MIGDIR=src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations
           # Glob protege contra mudanças de timestamp (Codex P2): casa qualquer
           # *_InitialCreate*.cs já existente, não apenas o ID atual.
+          # Trata Ingresso simetricamente — `dotnet ef migrations add` abaixo
+          # falharia se já existisse uma InitialCreate (de regeneração anterior
+          # ou branch divergente).
           shopt -s nullglob
-          REMOVED=0
-          for f in "$MIGDIR"/*_InitialCreate*.cs "$MIGDIR"/SelecaoDbContextModelSnapshot.cs; do
-            echo "removing $f"
-            rm -f "$f"
-            REMOVED=$((REMOVED+1))
+          for MIGDIR in \
+              src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations \
+              src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Migrations; do
+            REMOVED=0
+            for f in "$MIGDIR"/*_InitialCreate*.cs "$MIGDIR"/*DbContextModelSnapshot.cs; do
+              echo "removing $f"
+              rm -f "$f"
+              REMOVED=$((REMOVED+1))
+            done
+            if [ "$REMOVED" -eq 0 ]; then
+              echo "::notice::$MIGDIR — sem InitialCreate prévio (estado virgem)"
+            fi
           done
-          if [ "$REMOVED" -eq 0 ]; then
-            echo "::warning::Nenhuma migration *_InitialCreate*.cs ou snapshot encontrada — banco pode estar em outro estado."
-          fi
 
       - name: Build após mudanças
         run: dotnet build UniPlus.slnx --nologo


### PR DESCRIPTION
Workaround para bug do `dotnet ef` em SDK 10.0.x local. Workflow manual (workflow_dispatch) roda `dotnet ef migrations add` no runner Ubuntu e abre PR com arquivos regenerados.

Não tem efeito automático — só roda quando disparado manualmente. Mergear no main para tornar acessível via `gh workflow run`.