### PR TITLE
docs(adr): promove 8 ADRs do módulo Parametrizacao (0055-0062)

### DIFF
--- a/docs/adrs/0055-organizacao-institucional-bounded-context.md
+++ b/docs/adrs/0055-organizacao-institucional-bounded-context.md
@@ -1,0 +1,195 @@
+---
+status: "accepted"
+date: "2026-05-14"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0055: OrganizacaoInstitucional como bounded context dedicado com roster fechado
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` é uma plataforma com uma instância por instituição: a Unifesspa hospeda sua própria instância; qualquer outra IFES que adote a plataforma instala e opera seu próprio deployment. **Não há aspecto multi-tenant SaaS** — sem isolamento row-level por instituição, sem coluna `TenantId` em `EntityBase`, sem `HasQueryFilter` por tenant, sem claim de tenant no JWT.
+
+Dentro de uma instância da plataforma, a plataforma precisa atender múltiplas **áreas organizacionais** com responsabilidades administrativas distintas e propriedade sobre subconjuntos diferentes dos dados de referência:
+
+- **CEPS** (Centro de Processos Seletivos) — dono de Seleção; edita `TipoEdital`, `TipoEtapa`, `CriterioDesempate`, `LocalProva` para provas, `ObrigatoriedadeLegal` de editais.
+- **CRCA** (Centro de Registro e Controle Acadêmico) — dono de Ingresso; edita `TipoDocumento` para matrícula, configurações específicas de enrollment.
+- **PROEG** (Pró-Reitoria de Ensino de Graduação) — supervisora sobre CEPS/CRCA; edita parâmetros de política entre áreas quando aplicável.
+- **PROGEP** (Pró-Reitoria de Gestão de Pessoas) — domínio separado, módulo futuro.
+- **Plataforma / CTIC** — edita dados de referência universais (modalidades Lei 12.711/2023, regulamentações federais de acessibilidade), configurações platform-wide, e roles que atravessam áreas.
+- **Futuras áreas** — a plataforma deve aceitar novas áreas sem mudança arquitetural.
+
+O risco que esta ADR mitiga: sem um conceito explícito de área, a plataforma ou (a) concede todos os roles admin com acesso platform-wide flat (CEPS edita `TipoDocumento` do CRCA, audit trail diz "admin" sem atribuição de área, edições acidentais entre áreas viram rotina), ou (b) hardcoda mapeamentos área→módulo em filtros de autorização nos controllers (cada nova área exige mudança de código). Nenhum é aceitável.
+
+## Drivers da decisão
+
+- **Governança real, não cosmética**: áreas têm responsabilidades distintas que precisam de auditoria explícita; "quem editou o quê" deve responder a "qual área".
+- **Configurável sem deploy**: o princípio "quando a lei muda, edita o catálogo — sem deploy" exige que adicionar uma área nova (PROAE, PROEX, etc.) seja operação de dados, não de código.
+- **Coerência com ADR-0001** (monolito modular): áreas têm ciclo de vida próprio (CRUD, audit, soft-delete, eventos) — pertencem a um bounded context, não a `Kernel`.
+- **Closed roster controlado**: adicionar uma nova área é decisão arquitetural deliberada (afeta RBAC, governance, audit); a entidade tem mecanismo que torna a adição rastreável.
+- **`Kernel` permanece enxuto**: tipos com lifecycle (CRUD, eventos, soft-delete) violam a disciplina "Kernel = primitivos sem comportamento próprio".
+
+## Opções consideradas
+
+- **A**: `AreaOrganizacional` como enum C# fechado em `Kernel.Domain` (5 valores hardcoded; adicionar área exige PR + recompilação).
+- **B**: `AreaOrganizacional` como entidade em `Kernel.Domain.Entities` (mesmo shape mas localizada em Kernel).
+- **C**: `AreaOrganizacional` co-hospedada com catálogos no módulo `Parametrizacao`.
+- **D**: `AreaOrganizacional` em Keycloak groups apenas, sem entidade no banco.
+- **E**: Bounded context dedicado `OrganizacaoInstitucional` com `AreaOrganizacional` como agregado, invariante de roster fechado via `AdrReferenceCode`, e `AreaCodigo` como identificador strongly-typed.
+
+## Resultado da decisão
+
+**Escolhida:** "E — bounded context dedicado `OrganizacaoInstitucional`", porque é a única opção que reconhece áreas como conceito de domínio com lifecycle (CRUD, eventos, audit), preserva a disciplina de `Kernel` (primitivos apenas), respeita o princípio de configurável-sem-deploy e isola governance de catálogos (CRUD admin é distinto de áreas).
+
+### Estrutura do módulo
+
+```text
+src/organizacao-institucional/
+├── Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/
+│   └── Entities/
+│       └── AreaOrganizacional.cs
+├── Unifesspa.UniPlus.OrganizacaoInstitucional.Application/
+│   ├── Commands/                    (admin: registrar via ADR, atualizar, soft-delete)
+│   ├── Queries/
+│   └── DTOs/
+├── Unifesspa.UniPlus.OrganizacaoInstitucional.Contracts/
+│   ├── IAreaOrganizacionalReader.cs (leitor cross-módulo)
+│   ├── AreaCodigo.cs                (record struct sobre string, strongly-typed)
+│   ├── AreaOrganizacionalView.cs    (DTO read-only para consumo cross-módulo)
+│   └── ReferenceDataAttribute.cs
+├── Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/
+│   └── Persistence/
+│       ├── OrganizacaoInstitucionalDbContext.cs (banco `uniplus_organizacao`)
+│       └── Configurations/
+└── Unifesspa.UniPlus.OrganizacaoInstitucional.API/
+    └── Controllers/
+        └── AreasOrganizacionaisController.cs
+```
+
+### Entidade `AreaOrganizacional`
+
+```text
+Id: Guid (v7)
+Codigo: string (unique, uppercase, ex.: "CEPS", "CRCA", "PROEG", "PROGEP", "PLATAFORMA")
+Nome: string (ex.: "Centro de Processos Seletivos")
+Tipo: enum { ProReitoria, Centro, Coordenadoria, Plataforma, Outra }
+Descricao: string
+AdrReferenceCode: string (ex.: "0055-organizacao-institucional-bounded-context")
+— herda EntityBase (audit + soft delete)
+```
+
+### Invariante de roster fechado
+
+- Adicionar uma nova `AreaOrganizacional` é **decisão deliberada documentada em ADR** desta base (não apenas dado entrado pela UI admin).
+- A admin UI **suporta** criação de áreas novas via endpoint, mas a operação exige role `plataforma-admin` E campo `AdrReferenceCode` não-vazio — o campo é persistido e fitness test no CI valida que cada `AdrReferenceCode` aponta para arquivo existente em `docs/adrs/`.
+- Não é "áreas são imutáveis em código" (opção A — enum em Kernel). É "adicionar área é ato de governança com audit trail, não operação CRUD livre".
+
+### `AreaCodigo` — identificador strongly-typed
+
+`AreaCodigo` é `readonly record struct` em `OrganizacaoInstitucional.Contracts`:
+
+- Construtor privado; factory `From(string)` retorna `Result<AreaCodigo>` com validação (2-32 chars, uppercase, alfanum + underscore, sem leading digit).
+- Usado em todo o sistema: `Proprietario: AreaCodigo?` em entidades de catálogo, elementos de `AreasDeInteresse: IReadOnlySet<AreaCodigo>`, claims JWT derivados expõem `IReadOnlyCollection<AreaCodigo>`.
+- Previne typo bugs (`"ceps"` vs `"CEPS"`) e centraliza o ponto de conversão.
+
+### Acesso cross-módulo
+
+`IAreaOrganizacionalReader` em `OrganizacaoInstitucional.Contracts` expõe:
+
+- `Task<IReadOnlyList<AreaOrganizacionalView>> ListarAtivasAsync(CancellationToken)`
+- `Task<AreaOrganizacionalView?> ObterPorCodigoAsync(AreaCodigo codigo, CancellationToken)`
+
+Outros módulos consomem via DI in-process (ver [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md)). Write-side cross-módulo permanece Kafka-only (ADR-0001).
+
+### Convenção de roles Keycloak
+
+Cada `AreaOrganizacional.Codigo` projeta-se em 2 roles convencionais:
+
+- `{codigo-lowercase}-admin` — autoridade de escrita.
+- `{codigo-lowercase}-leitor` — autoridade de leitura.
+
+Adicionar uma área (com ADR) implica provisionar os roles correspondentes via o script de automação de identidade da plataforma. É parte do runbook de criação de área no `uniplus-infra`.
+
+### O que entra no módulo (V1)
+
+Apenas `AreaOrganizacional`. O módulo é deliberadamente enxuto.
+
+### O que pode entrar depois (deferido)
+
+- `HierarquiaInstitucional` — sub-áreas, parent-child (quando 2+ áreas pedirem subdivisão interna).
+- `CargoInstitucional` — posições/papéis dentro de áreas (quando authz precisar de granularidade role-within-area além de admin/leitor).
+- `VigenciaDelegacao` — delegação time-bounded de admin authority (quando handovers temporários entre áreas virarem rotina).
+
+Cada extensão exige sua própria ADR com trigger condition documentado; nenhuma está em escopo V1.
+
+## Consequências
+
+### Positivas
+
+- Cada área é dona de suas configurações de catálogo com provenance auditável.
+- Novas áreas (e.g., futura PROAE para ações afirmativas) podem ser adicionadas via ADR + admin CRUD, sem mudança de código nem deploy.
+- `EntityBase` permanece limpo — sem multi-tenancy plumbing platform-wide.
+- Contratos V1 (cursor, Kafka envelope, idempotency, audit) não sofrem amendments.
+- Roles Keycloak são previsíveis e self-documenting (convenção `{area}-admin`).
+- Catálogos universais (Modalidade Lei 12.711) permanecem platform-administered com semântica explícita.
+- Cooperação inter-área é o default (leituras entre áreas permitidas) — bate com a realidade operacional da Unifesspa.
+
+### Negativas
+
+- Entidades de catálogo área-scoped carregam campo extra `AreaProprietariaCodigo` (~16 bytes por linha).
+- Lógica de autorização middleware é levemente mais complexa (lê área do recurso antes de checar role do caller).
+- `plataforma-admin` editando dados área-scoped deve ser logado explicitamente com atribuição `on-behalf-of` — lógica audit extra.
+- Frontend admin UI deve filtrar catálogos editáveis baseado nos roles do caller — coordenação UX leve.
+
+### Neutras
+
+- A entidade carrega `AdrReferenceCode` que aponta para arquivo neste repositório de ADRs; o link é validado em build time, não runtime.
+
+## Confirmação
+
+1. **Fitness test ArchUnitNET**: `AreasOrganizacionais_AdrReferenceCodes_DevemReferenciarArquivoExistente` lê `seeds/seed-areas-organizacionais.json` em test time e valida que cada `adrReferenceCode` corresponde a arquivo em `docs/adrs/`. Falha o build em drift.
+2. **Provisioning script**: `tools/provision-area.sh` automatiza: criar áreas via API + criar roles Keycloak + atribuição inicial de admin user. Idempotente.
+3. **Revisão arquitetural de PR**: PRs que tentem adicionar uma nova `AreaOrganizacional` sem ADR correspondente são rejeitados.
+
+## Prós e contras das opções
+
+### A — Enum C# fechado em `Kernel.Domain`
+
+- **Prós**: Máxima simplicidade. Zero novo módulo. Exhaustiveness em compile-time.
+- **Contras**: Cada nova área = mudança de código + deploy + binary release. Não consegue armazenar metadata (`Nome`, `Tipo`, `Descricao`). Não pode auditar quem adicionou ou quando. Não pode soft-delete (valores de enum são imortais). Adicionar PROAE em 2027 = nova release, não `POST /areas` com audit. Viola o princípio "configurável sem deploy" para um conceito de governança essencial.
+
+### B — Entidade em `Kernel.Domain.Entities`
+
+- **Prós**: Sem novo módulo skeleton. Todo módulo já referencia `Kernel`, então DI é trivial.
+- **Contras**: `Kernel` é reservado para **primitivos sem lifecycle e sem comportamento** (`Cpf`, `Email`, `EntityBase`, `Result<T>`). `AreaOrganizacional` tem ciclo CRUD completo, autorização admin, audit, soft-delete e domain events. Hospedá-la em Kernel infla a superfície de Kernel com infra/admin concerns e gradualmente erode a disciplina "primitivos apenas".
+
+### C — Co-hospedada em `Parametrizacao`
+
+- **Prós**: Compartilha infra CRUD com catálogos irmãos. Um csproj a menos.
+- **Contras**: Áreas não estão no mesmo plano que `Modalidade` ou `LocalProva`. Áreas têm **integridade referencial** com RBAC, JWT, Keycloak, audit e o `Proprietario` / `AreasDeInteresse` de todo outro catálogo. São o **sujeito** da autorização, não um **objeto** governado por ela. Co-hospedagem confunde as camadas conceituais.
+
+### D — Apenas Keycloak groups, sem entidade no banco
+
+- **Prós**: Sem schema de DB para áreas; Keycloak é fonte da verdade.
+- **Contras**: Adicionar áreas é tarefa de admin Keycloak (out-of-band para admins de plataforma). Audit trail não consegue JOIN com metadata de áreas para relatórios. Display name (`"Centro de Processos Seletivos"` vs código `"CEPS"`) vive em atributos Keycloak, awkward para query. A `AreaOrganizacional` é referenciada vezes suficientes que ter como entidade simplifica o resto do sistema.
+
+### E — Bounded context dedicado (escolhida)
+
+- **Prós**: Separa governança organizacional de dados de catálogo. `AreaCodigo` strongly-typed elimina string-typo bugs. Roster expansion auditável (`AdrReferenceCode` enforçado). `AreaOrganizacional` tem ciclo de vida completo (audit, soft-delete, eventos) sem poluir `Kernel`. Conceitos futuros de hierarquia/cargo/delegação têm casa limpa — sem extração depois. Acesso cross-módulo via `IAreaOrganizacionalReader` mantém boundary consistente com o resto da plataforma.
+- **Contras**: Um módulo adicional na solution (5 csproj). DI wiring em cada consumer. Build time cresce ~3-5 segundos. Novos devs precisam aprender que "áreas NÃO estão em Parametrizacao" — contraintuitivo para quem está acostumado a "todos os dados de referência em um módulo".
+
+## Mais informações
+
+- [ADR-0001](0001-monolito-modular-como-estilo-arquitetural.md) — Monolito modular: áreas como bounded context distinto.
+- [ADR-0010](0010-audience-uniplus-em-tokens-oidc.md) — Audience Keycloak: roles `{area}-admin`/`{area}-leitor` projetados nesta convenção.
+- [ADR-0019](0019-proibir-pii-em-path-segments-de-url.md) — Sem PII em URLs (informa postura LGPD; `DeletedBy` é JWT sub, nunca CPF).
+- [ADR-0033](0033-icurrentuser-abstraction-via-iusercontext.md) — `IUserContext` é estendido com `AreasAdministradas: IReadOnlyCollection<AreaCodigo>` derivada dos roles JWT.
+- [ADR-0034](0034-problemdetails-em-401-403-via-jwtbearer-events.md) — ProblemDetails em 401/403 herdado.
+- [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) — Módulo Parametrizacao e carve-out read-side cross-módulo.
+- [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) — RBAC baseado em áreas com snapshot, histórico e invariantes.
+- [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md) — `ObrigatoriedadeLegal` como validação data-driven com citação legal.
+- Confirmação do sponsor (2026-05-13): roster fechado com adições via ADR; single-deployment per institution.

--- a/docs/adrs/0056-parametrizacao-modulo-e-read-side-carve-out.md
+++ b/docs/adrs/0056-parametrizacao-modulo-e-read-side-carve-out.md
@@ -1,0 +1,238 @@
+---
+status: "accepted"
+date: "2026-05-14"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0056: Módulo Parametrizacao e carve-out read-side cross-módulo via IXxxReader
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` tem oito catálogos admin-editáveis identificados pelo protótipo do wizard de edital, com naturezas distintas:
+
+| Catálogo | Natureza | Usado por |
+|---|---|---|
+| `TipoEdital` | Template de processo seletivo | Apenas Selecao |
+| `TipoEtapa` | Stage de workflow de seleção | Apenas Selecao |
+| `CriterioDesempate` | Primitiva do motor de classificação ([ADR-0013](0013-motor-de-classificacao-como-servicos-de-dominio-puros.md)) | Apenas Selecao |
+| `LocalProva` | Local de aplicação de prova (capacidade, responsável exam-specific) | Apenas Selecao |
+| `ObrigatoriedadeLegal` | Engine configurável de validação legal para editais | Apenas Selecao (ver [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md)) |
+| `Modalidade` | Modalidade de cota federal (Lei 12.711/2023) | Selecao + Ingresso + módulos futuros |
+| `NecessidadeEspecial` | Categorias de acessibilidade (LBI Lei 13.146/2015) | Selecao + Ingresso + módulos futuros |
+| `TipoDocumento` | Tipos de documento para inscrição (CEPS) e matrícula (CRCA) | Selecao + Ingresso |
+
+O sponsor esclareceu durante council R2: `LocalProva` é estritamente domínio Selecao (com metadata exam-specific), mas o **endereço físico em si** é reutilizável. O `LocalProva` do CEPS para uma prova em "Campus Marabá Folha 31" e um hipotético `LocalMatricula` do CRCA para evento de matrícula no mesmo site físico compartilham o **endereço** mas não os atributos venue-specific. Isso decompõe `LocalProva` (como desenhado no protótipo) em dois conceitos: o cross-cutting reutilizável `Endereco`, e o `LocalProva` Selecao-specific que **referencia** um `Endereco` e adiciona campos exam-specific.
+
+A justificativa para um módulo `Parametrizacao` separado repousa em:
+
+- **Coesão de governance shape** — `Modalidade`, `NecessidadeEspecial`, `TipoDocumento`, `Endereco` todos compartilham: `Proprietario` + `AreasDeInteresse` + vigência + base legal + snapshot-on-bind.
+- **Reuso entre módulos sem acoplamento direto** — Selecao e Ingresso ambos consomem esses catálogos; colocá-los em qualquer consumer cria o anti-pattern que [ADR-0001](0001-monolito-modular-como-estilo-arquitetural.md) foi desenhada para prevenir.
+- **Dados universais (modalidades Lei 12.711, regulamentações federais de acessibilidade) merecem uma casa que sinaliza seu escopo platform-wide.**
+
+[ADR-0001](0001-monolito-modular-como-estilo-arquitetural.md) (monolito modular, cross-módulo via Kafka apenas) governa **mutações write-side cross bounded contexts** — eventos, mudanças de estado, dispatch de comandos. Para **consultas read-side de dados de referência** (renderizar dropdowns, validar codes), a opção de carve-out: in-process DI síncrono é permitido via interfaces `IXxxReader` publicadas em assemblies `.Contracts`, enforçado por fitness test.
+
+## Drivers da decisão
+
+- **Coesão sobre cardinalidade de módulos**: 4 catálogos com mesma shape governance merecem casa comum mais do que ficar espalhados.
+- **Reuso explícito sem violar a fronteira do bounded context**: cross-módulo precisa de mecanismo controlado, não escape hatch implícito.
+- **Latência aceitável nas leituras do wizard (dezenas de lookups por render)**: wizard de edital faz dezenas de lookups de `Modalidade` por renderização; passar tudo por Kafka projection seria operacionalmente caro e latência-visível ao usuário.
+- **Auditabilidade da exceção**: fitness test deve detectar se cross-módulo dependencies violam o boundary.
+- **Forward-compatibilidade**: pattern deve suportar extensão a Ingresso/Portal/módulos futuros sem revisitar a decisão.
+
+## Opções consideradas
+
+- **A**: Todos os 8 catálogos dentro de `Selecao`. Cross-módulo consumption via `Selecao.Contracts`.
+- **B**: Cross-módulo apenas via Kafka projection — cada módulo materializa cópia local de `Modalidade` etc. via eventos.
+- **C**: Catálogos cross-cutting em `SharedKernel`.
+- **D**: REST admin genérica `/api/parametrizacao/{tipo}` com payload polimórfico, single resource.
+- **E**: Módulo `Parametrizacao` dedicado para catálogos cross-cutting; carve-out read-side via `IXxxReader` em `.Contracts`; write-side permanece restrita a Kafka.
+
+## Resultado da decisão
+
+**Escolhida:** "E — módulo `Parametrizacao` dedicado com carve-out read-side via `IXxxReader`", porque é a única opção que respeita a disciplina do monolito modular (ADR-0001) com fitness tests enforcando o pattern, mantém latência do wizard em níveis aceitáveis (sub-millisecond warm) e preserva per-resource vendor MIME (ADR-0028).
+
+### Estrutura do módulo
+
+```text
+src/parametrizacao/
+├── Unifesspa.UniPlus.Parametrizacao.Domain/
+│   └── Entities/                  ← Modalidade, NecessidadeEspecial, TipoDocumento, Endereco
+├── Unifesspa.UniPlus.Parametrizacao.Application/
+│   ├── Commands/                  (admin CRUD por catálogo)
+│   ├── Queries/                   (listar, obter por código, obter por vigência)
+│   ├── DTOs/
+│   └── Events/                    (CatalogItemRegistradoEvent, AtualizadoEvent, DesativadoEvent)
+├── Unifesspa.UniPlus.Parametrizacao.Contracts/
+│   ├── IModalidadeReader.cs       ← interface publicada para leitura cross-módulo
+│   ├── INecessidadeEspecialReader.cs
+│   ├── ITipoDocumentoReader.cs
+│   ├── IEnderecoReader.cs
+│   ├── Dtos/
+│   │   ├── ModalidadeView.cs
+│   │   ├── NecessidadeEspecialView.cs
+│   │   ├── TipoDocumentoView.cs
+│   │   └── EnderecoView.cs
+│   └── ReferenceDataAttribute.cs  ← marker
+├── Unifesspa.UniPlus.Parametrizacao.Infrastructure/
+│   └── Persistence/
+│       ├── ParametrizacaoDbContext.cs ← schema "parametrizacao"
+│       └── Configurations/
+└── Unifesspa.UniPlus.Parametrizacao.API/
+    └── Controllers/               (um controller por recurso: ModalidadeController, etc.)
+```
+
+### Catálogos em Parametrizacao (cross-cutting)
+
+1. **`Modalidade`** — modalidades de cota Lei 12.711/2023. Universal (`AreasDeInteresse = []`), `Proprietario = null` (apenas plataforma-admin). Lei federal; nunca área-específica.
+2. **`NecessidadeEspecial`** — categorias de acessibilidade LBI Lei 13.146/2015. Universal. `Proprietario = null`.
+3. **`TipoDocumento`** — tipos de documento. Maioria cross-area (CEPS usa para inscrição, CRCA para matrícula); algumas entradas área-específicas (`AreasDeInteresse = ["CRCA"]` para docs matriculation-only); algumas universais (RG, CPF, etc.).
+4. **`Endereco`** — endereço físico com município, código IBGE, UF, logradouro, CEP. Reutilizável por `LocalProva` (Selecao), futura `LocalMatricula` (Ingresso), `LocalEntrega` (qualquer módulo). `AreasDeInteresse` reflete quem usa atualmente cada endereço; `Proprietario` é a área que provisionou (tipicamente PLATAFORMA).
+
+### Catálogos que ficam no módulo dono (domain-specific)
+
+1. **`TipoEdital`** → Selecao (template de processo seletivo; primitiva pura de Selecao).
+2. **`TipoEtapa`** → Selecao (definições de stage de workflow; specific to selection).
+3. **`CriterioDesempate`** → Selecao (primitiva do motor de classificação per [ADR-0013](0013-motor-de-classificacao-como-servicos-de-dominio-puros.md)).
+4. **`LocalProva`** → Selecao (referencia `Endereco` por `EnderecoOrigemId` snapshot per [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md); adiciona campos exam-specific: `CapacidadeMaxima`, `ResponsavelExame`, `CondicoesAcessibilidade`. CEPS-administered).
+5. **`ObrigatoriedadeLegal`** → ver [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md) para design completo; fica em Selecao para V1 com critérios de promoção a futuro módulo `Normativos` documentados.
+
+### Carve-out cross-módulo read-side (refina ADR-0001)
+
+ADR-0001 é refinada conforme segue:
+
+**Leitura cross-módulo de dados de referência é permitida via in-process DI sob todas as condições abaixo:**
+
+1. O módulo dono publica interface `I{Resource}Reader` em assembly `{Module}.Contracts` apenas.
+2. A interface retorna DTOs read-only (`{Resource}View`), nunca entidades de `Domain`.
+3. Métodos recebem **contexto explícito de áreas** como parâmetro — caller passa `IReadOnlyCollection<AreaCodigo> areasCaller`, nunca resolvido internamente de `IUserContext`. (Isso endereça cache correctness — ver [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md).)
+4. A implementação é registrada como Singleton respaldada por **distributed cache (Redis 8 via `IDistributedCache`, TTL 5 minutos)**. O cache armazena o **raw set por recurso** sob chave canônica (`parametrizacao:{recurso}`, ex.: `parametrizacao:modalidades`), não views per-caller; o filtro de áreas acontece após retrieval do cache, no reader, baseado no parâmetro `areasCaller` explícito. Cache L1 in-process (`IMemoryCache`) **NÃO** é adicionado em V1 — é otimização adiada gated por evidência de P95 latency ou throughput (ver Riscos).
+5. Invalidação via subscriber de evento de domínio Kafka (`ModalidadeAtualizadaEvent` triggera `IDistributedCache.RemoveAsync("parametrizacao:modalidades")`). O `DEL` único é atômico cross-replicas — não há janela de inconsistência cross-pod.
+6. Stampede protection em cache miss: reader adquire lease curto (~300ms) via Redis `SET NX EX` antes de bater no PostgreSQL, fazendo requests concorrentes coalescerem em uma única source query.
+7. A entidade carrega atributo `[ReferenceData]` (declarado em `Parametrizacao.Contracts`).
+
+**Mutações write-side ou queries de aggregate state permanecem Kafka-only** (sem mudança no espírito de ADR-0001).
+
+**Background jobs e operações `plataforma-admin`** que legitimamente precisam de visibilidade unfiltered passam coleção `areasCaller` vazia E carregam atributo `[ExplicitlyUnscoped]` na call site. Fitness test ArchUnitNET falha o build se `[ExplicitlyUnscoped]` é usado sem assertion de role `plataforma-admin`.
+
+### Eventos de catálogo — PG queue apenas em V1 (sem registro Apicurio)
+
+Eventos de mutação de catálogo (`ModalidadeRegistradoEvent`, `ModalidadeAtualizadoEvent`, `ModalidadeDesativadoEvent`, e análogos para outros catálogos) são **intra-module** em V1: existem unicamente para invalidar a entry de `IDistributedCache` dentro do processo da API do módulo dono via subscriber Wolverine PG queue. Não há consumer cross-módulo subscrito a esses eventos no escopo Sprint 3. Per [ADR-0044](0044-roteamento-domain-events-pg-queue-kafka-opcional.md), esses eventos roteiam para PG queue apenas — sem publish Kafka, sem `.avsc` em `Parametrizacao.Domain/Events/Schemas/`, sem entry `SchemaRegistration.AddSchema(...)` em `Program.cs`, sem subject Apicurio.
+
+**Trigger para promover um evento de catálogo a Kafka + Avro** (per [ADR-0051](0051-apicurio-schema-registry-avro-wolverine.md) pattern hand-written, com threshold ≥3 schemas-total para migração a codegen):
+
+1. Um segundo módulo (Ingresso, Portal, Auxilio Estudantil) assina como consumer Kafka de um evento de catálogo — tipicamente porque mantém projeção própria ou invalida cache local que o processo Parametrizacao não alcança via Redis.
+2. Promoção segue o pattern canônico documentado em `docs/guia-apicurio-schema-registry.md`: adicionar `.avsc` embedded resource, classe `ISpecificRecord` hand-written em `Infrastructure/Messaging/Avro/`, `<Evento>ToAvroMapper` em `Infrastructure/Messaging/`, cascade handler projetando domain event → record Avro, routing entry em `Program.cs` com `SchemaRegistryAvroSerializer`, e call `.AddSchema("<topic>-value", ...)`.
+3. O threshold codegen-vs-hand-written (≥3 schemas total) é project-wide; uma vez que o projeto atinja 3 schemas Avro (hoje 1 — `EditalPublicado.avsc`; Sprint 3 adiciona zero), reavaliar switch para `Apache.Avro.Tools` MSBuild codegen per ADR-0051 §2.
+
+Essa decisão explícita "PG queue apenas" mantém Sprint 3 livre de superfície Avro/Apicurio preservando forward-compatibilidade com o pattern estabelecido.
+
+### Fitness tests (ArchUnitNET)
+
+- Nenhum projeto de módulo pode referenciar assemblies `.Domain` ou `.Application` de outro módulo.
+- Dependências cross-módulo são permitidas apenas contra assemblies `{Module}.Contracts`.
+- Métodos `I{Resource}Reader` devem aceitar `IReadOnlyCollection<AreaCodigo> areasCaller` OU ser marcados `[ExplicitlyUnscoped]`.
+- Entidades marcadas `[ReferenceData]` não podem ter dependências outbound sobre tipos de outros módulos.
+- `Parametrizacao.Contracts` pode depender de `OrganizacaoInstitucional.Contracts` (para `AreaCodigo`).
+- `LocalProva` em `Selecao.Domain` referencia `EnderecoOrigemId: Guid?` — sem dependência de domain em `Parametrizacao.Domain.Endereco`; validação da FK é por value-copy via `IEnderecoReader.ObterPorIdAsync` no command handler per [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md).
+
+### Contrato REST por catálogo
+
+Cada catálogo em Parametrizacao é seu próprio recurso REST com vendor MIME (estende [ADR-0028](0028-versionamento-per-resource-content-negotiation.md)):
+
+```text
+application/vnd.uniplus.modalidade.v1+json
+application/vnd.uniplus.necessidade-especial.v1+json
+application/vnd.uniplus.tipo-documento.v1+json
+application/vnd.uniplus.endereco.v1+json
+```
+
+Endpoints seguem contrato V1 estabelecido:
+
+- `GET /api/parametrizacao/{recurso}` — leitura; filtrada pelas áreas do caller; sem cursor pagination (catálogos são reference data bounded ≤ 100 linhas; exceção deliberada a [ADR-0026](0026-paginacao-cursor-opaco-cifrado.md)).
+- `GET /api/parametrizacao/{recurso}/{id:guid}` — single resource com HATEOAS `_links` ([ADR-0029](0029-hateoas-level-1-links.md)).
+- `POST /api/admin/parametrizacao/{recurso}` — admin área-scoped per [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md); `Idempotency-Key` required.
+- `PUT /api/admin/parametrizacao/{recurso}/{id:guid}` — admin área-scoped; idempotente.
+- `DELETE /api/admin/parametrizacao/{recurso}/{id:guid}` — soft delete apenas.
+
+Admin endpoints de `Endereco` são restritos: apenas `plataforma-admin` pode criar novos endereços (endereços são infraestrutura institucional); outras áreas pedem adições via processo interno. Isso evita proliferação de endereços duplicados.
+
+## Consequências
+
+### Positivas
+
+- Casa clara para reference data cross-cutting com governance consistente.
+- `Endereco` reutilizável cross-módulo; infraestrutura física modelada uma vez.
+- ADR-0001 refinada com carve-out preciso fitness-test-enforced — não violada ad hoc.
+- Wizard latency permanece aceitável para reference reads (~1–5ms warm via Redis; reference data é invocada uma vez por screen load, não por linha — overhead negligível contra budgets típicos de request 100–300ms).
+- **Consistência cross-pod é atômica** — invalidação Kafka triggera DEL Redis único, todas as réplicas imediatamente param de servir valor stale. Isso elimina a janela de não-determinismo que cache in-memory per-pod introduziria, material sob RN08 (parameter freeze) e obrigações de reproducibilidade judicial-audit.
+- Adicionar novo consumer module é trivial: referencia `Parametrizacao.Contracts`, injeta `IModalidadeReader`. Sem nova infra.
+- Per-resource vendor MIME preservado.
+- Passing explícito de áreas faz background jobs e operações admin naturalmente expressáveis.
+
+### Negativas
+
+- Adiciona 2 novos módulos à solution (`Parametrizacao` + `OrganizacaoInstitucional`).
+- `LocalProva` referencia `Endereco` por ID — seleção de endereço é step explícito no workflow do CEPS.
+- Fitness tests ArchUnitNET devem ser adicionados; novo pattern para o time aprender.
+- Reader é dependente de disponibilidade de Redis; outage degrada todos reference-data reads para PostgreSQL hits diretos. Mitigado por Redis ser dependência stack-wide já (sessions, idempotency cache) — failure mode é compartilhado, não específico a este carve-out.
+- Propagação de invalidação de cache não é instantânea da perspectiva do usuário: write commits → outbox publishes → Kafka delivers → subscriber DEL Redis → próxima reader call repopulates. Latência típica end-to-end é sub-second; admin UI deve mostrar toast "alteração propagando" brevemente post-save.
+
+### Neutras
+
+- A escolha não impede que coleções carreguem metadados auxiliares — mas isso vai **apenas em headers HTTP** (per [ADR-0025](0025-wire-formato-sucesso-body-direto.md)).
+
+## Confirmação
+
+- ArchUnitNET fitness tests asseram cross-module boundaries (regras R1–R7 documentadas).
+- Spectral rule no spec OpenAPI verifica que cada catálogo tem vendor MIME registrado.
+- Smoke E2E (Newman) cobre criar/listar/obter/admin-CRUD em cada catálogo.
+- Revisão arquitetural de PR: PRs que adicionem catálogo em módulo errado (ex.: Modalidade fora de Parametrizacao) são rejeitados.
+
+## Prós e contras das opções
+
+### A — Todos os 8 catálogos em Selecao
+
+- **Prós**: Zero novo módulo. Caminho mais rápido para wizard.
+- **Contras**: Quando Ingresso precisa de `Modalidade` (matriculation eligibility check, near-certainty em 6-12 meses dado roadmap), ou (i) Ingresso importa reader do Selecao (aceitável per carve-out, mas signal coupling) ou (ii) constrói duplicate local de `Modalidade` (drift inevitável). Futuros módulos compostam o problema. `Modalidade` e `NecessidadeEspecial` são explicitamente federal-universal — colocá-las em Selecao misrepresenta seu escopo.
+
+### B — Kafka-only cross-módulo (Architect's opening original)
+
+- **Prós**: Conformance estrito a ADR-0001. Zero coupling. Reads de cada módulo são self-contained.
+- **Contras**: Complexidade operacional: ~50–200ms eventual consistency lag; debug de consumer rebalance; recovery de projection corruption; N módulos × M reference catalogs = N×M projections para manter. Time CTIC de ~10 devs absorve esse custo para sempre. Bug UX "acabei de criar Modalidade em admin tab, por que não aparece aqui?" é support ticket perene.
+
+### C — SharedKernel grab-bag
+
+- **Prós**: Sem novo projeto de módulo.
+- **Contras**: SharedKernel vira gaveta de bagunça — value objects, base entities, reference data, DTOs comuns todos em um lugar. Aumenta coupling: cada módulo referencia SharedKernel; inflar bloata compilation graph e surface area.
+
+### D — REST admin genérica `/api/parametrizacao/{tipo}` polimórfica
+
+- **Prós**: Menos boilerplate; um controller para 4 catálogos.
+- **Contras**: Descarta type safety no contrato. Quebra semântica HATEOAS link (cada tipo de recurso tem relações diferentes). Versioning per resource (ADR-0028) fica impossível. Client codegen produz unions weakly typed. ProblemDetails error codes não podem ser específicos.
+
+### E — Módulo dedicado com carve-out (escolhida)
+
+- **Prós**: Discussão acima. Trade-offs absorvidos pelas justificativas centrais.
+- **Contras**: Discussão acima.
+
+## Mais informações
+
+- [ADR-0001](0001-monolito-modular-como-estilo-arquitetural.md) — Monolito modular (refinada aqui).
+- [ADR-0013](0013-motor-de-classificacao-como-servicos-de-dominio-puros.md) — Motor de classificação como pure domain services.
+- [ADR-0026](0026-paginacao-cursor-opaco-cifrado.md) — Paginação cursor (com exceção documentada para reference data bounded).
+- [ADR-0027](0027-idempotency-key-store-postgresql.md) — Idempotency-Key store.
+- [ADR-0028](0028-versionamento-per-resource-content-negotiation.md) — Versionamento per resource.
+- [ADR-0029](0029-hateoas-level-1-links.md) — HATEOAS Level 1.
+- [ADR-0033](0033-icurrentuser-abstraction-via-iusercontext.md) — IUserContext.
+- [ADR-0044](0044-roteamento-domain-events-pg-queue-kafka-opcional.md) — Roteamento eventos PG queue + Kafka opcional.
+- [ADR-0051](0051-apicurio-schema-registry-avro-wolverine.md) — Apicurio Schema Registry com Avro hand-written.
+- Kamil Grzybek — `modular-monolith-with-ddd` (precedent de Open Host Service).
+- Vaughn Vernon — *Implementing DDD* (Open Host Service vs Published Language).
+- [ADR-0055](0055-organizacao-institucional-bounded-context.md) — OrganizacaoInstitucional bounded context.
+- [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) — Áreas-based RBAC com snapshot, histórico e invariantes.
+- [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md) — Referência cross-módulo via snapshot copy.
+- Esclarecimento do sponsor (2026-05-13): `LocalProva` é domínio Selecao; `Endereco` é cross-cutting.

--- a/docs/adrs/0057-areas-rbac-snapshot-historia-invariantes.md
+++ b/docs/adrs/0057-areas-rbac-snapshot-historia-invariantes.md
@@ -1,0 +1,289 @@
+---
+status: "accepted"
+date: "2026-05-14"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0057: RBAC por áreas com snapshot, histórico e invariantes auditáveis
+
+## Contexto e enunciado do problema
+
+Toda entidade admin-editável dos catálogos cross-cutting de Parametrizacao e dos catálogos domain-specific de Selecao carrega dois campos de governança:
+
+- `Proprietario: AreaCodigo?` — a área que administra (edita) o item. Quando `null`, o item é gerido apenas pela plataforma (CTIC).
+- `AreasDeInteresse: IReadOnlySet<AreaCodigo>` — o conjunto de áreas que enxergam/usam o item. Conjunto vazio significa **global** (visível a todas as áreas).
+
+A regra de visibilidade no GET público: o caller enxerga o item se `caller.áreas ∩ item.AreasDeInteresse ≠ ∅` OU se `item.AreasDeInteresse = ∅` (item global). A regra de escrita: o caller pode editar se `caller ∈ {area}-admin` E `{area} == item.Proprietario`, OU se o caller for `plataforma-admin` (com auditoria do tipo "on-behalf-of").
+
+O modelo é poderoso mas tem armadilhas reais. Durante o council debate (rodada 2), o Devil's Advocate apontou seis pontos que, se ignorados, produzem o cenário de falha conhecido como **string-stuffing trap** em 18 meses — quando PROEX, PROGEP e Prefeitura demandarem governance shapes ligeiramente diferentes (sub-áreas, role-áreas, delegações com vigência) e o modelo simples absorver complexidade por proliferação de strings até forçar uma reescrita. O sponsor pediu que todos os seis pontos fossem endereçados nesta ADR, não adiados.
+
+Os seis pontos:
+
+1. **Drift de `AreasDeInteresse` no meio do ciclo do edital**: se um `LocalProva` é `["CEPS"]` na publicação do edital e depois muda para `["CEPS","PROEG"]`, projeções do edital publicado mudam silenciosamente. Sem snapshot.
+2. **Handover de `Proprietario` sem histórico**: quando o CRCA assume um `TipoDocumento` antes do CEPS, a auditoria precisa responder "quem podia editar isso em 12/04/2026?" — uma coluna única não basta.
+3. **Invariante `Proprietario ∈ AreasDeInteresse`** sem especificação explícita.
+4. **Cache correctness**: o reader é cached em Redis; visibilidade depende das áreas do caller — se o cache for por-caller a chave explode em combinatória.
+5. **Política conflitante em áreas compartilhadas**: CEPS quer desativar, PROEG ainda usa — `Ativo: bool` único não resolve.
+6. **Fan-out de auditoria do `plataforma-admin`**: edição on-behalf-of em item compartilhado por 3 áreas — cada área precisa ver o evento.
+
+## Drivers da decisão
+
+- **Reprodutibilidade jurídica**: dado um mandado de segurança sobre um edital publicado em data X, a plataforma precisa reconstruir exatamente quem enxergava o quê naquele momento.
+- **Closed roster sustentável**: o roster de `AreaOrganizacional` precisa permanecer fechado (per [ADR-0055](0055-organizacao-institucional-bounded-context.md)); adições viram ADR.
+- **Sem reinvenção descontrolada**: invariantes não documentados divergem entre módulos durante onboarding.
+- **Antecipação da armadilha "string-stuffing"**: sub-áreas, role-áreas e delegações com vigência ficam explicitamente fora de escopo V1, mas com triggers de revisão escritos.
+- **Cache eficiente sob carga**: a invalidação cross-pod deve ser atômica; views per-caller cached criam combinatória inviável.
+
+## Opções consideradas
+
+- **A**: Endereçar parcialmente (snapshot apenas, sem histórico de `Proprietario`).
+- **B**: Endereçar nenhum dos seis pontos em V1 e iterar quando aparecer dor real (YAGNI puro).
+- **C**: Endereçar todos os seis pontos agora com 7 invariantes/patterns documentados (snapshot + histórico SCD Type 2 + invariante explícita + cache caller-explícito + política cooperativa + fan-out at read time + closed roster reforçado).
+
+## Resultado da decisão
+
+**Escolhida:** "C — endereçar todos os seis pontos agora", porque a postura legal (reprodutibilidade jurídica para mandados de segurança) e a antecipação da string-stuffing trap justificam o investimento adiantado. As estruturas (tabelas history, junction temporal, snapshots) têm custo de manutenção baixo e custo de adição posterior alto.
+
+### Invariante 1: `Proprietario` deve estar em `AreasDeInteresse` (ou ambos vazios)
+
+**Regra:** se `Proprietario != null`, então `Proprietario ∈ AreasDeInteresse`. Se `AreasDeInteresse = ∅` (item global), então `Proprietario = null` (apenas plataforma-admin edita globais).
+
+**Enforcement:** validado nos construtores de domínio e nos command handlers. Retorna `Result.Failure(ProprietarioForaDeAreasDeInteresseError)` em violação. Não enforçado no nível de DB (sem check constraint cross-coluna-array); enforçado na fronteira da aplicação.
+
+**Caso de borda:** remover a área do `Proprietario` de `AreasDeInteresse` exige que o caller também atribua novo `Proprietario` (ou ambos null/empty) no mesmo comando. Update multi-campo é atômico.
+
+### Invariante 2: imutabilidade de `AreaCodigo` após criação
+
+`AreaOrganizacional.Codigo` é `protected init` — não muda após construção. Para "renomear" uma área:
+
+1. Cria nova área com novo código (ADR exigida per [ADR-0055](0055-organizacao-institucional-bounded-context.md)).
+2. Migra referências via procedimento operacional documentado (script de migração de dados).
+3. Soft-delete da área antiga. Referências continuam resolvendo para a área deletada (com flag `IsDeleted = true`), preservando auditoria histórica; operações novas não podem usar área deletada.
+
+### Pattern 1: snapshot de `AreasDeInteresse` e `Proprietario` ao publicar edital
+
+`Edital.Publicar()` snapshota a **governança em si** de cada item de catálogo referenciado pelo edital, além dos snapshots já especificados em RN08 (`docs/visao-do-projeto.md`).
+
+O snapshot inclui:
+
+- Para cada item de catálogo referenciado (Modalidade, LocalProva, TipoDocumento, etc.): `(item_id, item_codigo, proprietario_at_bind, areas_de_interesse_at_bind, vigencia_at_bind, hash)`.
+- Armazenado em tabela `edital_governance_snapshot`, append-only.
+
+**Motivo:** quando um candidato processa alegando "não fui aceito porque minha área foi excluída do edital", o snapshot prova exatamente qual era o conjunto `AreasDeInteresse` no momento da publicação — mesmo que tenha sido editado depois.
+
+**Implementação:**
+
+- Projeção `ParametrizacaoGovernanceProjection` (read-only, desnormalizada) materializa o tuple atual `(item, proprietario, areas_de_interesse)` para alta eficiência de leitura.
+- `Edital.Publicar()` lê a projeção e copia para `EditalGovernanceSnapshot`.
+- A consulta de auditoria usa o snapshot; a consulta operacional do dia a dia usa o estado atual.
+
+### Pattern 2: histórico SCD Type 2 para `Proprietario`
+
+Tabela `proprietario_historico`:
+
+```text
+item_id: Guid
+proprietario_codigo: AreaCodigo
+valid_from: timestamptz
+valid_to: timestamptz?  -- null = linha vigente
+changed_by: string
+```
+
+- Append-only.
+- Nova linha sempre que `Proprietario` muda em um item.
+- `valid_to = null` na linha vigente; fechar uma linha preenche `valid_to`.
+- Index em `(item_id, valid_from DESC)` para consulta "dono em momento X".
+
+**Exemplo de consulta:** "quem podia editar `TipoDocumento.HistoricoEscolar` em 12/04/2026?" — SQL: `SELECT proprietario_codigo FROM proprietario_historico WHERE item_id = ? AND ? BETWEEN valid_from AND COALESCE(valid_to, 'infinity')`.
+
+**O mesmo pattern para histórico de `AreasDeInteresse`:** tabela `area_interesse_binding_historico(item_id, area_codigo, valid_from, valid_to, changed_by)` — uma linha por ciclo de vida de `(item, area)`. Junction table com validade temporal.
+
+### Pattern 3: junction table com validade temporal
+
+Per decisão do council R2 (Architect e Pragmatic concordaram): junction table, não JSON column.
+
+```text
+catalog_item_areas_de_interesse(
+  item_id: Guid
+  item_type: string         -- discriminador para queries cross-table
+  area_codigo: AreaCodigo
+  valid_from: timestamptz
+  valid_to: timestamptz?    -- null = vigente
+  added_by: string          -- sub do JWT do admin que adicionou
+)
+PRIMARY KEY (item_id, area_codigo, valid_from)
+```
+
+A junction é **temporal por construção** — adicionar/remover binding é `INSERT new row` / `UPDATE valid_to = now()`, nunca `DELETE`. Isso faz `AreaInteresseBindingHistorico` e o estado atual virarem a mesma tabela, com queries diferentes.
+
+**Query de visibilidade** (apenas vigentes):
+
+```sql
+WHERE EXISTS (
+  SELECT 1 FROM catalog_item_areas_de_interesse cai
+  WHERE cai.item_id = item.id
+    AND cai.valid_to IS NULL
+    AND cai.area_codigo = ANY(:caller_areas)
+)
+OR NOT EXISTS (
+  SELECT 1 FROM catalog_item_areas_de_interesse cai
+  WHERE cai.item_id = item.id
+    AND cai.valid_to IS NULL
+)  -- item global: sem bindings = visível a todos
+```
+
+### Pattern 4: filtro de áreas com cache raw-set e parâmetro explícito
+
+Per decisão unânime do council R2: métodos `IXxxReader` recebem `IReadOnlyCollection<AreaCodigo> areasCaller` como parâmetro. O cache armazena o conjunto raw, não-filtrado; o filtro acontece depois da retrieval.
+
+```csharp
+public sealed class ModalidadeReader : IModalidadeReader
+{
+    private readonly IDistributedCache _cache;
+    private readonly IModalidadeRepository _repo;
+
+    public async Task<IReadOnlyList<ModalidadeView>> ListarVisiveisAsync(
+        IReadOnlyCollection<AreaCodigo> areasCaller,
+        CancellationToken ct)
+    {
+        var rawSet = await _cache.GetOrCreateAsync(
+            "parametrizacao:modalidades",
+            async _ => await _repo.ListarTodosComBindingsAsync(ct));
+
+        return rawSet
+            .Where(m => m.AreasDeInteresse.Count == 0 
+                       || m.AreasDeInteresse.Overlaps(areasCaller))
+            .Select(m => m.ToView())
+            .ToList();
+    }
+}
+```
+
+**A chave do cache é global, não por-caller.** O filtro é em memória depois do cache hit — O(N×M) onde N é tamanho do catálogo (≤ 100) e M é o número de áreas do caller (≤ 5). Negligível.
+
+**Background jobs e operações `plataforma-admin`** passam `areasCaller` vazio E declaram atributo `[ExplicitlyUnscoped]` na call site:
+
+```csharp
+[ExplicitlyUnscoped(Reason = "Relatório noturno — escopo plataforma-admin")]
+public async Task ExecutarRelatorioMensal(...)
+{
+    var todas = await _reader.ListarVisiveisAsync(
+        areasCaller: [],
+        ct);
+}
+```
+
+Quando `areasCaller` é vazio, o reader retorna **apenas itens globais** (`AreasDeInteresse = ∅`), NÃO todos os itens. "Unscoped" por padrão significa "vê só o que é globalmente visível" — comportamento seguro por default. Para ver mesmo tudo, o caller invoca `ListarTodasIncluindoAreaEspecificasAsync(...)` — método com nome que força intent deliberada, e fitness test assere obrigatoriedade de role `plataforma-admin`.
+
+### Pattern 5: `Ativo` único com política cooperativa documentada (ponto 5)
+
+Para V1, `Ativo: bool` permanece coluna única. **A política cooperativa é prática operacional documentada, não enforcement técnico:**
+
+- Antes de desativar item com múltiplas `AreasDeInteresse`, o `Proprietario` notifica as outras áreas interessadas via comunicação interna (email, ticket).
+- A admin UI mostra a lista de `AreasDeInteresse` e pergunta: "este item é compartilhado com {areas}. Confirmar desativação?"
+- Desativação publica `CatalogItemDesativadoEvent` via Kafka; áreas interessadas podem reagir (notificar usuários, arquivar referências).
+
+**Adiada para ADR futura (com trigger condition):** semântica de `Ativo` por área. Trigger: 2+ incidentes documentados de conflito inter-área de desativação em janela de 6 meses.
+
+**Justificativa:** construir ciclo de vida por-área agora é overengineering — a plataforma ainda não operou tempo suficiente para identificar quais conflitos são reais. Política cooperativa + audit trail são suficientes para V1.
+
+### Pattern 6: fan-out de auditoria em read time (ponto 6)
+
+Quando `plataforma-admin` (ou qualquer admin) edita um item compartilhado entre múltiplas áreas, o evento de auditoria é gravado **uma vez** na tabela canônica (`catalog_item_audit_log`). Views de auditoria por área são construídas em **read time** via JOIN sobre os bindings vigentes:
+
+```sql
+-- "Me mostre tudo que afetou itens visíveis ao CEPS na última semana"
+SELECT log.*
+FROM catalog_item_audit_log log
+JOIN catalog_item_areas_de_interesse cai
+  ON cai.item_id = log.item_id
+WHERE cai.area_codigo = 'CEPS'
+  AND log.changed_at >= '2026-05-06'
+  AND (cai.valid_from <= log.changed_at 
+       AND (cai.valid_to IS NULL OR cai.valid_to >= log.changed_at))
+```
+
+O JOIN temporal garante que o CEPS vê eventos de auditoria sobre itens que eram visíveis ao CEPS **no momento da mudança**, mesmo se a visibilidade mudou depois.
+
+**Edições on-behalf-of do `plataforma-admin`** carregam coluna `OnBehalfOfArea: AreaCodigo?` na linha de auditoria. Quando preenchida, views de auditoria por área destacam ("plataforma-admin editou em nome do CEPS").
+
+### Reforço de closed roster (anti string-stuffing)
+
+Per [ADR-0055](0055-organizacao-institucional-bounded-context.md), adicionar nova `AreaOrganizacional` exige ADR + `AdrReferenceCode`. Esta ADR adiciona o corolário:
+
+**Conceitos de sub-área, role-área e vigência-área são explicitamente fora de escopo V1.** Triggers para ADR futura:
+
+- **Sub-área**: 2+ áreas formalmente pedem subdivisão interna em reuniões operacionais (ex.: PROEX quer `PROEX.EditalPNAES` distinto de `PROEX.EditalBolsas`).
+- **Role-área**: qualquer área precisa de permissões por papel além de `admin`/`leitor` para mais de 3 sub-papéis distintos.
+- **Vigência-área**: 2+ casos documentados de delegação temporária de admin entre áreas em 6 meses.
+
+Quando triggered, nova ADR projeta a extensão. Até lá, **`AreaOrganizacional` é a única dimensão de governança** e `AreasDeInteresse: IReadOnlySet<AreaCodigo>` é o único elo de dados inter-área.
+
+## Consequências
+
+### Positivas
+
+- Os seis pontos do Devil's Advocate endereçados por invariantes explícitas e patterns.
+- Auditoria legal completa: snapshot na publicação + histórico de `Proprietario` + junction temporal de `AreasDeInteresse`.
+- Reforço de closed roster previne string-stuffing trap.
+- Estratégia de cache é eficiente (chave global única, filtro pós-cache).
+- Fan-out de auditoria evita amplificação de escrita (uma linha canônica, JOIN em leitura).
+- Evolução futura (sub-área, role-área, vigência-área) tem triggers documentados, não hand-waving aspiracional.
+
+### Negativas
+
+- Junction table com validade temporal é mais complexa que coluna list simples.
+- Tabelas de snapshot (`edital_governance_snapshot`, `proprietario_historico`, `catalog_item_areas_de_interesse` com temporal) crescem monotonicamente; disciplina de storage necessária.
+- Admin UI precisa apresentar a política cooperativa para desativação de `Ativo` (um step de confirmação extra).
+- Novos devs precisam aprender 7 patterns de uma vez — custo de onboarding.
+
+### Neutras
+
+- A escolha não fecha discussão sobre como `Ativo` por-área seria modelado no futuro; documenta apenas o trigger.
+
+## Confirmação
+
+- **Risco**: tabelas de snapshot crescem descontroladamente.
+  **Mitigação**: crescimento estimado ~1000 linhas/ano (100 catálogos × 10 ciclos de edital). Negligível no horizonte de 5 anos. Soft-delete + política de arquivamento para editais com mais de 7 anos per retenção LGPD.
+- **Risco**: queries temporais na junction ficam lentas em escala.
+  **Mitigação**: index parcial em `WHERE valid_to IS NULL` para bindings vigentes; query plans explicados documentados em `tools/db-performance/`.
+- **Risco**: roster fechado vira cerimônia — devs colam fake `AdrReferenceCode`.
+  **Mitigação**: fitness test ArchUnitNET em scripts de seed; checklist de revisão de PR.
+- **Risco**: política cooperativa para `Ativo` ignorada — CEPS desativa sem notificar PROEG.
+  **Mitigação**: prompt na admin UI + subscription Kafka dá visibilidade às áreas interessadas; monitorado como métrica operacional.
+- **Risco**: performance do JOIN de fan-out de auditoria degrada com volume de log.
+  **Mitigação**: audit log particionado por ano; queries por padrão escopadas a períodos recentes; queries frias contra partições arquivadas são caminhos lentos aceitos.
+
+## Prós e contras das opções
+
+### A — Endereçar parcialmente (snapshot apenas)
+
+- **Prós**: Storage menor; lógica de snapshot mais simples.
+- **Contras**: Auditoria legal "quem podia ver isto em 12/04/2026?" não responde se `AreasDeInteresse` mudou desde então. Mesma classe de risco de auditoria do histórico de `Proprietario`.
+
+### B — YAGNI puro (nada agora)
+
+- **Prós**: Zero estrutura extra hoje. Time foca em entregar funcionalidade.
+- **Contras**: Quando o primeiro mandado de segurança chegar, a plataforma não consegue reconstruir o estado histórico. Custo de adicionar snapshot/histórico **post-prod com dados ao vivo** é muito maior que adicioná-los agora durante pre-prod.
+
+### C — Endereçar todos (escolhida)
+
+- **Prós**: Discussão acima.
+- **Contras**: Discussão acima.
+
+## Mais informações
+
+- [ADR-0001](0001-monolito-modular-como-estilo-arquitetural.md) — Monolito modular.
+- [ADR-0013](0013-motor-de-classificacao-como-servicos-de-dominio-puros.md) — Motor de classificação como pure domain services.
+- [ADR-0019](0019-proibir-pii-em-path-segments-de-url.md) — Sem PII em URLs.
+- [ADR-0033](0033-icurrentuser-abstraction-via-iusercontext.md) — `IUserContext`.
+- RN08 de `docs/visao-do-projeto.md` — Congelamento de parâmetros na publicação do edital.
+- LGPD Lei 13.709/2018 — Requisitos de retenção e auditoria.
+- [ADR-0055](0055-organizacao-institucional-bounded-context.md) — OrganizacaoInstitucional bounded context.
+- [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) — Módulo Parametrizacao e carve-out read-side.
+- [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md) — ObrigatoriedadeLegal como validação data-driven.
+- Diretiva do sponsor (2026-05-13): endereçar TODOS os seis pontos do Devil's Advocate nas ADRs.

--- a/docs/adrs/0058-obrigatoriedade-legal-validacao-data-driven.md
+++ b/docs/adrs/0058-obrigatoriedade-legal-validacao-data-driven.md
@@ -1,0 +1,227 @@
+---
+status: "accepted"
+date: "2026-05-14"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0058: ObrigatoriedadeLegal como validação data-driven com citação e snapshot
+
+## Contexto e enunciado do problema
+
+`ObrigatoriedadeLegal` é o catálogo configurável de validação identificado no protótipo do wizard de edital: cerca de 14 regras que validam um `Edital` contra requisitos legais (Lei 12.711/2023, Resolução Unifesspa, Portarias MEC) antes da publicação. As regras cobrem etapa obrigatória, modalidades mínimas, documento obrigatório por modalidade, critério de desempate exigido, atendimento PcD disponível, etc.
+
+O protótipo validou com o CEPS o princípio: **"quando a lei muda, edita o catálogo — sem deploy"**. Isso torna `ObrigatoriedadeLegal` qualitativamente diferente dos outros sete catálogos:
+
+- Os outros sete são **dados enumerados** (listas de tipos, locais, documentos).
+- `ObrigatoriedadeLegal` é **lógica de validação executável** endereçada por dados.
+
+O council produziu três posições que convergiram na síntese:
+
+- **Pragmatic Engineer**: "14 regras não justificam DSL — enum tipado + predicate hardcoded em C# com annotations `[BaseLegal]`. Sem rules engine."
+- **Devil's Advocate**: "ObrigatoriedadeLegal é cavalo de Troia — DSL, evaluator, modelo de versionamento, surface de teste, história de auditoria, tudo de uma vez. Separe antes que coma o módulo."
+- **Product Mind**: "Quando o CEPS for processado (e vai — Lei 14.723 acabou de chegar, mandados de segurança a cada ciclo), o Jurídico precisa apresentar em juízo: *qual regra disparou, com qual base legal, com qual portaria interna, em qual data*. Predicates hardcoded falham em (b), (c), (d). Mas o caminho não é Drools/Camunda — é **validação data-driven com citação**, não rules engine."
+
+A síntese ficou com Product Mind: **validação data-driven com citação não é rules engine no sentido Drools/Camunda**. É um evaluator finito sobre discriminated union de tipos de predicado, com metadata de citação e snapshot na vinculação ao edital.
+
+Separadamente, o reframing do Thinker posicionou `ObrigatoriedadeLegal` como "o registry do domínio fonte do qual os outros sete catálogos derivam" — gravidade futura de um bounded context `Normativos`. O Architect aceitou como load-bearing no resource model mas propôs `Normativos` como módulo futuro. O Pragmatic rejeitou o módulo novo por YAGNI. O sponsor escolheu Pragmatic para V1: fica em Selecao com critérios de promoção documentados.
+
+Esta ADR resolve as duas perguntas: (a) a forma de `ObrigatoriedadeLegal` e (b) se vive em um módulo `Normativos` separado hoje.
+
+## Drivers da decisão
+
+- **Evidência judicial**: o catálogo precisa responder, com dados estruturados, "qual regra rodou em data X com qual base legal" — sem precisar consultar código-fonte.
+- **Sem deploy em mudança de lei**: editar a regra (texto, base legal, vigência) deve ser operação de dados, idêntica à edição de qualquer outro catálogo admin.
+- **Conjunto fechado de formas**: as 14 regras do protótipo caem em ~8 padrões de predicado distintos; engine Turing-completa é overkill.
+- **Coerência com snapshot pattern**: cada edital publicado precisa congelar quais regras se aplicaram, com hash de conteúdo (RN08).
+- **Evolução previsível**: quando um segundo módulo (Ingresso, Auxilio Estudantil) precisar do mesmo pattern, há trigger documentado para promover a um módulo `Normativos`.
+
+## Opções consideradas
+
+- **A**: Enum tipado + predicates hardcoded em C# com atributo `[BaseLegal]`.
+- **B**: Rules engine completo (Drools, Camunda, MS RulesEngine) com DSL e working memory.
+- **C**: Extrair `Normativos` como módulo separado já em V1.
+- **D**: Specification Pattern com hierarquia aberta de subclasses.
+- **E**: Validação data-driven com discriminated union de tipos de predicado + citação + snapshot-on-bind, fica em Selecao para V1 com critérios de promoção.
+
+## Resultado da decisão
+
+**Escolhida:** "E — validação data-driven com discriminated union, citação e snapshot-on-bind em Selecao para V1", porque atende a evidência judicial e o princípio de "sem deploy" sem cair em rules engine overkill, e mantém forward-compatibilidade com extração futura para `Normativos` quando o trigger acontecer.
+
+### Forma de `ObrigatoriedadeLegal`
+
+Entidade em `Unifesspa.UniPlus.Selecao.Domain.Entities`:
+
+```text
+Id: Guid (v7)
+TipoEditalCodigo: string                  ("*" para universal, ou FK para TipoEdital.Codigo)
+Categoria: enum { Etapa, Modalidade, Desempate, Documento, Bonus, Atendimento, Outros }
+RegracodIgo: string                       (ex.: ETAPA_OBRIGATORIA, MODALIDADES_MINIMAS)
+Predicado: PredicadoObrigatoriedade       (discriminated union — ver abaixo)
+DescricaoHumana: string                   (exibido para admin/jurídico em audit)
+BaseLegal: string                         (citação: "Lei 14.723/2023 art.2º")
+AtoNormativoUrl: string?                  (link para DOU/portal/PDF)
+PortariaInternaCodigo: string?            ("Portaria CTIC 2026/14")
+VigenciaInicio: DateOnly
+VigenciaFim: DateOnly?
+Hash: string                              (SHA-256 do conteúdo)
+Proprietario: AreaCodigo?                 (governance per ADR-0055 + ADR-0057)
+AreasDeInteresse: IReadOnlySet<AreaCodigo> (governance per ADR-0057)
+— herda EntityBase (audit + soft delete) + IAuditableEntity
+```
+
+### Discriminated union de tipos de predicado
+
+`PredicadoObrigatoriedade` é conjunto fechado de tipos (sealed abstract record + records derivados):
+
+1. `EtapaObrigatoria(string tipoEtapa)`
+2. `ModalidadesMinimas(IReadOnlyList<string> codigos)`
+3. `DesempateDeveIncluir(string criterio)`
+4. `DocumentoObrigatorioParaModalidade(string modalidade, string tipoDocumento)`
+5. `BonusObrigatorio(IReadOnlyList<string> modalidadesAplicaveis)`
+6. `AtendimentoDisponivel(IReadOnlyList<string> necessidades)`
+7. `ConcorrenciaDuplaObrigatoria()`
+8. `Customizado(JsonDocument parametros)` — válvula de escape; emite warning na avaliação; revisão periódica triggera nova variante tipada.
+
+EF Core persiste como coluna `jsonb` via serialização polimórfica de `System.Text.Json` (atributos `[JsonPolymorphic]`, `[JsonDerivedType]`) usando `ValueObjectConverter`.
+
+### Evaluator
+
+`ValidadorConformidadeEdital` é domain service puro em `Selecao.Domain.Services`:
+
+- Pattern match sobre a discriminated union.
+- Nunca executa código fornecido por usuário.
+- Sem parser, sem interpreter, sem AST.
+- Assinatura: `Evaluate(Edital, IReadOnlyList<ObrigatoriedadeLegal>) → ResultadoConformidade`.
+- Retorna lista de `RegraAvaliada(RegracodIgo, Aprovada, BaseLegal, PortariaInterna, DescricaoHumana, Hash)`.
+
+Injeção de repository acontece no handler; o domain service permanece infrastructure-free.
+
+### Snapshot-on-bind (estende RN08 e [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md))
+
+Quando `Edital.Publicar()` é invocado, o agregado persiste `ObrigatoriedadesSnapshot`:
+
+- Hashes de cada `ObrigatoriedadeLegal` avaliada contra o edital no momento da publicação.
+- Mais o conteúdo desnormalizado completo (predicate JSON, base legal, vigência) para reprodutibilidade independente do estado atual.
+- Mais os campos de governança (Proprietario, AreasDeInteresse no momento) per [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) Pattern 1.
+
+O snapshot é consultado para auditoria legal; o estado atual é consultado para operações do dia a dia.
+
+### Endpoint de auditoria
+
+```text
+GET /api/editais/{id:guid}/conformidade-historica
+```
+
+Retorna as regras snapshotadas **como eram na publicação**, recuperável para sempre como evidência legal. Mesmo se uma regra for desativada ou editada depois, o snapshot mantém o hash original e o conteúdo via tabela append-only `ObrigatoriedadeLegalHistorico`.
+
+### Localização: fica em Selecao para V1
+
+`ObrigatoriedadeLegal` vive em `Unifesspa.UniPlus.Selecao.Domain.Entities`. **Não** está em `Parametrizacao` (apenas catálogos cross-cutting per [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md)). **Não** está em módulo `Normativos` separado ainda.
+
+### Critérios de promoção a futuro módulo `Normativos`
+
+Promover quando **qualquer um** dos seguintes acontecer:
+
+1. Um segundo módulo (Ingresso, Auxilio Estudantil, Recursos) precisa validar seus próprios workflows contra regras com a mesma shape (discriminated predicate + base legal + vigência + snapshot).
+2. Número de `RegracodIgo` distintos passa de 50 (limite de complexidade operacional).
+3. Jurídico pede relatórios cross-edital ("me mostre todos os editais que referenciaram Lei 14.723 art.2º entre 2024 e 2026") que exigem registry normativo, não apenas snapshots por edital.
+4. Variante `Customizado` é usada em produção 3 vezes — sinal de que a discriminated union está estreita.
+5. Dois módulos distintos escreveram tipos de predicado com ≥60% de overlap estrutural e divergiram em semântica (adicionado pelo Architect em R2).
+
+Até que algum trigger dispare, `ObrigatoriedadeLegal` é entidade de domínio Selecao, exposta via endpoints REST Parametrizacao-style hospedados em `Selecao.API` para edição admin.
+
+### Integração com governança de áreas
+
+Per [ADR-0055](0055-organizacao-institucional-bounded-context.md) e [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md):
+
+- **Regras universais** (Lei 12.711, regulamentação federal): `Proprietario = null`, `AreasDeInteresse = ∅`. Edita só `plataforma-admin`.
+- **Regras CEPS-específicas** (Resolução Unifesspa para processos seletivos): `Proprietario = "CEPS"`, `AreasDeInteresse = ["CEPS"]` ou `["CEPS","PROEG"]` quando a PROEG supervisiona.
+- **Futuras regras CRCA** para matrícula: quando `ObrigatoriedadeLegal` estender a escopo Ingresso (trigger 1 acima), regras CRCA-owned com `Proprietario = "CRCA"`.
+
+### REST surface
+
+- `GET /api/catalogos/obrigatoriedades?tipoEdital={codigo}` — leitura pública, filtrada por tipo + áreas do caller; inclui regras universais (`"*"`).
+- `GET /api/catalogos/obrigatoriedades/{id:guid}` — single rule com HATEOAS `_links`.
+- `POST /api/admin/catalogos/obrigatoriedades` — admin scoped per [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md); `Idempotency-Key` obrigatório.
+- `PUT /api/admin/catalogos/obrigatoriedades/{id:guid}` — soft-delete a versão anterior, insere nova (hash muda); idempotente.
+- `DELETE /api/admin/catalogos/obrigatoriedades/{id:guid}` — soft-delete; regras já snapshotadas em editais permanecem intactas.
+- `GET /api/editais/{id:guid}/conformidade` — evaluator roda ruleset atual contra o edital (wizard passo 12).
+- `GET /api/editais/{id:guid}/conformidade-historica` — regras snapshotadas no momento da publicação (evidência legal).
+
+Vendor MIME: `application/vnd.uniplus.obrigatoriedade-legal.v1+json`.
+
+## Consequências
+
+### Positivas
+
+- "Quando a lei muda, edita o catálogo — sem deploy" é honrado para o conjunto fechado de 8 tipos de predicado.
+- Auditoria de evidência legal é first-class: `(rule_hash, base_legal, portaria_interna, vigencia, snapshot_id)` respondem as quatro perguntas forenses do Jurídico.
+- RN08 (parameter freeze) é operacionalizado para regras legais, não só para catálogos tabulares.
+- Discriminated union previne proliferação de DSL — cada nova variante exige adição explícita no código + amendment de ADR.
+- Forward-compatível com extração futura de `Normativos` — critérios de promoção explícitos.
+- Passo 12 do wizard (Revisão) é leitura pura contra o evaluator; meta de latência < 200ms p95 é trivial.
+- Integra com [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) áreas RBAC e snapshot patterns uniformemente.
+
+### Negativas
+
+- Válvula de escape `Customizado(JsonDocument)` é hazard YAGNI se usada liberalmente.
+- Tabela `ObrigatoriedadeLegalHistorico` e snapshots por edital crescem monotonicamente (~200 linhas/ano — negligível).
+- Evaluator + admin CRUD UI dá mais trabalho que predicates hardcoded (~2-3 dias extras).
+- Promoção futura a `Normativos` exige migração de linhas + adição de publishing de eventos. Mitigado por shape da entidade desenhada para esse movimento.
+
+### Neutras
+
+- Não fecha discussão sobre como semântica `Ativo` por-área seria modelada se `ObrigatoriedadeLegal` virar cross-módulo (mesmo trigger e mesma discussão de [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) Pattern 5).
+
+## Confirmação
+
+- **Risco**: variante `Customizado` vira escape hatch padrão.
+  **Mitigação**: emite warning logs na avaliação; revisão trimestral; nova variante tipada no próximo sprint se padrão emergir.
+- **Risco**: edição admin no meio de ciclo afeta editais em andamento.
+  **Mitigação**: snapshot acontece em `Publicar()`, não em render do wizard. Janela pré-publicação é consultiva; publicação é vinculante.
+- **Risco**: Jurídico considera o snapshot insuficiente para algum processo específico.
+  **Mitigação**: snapshot inclui `DescricaoHumana`, `BaseLegal`, `PortariaInterna`, `Hash`, serialização completa do predicate. Excede o que o COC legado produz.
+- **Risco**: colisão de hash.
+  **Mitigação**: SHA-256; probabilidade cosmologicamente negligível.
+
+## Prós e contras das opções
+
+### A — Enum tipado + predicates hardcoded
+
+- **Prós**: Zero risco de DSL. Type safety em compile-time. Testes triviais.
+- **Contras**: Quebra "sem deploy em mudança de lei". Adicionar regra exige PR + code review + CI + deploy. Ciclo Lei 14.723/2023: 3 meses da lei ao sistema. Jurídico não consegue auditar qual regra rodou sem suporte de dev — evidência judicial vira testemunho, não documento. Snapshot-on-bind não pode ser content-hashed porque a regra vive no código-fonte, não em linha.
+
+### B — Rules engine completo (Drools/Camunda/MS RulesEngine)
+
+- **Prós**: Expressividade arbitrária. Padrão de indústria para "aplicações rules-driven".
+- **Contras**: Overkill massivo para shape finita do problema (8 categorias × ~3 padrões cada). Time nunca operou rules engine. Drools exige JVM (carga operacional). MS RulesEngine é .NET nativo mas ainda é parser + AST surface. Validações de edital são **finitas e shape-bounded**; engine Turing-completa é ferramenta errada.
+
+### C — Extrair `Normativos` já em V1
+
+- **Prós**: Arquiteturalmente puro. Reuso cross-módulo desde o dia 1.
+- **Contras**: Prematuro. Nenhum segundo consumer existe. Sprint 3 não cabe. Risco YAGNI: construir para consumer hipotético que pode nunca materializar na forma imaginada. Critérios de promoção documentados aqui permitem extração quando o trigger disparar de fato.
+
+### D — Specification Pattern com hierarquia aberta
+
+- **Prós**: Extensibilidade OO clássica.
+- **Contras**: "Admin escreve subclasse C#" não é o workflow (admin edita dados). Para virar data-driven, serializa a spec — daí voltamos a discriminated union com deserialização, não herança.
+
+### E — Validação data-driven com discriminated union (escolhida)
+
+- **Prós**: Discussão acima.
+- **Contras**: Discussão acima.
+
+## Mais informações
+
+- [ADR-0013](0013-motor-de-classificacao-como-servicos-de-dominio-puros.md) — Motor de classificação como pure domain services (precedent para evaluator data-driven sem DSL).
+- [ADR-0028](0028-versionamento-per-resource-content-negotiation.md) — Versionamento per-resource.
+- RN08 de `docs/visao-do-projeto.md` — Congelamento de parâmetros na publicação do edital.
+- DAMA-DMBOK 2 — Reference Data Management (snapshot patterns).
+- Specification Pattern com Rule Repository — Microsoft Learn, DevIQ.
+- [ADR-0055](0055-organizacao-institucional-bounded-context.md) — OrganizacaoInstitucional bounded context.
+- [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) — Módulo Parametrizacao e carve-out read-side.
+- [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) — RBAC por áreas com snapshot, histórico, invariantes.

--- a/docs/adrs/0059-sprint-3-decomposicao-estrategia-paralela.md
+++ b/docs/adrs/0059-sprint-3-decomposicao-estrategia-paralela.md
@@ -1,0 +1,159 @@
+---
+status: "accepted"
+date: "2026-05-14"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0059: Decomposição da Sprint 3 e estratégia paralela para entrega de Parametrizacao
+
+## Contexto e enunciado do problema
+
+A estratégia do módulo Parametrizacao (per ADRs [0055](0055-organizacao-institucional-bounded-context.md), [0056](0056-parametrizacao-modulo-e-read-side-carve-out.md), [0057](0057-areas-rbac-snapshot-historia-invariantes.md) e [0058](0058-obrigatoriedade-legal-validacao-data-driven.md)) envolve seis sub-features identificadas:
+
+1. Módulo `OrganizacaoInstitucional` (foundation).
+2. Módulo `Parametrizacao` + 4 catálogos cross-cutting (Modalidade, NecessidadeEspecial, TipoDocumento, Endereco).
+3. RBAC por áreas com snapshot/histórico infrastructure.
+4. Carve-out read-side cross-módulo (`IXxxReader` + `.Contracts` + ArchUnitNET).
+5. `ObrigatoriedadeLegal` validação data-driven em Selecao.
+6. Catálogos Selecao-específicos (TipoEdital, TipoEtapa, CriterioDesempate, LocalProva) — promove enums para entidades + endpoints do wizard.
+
+Escopo estimado: ~25–30 stories total. O sponsor confirmou que o escopo completo está commitado para Sprint 3 com **3 desenvolvedores backend dedicados** na camada de API (coordenação com frontend é assíncrona via PRD separado em `uniplus-web`). Com 3 devs dedicados em sprint de 2 semanas e razão alta de boilerplate (CRUD por catálogo segue o mesmo template), a capacidade do time fica materialmente acima da baseline de ~12 stories/sprint (que assume time compartilhado, multi-domínio).
+
+A questão de estratégia não é "o que entregar" (escopo completo confirmado), mas "como decompor e paralelizar entre 3 devs para minimizar conflitos de merge, maximizar transfer de aprendizado e garantir que a foundation esteja sólida antes que catálogos dependam dela".
+
+Três estratégias foram consideradas no brainstorming:
+
+- Foundation primeiro, depois catálogos em paralelo (escolhida).
+- Três vertical slices em paralelo desde o dia 1 (Dev A: OrganizacaoInstitucional + Áreas; Dev B: Parametrizacao + 4 catálogos; Dev C: endpoints Selecao + ObrigatoriedadeLegal).
+- Rotação em par com 1 dev dedicado a infra RBAC (Dev C dono de infra RBAC; Dev A+B rotacionam em par entre catálogos Parametrizacao e endpoints Selecao).
+
+## Drivers da decisão
+
+- **Minimizar drift de decisões load-bearing**: junction table, history table, fitness test boundaries são decisões cross-cutting que se beneficiam de design coletivo.
+- **Paralelismo real depois da fundação**: cada lane na semana 2 deve ter superfície de código independente para reduzir conflitos de merge.
+- **Aprender de uma vez**: o primeiro `IXxxReader` canônico deve ser construído com os 3 devs alinhados, para servir de template aos demais.
+- **Capacidade do time**: 3 devs dedicados × 2 semanas com boilerplate alto sustenta ~25–30 stories.
+- **Riscos por lane**: Lane B (10 wizard endpoints) é a mais larga; Lane C (ObrigatoriedadeLegal) é a mais complexa em design; mitigações por lane são necessárias.
+
+## Opções consideradas
+
+- **A**: Foundation primeiro (semana 1, 3 devs juntos) + lanes paralelas (semana 2, 1 dev por lane).
+- **B**: Três vertical slices em paralelo desde o dia 1 (cada dev pega uma sub-feature inteira; vai do Domain à API independentemente).
+- **C**: Rotação em par com 1 dev dedicado a infra RBAC (3 dias por par entre catálogos e endpoints).
+
+## Resultado da decisão
+
+**Escolhida:** "A — foundation primeiro, depois lanes paralelas", porque é a única opção que combina design coletivo nas decisões cross-cutting load-bearing (week 1) com paralelismo real depois (week 2) — sem o custo de overhead de pair programming nem o risco de drift por vertical slices isolados.
+
+### Fase 1 — Semana 1 (foundation, 3 devs colaborando)
+
+Todos os três devs trabalham como sub-time único na foundation load-bearing:
+
+- Esqueleto do módulo `OrganizacaoInstitucional` + entidade `AreaOrganizacional` + identifier tipado `AreaCodigo` + invariante de roster fechado + migration de seed (5 áreas).
+- Esqueleto do módulo `Parametrizacao` (5 projetos: Domain, Application, Infrastructure, API, Contracts).
+- Integração de `EntityBase` com o conceito de áreas (sem `TenantId`, sem `HasQueryFilter` por tenant — apenas adição de `Proprietario: AreaCodigo?` e `AreasDeInteresse: IReadOnlySet<AreaCodigo>` onde aplicável).
+- Infraestrutura de junction table para `AreasDeInteresse` com validade temporal (Pattern 3 de [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md)).
+- Tabela history SCD Type 2 para mudanças de `Proprietario` (Pattern 2).
+- Documentação do pattern `IXxxReader` em `Infrastructure.Core` + primeira implementação canônica como exemplar.
+- Fitness tests ArchUnitNET para o carve-out cross-módulo ([ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md)).
+- Dois novos bancos PostgreSQL provisionados: `uniplus_parametrizacao`, `uniplus_organizacao` com usuários isolados.
+- Naming convention snake_case aplicada desde a concepção (per [ADR-0054](0054-naming-convention-e-strategy-migrations.md)).
+
+**Critério de saída da Fase 1:** toda a foundation mergeada na main; primeiro `IAreaOrganizacionalReader` funcionando end-to-end como prova do pattern; fitness tests verdes no CI.
+
+### Fase 2 — Semana 2 (catálogos em lanes paralelas, 1 dev por lane)
+
+Cada dev assume uma das três lanes, trabalhando de forma independente com baixo risco de merge.
+
+**Lane A — Dev 1 — Catálogos Parametrizacao:**
+
+- `Modalidade` entidade + EF config (com `CatalogVisibilityConfiguration<Modalidade>`) + migration adicionando tabelas `modalidades` + `modalidade_areas_de_interesse` + JSON seed (12 entradas Lei 12.711) + `IModalidadeReader`.
+- `NecessidadeEspecial` analogous.
+- `TipoDocumento` analogous.
+- `Endereco` analogous (admin POST restrito a `plataforma-admin` per [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md)).
+
+**Lane B — Dev 2 — Promoções Selecao e endpoints do wizard:**
+
+- Promove enums para entidades: `TipoEdital`, `TipoEtapa`, `CriterioDesempate` (cada um com admin CRUD, mantidos em `Selecao.Domain`).
+- Refatora `LocalProva` para referenciar `Endereco.Id` via `IEnderecoReader` com snapshot-on-bind; adiciona campos exam-specific.
+- Novos endpoints do wizard em `EditalController` (ou controllers irmãos): `PATCH /api/editais/{id}/identificacao`, `PUT .../vagas-modalidades`, `PUT .../etapas`, `PATCH .../formula`, `PATCH .../bonus`, `PUT .../desempate`, `PUT .../eliminacao`, `PUT .../documentos-modalidade`, `PUT .../locais-prova`, `PUT .../atendimento-especial`.
+
+**Lane C — Dev 3 — ObrigatoriedadeLegal e conformidade:**
+
+- Entidade `ObrigatoriedadeLegal` em `Selecao.Domain` com discriminated union de 8 tipos de predicado per [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md).
+- Domain service puro `ValidadorConformidadeEdital`.
+- Tabelas append-only `ObrigatoriedadeLegalHistorico` + `EditalGovernanceSnapshot`.
+- Endpoints admin CRUD em `Selecao.API` para gestão de regras.
+- Novos endpoints: `GET /api/editais/{id}/conformidade` (current) + `GET /api/editais/{id}/conformidade-historica` (snapshot).
+- Migration de seed: 14 regras do protótipo, classificadas por governança de áreas.
+
+**Critério de saída da Fase 2:** todos os 4 catálogos cross-cutting operacionais com admin CRUD + read endpoints; 4 catálogos Selecao-específicos promovidos + 10 endpoints de wizard operacionais; ObrigatoriedadeLegal data-driven + endpoints de conformidade funcionando; testes de integração verdes.
+
+### Cross-cutting durante toda a sprint
+
+- Sync diário de 15 minutos entre os 3 devs para questões cross-lane (especialmente entre `IModalidadeReader` da Lane A e `EditalController` da Lane B que o consome).
+- PRs revisados por pelo menos um dev de outra lane (revisor da Lane A para PR da Lane B envolvendo readers, etc.).
+- `@marciliomarques` (FullStack CTIC) aprova cross-account per prática padrão de revisão do projeto.
+
+## Consequências
+
+### Positivas
+
+- Foundation é construída uma vez pelo sub-time completo, eliminando drift cross-lane em decisões load-bearing.
+- Paralelismo da semana 2 é maximizado — cada dev é dono de uma lane independente com risco mínimo de merge.
+- Fronteiras das lanes seguem fronteiras naturais de domínio (catálogos Parametrizacao vs primitivas Selecao vs ObrigatoriedadeLegal).
+- Sync diário pega questões de integração cross-lane cedo, sem custo de pair programming.
+- A primeira implementação canônica de `IXxxReader` na Fase 1 serve de template para as lanes da semana 2.
+- Sprint 3 termina com o backend do wizard pronto para integração frontend na Sprint 4.
+
+### Negativas
+
+- A Fase 1 tem custo de coordenação "stop the world" — 3 devs trabalhando como um sub-time por uma semana perdem alguma throughput individual.
+- Lane B (Selecao) tem trabalho mais diverso (promoções de catálogo + 10 endpoints de wizard) que Lane A ou Lane C — possível desbalanço de carga.
+- ObrigatoriedadeLegal (Lane C) é a lane individual mais complexa; risco de extrapolar a fronteira do sprint se o escopo for subestimado.
+
+### Neutras
+
+- Estratégia assume que os 3 devs estão dedicados — substituições parciais podem comprometer o paralelismo da semana 2.
+
+## Confirmação
+
+- **Risco**: Fase 1 extrapola para a semana 2.
+  **Mitigação**: foundation está bem-especificada pelas ADRs 0055–0058. Sync diário no dia 3 da semana 1 — se estiver atrasado, escopar a foundation para apenas OrganizacaoInstitucional + esqueleto Parametrizacao + primeiro reader, adiar fitness tests ArchUnitNET para a semana 2 conforme Dev 1 cobre.
+- **Risco**: Lane B subestimada — 10 endpoints PATCH/PUT é superfície ampla.
+  **Mitigação**: endpoints seguem pattern já estabelecido pelo `EditalController` (Criar, Listar, Obter, Publicar) — são templatáveis. Se Dev 2 atrasar, Dev 3 pega os endpoints mais simples (PATCH fórmula, bônus) na ociosidade da Lane C.
+- **Risco**: Lane C estoura prazo pela complexidade da discriminated union + snapshot + histórico + evaluator + seed de 14 regras.
+  **Mitigação**: mínimo viável é 4 das 8 variantes implementadas (cobrindo `ETAPA_OBRIGATORIA`, `MODALIDADES_MINIMAS`, `DOCUMENTO_OBRIGATORIO_PARA_MODALIDADE`, `DESEMPATE_DEVE_INCLUIR` — as mais usadas no seed de 14 regras). Outras 4 variantes lançam stub-throw com follow-up documentado.
+- **Risco**: Time frontend começa a consumir endpoints antes deles estarem estáveis.
+  **Mitigação**: OpenAPI spec é contract-first ([ADR-0030](0030-openapi-3-1-contract-first-microsoft-aspnetcore-openapi.md)); frontend pode consumir do spec enquanto o backend estabiliza; "API freeze" milestone explícito no merge do PR final da Lane B.
+
+## Prós e contras das opções
+
+### A — Foundation primeiro + lanes paralelas (escolhida)
+
+- **Prós**: Foundation construída uma vez por todo o time, sem drift. Paralelismo real na semana 2. Cada lane independente em superfície de código. Daily sync pega integração cross-lane cedo. Template canônico construído cedo.
+- **Contras**: Coordenação stop-the-world na semana 1 reduz throughput individual. Possível desbalanço entre lanes (B mais larga, C mais complexa).
+
+### B — Três vertical slices em paralelo desde o dia 1
+
+- **Prós**: Paralelismo máximo; cada dev tem ownership total de sua slice; sem espera pela foundation.
+- **Contras**: Risco grave de conflitos de merge em infraestrutura compartilhada (pattern `IXxxReader`, fitness tests, identifier `AreaCodigo`, extensões de `EntityBase`). Dev B e Dev C ambos dependem do `AreaCodigo` e `IAreaOrganizacionalReader` do Dev A desde o dia 1 — ou reinventam localmente (drift) ou bloqueiam no Dev A (mata o paralelismo). A infraestrutura de áreas/snapshot/history é compartilhada por todas as entidades; um dev definindo isolado cria decisões load-bearing que os três precisam adotar.
+
+### C — Rotação em par com 1 dev dedicado a infra RBAC
+
+- **Prós**: Infra RBAC tem dono único que mantém consistência de design. Pair programming espalha conhecimento.
+- **Contras**: Overhead de pair programming reduz throughput efetivo (~30% perda empírica com sprints de 2 semanas sob pressão de prazo). Dev C vira dependência sequencial para qualquer entidade que precise de integração de áreas. O custo de rotação (~1 dia de context-switching por troca de par) é significativo para um sprint de 2 semanas.
+
+## Mais informações
+
+- [ADR-0055](0055-organizacao-institucional-bounded-context.md) — OrganizacaoInstitucional bounded context.
+- [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) — Módulo Parametrizacao e carve-out read-side.
+- [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) — RBAC por áreas com snapshot/histórico.
+- [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md) — ObrigatoriedadeLegal como validação data-driven.
+- [ADR-0054](0054-naming-convention-e-strategy-migrations.md) — Snake_case + 3-DB isolation (informa as migrations dos novos módulos).
+- `docs/guia-banco-de-dados.md` — Convenções de DB (3 → 5 bancos isolados, pattern estendido).
+- Memória do projeto: `project_code_review_practice.md` — Prática de revisão cross-account.

--- a/docs/adrs/0060-junction-tables-por-entidade-com-view-unificada.md
+++ b/docs/adrs/0060-junction-tables-por-entidade-com-view-unificada.md
@@ -1,0 +1,199 @@
+---
+status: "accepted"
+date: "2026-05-14"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0060: Junction tables por entidade com view unificada para AreasDeInteresse
+
+## Contexto e enunciado do problema
+
+[ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) estabelece o Pattern 3 — junction table com validade temporal para `AreasDeInteresse` — como mecanismo de armazenamento do modelo de visibilidade por áreas. A ADR especificou "junction table" mas deixou em aberto se devíamos usar uma única tabela polimórfica ou uma tabela por entidade. Com 9 entidades de catálogo distribuídas em 3 bancos PostgreSQL isolados (per [ADR-0054](0054-naming-convention-e-strategy-migrations.md) e `docs/guia-banco-de-dados.md`), a escolha de topologia tem consequências materiais.
+
+Uma única tabela polimórfica cruzando as 9 entidades é **tecnicamente impossível** porque elas vivem em 3 bancos isolados (`uniplus_parametrizacao`, `uniplus_selecao`, `uniplus_organizacao`) com usuários e connection strings distintos. Tabela polimórfica não consegue declarar foreign key para tabelas em outro banco.
+
+As opções remanescentes:
+
+- **Opção B**: uma junction table por entidade de catálogo, com FK real ao pai. Total ~9 tabelas.
+- **Opção C**: uma tabela polimórfica por DbContext (3 no total), com discriminador `item_type` e sem FK.
+- **Opção D**: Opção B (FK por entidade) mais uma SQL view por DbContext que unifica consultas cross-catálogo para leituras administrativas.
+
+Council (Architect + Pragmatic Engineer + Devil's Advocate) chegou a consenso na Opção D como a forma correta — Architect e Pragmatic convergem em tabelas por entidade (B) para o modelo de escrita, e Devil's Advocate acrescenta a view unificada como reforço do lado de leitura.
+
+Argumentos principais do council:
+
+- **Architect**: enforcement de FK não é negociável para a verdade de snapshot/histórico; discriminador polimórfico derrota exclusion constraints do PostgreSQL; ter ~9 tabelas é feature (evolução independente); template via `CatalogVisibilityConfiguration<T>` resolve a boilerplate.
+- **Pragmatic Engineer**: "9 vs 3 tabelas" é métrica de vaidade; o que grita às 3 da manhã é a integridade da FK; debug no plantão ganha de cardinalidade de schema.
+- **Devil's Advocate**: por-entidade está certo no write, mas reads cross-catálogo (relatórios LGPD, "tudo visível para o CEPS em data X") viram 9 UNIONs em 9 sites distintos; entregar Opção D = B + view unificada já no dia 1, porque adicionar a view depois quando já há dados custa mais; desenhar a view com coluna `module_id` desde o início para acomodar módulos futuros.
+
+## Drivers da decisão
+
+- **Integridade referencial não negociável** para verdade de snapshot/histórico exigida por evidência judicial.
+- **Operabilidade no plantão**: orphans cross-table viram bug noturno se discriminador for typo silencioso.
+- **Reads cross-catálogo são cenário real** (LGPD, audit) e não devem virar 9 UNIONs por call site.
+- **Bounded reference data**: cardinalidade pequena ≤ 500 linhas por tabela permite GIST exclusion sem custo.
+- **Forward-compat**: a view precisa acomodar `Ingresso`, `Auxilio` etc. sem refactor mais tarde.
+
+## Opções consideradas
+
+- **A**: Tabela polimórfica única cruzando módulos (descartada como impossível pela isolation).
+- **B**: Uma junction table por entidade.
+- **C**: Tabela polimórfica por DbContext (3 no total).
+- **D**: Por-entidade (B) + view unificada por DbContext (escolhida).
+
+## Resultado da decisão
+
+**Escolhida:** "D — junction tables por entidade no write, view unificada por DbContext no read", porque combina FK enforcement no nível do banco (Architect + Pragmatic) com economia de UNIONs no read cross-catálogo (Devil's Advocate), sem violar a isolation entre bancos.
+
+### Write model — junction tables por entidade
+
+Cada entidade de catálogo é dona da sua junction table de `AreasDeInteresse`. Total 9 tabelas em 3 bancos:
+
+**Banco `uniplus_organizacao`**:
+
+- (nenhuma — `AreaOrganizacional` não tem `AreasDeInteresse`; ela **é** a área, não é visível-para-áreas).
+
+**Banco `uniplus_parametrizacao`**:
+
+- `modalidade_areas_de_interesse`
+- `necessidade_especial_areas_de_interesse`
+- `tipo_documento_areas_de_interesse`
+- `endereco_areas_de_interesse`
+
+**Banco `uniplus_selecao`** (estende o existente):
+
+- `tipo_edital_areas_de_interesse`
+- `tipo_etapa_areas_de_interesse`
+- `criterio_desempate_areas_de_interesse`
+- `local_prova_areas_de_interesse`
+- `obrigatoriedade_legal_areas_de_interesse`
+
+Todas têm a mesma forma:
+
+```sql
+{entity}_areas_de_interesse(
+  {entity}_id        uuid    NOT NULL REFERENCES {entity}(id) ON DELETE RESTRICT,
+  area_codigo        varchar(32) NOT NULL,
+  valid_from         timestamptz NOT NULL,
+  valid_to           timestamptz NULL,                          -- NULL = ativa
+  added_by           varchar(255) NOT NULL,                     -- sub do admin
+  PRIMARY KEY ({entity}_id, area_codigo, valid_from),
+  EXCLUDE USING GIST (
+    {entity}_id WITH =,
+    area_codigo WITH =,
+    tstzrange(valid_from, valid_to, '[)') WITH &&
+  )                                                              -- impede sobreposição de janelas
+);
+
+CREATE INDEX ix_{entity}_areas_active
+  ON {entity}_areas_de_interesse ({entity}_id, area_codigo)
+  WHERE valid_to IS NULL;
+```
+
+**EF Core**: configuração templatada via classe base `CatalogVisibilityConfiguration<TParent>` em `Unifesspa.UniPlus.Infrastructure.Core.Persistence.Configurations`. Cada `IEntityTypeConfiguration` de catálogo invoca a base. Boilerplate por catálogo cai para ~5 linhas.
+
+### Read model — view unificada por DbContext
+
+Cada DbContext expõe uma view que faz `UNION ALL` das suas junctions, com discriminador de tipo e identificador de módulo:
+
+**`parametrizacao.vw_catalog_area_visibility`**:
+
+```sql
+CREATE VIEW vw_catalog_area_visibility AS
+SELECT 'parametrizacao' AS modulo, 'modalidade' AS item_type, modalidade_id AS item_id,
+       area_codigo, valid_from, valid_to, added_by
+FROM modalidade_areas_de_interesse
+UNION ALL
+SELECT 'parametrizacao', 'necessidade_especial', necessidade_especial_id,
+       area_codigo, valid_from, valid_to, added_by
+FROM necessidade_especial_areas_de_interesse
+UNION ALL
+-- tipo_documento, endereco
+;
+```
+
+**`selecao.vw_catalog_area_visibility`**: análoga para os 5 catálogos do Selecao com `modulo = 'selecao'`.
+
+A view suporta consultas tipo "mostre tudo visível para CEPS em 2026-04-12" com 1 query por DbContext em vez de 4-5 UNIONs inline em cada call site.
+
+### Agregação cross-banco (quando precisar)
+
+Para consultas genuinamente cross-módulo ("todo catálogo onde CRCA teve visibilidade em 2026, em toda a plataforma"), um agregador de aplicação consulta cada banco via Wolverine e combina os resultados. É hot-path frio (relatórios LGPD), não path quente. O agregador vai em `Unifesspa.UniPlus.Audit.Application` (módulo Audit futuro, post-V1) ou em script SQL em `tools/audit/` para V1.
+
+### Enforcement do exclusion constraint
+
+`EXCLUDE USING GIST` exige a extensão `btree_gist` do PostgreSQL. A primeira migration de cada DbContext novo adiciona:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+```
+
+### Integração com snapshot do ADR-0057
+
+Quando `Edital.Publicar()` roda (Pattern 1 de [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md)), o snapshot lê da **view unificada** para os catálogos referenciados pelo edital, materializando o estado temporal de `AreasDeInteresse`. A tabela `edital_governance_snapshot` armazena as tuplas resolvidas por hash para evidência legal.
+
+## Consequências
+
+### Positivas
+
+- FK enforcement no banco pega violações antes que corrompam histórico de auditoria.
+- `tstzrange` + GIST impedem janelas de validade sobrepostas para o mesmo `(pai, área)`.
+- Consultas cross-catálogo passam pela view unificada — 1 query por DbContext com índice composto `(area_codigo, valid_from, valid_to)`.
+- Tabelas por entidade evoluem independentemente; novo catálogo é 1 migration + 1 chamada à config base.
+- `CatalogVisibilityConfiguration<T>` torna o overhead de 9 tabelas barato (preocupação do Pragmatic resolvida).
+- Forward-compat: coluna `modulo` na view acomoda módulos futuros (Ingresso, Auxilio etc.).
+
+### Negativas
+
+- 9 junction tables + 2 views vs 3 polimórficas.
+- Extensão `btree_gist` precisa estar provisionada (pequena mudança de infra, inclusa na primeira migration).
+- Quando um catálogo novo entra, a view precisa ser atualizada (`CREATE OR REPLACE VIEW` em migration).
+
+## Confirmação
+
+- **Risco**: catálogo novo é adicionado e esquecem de atualizar a view.
+  **Mitigação**: fitness test ArchUnitNET — toda entidade que herda `CatalogEntityBase` (marker) deve aparecer em UNION na view correspondente. Teste lê DDL da view em runtime e quebra o build se faltar.
+- **Risco**: performance do GIST exclusion em escala.
+  **Mitigação**: catálogos são bounded reference data (≤ 100 linhas por entidade); junctions ≤ 100 × ~5 áreas = ≤ 500 por tabela. Negligível.
+- **Risco**: view fica lenta se uma junction crescer desproporcionalmente.
+  **Mitigação**: é `UNION ALL` (sem DISTINCT), pushdown para índices subjacentes; se necessário, `MATERIALIZED VIEW` refrescada por evento Kafka (defer até dor empírica).
+- **Risco**: devs copy-pasteiam config de junction e divergem (cheiro "mês 18" do Devil's Advocate).
+  **Mitigação**: base `CatalogVisibilityConfiguration<T>` centraliza o boilerplate; fitness test confirma que toda config usa a base.
+
+## Prós e contras das opções
+
+### A — Tabela polimórfica única cruzando módulos
+
+- **Prós**: 1 config única; cross-catálogo trivial.
+- **Contras**: Arquiteturalmente inadmissível com 3 bancos isolados. Mesmo em 1 banco, sem FK, exclusion defeated.
+- **Por que rejeitada**: viola a isolation policy do [ADR-0054](0054-naming-convention-e-strategy-migrations.md).
+
+### C — Polimórfica por DbContext (3 no total)
+
+- **Prós**: 3 tabelas em vez de 9; 1 config EF por DbContext.
+- **Contras**: sem FK; orphans inevitáveis; typo em `item_type` compila e queima em prod; exclusion para janelas não-sobrepostas falha; junior dev não lê resolução polimórfica em 90 segundos; reconstrução LGPD por `(item_type, item_id)` composite é frágil.
+- **Por que rejeitada**: council unânime no FK enforcement; "9 vs 3 tabelas" é vaidade; failure modes de junctions polimórficas em catálogos de produção são anti-pattern bem documentado.
+
+### B (sozinha) — sem view unificada
+
+- **Prós**: marginalmente mais simples.
+- **Contras**: cross-catálogo explode em 4-5 UNIONs por call site; "todos os itens visíveis para CEPS em data X" vira range scan temporal 9-vias que o otimizador não pré-agrega.
+- **Por que rejeitada**: adicionar view depois custa mais que adicionar agora (Devil's Advocate decisivo).
+
+### D — Por-entidade + view unificada (escolhida)
+
+- **Prós**: discussão acima.
+- **Contras**: discussão acima.
+
+## Mais informações
+
+- [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) — Módulo Parametrizacao e carve-out read-side.
+- [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) — RBAC por áreas, Pattern 3 detalhado nesta ADR.
+- [ADR-0059](0059-sprint-3-decomposicao-estrategia-paralela.md) — Decomposição Sprint 3 (Phase 1 inclui essa infra).
+- [ADR-0054](0054-naming-convention-e-strategy-migrations.md) — snake_case + isolation 3-DB.
+- Documentação do PostgreSQL `btree_gist` extension.
+- DAMA-DMBOK 2 — Padrões de temporal validity.

--- a/docs/adrs/0061-referencia-cross-modulo-via-snapshot-copy.md
+++ b/docs/adrs/0061-referencia-cross-modulo-via-snapshot-copy.md
@@ -1,0 +1,201 @@
+---
+status: "accepted"
+date: "2026-05-14"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0061: Referência cross-módulo via snapshot-copy (não FK)
+
+## Contexto e enunciado do problema
+
+[ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) estabelece o carve-out read-side cross-módulo: módulos consomem dados de referência uns dos outros via `IXxxReader` em assemblies `.Contracts`. A ADR deixou implícita uma questão crítica sobre **semântica de escrita** quando uma entidade de domínio em um módulo referencia um catálogo em outro módulo.
+
+Exemplo concreto: `Selecao.LocalProva` (local de prova) precisa do endereço físico. Per [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md), o endereço vive em `Parametrizacao.Endereco`. Pergunta: `LocalProva.EnderecoId` carrega referência viva por foreign key para `Endereco` em outro banco, ou tira snapshot dos dados do endereço no momento do binding?
+
+A restrição é firme: per [ADR-0054](0054-naming-convention-e-strategy-migrations.md) e `docs/guia-banco-de-dados.md`, a plataforma usa **bancos PostgreSQL isolados por módulo** (connection strings e usuários separados). Não há schema compartilhado; **FK cross-banco não é exequível** no PostgreSQL.
+
+Diretriz do sponsor durante o brainstorming do TechSpec (2026-05-13): "Não pretendo fazer FK cross-db, podemos apenas usar os dados para evitar ficar cadastrando manual toda vez e usar os dados com snapshot no destino".
+
+Isso é coerente com dois patterns já binding no projeto:
+
+- **RN08** de `docs/visao-do-projeto.md` — congelamento de parâmetros no `Edital.Publicar()`: cada parâmetro que influencia a classificação é snapshotado no edital para que auditoria retrospectiva reproduza exatamente o estado da publicação.
+- **Pattern 1 do [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md)** — snapshot do `Proprietario` + `AreasDeInteresse` de cada item de catálogo referenciado por um edital, persistido em `EditalGovernanceSnapshot`.
+
+Esta ADR estende a mesma disciplina ao binding cross-módulo de dados de referência: quando uma entidade de domínio do módulo A se vincula a um catálogo do módulo B, a operação copia os dados relevantes para dentro da entidade consumidora como value object imutável.
+
+## Drivers da decisão
+
+- **Reprodutibilidade legal**: RN08 e [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) já estabelecem snapshot como disciplina do projeto.
+- **Isolation de bancos**: FK cross-banco não é opção técnica.
+- **UX admin**: admin não quer redigitar o mesmo endereço de Marabá toda vez (validado pelo protótipo).
+- **Operacionalidade**: evitar projection machinery (consumers Kafka, replay, reconciliação) para um caso 1-DB → 1-consumer.
+- **Defensibilidade em mandado de segurança**: "qual endereço foi comunicado ao candidato?" deve ser respondível independentemente de edições posteriores no catálogo.
+
+## Opções consideradas
+
+- **A**: Validação síncrona cross-DB via `IXxxReader.ExisteAsync` no handler, sem snapshot.
+- **B**: Projeção Kafka — réplica local read-only de `Endereco` em `Selecao`.
+- **C**: Nenhuma referência — admin redigita endereço a cada `LocalProva`.
+- **D**: Re-resolução ao vivo na leitura, sem snapshot.
+- **E**: Snapshot-copy (value object embedded) com `OrigemId` opcional para rastreabilidade (escolhida).
+
+## Resultado da decisão
+
+**Escolhida:** "E — snapshot-copy via value object embedded, com `{Catalogo}OrigemId` opcional como rastreabilidade sem FK", porque entrega o ganho de UX (admin escolhe de catálogo) sem perder a defensibilidade do snapshot, e respeita a isolation entre bancos.
+
+### Regras do pattern
+
+1. A entidade consumidora armazena os dados do catálogo como **value object embedded** (EF Core `OwnsOne`), não apenas como ID por foreign key.
+2. A entidade consumidora opcionalmente armazena `{Catalogo}OrigemId: Guid?` como **rastreabilidade** — aponta para a linha do catálogo de origem, mas **sem FK no banco**.
+3. `IXxxReader.ObterPorIdAsync` e `ListarVisiveisAsync` suportam a **UI admin de seleção** (admin escolhe linha existente em vez de digitar campos).
+4. A operação de escrita resolve os dados do catálogo via reader e **copia** os campos relevantes para o value object embedded.
+5. Edições subsequentes na linha-fonte do catálogo **não** propagam para a entidade consumidora. Snapshot é imutável pela vida da entidade (sujeito a soft-delete ou re-bind explícito).
+6. **Nenhuma declaração `FOREIGN KEY`** existe no banco consumidor apontando para o banco produtor.
+
+### Exemplo: `LocalProva` referenciando `Endereco`
+
+`Selecao.LocalProva`:
+
+```csharp
+public sealed class LocalProva : EntityBase, IAuditableEntity
+{
+    public string Codigo { get; private set; }                     // "MARABA"
+    public string Nome { get; private set; }                       // display
+    public EnderecoSnapshot Endereco { get; private set; }         // OwnsOne — IMUTÁVEL
+    public Guid? EnderecoOrigemId { get; private set; }            // rastreabilidade (sem FK)
+    public int CapacidadeMaxima { get; private set; }
+    public string? ResponsavelExame { get; private set; }
+    public IReadOnlyList<string> CondicoesAcessibilidade { get; }
+    // governança de áreas per ADR-0057
+}
+
+public sealed record EnderecoSnapshot(
+    string CEP,
+    string Logradouro,
+    string Numero,
+    string? Complemento,
+    string Bairro,
+    string Municipio,
+    string MunicipioIbgeId,
+    string UF);
+```
+
+Quando admin cria um `LocalProva` via `POST /api/admin/selecao/locais-prova`, o handler:
+
+1. Chama `_enderecoReader.ObterPorIdAsync(command.EnderecoOrigemId)`.
+2. Devolve `Result.Failure(DomainError("LocalProva.EnderecoOrigemNaoEncontrado", ...))` se nada vier.
+3. Senão monta `EnderecoSnapshot` a partir da resposta do reader.
+4. Cria o agregado `LocalProva` com o snapshot dentro.
+5. Persiste.
+
+Os campos de endereço ficam congelados em `selecao.locais_prova`. Se um admin de `Parametrizacao` editar o `Endereco` depois, o `LocalProva` mantém seu snapshot original — coerente com RN08 ("auditoria deve reproduzir o estado no momento do binding").
+
+### Onde o pattern se aplica
+
+- `Selecao.LocalProva.Endereco` ← `Parametrizacao.Endereco` (caso sponsor-clarified).
+- `Selecao.Edital.ConfiguracaoModalidade.Modalidade` ← `Parametrizacao.Modalidade` no `Publicar()` (per RN08 + Pattern 1 de [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md)).
+- `Selecao.Edital.DocumentoExigido.TipoDocumento` ← `Parametrizacao.TipoDocumento` no `Publicar()`.
+- `Selecao.Edital.AtendimentoEspecial.NecessidadeEspecial` ← `Parametrizacao.NecessidadeEspecial` no `Publicar()`.
+- Futuro: qualquer `Ingresso.Matricula` referenciando `Modalidade`, `TipoDocumento` etc. segue o mesmo pattern.
+
+### Onde o pattern NÃO se aplica
+
+- Referências intra-módulo (ex.: `Selecao.Etapa.EditalId` → `Selecao.Edital.Id`) — FK normal no mesmo banco.
+- Joins dentro do mesmo DbContext entre entidades de catálogo (ex.: `Parametrizacao.TipoDocumento` referenciando outra entidade `Parametrizacao`) — FK normal.
+- Referência a `OrganizacaoInstitucional.AreaOrganizacional` via `AreaCodigo: string` — é por código (não por id) e `AreaCodigo` é imutável post-criação per Invariante 2 do [ADR-0055](0055-organizacao-institucional-bounded-context.md). Mesma disciplina por mecanismo diferente.
+
+### Por que `OrigemId` opcional mas sem FK
+
+`EnderecoOrigemId` serve para:
+
+- **UX admin**: "este LocalProva veio do Endereco X — abre o original para comparar".
+- **Relatórios de auditoria**: "todos os LocalProva criados a partir do Endereco X".
+
+Não é garantia referencial. A linha-fonte pode ter sido soft-deletada; o ID de rastreabilidade permanece. Relatórios lidam com `IsDeleted` graciosamente via agregador de aplicação.
+
+### Papel do reader
+
+`IEnderecoReader` (e análogos) tem três usos:
+
+1. **Listas de seleção admin** — `ListarVisiveisAsync` popula pickers.
+2. **Validação na escrita** — `ObterPorIdAsync` resolve a linha-fonte para montar o snapshot.
+3. **Workflow opcional de re-bind** — admin pode re-resolver `LocalProva.EnderecoOrigemId` e atualizar o snapshot (ação explícita, auditada).
+
+O reader **não** materializa o valor continuamente na entidade consumidora. Não há tabela de projeção espelhando `Endereco` em `Selecao`. O cache distribuído Redis 5 minutos sobre o reader (Pattern 4 do [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md)) atende as leituras.
+
+## Consequências
+
+### Positivas
+
+- **Reprodutibilidade de auditoria**: `LocalProva` histórico preserva o endereço exato que foi comunicado ao candidato no binding. Defensável em juízo.
+- **Sem FK cross-banco**: respeita isolation do [ADR-0054](0054-naming-convention-e-strategy-migrations.md); zero acoplamento de schema.
+- **Sem projection machinery**: nada de consumer Kafka, sem janela de eventual consistency no read-side, sem risco de replay storm.
+- **Coerente com RN08 e Pattern 1**: a mesma disciplina de snapshot uniformemente aplicada a referência cross-módulo e a metadata de governança de áreas.
+- **Papel do reader claro**: admin escolhe de catálogo existente (UX); write copia dado (integridade).
+- **Custo de armazenamento negligível**: 8 campos de endereço × 6 LocalProvas × poucos editais/ano = trivial.
+
+### Negativas
+
+- Duplicação de dado: se admin corrigir typo no `Endereco`, snapshots existentes mantêm valor antigo.
+  **Mitigação**: operação explícita "re-bind" re-resolve e atualiza o snapshot, auditada como ação de usuário.
+- Schema do `LocalProva` cresce ~8 colunas. Aceitável.
+
+### Neutras
+
+- `EnderecoSnapshot` (e demais snapshots de catálogo) vive na Domain do **módulo consumidor**, não no `.Contracts` do produtor — fica claro quem é dono do shape.
+
+## Confirmação
+
+- **Risco**: admin assume que editar `Endereco` propaga; surpresa quando histórico não muda.
+  **Mitigação**: UI admin avisa ao editar Endereco: "Mudanças aplicam apenas a futuros bindings. Para atualizar LocalProva existente, use a ação Re-bind." Documentado no runbook operacional.
+- **Risco**: re-bind é usado descuidadamente, destrói trilha de auditoria.
+  **Mitigação**: re-bind cria nova entrada de audit log; snapshot anterior preservado em `LocalProvaHistorico` (SCD Type 2, análogo ao Pattern 2 do [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md)). Operação deliberada com confirmação.
+- **Risco**: cresce o armazenamento se muitos catálogos adotarem o pattern.
+  **Mitigação**: catálogos bounded; entidades consumidoras bounded. Negligível na escala esperada.
+- **Risco**: `EnderecoOrigemId` é tratado como FK real por junior dev.
+  **Mitigação**: comentário no código + fitness test ArchUnitNET — nenhuma config EF Core declara `HasOne()`; é `Guid?` puro. Linter check.
+
+## Prós e contras das opções
+
+### A — Validação síncrona cross-DB no handler, sem snapshot
+
+- **Prós**: sem duplicação; economia de storage; updates de endereço propagam.
+- **Contras**: sem integridade no banco; janela TTL de cache permite criação órfã (admin deleta Endereco, write acontece durante stale cache). Auditoria "qual endereço foi usado em data X?" requer join cross-banco + lógica de soft-delete — frágil.
+- **Por que rejeitada**: mesmos vícios das junctions polimórficas em [ADR-0060](0060-junction-tables-por-entidade-com-view-unificada.md) — sem integridade real, audit story depende de correção da aplicação. Sponsor rejeitou explicitamente.
+
+### B — Projeção Kafka, réplica local read-only
+
+- **Prós**: FK real; eventual consistency; padrão event-driven.
+- **Contras**: caro operacionalmente: projection handler, replay logic, dead-letter handling, jobs de reconciliação, invalidação de cache, debug de projeção stale. Prematuro para 1-DB-1-consumer. Janela de eventual consistency cria bugs visíveis para usuário ("acabei de criar Endereco X — por que LocalProva não vê?").
+- **Por que rejeitada**: complexidade injustificada para V1; snapshot entrega o mesmo benefício de fluxo de dado sem a maquinaria.
+
+### C — Sem referência alguma, admin redigita endereço
+
+- **Prós**: o mais simples possível. Zero acoplamento cross-módulo.
+- **Contras**: derrota o valor validado pelo protótipo: "admins não querem recadastrar Marabá toda vez que criamos um LocalProva". Duplicação leva a typos.
+- **Por que rejeitada**: sponsor escolheu manter `Endereco` reutilizável; reduz atrito.
+
+### D — Referência viva com re-resolução em toda leitura
+
+- **Prós**: sem staleness; sempre dado atual.
+- **Contras**: derrota RN08/audit por completo — LocalProva histórico mudaria silenciosamente o endereço quando o catálogo fonte fosse editado. Mandados de segurança seriam indefensáveis.
+- **Por que rejeitada**: viola a disciplina de snapshot que existe especificamente para evidência legal reproduzível.
+
+### E — Snapshot-copy + OrigemId opcional (escolhida)
+
+- **Prós**: discussão acima.
+- **Contras**: discussão acima.
+
+## Mais informações
+
+- [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) — Módulo Parametrizacao e carve-out read-side (esta ADR clarifica a semântica do write).
+- [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) — Pattern 1 é precedente para snapshot-on-bind de metadata de governança.
+- [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md) — Snapshot-on-bind para regras legais.
+- [ADR-0060](0060-junction-tables-por-entidade-com-view-unificada.md) — Mesmo raciocínio de isolation entre bancos.
+- RN08 de `docs/visao-do-projeto.md` — Congelamento de parâmetros no `Publicar()` do edital.
+- [ADR-0054](0054-naming-convention-e-strategy-migrations.md) — Política de isolation de bancos.
+- [ADR-0028](0028-versionamento-per-resource-content-negotiation.md) — Snapshot-on-bind no motor de classificação.

--- a/docs/adrs/0062-seed-de-catalogos-via-newman-e-endpoints-admin.md
+++ b/docs/adrs/0062-seed-de-catalogos-via-newman-e-endpoints-admin.md
@@ -1,0 +1,225 @@
+---
+status: "accepted"
+date: "2026-05-14"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+  - "DevOps (DIRSI)"
+---
+
+# ADR-0062: Seed de catálogos via Newman + endpoints admin (sem auto-seeder)
+
+## Contexto e enunciado do problema
+
+O escopo da Sprint 3 exige popular dados canônicos de referência em 3 bancos PostgreSQL isolados:
+
+- `uniplus_organizacao`: 5 áreas (CEPS, CRCA, PROEG, PROGEP, PLATAFORMA).
+- `uniplus_parametrizacao`: 12 modalidades, 12 necessidades especiais, 18 tipos de documento, 6 endereços.
+- `uniplus_selecao`: 8 tipos de edital, 14 tipos de etapa, 9 critérios de desempate, 6 locais de prova, 14 obrigatoriedades legais.
+
+Total ~100 linhas de dado canônico, originadas dos JSONs validados no protótipo HTML em `repositories/uniplus-prototipos-html/prototipo-cadastro-edital/data/seed-*.json`.
+
+O design inicial (rejeitado — ver seção "Histórico") propunha um subsistema `IReferenceDataSeeder` + `EmbeddedJsonSeedSource` auto-invocado pelo `MigrationHostedService` na startup da API, com sentinel `CreatedBy = "seed:embedded@v1"` para distinguir linhas de seed das edições humanas. O sponsor rejeitou esse approach com duas clarificações:
+
+1. **Auditoria precisa refletir o admin real.** Linhas registradas durante o deploy devem carregar o `sub` do JWT do plataforma-admin que disparou o registro, não um sentinel fabricado. Isso casa com a semântica existente do `AuditableInterceptor` (per `docs/guia-banco-de-dados.md` §5) e evita override especial de `IUserContext` no escopo do seed.
+2. **Os mesmos endpoints admin** que a futura UI (em `uniplus-web`) consumirá devem ser a superfície canônica de escrita desde o dia 1. Bootstrap e operação contínua compartilham um único caminho de código; a diferença é apenas quem dispara cada chamada (DevOps via CLI no install → admin via formulário depois).
+
+O sponsor também propôs **Newman** (Postman CLI) como ferramenta para o registro inicial: uma collection roda contra cada ambiente (dev, standalone, HML, PROD) usando OAuth2 client_credentials contra o Keycloak para obter token plataforma-admin, depois itera sobre os arquivos de seed fazendo POST de uma linha por request. Newman é padrão de indústria, integra em CI e serve como **documentação viva** do shape da API admin — a mesma collection é consumível pelos devs frontend ao construir os formulários do `uniplus-web`.
+
+## Drivers da decisão
+
+- **Auditoria honesta**: `CreatedBy` precisa refletir um usuário Keycloak real, não um sentinel.
+- **Caminho de escrita único**: bootstrap e operação contínua não devem ter código separado.
+- **Documentação viva**: a collection serve aos devs frontend quando forem construir o formulário.
+- **CI-friendly**: Newman roda em qualquer runner que tenha Node.js.
+- **Idempotência**: re-rodar Newman após deploy parcial não pode duplicar nem quebrar.
+- **Multi-instituição**: outras IFES devem conseguir fork-ar os seeds (JSONs), não código C#.
+
+## Opções consideradas
+
+- **A**: `IReferenceDataSeeder` + `EmbeddedJsonSeedSource` auto-invocado na startup.
+- **B**: `HasData` em `IEntityTypeConfiguration` do EF Core.
+- **C**: Migration com `InsertData` raw SQL.
+- **D**: Híbrido — `HasData` para áreas + JSON loader para os demais.
+- **E**: Newman + endpoints admin (escolhida).
+
+## Resultado da decisão
+
+**Escolhida:** "E — bootstrap via Newman invocando os mesmos endpoints admin", porque é a única opção que preserva audit honesta (real JWT sub), unifica o caminho de escrita entre bootstrap e admin UI, e gera documentação viva consumível pelo time frontend — sem o custo de manter infra de seeder customizada.
+
+### Layout do repositório
+
+```text
+repositories/uniplus-api/
+├── seeds/                                              # apenas arquivos de dado (sem código)
+│   ├── seed-areas-organizacionais.json
+│   ├── seed-modalidades.json
+│   ├── seed-necessidades-especiais.json
+│   ├── seed-tipos-documento.json
+│   ├── seed-enderecos.json
+│   ├── seed-tipos-edital.json
+│   ├── seed-tipos-etapa.json
+│   ├── seed-criterios-desempate.json
+│   ├── seed-locais-prova.json
+│   └── seed-obrigatoriedades-legais.json
+└── tools/seeds/
+    ├── seed-catalogos.postman_collection.json
+    ├── envs/
+    │   ├── dev.postman_environment.json
+    │   ├── standalone.postman_environment.json
+    │   └── hml.postman_environment.json
+    ├── run.sh
+    └── README.md
+```
+
+Cada `seeds/seed-*.json` é array JSON flat de linhas (sem envelope), no shape que o endpoint admin correspondente espera no body. Chaves JSON em camelCase (convenção HTTP); colunas de banco em snake_case (per [ADR-0054](0054-naming-convention-e-strategy-migrations.md)) — `System.Text.Json` `PropertyNamingPolicy.CamelCase` na API + EFCore.NamingConventions na camada de banco.
+
+### Estrutura da collection
+
+A collection Postman tem:
+
+- **Pre-request script no nível collection** — obtém token plataforma-admin via OAuth2 `client_credentials` no Keycloak, cacheia em `{{access_token}}` com TTL, refresca na expiração.
+- **10 folders, um por catálogo** — cada um itera sobre o `seeds/seed-*.json` correspondente via `--iteration-data` do Newman.
+- **Configuração por request**:
+  - `Authorization: Bearer {{access_token}}`
+  - `Accept: application/vnd.uniplus.{recurso}.v1+json` (vendor MIME per [ADR-0028](0028-versionamento-per-resource-content-negotiation.md))
+  - `Content-Type: application/vnd.uniplus.{recurso}.v1+json`
+  - `Idempotency-Key: {recurso}-{{codigo}}` (determinístico — re-run é idempotente per [ADR-0027](0027-idempotency-key-store.md))
+  - Body: uma linha do arquivo de seed.
+- **Teste por request** — assert response `201` (primeira execução) ou `200` (re-run via cache de idempotência); falha caso contrário.
+
+### Execução
+
+Runbook DevOps em standalone/HML/PROD inclui um passo "post-deploy bootstrap":
+
+```bash
+# Standalone
+ENV=standalone bash tools/seeds/run.sh
+
+# Catálogo específico (ex.: depois de adicionar nova área)
+ENV=standalone CATALOG=AreasOrganizacionais bash tools/seeds/run.sh
+```
+
+`run.sh` invoca `newman run` com env file e flags de folder/iteration-data apropriados. Exit code propaga — pipeline CI/CD falha se o bootstrap falhar.
+
+### Semântica de auditoria
+
+Toda linha registrada via Newman carrega `CreatedBy` = JWT `sub` do principal do client_credentials (`uniplus-api-bootstrap-plataforma-admin` ou similar — provisionado no Keycloak como parte do setup standalone). Isso torna a trilha explícita:
+
+- Linhas com `CreatedBy = '<bootstrap-client-sub>'` foram registradas no deploy via Newman.
+- Linhas com `CreatedBy = '<human-user-sub>'` foram registradas depois via UI admin do `uniplus-web` (post-frontend-ready).
+- Ambos os caminhos passam pelo mesmo `AuditableInterceptor` populando a partir de `IUserContext.UserId` (per `docs/guia-banco-de-dados.md` §5, padrão opt-in). Sem sentinel. Sem override especial de `IUserContext`.
+
+Precondição: entidades que participam desse fluxo **devem implementar `IAuditableEntity`** explicitamente (per diretriz do sponsor sobre auditoria opt-in entidade-a-entidade). As 10 entidades de catálogo desta demanda implementam a interface.
+
+### Transição para o frontend
+
+Quando `uniplus-web` entregar os formulários admin (PRD separado, pós-Sprint 3):
+
+1. Admins autenticam pelo Keycloak no navegador.
+2. Formulários fazem POST nos mesmos `/api/admin/{recurso}`.
+3. `CreatedBy` é populado com o `sub` do admin humano (não o sub do client bootstrap).
+4. A collection Newman permanece como:
+   - **Ferramenta de bootstrap inicial** para novos deploys.
+   - **Documentação viva** do shape da API admin para devs frontend.
+   - **Fixture de smoke test** em integração CI.
+
+### Invariante de roster fechado do AreaOrganizacional
+
+Per [ADR-0055](0055-organizacao-institucional-bounded-context.md), o roster de `AreaOrganizacional` é fechado — adicionar nova área exige nova ADR. O invariante é enforce-ado por **fitness test** (xUnit + ArchUnitNET) que lê `seeds/seed-areas-organizacionais.json` em build time e confirma que cada linha tem `adrReferenceCode` apontando para um arquivo em `docs/adrs/`. Roda em CI a cada PR. Se uma área for adicionada ao seed sem ADR correspondente, o build quebra.
+
+Esse fitness test é o **único ponto** do código que toca o JSON do seed em compile/test time. Runtime nunca lê — Newman é o único consumer em runtime.
+
+### Integração com fixture de teste
+
+Testes de integração que precisam de catálogo populado (ex.: testes de endpoint de wizard que consomem `IModalidadeReader` via DI cross-módulo) têm duas opções:
+
+- **Opção A (preferida para V1)**: fixture chama `newman run` contra a instância de teste da API antes da suíte rodar. Adiciona dependência Newman no ambiente CI (já presente via npm).
+- **Opção B (alternativa)**: fixture lê os JSONs direto, deserializa e faz POST via `HttpClient` do `WebApplicationFactory` — replica a lógica do Newman em C#. Evita dependência mas duplica o shape da request.
+
+Decisão por classe de teste durante a implementação. Call sites mais simples preferem A; cenários de alta cobertura podem preferir B para controle.
+
+## Consequências
+
+### Positivas
+
+- **Auditoria é honesta.** Cada linha carrega um Keycloak subject real em `CreatedBy`, sem sentinel sintético.
+- **Caminho único de escrita.** Bootstrap e operação contínua batem nos mesmos endpoints — discrepâncias impossíveis.
+- **Documentação viva.** A collection Postman é em si um registro de como a API admin funciona; devs frontend consomem como referência ao construir formulário.
+- **CI-friendly.** Newman roda em qualquer runner com Node.js. JSON da collection é revisável em PR.
+- **Idempotente.** `Idempotency-Key` determinístico (`{recurso}-{{codigo}}`) garante que re-rodar Newman é seguro.
+- **Fork multi-instituição.** Cada IFES adotante mantém seu próprio `seeds/` e env files — fork dos JSONs, não do C#.
+- **Sem infra especial.** Sem `IReferenceDataSeeder` / `ISeedDataSource` / extensão do `MigrationHostedService`. Elimina uma classe de bugs (seeder falha no meio da startup, deixa estado parcial, bloqueia readiness da API).
+
+### Negativas
+
+- **Passo manual no deploy.** Newman precisa ser invocado depois da API subir — deployment fresco não está imediatamente funcional. Mitigado por inclusão explícita no runbook de standalone/HML/PROD + smoke step no CI.
+- **Dependência externa em Newman.** Adiciona Node.js à toolchain de deploy. Já presente na maioria dos runners CI; preocupação menor.
+- **Testes de integração precisam de bootstrap.** Tests que requerem catálogo populado precisam invocar Newman (ou replicar via `HttpClient`). Setup mais lento que seed em memória, mas mais realista.
+- **JSONs não são embedded resources.** Arquivo faltando/errado só é detectado em runtime (Newman falha) ou no fitness test (para áreas). Mitigado por `newman --dry-run` no CI.
+
+### Neutras
+
+- A collection Postman fica em `tools/seeds/seed-catalogos.postman_collection.json` — fonte única.
+
+## Confirmação
+
+- **Risco**: passo bootstrap esquecido no deploy.
+  **Mitigação**: runbook deploy explícito; smoke standalone inclui `GET /api/areas-organizacionais` retornando as 5 entradas esperadas.
+- **Risco**: drift de versão do Newman.
+  **Mitigação**: pinning de `newman` em `package.json`; CI usa versão pinada.
+- **Risco**: credenciais Keycloak rotacionadas.
+  **Mitigação**: env files referenciam segredo via env var, resolvido do Vault per pattern ESO 5 do `uniplus-infra`.
+- **Risco**: JSON do seed diverge do schema da entidade.
+  **Mitigação**: body validado pela API em runtime (422 ProblemDetails em mismatch); `newman --dry-run` no CI pega collection JSON malformada; fitness test valida `adrReferenceCode` em áreas.
+
+## Histórico
+
+**2026-05-13 (inicial):** Decidido `IReferenceDataSeeder` + `EmbeddedJsonSeedSource` com sentinel `"seed:embedded@v1"`.
+
+**2026-05-14 (revisado):** Diretriz do sponsor substitui o auto-seeder pelo bootstrap via Newman. Auditoria captura usuário real; formulários admin (pós-frontend-ready) usam o mesmo caminho de escrita. ADR reescrita; [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) §"Implementation Notes" atualizada para remover referências ao seeder.
+
+## Prós e contras das opções
+
+### A — `IReferenceDataSeeder` + `EmbeddedJsonSeedSource` (original, rejeitada)
+
+- **Prós**: totalmente automático — DB fresco sempre tem catálogos após API subir. Sem dependência externa de CLI.
+- **Contras**: auditoria fabricada — sentinel `"seed:embedded@v1"` é ator sintético que não existe como subject Keycloak real. Viola "audit reflete user real". Override especial de `IUserContext` durante scope do seed adiciona complexidade. Diverge do fluxo de endpoint admin estabelecido — bootstrap e operação contínua são dois code paths distintos com invariantes sutilmente diferentes. Quando UI admin entrar em `uniplus-web`, precisaria coexistir com linhas que o seeder criou com sentinel — duas "famílias" de linha de catálogo na mesma tabela.
+- **Por que rejeitada**: diretriz sponsor (2026-05-14): "remover os seeds e termos os arquivos json para fazer as requests e cadastrar — assim fica registrado o user real com base no token". Audit honesty e write path único superam a conveniência do auto-seed.
+
+### B — `HasData` em EF Configuration
+
+- **Prós**: mecanismo nativo do EF. Idempotente por construção.
+- **Contras**: `EntityBase.Id = Guid.CreateVersion7()` é não-determinístico — `HasData` exige GUID compile-time constant. `HasData` bypassa o `AuditableInterceptor` (grava via SQL de migration), então `CreatedBy` fica null ou hardcoded — mesma fabricação de auditoria do alternativa A. Não suporta `Predicado` polimórfico do `ObrigatoriedadeLegal` limpo (drift no model snapshot). Toda correção no seed gera migration destrutiva.
+- **Por que rejeitada**: mesma raiz audit + polimorfismo.
+
+### C — Migration com `InsertData` raw SQL
+
+- **Prós**: idempotente re-run-safe; isolada de migrations de schema.
+- **Contras**: campos de audit hardcoded (`'system-seed'` ou null) — mesma fabricação. Correções no seed exigem novas migrations entulhando histórico. JSON polimórfico (`Predicado`) em arquivo de migration é hell de escape. Fork multi-instituição exige fork de migrations.
+- **Por que rejeitada**: semântica de auditoria. Migrations são para schema, não para seed.
+
+### D — Híbrido (`HasData` para áreas + JSON loader para os demais)
+
+- **Prós**: estrutural ganha o `HasData`; resto fica dinâmico.
+- **Por que rejeitada**: dois mecanismos para manter. Áreas via `HasData` ainda batem nos problemas de Guid dinâmico + bypass do interceptor + sentinel. Uniformidade vence.
+
+### E — Newman + endpoints admin (escolhida)
+
+- **Prós**: discussão acima.
+- **Contras**: discussão acima.
+
+## Mais informações
+
+- [ADR-0023](0023-problemdetails-rfc-9457.md) — ProblemDetails RFC 9457 (Newman tests checam contra).
+- [ADR-0027](0027-idempotency-key-store.md) — Idempotency-Key store (semântica de replay).
+- [ADR-0028](0028-versionamento-per-resource-content-negotiation.md) — Vendor MIME per resource (Accept/Content-Type por linha).
+- [ADR-0054](0054-naming-convention-e-strategy-migrations.md) — Naming snake_case + migrations.
+- `docs/guia-banco-de-dados.md` §5 — Pattern opt-in do `IAuditableEntity`.
+- [ADR-0055](0055-organizacao-institucional-bounded-context.md) — Invariante de roster fechado para AreaOrganizacional.
+- [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) — Módulo Parametrizacao e read-side carve-out (referências ao seeder removidas).
+- [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md) — Pattern de snapshot-copy cross-módulo (independente deste seed).
+- Documentação Newman — <https://learning.postman.com/docs/running-collections/using-newman-cli/command-line-integration-with-newman/>.
+- Diretrizes do sponsor (2026-05-14): "remover os seeds e termos os arquivos json para fazer as requests"; "quando a interface gráfica tiver pronta aí pode cadastrar pelo formulario"; "podemos usar newman para fazer isso para nós".

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -82,6 +82,15 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0051](0051-apicurio-schema-registry-avro-wolverine.md) | Apicurio Schema Registry com Avro e Wolverine — schemas no Domain, registro idempotente, OAuth client_credentials | accepted | 2026-05-09 |
 | [0052](0052-rastreabilidade-cross-service-traceparent-service-name-enricher.md) | Rastreabilidade cross-service via `traceparent` W3C + Serilog `ServiceName` enricher + Wolverine envelope middleware para `CorrelationId` | proposed | 2026-05-11 |
 | [0053](0053-zero-test-environment-branches-in-production-code.md) | Zero ramos de ambiente de teste em código de produção — `IsEnvironment(literal)` e `EnvironmentName == literal` banidos em `src/` (ADR normativa sem enforcement automático) | accepted | 2026-05-11 |
+| [0054](0054-naming-convention-e-strategy-migrations.md) | Convenção de nomenclatura `snake_case` via `EFCore.NamingConventions` + isolamento por banco e estratégia de migrations | accepted | 2026-05-13 |
+| [0055](0055-organizacao-institucional-bounded-context.md) | `OrganizacaoInstitucional` como bounded context para áreas (CEPS, CRCA, PROEG, PROGEP, PLATAFORMA) com roster fechado | accepted | 2026-05-14 |
+| [0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) | Módulo `Parametrizacao` para catálogos cross-cutting + carve-out read-side cross-módulo via `IXxxReader` | accepted | 2026-05-14 |
+| [0057](0057-areas-rbac-snapshot-historia-invariantes.md) | RBAC por áreas com snapshot na publicação, histórico SCD Type 2 e invariantes de governança | accepted | 2026-05-14 |
+| [0058](0058-obrigatoriedade-legal-validacao-data-driven.md) | `ObrigatoriedadeLegal` como validação data-driven com citação legal e snapshot-on-bind | accepted | 2026-05-14 |
+| [0059](0059-sprint-3-decomposicao-estrategia-paralela.md) | Decomposição da Sprint 3 — foundation primeiro, depois 3 lanes paralelas | accepted | 2026-05-14 |
+| [0060](0060-junction-tables-por-entidade-com-view-unificada.md) | Junction tables por entidade para `AreasDeInteresse` + view unificada por DbContext para leituras cross-catálogo | accepted | 2026-05-14 |
+| [0061](0061-referencia-cross-modulo-via-snapshot-copy.md) | Referência cross-módulo via snapshot-copy (value object embedded) com `OrigemId` opcional sem FK | accepted | 2026-05-14 |
+| [0062](0062-seed-de-catalogos-via-newman-e-endpoints-admin.md) | Seed de catálogos via Newman + endpoints admin (sem auto-seeder, audit captura usuário real) | accepted | 2026-05-14 |
 
 ## Como adicionar um novo ADR
 


### PR DESCRIPTION
## Resumo

Promove o pacote de decisões arquiteturais do módulo Parametrizacao do pipeline Compozy para a base canônica em `docs/adrs/`, em pt-BR.

- **ADR-0055** — `OrganizacaoInstitucional` como bounded context para áreas (CEPS, CRCA, PROEG, PROGEP, PLATAFORMA), com roster fechado por ADR.
- **ADR-0056** — Módulo `Parametrizacao` para catálogos cross-cutting (Modalidade, NecessidadeEspecial, TipoDocumento, Endereco) + carve-out read-side via `IXxxReader` em `.Contracts`, com cache distribuído Redis 8 e stampede protection.
- **ADR-0057** — RBAC por áreas com snapshot na publicação do edital, histórico SCD Type 2 e invariantes de governança.
- **ADR-0058** — `ObrigatoriedadeLegal` como validação data-driven (discriminated union de 8 tipos de predicado), com snapshot-on-bind para evidência legal e critérios de promoção a futuro módulo `Normativos`.
- **ADR-0059** — Decomposição da Sprint 3 em foundation coletiva (semana 1) + 3 lanes paralelas (semana 2) com 3 devs backend dedicados.
- **ADR-0060** — Junction tables por entidade para `AreasDeInteresse` + view unificada por DbContext para leituras cross-catálogo.
- **ADR-0061** — Referência cross-módulo via snapshot-copy (value object embedded), sem FK cross-banco e com `OrigemId` opcional como rastreabilidade.
- **ADR-0062** — Seed de catálogos via Newman + endpoints admin, eliminando auto-seeder e preservando audit honesta com sub real do Keycloak.

Também adiciona a entrada de **ADR-0054** (snake_case + isolamento por banco) ao índice, que faltava.

## Origem

ADRs foram produzidas no pipeline Compozy em `.compozy/tasks/parametrizacao-module-strategy/` (idea factory → PRD → TechSpec → tasks → ADRs binding), depois traduzidas para pt-BR com adaptações ao estilo do projeto. Conteúdo das 8 ADRs originais permanece no workspace Compozy como histórico do workflow.

## Validações

- `bash tools/adr-lint/validate.sh` — 62 ADRs ok, frontmatter MADR 4.0 válido.
- `npx markdownlint-cli2 'docs/adrs/**/*.md'` — 0 erros.

## Test plan

- [x] Linter ADR (frontmatter MADR 4.0) passa nas 8 novas ADRs.
- [x] `markdownlint-cli2` passa com 0 erros nas 64 ADRs.
- [x] Índice `docs/adrs/README.md` atualizado e com link clicável para cada uma das 8 novas entradas.
- [x] Cross-references entre as 8 ADRs preservados ao traduzir links `[[adr-NNN]]` do Compozy para `[ADR-00NN]` do projeto.