### PR TITLE
feat: infra base da Sprint 3 — bancos, AreaCodigo, RBAC, EF templates

### DIFF
--- a/UniPlus.slnx
+++ b/UniPlus.slnx
@@ -18,12 +18,14 @@
   </Folder>
   <Folder Name="/src/shared/">
     <Project Path="src/shared/Unifesspa.UniPlus.Application.Abstractions/Unifesspa.UniPlus.Application.Abstractions.csproj" />
+    <Project Path="src/shared/Unifesspa.UniPlus.Governance.Contracts/Unifesspa.UniPlus.Governance.Contracts.csproj" />
     <Project Path="src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj" />
     <Project Path="src/shared/Unifesspa.UniPlus.Kernel/Unifesspa.UniPlus.Kernel.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/Unifesspa.UniPlus.Application.Abstractions.UnitTests/Unifesspa.UniPlus.Application.Abstractions.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.Governance.Contracts.UnitTests/Unifesspa.UniPlus.Governance.Contracts.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj" />

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -7,6 +7,16 @@ POSTGRES_USER=uniplus
 POSTGRES_PASSWORD=uniplus_dev
 POSTGRES_DB=uniplus
 
+# PostgreSQL — bancos da Sprint 3 (Parametrizacao + Organizacao)
+# Usuários isolados, cada um dono do próprio banco. Provisionados por
+# docker/init-db.sql com a senha dev fixa abaixo (init-db.sql não interpola
+# env vars). As connection strings em appsettings serão adicionadas quando
+# os módulos forem scaffoldados (F1.S2 / F1.S3).
+PARAMETRIZACAO_DB_USER=uniplus_parametrizacao_app
+PARAMETRIZACAO_DB_PASSWORD=uniplus_dev
+ORGANIZACAO_DB_USER=uniplus_organizacao_app
+ORGANIZACAO_DB_PASSWORD=uniplus_dev
+
 # MinIO (Object Storage S3-compatible)
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin

--- a/docker/init-db.sql
+++ b/docker/init-db.sql
@@ -1,16 +1,48 @@
--- Criar databases adicionais para os módulos do UniPlus
+-- Provisionamento dos databases dos módulos do UniPlus + extensões.
+--
+-- Topologia (docs/guia-banco-de-dados.md §1): um banco PostgreSQL por módulo,
+-- todos no mesmo host PG (custo de dev local) mas isolados por database.
+-- Selecao/Ingresso/Portal compartilham o superusuário `uniplus` (legado);
+-- Parametrizacao e Organizacao (Sprint 3) usam usuários `_app` dedicados,
+-- cada um dono (OWNER) do seu próprio banco.
+--
+-- Este script roda como `POSTGRES_USER` (superusuário) no primeiro boot do
+-- container, via /docker-entrypoint-initdb.d.
+
+-- Bancos legados (módulos pré-Sprint 3) — dono: superusuário `uniplus`.
 CREATE DATABASE uniplus_selecao;
 CREATE DATABASE uniplus_ingresso;
 CREATE DATABASE uniplus_portal;
 CREATE DATABASE keycloak;
 
--- Instalar extensões nos databases de aplicação
--- uuid-ossp: geração de UUIDs como chave primária
--- pg_trgm: busca por similaridade (trigram matching)
+-- Bancos da Sprint 3 — usuários isolados, dono do próprio banco.
+-- OWNER (não apenas GRANT) é necessário: a partir do PostgreSQL 15 o schema
+-- `public` deixou de conceder CREATE implicitamente, então um usuário com
+-- apenas GRANT no database não consegue criar tabelas/índices. Como dono, o
+-- usuário `_app` tem DDL completo no seu banco e instala extensões trusted
+-- (btree_gist, uuid-ossp, pg_trgm) sem precisar de superusuário.
+--
+-- A senha `uniplus_dev` abaixo é dev-only (mesmo padrão de POSTGRES_PASSWORD).
+-- Em standalone/HML/PROD os usuários `_app` são provisionados com segredos
+-- reais via o RUNBOOK do uniplus-infra — nunca esta senha.
+CREATE ROLE uniplus_parametrizacao_app LOGIN PASSWORD 'uniplus_dev';
+CREATE DATABASE uniplus_parametrizacao OWNER uniplus_parametrizacao_app;
+
+CREATE ROLE uniplus_organizacao_app LOGIN PASSWORD 'uniplus_dev';
+CREATE DATABASE uniplus_organizacao OWNER uniplus_organizacao_app;
+
+-- Extensões dos databases de aplicação:
+--   uuid-ossp  — geração de UUIDs
+--   pg_trgm    — busca por similaridade (trigram matching)
+--   btree_gist — exclusion constraints GIST das junction tables de
+--                AreasDeInteresse (ADR-0060). Habilitada nos bancos que
+--                hospedam entidades com governança por área na Sprint 3:
+--                selecao, parametrizacao e organizacao.
 
 \c uniplus_selecao
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+CREATE EXTENSION IF NOT EXISTS btree_gist;
 
 \c uniplus_ingresso
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
@@ -19,3 +51,13 @@ CREATE EXTENSION IF NOT EXISTS "pg_trgm";
 \c uniplus_portal
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+
+\c uniplus_parametrizacao
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+\c uniplus_organizacao
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+CREATE EXTENSION IF NOT EXISTS btree_gist;

--- a/docker/keycloak/README.md
+++ b/docker/keycloak/README.md
@@ -84,12 +84,40 @@ Esses claims são consumidos pelo frontend para preencher o perfil do usuário a
 
 ## Roles (realm roles)
 
+### Personas do sistema
+
 - `admin`
 - `gestor`
 - `avaliador`
 - `candidato`
 
-Correspondem às personas do sistema.
+### Roles de área organizacional (RBAC por áreas — ADR-0055 / ADR-0057)
+
+Cada `AreaOrganizacional` do roster fechado (CEPS, CRCA, PROEG, PROGEP, PLATAFORMA) projeta-se em **dois realm roles** seguindo a convenção `{codigo-lowercase}-{papel}`:
+
+| Role | Autoridade |
+| ---- | ---------- |
+| `{area}-admin` | Escrita — edita catálogos cujo `Proprietario` é aquela área. |
+| `{area}-leitor` | Leitura — enxerga catálogos visíveis à área, sem escrita. |
+
+Roles atuais: `ceps-admin`, `ceps-leitor`, `crca-admin`, `crca-leitor`, `proeg-admin`, `proeg-leitor`, `progep-admin`, `progep-leitor`, `plataforma-admin`, `plataforma-leitor`.
+
+O `IUserContext.AreasAdministradas` deriva `AreaCodigo` a partir dos roles `{area}-admin` do JWT; `plataforma-admin` é tratado à parte (`IsPlataformaAdmin`) — é o bypass platform-wide, não uma área comum (ver `HttpUserContext`).
+
+**Adicionar uma área nova** é ato de governança (ADR exigida — ADR-0055). Ao registrar uma `AreaOrganizacional` nova, provisionar os 2 roles correspondentes:
+
+```sh
+# Substituir {area} pelo código em minúsculas.
+for papel in admin leitor; do
+  /opt/keycloak/bin/kcadm.sh create roles -r unifesspa \
+    -s name={area}-$papel \
+    -s "description=Role da área {area} ({papel})"
+done
+```
+
+Em dev o realm é importado de `realm-export.json` (já contém os 10 roles). Em standalone/HML/PROD o provisionamento via `kcadm.sh` acima é parte do runbook de criação de área no `uniplus-infra`.
+
+O usuário de teste `admin` recebe `plataforma-admin` no realm de dev para permitir exercitar os endpoints admin de catálogo localmente.
 
 ## Usuários de teste
 

--- a/docker/keycloak/realm-export.json
+++ b/docker/keycloak/realm-export.json
@@ -112,6 +112,96 @@
         "clientRole": false,
         "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
         "attributes": {}
+      },
+      {
+        "id": "1ec5178d-f024-5075-bbe0-b2d793ab0a7b",
+        "name": "ceps-admin",
+        "description": "Administrador da área CEPS — Centro de Processos Seletivos: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
+      },
+      {
+        "id": "24851a58-dc13-5ffd-ab7f-0c36670fb059",
+        "name": "ceps-leitor",
+        "description": "Leitor da área CEPS — Centro de Processos Seletivos: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
+      },
+      {
+        "id": "2c3eeb0e-c5b2-589d-abd1-b0e12c200290",
+        "name": "crca-admin",
+        "description": "Administrador da área CRCA — Centro de Registro e Controle Acadêmico: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
+      },
+      {
+        "id": "88097d18-4131-5f9c-b25c-8ccff0af4f4a",
+        "name": "crca-leitor",
+        "description": "Leitor da área CRCA — Centro de Registro e Controle Acadêmico: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
+      },
+      {
+        "id": "040b9f8c-8af1-5931-addf-35a177cd2405",
+        "name": "proeg-admin",
+        "description": "Administrador da área PROEG — Pró-Reitoria de Ensino de Graduação: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
+      },
+      {
+        "id": "316b8dbc-a1fd-5c43-b929-9f745701c579",
+        "name": "proeg-leitor",
+        "description": "Leitor da área PROEG — Pró-Reitoria de Ensino de Graduação: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
+      },
+      {
+        "id": "649db30d-da3b-596e-8469-de1eeca50a95",
+        "name": "progep-admin",
+        "description": "Administrador da área PROGEP — Pró-Reitoria de Gestão de Pessoas: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
+      },
+      {
+        "id": "22463508-ecdb-5620-8c4e-c9a21965f7f1",
+        "name": "progep-leitor",
+        "description": "Leitor da área PROGEP — Pró-Reitoria de Gestão de Pessoas: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
+      },
+      {
+        "id": "6cfa5cfa-3a92-518e-9cb7-22684eed0cdd",
+        "name": "plataforma-admin",
+        "description": "Administrador da área Plataforma / CTIC: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
+      },
+      {
+        "id": "f0cbd504-f67e-5b0c-852b-e9f42fba1a7e",
+        "name": "plataforma-leitor",
+        "description": "Leitor da área Plataforma / CTIC: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "3310e85a-fc31-4029-a33a-dd49f8085fc5",
+        "attributes": {}
       }
     ],
     "client": {
@@ -2935,7 +3025,8 @@
       "firstName": "Usuário",
       "lastName": "Admin",
       "realmRoles": [
-        "admin"
+        "admin",
+        "plataforma-admin"
       ],
       "clientRoles": {
         "account": [

--- a/docs/adrs/0055-organizacao-institucional-bounded-context.md
+++ b/docs/adrs/0055-organizacao-institucional-bounded-context.md
@@ -47,7 +47,20 @@ O risco que esta ADR mitiga: sem um conceito explícito de área, a plataforma o
 
 ### Estrutura do módulo
 
+> **Atualizado pela Emenda 1** (ver seção ao final): a superfície de contrato foi
+> renomeada para `Unifesspa.UniPlus.Governance.Contracts` e fica em `src/shared/`,
+> não na pasta do módulo. Os outros 4 csprojs permanecem em
+> `src/organizacao-institucional/`.
+
 ```text
+src/shared/
+└── Unifesspa.UniPlus.Governance.Contracts/   (contratos foundation — Emenda 1)
+    ├── IAreaOrganizacionalReader.cs           (leitor cross-módulo)
+    ├── AreaCodigo.cs                          (record struct sobre string, strongly-typed)
+    ├── AreaOrganizacionalView.cs              (DTO read-only para consumo cross-módulo)
+    ├── ICatalogEntity.cs                      (marker de catálogo área-scoped)
+    └── ReferenceDataAttribute.cs
+
 src/organizacao-institucional/
 ├── Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/
 │   └── Entities/
@@ -56,11 +69,6 @@ src/organizacao-institucional/
 │   ├── Commands/                    (admin: registrar via ADR, atualizar, soft-delete)
 │   ├── Queries/
 │   └── DTOs/
-├── Unifesspa.UniPlus.OrganizacaoInstitucional.Contracts/
-│   ├── IAreaOrganizacionalReader.cs (leitor cross-módulo)
-│   ├── AreaCodigo.cs                (record struct sobre string, strongly-typed)
-│   ├── AreaOrganizacionalView.cs    (DTO read-only para consumo cross-módulo)
-│   └── ReferenceDataAttribute.cs
 ├── Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/
 │   └── Persistence/
 │       ├── OrganizacaoInstitucionalDbContext.cs (banco `uniplus_organizacao`)
@@ -90,7 +98,7 @@ AdrReferenceCode: string (ex.: "0055-organizacao-institucional-bounded-context")
 
 ### `AreaCodigo` — identificador strongly-typed
 
-`AreaCodigo` é `readonly record struct` em `OrganizacaoInstitucional.Contracts`:
+`AreaCodigo` é `readonly record struct` em `Unifesspa.UniPlus.Governance.Contracts` (`src/shared/`, ver Emenda 1):
 
 - Construtor privado; factory `From(string)` retorna `Result<AreaCodigo>` com validação (2-32 chars, uppercase, alfanum + underscore, sem leading digit).
 - Usado em todo o sistema: `Proprietario: AreaCodigo?` em entidades de catálogo, elementos de `AreasDeInteresse: IReadOnlySet<AreaCodigo>`, claims JWT derivados expõem `IReadOnlyCollection<AreaCodigo>`.
@@ -98,7 +106,7 @@ AdrReferenceCode: string (ex.: "0055-organizacao-institucional-bounded-context")
 
 ### Acesso cross-módulo
 
-`IAreaOrganizacionalReader` em `OrganizacaoInstitucional.Contracts` expõe:
+`IAreaOrganizacionalReader` em `Unifesspa.UniPlus.Governance.Contracts` (`src/shared/`, ver Emenda 1) expõe:
 
 - `Task<IReadOnlyList<AreaOrganizacionalView>> ListarAtivasAsync(CancellationToken)`
 - `Task<AreaOrganizacionalView?> ObterPorCodigoAsync(AreaCodigo codigo, CancellationToken)`
@@ -181,6 +189,45 @@ Cada extensão exige sua própria ADR com trigger condition documentado; nenhuma
 
 - **Prós**: Separa governança organizacional de dados de catálogo. `AreaCodigo` strongly-typed elimina string-typo bugs. Roster expansion auditável (`AdrReferenceCode` enforçado). `AreaOrganizacional` tem ciclo de vida completo (audit, soft-delete, eventos) sem poluir `Kernel`. Conceitos futuros de hierarquia/cargo/delegação têm casa limpa — sem extração depois. Acesso cross-módulo via `IAreaOrganizacionalReader` mantém boundary consistente com o resto da plataforma.
 - **Contras**: Um módulo adicional na solution (5 csproj). DI wiring em cada consumer. Build time cresce ~3-5 segundos. Novos devs precisam aprender que "áreas NÃO estão em Parametrizacao" — contraintuitivo para quem está acostumado a "todos os dados de referência em um módulo".
+
+## Emenda 1 — relocação de `Contracts` para `src/shared/` (2026-05-14)
+
+Durante a implementação de F1.S1 (Story #446), o assembly de contratos do
+módulo precisou de uma decisão de localização física que a versão original
+desta ADR não previa.
+
+**O que muda:** o projeto antes desenhado como
+`src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Contracts/`
+passa a ser `src/shared/Unifesspa.UniPlus.Governance.Contracts/` — renomeado
+(nome de *capability*, não de bounded context) e fisicamente em `src/shared/`.
+
+**Por quê:** `AreaCodigo`, `ICatalogEntity` e os atributos marker de área são
+contratos *foundation* — consumidos por `Infrastructure.Core` (EF value
+converter, authorization handler) e `Application.Abstractions`
+(`IUserContext.AreasAdministradas`), além das entidades de `Domain` de todos
+os módulos de catálogo. `src/shared/` é uma ilha de dependências fechada:
+nenhum projeto de `src/shared/` pode referenciar para dentro de uma pasta de
+módulo (`src/<modulo>/`). Um `.Contracts` dentro de `src/organizacao-institucional/`
+forçaria exatamente essa violação.
+
+**O que NÃO muda:** a decisão E (bounded context dedicado) permanece. Os
+outros 4 csprojs (`Domain`, `Application`, `Infrastructure`, `API`) continuam
+em `src/organizacao-institucional/`, criados em F1.S2. O `Kernel` permanece
+intocado — `AreaCodigo` e `ICatalogEntity` carregam semântica de governança
+por área, não primitivos universais, então não entram no `Kernel`.
+
+**Alternativas descartadas:**
+
+- *Manter `.Contracts` em `src/organizacao-institucional/`* — força `src/shared/`
+  a referenciar para dentro de uma pasta de módulo, violando a ilha fechada.
+- *Fundir `AreaCodigo`/`ICatalogEntity` no `Kernel`* — dilui o layer de
+  primitivos universais com semântica de um bounded context específico, sem
+  fronteira de assembly marcando onde a erosão começa.
+
+A opção adotada — projeto próprio em `src/shared/` com nome de *capability*
+(`Governance.Contracts`) — preserva a ilha fechada, dá dono e fronteira
+explícitos aos contratos foundation e não toca o `Kernel`. Decisão do Tech
+Lead do projeto; esta emenda registra o desvio do diagrama original.
 
 ## Mais informações
 

--- a/docs/adrs/0057-areas-rbac-snapshot-historia-invariantes.md
+++ b/docs/adrs/0057-areas-rbac-snapshot-historia-invariantes.md
@@ -275,6 +275,20 @@ Quando triggered, nova ADR projeta a extensão. Até lá, **`AreaOrganizacional`
 - **Prós**: Discussão acima.
 - **Contras**: Discussão acima.
 
+## Emenda — vocabulário (2026-05-14)
+
+Onde este ADR diz **"catálogo"**, "entidade de catálogo" ou "catálogos
+cross-cutting", o **código usa "entidade área-scoped"**: a interface marker é
+`IAreaScopedEntity` (em `Governance.Contracts`) e a base EF é
+`AreaVisibilityConfiguration<TParent>` (em `Infrastructure.Core`).
+
+O termo "catálogo" fica **reservado a um futuro conceito de domínio** de fato
+(ex.: um catálogo de serviços) — não é vocabulário da demanda de
+configuração/Parametrização. A decisão foi tomada na ideação do módulo
+Parametrizacao; esta emenda registra o mapeamento para que a próxima pessoa
+não reintroduza "catálogo" achando que segue o ADR. O texto do corpo deste
+ADR é mantido como está; vale o mapeamento desta emenda.
+
 ## Mais informações
 
 - [ADR-0001](0001-monolito-modular-como-estilo-arquitetural.md) — Monolito modular.

--- a/docs/adrs/0060-junction-tables-por-entidade-com-view-unificada.md
+++ b/docs/adrs/0060-junction-tables-por-entidade-com-view-unificada.md
@@ -189,6 +189,22 @@ Quando `Edital.Publicar()` roda (Pattern 1 de [ADR-0057](0057-areas-rbac-snapsho
 - **Prós**: discussão acima.
 - **Contras**: discussão acima.
 
+## Emenda — vocabulário (2026-05-14)
+
+Onde este ADR diz **"catálogo"**, "entidade de catálogo" ou
+`CatalogVisibilityConfiguration<T>`, o **código usa "entidade área-scoped"**:
+a interface marker é `IAreaScopedEntity` (em `Governance.Contracts`) e a base
+EF templatada é `AreaVisibilityConfiguration<TParent>` (em
+`Infrastructure.Core/Persistence/Configurations/`).
+
+O termo "catálogo" fica **reservado a um futuro conceito de domínio** de fato
+— não é vocabulário da demanda de configuração/Parametrização. A decisão foi
+tomada na ideação do módulo Parametrizacao; esta emenda registra o mapeamento
+para que a próxima pessoa não reintroduza "catálogo" achando que segue o ADR.
+Os nomes de banco permanecem como estão (`{entidade}_areas_de_interesse`,
+`area_codigo`) — são neutros. O texto do corpo deste ADR é mantido; vale o
+mapeamento desta emenda.
+
 ## Mais informações
 
 - [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) — Módulo Parametrizacao e carve-out read-side.

--- a/docs/guia-banco-de-dados.md
+++ b/docs/guia-banco-de-dados.md
@@ -26,13 +26,22 @@ Referência canônica para devs que tocam persistência: naming convention, tipo
 
 ## 1. Topologia
 
-Uni+ usa **3 bancos PostgreSQL 18 isolados** (um por módulo), no mesmo host PG mas com usuários distintos:
+Uni+ usa **5 bancos PostgreSQL 18 isolados** (um por módulo), no mesmo host PG mas isolados por database:
 
 | Banco | Usuário | DbContext | Cobertura |
 |---|---|---|---|
-| `uniplus_selecao` | `selecao` | `SelecaoDbContext` | Editais, Candidatos, Inscrições, Cotas, Etapas, ProcessosSeletivos |
-| `uniplus_ingresso` | `ingresso` | `IngressoDbContext` | Chamadas, Convocações, Matrículas, DocumentosMatricula |
-| `uniplus_portal` | `portal` | `PortalDbContext` | Vazio até primeira Story tocar entity Portal |
+| `uniplus_selecao` | `uniplus` | `SelecaoDbContext` | Editais, Candidatos, Inscrições, Cotas, Etapas, ProcessosSeletivos |
+| `uniplus_ingresso` | `uniplus` | `IngressoDbContext` | Chamadas, Convocações, Matrículas, DocumentosMatricula |
+| `uniplus_portal` | `uniplus` | `PortalDbContext` | Vazio até primeira Story tocar entity Portal |
+| `uniplus_parametrizacao` | `uniplus_parametrizacao_app` | `ParametrizacaoDbContext` (a criar — F1.S3) | Catálogos cross-cutting: Modalidade, NecessidadeEspecial, TipoDocumento, Endereco |
+| `uniplus_organizacao` | `uniplus_organizacao_app` | `OrganizacaoInstitucionalDbContext` (a criar — F1.S2) | AreaOrganizacional |
+
+Os bancos legados (Selecao/Ingresso/Portal) compartilham o superusuário `uniplus`. Os bancos da Sprint 3 (Parametrizacao/Organizacao) usam **usuários `_app` dedicados, cada um dono (`OWNER`) do seu próprio banco** — o owner tem DDL completo no schema `public` (necessário a partir do PG 15, que removeu o `CREATE` implícito) e instala extensões trusted sem superusuário. Provisionamento em `docker/init-db.sql`.
+
+Extensões habilitadas:
+
+- `uuid-ossp`, `pg_trgm` — em todos os bancos de aplicação.
+- `btree_gist` — em `uniplus_selecao`, `uniplus_parametrizacao` e `uniplus_organizacao`: requerida pelos exclusion constraints GIST das junction tables de `AreasDeInteresse` ([ADR-0060](adrs/0060-junction-tables-por-entidade-com-view-unificada.md)). Em dev é habilitada via `init-db.sql`; em standalone/HML/PROD, via a primeira migration de cada DbContext (idempotente, `CREATE EXTENSION IF NOT EXISTS`).
 
 Schemas usados em cada banco:
 
@@ -286,8 +295,8 @@ migrationBuilder.Sql(@"
 docker compose -f docker/docker-compose.yml up postgres -d
 
 # Bancos criados automaticamente via docker/init-db.sql:
-# uniplus_selecao, uniplus_ingresso, uniplus_portal
-# Usuários: selecao, ingresso, portal (senhas no .env local)
+# uniplus_selecao, uniplus_ingresso, uniplus_portal (usuário uniplus)
+# uniplus_parametrizacao, uniplus_organizacao (usuários _app dedicados)
 ```
 
 ### Aplicar migrations local

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
@@ -969,6 +969,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
@@ -972,6 +972,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -996,6 +1002,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
@@ -974,6 +974,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
@@ -977,6 +977,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1001,6 +1007,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
@@ -969,6 +969,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
@@ -972,6 +972,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -996,6 +1002,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
@@ -974,6 +974,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
@@ -977,6 +977,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1001,6 +1007,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
@@ -993,6 +993,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1017,6 +1023,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
@@ -990,6 +990,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/packages.lock.json
@@ -28,6 +28,13 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
@@ -998,6 +998,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1022,6 +1028,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
@@ -995,6 +995,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/shared/Unifesspa.UniPlus.Application.Abstractions/Authentication/IUserContext.cs
+++ b/src/shared/Unifesspa.UniPlus.Application.Abstractions/Authentication/IUserContext.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Application.Abstractions.Authentication;
 
+using Unifesspa.UniPlus.Governance.Contracts;
+
 /// <summary>
 /// Provides access to the authenticated user context extracted from the current request.
 /// </summary>
@@ -57,4 +59,25 @@ public interface IUserContext
     /// <param name="resourceName">The resource name.</param>
     /// <returns>The list of roles associated with the resource.</returns>
     IReadOnlyList<string> GetResourceRoles(string resourceName);
+
+    /// <summary>
+    /// Gets the organizational areas the user administers, derived from the
+    /// <c>{area}-admin</c> roles in the JWT (ADR-0055 / ADR-0057). Empty when the
+    /// request is anonymous or carries no area-admin role.
+    /// </summary>
+    /// <remarks>
+    /// The <c>plataforma-admin</c> role is deliberately excluded — it is the
+    /// platform-wide bypass, surfaced via <see cref="IsPlataformaAdmin"/>, not an
+    /// area-scoped administration grant. Roles whose stripped code is not a valid
+    /// <see cref="AreaCodigo"/> are skipped (defensive: an IdP misconfiguration
+    /// must not break authorization).
+    /// </remarks>
+    IReadOnlyCollection<AreaCodigo> AreasAdministradas { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the user holds the <c>plataforma-admin</c>
+    /// role — the platform-wide administration bypass (ADR-0057). Kept separate
+    /// from <see cref="AreasAdministradas"/> because it is not area-scoped.
+    /// </summary>
+    bool IsPlataformaAdmin { get; }
 }

--- a/src/shared/Unifesspa.UniPlus.Application.Abstractions/Unifesspa.UniPlus.Application.Abstractions.csproj
+++ b/src/shared/Unifesspa.UniPlus.Application.Abstractions/Unifesspa.UniPlus.Application.Abstractions.csproj
@@ -6,6 +6,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Unifesspa.UniPlus.Governance.Contracts\Unifesspa.UniPlus.Governance.Contracts.csproj" />
     <ProjectReference Include="..\Unifesspa.UniPlus.Kernel\Unifesspa.UniPlus.Kernel.csproj" />
   </ItemGroup>
 

--- a/src/shared/Unifesspa.UniPlus.Application.Abstractions/packages.lock.json
+++ b/src/shared/Unifesspa.UniPlus.Application.Abstractions/packages.lock.json
@@ -22,6 +22,12 @@
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       }

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/AreaCodigo.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/AreaCodigo.cs
@@ -1,0 +1,101 @@
+namespace Unifesspa.UniPlus.Governance.Contracts;
+
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Governance.Contracts.Serialization;
+
+/// <summary>
+/// Identificador strongly-typed de uma <c>AreaOrganizacional</c> (ADR-0055).
+/// Usado em todo o sistema como tipo de <c>Proprietario</c> e dos elementos de
+/// <c>AreasDeInteresse</c> nas entidades área-scoped, e nas roles de área
+/// derivadas do JWT — elimina a classe de bugs de typo <c>"ceps"</c> vs
+/// <c>"CEPS"</c> e centraliza o ponto de validação/normalização.
+/// </summary>
+/// <remarks>
+/// Construtor privado: a única forma de obter um valor válido é
+/// <see cref="From"/>, que retorna <see cref="Result{T}"/> conforme o padrão
+/// de Value Object do projeto (<c>Cpf.Criar</c>, <c>Email.Criar</c>). O valor
+/// é normalizado para uppercase antes de ser armazenado.
+/// <para>
+/// Por ser <c>record struct</c>, <c>default(AreaCodigo)</c> existe e tem
+/// <see cref="Value"/> nulo — estado que nunca é produzido por <see cref="From"/>.
+/// Os membros (<see cref="ToString"/>, <see cref="CompareTo"/>) tratam esse
+/// caso graciosamente; o <c>AreaCodigoValueConverter</c> faz fail-fast ao
+/// materializar dado inválido vindo do banco.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(AreaCodigoJsonConverter))]
+public readonly partial record struct AreaCodigo : IComparable<AreaCodigo>
+{
+    /// <summary>Código de erro de domínio para entrada inválida em <see cref="From"/>.</summary>
+    public const string CodigoErroInvalido = "AreaCodigo.Invalido";
+
+    private const int ComprimentoMinimo = 2;
+    private const int ComprimentoMaximo = 32;
+
+    /// <summary>Valor normalizado (uppercase). É <see langword="null"/> em <c>default(AreaCodigo)</c>.</summary>
+    public string Value { get; }
+
+    private AreaCodigo(string value) => Value = value;
+
+    /// <summary>
+    /// Cria um <see cref="AreaCodigo"/> validado a partir de uma string.
+    /// Regras (ADR-0055): 2 a 32 caracteres, apenas letras ASCII maiúsculas,
+    /// dígitos e underscore, sem iniciar por dígito. A entrada é normalizada
+    /// para uppercase antes da validação — <c>"ceps"</c> vira <c>"CEPS"</c>.
+    /// </summary>
+    /// <param name="codigo">A string de entrada (qualquer caixa).</param>
+    /// <returns>
+    /// <see cref="Result{T}"/> de sucesso com o código normalizado, ou falha
+    /// com <see cref="DomainError"/> de código <see cref="CodigoErroInvalido"/>.
+    /// </returns>
+    public static Result<AreaCodigo> From(string? codigo)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return Result<AreaCodigo>.Failure(new DomainError(
+                CodigoErroInvalido,
+                "Código de área é obrigatório."));
+        }
+
+        string normalizado = codigo.Trim().ToUpperInvariant();
+
+        if (normalizado.Length is < ComprimentoMinimo or > ComprimentoMaximo)
+        {
+            return Result<AreaCodigo>.Failure(new DomainError(
+                CodigoErroInvalido,
+                $"Código de área deve ter entre {ComprimentoMinimo} e {ComprimentoMaximo} caracteres."));
+        }
+
+        if (!FormatoValido().IsMatch(normalizado))
+        {
+            return Result<AreaCodigo>.Failure(new DomainError(
+                CodigoErroInvalido,
+                "Código de área deve conter apenas letras maiúsculas ASCII, dígitos e underscore, "
+                + "e não pode iniciar por dígito."));
+        }
+
+        return Result<AreaCodigo>.Success(new AreaCodigo(normalizado));
+    }
+
+    /// <summary>Ordenação ordinal por <see cref="Value"/>; <c>default</c> ordena antes de qualquer código válido.</summary>
+    public int CompareTo(AreaCodigo other) => string.CompareOrdinal(Value, other.Value);
+
+    public static bool operator <(AreaCodigo left, AreaCodigo right) => left.CompareTo(right) < 0;
+
+    public static bool operator <=(AreaCodigo left, AreaCodigo right) => left.CompareTo(right) <= 0;
+
+    public static bool operator >(AreaCodigo left, AreaCodigo right) => left.CompareTo(right) > 0;
+
+    public static bool operator >=(AreaCodigo left, AreaCodigo right) => left.CompareTo(right) >= 0;
+
+    /// <summary>Retorna o valor normalizado, ou string vazia para <c>default(AreaCodigo)</c>.</summary>
+    public override string ToString() => Value ?? string.Empty;
+
+    // Primeiro caractere letra ou underscore (nunca dígito), demais
+    // alfanuméricos ou underscore. Comprimento já validado fora da regex.
+    [GeneratedRegex("^[A-Z_][A-Z0-9_]*$")]
+    private static partial Regex FormatoValido();
+}

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/ExplicitlyUnscopedAttribute.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/ExplicitlyUnscopedAttribute.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// Marca um método que opera deliberadamente sem o filtro de áreas (ADR-0057
+/// Pattern 4) — por exemplo, jobs noturnos com escopo <c>plataforma-admin</c>.
+/// O <see cref="Reason"/> é obrigatório: documenta por que o escopo de áreas
+/// não se aplica ali. Um fitness test ArchUnitNET (F1.S3) valida que todo
+/// call site assim assegura o role <c>plataforma-admin</c>.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+public sealed class ExplicitlyUnscopedAttribute : Attribute
+{
+    /// <param name="reason">
+    /// Justificativa de por que este call site opera sem filtro de áreas.
+    /// </param>
+    public ExplicitlyUnscopedAttribute(string reason)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+        Reason = reason;
+    }
+
+    /// <summary>Justificativa de por que o filtro de áreas não se aplica.</summary>
+    public string Reason { get; }
+}

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/IAreaScopedEntity.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/IAreaScopedEntity.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// Marca entidades de domínio que carregam governança por área organizacional
+/// (ADR-0057). O <see cref="Proprietario"/> identifica a área que pode editar
+/// o item; quando <see langword="null"/>, o item é global e gerido apenas pela
+/// plataforma (CTIC).
+/// </summary>
+/// <remarks>
+/// Vive em <c>Governance.Contracts</c> (dentro de <c>src/shared/</c>) — e não em
+/// <c>Infrastructure.Core</c> — porque as entidades área-scoped de
+/// <c>Domain</c> (Modalidade, TipoDocumento, etc.) a implementam, e a regra de
+/// dependência da Clean Architecture proíbe <c>Domain</c> de referenciar
+/// <c>Infrastructure</c>. O <c>AreaScopedAuthorizationHandler</c> em
+/// <c>Infrastructure.Core</c> consome este marcador como recurso da
+/// autorização baseada em recurso.
+/// </remarks>
+public interface IAreaScopedEntity
+{
+    /// <summary>
+    /// Área organizacional dona do item (autoridade de escrita), ou
+    /// <see langword="null"/> para itens globais geridos apenas pela plataforma.
+    /// </summary>
+    AreaCodigo? Proprietario { get; }
+}

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/ReferenceDataAttribute.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/ReferenceDataAttribute.cs
@@ -1,0 +1,10 @@
+namespace Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// Marca uma entidade de domínio como dado de referência área-scoped. Não tem
+/// comportamento em runtime — é consumido pelos fitness tests ArchUnitNET
+/// (F1.S3) que garantem que toda entidade marcada tem uma
+/// <c>AreaVisibilityConfiguration</c> correspondente (ADR-0060).
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public sealed class ReferenceDataAttribute : Attribute;

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/Serialization/AreaCodigoJsonConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/Serialization/AreaCodigoJsonConverter.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Governance.Contracts.Serialization;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Serializa <see cref="AreaCodigo"/> como string JSON plana (não objeto),
+/// com fail-fast simétrico: a leitura rejeita token não-string ou valor
+/// inválido, e a escrita rejeita <c>default(AreaCodigo)</c> — ambos viram
+/// <see cref="JsonException"/> com contexto, em vez de um round-trip
+/// silenciosamente inconsistente.
+/// </summary>
+public sealed class AreaCodigoJsonConverter : JsonConverter<AreaCodigo>
+{
+    public override AreaCodigo Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException(
+                $"AreaCodigo espera um valor string em JSON, recebido {reader.TokenType}.");
+        }
+
+        string? bruto = reader.GetString();
+        Result<AreaCodigo> resultado = AreaCodigo.From(bruto);
+        if (resultado.IsFailure)
+        {
+            throw new JsonException(
+                $"Valor inválido para AreaCodigo: '{bruto}'. {resultado.Error!.Message}");
+        }
+
+        return resultado.Value!;
+    }
+
+    public override void Write(Utf8JsonWriter writer, AreaCodigo value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (value.Value is null)
+        {
+            throw new JsonException(
+                "Não é possível serializar default(AreaCodigo): valor não inicializado. "
+                + "AreaCodigo válido só é produzido por AreaCodigo.From.");
+        }
+
+        writer.WriteStringValue(value.Value);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/Unifesspa.UniPlus.Governance.Contracts.csproj
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/Unifesspa.UniPlus.Governance.Contracts.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Contratos de governança por área compartilhados entre as camadas
+    foundation (Infrastructure.Core, Application.Abstractions) e todos os
+    módulos de negócio: AreaCodigo, ICatalogEntity e os atributos marker
+    de área. Vive em src/shared/ — e não na pasta do módulo
+    OrganizacaoInstitucional — porque é consumido pela ilha fechada de
+    src/shared/, que nunca pode referenciar para dentro de uma pasta de
+    módulo. Ver ADR-0055 (seção "Localização física de Governance.Contracts").
+
+    Mantém-se enxuto: só tipos de contrato, sem dependência além do Kernel
+    (para Result<T>). Em F1.S2 ganha IAreaOrganizacionalReader e
+    AreaOrganizacionalView.
+  -->
+
+  <ItemGroup>
+    <ProjectReference Include="..\Unifesspa.UniPlus.Kernel\Unifesspa.UniPlus.Kernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/packages.lock.json
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/packages.lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/HttpUserContext.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authentication/HttpUserContext.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 
 using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Resolves authenticated user data from the current HTTP context.
@@ -20,9 +22,18 @@ public sealed partial class HttpUserContext : IUserContext
     private static readonly string[] EmailClaimCandidates = [ClaimTypes.Email, OidcClaims.Email];
     private static readonly string[] DirectRoleClaimTypes = [ClaimTypes.Role, KeycloakClaims.Role, KeycloakClaims.Roles];
 
+    // Convenção de roles de área (ADR-0055): `{codigo-lowercase}-admin`.
+    private const string AdminRoleSuffix = "-admin";
+    private const string PlataformaAdminRole = "plataforma" + AdminRoleSuffix;
+
+    // plataforma-admin é o bypass platform-wide (IsPlataformaAdmin); não entra
+    // em AreasAdministradas. Comparado contra o AreaCodigo já normalizado.
+    private static readonly AreaCodigo PlataformaCodigo = AreaCodigo.From("PLATAFORMA").Value!;
+
     private readonly ClaimsPrincipal? _user;
     private readonly ILogger<HttpUserContext> _logger;
     private readonly Lazy<IReadOnlyList<string>> _roles;
+    private readonly Lazy<IReadOnlyCollection<AreaCodigo>> _areasAdministradas;
     private readonly ConcurrentDictionary<string, IReadOnlyList<string>> _resourceRolesCache = new(StringComparer.Ordinal);
 
     public HttpUserContext(
@@ -35,6 +46,7 @@ public sealed partial class HttpUserContext : IUserContext
         _user = httpContextAccessor.HttpContext?.User;
         _logger = logger;
         _roles = new Lazy<IReadOnlyList<string>>(ResolveRoles);
+        _areasAdministradas = new Lazy<IReadOnlyCollection<AreaCodigo>>(ResolveAreasAdministradas);
     }
 
     public bool IsAuthenticated => _user?.Identity?.IsAuthenticated == true;
@@ -50,6 +62,10 @@ public sealed partial class HttpUserContext : IUserContext
     public string? NomeSocial => GetSingleClaimValue(UniPlusClaims.NomeSocial);
 
     public IReadOnlyList<string> Roles => _roles.Value;
+
+    public IReadOnlyCollection<AreaCodigo> AreasAdministradas => _areasAdministradas.Value;
+
+    public bool IsPlataformaAdmin => HasRole(PlataformaAdminRole);
 
     public bool HasRole(string role)
     {
@@ -108,6 +124,44 @@ public sealed partial class HttpUserContext : IUserContext
             .Distinct(RoleComparer)
             .ToArray();
 
+    private HashSet<AreaCodigo> ResolveAreasAdministradas()
+    {
+        HashSet<AreaCodigo> areas = [];
+
+        foreach (string role in Roles)
+        {
+            if (!role.EndsWith(AdminRoleSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            string candidato = role[..^AdminRoleSuffix.Length];
+            if (string.IsNullOrEmpty(candidato))
+            {
+                continue;
+            }
+
+            Result<AreaCodigo> resultado = AreaCodigo.From(candidato);
+            if (resultado.IsFailure)
+            {
+                // IdP mal configurado não pode quebrar a autorização — loga e ignora.
+                LogRoleAreaInvalida(_logger, role, resultado.Error!.Message);
+                continue;
+            }
+
+            AreaCodigo codigo = resultado.Value!;
+            if (codigo == PlataformaCodigo)
+            {
+                // plataforma-admin é bypass platform-wide, exposto via IsPlataformaAdmin.
+                continue;
+            }
+
+            areas.Add(codigo);
+        }
+
+        return areas;
+    }
+
     private IEnumerable<string> EnumerateDirectRoleClaims()
     {
         if (_user is null)
@@ -148,8 +202,14 @@ public sealed partial class HttpUserContext : IUserContext
                 return [];
             }
 
+            // Filtra elementos não-string ANTES de GetString(): um
+            // realm_access.roles malformado (número, objeto) faria GetString()
+            // lançar InvalidOperationException, que não cai no catch
+            // JsonException abaixo — viraria 500. Mesma defesa de
+            // KeycloakRolesClaimsTransformation.
             return rolesArray
                 .EnumerateArray()
+                .Where(static role => role.ValueKind == JsonValueKind.String)
                 .Select(static role => role.GetString())
                 .OfType<string>()
                 .ToArray();
@@ -169,4 +229,9 @@ public sealed partial class HttpUserContext : IUserContext
         string claimName,
         string? resourceName,
         Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Role de área {Role} ignorada — código de área inválido: {Motivo}")]
+    private static partial void LogRoleAreaInvalida(ILogger logger, string role, string motivo);
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authorization/AreaScopedAuthorizationHandler.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authorization/AreaScopedAuthorizationHandler.cs
@@ -1,0 +1,102 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Authorization;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// Handler de autorização baseada em recurso para <see cref="RequireAreaProprietarioRequirement"/>
+/// (ADR-0057). Decide se o caller pode escrever num <c>IAreaScopedEntity</c>:
+/// <list type="number">
+///   <item>admin da área <c>Proprietario</c> do recurso — autoriza;</item>
+///   <item><c>plataforma-admin</c> — autoriza (bypass platform-wide); quando o
+///   item é área-scoped, emite um log operacional de edição on-behalf-of;</item>
+///   <item>demais casos — nega (o 403 ProblemDetails vem da pipeline, ADR-0034).</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// O handler resolve o principal pelo <see cref="IUserContext"/> injetado — a
+/// abstração canônica do usuário corrente do projeto (ADR-0033), request-scoped
+/// e equivalente ao <c>HttpContext.User</c> — e não pelo
+/// <c>AuthorizationHandlerContext.User</c>. No caminho canônico
+/// (<c>IAuthorizationService.AuthorizeAsync(User, recurso, policy)</c>) os dois
+/// são o mesmo principal; a policy <c>AreaScopedPolicies.RequireAreaProprietario</c>
+/// inclui <c>RequireAuthenticatedUser()</c>, então uma request anônima é barrada
+/// antes de chegar a este handler.
+/// </para>
+/// <para>
+/// O log on-behalf-of é operacional, não a trilha de auditoria durável — a
+/// tabela de auditoria do ADR-0057 entra com as entidades área-scoped (F2).
+/// </para>
+/// </remarks>
+public sealed partial class AreaScopedAuthorizationHandler
+    : AuthorizationHandler<RequireAreaProprietarioRequirement, IAreaScopedEntity>
+{
+    private readonly IUserContext _userContext;
+    private readonly ILogger<AreaScopedAuthorizationHandler> _logger;
+
+    public AreaScopedAuthorizationHandler(
+        IUserContext userContext,
+        ILogger<AreaScopedAuthorizationHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(userContext);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _userContext = userContext;
+        _logger = logger;
+    }
+
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        RequireAreaProprietarioRequirement requirement,
+        IAreaScopedEntity resource)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(resource);
+
+        AreaCodigo? proprietario = resource.Proprietario;
+
+        // 1. Admin da área dona do recurso edita a própria entidade.
+        if (proprietario is { } area && _userContext.AreasAdministradas.Contains(area))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        // 2. plataforma-admin: bypass platform-wide (ADR-0057). Quando o item é
+        //    área-scoped, a edição é on-behalf-of e fica registrada em log.
+        if (_userContext.IsPlataformaAdmin)
+        {
+            if (proprietario is { } areaOnBehalf)
+            {
+                LogEdicaoOnBehalfOf(
+                    _logger,
+                    _userContext.UserId ?? "desconhecido",
+                    resource.GetType().Name,
+                    areaOnBehalf.Value);
+            }
+
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        // 3. Demais casos — nega. Itens globais (Proprietario nulo) também caem
+        //    aqui quando o caller não é plataforma-admin.
+        context.Fail(new AuthorizationFailureReason(
+            this,
+            "O caller não administra a área proprietária do recurso e não é plataforma-admin."));
+        return Task.CompletedTask;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Edição on-behalf-of: plataforma-admin {ActorSub} editou {ResourceType} da área {OnBehalfOfArea}")]
+    private static partial void LogEdicaoOnBehalfOf(
+        ILogger logger,
+        string actorSub,
+        string resourceType,
+        string onBehalfOfArea);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authorization/AreaScopedPolicies.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authorization/AreaScopedPolicies.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Authorization;
+
+/// <summary>
+/// Nomes das policies de autorização por área organizacional (ADR-0057).
+/// </summary>
+public static class AreaScopedPolicies
+{
+    /// <summary>
+    /// Policy baseada em recurso: exige que o caller administre a área
+    /// <c>Proprietario</c> do <c>IAreaScopedEntity</c>, ou seja
+    /// <c>plataforma-admin</c>.
+    /// </summary>
+    /// <remarks>
+    /// Invocada imperativamente — <c>IAuthorizationService.AuthorizeAsync(user,
+    /// entidadeAreaScoped, AreaScopedPolicies.RequireAreaProprietario)</c> — e não
+    /// como <c>[Authorize(Policy = ...)]</c> declarativo, porque o atributo
+    /// declarativo não carrega o recurso (<c>IAreaScopedEntity</c>) que o handler
+    /// precisa para decidir.
+    /// </remarks>
+    public const string RequireAreaProprietario = "uniplus:require-area-proprietario";
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authorization/RequireAreaProprietarioRequirement.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Authorization/RequireAreaProprietarioRequirement.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Authorization;
+
+using Microsoft.AspNetCore.Authorization;
+
+/// <summary>
+/// Requirement de autorização baseada em recurso: o caller pode escrever num
+/// <c>IAreaScopedEntity</c> se administra a área <c>Proprietario</c> do recurso,
+/// ou se é <c>plataforma-admin</c> (ADR-0057). Avaliado por
+/// <see cref="AreaScopedAuthorizationHandler"/> contra o recurso passado em
+/// <c>IAuthorizationService.AuthorizeAsync</c>.
+/// </summary>
+public sealed class RequireAreaProprietarioRequirement : IAuthorizationRequirement;

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/AuthorizationServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/AuthorizationServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Authorization;
+
+/// <summary>
+/// Registra a autorização baseada em áreas organizacionais (ADR-0057): o
+/// <see cref="AreaScopedAuthorizationHandler"/> e a policy nomeada
+/// <see cref="AreaScopedPolicies.RequireAreaProprietario"/>.
+/// </summary>
+/// <remarks>
+/// A policy é baseada em RECURSO — os controllers admin de configuração (F2)
+/// invocam imperativamente, passando o <c>IAreaScopedEntity</c> carregado:
+/// <code>
+/// await authorizationService.AuthorizeAsync(
+///     User, entidadeAreaScoped, AreaScopedPolicies.RequireAreaProprietario);
+/// </code>
+/// Não há <c>[Authorize(Policy = ...)]</c> declarativo porque o atributo não
+/// carrega o recurso que o handler precisa para decidir.
+/// </remarks>
+public static class AuthorizationServiceCollectionExtensions
+{
+    public static IServiceCollection AddAreaScopedAuthorization(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Scoped: o handler depende de IUserContext (HttpUserContext), Scoped
+        // por ciclo de request.
+        services.AddScoped<IAuthorizationHandler, AreaScopedAuthorizationHandler>();
+
+        // RequireAuthenticatedUser antes do requirement de recurso: principal
+        // anônimo é barrado na policy, sem chegar ao AreaScopedAuthorizationHandler.
+        services.AddAuthorizationBuilder()
+            .AddPolicy(
+                AreaScopedPolicies.RequireAreaProprietario,
+                policy => policy
+                    .RequireAuthenticatedUser()
+                    .AddRequirements(new RequireAreaProprietarioRequirement()));
+
+        return services;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/AreaDeInteresseBinding.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/AreaDeInteresseBinding.cs
@@ -1,0 +1,95 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// Linha da junction table <c>{parent}_areas_de_interesse</c>: vincula uma
+/// entidade área-scoped a uma área de interesse com validade temporal
+/// (ADR-0057 Pattern 3, ADR-0060). É temporal por construção — adicionar ou
+/// remover um binding é <c>INSERT</c> de nova linha / <c>UPDATE valid_to</c>,
+/// nunca <c>DELETE</c>; o estado atual e o histórico são a mesma tabela, com
+/// queries diferentes.
+/// </summary>
+/// <typeparam name="TParent">
+/// A entidade área-scoped dona da junction. Fechar o genérico (ex.:
+/// <c>AreaDeInteresseBinding&lt;Modalidade&gt;</c>) produz um tipo CLR distinto
+/// e, portanto, uma tabela EF distinta — alinhado a ADR-0060 (uma junction
+/// table por entidade área-scoped).
+/// </typeparam>
+public sealed class AreaDeInteresseBinding<TParent>
+    where TParent : class, IAreaScopedEntity
+{
+    /// <summary>FK para a entidade área-scoped dona (parte da PK composta).</summary>
+    public Guid ParentId { get; private set; }
+
+    /// <summary>Área de interesse vinculada (parte da PK composta).</summary>
+    public AreaCodigo AreaCodigo { get; private set; }
+
+    /// <summary>Início da janela de validade do vínculo (parte da PK composta).</summary>
+    public DateTimeOffset ValidoDe { get; private set; }
+
+    /// <summary>Fim da janela de validade, ou <see langword="null"/> para o vínculo vigente.</summary>
+    public DateTimeOffset? ValidoAte { get; private set; }
+
+    /// <summary>Identificador (<c>sub</c> do JWT) do admin que adicionou o vínculo.</summary>
+    public string AdicionadoPor { get; private set; }
+
+    private AreaDeInteresseBinding(
+        Guid parentId,
+        AreaCodigo areaCodigo,
+        DateTimeOffset validoDe,
+        string adicionadoPor)
+    {
+        ParentId = parentId;
+        AreaCodigo = areaCodigo;
+        ValidoDe = validoDe;
+        AdicionadoPor = adicionadoPor;
+    }
+
+    // Construtor de materialização do EF Core.
+    private AreaDeInteresseBinding() => AdicionadoPor = string.Empty;
+
+    /// <summary>
+    /// Abre um vínculo vigente (<see cref="ValidoAte"/> nulo) entre a entidade
+    /// área-scoped e a área de interesse.
+    /// </summary>
+    [SuppressMessage(
+        "Design",
+        "CA1000:Do not declare static members on generic types",
+        Justification = "Factory method em tipo genérico — mesmo padrão de Result<T> no Kernel; "
+            + "a alternativa (construtor público) viola a convenção de factory + construtor privado.")]
+    public static AreaDeInteresseBinding<TParent> Criar(
+        Guid parentId,
+        AreaCodigo areaCodigo,
+        DateTimeOffset validoDe,
+        string adicionadoPor)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(adicionadoPor);
+
+        return new AreaDeInteresseBinding<TParent>(parentId, areaCodigo, validoDe, adicionadoPor);
+    }
+
+    /// <summary>
+    /// Encerra a janela de validade do vínculo. O encerramento é a forma
+    /// canônica de "remover" um binding — a linha permanece como histórico.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Quando <paramref name="validoAte"/> não é posterior a
+    /// <see cref="ValidoDe"/> — uma janela vazia ou invertida não tem
+    /// significado e o <c>tstzrange</c> do exclusion constraint a rejeitaria
+    /// tarde, no banco.
+    /// </exception>
+    public void Encerrar(DateTimeOffset validoAte)
+    {
+        if (validoAte <= ValidoDe)
+        {
+            throw new ArgumentException(
+                $"validoAte ({validoAte:O}) deve ser posterior a ValidoDe ({ValidoDe:O}).",
+                nameof(validoAte));
+        }
+
+        ValidoAte = validoAte;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Configurations/AreaVisibilityConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Configurations/AreaVisibilityConfiguration.cs
@@ -1,0 +1,168 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Configurations;
+
+using System.Text.RegularExpressions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+
+/// <summary>
+/// Base templatada das configurações EF Core de entidades área-scoped
+/// (ADR-0060). Mapeia, junto da entidade, a sua junction table
+/// <c>{prefixo}_areas_de_interesse</c> de <c>AreasDeInteresse</c> com validade
+/// temporal: PK composta, FK <c>ON DELETE RESTRICT</c> e índice parcial dos
+/// vínculos vigentes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// O exclusion constraint GIST que impede janelas sobrepostas NÃO é
+/// expressável no fluent API do EF — é emitido via SQL bruto na migration da
+/// entidade (ver <see cref="JunctionTableMigrationHelper"/>). Esta classe
+/// configura tudo que o modelo EF consegue expressar.
+/// </para>
+/// <para>
+/// Uso canônico — a config concreta herda a base, passa o prefixo singular da
+/// tabela ao construtor e invoca <see cref="ConfigureAreaVisibility"/>:
+/// </para>
+/// <code>
+/// public sealed class ModalidadeConfiguration()
+///     : AreaVisibilityConfiguration&lt;Modalidade&gt;("modalidade")
+/// {
+///     public override void Configure(EntityTypeBuilder&lt;Modalidade&gt; builder)
+///     {
+///         builder.ToTable("modalidades");
+///         // ... colunas específicas da Modalidade
+///         ConfigureAreaVisibility(builder);
+///     }
+/// }
+/// </code>
+/// <para>
+/// <c>ApplyConfigurationsFromAssembly</c> aplica a config concreta para os
+/// DOIS tipos que ela configura: a entidade área-scoped
+/// (<typeparamref name="TParent"/>) e o
+/// <see cref="AreaDeInteresseBinding{TParent}"/> da junction.
+/// </para>
+/// </remarks>
+/// <typeparam name="TParent">A entidade área-scoped.</typeparam>
+public abstract partial class AreaVisibilityConfiguration<TParent>
+    : IEntityTypeConfiguration<TParent>,
+      IEntityTypeConfiguration<AreaDeInteresseBinding<TParent>>
+    where TParent : EntityBase, IAreaScopedEntity
+{
+    private const int AdicionadoPorMaxLength = 255;
+
+    // O nome de constraint derivado mais longo é
+    // `excl_{prefixo}_areas_de_interesse_overlap` (32 chars de fixo). O limite
+    // de identificador do PostgreSQL é 63 chars — truncamento silencioso
+    // arriscaria colisão de nomes. 31 mantém todos os identificadores derivados
+    // sob o limite com folga (prefixos de catálogo reais têm ~8-21 chars).
+    private const int MaxPrefixoLength = 31;
+
+    private readonly string _junctionTable;
+    private readonly string _parentForeignKeyColumn;
+
+    /// <param name="prefixoTabelaPai">
+    /// Prefixo singular snake_case da tabela da entidade (ex.: <c>modalidade</c>
+    /// para a tabela <c>modalidades</c>). Deriva a junction table
+    /// <c>{prefixo}_areas_de_interesse</c> e a coluna FK <c>{prefixo}_id</c>.
+    /// Deve ser snake_case minúsculo (iniciando por letra) e ter no máximo
+    /// <c>31</c> caracteres.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Quando <paramref name="prefixoTabelaPai"/> é vazio, excede 31 caracteres
+    /// ou não é snake_case minúsculo — os identificadores SQL derivados (tabela,
+    /// coluna FK, constraint GIST, índice) seriam inválidos ou longos demais.
+    /// </exception>
+    protected AreaVisibilityConfiguration(string prefixoTabelaPai)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(prefixoTabelaPai);
+
+        if (prefixoTabelaPai.Length > MaxPrefixoLength)
+        {
+            throw new ArgumentException(
+                $"prefixoTabelaPai '{prefixoTabelaPai}' excede {MaxPrefixoLength} caracteres — "
+                + "a constraint GIST derivada estouraria o limite de 63 chars de identificador do PostgreSQL.",
+                nameof(prefixoTabelaPai));
+        }
+
+        if (!PrefixoSnakeCase().IsMatch(prefixoTabelaPai))
+        {
+            throw new ArgumentException(
+                $"prefixoTabelaPai '{prefixoTabelaPai}' deve ser snake_case minúsculo "
+                + "(letra minúscula inicial, depois letras minúsculas, dígitos ou underscore).",
+                nameof(prefixoTabelaPai));
+        }
+
+        _junctionTable = $"{prefixoTabelaPai}_areas_de_interesse";
+        _parentForeignKeyColumn = $"{prefixoTabelaPai}_id";
+    }
+
+    // snake_case minúsculo, iniciando por letra — garante que tabela, coluna FK,
+    // constraint e índice derivados sejam identificadores PostgreSQL válidos.
+    [GeneratedRegex("^[a-z][a-z0-9_]*$")]
+    private static partial Regex PrefixoSnakeCase();
+
+    /// <summary>Nome da junction table (ex.: <c>modalidade_areas_de_interesse</c>).</summary>
+    public string JunctionTable => _junctionTable;
+
+    /// <summary>Nome da coluna FK para a entidade pai (ex.: <c>modalidade_id</c>).</summary>
+    public string ParentForeignKeyColumn => _parentForeignKeyColumn;
+
+    /// <summary>
+    /// Configuração da entidade área-scoped — implementada pela config concreta,
+    /// que deve invocar <see cref="ConfigureAreaVisibility"/>.
+    /// </summary>
+    public abstract void Configure(EntityTypeBuilder<TParent> builder);
+
+    /// <summary>
+    /// Declara, no lado da entidade pai, o relacionamento com a junction table:
+    /// FK para <see cref="AreaDeInteresseBinding{TParent}.ParentId"/> com
+    /// <c>ON DELETE RESTRICT</c> (ADR-0060). Invocado pela config concreta
+    /// dentro do seu <see cref="Configure(EntityTypeBuilder{TParent})"/>.
+    /// </summary>
+    protected void ConfigureAreaVisibility(EntityTypeBuilder<TParent> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder
+            .HasMany<AreaDeInteresseBinding<TParent>>()
+            .WithOne()
+            .HasForeignKey(binding => binding.ParentId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+
+    /// <summary>
+    /// Configuração da junction table — aplicada pela base. Mapeada como
+    /// implementação explícita de interface porque a config concreta só
+    /// sobrescreve <see cref="Configure(EntityTypeBuilder{TParent})"/>.
+    /// </summary>
+    void IEntityTypeConfiguration<AreaDeInteresseBinding<TParent>>.Configure(
+        EntityTypeBuilder<AreaDeInteresseBinding<TParent>> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(_junctionTable);
+
+        builder.HasKey(binding => new { binding.ParentId, binding.AreaCodigo, binding.ValidoDe });
+
+        builder.Property(binding => binding.ParentId).HasColumnName(_parentForeignKeyColumn);
+        builder.Property(binding => binding.AreaCodigo).HasColumnName("area_codigo");
+        builder.Property(binding => binding.ValidoDe).HasColumnName("valid_from");
+        builder.Property(binding => binding.ValidoAte).HasColumnName("valid_to");
+        builder.Property(binding => binding.AdicionadoPor)
+            .HasColumnName("added_by")
+            .HasMaxLength(AdicionadoPorMaxLength)
+            .IsRequired();
+
+        // Índice parcial dos vínculos vigentes — hot path da query de
+        // visibilidade (ADR-0060). O exclusion constraint GIST de não
+        // sobreposição é emitido à parte via JunctionTableMigrationHelper.
+        builder
+            .HasIndex(binding => new { binding.ParentId, binding.AreaCodigo })
+            .HasFilter("valid_to IS NULL")
+            .HasDatabaseName($"ix_{_junctionTable}_vigentes");
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/AreaCodigoValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/AreaCodigoValueConverter.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+
+// Mapeia AreaCodigo <-> string (varchar) no banco, com fail-fast nos dois
+// sentidos:
+//  - Escrita: default(AreaCodigo) tem Value null e é estado inválido (nunca
+//    produzido por From). Persistir como NULL ficaria indistinguível de
+//    "sem proprietário" numa coluna AreaCodigo? — então falha alto na escrita.
+//  - Leitura: dado corrompido (alteração manual da coluna) falha alto via
+//    InvalidOperationException com contexto, em vez de produzir um
+//    default(AreaCodigo) e NRE tardia no primeiro uso.
+//
+// ValueObjectMaterialization.Reidratar não é reutilizável aqui: tem
+// restrição `where T : class` e AreaCodigo é um record struct. O fail-fast
+// é replicado localmente com a mesma semântica.
+public sealed class AreaCodigoValueConverter : ValueConverter<AreaCodigo, string>
+{
+    public AreaCodigoValueConverter()
+        : base(
+            codigo => ParaProvider(codigo),
+            valor => Reidratar(valor))
+    {
+    }
+
+    private static string ParaProvider(AreaCodigo codigo)
+    {
+        if (codigo.Value is null)
+        {
+            throw new InvalidOperationException(
+                "Tentativa de persistir default(AreaCodigo): valor não inicializado. "
+                + "AreaCodigo válido só é produzido por AreaCodigo.From; "
+                + "uma coluna sem proprietário deve usar AreaCodigo? nulo, não o struct default.");
+        }
+
+        return codigo.Value;
+    }
+
+    private static AreaCodigo Reidratar(string valor)
+    {
+        Result<AreaCodigo> resultado = AreaCodigo.From(valor);
+        if (resultado.IsFailure)
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar AreaCodigo: '{valor}' "
+                + $"({resultado.Error!.Code}). "
+                + "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return resultado.Value!;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/ValueObjectConventions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/ValueObjectConventions.cs
@@ -2,13 +2,15 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
 
 using Microsoft.EntityFrameworkCore;
 
+using Unifesspa.UniPlus.Governance.Contracts;
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
 
-// Convenções de mapeamento dos Value Objects do Kernel para o EF Core.
+// Convenções de mapeamento dos Value Objects para o EF Core.
 // Chamado no override `ConfigureConventions` dos DbContexts dos módulos
-// (Selecao, Ingresso, Portal) para que toda propriedade tipada como
-// Cpf/Email/NomeSocial/NotaFinal receba o converter e as restrições de
-// coluna apropriadas (tipo, tamanho máximo, precisão).
+// (Selecao, Ingresso, Portal, e os módulos da Sprint 3) para que toda
+// propriedade tipada como Cpf/Email/NomeSocial/NotaFinal/AreaCodigo receba
+// o converter e as restrições de coluna apropriadas (tipo, tamanho máximo,
+// precisão).
 //
 // IMPORTANTE — incompatível com `OwnsOne` para os mesmos VOs:
 // se um IEntityTypeConfiguration<T> existente mapeia Cpf/Email/NomeSocial
@@ -40,6 +42,10 @@ public static class ValueObjectConventions
     private const int NotaFinalPrecision = 9;
     private const int NotaFinalScale = 4;
 
+    // AreaCodigo é normalizado para 2-32 caracteres uppercase ASCII pelo VO
+    // (ADR-0055). `varchar(32)` enforça o limite no schema.
+    private const int AreaCodigoMaxLength = 32;
+
     public static void ConfigureValueObjectConverters(this ModelConfigurationBuilder configurationBuilder)
     {
         ArgumentNullException.ThrowIfNull(configurationBuilder);
@@ -60,5 +66,10 @@ public static class ValueObjectConventions
         configurationBuilder.Properties<NotaFinal>()
             .HaveConversion<NotaFinalValueConverter>()
             .HavePrecision(NotaFinalPrecision, NotaFinalScale);
+
+        configurationBuilder.Properties<AreaCodigo>()
+            .HaveConversion<AreaCodigoValueConverter>()
+            .HaveColumnType($"varchar({AreaCodigoMaxLength})")
+            .HaveMaxLength(AreaCodigoMaxLength);
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/JunctionTableMigrationHelper.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/JunctionTableMigrationHelper.cs
@@ -1,0 +1,57 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <summary>
+/// Emite o exclusion constraint GIST das junction tables de
+/// <c>AreasDeInteresse</c> (ADR-0060). O EF Core não expressa
+/// <c>EXCLUDE USING GIST</c> no fluent API — o resto da junction table
+/// (colunas, PK, FK, índice parcial) vem do modelo EF via
+/// <see cref="Configurations.AreaVisibilityConfiguration{TParent}"/>; só
+/// esta constraint é SQL bruto, emitido na migration logo após o
+/// <c>CreateTable</c> gerado pelo EF.
+/// </summary>
+/// <remarks>
+/// Requer a extensão <c>btree_gist</c> provisionada no banco — em dev via
+/// <c>docker/init-db.sql</c>; em standalone/HML/PROD via a primeira migration
+/// do DbContext (<c>CREATE EXTENSION IF NOT EXISTS btree_gist</c>).
+/// </remarks>
+public static class JunctionTableMigrationHelper
+{
+    /// <summary>
+    /// SQL do exclusion constraint que impede janelas de validade sobrepostas
+    /// para o mesmo <c>(parent, área)</c> numa junction table.
+    /// </summary>
+    /// <param name="junctionTable">Nome da junction table (ex.: <c>modalidade_areas_de_interesse</c>).</param>
+    /// <param name="parentForeignKeyColumn">Nome da coluna FK para o pai (ex.: <c>modalidade_id</c>).</param>
+    public static string ExclusionConstraintSql(string junctionTable, string parentForeignKeyColumn)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(junctionTable);
+        ArgumentException.ThrowIfNullOrWhiteSpace(parentForeignKeyColumn);
+
+        return $"""
+            ALTER TABLE {junctionTable}
+              ADD CONSTRAINT excl_{junctionTable}_overlap
+              EXCLUDE USING GIST (
+                {parentForeignKeyColumn} WITH =,
+                area_codigo WITH =,
+                tstzrange(valid_from, valid_to, '[)') WITH &&
+              );
+            """;
+    }
+
+    /// <summary>
+    /// Adiciona o exclusion constraint GIST à junction table via
+    /// <see cref="MigrationBuilder.Sql(string, bool)"/>. Chamado na migration
+    /// logo após o <c>CreateTable</c> gerado pelo EF para a junction.
+    /// </summary>
+    public static void AddAreaDeInteresseExclusionConstraint(
+        this MigrationBuilder migrationBuilder,
+        string junctionTable,
+        string parentForeignKeyColumn)
+    {
+        ArgumentNullException.ThrowIfNull(migrationBuilder);
+
+        migrationBuilder.Sql(ExclusionConstraintSql(junctionTable, parentForeignKeyColumn));
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Unifesspa.UniPlus.Application.Abstractions\Unifesspa.UniPlus.Application.Abstractions.csproj" />
     <ProjectReference Include="..\Unifesspa.UniPlus.Kernel\Unifesspa.UniPlus.Kernel.csproj" />
+    <ProjectReference Include="..\Unifesspa.UniPlus.Governance.Contracts\Unifesspa.UniPlus.Governance.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
@@ -1208,6 +1208,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
@@ -1211,6 +1211,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },

--- a/tests/Unifesspa.UniPlus.Application.Abstractions.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Application.Abstractions.UnitTests/packages.lock.json
@@ -143,6 +143,13 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -1099,6 +1099,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1123,6 +1129,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -1096,6 +1096,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Governance.Contracts.UnitTests/AreaCodigoTests.cs
+++ b/tests/Unifesspa.UniPlus.Governance.Contracts.UnitTests/AreaCodigoTests.cs
@@ -1,0 +1,190 @@
+namespace Unifesspa.UniPlus.Governance.Contracts.UnitTests;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AreaCodigoTests
+{
+    // ─── Factory — caminhos felizes + normalização ─────────────────────────
+
+    [Theory]
+    [InlineData("CEPS", "CEPS")]
+    [InlineData("ceps", "CEPS")]
+    [InlineData("CePs", "CEPS")]
+    [InlineData("  ceps  ", "CEPS")]
+    [InlineData("CEPS_ADMIN", "CEPS_ADMIN")]
+    [InlineData("_CEPS", "_CEPS")]
+    [InlineData("AREA2", "AREA2")]
+    public void From_DadoCodigoValido_DeveNormalizarParaUppercase(string entrada, string esperado)
+    {
+        Result<AreaCodigo> resultado = AreaCodigo.From(entrada);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Value.Should().Be(esperado);
+    }
+
+    [Theory]
+    [InlineData("CE", "comprimento mínimo (2)")]
+    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ012345", "comprimento máximo (32)")]
+    public void From_DadoCodigoNosLimitesDeComprimento_DeveRetornarSuccess(string entrada, string razao)
+    {
+        Result<AreaCodigo> resultado = AreaCodigo.From(entrada);
+
+        resultado.IsSuccess.Should().BeTrue(razao);
+    }
+
+    // ─── Factory — validações ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void From_DadoCodigoVazioOuNulo_DeveRetornarFailure(string? entrada)
+    {
+        Result<AreaCodigo> resultado = AreaCodigo.From(entrada);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AreaCodigo.CodigoErroInvalido);
+    }
+
+    [Theory]
+    [InlineData("A", "menos de 2 caracteres")]
+    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456", "mais de 32 caracteres")]
+    [InlineData("1CEPS", "inicia por dígito")]
+    [InlineData("9", "dígito único")]
+    [InlineData("CEPS-ADMIN", "hífen não é permitido")]
+    [InlineData("CEPS ADMIN", "espaço não é permitido")]
+    [InlineData("CEPS.ADMIN", "ponto não é permitido")]
+    [InlineData("ÁREA", "caractere não-ASCII")]
+    public void From_DadoCodigoComFormatoInvalido_DeveRetornarFailure(string entrada, string razao)
+    {
+        Result<AreaCodigo> resultado = AreaCodigo.From(entrada);
+
+        resultado.IsFailure.Should().BeTrue(razao);
+        resultado.Error!.Code.Should().Be(AreaCodigo.CodigoErroInvalido, razao);
+    }
+
+    // ─── Igualdade de record struct ────────────────────────────────────────
+
+    [Fact]
+    public void From_DoisCodigosComMesmoValorAposNormalizacao_DevemSerIguais()
+    {
+        AreaCodigo a = AreaCodigo.From("CEPS").Value!;
+        AreaCodigo b = AreaCodigo.From("ceps").Value!;
+
+        a.Should().Be(b, "record struct compara por valor após normalização");
+        (a == b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    // ─── ToString + ordenação ──────────────────────────────────────────────
+
+    [Fact]
+    public void ToString_DeveRetornarOValorNormalizado()
+    {
+        AreaCodigo codigo = AreaCodigo.From("ceps").Value!;
+
+        codigo.ToString().Should().Be("CEPS");
+    }
+
+    [Fact]
+    public void CompareTo_DeveOrdenarOrdinalmentePorValor()
+    {
+        AreaCodigo ceps = AreaCodigo.From("CEPS").Value!;
+        AreaCodigo crca = AreaCodigo.From("CRCA").Value!;
+
+        ceps.CompareTo(crca).Should().BeNegative();
+        crca.CompareTo(ceps).Should().BePositive();
+        ceps.CompareTo(ceps).Should().Be(0);
+    }
+
+    [Fact]
+    public void OperadoresDeComparacao_DevemRefletirOrdenacaoOrdinal()
+    {
+        AreaCodigo ceps = AreaCodigo.From("CEPS").Value!;
+        AreaCodigo cepsBis = AreaCodigo.From("ceps").Value!;
+        AreaCodigo crca = AreaCodigo.From("CRCA").Value!;
+
+        (ceps < crca).Should().BeTrue();
+        (ceps <= crca).Should().BeTrue();
+        (crca > ceps).Should().BeTrue();
+        (crca >= ceps).Should().BeTrue();
+        (ceps <= cepsBis).Should().BeTrue("códigos iguais satisfazem <=");
+        (ceps >= cepsBis).Should().BeTrue("códigos iguais satisfazem >=");
+    }
+
+    // ─── default(AreaCodigo) — estado inválido nunca produzido por From ────
+
+    [Fact]
+    public void Default_DeveTerValueNuloEToStringVazia()
+    {
+        AreaCodigo padrao = default;
+
+        padrao.Value.Should().BeNull("default(AreaCodigo) nunca é produzido por From");
+        padrao.ToString().Should().BeEmpty("ToString trata default graciosamente, sem NRE");
+    }
+
+    [Fact]
+    public void Default_DeveOrdenarAntesDeQualquerCodigoValido()
+    {
+        AreaCodigo padrao = default;
+        AreaCodigo ceps = AreaCodigo.From("CEPS").Value!;
+
+        padrao.CompareTo(ceps).Should().BeNegative();
+        padrao.CompareTo(default).Should().Be(0);
+    }
+
+    // ─── Serialização JSON — string plana ──────────────────────────────────
+
+    [Fact]
+    public void Json_DeveSerializarComoStringPlana()
+    {
+        AreaCodigo codigo = AreaCodigo.From("CEPS").Value!;
+
+        string json = JsonSerializer.Serialize(codigo);
+
+        json.Should().Be("\"CEPS\"");
+    }
+
+    [Fact]
+    public void Json_RoundTrip_DevePreservarOValor()
+    {
+        AreaCodigo original = AreaCodigo.From("PLATAFORMA").Value!;
+
+        string json = JsonSerializer.Serialize(original);
+        AreaCodigo recuperado = JsonSerializer.Deserialize<AreaCodigo>(json);
+
+        recuperado.Should().Be(original);
+    }
+
+    [Fact]
+    public void Json_DeserializarStringInvalida_DeveLancarJsonException()
+    {
+        Action desserializar = () => JsonSerializer.Deserialize<AreaCodigo>("\"1invalido\"");
+
+        desserializar.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Json_DeserializarTokenNaoString_DeveLancarJsonException()
+    {
+        Action desserializar = () => JsonSerializer.Deserialize<AreaCodigo>("123");
+
+        desserializar.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Json_SerializarDefault_DeveLancarJsonException()
+    {
+        // default(AreaCodigo) tem Value null — estado inválido nunca produzido
+        // por From. A escrita falha alto, simétrica com a leitura que rejeita
+        // token null.
+        Action serializar = () => JsonSerializer.Serialize(default(AreaCodigo));
+
+        serializar.Should().Throw<JsonException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Governance.Contracts.UnitTests/Unifesspa.UniPlus.Governance.Contracts.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Governance.Contracts.UnitTests/Unifesspa.UniPlus.Governance.Contracts.UnitTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="AwesomeAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\shared\Unifesspa.UniPlus.Governance.Contracts\Unifesspa.UniPlus.Governance.Contracts.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.Governance.Contracts.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Governance.Contracts.UnitTests/packages.lock.json
@@ -1,0 +1,119 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.4.0, )",
+        "resolved": "9.4.0",
+        "contentHash": "dJxkWiQ8D+xT6Gr2sSL83+Mar+Vpy2JTcUPxFcckpPJ8VYBfSgnk+zqpS6t7kcGnjz8NLyF14qfuoL4bKzzoew=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Persistence/Configurations/AreaVisibilityConfigurationIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Persistence/Configurations/AreaVisibilityConfigurationIntegrationTests.cs
@@ -1,0 +1,248 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Persistence.Configurations;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Npgsql;
+
+using Testcontainers.PostgreSql;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Configurations;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+
+// Valida a junction table de AreaVisibilityConfiguration<TParent> contra
+// PostgreSQL real: exclusion constraint GIST de não sobreposição (ADR-0060),
+// índice parcial dos vínculos vigentes, FK e ON DELETE RESTRICT. O esquema EF
+// vem de EnsureCreatedAsync; o GIST é aplicado via JunctionTableMigrationHelper.
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção xUnit para classes de teste.")]
+public sealed class AreaVisibilityConfigurationIntegrationTests : IAsyncLifetime
+{
+    private const string JunctionTable = "entidade_area_scoped_areas_de_interesse";
+    private const string ParentFkColumn = "entidade_area_scoped_id";
+
+    private static readonly AreaCodigo Ceps = AreaCodigo.From("CEPS").Value!;
+    private static readonly DateTimeOffset T0 = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset TMeio = new(2026, 3, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset T1 = new(2026, 6, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset T2 = new(2026, 9, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_area_visibility_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync();
+
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        // btree_gist + o exclusion constraint GIST não vêm do modelo EF —
+        // em produção a primeira migration os emite; aqui replicamos o passo.
+        await using NpgsqlConnection conexao = new(_postgres.GetConnectionString());
+        await conexao.OpenAsync();
+        await ExecutarAsync(conexao, "CREATE EXTENSION IF NOT EXISTS btree_gist;");
+        await ExecutarAsync(
+            conexao,
+            JunctionTableMigrationHelper.ExclusionConstraintSql(JunctionTable, ParentFkColumn));
+    }
+
+    public Task DisposeAsync() => _postgres.DisposeAsync().AsTask();
+
+    [Fact(DisplayName = "GIST — janelas de validade disjuntas para o mesmo (pai, área) são aceitas")]
+    public async Task Gist_JanelasDisjuntas_SaoAceitas()
+    {
+        await using TestDbContext context = CriarContext();
+        EntidadeAreaScopedFicticia pai = await SemearEntidadeAsync(context);
+
+        context.Bindings.Add(Binding(pai.Id, Ceps, T0, T1));
+        context.Bindings.Add(Binding(pai.Id, Ceps, T2, validoAte: null));
+
+        Func<Task> salvar = () => context.SaveChangesAsync();
+
+        await salvar.Should().NotThrowAsync("[T0,T1) e [T2,∞) não se sobrepõem");
+    }
+
+    [Fact(DisplayName = "GIST — janelas sobrepostas para o mesmo (pai, área) violam o exclusion constraint")]
+    public async Task Gist_JanelasSobrepostas_ViolamOConstraint()
+    {
+        await using TestDbContext context = CriarContext();
+        EntidadeAreaScopedFicticia pai = await SemearEntidadeAsync(context);
+
+        context.Bindings.Add(Binding(pai.Id, Ceps, T0, T1));
+        context.Bindings.Add(Binding(pai.Id, Ceps, TMeio, validoAte: null));
+
+        Func<Task> salvar = () => context.SaveChangesAsync();
+
+        (await salvar.Should().ThrowAsync<DbUpdateException>()
+            .WithInnerException<DbUpdateException, PostgresException>())
+            .Which.SqlState.Should().Be(
+                PostgresErrorCodes.ExclusionViolation,
+                "[T0,T1) e [TMeio,∞) se sobrepõem");
+    }
+
+    [Fact(DisplayName = "Índice parcial — ix_{junction}_vigentes existe filtrando valid_to IS NULL")]
+    public async Task IndiceParcial_DosVinculosVigentes_Existe()
+    {
+        await using NpgsqlConnection conexao = new(_postgres.GetConnectionString());
+        await conexao.OpenAsync();
+        await using NpgsqlCommand cmd = new(
+            "SELECT indexdef FROM pg_indexes WHERE indexname = @nome",
+            conexao);
+        cmd.Parameters.AddWithValue("nome", $"ix_{JunctionTable}_vigentes");
+
+        object? indexDef = await cmd.ExecuteScalarAsync();
+
+        indexDef.Should().NotBeNull("o índice parcial dos vínculos vigentes deve existir");
+        ((string)indexDef!).Should().Contain("valid_to IS NULL");
+    }
+
+    [Fact(DisplayName = "FK — binding com parent_id inexistente viola foreign key")]
+    public async Task Fk_ParentIdInexistente_ViolaForeignKey()
+    {
+        await using TestDbContext context = CriarContext();
+        context.Bindings.Add(Binding(Guid.CreateVersion7(), Ceps, T0, validoAte: null));
+
+        Func<Task> salvar = () => context.SaveChangesAsync();
+
+        (await salvar.Should().ThrowAsync<DbUpdateException>()
+            .WithInnerException<DbUpdateException, PostgresException>())
+            .Which.SqlState.Should().Be(PostgresErrorCodes.ForeignKeyViolation);
+    }
+
+    [Fact(DisplayName = "ON DELETE RESTRICT — apagar a entidade pai com bindings é bloqueado pelo banco")]
+    public async Task OnDeleteRestrict_ApagarPaiComBindings_EBloqueado()
+    {
+        Guid paiId;
+        await using (TestDbContext semeador = CriarContext())
+        {
+            EntidadeAreaScopedFicticia pai = EntidadeAreaScopedFicticia.Criar("Entidade de teste");
+            semeador.Entidades.Add(pai);
+            semeador.Bindings.Add(Binding(pai.Id, Ceps, T0, validoAte: null));
+            await semeador.SaveChangesAsync();
+            paiId = pai.Id;
+        }
+
+        // Context novo: o binding não está rastreado, então o EF emite o
+        // DELETE e a FK ON DELETE RESTRICT do banco é quem bloqueia.
+        await using TestDbContext context = CriarContext();
+        EntidadeAreaScopedFicticia paraApagar = await context.Entidades.SingleAsync(e => e.Id == paiId);
+        context.Entidades.Remove(paraApagar);
+        Func<Task> apagar = () => context.SaveChangesAsync();
+
+        // 23001 (restrict_violation), não 23503: o PG levanta esse código
+        // específico justamente porque a FK foi criada com ON DELETE RESTRICT
+        // literal — o que confirma que o EF não degradou para NO ACTION.
+        (await apagar.Should().ThrowAsync<DbUpdateException>()
+            .WithInnerException<DbUpdateException, PostgresException>())
+            .Which.SqlState.Should().Be(
+                PostgresErrorCodes.RestrictViolation,
+                "ADR-0060: a FK da junction é ON DELETE RESTRICT");
+    }
+
+    private static AreaDeInteresseBinding<EntidadeAreaScopedFicticia> Binding(
+        Guid parentId, AreaCodigo area, DateTimeOffset validoDe, DateTimeOffset? validoAte)
+    {
+        AreaDeInteresseBinding<EntidadeAreaScopedFicticia> binding =
+            AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.Criar(parentId, area, validoDe, "sub-teste");
+        if (validoAte is not null)
+        {
+            binding.Encerrar(validoAte.Value);
+        }
+
+        return binding;
+    }
+
+    private static async Task<EntidadeAreaScopedFicticia> SemearEntidadeAsync(TestDbContext context)
+    {
+        EntidadeAreaScopedFicticia pai = EntidadeAreaScopedFicticia.Criar("Entidade de teste");
+        context.Entidades.Add(pai);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+        return pai;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Security",
+        "CA2100:Review SQL queries for security vulnerabilities",
+        Justification = "DDL de teste com entrada controlada — literais e o SQL gerado por "
+            + "JunctionTableMigrationHelper; não há entrada de usuário.")]
+    private static async Task ExecutarAsync(NpgsqlConnection conexao, string sql)
+    {
+        await using NpgsqlCommand cmd = new(sql, conexao);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private TestDbContext CriarContext()
+    {
+        DbContextOptionsBuilder<TestDbContext> options = new();
+        options.UseNpgsql(_postgres.GetConnectionString());
+        return new TestDbContext(options.Options);
+    }
+
+    // ─── Fixtures de teste ─────────────────────────────────────────────────
+
+    private sealed class EntidadeAreaScopedFicticia : EntityBase, IAreaScopedEntity
+    {
+        public AreaCodigo? Proprietario { get; private set; }
+
+        public string Nome { get; private set; } = string.Empty;
+
+        private EntidadeAreaScopedFicticia()
+        {
+        }
+
+        public static EntidadeAreaScopedFicticia Criar(string nome) => new() { Nome = nome };
+    }
+
+    private sealed class EntidadeAreaScopedFicticiaConfiguration()
+        : AreaVisibilityConfiguration<EntidadeAreaScopedFicticia>("entidade_area_scoped")
+    {
+        public override void Configure(
+            Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<EntidadeAreaScopedFicticia> builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            builder.ToTable("entidades_area_scoped_ficticias");
+            builder.HasKey(e => e.Id);
+            builder.Property(e => e.Nome).HasMaxLength(200).IsRequired();
+            ConfigureAreaVisibility(builder);
+        }
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciada pelo EF Core e por CriarContext.")]
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        public DbSet<EntidadeAreaScopedFicticia> Entidades => Set<EntidadeAreaScopedFicticia>();
+
+        public DbSet<AreaDeInteresseBinding<EntidadeAreaScopedFicticia>> Bindings =>
+            Set<AreaDeInteresseBinding<EntidadeAreaScopedFicticia>>();
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+        {
+            base.ConfigureConventions(configurationBuilder);
+            configurationBuilder.ConfigureValueObjectConverters();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            EntidadeAreaScopedFicticiaConfiguration config = new();
+            modelBuilder.ApplyConfiguration<EntidadeAreaScopedFicticia>(config);
+            modelBuilder.ApplyConfiguration<AreaDeInteresseBinding<EntidadeAreaScopedFicticia>>(config);
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Persistence/Converters/AreaCodigoValueConverterIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Persistence/Converters/AreaCodigoValueConverterIntegrationTests.cs
@@ -1,0 +1,184 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.Persistence.Converters;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Testcontainers.PostgreSql;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+
+// Valida AreaCodigo end-to-end contra PostgreSQL real, exercitando a
+// convenção global ConfigureValueObjectConverters (não HasConversion manual):
+// round-trip de AreaCodigo obrigatório e AreaCodigo? nullable, schema gerado
+// (varchar(32)) e o fail-fast quando a coluna é corrompida.
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção xUnit para classes de teste.")]
+public sealed class AreaCodigoValueConverterIntegrationTests : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_areacodigo_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    public Task InitializeAsync() => _postgres.StartAsync();
+
+    public Task DisposeAsync() => _postgres.DisposeAsync().AsTask();
+
+    [Fact(DisplayName = "Round-trip — AreaCodigo obrigatório persiste e recupera idêntico")]
+    public async Task RoundTrip_AreaCodigoObrigatorio()
+    {
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        AreaCodigo codigo = AreaCodigo.From("CEPS").Value!;
+        context.Entidades.Add(EntidadeComArea.Criar(codigo, proprietario: null));
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        EntidadeComArea lida = await context.Entidades.AsNoTracking().SingleAsync();
+
+        lida.Codigo.Should().Be(codigo);
+        lida.ProprietarioOpcional.Should().BeNull("AreaCodigo? não preenchido persiste como NULL");
+    }
+
+    [Fact(DisplayName = "Round-trip — AreaCodigo? nullable preenchido persiste e recupera")]
+    public async Task RoundTrip_AreaCodigoNullablePreenchido()
+    {
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        AreaCodigo codigo = AreaCodigo.From("PROEG").Value!;
+        AreaCodigo proprietario = AreaCodigo.From("PLATAFORMA").Value!;
+        context.Entidades.Add(EntidadeComArea.Criar(codigo, proprietario));
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        EntidadeComArea lida = await context.Entidades.AsNoTracking().SingleAsync();
+
+        lida.Codigo.Should().Be(codigo);
+        lida.ProprietarioOpcional.Should().Be(proprietario);
+    }
+
+    [Fact(DisplayName = "Schema — convenção global gera coluna varchar(32) para AreaCodigo")]
+    public async Task Schema_ConvencaoGeraVarchar32()
+    {
+        // Confirma que ConfigureValueObjectConverters (e não um HasConversion
+        // pontual) aplicou o converter + o tipo de coluna. Falha aqui = o
+        // AreaCodigoValueConverter não está registrado em ValueObjectConventions.
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        await using Npgsql.NpgsqlConnection conexao = new(_postgres.GetConnectionString());
+        await conexao.OpenAsync();
+        await using Npgsql.NpgsqlCommand cmd = new(
+            """
+            SELECT column_name, udt_name, character_maximum_length
+              FROM information_schema.columns
+             WHERE table_name = 'entidades_com_area' AND column_name IN ('codigo', 'proprietario')
+            """,
+            conexao);
+
+        Dictionary<string, (string Udt, int? MaxLength)> colunas = [];
+        await using Npgsql.NpgsqlDataReader reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            colunas[reader.GetString(0)] = (
+                reader.GetString(1),
+                await reader.IsDBNullAsync(2) ? null : reader.GetInt32(2));
+        }
+
+        colunas["codigo"].Udt.Should().Be("varchar");
+        colunas["codigo"].MaxLength.Should().Be(32);
+        colunas["proprietario"].Udt.Should().Be("varchar");
+        colunas["proprietario"].MaxLength.Should().Be(32);
+    }
+
+    [Fact(DisplayName = "Materialização — coluna corrompida lança InvalidOperationException com contexto")]
+    public async Task Materializacao_DadoCorrompido_LancaComContexto()
+    {
+        // Simula corrupção: a coluna varchar aceita qualquer string, mas
+        // '1-invalido' não passa em AreaCodigo.From (inicia por dígito, tem
+        // hífen). A leitura via converter deve falhar alto com
+        // InvalidOperationException citando o VO e o código do erro — não
+        // produzir um default(AreaCodigo) silencioso.
+        await using TestDbContext context = CriarContext();
+        await context.Database.EnsureCreatedAsync();
+
+        context.Entidades.Add(EntidadeComArea.Criar(AreaCodigo.From("CEPS").Value!, proprietario: null));
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        await using Npgsql.NpgsqlConnection conexao = new(_postgres.GetConnectionString());
+        await conexao.OpenAsync();
+        await using Npgsql.NpgsqlCommand corromper = new(
+            "UPDATE entidades_com_area SET codigo = '1-invalido'", conexao);
+        await corromper.ExecuteNonQueryAsync();
+
+        Func<Task> leitura = async () => await context.Entidades.AsNoTracking().SingleAsync();
+
+        await leitura.Should().ThrowAsync<InvalidOperationException>()
+            .Where(e => e.Message.Contains(nameof(AreaCodigo), StringComparison.Ordinal)
+                     && e.Message.Contains(AreaCodigo.CodigoErroInvalido, StringComparison.Ordinal));
+    }
+
+    private TestDbContext CriarContext()
+    {
+        DbContextOptionsBuilder<TestDbContext> options = new();
+        options.UseNpgsql(_postgres.GetConnectionString());
+        return new TestDbContext(options.Options);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciada pelo EF Core e por CriarContext.")]
+    private sealed class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        public DbSet<EntidadeComArea> Entidades => Set<EntidadeComArea>();
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+        {
+            base.ConfigureConventions(configurationBuilder);
+            configurationBuilder.ConfigureValueObjectConverters();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<EntidadeComArea>(b =>
+            {
+                b.ToTable("entidades_com_area");
+                // Apenas o nome da coluna — o converter e o tipo (varchar(32))
+                // vêm da convenção global ConfigureValueObjectConverters.
+                b.Property(e => e.Codigo).HasColumnName("codigo");
+                b.Property(e => e.ProprietarioOpcional).HasColumnName("proprietario");
+            });
+        }
+    }
+
+    // Agregado de teste — herda EntityBase para ganhar Id UUIDv7 e audit;
+    // existe só para exercitar o AreaCodigoValueConverter via convenção.
+    private sealed class EntidadeComArea : EntityBase
+    {
+        public AreaCodigo Codigo { get; private set; }
+
+        public AreaCodigo? ProprietarioOpcional { get; private set; }
+
+        private EntidadeComArea()
+        {
+        }
+
+        public static EntidadeComArea Criar(AreaCodigo codigo, AreaCodigo? proprietario) =>
+            new()
+            {
+                Codigo = codigo,
+                ProprietarioOpcional = proprietario,
+            };
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -1120,6 +1120,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -1123,6 +1123,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1147,6 +1153,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/HttpUserContextTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authentication/HttpUserContextTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using NSubstitute;
 
+using Unifesspa.UniPlus.Governance.Contracts;
 using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
 
 public sealed class HttpUserContextTests
@@ -69,6 +70,17 @@ public sealed class HttpUserContextTests
             new Claim("realm_access", "{ this isn't valid json"));
 
         context.Roles.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Roles_Should_SkipNonStringElements_WithoutThrowing()
+    {
+        // realm_access.roles com elementos não-string (número, objeto) é
+        // misconfiguração de IdP — deve ser ignorado, não virar 500.
+        HttpUserContext context = CreateContext(
+            new Claim("realm_access", """{ "roles": ["gestor", 123, { "x": 1 }, "admin"] }"""));
+
+        context.Roles.Should().BeEquivalentTo(["gestor", "admin"]);
     }
 
     [Fact]
@@ -209,6 +221,99 @@ public sealed class HttpUserContextTests
 
         context.IsAuthenticated.Should().BeFalse();
     }
+
+    // ─── AreasAdministradas + IsPlataformaAdmin (ADR-0055 / ADR-0057) ──────
+
+    [Fact]
+    public void AreasAdministradas_Should_DeriveAreaCodes_FromAdminRoles()
+    {
+        HttpUserContext context = CreateContext(RealmRoles("ceps-admin", "proeg-admin"));
+
+        context.AreasAdministradas.Should().BeEquivalentTo(
+        [
+            AreaCodigo.From("CEPS").Value!,
+            AreaCodigo.From("PROEG").Value!,
+        ]);
+        context.IsPlataformaAdmin.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AreasAdministradas_Should_ExcludePlataforma_WhilePlataformaAdminIsSurfacedSeparately()
+    {
+        // plataforma-admin é o bypass platform-wide — não polui AreasAdministradas.
+        HttpUserContext context = CreateContext(
+            RealmRoles("ceps-admin", "crca-admin", "plataforma-admin"));
+
+        context.AreasAdministradas.Should().BeEquivalentTo(
+        [
+            AreaCodigo.From("CEPS").Value!,
+            AreaCodigo.From("CRCA").Value!,
+        ]);
+        context.IsPlataformaAdmin.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreasAdministradas_Should_IgnoreLeitorRoles()
+    {
+        HttpUserContext context = CreateContext(RealmRoles("ceps-leitor", "crca-admin"));
+
+        context.AreasAdministradas.Should().BeEquivalentTo([AreaCodigo.From("CRCA").Value!]);
+    }
+
+    [Fact]
+    public void AreasAdministradas_Should_NormalizeCase_FromRole()
+    {
+        HttpUserContext context = CreateContext(RealmRoles("CEPS-ADMIN"));
+
+        context.AreasAdministradas.Should().ContainSingle()
+            .Which.Should().Be(AreaCodigo.From("CEPS").Value!);
+    }
+
+    [Theory]
+    [InlineData("candidato", "role sem hífen não é role de área")]
+    [InlineData("1bad-admin", "código inicia por dígito — AreaCodigo.From falha")]
+    [InlineData("ceps-extra-admin", "código com hífen — AreaCodigo.From falha")]
+    [InlineData("-admin", "código vazio após remover o sufixo")]
+    public void AreasAdministradas_Should_SkipInvalidRoles_WithoutCrashing(string role, string razao)
+    {
+        HttpUserContext context = CreateContext(RealmRoles(role));
+
+        context.AreasAdministradas.Should().BeEmpty(razao);
+    }
+
+    [Fact]
+    public void AreasAdministradas_Should_BeEmpty_WhenNoRealmAccessClaim()
+    {
+        HttpUserContext context = CreateContext(new Claim("sub", "user-42"));
+
+        context.AreasAdministradas.Should().BeEmpty();
+        context.IsPlataformaAdmin.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AreasAdministradas_Should_BeEmpty_ForAnonymousUser()
+    {
+        IHttpContextAccessor accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+        HttpUserContext context = new(accessor, NullLogger<HttpUserContext>.Instance);
+
+        context.AreasAdministradas.Should().BeEmpty();
+        context.IsPlataformaAdmin.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AreasAdministradas_Should_CacheResult_AcrossCalls()
+    {
+        HttpUserContext context = CreateContext(RealmRoles("ceps-admin"));
+
+        IReadOnlyCollection<AreaCodigo> first = context.AreasAdministradas;
+        IReadOnlyCollection<AreaCodigo> second = context.AreasAdministradas;
+
+        second.Should().BeSameAs(first, "a coleção é resolvida uma vez por request via Lazy");
+    }
+
+    private static Claim RealmRoles(params string[] roles) =>
+        new("realm_access", JsonSerializer.Serialize(new { roles }));
 
     private static HttpUserContext CreateContext(params Claim[] claims)
     {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authorization/AreaScopedAuthorizationHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Authorization/AreaScopedAuthorizationHandlerTests.cs
@@ -1,0 +1,156 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Authorization;
+
+using System.Security.Claims;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Authorization;
+
+public sealed class AreaScopedAuthorizationHandlerTests
+{
+    private static readonly AreaCodigo Ceps = AreaCodigo.From("CEPS").Value!;
+    private static readonly AreaCodigo Crca = AreaCodigo.From("CRCA").Value!;
+
+    [Fact]
+    public async Task AdminDaArea_EditandoEntidadeDaPropriaArea_DeveAutorizar()
+    {
+        AreaScopedAuthorizationHandler handler = BuildHandler(areasAdministradas: [Ceps], isPlataformaAdmin: false);
+        AuthorizationHandlerContext context = BuildContext(new EntidadeAreaScopedFake { Proprietario = Ceps });
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeTrue();
+        context.HasFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AdminDaArea_EditandoEntidadeDeOutraArea_DeveNegar()
+    {
+        AreaScopedAuthorizationHandler handler = BuildHandler(areasAdministradas: [Ceps], isPlataformaAdmin: false);
+        AuthorizationHandlerContext context = BuildContext(new EntidadeAreaScopedFake { Proprietario = Crca });
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeFalse();
+        context.HasFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PlataformaAdmin_EditandoEntidadeAreaScoped_DeveAutorizarERegistrarOnBehalfOf()
+    {
+        ILogger<AreaScopedAuthorizationHandler> logger = CreateRecordingLogger();
+        AreaScopedAuthorizationHandler handler = BuildHandler(
+            areasAdministradas: [], isPlataformaAdmin: true, logger);
+        AuthorizationHandlerContext context = BuildContext(new EntidadeAreaScopedFake { Proprietario = Ceps });
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeTrue();
+        LogCallCount(logger).Should().Be(1, "edição on-behalf-of de item área-scoped emite log operacional");
+    }
+
+    [Fact]
+    public async Task PlataformaAdmin_EditandoItemGlobal_DeveAutorizarSemOnBehalfOf()
+    {
+        ILogger<AreaScopedAuthorizationHandler> logger = CreateRecordingLogger();
+        AreaScopedAuthorizationHandler handler = BuildHandler(
+            areasAdministradas: [], isPlataformaAdmin: true, logger);
+        AuthorizationHandlerContext context = BuildContext(new EntidadeAreaScopedFake { Proprietario = null });
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeTrue();
+        LogCallCount(logger).Should().Be(0, "item global não tem área proprietária — não há on-behalf-of");
+    }
+
+    [Fact]
+    public async Task AdminDaAreaQueTambemEPlataformaAdmin_EditandoEntidadeDaPropriaArea_NaoRegistraOnBehalfOf()
+    {
+        // Quando o caller é genuinamente admin da área dona, ele edita por
+        // direito próprio — não é uma edição on-behalf-of.
+        ILogger<AreaScopedAuthorizationHandler> logger = CreateRecordingLogger();
+        AreaScopedAuthorizationHandler handler = BuildHandler(
+            areasAdministradas: [Ceps], isPlataformaAdmin: true, logger);
+        AuthorizationHandlerContext context = BuildContext(new EntidadeAreaScopedFake { Proprietario = Ceps });
+
+        await handler.HandleAsync(context);
+
+        context.HasSucceeded.Should().BeTrue();
+        LogCallCount(logger).Should().Be(0, "admin da própria área edita por direito próprio, não on-behalf-of");
+    }
+
+    [Fact]
+    public async Task LeitorDaArea_EditandoEntidadeDaArea_DeveNegar()
+    {
+        // Roles -leitor não entram em AreasAdministradas, e leitor não é
+        // plataforma-admin — logo não pode escrever.
+        AreaScopedAuthorizationHandler handler = BuildHandler(areasAdministradas: [], isPlataformaAdmin: false);
+        AuthorizationHandlerContext context = BuildContext(new EntidadeAreaScopedFake { Proprietario = Ceps });
+
+        await handler.HandleAsync(context);
+
+        context.HasFailed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task SemRoleDeArea_EditandoItemGlobal_DeveNegar()
+    {
+        // Itens globais (Proprietario nulo) só podem ser editados por plataforma-admin.
+        AreaScopedAuthorizationHandler handler = BuildHandler(areasAdministradas: [], isPlataformaAdmin: false);
+        AuthorizationHandlerContext context = BuildContext(new EntidadeAreaScopedFake { Proprietario = null });
+
+        await handler.HandleAsync(context);
+
+        context.HasFailed.Should().BeTrue();
+    }
+
+    // ─── Helpers ───────────────────────────────────────────────────────────
+
+    private static AreaScopedAuthorizationHandler BuildHandler(
+        IReadOnlyCollection<AreaCodigo> areasAdministradas,
+        bool isPlataformaAdmin,
+        ILogger<AreaScopedAuthorizationHandler>? logger = null)
+    {
+        IUserContext userContext = Substitute.For<IUserContext>();
+        userContext.AreasAdministradas.Returns(areasAdministradas);
+        userContext.IsPlataformaAdmin.Returns(isPlataformaAdmin);
+        userContext.UserId.Returns("sub-actor");
+
+        return new AreaScopedAuthorizationHandler(
+            userContext,
+            logger ?? NullLogger<AreaScopedAuthorizationHandler>.Instance);
+    }
+
+    private static AuthorizationHandlerContext BuildContext(IAreaScopedEntity resource)
+    {
+        RequireAreaProprietarioRequirement requirement = new();
+        return new AuthorizationHandlerContext(
+            [requirement],
+            new ClaimsPrincipal(new ClaimsIdentity()),
+            resource);
+    }
+
+    private static ILogger<AreaScopedAuthorizationHandler> CreateRecordingLogger()
+    {
+        ILogger<AreaScopedAuthorizationHandler> logger = Substitute.For<ILogger<AreaScopedAuthorizationHandler>>();
+        logger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
+        return logger;
+    }
+
+    private static int LogCallCount(ILogger logger) =>
+        logger.ReceivedCalls().Count(call =>
+            string.Equals(call.GetMethodInfo().Name, nameof(ILogger.Log), StringComparison.Ordinal));
+
+    private sealed class EntidadeAreaScopedFake : IAreaScopedEntity
+    {
+        public AreaCodigo? Proprietario { get; init; }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/AreaDeInteresseBindingTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/AreaDeInteresseBindingTests.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Persistence;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+
+public sealed class AreaDeInteresseBindingTests
+{
+    private static readonly AreaCodigo Ceps = AreaCodigo.From("CEPS").Value!;
+    private static readonly DateTimeOffset ValidoDe = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Criar_DeveAbrirVinculoVigente()
+    {
+        AreaDeInteresseBinding<EntidadeAreaScopedFake> binding =
+            AreaDeInteresseBinding<EntidadeAreaScopedFake>.Criar(Guid.CreateVersion7(), Ceps, ValidoDe, "sub-1");
+
+        binding.AreaCodigo.Should().Be(Ceps);
+        binding.ValidoDe.Should().Be(ValidoDe);
+        binding.ValidoAte.Should().BeNull("um vínculo recém-criado é vigente");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_DadoAdicionadoPorVazio_DeveLancar(string adicionadoPor)
+    {
+        Action criar = () => AreaDeInteresseBinding<EntidadeAreaScopedFake>.Criar(
+            Guid.CreateVersion7(), Ceps, ValidoDe, adicionadoPor);
+
+        criar.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Encerrar_DadoValidoAtePosterior_DeveFecharAJanela()
+    {
+        AreaDeInteresseBinding<EntidadeAreaScopedFake> binding =
+            AreaDeInteresseBinding<EntidadeAreaScopedFake>.Criar(Guid.CreateVersion7(), Ceps, ValidoDe, "sub-1");
+        DateTimeOffset validoAte = ValidoDe.AddDays(30);
+
+        binding.Encerrar(validoAte);
+
+        binding.ValidoAte.Should().Be(validoAte);
+    }
+
+    [Theory]
+    [InlineData(0, "janela vazia (validoAte == validoDe)")]
+    [InlineData(-1, "janela invertida (validoAte < validoDe)")]
+    public void Encerrar_DadoValidoAteNaoPosterior_DeveLancar(int diasOffset, string razao)
+    {
+        AreaDeInteresseBinding<EntidadeAreaScopedFake> binding =
+            AreaDeInteresseBinding<EntidadeAreaScopedFake>.Criar(Guid.CreateVersion7(), Ceps, ValidoDe, "sub-1");
+
+        Action encerrar = () => binding.Encerrar(ValidoDe.AddDays(diasOffset));
+
+        encerrar.Should().Throw<ArgumentException>(razao);
+        binding.ValidoAte.Should().BeNull("a tentativa inválida não altera o estado");
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Usada apenas como argumento de tipo genérico de AreaDeInteresseBinding<T>.")]
+    private sealed class EntidadeAreaScopedFake : IAreaScopedEntity
+    {
+        public AreaCodigo? Proprietario => null;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Configurations/AreaVisibilityConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Configurations/AreaVisibilityConfigurationTests.cs
@@ -1,0 +1,255 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Persistence.Configurations;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Configurations;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+
+// Valida que AreaVisibilityConfiguration<TParent> registra a junction table
+// no modelo EF com a forma de ADR-0060 (nome, PK composta, FK ON DELETE
+// RESTRICT, índice parcial). O exclusion constraint GIST é SQL bruto e fica
+// coberto pelo teste de integração.
+public sealed class AreaVisibilityConfigurationTests
+{
+    private const string JunctionTable = "entidade_area_scoped_areas_de_interesse";
+    private const string ParentFkColumn = "entidade_area_scoped_id";
+
+    private readonly IEntityType _junction;
+
+    public AreaVisibilityConfigurationTests()
+    {
+        using TestDbContext context = new();
+        _junction = context.Model.FindEntityType(typeof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>))!;
+    }
+
+    [Fact]
+    public void Configuracao_DeveRegistrarAJunctionTableNoModelo()
+    {
+        _junction.Should().NotBeNull("a config concreta herda a base e invoca ConfigureAreaVisibility");
+        _junction.GetTableName().Should().Be(JunctionTable, "convenção: prefixo singular + _areas_de_interesse");
+    }
+
+    [Fact]
+    public void Configuracao_DeveUsarPkCompostaParentIdAreaCodigoValidoDe()
+    {
+        IReadOnlyList<IProperty> pk = _junction.FindPrimaryKey()!.Properties;
+
+        pk.Select(p => p.Name).Should().Equal(
+            nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.ParentId),
+            nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.AreaCodigo),
+            nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.ValidoDe));
+    }
+
+    [Theory]
+    [InlineData(nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.ParentId), ParentFkColumn)]
+    [InlineData(nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.AreaCodigo), "area_codigo")]
+    [InlineData(nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.ValidoDe), "valid_from")]
+    [InlineData(nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.ValidoAte), "valid_to")]
+    [InlineData(nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.AdicionadoPor), "added_by")]
+    public void Configuracao_DeveMapearAsColunasComNomesDeAdr0060(string propriedade, string colunaEsperada)
+    {
+        StoreObjectIdentifier tabela = StoreObjectIdentifier.Table(JunctionTable);
+
+        _junction.FindProperty(propriedade)!.GetColumnName(tabela)
+            .Should().Be(colunaEsperada);
+    }
+
+    [Fact]
+    public void Configuracao_DeveAplicarFkParaOPaiComOnDeleteRestrict()
+    {
+        IForeignKey fk = _junction.GetForeignKeys().Single();
+
+        fk.PrincipalEntityType.ClrType.Should().Be<EntidadeAreaScopedFicticia>();
+        fk.Properties.Single().Name.Should().Be(nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.ParentId));
+        fk.DeleteBehavior.Should().Be(DeleteBehavior.Restrict, "ADR-0060: a junction não cascateia com o pai");
+    }
+
+    [Fact]
+    public void Configuracao_DeveCriarIndiceParcialDosVinculosVigentes()
+    {
+        IIndex indice = _junction.GetIndexes()
+            .Single(i => i.GetFilter() is not null);
+
+        indice.Properties.Select(p => p.Name).Should().Equal(
+            nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.ParentId),
+            nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.AreaCodigo));
+        indice.GetFilter().Should().Be("valid_to IS NULL");
+        indice.GetDatabaseName().Should().Be($"ix_{JunctionTable}_vigentes");
+    }
+
+    [Fact]
+    public void Configuracao_DeveMapearAreaCodigoComoVarchar32ViaConvencao()
+    {
+        StoreObjectIdentifier tabela = StoreObjectIdentifier.Table(JunctionTable);
+
+        // varchar(32) vem da convenção global ConfigureValueObjectConverters —
+        // confirma que AreaCodigo na junction usa o mesmo mapeamento canônico.
+        _junction.FindProperty(nameof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>.AreaCodigo))!
+            .GetColumnType(tabela)
+            .Should().Be("varchar(32)");
+    }
+
+    [Fact]
+    public void DerivacaoDeNomes_DeveSeguirOPrefixoDaTabelaPai()
+    {
+        EntidadeAreaScopedFicticiaConfiguration config = new();
+
+        config.JunctionTable.Should().Be(JunctionTable);
+        config.ParentForeignKeyColumn.Should().Be(ParentFkColumn);
+    }
+
+    [Fact]
+    public void Descoberta_ApplyConfigurationsFromAssembly_DeveAplicarAConfigParaOsDoisTipos()
+    {
+        // A config concreta implementa IEntityTypeConfiguration<TParent> E
+        // <AreaDeInteresseBinding<TParent>>. ApplyConfigurationsFromAssembly
+        // deve aplicá-la para os DOIS — é o mecanismo que F2 usa por entidade.
+        using AssemblyScanTestDbContext context = new();
+
+        context.Model.FindEntityType(typeof(EntidadeAreaScopedFicticia))
+            .Should().NotBeNull("a config é descoberta e aplicada para a entidade pai");
+        context.Model.FindEntityType(typeof(AreaDeInteresseBinding<EntidadeAreaScopedFicticia>))
+            .Should().NotBeNull("e também para a junction, pela interface explícita da mesma config");
+    }
+
+    [Theory]
+    [InlineData("PREFIXO_MAIUSCULO", "não é snake_case minúsculo")]
+    [InlineData("1prefixo", "inicia por dígito")]
+    [InlineData("prefixo-com-hifen", "hífen não é caractere de identificador")]
+    [InlineData("prefixo com espaco", "espaço não é caractere de identificador")]
+    [InlineData("_prefixo", "inicia por underscore, não por letra")]
+    public void Construtor_DadoPrefixoComFormatoInvalido_DeveLancar(string prefixo, string razao)
+    {
+        Func<PrefixoProbe> criar = () => new PrefixoProbe(prefixo);
+
+        criar.Should().Throw<ArgumentException>(razao);
+    }
+
+    [Fact]
+    public void Construtor_DadoPrefixoLongoDemais_DeveLancar()
+    {
+        // 32 chars > limite de 31 — a constraint GIST derivada estouraria o
+        // limite de 63 chars de identificador do PostgreSQL.
+        Func<PrefixoProbe> criar = () => new PrefixoProbe(new string('a', 32));
+
+        criar.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Construtor_DadoPrefixoSnakeCaseValido_NaoDeveLancar()
+    {
+        Func<PrefixoProbe> criar = () => new PrefixoProbe("tipo_documento");
+
+        criar.Should().NotThrow();
+    }
+
+    // ─── Fixtures de teste ─────────────────────────────────────────────────
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciada pelo EF Core.")]
+    private sealed class EntidadeAreaScopedFicticia : EntityBase, IAreaScopedEntity
+    {
+        public AreaCodigo? Proprietario { get; private set; }
+
+        public string Nome { get; private set; } = string.Empty;
+    }
+
+    private sealed class EntidadeAreaScopedFicticiaConfiguration
+        : AreaVisibilityConfiguration<EntidadeAreaScopedFicticia>
+    {
+        // Construtor público explícito: ApplyConfigurationsFromAssembly
+        // instancia a config via Activator.CreateInstance, que exige ctor público.
+        public EntidadeAreaScopedFicticiaConfiguration()
+            : base("entidade_area_scoped")
+        {
+        }
+
+        public override void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<EntidadeAreaScopedFicticia> builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            builder.ToTable("entidades_area_scoped_ficticias");
+            builder.HasKey(e => e.Id);
+            builder.Property(e => e.Nome).HasMaxLength(200).IsRequired();
+            ConfigureAreaVisibility(builder);
+        }
+    }
+
+    // Probe que só exercita o construtor base de AreaVisibilityConfiguration —
+    // a validação do prefixo dispara antes de qualquer Configure.
+    private sealed class PrefixoProbe : AreaVisibilityConfiguration<EntidadeAreaScopedFicticia>
+    {
+        public PrefixoProbe(string prefixo)
+            : base(prefixo)
+        {
+        }
+
+        public override void Configure(Microsoft.EntityFrameworkCore.Metadata.Builders.EntityTypeBuilder<EntidadeAreaScopedFicticia> builder)
+            => ArgumentNullException.ThrowIfNull(builder);
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciada pelos testes para inspeção do modelo.")]
+    private sealed class TestDbContext : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            // Connection string sintética — os testes só inspecionam o modelo,
+            // nunca conectam.
+            optionsBuilder.UseNpgsql("Host=stub;Database=stub;Username=stub;Password=stub");
+        }
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+        {
+            base.ConfigureConventions(configurationBuilder);
+            configurationBuilder.ConfigureValueObjectConverters();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            EntidadeAreaScopedFicticiaConfiguration config = new();
+            modelBuilder.ApplyConfiguration<EntidadeAreaScopedFicticia>(config);
+            modelBuilder.ApplyConfiguration<AreaDeInteresseBinding<EntidadeAreaScopedFicticia>>(config);
+        }
+    }
+
+    // Variante que aplica a config via ApplyConfigurationsFromAssembly (em vez
+    // de ApplyConfiguration manual), filtrando para SÓ a config de teste — evita
+    // capturar configs de outros testes deste assembly.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciada pelos testes para inspeção do modelo.")]
+    private sealed class AssemblyScanTestDbContext : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            => optionsBuilder.UseNpgsql("Host=stub;Database=stub;Username=stub;Password=stub");
+
+        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+        {
+            base.ConfigureConventions(configurationBuilder);
+            configurationBuilder.ConfigureValueObjectConverters();
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.ApplyConfigurationsFromAssembly(
+                typeof(AreaVisibilityConfigurationTests).Assembly,
+                type => type == typeof(EntidadeAreaScopedFicticiaConfiguration));
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Converters/AreaCodigoValueConverterTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Converters/AreaCodigoValueConverterTests.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Persistence.Converters;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+
+public sealed class AreaCodigoValueConverterTests
+{
+    private readonly AreaCodigoValueConverter _converter = new();
+
+    [Fact]
+    public void ConvertToProvider_DadoAreaCodigoValido_DeveRetornarAStringSubjacente()
+    {
+        AreaCodigo codigo = AreaCodigo.From("CEPS").Value!;
+
+        object? provider = _converter.ConvertToProvider(codigo);
+
+        provider.Should().Be("CEPS");
+    }
+
+    [Fact]
+    public void ConvertToProvider_DadoDefaultAreaCodigo_DeveLancarInvalidOperationException()
+    {
+        // default(AreaCodigo) tem Value null — persistir como NULL ficaria
+        // indistinguível de "sem proprietário" numa coluna AreaCodigo?.
+        // O converter falha alto na escrita.
+        Action converter = () => _converter.ConvertToProvider(default(AreaCodigo));
+
+        converter.Should().Throw<InvalidOperationException>()
+            .WithMessage("*default(AreaCodigo)*");
+    }
+
+    [Fact]
+    public void ConvertFromProvider_DadoStringValida_DeveReidratarOAreaCodigo()
+    {
+        object? codigo = _converter.ConvertFromProvider("PLATAFORMA");
+
+        codigo.Should().Be(AreaCodigo.From("PLATAFORMA").Value!);
+    }
+
+    [Fact]
+    public void ConvertFromProvider_DadoStringCorrompida_DeveLancarInvalidOperationExceptionComContexto()
+    {
+        Action converter = () => _converter.ConvertFromProvider("1-invalido");
+
+        converter.Should().Throw<InvalidOperationException>()
+            .Where(e => e.Message.Contains(nameof(AreaCodigo), StringComparison.Ordinal)
+                     && e.Message.Contains(AreaCodigo.CodigoErroInvalido, StringComparison.Ordinal));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
@@ -1065,6 +1065,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
@@ -1068,6 +1068,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1092,6 +1098,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
@@ -1083,6 +1083,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1107,6 +1113,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
@@ -1080,6 +1080,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
@@ -1088,6 +1088,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
@@ -1091,6 +1091,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1115,6 +1121,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
@@ -1089,6 +1089,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1113,6 +1119,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
@@ -1086,6 +1086,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/packages.lock.json
@@ -143,6 +143,13 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
@@ -1083,6 +1083,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1107,6 +1113,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
@@ -1080,6 +1080,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -1160,6 +1160,7 @@
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -1163,6 +1163,12 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
       "unifesspa.uniplus.infrastructure.core": {
         "type": "Project",
         "dependencies": {
@@ -1187,6 +1193,7 @@
           "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
           "StackExchange.Redis": "[2.12.14, )",
           "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
           "VaultSharp": "[1.17.5.1, )",
           "WolverineFx": "[5.39.0, )",


### PR DESCRIPTION
## Resumo

Story **US-F1-01** (#446) — a foundation da Sprint 3 do módulo Parametrizacao. É o gargalo único: enquanto não estiver na `main`, F2 (catálogos), F3 (promoções) e F4 (ObrigatoriedadeLegal) ficam 100% bloqueadas. Entrega 6 tasks em 6 commits atômicos.

## O que entra (6 tasks)

| Commit | Task | Entrega |
|---|---|---|
| `chore(infra)` | #464 | Bancos `uniplus_parametrizacao` + `uniplus_organizacao` (users `_app`, owner do próprio banco) + `btree_gist` nos 3 bancos relevantes, via `init-db.sql` |
| `chore(keycloak)` | #465 | 10 realm roles de área (`{ceps,crca,proeg,progep,plataforma}-{admin,leitor}`) + `plataforma-admin` no user de teste |
| `feat(governance)` | #466 | Projeto `Governance.Contracts` em `src/shared/`: `AreaCodigo` (record struct validado), `IAreaScopedEntity` (marker), JSON + EF value converters |
| `feat(auth)` | #469 | `IUserContext.AreasAdministradas` + `IsPlataformaAdmin` derivados dos roles JWT |
| `feat(persistence)` | #468 | `AreaVisibilityConfiguration<TParent>` — base EF templatada de junction table; `AreaDeInteresseBinding<TParent>`; `JunctionTableMigrationHelper` (GIST exclusion) |
| `feat(auth)` | #467 | `AreaScopedAuthorizationHandler` (autorização por recurso) + atributos `[ReferenceData]`/`[ExplicitlyUnscoped]` + `AddAreaScopedAuthorization()` |

## Decisões registradas

- **`Governance.Contracts` em `src/shared/`, não na pasta do módulo** — `src/shared/` é uma ilha de dependências fechada; um `.Contracts` dentro de `src/organizacao-institucional/` forçaria `src/shared/` a referenciar para dentro de um módulo. ADR-0055 ganha a **Emenda 1** registrando a relocação.
- **Vocabulário: "catálogo" não é usado no código da demanda de configuração** — a interface marker é `IAreaScopedEntity`, a base EF é `AreaVisibilityConfiguration`. "Catálogo" fica reservado a um futuro conceito de domínio de fato. ADR-0057 e ADR-0060 ganham **Emenda de vocabulário** com o mapeamento.
- **`AreaCodigo`: `From() -> Result<AreaCodigo>`** (não construtor que lança), normaliza para uppercase — alinhado a ADR-0055 e à convenção dos VOs do Kernel (`Cpf`, `Email`).
- **`plataforma-admin` fora de `AreasAdministradas`** — é o bypass platform-wide, exposto via `IsPlataformaAdmin` separado (ADR-0057).
- **Exclusion constraint GIST via SQL bruto** — o EF não expressa `EXCLUDE USING GIST` no fluent API; só essa constraint é raw SQL (via `JunctionTableMigrationHelper`), o resto da junction vem do modelo EF.

## Fora de escopo (deferido com justificativa)

- **Wire-up de `AddAreaScopedAuthorization()` nos `Program.cs`** — F1.S1 cria a extensão; F2 a invoca quando existirem controllers de catálogo. Registrar agora seria handler + policy sem consumidor.
- **Connection strings em `appsettings`** — F1.S1 não cria os projetos `.API` de parametrizacao/organizacao (F1.S2/F1.S3); documentadas em `.env.example` + `guia-banco-de-dados.md`.
- **Mapeamento HTTP do erro `AreaCodigo.Invalido`** — F1.S2, junto da `OrganizacaoInstitucionalDomainErrorRegistration`.
- **Habilitação de `btree_gist` via migration** — F1.S1 habilita via `init-db.sql` (dev); F1.S2/F1.S3/F3 emitem `CREATE EXTENSION IF NOT EXISTS` nas suas migrations.
- **Trilha de auditoria durável do ADR-0057** — entra com as entidades área-scoped em F2; F1.S1 emite só log operacional de edição on-behalf-of.

## Cobertura de testes

Build limpo (`TreatWarningsAsErrors`, 0 warnings). Suíte completa verde. Novos: 31 testes de `AreaCodigo`, 620 em `Infrastructure.Core.UnitTests` (+ `IUserContext`, `AreaVisibilityConfiguration`, `AreaScopedAuthorizationHandler`, `AreaDeInteresseBinding`, converters), 29 de integração contra PostgreSQL real (round-trip EF, schema `varchar(32)`, GIST rejeita janelas sobrepostas, FK, `ON DELETE RESTRICT` via SQLSTATE 23001).

> Smoke do import do realm Keycloak validado num Keycloak local: os 10 roles de área importados, o usuário `admin` com `plataforma-admin`, roles/usuários existentes intactos. O import de realm não faz parte do CI (testes E2E usam realm sintético via Testcontainers).

## Test plan

- [x] CI verde (Build, Unit + arch tests, Integration tests, Coverage)
- [x] `docker compose -f docker/docker-compose.yml up -d` provisiona os 5 bancos com `btree_gist` nos 3 relevantes
- [x] Revisão das 3 Emendas de ADR (0055 / 0057 / 0060)

Closes #446
Refs #441
