### PR TITLE
feat(observability): filtra rotas /health* do tracing AspNetCore

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/OpenTelemetryConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/OpenTelemetryConfiguration.cs
@@ -2,6 +2,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Observability;
 
 using System.Collections.Generic;
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -112,7 +113,8 @@ public static class OpenTelemetryConfiguration
                 .SetSampler(sampler)
                 .AddSource(nomeServico)
                 .AddSource(WolverineActivityAndMeterName)
-                .AddAspNetCoreInstrumentation()
+                .AddAspNetCoreInstrumentation(opts =>
+                    opts.Filter = ctx => EhRotaInstrumentavel(ctx.Request.Path))
                 .AddHttpClientInstrumentation()
                 .AddEntityFrameworkCoreInstrumentation()
                 .AddOtlpExporter())
@@ -126,6 +128,17 @@ public static class OpenTelemetryConfiguration
 
         return services;
     }
+
+    /// <summary>
+    /// Retorna <see langword="true"/> quando a rota deve ser instrumentada (spans e métricas).
+    /// Rotas de health check (<c>/health*</c>) são excluídas: o Kubernetes já as monitora
+    /// via <c>kube_pod_status_ready</c> e incluí-las distorceria SLO, percentis de latência
+    /// e cardinality no Prometheus com volume de tráfego não-usuário.
+    /// <c>StartsWithSegments</c> respeita fronteiras de segmento — <c>/healthz</c> não
+    /// é excluído acidentalmente.
+    /// </summary>
+    internal static bool EhRotaInstrumentavel(PathString path)
+        => !path.StartsWithSegments("/health", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Seleciona o sampler conforme ambiente: <see cref="AlwaysOnSampler"/>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/OpenTelemetryConfiguration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/OpenTelemetryConfiguration.cs
@@ -130,13 +130,19 @@ public static class OpenTelemetryConfiguration
     }
 
     /// <summary>
-    /// Retorna <see langword="true"/> quando a rota deve ser instrumentada (spans e métricas).
+    /// Retorna <see langword="true"/> quando a rota deve ser instrumentada.
     /// Rotas de health check (<c>/health*</c>) são excluídas: o Kubernetes já as monitora
     /// via <c>kube_pod_status_ready</c> e incluí-las distorceria SLO, percentis de latência
     /// e cardinality no Prometheus com volume de tráfego não-usuário.
     /// <c>StartsWithSegments</c> respeita fronteiras de segmento — <c>/healthz</c> não
     /// é excluído acidentalmente.
     /// </summary>
+    /// <remarks>
+    /// Usado atualmente apenas para filtro de tracing
+    /// (<c>AspNetCoreTraceInstrumentationOptions.Filter</c>).
+    /// O <see cref="MeterProviderBuilder"/> não oferece sobrecarga com filtro na versão 1.15.1
+    /// do SDK; quando suportado, este predicado deverá ser reutilizado para métricas também.
+    /// </remarks>
     internal static bool EhRotaInstrumentavel(PathString path)
         => !path.StartsWithSegments("/health", StringComparison.OrdinalIgnoreCase);
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Observability/OpenTelemetryConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Observability/OpenTelemetryConfigurationTests.cs
@@ -164,6 +164,17 @@ public class OpenTelemetryConfigurationTests
     }
 
     [Theory]
+    [InlineData("/Health")]
+    [InlineData("/HEALTH/live")]
+    [InlineData("/Health/ready")]
+    public void EhRotaInstrumentavel_RotasHealthComCaseVariado_RetornaFalse(string path)
+    {
+        bool resultado = OpenTelemetryConfiguration.EhRotaInstrumentavel(new PathString(path));
+
+        resultado.Should().BeFalse(because: $"OrdinalIgnoreCase deve excluir '{path}' independente de capitalização");
+    }
+
+    [Theory]
     [InlineData("/api/editais")]
     [InlineData("/api/editais/123")]
     [InlineData("/api/inscricoes")]

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Observability/OpenTelemetryConfigurationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Observability/OpenTelemetryConfigurationTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 using AwesomeAssertions;
 
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -148,6 +149,32 @@ public class OpenTelemetryConfigurationTests
         Action acao = () => OpenTelemetryConfiguration.SelecionarSampler(environment!);
 
         acao.Should().Throw<ArgumentNullException>();
+    }
+
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/health/live")]
+    [InlineData("/health/ready")]
+    [InlineData("/health/startup")]
+    public void EhRotaInstrumentavel_RotasHealth_RetornaFalse(string path)
+    {
+        bool resultado = OpenTelemetryConfiguration.EhRotaInstrumentavel(new PathString(path));
+
+        resultado.Should().BeFalse(because: $"a rota '{path}' é health check e não deve gerar telemetria");
+    }
+
+    [Theory]
+    [InlineData("/api/editais")]
+    [InlineData("/api/editais/123")]
+    [InlineData("/api/inscricoes")]
+    [InlineData("/swagger")]
+    [InlineData("/healthz")]
+    [InlineData("/")]
+    public void EhRotaInstrumentavel_RotasNegocioEOutras_RetornaTrue(string path)
+    {
+        bool resultado = OpenTelemetryConfiguration.EhRotaInstrumentavel(new PathString(path));
+
+        resultado.Should().BeTrue(because: $"a rota '{path}' deve ser instrumentada normalmente");
     }
 
     private static IConfiguration NovaConfiguracao(IEnumerable<KeyValuePair<string, string?>>? values = null)


### PR DESCRIPTION
## Resumo

- Exclui rotas `/health*` do `TracerProvider` via `AspNetCoreTraceInstrumentationOptions.Filter` antes de gerar spans — filtragem **na fonte**, não no Collector
- Introduz `EhRotaInstrumentavel(PathString)` como `internal static` testável (`StartsWithSegments` + `OrdinalIgnoreCase` para respeitar fronteiras de segmento)
- Adiciona 10 casos de teste unitários (`Theory`) cobrindo rotas health e rotas de negócio, incluindo o caso-limite `/healthz` (não excluído)

## Motivação

Probes Kubernetes (liveness, readiness, startup) com intervalo de 5–10 s representavam ~94% do volume de spans da API. Isso distorcia:
- SLOs de latência (p95/p99 inflados por latência muito baixa das probes)
- Taxa de erro e disponibilidade nos dashboards RED
- Cardinality no Prometheus (série `http_route=/health/live` sem valor para SLOs de negócio)

Kubernetes já monitora a saúde dos pods via `kube_pod_status_ready` — duplicar no OTel não agrega valor operacional.

## Limitação documentada

`OpenTelemetry.Instrumentation.AspNetCore` 1.15.1 não oferece sobrecarga com opções no `MeterProviderBuilder.AddAspNetCoreInstrumentation()` — apenas o pipeline de tracing aceita filtro. A filtragem de métricas de `/health*` deve ser feita nas queries PromQL dos dashboards Grafana com `http_route!~"/health.*|"`.

## Validação

- `dotnet build UniPlus.slnx -c Release`: 0 erros, 0 avisos
- `dotnet test` (Infrastructure.Core.UnitTests): 630/630 aprovados, incluindo 10 novos testes `EhRotaInstrumentavel_*`

## Referências

Closes #508