### PR TITLE
fix(persistence): pin __EFMigrationsHistory para evitar drift entre rollouts

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/IngressoDbContextDesignTimeFactory.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/IngressoDbContextDesignTimeFactory.cs
@@ -1,7 +1,8 @@
 namespace Unifesspa.UniPlus.Ingresso.Infrastructure.Persistence;
 
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
 /// Factory consumido apenas pelo <c>dotnet ef</c> CLI em design-time. Ver
@@ -11,13 +12,7 @@ public sealed class IngressoDbContextDesignTimeFactory : IDesignTimeDbContextFac
 {
     public IngressoDbContext CreateDbContext(string[] args)
     {
-        DbContextOptions<IngressoDbContext> options = new DbContextOptionsBuilder<IngressoDbContext>()
-            .UseNpgsql(
-                "Host=design-time-stub;Database=design_time_stub;Username=stub;Password=stub",
-                npgsqlOptions => npgsqlOptions.MigrationsAssembly(typeof(IngressoDbContext).Assembly.FullName))
-            .UseSnakeCaseNamingConvention()
-            .Options;
-
-        return new IngressoDbContext(options);
+        return new IngressoDbContext(
+            UniPlusDbContextOptionsExtensions.BuildDesignTimeOptions<IngressoDbContext>());
     }
 }

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/Persistence/PortalDbContextDesignTimeFactory.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/Persistence/PortalDbContextDesignTimeFactory.cs
@@ -1,7 +1,8 @@
 namespace Unifesspa.UniPlus.Portal.Infrastructure.Persistence;
 
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
 /// Factory consumido apenas pelo <c>dotnet ef</c> CLI em design-time. Ver
@@ -11,13 +12,7 @@ public sealed class PortalDbContextDesignTimeFactory : IDesignTimeDbContextFacto
 {
     public PortalDbContext CreateDbContext(string[] args)
     {
-        DbContextOptions<PortalDbContext> options = new DbContextOptionsBuilder<PortalDbContext>()
-            .UseNpgsql(
-                "Host=design-time-stub;Database=design_time_stub;Username=stub;Password=stub",
-                npgsqlOptions => npgsqlOptions.MigrationsAssembly(typeof(PortalDbContext).Assembly.FullName))
-            .UseSnakeCaseNamingConvention()
-            .Options;
-
-        return new PortalDbContext(options);
+        return new PortalDbContext(
+            UniPlusDbContextOptionsExtensions.BuildDesignTimeOptions<PortalDbContext>());
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContextDesignTimeFactory.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContextDesignTimeFactory.cs
@@ -1,7 +1,8 @@
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
 /// Factory consumido apenas pelo <c>dotnet ef</c> CLI em design-time (geração
@@ -9,28 +10,19 @@ using Microsoft.EntityFrameworkCore.Design;
 /// usando <c>UseUniPlusNpgsqlConventions</c> com interceptors + connection
 /// string lida de <see cref="Microsoft.Extensions.Configuration.IConfiguration"/>.
 ///
-/// <para>Connection string usada aqui é sintética porque migrations EF Core
-/// inspecionam apenas o model + provider; não conectam ao banco durante
-/// <c>migrations add</c>. <c>database update</c> e <c>migrations script</c>
-/// também não precisam de connection real se rodados em modo offline.</para>
-///
-/// <para><c>UseSnakeCaseNamingConvention()</c> é aplicado AQUI (mas não no
-/// runtime ainda — ver <c>UniPlusDbContextOptionsExtensions</c>) para que a
-/// próxima Story que regenerar a <c>InitialCreate</c> via <c>dotnet ef</c>
-/// produza o SQL já em snake_case. A ativação runtime acontece junto com a
-/// migration de normalização (ADR-0054 §"Consequências").</para>
+/// <para>Delega a construção das options para
+/// <see cref="UniPlusDbContextOptionsExtensions.BuildDesignTimeOptions{TContext}"/>
+/// para manter naming convention (snake_case) e o pin do
+/// <c>__EFMigrationsHistory</c> simétricos entre design-time e runtime —
+/// caso contrário, <c>dotnet ef migrations script</c> e o
+/// <c>MigrationHostedService</c> poderiam consultar tabelas de histórico
+/// distintas (ADR-0054 + #437).</para>
 /// </summary>
 public sealed class SelecaoDbContextDesignTimeFactory : IDesignTimeDbContextFactory<SelecaoDbContext>
 {
     public SelecaoDbContext CreateDbContext(string[] args)
     {
-        DbContextOptions<SelecaoDbContext> options = new DbContextOptionsBuilder<SelecaoDbContext>()
-            .UseNpgsql(
-                "Host=design-time-stub;Database=design_time_stub;Username=stub;Password=stub",
-                npgsqlOptions => npgsqlOptions.MigrationsAssembly(typeof(SelecaoDbContext).Assembly.FullName))
-            .UseSnakeCaseNamingConvention()
-            .Options;
-
-        return new SelecaoDbContext(options);
+        return new SelecaoDbContext(
+            UniPlusDbContextOptionsExtensions.BuildDesignTimeOptions<SelecaoDbContext>());
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
@@ -92,6 +92,41 @@ public static class UniPlusDbContextOptionsExtensions
     }
 
     /// <summary>
+    /// Constrói <see cref="DbContextOptions{TContext}"/> para uso de
+    /// <c>IDesignTimeDbContextFactory&lt;T&gt;</c> consumidos pelo
+    /// <c>dotnet ef</c> CLI. Compartilha com o runtime as duas decisões
+    /// sensíveis à geração de migrations:
+    /// <list type="bullet">
+    ///   <item><see cref="UseSnakeCaseNamingConvention"/> garante que o SQL
+    ///   emitido pela migration nasça em snake_case (ADR-0054);</item>
+    ///   <item><c>MigrationsHistoryTable("__EFMigrationsHistory")</c> evita
+    ///   split-brain entre o nome da tabela usado em design-time (ex.:
+    ///   <c>dotnet ef migrations script</c>) e o usado em runtime — caso
+    ///   contrário, o EF poderia inserir/consultar histórias em duas tabelas
+    ///   distintas.</item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// A connection string é sintética porque migrations EF Core não conectam
+    /// ao banco durante <c>migrations add</c>. <c>database update</c> rodado
+    /// localmente sobrescreve via <c>--connection</c>.
+    /// </remarks>
+    public static DbContextOptions<TContext> BuildDesignTimeOptions<TContext>()
+        where TContext : DbContext
+    {
+        return new DbContextOptionsBuilder<TContext>()
+            .UseNpgsql(
+                "Host=design-time-stub;Database=design_time_stub;Username=stub;Password=stub",
+                npgsqlOptions =>
+                {
+                    npgsqlOptions.MigrationsAssembly(typeof(TContext).Assembly.FullName);
+                    npgsqlOptions.MigrationsHistoryTable("__EFMigrationsHistory");
+                })
+            .UseSnakeCaseNamingConvention()
+            .Options;
+    }
+
+    /// <summary>
     /// Registra os interceptors transversais consumidos pelo
     /// <see cref="UseUniPlusNpgsqlConventions{TContext}"/> — Scoped por
     /// ciclo de request, pois ambos dependem de <c>IUserContext</c> scoped

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
@@ -65,6 +65,14 @@ public static class UniPlusDbContextOptionsExtensions
         options.UseNpgsql(connectionString, npgsqlOptions =>
         {
             npgsqlOptions.MigrationsAssembly(typeof(TContext).Assembly.FullName);
+
+            // EFCore.NamingConventions aplica snake_case TAMBÉM na tabela
+            // system `__EFMigrationsHistory` (issue efcore/EFCore.NamingConventions#108):
+            // o EF Core escreve a tabela com colunas `MigrationId`/`ProductVersion`
+            // mas a convention faz queries em runtime esperarem `migration_id`/
+            // `product_version`. Forçar o nome explícito mantém o contrato system
+            // intacto e PascalCase, sem afetar tabelas de domínio.
+            npgsqlOptions.MigrationsHistoryTable("__EFMigrationsHistory");
         });
 
         // snake_case automático em tabelas, colunas, índices e FKs (ADR-0054).

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
@@ -66,12 +66,16 @@ public static class UniPlusDbContextOptionsExtensions
         {
             npgsqlOptions.MigrationsAssembly(typeof(TContext).Assembly.FullName);
 
-            // EFCore.NamingConventions aplica snake_case TAMBÉM na tabela
-            // system `__EFMigrationsHistory` (issue efcore/EFCore.NamingConventions#108):
-            // o EF Core escreve a tabela com colunas `MigrationId`/`ProductVersion`
-            // mas a convention faz queries em runtime esperarem `migration_id`/
-            // `product_version`. Forçar o nome explícito mantém o contrato system
-            // intacto e PascalCase, sem afetar tabelas de domínio.
+            // EFCore.NamingConventions aplica snake_case também na tabela
+            // system `__EFMigrationsHistory` (issue efcore/EFCore.NamingConventions#108).
+            // Sem pin do nome, a convention pode renomear a tabela para
+            // `__ef_migrations_history`, criando drift quando outro pod
+            // (sem a convention) já criou com o nome PascalCase default
+            // do EF Core. Pin garante que todos os pods do rollout enxerguem
+            // a mesma tabela. As COLUNAS continuam sendo processadas pela
+            // convention — em rollouts mistos com pods sem convention, o
+            // drift de colunas ainda exige drop+recreate; este pin estabiliza
+            // apenas o nome da tabela.
             npgsqlOptions.MigrationsHistoryTable("__EFMigrationsHistory");
         });
 


### PR DESCRIPTION
## Sumário

Pin do nome da tabela system `__EFMigrationsHistory` via `npgsqlOptions.MigrationsHistoryTable(...)` no helper centralizado `UseUniPlusNpgsqlConventions`. Resolve o cenário observado no rollout do standalone em que um pod legado sem `UseSnakeCaseNamingConvention()` cria a tabela com colunas PascalCase e o pod novo (já com a convention de #155/ADR-0054) quebra ao consultar histórico:

```
column "migration_id" does not exist (SQLSTATE 42703)
```

A `EFCore.NamingConventions` aplica a convention também na tabela system ([efcore/EFCore.NamingConventions#108](https://github.com/efcore/EFCore.NamingConventions/issues/108)) — comportamento documentado. Pinpoint do nome ancora o contrato e torna o startup determinístico independente da ordem de rollout.

## Impacto

- **Domínio**: nenhum — tabelas continuam em snake_case nativo conforme ADR-0054.
- **System**: nome `__EFMigrationsHistory` explícito, evita variações entre rollouts mistos.
- **Migrations existentes**: não regeneradas (já estão corretas em snake_case nativo).
- **Cobertura**: `CascadingApiFactory` + `MigrationHostedService` ainda fazem `MigrateAsync` contra Postgres efêmero em cada run; suíte continua a validar o startup ponta-a-ponta.

## Test plan

- [x] `dotnet build UniPlus.slnx` — 0 erro, 0 warning
- [x] `dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests` — 75/75 verde
- [x] `dotnet test tests/Unifesspa.UniPlus.Ingresso.IntegrationTests` — 8/8 verde
- [x] `dotnet test tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests` — 20/20 verde
- [ ] CI completo verde
- [ ] Smoke E2E no standalone após drop+recreate dos 2 bancos (faz parte do AC da issue #437, pendente de tag v0.3.8 + bump em `uniplus-infra`)

Closes #437
Refs #155