### PR TITLE
feat(selecao): drop enum columns pre-promotion (US-F3-01)

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -553,8 +553,7 @@
         "required": [
           "numeroEdital",
           "anoEdital",
-          "titulo",
-          "tipoProcesso"
+          "titulo"
         ],
         "type": "object",
         "properties": {
@@ -577,8 +576,12 @@
           "titulo": {
             "type": "string"
           },
-          "tipoProcesso": {
-            "$ref": "#/components/schemas/TipoProcesso"
+          "tipoEditalId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
           },
           "maximoOpcoesCurso": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
@@ -596,7 +599,7 @@
           "id",
           "numeroEdital",
           "titulo",
-          "tipoProcesso",
+          "tipoEditalId",
           "status",
           "maximoOpcoesCurso",
           "bonusRegionalHabilitado",
@@ -614,8 +617,12 @@
           "titulo": {
             "type": "string"
           },
-          "tipoProcesso": {
-            "type": "string"
+          "tipoEditalId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
           },
           "status": {
             "type": "string"
@@ -687,9 +694,6 @@
             ]
           }
         }
-      },
-      "TipoProcesso": {
-        "type": "integer"
       },
       "UserProfileResponse": {
         "required": [

--- a/docs/guia-banco-de-dados.md
+++ b/docs/guia-banco-de-dados.md
@@ -21,6 +21,7 @@ Referência canônica para devs que tocam persistência: naming convention, tipo
 13. [Inspecionar schema](#13-inspecionar-schema)
 14. [Cifragem at-rest](#14-cifragem-at-rest)
 15. [FAQ](#15-faq)
+16. [Promoção de enum → entidade](#16-promoção-de-enum--entidade)
 
 ---
 
@@ -403,3 +404,48 @@ Confira se a entidade expõe método de restauração (não é padrão — imple
 ### Onde vejo o schema atual em produção/standalone?
 
 Procedimentos de cluster (SSH, `psql` no host, troubleshooting) vivem no repositório `uniplus-infra`, fora deste repo. Consulte RUNBOOKS lá ou peça acesso ao SRE/DevOps.
+
+## 16. Promoção de enum → entidade
+
+Quando um enum modelado como `int4` em coluna de tabela (`HasConversion<int>`) precisa virar uma **entidade plena** (com aggregate próprio, código strongly-typed, atributos extensíveis), o cutover é feito em **três Stories sequenciais** para evitar schema drift entre o domain model e o banco. O padrão foi consolidado na promoção `TipoProcesso → TipoEdital` (Stories #454 → #455) e vale para qualquer enum futuro que ganhar status de entidade.
+
+### Etapa 1 — Migration preparatória (drop + add FK NULL)
+
+Story de schema-only que **dropa a coluna `<nome>_<enum>` (`int`)** e **adiciona uma coluna FK preparatória `<nome>_id uuid NULL`**, sem `HasOne` configurado e sem constraint.
+
+- A propriedade na entidade vira `Guid? <Nome>Id { get; private set; }`.
+- Configurations EF removem o `HasConversion<int>()`; a propriedade passa a ser mapeada nativamente como `uuid` nullable (snake_case automático via `EFCore.NamingConventions`).
+- Migration `Up()` executa `DropColumn` + `AddColumn`. `Down()` lança `NotSupportedException("Forward-only migration per ADR-0054 §J.")`.
+- Command/Validator: parâmetro `<Nome>Id` opcional e nullable; validator rejeita `Guid.Empty` quando informado.
+- DTOs e schemas OpenAPI são regerados — a baseline `contracts/openapi.<modulo>.json` muda neste passo (`UPDATE_OPENAPI_BASELINE=1 dotnet test --filter SpecRuntime`).
+
+Referência: [Story #454](https://github.com/unifesspa-edu-br/uniplus-api/issues/454) — migration `DropEnumColumnsPrePromotion` em `SelecaoDbContext`.
+
+### Etapa 2 — Criação da entidade + seed Newman
+
+Story que **cria o agregado** (`<Nome>` em `Selecao.Domain.Entities`) com todos os atributos planejados, incluindo `Codigo` strongly-typed (substitui o enum), `Descricao`, audit fields. Configurações EF, repositório, command de criação e seed via Newman (CSV/JSON committed sob `seeds/`).
+
+- A coluna FK introduzida na Etapa 1 ainda é `NULL`able. Adiciona `HasOne(e => e.<Nome>).WithMany().HasForeignKey(e => e.<Nome>Id)` em Configuration.
+- Enum legado (`Selecao.Domain.Enums.<EnumLegado>`) é **removido nesta etapa** — não na Etapa 1 — para evitar refactor amplo enquanto schema migration ainda está em vôo.
+- Seed via Newman popula linhas-template em todos os ambientes (dev local, CI, HML, prod) — o CD não cria entries em runtime.
+
+Referência: [Story #455](https://github.com/unifesspa-edu-br/uniplus-api/issues/455) — promove `TipoProcesso → TipoEdital` entidade.
+
+### Etapa 3 — Constraint NOT NULL
+
+Story de schema-only **separada**, executada quando dados de produção foram migrados (via script ou seed) para que toda linha tenha `<nome>_id` preenchido. Migration `AlterColumn` muda a coluna de `nullable: true` para `nullable: false`.
+
+- Pré-requisito: query auditiva em prod (`SELECT COUNT(*) WHERE <nome>_id IS NULL`) retorna zero.
+- Sem essa garantia, `AlterColumn` falha com `23502 not_null_violation` no `MigrationHostedService` no `StartAsync` do pod, derrubando o rollout.
+
+### Por quê três Stories e não uma só
+
+- **Risco de rollback**: três migrations forward-only permitem revert via nova migration parcial (ex.: voltar Etapa 3 sem perder Etapa 2).
+- **PR review focado**: cada Story tem um único concern (schema, domain, constraint), reduzindo superfície de revisão.
+- **CI testável incrementalmente**: a Etapa 1 já fica verde no CI antes de a entidade existir, permitindo merge sem aguardar #455.
+
+### Anti-patterns proibidos
+
+- ❌ **Drop + create entidade na mesma migration**: PR fica grande, qualquer issue de domain/EF reverte schema também. Aumenta risco de coluna órfã ou data loss em rollout parcial.
+- ❌ **NOT NULL na Etapa 1**: dados não existem ainda — a coluna nasce `NULL` por design. Tentar `nullable: false` no DropColumn+AddColumn quebra inserts existentes em qualquer ambiente já com dados.
+- ❌ **Manter o enum em `Domain.Enums` após Etapa 2**: causa risco de devs continuarem instanciando `<Nome>Id` a partir do enum legado, gerando GUIDs hardcoded sem entrada no agregado real.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/CriarEditalCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/CriarEditalCommand.cs
@@ -2,7 +2,6 @@ namespace Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
 
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
 using Kernel.Results;
-using Domain.Enums;
 
 /// <summary>
 /// Comando para criação de um novo edital. Validado automaticamente pelo
@@ -11,9 +10,17 @@ using Domain.Enums;
 /// <c>FluentValidation.ValidationException</c>, mapeada como ProblemDetails 400
 /// pelo <c>GlobalExceptionMiddleware</c>.
 /// </summary>
+/// <remarks>
+/// <para><c>TipoEditalId</c> é a FK preparatória para a futura entidade
+/// <c>TipoEdital</c> (Story #455 — promove o enum <c>TipoProcesso</c> em
+/// entidade). Permanece opcional/nulo nesta Story #454 porque a entidade
+/// ainda não existe em <c>Selecao.Domain</c>; quando #455 introduzir o
+/// agregado e o seed Newman (#463) popular as linhas-template, o campo
+/// passa a ser obrigatório por validador.</para>
+/// </remarks>
 public sealed record CriarEditalCommand(
     int NumeroEdital,
     int AnoEdital,
     string Titulo,
-    TipoProcesso TipoProcesso,
+    Guid? TipoEditalId = null,
     int MaximoOpcoesCurso = 1) : ICommand<Result<Guid>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/CriarEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/CriarEditalCommandHandler.cs
@@ -31,7 +31,7 @@ public static class CriarEditalCommandHandler
             return Result<Guid>.Failure(numeroResult.Error!);
         }
 
-        Edital edital = Edital.Criar(numeroResult.Value!, command.Titulo, command.TipoProcesso);
+        Edital edital = Edital.Criar(numeroResult.Value!, command.Titulo, command.TipoEditalId);
 
         await editalRepository.AdicionarAsync(edital, cancellationToken).ConfigureAwait(false);
         await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/EditalDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/EditalDto.cs
@@ -6,7 +6,7 @@ public sealed record EditalDto(
     Guid Id,
     string NumeroEdital,
     string Titulo,
-    string TipoProcesso,
+    Guid? TipoEditalId,
     string Status,
     int MaximoOpcoesCurso,
     bool BonusRegionalHabilitado,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ListarEditaisQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ListarEditaisQueryHandler.cs
@@ -43,7 +43,7 @@ public static class ListarEditaisQueryHandler
         edital.Id,
         edital.NumeroEdital.ToString(),
         edital.Titulo,
-        edital.TipoProcesso.ToString(),
+        edital.TipoEditalId,
         edital.Status.ToString(),
         edital.MaximoOpcoesCurso,
         edital.BonusRegionalHabilitado,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ObterEditalQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ObterEditalQueryHandler.cs
@@ -29,7 +29,7 @@ public static class ObterEditalQueryHandler
             edital.Id,
             edital.NumeroEdital.ToString(),
             edital.Titulo,
-            edital.TipoProcesso.ToString(),
+            edital.TipoEditalId,
             edital.Status.ToString(),
             edital.MaximoOpcoesCurso,
             edital.BonusRegionalHabilitado,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/CriarEditalCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/CriarEditalCommandValidator.cs
@@ -26,9 +26,11 @@ public sealed class CriarEditalCommandValidator : AbstractValidator<CriarEditalC
         // ainda não existe (será criada em #455). Quando informado, rejeita
         // Guid.Empty defensivamente: payload do cliente não deve carregar
         // valor "vazio" mascarando a ausência. `null` continua válido.
-        RuleFor(x => x.TipoEditalId!.Value)
-            .NotEqual(Guid.Empty)
-            .When(x => x.TipoEditalId.HasValue)
+        // Predicate sobre a propriedade `Guid?` direto preserva o PropertyName
+        // como `TipoEditalId` no ValidationFailure — clientes mapeiam erros
+        // pelo nome do campo do request, não por `TipoEditalId.Value`.
+        RuleFor(x => x.TipoEditalId)
+            .Must(static value => !value.HasValue || value.Value != Guid.Empty)
             .WithMessage("TipoEditalId não pode ser Guid vazio. Omita o campo para deixá-lo nulo.");
 
         RuleFor(x => x.MaximoOpcoesCurso)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/CriarEditalCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/CriarEditalCommandValidator.cs
@@ -22,9 +22,14 @@ public sealed class CriarEditalCommandValidator : AbstractValidator<CriarEditalC
             .MaximumLength(500)
             .WithMessage("Título do edital deve ter no máximo 500 caracteres.");
 
-        RuleFor(x => x.TipoProcesso)
-            .IsInEnum()
-            .WithMessage("Tipo de processo seletivo inválido.");
+        // TipoEditalId opcional nesta Story #454 — a entidade `TipoEdital`
+        // ainda não existe (será criada em #455). Quando informado, rejeita
+        // Guid.Empty defensivamente: payload do cliente não deve carregar
+        // valor "vazio" mascarando a ausência. `null` continua válido.
+        RuleFor(x => x.TipoEditalId!.Value)
+            .NotEqual(Guid.Empty)
+            .When(x => x.TipoEditalId.HasValue)
+            .WithMessage("TipoEditalId não pode ser Guid vazio. Omita o campo para deixá-lo nulo.");
 
         RuleFor(x => x.MaximoOpcoesCurso)
             .InclusiveBetween(1, 2)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
@@ -9,7 +9,15 @@ public sealed class Edital : EntityBase
 {
     public NumeroEdital NumeroEdital { get; private set; } = null!;
     public string Titulo { get; private set; } = string.Empty;
-    public TipoProcesso TipoProcesso { get; private set; }
+
+    /// <summary>
+    /// FK preparatória para a futura entidade <c>TipoEdital</c> (Story #455).
+    /// Permanece <c>null</c> nesta Story #454 — a entidade ainda não existe;
+    /// será populada quando a promoção do enum <see cref="TipoProcesso"/>
+    /// for concluída e o seed Newman (#463) tiver inserido as linhas-template.
+    /// FK não-nula entra em migration futura quando dados existirem.
+    /// </summary>
+    public Guid? TipoEditalId { get; private set; }
     public StatusEdital Status { get; private set; }
     public PeriodoInscricao? PeriodoInscricao { get; private set; }
     public FormulaCalculo? FormulaCalculo { get; private set; }
@@ -24,17 +32,26 @@ public sealed class Edital : EntityBase
 
     private Edital() { }
 
-    public static Edital Criar(NumeroEdital numeroEdital, string titulo, TipoProcesso tipoProcesso)
+    public static Edital Criar(NumeroEdital numeroEdital, string titulo, Guid? tipoEditalId = null)
     {
-        var edital = new Edital
+        // Invariante de factory: TipoEditalId é opcional (null), mas
+        // Guid.Empty é estado inválido — significa "informado, mas vazio".
+        // Validator espelha a regra na borda HTTP; este guard cobre callers
+        // internos (handlers, seeds) que não passam pelo command bus.
+        if (tipoEditalId.HasValue && tipoEditalId.Value == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "TipoEditalId não pode ser Guid vazio. Omita o argumento para nulo.",
+                nameof(tipoEditalId));
+        }
+
+        return new Edital
         {
             NumeroEdital = numeroEdital,
             Titulo = titulo,
-            TipoProcesso = tipoProcesso,
-            Status = StatusEdital.Rascunho
+            TipoEditalId = tipoEditalId,
+            Status = StatusEdital.Rascunho,
         };
-
-        return edital;
     }
 
     public void DefinirPeriodoInscricao(PeriodoInscricao periodo) =>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Etapa.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Etapa.cs
@@ -1,13 +1,20 @@
 namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
 
-using Enums;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
 public sealed class Etapa : EntityBase
 {
     public Guid EditalId { get; private set; }
     public string Nome { get; private set; } = string.Empty;
-    public TipoEtapa Tipo { get; private set; }
+
+    /// <summary>
+    /// FK preparatória para a futura entidade <c>TipoEtapa</c> (Story #455).
+    /// Permanece <c>null</c> nesta Story #454 — a entidade ainda não existe;
+    /// será populada quando a promoção do enum
+    /// <c>Enums.TipoEtapa</c> for concluída.
+    /// FK não-nula entra em migration futura quando dados existirem.
+    /// </summary>
+    public Guid? TipoEtapaId { get; private set; }
     public decimal Peso { get; private set; }
     public int Ordem { get; private set; }
     public decimal? NotaMinima { get; private set; }
@@ -15,17 +22,33 @@ public sealed class Etapa : EntityBase
 
     private Etapa() { }
 
-    public static Etapa Criar(Guid editalId, string nome, TipoEtapa tipo, decimal peso, int ordem, bool eliminatoria = false, decimal? notaMinima = null)
+    public static Etapa Criar(
+        Guid editalId,
+        string nome,
+        decimal peso,
+        int ordem,
+        bool eliminatoria = false,
+        decimal? notaMinima = null,
+        Guid? tipoEtapaId = null)
     {
+        // Invariante de factory simétrica a Edital.Criar: opcional (null) é
+        // válido, Guid.Empty é estado inválido (informado mas vazio).
+        if (tipoEtapaId.HasValue && tipoEtapaId.Value == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "TipoEtapaId não pode ser Guid vazio. Omita o argumento para nulo.",
+                nameof(tipoEtapaId));
+        }
+
         return new Etapa
         {
             EditalId = editalId,
             Nome = nome,
-            Tipo = tipo,
             Peso = peso,
             Ordem = ordem,
             Eliminatoria = eliminatoria,
-            NotaMinima = notaMinima
+            NotaMinima = notaMinima,
+            TipoEtapaId = tipoEtapaId,
         };
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EditalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EditalConfiguration.cs
@@ -21,7 +21,14 @@ public sealed class EditalConfiguration : IEntityTypeConfiguration<Edital>
         });
 
         builder.Property(e => e.Titulo).HasMaxLength(500).IsRequired();
-        builder.Property(e => e.TipoProcesso).HasConversion<int>().IsRequired();
+
+        // FK preparatória para a futura entidade `TipoEdital` (Story #455).
+        // Permanece nullable nesta Story #454 — ainda não existe agregado
+        // referenciável; a constraint NOT NULL e a HasOne(...).WithMany(...)
+        // entram em migration futura quando #455 popular as linhas-template.
+        // EFCore.NamingConventions mapeia para `tipo_edital_id` (snake_case).
+        builder.Property(e => e.TipoEditalId);
+
         builder.Property(e => e.Status).HasConversion<int>().IsRequired();
         builder.Property(e => e.MaximoOpcoesCurso).HasDefaultValue(1);
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EtapaConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EtapaConfiguration.cs
@@ -15,7 +15,12 @@ public sealed class EtapaConfiguration : IEntityTypeConfiguration<Etapa>
         builder.HasKey(e => e.Id);
 
         builder.Property(e => e.Nome).HasMaxLength(200).IsRequired();
-        builder.Property(e => e.Tipo).HasConversion<int>().IsRequired();
+
+        // FK preparatória para a futura entidade `TipoEtapa` (Story #455).
+        // Mesma justificativa de EditalConfiguration.TipoEditalId — nullable
+        // até a entidade existir; mapeada para `tipo_etapa_id` automaticamente.
+        builder.Property(e => e.TipoEtapaId);
+
         builder.Property(e => e.Peso).HasPrecision(5, 2).IsRequired();
         builder.Property(e => e.Ordem).IsRequired();
         builder.Property(e => e.NotaMinima).HasPrecision(5, 2);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260516015511_DropEnumColumnsPrePromotion.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260516015511_DropEnumColumnsPrePromotion.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516015511_DropEnumColumnsPrePromotion")]
+    partial class DropEnumColumnsPrePromotion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260516015511_DropEnumColumnsPrePromotion.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260516015511_DropEnumColumnsPrePromotion.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropEnumColumnsPrePromotion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "tipo",
+                table: "etapas");
+
+            migrationBuilder.DropColumn(
+                name: "tipo_processo",
+                table: "editais");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "tipo_etapa_id",
+                table: "etapas",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "tipo_edital_id",
+                table: "editais",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Forward-only por ADR-0054 §J: nova migration "Reverte..." é o
+            // mecanismo canônico de revert. Recriar tipo_processo/tipo aqui
+            // induziria desenvolvedores a `database update <baseline>` em
+            // staging/prod, restabelecendo enums em vez de seguir o caminho
+            // de promoção #455 → constraint NOT NULL.
+            throw new NotSupportedException("Forward-only migration per ADR-0054 §J.");
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/CriarEditalCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/CriarEditalCommandValidatorTests.cs
@@ -45,7 +45,11 @@ public sealed class CriarEditalCommandValidatorTests
         ValidationResult result = new CriarEditalCommandValidator().Validate(BaseValid(tipoEditalId: Guid.Empty));
 
         result.IsValid.Should().BeFalse();
-        result.Errors.Should().ContainSingle(e => e.PropertyName == "TipoEditalId.Value");
+
+        // PropertyName ancorado ao campo do request (`TipoEditalId`, não
+        // `TipoEditalId.Value`) — clientes que mapeiam ProblemDetails para
+        // input fields esperam a chave `tipoEditalId` no envelope de erro.
+        result.Errors.Should().ContainSingle(e => e.PropertyName == "TipoEditalId");
         result.Errors[0].ErrorMessage.Should().Contain("Guid vazio");
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/CriarEditalCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/CriarEditalCommandValidatorTests.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
+using Unifesspa.UniPlus.Selecao.Application.Validators;
+
+/// <summary>
+/// Cobertura do <see cref="CriarEditalCommandValidator"/> após a Story #454
+/// ter substituído o enum <c>TipoProcesso</c> pela FK preparatória
+/// <c>TipoEditalId</c> (Guid?). A regra antiga (<c>IsInEnum</c>) saiu;
+/// a nova rejeita <c>Guid.Empty</c> quando informado, sem invalidar
+/// o caso opcional (null).
+/// </summary>
+public sealed class CriarEditalCommandValidatorTests
+{
+    private static CriarEditalCommand BaseValid(Guid? tipoEditalId = null) => new(
+        NumeroEdital: 42,
+        AnoEdital: 2026,
+        Titulo: "Edital teste",
+        TipoEditalId: tipoEditalId,
+        MaximoOpcoesCurso: 1);
+
+    [Fact(DisplayName = "Validator passa quando TipoEditalId e null (opcional na Story #454)")]
+    public void Aceita_TipoEditalIdNulo()
+    {
+        ValidationResult result = new CriarEditalCommandValidator().Validate(BaseValid(tipoEditalId: null));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Validator passa quando TipoEditalId e Guid v7 valido")]
+    public void Aceita_TipoEditalIdValido()
+    {
+        ValidationResult result = new CriarEditalCommandValidator().Validate(BaseValid(tipoEditalId: Guid.CreateVersion7()));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Validator falha quando TipoEditalId = Guid.Empty (informado mas vazio)")]
+    public void Rejeita_TipoEditalIdEmpty()
+    {
+        ValidationResult result = new CriarEditalCommandValidator().Validate(BaseValid(tipoEditalId: Guid.Empty));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.PropertyName == "TipoEditalId.Value");
+        result.Errors[0].ErrorMessage.Should().Contain("Guid vazio");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/EditalCriarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/EditalCriarTests.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura da factory <see cref="Edital.Criar"/> após a Story #454 ter
+/// substituído o enum <c>TipoProcesso</c> pela FK preparatória
+/// <c>TipoEditalId</c> (Guid?). Garante que a invariante "opcional ou
+/// FK válida" é honrada pelo domínio, mesmo quando callers internos
+/// (handlers, seeds, fixtures) bypassam o validator de borda.
+/// </summary>
+public sealed class EditalCriarTests
+{
+    private static NumeroEdital ValidNumeroEdital()
+    {
+        Result<NumeroEdital> result = NumeroEdital.Criar(numero: 1, ano: 2026);
+        result.IsSuccess.Should().BeTrue();
+        return result.Value!;
+    }
+
+    [Fact(DisplayName = "Edital.Criar sem TipoEditalId mantem o campo nulo e nasce em Rascunho")]
+    public void Criar_SemTipoEditalId_FicaNulo()
+    {
+        Edital edital = Edital.Criar(ValidNumeroEdital(), "Edital teste");
+
+        edital.TipoEditalId.Should().BeNull();
+        edital.Status.Should().Be(StatusEdital.Rascunho);
+    }
+
+    [Fact(DisplayName = "Edital.Criar com TipoEditalId valido (Guid v7) preserva o valor")]
+    public void Criar_ComTipoEditalIdValido_PreservaValor()
+    {
+        Guid tipoEditalId = Guid.CreateVersion7();
+
+        Edital edital = Edital.Criar(ValidNumeroEdital(), "Edital teste", tipoEditalId);
+
+        edital.TipoEditalId.Should().Be(tipoEditalId);
+    }
+
+    [Fact(DisplayName = "Edital.Criar com TipoEditalId = Guid.Empty lanca ArgumentException")]
+    public void Criar_ComTipoEditalIdEmpty_Lanca()
+    {
+        Action act = () => Edital.Criar(ValidNumeroEdital(), "Edital teste", Guid.Empty);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("tipoEditalId")
+            .WithMessage("*Guid vazio*");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/EtapaCriarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/EtapaCriarTests.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+/// <summary>
+/// Cobertura da factory <see cref="Etapa.Criar"/> após a Story #454 ter
+/// substituído o enum <c>TipoEtapa</c> pela FK preparatória
+/// <c>TipoEtapaId</c> (Guid?). Simétrica a
+/// <see cref="EditalCriarTests"/> — guarda contra <c>Guid.Empty</c>.
+/// </summary>
+public sealed class EtapaCriarTests
+{
+    [Fact(DisplayName = "Etapa.Criar sem TipoEtapaId mantem o campo nulo")]
+    public void Criar_SemTipoEtapaId_FicaNulo()
+    {
+        Etapa etapa = Etapa.Criar(
+            editalId: Guid.CreateVersion7(),
+            nome: "Prova objetiva",
+            peso: 1.0m,
+            ordem: 1);
+
+        etapa.TipoEtapaId.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Etapa.Criar com TipoEtapaId valido preserva o valor")]
+    public void Criar_ComTipoEtapaIdValido_PreservaValor()
+    {
+        Guid tipoEtapaId = Guid.CreateVersion7();
+
+        Etapa etapa = Etapa.Criar(
+            editalId: Guid.CreateVersion7(),
+            nome: "Prova objetiva",
+            peso: 1.0m,
+            ordem: 1,
+            tipoEtapaId: tipoEtapaId);
+
+        etapa.TipoEtapaId.Should().Be(tipoEtapaId);
+    }
+
+    [Fact(DisplayName = "Etapa.Criar com TipoEtapaId = Guid.Empty lanca ArgumentException")]
+    public void Criar_ComTipoEtapaIdEmpty_Lanca()
+    {
+        Action act = () => Etapa.Criar(
+            editalId: Guid.CreateVersion7(),
+            nome: "Prova objetiva",
+            peso: 1.0m,
+            ordem: 1,
+            tipoEtapaId: Guid.Empty);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName("tipoEtapaId")
+            .WithMessage("*Guid vazio*");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ListarEditaisEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ListarEditaisEndpointTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Assertions;
 using Kernel.Results;
 using Domain.Entities;
-using Domain.Enums;
 using Domain.ValueObjects;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 using Outbox.Cascading;
@@ -177,7 +176,7 @@ public sealed class ListarEditaisEndpointTests
             int numeroSeed = Math.Abs((Guid.NewGuid().GetHashCode() + i) % 9000) + 1;
             Result<NumeroEdital> numero = NumeroEdital.Criar(numero: numeroSeed, ano: 2026);
             numero.IsSuccess.Should().BeTrue();
-            Edital edital = Edital.Criar(numero.Value!, $"ListarEditaisEndpointTests seed {i}", TipoProcesso.SiSU);
+            Edital edital = Edital.Criar(numero.Value!, $"ListarEditaisEndpointTests seed {i}");
             edital.ClearDomainEvents();
             await db.Editais.AddAsync(edital);
             seeded.Add(edital);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ObterEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ObterEditalEndpointTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Assertions;
 using Kernel.Results;
 using Domain.Entities;
-using Domain.Enums;
 using Domain.ValueObjects;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 using Outbox.Cascading;
@@ -97,7 +96,7 @@ public sealed class ObterEditalEndpointTests
         Result<NumeroEdital> numero = NumeroEdital.Criar(numero: numeroSeed, ano: 2026);
         numero.IsSuccess.Should().BeTrue();
 
-        Edital edital = Edital.Criar(numero.Value!, "ObterEditalEndpointTests seed", TipoProcesso.SiSU);
+        Edital edital = Edital.Criar(numero.Value!, "ObterEditalEndpointTests seed");
         edital.ClearDomainEvents();
         await db.Editais.AddAsync(edital);
         await db.SaveChangesAsync();

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
@@ -6,7 +6,6 @@ using Microsoft.EntityFrameworkCore;
 
 using Kernel.Results;
 using Domain.Entities;
-using Domain.Enums;
 using Domain.Events;
 using Domain.ValueObjects;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -39,8 +38,7 @@ public sealed class CascadingHandlerUnitTests
 
         var command = new PublicarEditalCascadingCommand(
             numero,
-            "UnitTest cascading",
-            TipoProcesso.SiSU);
+            "UnitTest cascading");
 
         IEnumerable<object> cascading = await PublicarEditalCascadingHandler.Handle(
             command,

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
@@ -12,7 +12,6 @@ using Npgsql;
 using Wolverine;
 
 using Kernel.Results;
-using Domain.Enums;
 using Domain.Events;
 using Domain.ValueObjects;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -61,8 +60,7 @@ public sealed class CascadingScenariosTests
 
         var command = new PublicarEditalCascadingCommand(
             numero,
-            "V8 — cascading happy path",
-            TipoProcesso.SiSU);
+            "V8 — cascading happy path");
 
         await bus.InvokeAsync(command);
 
@@ -105,8 +103,7 @@ public sealed class CascadingScenariosTests
 
         var command = new FalharAposSaveChangesCascadingCommand(
             numero,
-            "V9 — cascading rollback",
-            TipoProcesso.SiSU);
+            "V9 — cascading rollback");
 
         Func<Task> act = () => bus.InvokeAsync(command);
 

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
@@ -28,7 +28,7 @@ public sealed class PublicarEditalCascadingHandler
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(db);
 
-        Edital edital = Edital.Criar(command.Numero, command.Titulo, command.Tipo);
+        Edital edital = Edital.Criar(command.Numero, command.Titulo);
         edital.Publicar();
         db.Editais.Add(edital);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -60,7 +60,7 @@ public sealed class FalharAposSaveChangesCascadingHandler
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(db);
 
-        Edital edital = Edital.Criar(command.Numero, command.Titulo, command.Tipo);
+        Edital edital = Edital.Criar(command.Numero, command.Titulo);
         edital.Publicar();
         db.Editais.Add(edital);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestMessages.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestMessages.cs
@@ -2,17 +2,16 @@ namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
 
 using System.Diagnostics.CodeAnalysis;
 
-using Domain.Enums;
 using Domain.ValueObjects;
 
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",
     Justification = "Mensagens descobertas pela convenção do Wolverine precisam ser públicas.")]
-public sealed record PublicarEditalCascadingCommand(NumeroEdital Numero, string Titulo, TipoProcesso Tipo);
+public sealed record PublicarEditalCascadingCommand(NumeroEdital Numero, string Titulo);
 
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",
     Justification = "Mensagens descobertas pela convenção do Wolverine precisam ser públicas.")]
-public sealed record FalharAposSaveChangesCascadingCommand(NumeroEdital Numero, string Titulo, TipoProcesso Tipo);
+public sealed record FalharAposSaveChangesCascadingCommand(NumeroEdital Numero, string Titulo);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalEndpointTests.cs
@@ -11,7 +11,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 using Domain.Entities;
-using Domain.Enums;
 using Domain.ValueObjects;
 using Kernel.Results;
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
@@ -57,7 +56,6 @@ public sealed class EditalEndpointTests
                 numeroEdital = numero,
                 anoEdital = 2026,
                 titulo = "EditalEndpointTests CriarEdital",
-                tipoProcesso = (int)TipoProcesso.SiSU,
             }),
         };
         AppendTestAuth(request);
@@ -73,6 +71,70 @@ public sealed class EditalEndpointTests
         using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Guid editalId = doc.RootElement.GetGuid();
         editalId.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact(DisplayName = "POST /api/editais com tipoEditalId Guid v7 persiste e GET retorna o mesmo valor")]
+    public async Task CriarEdital_ComTipoEditalIdInformado_PersisteEReflete()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        Guid tipoEditalId = Guid.CreateVersion7();
+        int numero = NextNumeroSeed();
+
+        using HttpRequestMessage post = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        {
+            Content = JsonContent.Create(new
+            {
+                numeroEdital = numero,
+                anoEdital = 2026,
+                titulo = "EditalEndpointTests com TipoEditalId",
+                tipoEditalId = tipoEditalId,
+            }),
+        };
+        AppendTestAuth(post);
+        post.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+
+        HttpResponseMessage created = await client.SendAsync(post);
+        created.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        Guid editalId = JsonDocument.Parse(await created.Content.ReadAsStringAsync()).RootElement.GetGuid();
+
+        using HttpRequestMessage get = new(HttpMethod.Get,
+            new Uri($"/api/editais/{editalId}", UriKind.Relative));
+        AppendTestAuth(get);
+        get.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.edital.v1+json"));
+
+        HttpResponseMessage response = await client.SendAsync(get);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        body.RootElement.GetProperty("tipoEditalId").GetGuid().Should().Be(tipoEditalId);
+    }
+
+    [Fact(DisplayName = "POST /api/editais com tipoEditalId = Guid.Empty retorna 422 (validator)")]
+    public async Task CriarEdital_ComTipoEditalIdEmpty_Retorna422()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        int numero = NextNumeroSeed();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        {
+            Content = JsonContent.Create(new
+            {
+                numeroEdital = numero,
+                anoEdital = 2026,
+                titulo = "EditalEndpointTests com TipoEditalId vazio",
+                tipoEditalId = Guid.Empty,
+            }),
+        };
+        AppendTestAuth(request);
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
     }
 
     [Fact(DisplayName = "GET /api/editais/{id} retorna 200 quando o edital existe")]
@@ -160,7 +222,7 @@ public sealed class EditalEndpointTests
         int numeroSeed = NextNumeroSeed();
         Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: numeroSeed, ano: 2026);
         numeroResult.IsSuccess.Should().BeTrue();
-        Edital edital = Edital.Criar(numeroResult.Value!, "EditalEndpointTests seed", TipoProcesso.SiSU);
+        Edital edital = Edital.Criar(numeroResult.Value!, "EditalEndpointTests seed");
         edital.ClearDomainEvents();
         await db.Editais.AddAsync(edital);
         await db.SaveChangesAsync();

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
@@ -219,7 +219,6 @@ public sealed class PublicarEditalEndpointTests
                 numeroEdital = numero1,
                 anoEdital = 2026,
                 titulo = "Body-mismatch test",
-                tipoProcesso = 1, // SiSU — enum serializado como número (System.Text.Json default)
             }),
         };
         AppendTestAuth(primeiraReq);
@@ -235,7 +234,6 @@ public sealed class PublicarEditalEndpointTests
                 numeroEdital = numero2,
                 anoEdital = 2026,
                 titulo = "Body-mismatch test",
-                tipoProcesso = 1, // SiSU — enum serializado como número (System.Text.Json default)
             }),
         };
         AppendTestAuth(segundaReq);
@@ -282,7 +280,7 @@ public sealed class PublicarEditalEndpointTests
         int numeroSeed = NextNumeroSeed();
         Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: numeroSeed, ano: 2026);
         numeroResult.IsSuccess.Should().BeTrue();
-        Edital edital = Edital.Criar(numeroResult.Value!, "PublicarEditalEndpointTests seed", TipoProcesso.SiSU);
+        Edital edital = Edital.Criar(numeroResult.Value!, "PublicarEditalEndpointTests seed");
         // O agregado já tem domain events na coleção (do `Criar`/Publicar futuro).
         // Como esta seed bypassa o handler produtivo, drenamos manualmente para
         // não vazar eventos no coletor antes do POST.


### PR DESCRIPTION
## Story

- Closes #454 — US-F3-01: Migration baseline — drop dos enum columns existentes em Selecao
- Refs Feature pai #443 (F3 — Promoção de enums em entidades de Seleção)
- Habilita Story #455 (promove `TipoProcesso → TipoEdital` e `TipoEtapa → TipoEtapa` entidades) e #463 (seed Newman das linhas-template)

## Resumo

Migration EF Core incremental no `SelecaoDbContext` que **dropa** as colunas enum (`editais.tipo_processo`, `etapas.tipo`) e **adiciona** as FKs preparatórias (`tipo_edital_id uuid NULL`, `tipo_etapa_id uuid NULL`). Os enums `Selecao.Domain.Enums.TipoProcesso` e `TipoEtapa` permanecem em código — serão removidos na Story #455 quando a promoção em entidade for concluída. FK não-nula entra em migration futura quando dados existirem.

## Critérios de aceite

- [x] **CA-01** — Nova migration `20260516015511_DropEnumColumnsPrePromotion` no topo de `20260513220911_InitialCreate`, gerada via `dotnet ef migrations add ... --startup-project=...API` (per ADR-0054 §H).
- [x] **CA-02** — Migration:
  - Dropa `tipo_processo` (`int`) de `editais` e `tipo` (`int`) de `etapas`.
  - Adiciona `tipo_edital_id uuid NULL` em `editais` e `tipo_etapa_id uuid NULL` em `etapas` (sem FK ainda — entra em #455).
- [x] **CA-03** — `CriterioDesempate` fora de escopo (não existia em `main`; será criado from-scratch em #455 sem precisar de drop prévio).
- [x] **CA-04** — `Down()` lança `NotSupportedException("Forward-only migration per ADR-0054 §J.")` em vez do skeleton padrão do EF tool.
- [x] **CA-05** — Sem perda de dados: `__EFMigrationsHistory` em `main` contém só `20260513220911_InitialCreate`; rollouts pré-MVP rodam ainda com banco vazio.
- [x] **CA-06** — Documentação: nova §16 "Promoção de enum → entidade" em `docs/guia-banco-de-dados.md` cobrindo a sequência de 3 Stories (drop + add FK NULL → cria entidade + seed → constraint NOT NULL futura).

## Bloco de mudanças

### Migration
- `src/.../Migrations/20260516015511_DropEnumColumnsPrePromotion.cs` (Up + Down forward-only)
- `src/.../Migrations/20260516015511_DropEnumColumnsPrePromotion.Designer.cs`
- `src/.../Migrations/SelecaoDbContextModelSnapshot.cs` (atualizado para refletir o novo shape)

### Domain
- `Edital.cs` — `TipoProcesso TipoProcesso` → `Guid? TipoEditalId`. Factory `Edital.Criar` aceita `Guid?` (default `null`); rejeita `Guid.Empty` defensivamente como invariante de domínio.
- `Etapa.cs` — `TipoEtapa Tipo` → `Guid? TipoEtapaId`. Factory `Etapa.Criar` simétrica.

### Application
- `CriarEditalCommand.cs` — `TipoProcesso TipoProcesso` → `Guid? TipoEditalId = null`.
- `CriarEditalCommandHandler.cs` — usa `command.TipoEditalId`.
- `CriarEditalCommandValidator.cs` — substitui `IsInEnum` por defensiva contra `Guid.Empty` (`null` continua válido).
- `EditalDto.cs` — `string TipoProcesso` → `Guid? TipoEditalId` (BREAKING CHANGE no V1, intencional).
- `Queries/Editais/{Listar,Obter}EditaisQueryHandler.cs` — projeção atualizada.

### Infrastructure
- `EditalConfiguration.cs` / `EtapaConfiguration.cs` — removem `Property(...).HasConversion<int>()`. `EFCore.NamingConventions` mapeia `TipoEditalId → tipo_edital_id` (snake_case automático).

### OpenAPI baseline
- `contracts/openapi.selecao.json` regenerada via `UPDATE_OPENAPI_BASELINE=1 dotnet test --filter SpecRuntime`. Schema `TipoProcesso` removido; propriedades `tipoProcesso` viram `tipoEditalId : uuid?`.

### Tests
- **Novos**:
  - `Selecao.Domain.UnitTests/Entities/EditalCriarTests.cs` (3 cenários — opcional, válido, Empty)
  - `Selecao.Domain.UnitTests/Entities/EtapaCriarTests.cs` (3 cenários simétricos)
  - `Selecao.Application.UnitTests/Validators/CriarEditalCommandValidatorTests.cs` (3 cenários)
  - `EditalEndpointTests.CriarEdital_ComTipoEditalIdInformado_PersisteEReflete` (cenário positivo end-to-end)
  - `EditalEndpointTests.CriarEdital_ComTipoEditalIdEmpty_Retorna422` (validator na borda)
- **Adaptados** (substituição mecânica do argumento enum):
  - `Editais/{Listar,Obter}EditaisEndpointTests`
  - `Outbox/Cascading/{Edital,PublicarEdital}EndpointTests`
  - `Outbox/Cascading/CascadingScenariosTests`, `CascadingHandlerUnitTests`
  - `Outbox/Cascading/CascadingTestMessages` (records simplificados — removeu `TipoProcesso Tipo` que só servia para passar à factory)
  - `Outbox/Cascading/CascadingTestHandlers` (handlers `Edital.Criar` sem o 3º arg)

### Docs
- `docs/guia-banco-de-dados.md` §16 nova — "Promoção de enum → entidade" com 3 Stories sequenciais, justificativa e anti-patterns.

## Cenários BDD

```gherkin
# language: pt
Funcionalidade: Migration incremental prepara schema para promoção enum → entidade

  Cenário: Migration roda em DB fresco (CA-02)
    Dado um banco uniplus_selecao recém-provisionado
    Quando dotnet ef database update --context SelecaoDbContext roda
    Então a tabela editais não tem mais coluna tipo_processo
    E tem coluna tipo_edital_id uuid NULL
    E a tabela etapas não tem mais coluna tipo
    E tem coluna tipo_etapa_id uuid NULL

  Cenário: Snapshot do modelo confirma drift zero pós-migration
    Quando dotnet ef migrations script roda em DB pós-migration
    Então o script é vazio (modelo == DB)

  Cenário: Down() falha fail-fast (CA-04)
    Quando dotnet ef database update <baseline_anterior> roda
    Então NotSupportedException é lançada citando "ADR-0054 §J"
```

Cobertos pela suite integration `Selecao.IntegrationTests` (PG efêmero via Testcontainers — fixture aplica migrations no `MigrationHostedService`, validando o caminho real).

## Validação local

- `dotnet build UniPlus.slnx`: 0 warnings, 0 errors (TreatWarningsAsErrors).
- `dotnet test UniPlus.slnx --filter Category!=E2E`: todos os módulos verdes.
  - `Selecao.IntegrationTests`: **77/77** (75 pré-existentes + 2 novos).
  - `Selecao.Domain.UnitTests`: **6/6** (novo).
  - `Selecao.Application.UnitTests`: **3/3** (novo).
  - `Selecao.ArchTests`: **6/6**.
  - `Infrastructure.Core.UnitTests`: **620/620**.
  - `Infrastructure.Core.IntegrationTests`: **29/29**.
  - `Ingresso.IntegrationTests`: **8/8**, `OrganizacaoInstitucional.*`: verde.

## Pré-revisão local (Codex CLI)

Codex review do diff produziu 2 P2 (resolvidos antes do push):
- P2 — Domain factories `Edital.Criar`/`Etapa.Criar` aceitavam `Guid.Empty` se chamadas fora do validator. **Resolvido**: invariante de factory adicionada (lança `ArgumentException`).
- P2 — Cobertura faltante para a nova regra (`Guid.Empty` retornar erro + cenário positivo de persistência). **Resolvido**: 3 testes unit (Domain) + 3 testes unit (Validator) + 2 cenários HTTP novos.

P3 (aceito): a baseline OpenAPI V1 muda — `tipoProcesso` removido, `tipoEditalId` introduzido. Alinhado ao escopo da Story preparatória; consumers do contrato V1 (codegen frontend `uniplus-web` via `openapi-typescript`) precisarão regerar o schema localmente após este merge — sem ação no PR atual.

## ADRs binding

- [ADR-0054 — Naming convention + forward-only migrations](docs/adrs/0054-naming-convention-e-strategy-migrations.md)
- [ADR-0042 — Application via Repository + UoW](docs/adrs/0042-application-nao-depende-diretamente-de-dbcontext.md)
- ADR-0056 (Parametrização) — referência semântica para "TipoEdital = template de processo seletivo"

## Risco e rollback

- **Risco**: migration drop+add column. Forward-only — revert via nova migration "Reverte..." (não `database update <previous>`).
- **Rollback**: se necessário antes de #455 mergear, criar migration `RevertePromocaoEnum` que reintroduz `tipo_processo`/`tipo` (`int4`, default 0) e dropa as FKs preparatórias. Custo cognitivo baixo (sem dados ainda).

## Próximos passos (não escopo deste PR)

- Story #455 — promove `TipoProcesso/TipoEtapa` em entidades plenas com `Codigo` strongly-typed; remove os enums legados de `Selecao.Domain.Enums`.
- Story #463 — seed Newman das linhas-template em todos os ambientes.
- Migration futura — `AlterColumn` para `nullable: false` quando dados existirem em prod/HML.
- Frontend `uniplus-web` — regerar schema TypeScript via `openapi-typescript` (ADR-0013 web).