### PR TITLE
feat(selecao): adiciona PredicadoObrigatoriedade e ValidadorConformidadeEdital (#459)

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -20,6 +20,13 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("FormulaCalculo.FatorInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.formula_calculo.fator_invalido", "Fator de divisão inválido")),
         new("FormulaCalculo.BonusInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.formula_calculo.bonus_invalido", "Bônus regional inválido")),
         new("Inscricao.StatusInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.inscricao.status_invalido", "Status de inscrição inválido")),
+        // ObrigatoriedadeLegal placeholder (Story #459) — campos básicos. Forma plena com
+        // hash canônico/vigência/governance entra em #460 (US-F4-02), momento em que
+        // novos códigos (RegraCodigoDuplicada, VigenciaInvalida, HashColisao) são adicionados.
+        new("ObrigatoriedadeLegal.RegraCodigoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.obrigatoriedade_legal.regra_codigo_obrigatorio", "RegraCodigo obrigatório")),
+        new("ObrigatoriedadeLegal.PredicadoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.obrigatoriedade_legal.predicado_obrigatorio", "Predicado obrigatório")),
+        new("ObrigatoriedadeLegal.BaseLegalObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.obrigatoriedade_legal.base_legal_obrigatoria", "BaseLegal obrigatória")),
+        new("ObrigatoriedadeLegal.DescricaoHumanaObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.obrigatoriedade_legal.descricao_humana_obrigatoria", "DescricaoHumana obrigatória")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
@@ -1049,6 +1049,7 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/packages.lock.json
@@ -44,6 +44,7 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ObrigatoriedadeLegal.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ObrigatoriedadeLegal.cs
@@ -1,0 +1,93 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using Kernel.Results;
+using ValueObjects;
+
+/// <summary>
+/// Placeholder mínimo da entidade <c>ObrigatoriedadeLegal</c> para destravar
+/// a compilação da Story #459 (avaliador de conformidade). A forma plena
+/// — herdando <c>EntityBase</c>, com <c>Vigencia</c>, <c>Hash</c> canônico,
+/// <c>TipoEditalCodigo</c>, <c>Categoria</c>, governança per ADR-0057 e
+/// audit interceptor — entra em <c>#460</c> (US-F4-02).
+/// </summary>
+/// <remarks>
+/// <para>Em V1 a entidade é um <c>sealed record</c> imutável sem persistência
+/// (não há EF mapping, repositório nem migration nesta Story). O avaliador
+/// recebe a coleção de regras como argumento — o caller é responsável por
+/// hidratá-las (em testes, manualmente; em #461 admin CRUD via repository).</para>
+/// <para>Construção via factory <see cref="Criar"/> retornando
+/// <see cref="Result{T}"/> (path canônico) <strong>ou</strong> diretamente via
+/// construtor que valida e lança <see cref="ArgumentException"/> em entradas
+/// inválidas. Os dois caminhos aplicam a mesma rede de invariantes — não há
+/// bypass mesmo via deserialização polimórfica STJ.</para>
+/// </remarks>
+public sealed record ObrigatoriedadeLegal
+{
+    public string RegraCodigo { get; }
+    public PredicadoObrigatoriedade Predicado { get; }
+    public string BaseLegal { get; }
+    public string DescricaoHumana { get; }
+    public string? PortariaInternaCodigo { get; }
+
+    public ObrigatoriedadeLegal(
+        string regraCodigo,
+        PredicadoObrigatoriedade predicado,
+        string baseLegal,
+        string descricaoHumana,
+        string? portariaInternaCodigo = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(regraCodigo);
+        ArgumentNullException.ThrowIfNull(predicado);
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseLegal);
+        ArgumentException.ThrowIfNullOrWhiteSpace(descricaoHumana);
+
+        RegraCodigo = regraCodigo.Trim();
+        Predicado = predicado;
+        BaseLegal = baseLegal.Trim();
+        DescricaoHumana = descricaoHumana.Trim();
+        PortariaInternaCodigo = string.IsNullOrWhiteSpace(portariaInternaCodigo)
+            ? null
+            : portariaInternaCodigo.Trim();
+    }
+
+    /// <summary>
+    /// Factory canônica retornando <see cref="Result{T}"/> com
+    /// <see cref="DomainError"/> codificado (compatível com
+    /// <c>SelecaoDomainErrorRegistration</c>). Wrappers de aplicação devem
+    /// preferir esta API à construção direta.
+    /// </summary>
+    public static Result<ObrigatoriedadeLegal> Criar(
+        string regraCodigo,
+        PredicadoObrigatoriedade predicado,
+        string baseLegal,
+        string descricaoHumana,
+        string? portariaInternaCodigo = null)
+    {
+        if (string.IsNullOrWhiteSpace(regraCodigo))
+            return Result<ObrigatoriedadeLegal>.Failure(new DomainError(
+                "ObrigatoriedadeLegal.RegraCodigoObrigatorio",
+                "RegraCodigo é obrigatório."));
+
+        if (predicado is null)
+            return Result<ObrigatoriedadeLegal>.Failure(new DomainError(
+                "ObrigatoriedadeLegal.PredicadoObrigatorio",
+                "Predicado é obrigatório."));
+
+        if (string.IsNullOrWhiteSpace(baseLegal))
+            return Result<ObrigatoriedadeLegal>.Failure(new DomainError(
+                "ObrigatoriedadeLegal.BaseLegalObrigatoria",
+                "BaseLegal é obrigatória."));
+
+        if (string.IsNullOrWhiteSpace(descricaoHumana))
+            return Result<ObrigatoriedadeLegal>.Failure(new DomainError(
+                "ObrigatoriedadeLegal.DescricaoHumanaObrigatoria",
+                "DescricaoHumana é obrigatória."));
+
+        return Result<ObrigatoriedadeLegal>.Success(new ObrigatoriedadeLegal(
+            regraCodigo,
+            predicado,
+            baseLegal,
+            descricaoHumana,
+            portariaInternaCodigo));
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ValidadorConformidadeEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ValidadorConformidadeEdital.cs
@@ -1,0 +1,298 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Services;
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+using Microsoft.Extensions.Logging;
+
+using Entities;
+using ValueObjects;
+
+/// <summary>
+/// Domain service puro que avalia um conjunto de
+/// <see cref="ObrigatoriedadeLegal"/> contra um <see cref="Edital"/>
+/// (ou sua projeção <see cref="EditalConformidadeView"/>), conforme
+/// ADR-0058. Sem dependência de infraestrutura: o avaliador é função pura
+/// modulo o logger opcional usado para a variante
+/// <see cref="Customizado"/>.
+/// </summary>
+/// <remarks>
+/// <para>Pattern match: 8 cases concretos + catch-all <c>_ => throw</c>
+/// (C# não suporta union fechado; CS8509 só dispararia se removêssemos
+/// o catch-all, o que silenciaria variantes futuras). A garantia
+/// substantiva de exhaustividade vive no fitness reflectivo
+/// <c>ValidadorConformidadeEditalExhaustividadeTests</c> em
+/// <c>Selecao.Domain.UnitTests</c>: ele itera por reflection cada tipo
+/// derivado e exige que o avaliador responda sem cair no catch-all.</para>
+/// <para>Comparações textuais usam <see cref="StringComparison.OrdinalIgnoreCase"/>
+/// com <c>Trim()</c> nos inputs (admin UI pode chegar com capitalização
+/// inconsistente). Predicados cujas listas obrigatórias só contêm
+/// whitespace/null são tratados como <em>malformados</em> e reprovam com
+/// motivo explícito — não como "tudo presente, lista vazia equivale a
+/// nenhum requisito".</para>
+/// <para>Avisos diagnósticos (uso de <see cref="Customizado"/>, por
+/// exemplo) são propagados via <see cref="ResultadoConformidade.Avisos"/>
+/// E também via <see cref="ILogger"/> opcional quando o caller passa um.
+/// Application layers que quiserem manter Domain ainda mais frio podem
+/// consumir só <see cref="ResultadoConformidade.Avisos"/>.</para>
+/// </remarks>
+public static partial class ValidadorConformidadeEdital
+{
+    /// <summary>
+    /// Avalia as regras contra o agregado <see cref="Edital"/>. Internamente
+    /// projeta para <see cref="EditalConformidadeView"/> via
+    /// <see cref="EditalConformidadeView.From(Edital)"/>.
+    /// </summary>
+    public static ResultadoConformidade Evaluate(
+        Edital edital,
+        IReadOnlyList<ObrigatoriedadeLegal> regras,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(edital);
+        ArgumentNullException.ThrowIfNull(regras);
+
+        return Evaluate(EditalConformidadeView.From(edital), regras, logger);
+    }
+
+    /// <summary>
+    /// Avalia as regras contra a projeção. Útil em testes (constrói view
+    /// diretamente) e em pipelines onde a view já foi materializada.
+    /// </summary>
+    public static ResultadoConformidade Evaluate(
+        EditalConformidadeView view,
+        IReadOnlyList<ObrigatoriedadeLegal> regras,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+        ArgumentNullException.ThrowIfNull(regras);
+
+        List<RegraAvaliada> avaliadas = new(regras.Count);
+        List<string> avisos = [];
+        foreach (ObrigatoriedadeLegal regra in regras)
+        {
+            avaliadas.Add(Avaliar(regra, view, logger, avisos));
+        }
+
+        return new ResultadoConformidade(avaliadas, avisos);
+    }
+
+    private static RegraAvaliada Avaliar(
+        ObrigatoriedadeLegal regra,
+        EditalConformidadeView view,
+        ILogger? logger,
+        List<string> avisos)
+    {
+        ArgumentNullException.ThrowIfNull(regra);
+
+        (bool aprovada, string motivo) = regra.Predicado switch
+        {
+            EtapaObrigatoria p => AvaliarEtapa(p, view),
+            ModalidadesMinimas p => AvaliarModalidades(p, view),
+            DesempateDeveIncluir p => AvaliarDesempate(p, view),
+            DocumentoObrigatorioParaModalidade p => AvaliarDocumento(p, view),
+            BonusObrigatorio p => AvaliarBonus(p, view),
+            AtendimentoDisponivel p => AvaliarAtendimento(p, view),
+            ConcorrenciaDuplaObrigatoria => AvaliarConcorrenciaDupla(view),
+            Customizado p => AvaliarCustomizado(p, regra, logger, avisos),
+            _ => throw new InvalidOperationException(
+                $"Variante PredicadoObrigatoriedade não suportada: {regra.Predicado.GetType().Name}. "
+                + "Adicione um case explícito em ValidadorConformidadeEdital.Avaliar."),
+        };
+
+        string descricao = string.IsNullOrEmpty(motivo)
+            ? regra.DescricaoHumana
+            : $"{regra.DescricaoHumana} — {motivo}";
+
+        return new RegraAvaliada(
+            RegraCodigo: regra.RegraCodigo,
+            Aprovada: aprovada,
+            BaseLegal: regra.BaseLegal,
+            PortariaInterna: regra.PortariaInternaCodigo,
+            DescricaoHumana: descricao,
+            Hash: HashPlaceholder(regra));
+    }
+
+    private static (bool, string) AvaliarEtapa(EtapaObrigatoria p, EditalConformidadeView view)
+    {
+        if (string.IsNullOrWhiteSpace(p.TipoEtapaCodigo))
+            return (false, "Predicado malformado: TipoEtapaCodigo vazio.");
+
+        string alvo = p.TipoEtapaCodigo.Trim();
+        bool presente = view.CodigosTiposEtapaPresentes
+            .Any(c => string.Equals(c?.Trim(), alvo, StringComparison.OrdinalIgnoreCase));
+
+        return presente
+            ? (true, string.Empty)
+            : (false, $"Etapa '{alvo}' ausente no edital.");
+    }
+
+    private static (bool, string) AvaliarModalidades(ModalidadesMinimas p, EditalConformidadeView view)
+    {
+        List<string>? exigidos = NormalizarListaObrigatoria(p.Codigos);
+        if (exigidos is null)
+            return (false, "Predicado malformado: lista de modalidades vazia ou só com itens em branco.");
+
+        HashSet<string> presentes = ConstruirIndice(view.CodigosModalidadesPresentes);
+        List<string> ausentes = exigidos.Where(c => !presentes.Contains(c)).ToList();
+
+        return ausentes.Count == 0
+            ? (true, string.Empty)
+            : (false, $"Modalidade(s) ausente(s): {string.Join(", ", ausentes)}.");
+    }
+
+    private static (bool, string) AvaliarDesempate(DesempateDeveIncluir p, EditalConformidadeView view)
+    {
+        if (string.IsNullOrWhiteSpace(p.Criterio))
+            return (false, "Predicado malformado: critério vazio.");
+
+        string alvo = p.Criterio.Trim();
+        bool presente = view.CriteriosDesempateConfigurados
+            .Any(c => string.Equals(c?.Trim(), alvo, StringComparison.OrdinalIgnoreCase));
+
+        return presente
+            ? (true, string.Empty)
+            : (false, $"Critério de desempate '{alvo}' não configurado no edital.");
+    }
+
+    private static (bool, string) AvaliarDocumento(DocumentoObrigatorioParaModalidade p, EditalConformidadeView view)
+    {
+        if (string.IsNullOrWhiteSpace(p.Modalidade) || string.IsNullOrWhiteSpace(p.TipoDocumento))
+            return (false, "Predicado malformado: Modalidade ou TipoDocumento vazio.");
+
+        string modalidade = p.Modalidade.Trim();
+        string tipo = p.TipoDocumento.Trim();
+        bool exigido = view.DocumentosObrigatorios.Any(d =>
+            d is not null &&
+            string.Equals(d.Modalidade?.Trim(), modalidade, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(d.TipoDocumento?.Trim(), tipo, StringComparison.OrdinalIgnoreCase));
+
+        return exigido
+            ? (true, string.Empty)
+            : (false, $"Documento '{tipo}' não exigido para modalidade '{modalidade}'.");
+    }
+
+    private static (bool, string) AvaliarBonus(BonusObrigatorio p, EditalConformidadeView view)
+    {
+        List<string>? exigidas = NormalizarListaObrigatoria(p.ModalidadesAplicaveis);
+        if (exigidas is null)
+            return (false, "Predicado malformado: lista de modalidades aplicáveis vazia ou só com itens em branco.");
+
+        HashSet<string> comBonus = ConstruirIndice(view.ModalidadesComBonus);
+        List<string> faltando = exigidas.Where(m => !comBonus.Contains(m)).ToList();
+
+        return faltando.Count == 0
+            ? (true, string.Empty)
+            : (false, $"Bônus não habilitado para: {string.Join(", ", faltando)}.");
+    }
+
+    private static (bool, string) AvaliarAtendimento(AtendimentoDisponivel p, EditalConformidadeView view)
+    {
+        List<string>? exigidas = NormalizarListaObrigatoria(p.Necessidades);
+        if (exigidas is null)
+            return (false, "Predicado malformado: lista de necessidades vazia ou só com itens em branco.");
+
+        HashSet<string> disponiveis = ConstruirIndice(view.AtendimentosDisponiveis);
+        List<string> faltando = exigidas.Where(n => !disponiveis.Contains(n)).ToList();
+
+        return faltando.Count == 0
+            ? (true, string.Empty)
+            : (false, $"Atendimento(s) ausente(s): {string.Join(", ", faltando)}.");
+    }
+
+    private static (bool, string) AvaliarConcorrenciaDupla(EditalConformidadeView view)
+    {
+        return view.ConcorrenciaDuplaHabilitada
+            ? (true, string.Empty)
+            : (false, "Concorrência dupla (Lei 14.723/2023) não habilitada no edital.");
+    }
+
+    /// <summary>
+    /// Variante de escape (ADR-0058 §"válvula de escape"). Para preservar
+    /// a integridade da evidência legal, a avaliação é <strong>conservadora
+    /// (Aprovada=false)</strong> — o admin que adotou Customizado precisa
+    /// substituir por variante tipada ou anexar parecer manual.
+    /// Aviso estruturado é propagado via <see cref="ResultadoConformidade.Avisos"/>
+    /// e (quando logger fornecido) via <see cref="ILogger"/> warning,
+    /// rastreável em telemetria.
+    /// </summary>
+    private static (bool, string) AvaliarCustomizado(
+        Customizado p,
+        ObrigatoriedadeLegal regra,
+        ILogger? logger,
+        List<string> avisos)
+    {
+        string aviso = $"Predicado.Customizado em uso — RegraCodigo={regra.RegraCodigo} BaseLegal={regra.BaseLegal}. Considere variante tipada.";
+        avisos.Add(aviso);
+
+        if (logger is not null)
+            LogCustomizadoEmUso(logger, regra.RegraCodigo, regra.BaseLegal);
+
+        // p.Parametros é preservado na regra para snapshot/auditoria; nesta
+        // V1 não tentamos interpretar conteúdo arbitrário.
+        _ = p.Parametros;
+
+        return (false, "Predicado.Customizado em uso — avaliação manual exigida; resultado conservador.");
+    }
+
+    /// <summary>
+    /// Normaliza listas obrigatórias: filtra itens null/whitespace, faz
+    /// Trim, e retorna <c>null</c> se a lista resultante for vazia
+    /// (cenário malformado: o caller pediu requisitos, mas nenhum item
+    /// chegou íntegro).
+    /// </summary>
+    private static List<string>? NormalizarListaObrigatoria(IReadOnlyList<string>? lista)
+    {
+        if (lista is null || lista.Count == 0)
+            return null;
+
+        List<string> normalizados = lista
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Select(item => item.Trim())
+            .ToList();
+
+        return normalizados.Count == 0 ? null : normalizados;
+    }
+
+    private static HashSet<string> ConstruirIndice(IReadOnlyList<string> origem)
+        => new(
+            origem.Where(c => !string.IsNullOrWhiteSpace(c)).Select(c => c.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Hash V1 do <see cref="RegraAvaliada"/>. Computa SHA-256 sobre uma
+    /// concatenação dos campos textuais do placeholder
+    /// <see cref="ObrigatoriedadeLegal"/> <em>e</em> da serialização JSON
+    /// do <see cref="PredicadoObrigatoriedade"/> (camelCase, polimórfica),
+    /// para que regras com mesmo <c>RegraCodigo</c> mas predicados
+    /// diferentes produzam hashes distintos. Não é o hash canônico
+    /// determinístico do JSON da regra completa — esse é entregue pela
+    /// Story #460 (US-F4-02) junto com a entidade plena. Não usar este
+    /// valor como evidência forense estável antes da #460 mergear.
+    /// </summary>
+    private static string HashPlaceholder(ObrigatoriedadeLegal regra)
+    {
+        string predicadoJson = JsonSerializer.Serialize<PredicadoObrigatoriedade>(
+            regra.Predicado,
+            PredicadoObrigatoriedade.JsonOptions);
+
+        string payload = string.Join('|', [
+            regra.RegraCodigo,
+            regra.BaseLegal,
+            regra.PortariaInternaCodigo ?? string.Empty,
+            predicadoJson,
+        ]);
+
+        byte[] bytes = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        // Convert.ToHexString já produz uppercase — aceitamos para evitar CA1308.
+        return Convert.ToHexString(bytes);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Predicado.Customizado em uso — considerar variante tipada. RegraCodigo={RegraCodigo} BaseLegal={BaseLegal}")]
+    private static partial void LogCustomizadoEmUso(
+        ILogger logger,
+        string regraCodigo,
+        string baseLegal);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Unifesspa.UniPlus.Selecao.Domain.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Unifesspa.UniPlus.Selecao.Domain.csproj
@@ -1,6 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <!--
+      Microsoft.Extensions.Logging.Abstractions é abstração pura (interfaces +
+      LoggerMessage source generator). Usada exclusivamente pelo domain service
+      ValidadorConformidadeEdital para emitir warning na variante
+      PredicadoObrigatoriedade.Customizado (ADR-0058 §"válvula de escape").
+      Não viola ADR-0013 "pure domain services" — é dependency invertida,
+      não infraestrutura concreta.
+    -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <ProjectReference Include="..\..\shared\Unifesspa.UniPlus.Kernel\Unifesspa.UniPlus.Kernel.csproj" />
   </ItemGroup>
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/EditalConformidadeView.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/EditalConformidadeView.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using Entities;
+
+/// <summary>
+/// Projeção tipada de um <see cref="Edital"/> consumida pelo
+/// <c>ValidadorConformidadeEdital</c>. Existe para que o avaliador opere
+/// contra uma view determinística de campos comparáveis, sem precisar
+/// expandir o agregado <see cref="Edital"/> com propriedades que ainda
+/// não estão modeladas no domínio (critérios de desempate explícitos,
+/// documentos por modalidade, atendimentos PcD, concorrência dupla).
+/// </summary>
+/// <remarks>
+/// <para>A projeção V1 via <see cref="From(Edital)"/> só preenche os
+/// campos que o agregado atual modela: tipos de etapa (via
+/// <c>Etapa.Nome</c> — best-effort até #455 trazer <c>TipoEtapa.Codigo</c>),
+/// modalidades (via <c>Cota.Modalidade.ToString()</c>) e bônus
+/// (via <c>Edital.BonusRegionalHabilitado</c>). Os demais campos saem
+/// vazios/false e os predicados correspondentes reprovam por default —
+/// comportamento documentado como limitação V1 no PR da Story #459.</para>
+/// <para>Testes que precisam exercitar variantes não suportadas pelo
+/// agregado (cenário "Aprovada" de <see cref="DesempateDeveIncluir"/>,
+/// por exemplo) constroem a view diretamente via construtor, sem passar
+/// pelo método <see cref="From(Edital)"/>.</para>
+/// </remarks>
+public sealed record EditalConformidadeView(
+    Guid EditalId,
+    IReadOnlyList<string> CodigosTiposEtapaPresentes,
+    IReadOnlyList<string> CodigosModalidadesPresentes,
+    IReadOnlyList<string> CriteriosDesempateConfigurados,
+    IReadOnlyList<DocumentoObrigatoriedadeView> DocumentosObrigatorios,
+    IReadOnlyList<string> ModalidadesComBonus,
+    IReadOnlyList<string> AtendimentosDisponiveis,
+    bool ConcorrenciaDuplaHabilitada)
+{
+    /// <summary>
+    /// Projeta o agregado <see cref="Edital"/> para a view mínima de V1.
+    /// Campos sem cobertura no agregado atual saem vazios/false — ver
+    /// remarks da classe.
+    /// </summary>
+    public static EditalConformidadeView From(Edital edital)
+    {
+        ArgumentNullException.ThrowIfNull(edital);
+
+        IReadOnlyList<string> tiposEtapa = [.. edital.Etapas.Select(e => e.Nome)];
+        IReadOnlyList<string> modalidades = [.. edital.Cotas.Select(c => c.Modalidade.ToString())];
+        IReadOnlyList<string> modalidadesComBonus = edital.BonusRegionalHabilitado
+            ? modalidades
+            : [];
+
+        return new EditalConformidadeView(
+            EditalId: edital.Id,
+            CodigosTiposEtapaPresentes: tiposEtapa,
+            CodigosModalidadesPresentes: modalidades,
+            CriteriosDesempateConfigurados: [],
+            DocumentosObrigatorios: [],
+            ModalidadesComBonus: modalidadesComBonus,
+            AtendimentosDisponiveis: [],
+            ConcorrenciaDuplaHabilitada: false);
+    }
+}
+
+/// <summary>
+/// Par (modalidade, tipo de documento) usado por
+/// <see cref="DocumentoObrigatorioParaModalidade"/> para representar
+/// quais documentos cada modalidade do edital exige. Modelado como
+/// par textual em V1; entidades dedicadas entram em sprint futura.
+/// </summary>
+public sealed record DocumentoObrigatoriedadeView(string Modalidade, string TipoDocumento);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/PredicadoObrigatoriedade.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/PredicadoObrigatoriedade.cs
@@ -1,0 +1,118 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Conjunto fechado de predicados de validação legal aplicáveis a um edital,
+/// modelado como discriminated union (sealed records derivados de
+/// <see cref="PredicadoObrigatoriedade"/>). Cada variante representa uma
+/// shape distinta de regra reconhecida pelo
+/// <c>ValidadorConformidadeEdital</c> — ver
+/// <c>Selecao.Domain.Services.ValidadorConformidadeEdital</c>.
+/// </summary>
+/// <remarks>
+/// <para>Conforme ADR-0058 (validação data-driven com citação), a forma é
+/// fechada por design: novas categorias de regra exigem adição de variante
+/// tipada explícita + amendment do ADR. A válvula <see cref="Customizado"/>
+/// existe apenas para regras transitórias enquanto a categoria definitiva
+/// não é desenhada — uso emite warning no avaliador.</para>
+/// <para>Persistência via System.Text.Json polimórfico (atributos abaixo).
+/// O discriminator <c>$tipo</c> bate com o ADR-0058 §"Discriminated union".
+/// Os 8 names são camelCase para alinhar com a política do projeto.</para>
+/// <para>Exhaustividade do pattern match consumidor é garantida em build:
+/// o switch expression no avaliador NÃO usa catch-all, e <c>CS8509</c> é
+/// promovido a erro via <c>TreatWarningsAsErrors</c>. Logo, adicionar
+/// uma 9ª variante quebra a build até o avaliador absorver o caso.</para>
+/// </remarks>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$tipo")]
+[JsonDerivedType(typeof(EtapaObrigatoria), "etapaObrigatoria")]
+[JsonDerivedType(typeof(ModalidadesMinimas), "modalidadesMinimas")]
+[JsonDerivedType(typeof(DesempateDeveIncluir), "desempateDeveIncluir")]
+[JsonDerivedType(typeof(DocumentoObrigatorioParaModalidade), "documentoObrigatorioParaModalidade")]
+[JsonDerivedType(typeof(BonusObrigatorio), "bonusObrigatorio")]
+[JsonDerivedType(typeof(AtendimentoDisponivel), "atendimentoDisponivel")]
+[JsonDerivedType(typeof(ConcorrenciaDuplaObrigatoria), "concorrenciaDuplaObrigatoria")]
+[JsonDerivedType(typeof(Customizado), "customizado")]
+public abstract record PredicadoObrigatoriedade
+{
+    /// <summary>
+    /// Opções canônicas de serialização para
+    /// <see cref="PredicadoObrigatoriedade"/>: camelCase + leitura
+    /// case-insensitive. Garante que serialização/round-trip em testes,
+    /// EF Core jsonb (via <c>ValueObjectConverter</c>) e endpoints HTTP
+    /// produzam representações comparáveis.
+    /// </summary>
+    public static JsonSerializerOptions JsonOptions { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = false,
+    };
+}
+
+/// <summary>
+/// Regra: o edital DEVE incluir uma etapa cujo código corresponde a
+/// <paramref name="TipoEtapaCodigo"/>. Em V1, o "código" é comparado
+/// contra a propriedade <c>Etapa.Nome</c> do agregado (ordinal,
+/// case-insensitive). Quando #455 promover <c>TipoEtapa</c> para entidade
+/// com <c>Codigo</c> próprio, a projeção
+/// <c>EditalConformidadeView.CodigosTiposEtapaPresentes</c> passa a usar
+/// esse <c>Codigo</c> — a regra em si não muda.
+/// </summary>
+public sealed record EtapaObrigatoria(string TipoEtapaCodigo) : PredicadoObrigatoriedade;
+
+/// <summary>
+/// Regra: o edital DEVE oferecer todas as modalidades de concorrência
+/// listadas em <paramref name="Codigos"/>. Códigos seguem o naming do
+/// enum <c>ModalidadeConcorrencia</c> (AC, LbPpi, LbQ, …).
+/// </summary>
+public sealed record ModalidadesMinimas(IReadOnlyList<string> Codigos) : PredicadoObrigatoriedade;
+
+/// <summary>
+/// Regra: o edital DEVE configurar critério de desempate
+/// <paramref name="Criterio"/> (ex.: "Idoso", "Nota da etapa X",
+/// "Data de nascimento").
+/// </summary>
+public sealed record DesempateDeveIncluir(string Criterio) : PredicadoObrigatoriedade;
+
+/// <summary>
+/// Regra: a <paramref name="Modalidade"/> indicada DEVE exigir o
+/// <paramref name="TipoDocumento"/> indicado.
+/// </summary>
+public sealed record DocumentoObrigatorioParaModalidade(string Modalidade, string TipoDocumento) : PredicadoObrigatoriedade;
+
+/// <summary>
+/// Regra: o bônus regional DEVE estar ativo para as modalidades listadas
+/// em <paramref name="ModalidadesAplicaveis"/>.
+/// </summary>
+public sealed record BonusObrigatorio(IReadOnlyList<string> ModalidadesAplicaveis) : PredicadoObrigatoriedade;
+
+/// <summary>
+/// Regra: o edital DEVE oferecer atendimento PcD para todas as necessidades
+/// listadas em <paramref name="Necessidades"/>.
+/// </summary>
+public sealed record AtendimentoDisponivel(IReadOnlyList<string> Necessidades) : PredicadoObrigatoriedade;
+
+/// <summary>
+/// Regra: o edital DEVE habilitar concorrência simultânea (Lei 14.723/2023)
+/// — candidato cotista concorre em ampla e na modalidade reservada, sendo
+/// classificado na situação mais favorável.
+/// </summary>
+public sealed record ConcorrenciaDuplaObrigatoria : PredicadoObrigatoriedade;
+
+/// <summary>
+/// Válvula de escape para regras transitórias que não casam com nenhuma
+/// das 7 variantes tipadas acima. Uso é monitorado: o avaliador emite
+/// warning a cada execução. Revisão trimestral promove uma variante tipada
+/// se houver padrão emergente (ADR-0058 §"válvula de escape").
+/// </summary>
+/// <remarks>
+/// <para><c>Parametros</c> é <see cref="JsonElement"/> (não
+/// <see cref="JsonDocument"/>) para evitar gerenciamento de
+/// <see cref="IDisposable"/> em um value object imutável — o pattern
+/// canônico para JSON aninhado em records é <c>JsonElement</c> clonado.
+/// O ADR-0058 fala "JsonDocument parametros" como descrição informal;
+/// a forma técnica adotada é <c>JsonElement</c>.</para>
+/// </remarks>
+public sealed record Customizado(JsonElement Parametros) : PredicadoObrigatoriedade;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ResultadoConformidade.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ResultadoConformidade.cs
@@ -1,0 +1,39 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Resultado da avaliação de um conjunto de
+/// <see cref="Entities.ObrigatoriedadeLegal"/> contra um edital. Cada item
+/// em <see cref="Regras"/> é uma evaluação independente; o veredicto
+/// agregado ("edital conforme") é responsabilidade do consumer (ex.:
+/// `GET /api/editais/{id}/conformidade` no <c>Selecao.API</c>).
+/// </summary>
+/// <param name="Regras">Veredicto por regra avaliada.</param>
+/// <param name="Avisos">
+/// Mensagens diagnósticas geradas durante a avaliação (ex.:
+/// <see cref="PredicadoObrigatoriedade.Customizado"/> em uso). Existe para
+/// permitir que callers — Application/API — propaguem o sinal para logs
+/// estruturados sem o domain service depender de uma stack de logging
+/// concreta. O domain service também publica o sinal via
+/// <c>ILogger</c> opcional (CA-05 da Story #459), mas a propagação
+/// estruturada via <see cref="Avisos"/> é a forma autoritativa.
+/// </param>
+public sealed record ResultadoConformidade(
+    IReadOnlyList<RegraAvaliada> Regras,
+    IReadOnlyList<string> Avisos);
+
+/// <summary>
+/// Veredicto sobre uma <see cref="Entities.ObrigatoriedadeLegal"/>
+/// específica. <see cref="Hash"/> identifica a versão exata da regra
+/// avaliada — em V1 é placeholder computado a partir dos campos textuais
+/// (<see cref="RegraCodigo"/>, <see cref="BaseLegal"/>,
+/// <see cref="PortariaInterna"/>). #460 substitui pelo hash canônico
+/// determinístico do JSON da regra completa, momento em que esse campo
+/// vira evidência forense estável.
+/// </summary>
+public sealed record RegraAvaliada(
+    string RegraCodigo,
+    bool Aprovada,
+    string BaseLegal,
+    string? PortariaInterna,
+    string DescricaoHumana,
+    string Hash);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/packages.lock.json
@@ -2,6 +2,20 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
@@ -1054,6 +1054,7 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -1303,6 +1303,7 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -1202,6 +1202,7 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
@@ -1176,6 +1176,7 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/packages.lock.json
@@ -169,6 +169,7 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
@@ -1176,6 +1176,7 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorConformidadeEditalTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorConformidadeEditalTests.cs
@@ -1,0 +1,504 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Services;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Services;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura unit do <see cref="ValidadorConformidadeEdital"/> conforme
+/// CA-06 da Story #459. As 4 variantes core
+/// (<see cref="EtapaObrigatoria"/>, <see cref="ModalidadesMinimas"/>,
+/// <see cref="DocumentoObrigatorioParaModalidade"/>,
+/// <see cref="DesempateDeveIncluir"/>) recebem 3 cenários cada
+/// (Aprovada/Reprovada/Malformada). As 4 variantes não-core
+/// recebem smoke. Cobertura exaustiva é follow-up registrado antes do merge.
+/// </summary>
+public sealed class ValidadorConformidadeEditalTests
+{
+    // ─── EtapaObrigatoria ───────────────────────────────────────────────
+
+    [Fact(DisplayName = "EtapaObrigatoria aprova quando etapa presente no edital")]
+    public void EtapaObrigatoria_Aprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CodigosTiposEtapaPresentes = ["TipoEtapaA", "TipoEtapaB"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new EtapaObrigatoria("TipoEtapaA"));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras.Should().HaveCount(1);
+        resultado.Regras[0].Aprovada.Should().BeTrue();
+        resultado.Regras[0].RegraCodigo.Should().Be(regra.RegraCodigo);
+    }
+
+    [Fact(DisplayName = "EtapaObrigatoria reprova quando etapa ausente")]
+    public void EtapaObrigatoria_Reprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CodigosTiposEtapaPresentes = ["TipoEtapaB"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new EtapaObrigatoria("TipoEtapaA"));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+        resultado.Regras[0].DescricaoHumana.Should().Contain("TipoEtapaA");
+    }
+
+    [Fact(DisplayName = "EtapaObrigatoria reprova quando TipoEtapaCodigo vazio (malformado)")]
+    public void EtapaObrigatoria_Malformada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CodigosTiposEtapaPresentes = ["TipoEtapaA"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new EtapaObrigatoria("   "));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+        resultado.Regras[0].DescricaoHumana.Should().Contain("malformado");
+    }
+
+    // ─── ModalidadesMinimas ─────────────────────────────────────────────
+
+    [Fact(DisplayName = "ModalidadesMinimas aprova quando todas modalidades presentes")]
+    public void ModalidadesMinimas_Aprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CodigosModalidadesPresentes = ["AC", "LbPpi", "LiQ"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new ModalidadesMinimas(["AC", "LbPpi"]));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "ModalidadesMinimas reprova quando falta modalidade e cita ausente")]
+    public void ModalidadesMinimas_Reprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CodigosModalidadesPresentes = ["AC", "LbPpi"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new ModalidadesMinimas(["AC", "LbPpi", "LiQ"]));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+        resultado.Regras[0].DescricaoHumana.Should().Contain("LiQ");
+    }
+
+    [Fact(DisplayName = "ModalidadesMinimas reprova quando lista vazia (malformada)")]
+    public void ModalidadesMinimas_Malformada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CodigosModalidadesPresentes = ["AC"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new ModalidadesMinimas([]));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+        resultado.Regras[0].DescricaoHumana.Should().Contain("malformado");
+    }
+
+    [Fact(DisplayName = "ModalidadesMinimas reprova quando lista contém só whitespace (malformada)")]
+    public void ModalidadesMinimas_SoBranco_Malformada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CodigosModalidadesPresentes = ["AC"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new ModalidadesMinimas(["  ", "\t", ""]));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+        resultado.Regras[0].DescricaoHumana.Should().Contain("malformado");
+    }
+
+    // ─── DesempateDeveIncluir ───────────────────────────────────────────
+
+    [Fact(DisplayName = "DesempateDeveIncluir aprova quando critério configurado")]
+    public void Desempate_Aprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CriteriosDesempateConfigurados = ["Idoso", "DataNascimento"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new DesempateDeveIncluir("Idoso"));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "DesempateDeveIncluir reprova quando critério ausente")]
+    public void Desempate_Reprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CriteriosDesempateConfigurados = ["DataNascimento"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new DesempateDeveIncluir("Idoso"));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+        resultado.Regras[0].DescricaoHumana.Should().Contain("Idoso");
+    }
+
+    [Fact(DisplayName = "DesempateDeveIncluir reprova quando critério vazio (malformado)")]
+    public void Desempate_Malformada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            CriteriosDesempateConfigurados = ["Idoso"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new DesempateDeveIncluir("   "));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+        resultado.Regras[0].DescricaoHumana.Should().Contain("malformado");
+    }
+
+    // ─── DocumentoObrigatorioParaModalidade ─────────────────────────────
+
+    [Fact(DisplayName = "DocumentoObrigatorioParaModalidade aprova quando par configurado")]
+    public void Documento_Aprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            DocumentosObrigatorios = [new DocumentoObrigatoriedadeView("LbPpi", "AutoDeclaracao")],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new DocumentoObrigatorioParaModalidade("LbPpi", "AutoDeclaracao"));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "DocumentoObrigatorioParaModalidade reprova quando par ausente")]
+    public void Documento_Reprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            DocumentosObrigatorios = [new DocumentoObrigatoriedadeView("LbPpi", "AutoDeclaracao")],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new DocumentoObrigatorioParaModalidade("LbQ", "Heteroidentificacao"));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+        resultado.Regras[0].DescricaoHumana.Should().Contain("LbQ");
+    }
+
+    [Fact(DisplayName = "DocumentoObrigatorioParaModalidade reprova quando modalidade vazia (malformado)")]
+    public void Documento_Malformada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            DocumentosObrigatorios = [new DocumentoObrigatoriedadeView("LbPpi", "AutoDeclaracao")],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new DocumentoObrigatorioParaModalidade("   ", "AutoDeclaracao"));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+        resultado.Regras[0].DescricaoHumana.Should().Contain("malformado");
+    }
+
+    // ─── Smokes das 4 variantes não-core ────────────────────────────────
+
+    [Fact(DisplayName = "BonusObrigatorio aprova quando todas modalidades aplicáveis têm bônus")]
+    public void Bonus_Smoke_Aprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            ModalidadesComBonus = ["AC", "LbPpi"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new BonusObrigatorio(["AC"]));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "AtendimentoDisponivel aprova quando necessidades cobertas")]
+    public void Atendimento_Smoke_Aprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with
+        {
+            AtendimentosDisponiveis = ["LibrasInterprete", "ProvaAmpliada"],
+        };
+        ObrigatoriedadeLegal regra = NovaRegra(new AtendimentoDisponivel(["LibrasInterprete"]));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "ConcorrenciaDuplaObrigatoria aprova quando habilitada no edital")]
+    public void ConcorrenciaDupla_Smoke_Aprovada()
+    {
+        EditalConformidadeView view = ViewVazia() with { ConcorrenciaDuplaHabilitada = true };
+        ObrigatoriedadeLegal regra = NovaRegra(new ConcorrenciaDuplaObrigatoria());
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(view, [regra]);
+
+        resultado.Regras[0].Aprovada.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Customizado reprova conservadoramente e emite warning + aviso estruturado")]
+    public void Customizado_Smoke_Reprova_E_Avisa()
+    {
+        using JsonDocument doc = JsonDocument.Parse("{\"campoArbitrario\":\"valor\"}");
+        ObrigatoriedadeLegal regra = NovaRegra(new Customizado(doc.RootElement.Clone()));
+        RecordingLogger logger = new();
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(
+            ViewVazia(),
+            [regra],
+            logger);
+
+        resultado.Regras[0].Aprovada.Should().BeFalse(
+            "ADR-0058 §válvula de escape: avaliação manual é exigida para preservar evidência legal");
+        resultado.Regras[0].DescricaoHumana.Should().Contain("Customizado");
+        resultado.Avisos.Should().Contain(a => a.Contains("Customizado em uso", StringComparison.Ordinal));
+        logger.Records.Should().Contain(r =>
+            r.Level == LogLevel.Warning &&
+            r.Message.Contains("Customizado em uso", StringComparison.Ordinal));
+    }
+
+    // ─── Round-trip JSON polimórfico (P3 Codex) ─────────────────────────
+
+    [Theory(DisplayName = "PredicadoObrigatoriedade serializa/deserializa polimorficamente preservando $tipo")]
+    [MemberData(nameof(VariantesParaRoundTrip))]
+    public void RoundTrip_JsonPolimorfico(PredicadoObrigatoriedade original)
+    {
+        ArgumentNullException.ThrowIfNull(original);
+        string json = JsonSerializer.Serialize(original, PredicadoObrigatoriedade.JsonOptions);
+        PredicadoObrigatoriedade? voltou = JsonSerializer.Deserialize<PredicadoObrigatoriedade>(
+            json,
+            PredicadoObrigatoriedade.JsonOptions);
+
+        json.Should().Contain("\"$tipo\":");
+        voltou.Should().NotBeNull();
+        voltou!.GetType().Should().Be(original.GetType());
+    }
+
+    public static TheoryData<PredicadoObrigatoriedade> VariantesParaRoundTrip()
+    {
+        TheoryData<PredicadoObrigatoriedade> data = new()
+        {
+            new EtapaObrigatoria("ProvaObjetiva"),
+            new ModalidadesMinimas(["AC", "LbPpi"]),
+            new DesempateDeveIncluir("Idoso"),
+            new DocumentoObrigatorioParaModalidade("LbPpi", "AutoDeclaracao"),
+            new BonusObrigatorio(["AC"]),
+            new AtendimentoDisponivel(["LibrasInterprete"]),
+            new ConcorrenciaDuplaObrigatoria(),
+        };
+        return data;
+    }
+
+    // ─── Guards de argumento ────────────────────────────────────────────
+
+    [Fact(DisplayName = "Evaluate com view nula lança ArgumentNullException")]
+    public void Evaluate_ViewNula_Lanca()
+    {
+        Action act = () => ValidadorConformidadeEdital.Evaluate(
+            (EditalConformidadeView)null!,
+            []);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "Evaluate com regras nulas lança ArgumentNullException")]
+    public void Evaluate_RegrasNulas_Lanca()
+    {
+        Action act = () => ValidadorConformidadeEdital.Evaluate(ViewVazia(), null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────
+
+    private static EditalConformidadeView ViewVazia() => new(
+        EditalId: Guid.CreateVersion7(),
+        CodigosTiposEtapaPresentes: [],
+        CodigosModalidadesPresentes: [],
+        CriteriosDesempateConfigurados: [],
+        DocumentosObrigatorios: [],
+        ModalidadesComBonus: [],
+        AtendimentosDisponiveis: [],
+        ConcorrenciaDuplaHabilitada: false);
+
+    private static ObrigatoriedadeLegal NovaRegra(PredicadoObrigatoriedade predicado)
+    {
+        Kernel.Results.Result<ObrigatoriedadeLegal> r = ObrigatoriedadeLegal.Criar(
+            regraCodigo: "REGRA_TESTE",
+            predicado: predicado,
+            baseLegal: "Lei 12.711/2012 art.1º",
+            descricaoHumana: "Regra de teste",
+            portariaInternaCodigo: "Portaria CTIC 2026/01");
+
+        r.IsSuccess.Should().BeTrue();
+        return r.Value!;
+    }
+
+    /// <summary>
+    /// Coletor minimal de logs em memória; substitui NSubstitute para evitar
+    /// dependência adicional no projeto de testes de domínio.
+    /// </summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<(LogLevel Level, string Message)> Records { get; } = [];
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
+            => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+            Records.Add((logLevel, formatter(state, exception)));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    [Fact(DisplayName = "Evaluate sem logger ainda funciona para Customizado (não lança)")]
+    public void Customizado_SemLogger_NaoLanca()
+    {
+        using JsonDocument doc = JsonDocument.Parse("{\"x\":1}");
+        ObrigatoriedadeLegal regra = NovaRegra(new Customizado(doc.RootElement.Clone()));
+
+        Action act = () => ValidadorConformidadeEdital.Evaluate(ViewVazia(), [regra], logger: null);
+        act.Should().NotThrow();
+    }
+
+    [Fact(DisplayName = "Evaluate com Edital agregado projeta para view via From e funciona")]
+    public void Evaluate_ComEdital_FuncionaViaProjecao()
+    {
+        // Cobre o overload público que recebe Edital — confirma que o From
+        // extrai etapas/modalidades sem explodir.
+        Kernel.Results.Result<NumeroEdital> numero = NumeroEdital.Criar(1, 2026);
+        numero.IsSuccess.Should().BeTrue();
+
+        Edital edital = Edital.Criar(numero.Value!, "Edital de teste");
+        ObrigatoriedadeLegal regra = NovaRegra(new EtapaObrigatoria("ProvaObjetiva"));
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(
+            edital,
+            [regra],
+            NullLogger.Instance);
+
+        // Edital sem etapas → EtapaObrigatoria reprova.
+        resultado.Regras[0].Aprovada.Should().BeFalse();
+    }
+}
+
+/// <summary>
+/// Fitness reflectivo: itera por reflection sobre todos os tipos
+/// derivados de <see cref="PredicadoObrigatoriedade"/> e verifica que
+/// o avaliador responde a cada variante sem cair no catch-all do switch
+/// (<see cref="InvalidOperationException"/>). Esse é o gate real de
+/// exhaustividade exigido pelo CA-04 da #459 — C# não suporta union
+/// fechada nativamente, então a garantia vive aqui.
+/// </summary>
+public sealed class ValidadorConformidadeEditalExhaustividadeTests
+{
+    [Fact(DisplayName = "Avaliador responde a TODAS as variantes derivadas de PredicadoObrigatoriedade")]
+    public void TodasVariantesAvaliadasSemFallback()
+    {
+        Type baseType = typeof(PredicadoObrigatoriedade);
+        Type[] derivados = baseType.Assembly
+            .GetTypes()
+            .Where(t => baseType.IsAssignableFrom(t) && t != baseType && !t.IsAbstract)
+            .ToArray();
+
+        derivados.Should().NotBeEmpty("PredicadoObrigatoriedade deve ter variantes concretas registradas");
+
+        EditalConformidadeView view = new(
+            EditalId: Guid.CreateVersion7(),
+            CodigosTiposEtapaPresentes: ["ProvaObjetiva"],
+            CodigosModalidadesPresentes: ["AC"],
+            CriteriosDesempateConfigurados: ["Idoso"],
+            DocumentosObrigatorios: [new DocumentoObrigatoriedadeView("AC", "RG")],
+            ModalidadesComBonus: ["AC"],
+            AtendimentosDisponiveis: ["LibrasInterprete"],
+            ConcorrenciaDuplaHabilitada: true);
+
+        foreach (Type derivado in derivados)
+        {
+            PredicadoObrigatoriedade predicado = InstanciarVariante(derivado);
+            Kernel.Results.Result<ObrigatoriedadeLegal> regra = ObrigatoriedadeLegal.Criar(
+                regraCodigo: $"FITNESS_{derivado.Name}",
+                predicado: predicado,
+                baseLegal: "Lei 12.711/2012",
+                descricaoHumana: "Fitness");
+            regra.IsSuccess.Should().BeTrue();
+
+            Action act = () => ValidadorConformidadeEdital.Evaluate(
+                view,
+                [regra.Value!],
+                NullLogger.Instance);
+
+            act.Should().NotThrow(
+                $"variante {derivado.Name} precisa ter case explícito em ValidadorConformidadeEdital.Avaliar");
+        }
+    }
+
+    private static PredicadoObrigatoriedade InstanciarVariante(Type tipo)
+    {
+        if (tipo == typeof(EtapaObrigatoria))
+            return new EtapaObrigatoria("ProvaObjetiva");
+        if (tipo == typeof(ModalidadesMinimas))
+            return new ModalidadesMinimas(["AC"]);
+        if (tipo == typeof(DesempateDeveIncluir))
+            return new DesempateDeveIncluir("Idoso");
+        if (tipo == typeof(DocumentoObrigatorioParaModalidade))
+            return new DocumentoObrigatorioParaModalidade("AC", "RG");
+        if (tipo == typeof(BonusObrigatorio))
+            return new BonusObrigatorio(["AC"]);
+        if (tipo == typeof(AtendimentoDisponivel))
+            return new AtendimentoDisponivel(["LibrasInterprete"]);
+        if (tipo == typeof(ConcorrenciaDuplaObrigatoria))
+            return new ConcorrenciaDuplaObrigatoria();
+        if (tipo == typeof(Customizado))
+        {
+            using JsonDocument doc = JsonDocument.Parse("{}");
+            return new Customizado(doc.RootElement.Clone());
+        }
+
+        throw new NotSupportedException(
+            $"Adicione factory para nova variante {tipo.Name} em ValidadorConformidadeEditalExhaustividadeTests.InstanciarVariante "
+            + "(esse erro é intencional — confirma que o fitness sabe instanciar cada derivado).");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/packages.lock.json
@@ -52,6 +52,11 @@
         "resolved": "18.5.1",
         "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.5.1",
@@ -117,7 +122,17 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
         }
       }
     }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -1242,6 +1242,7 @@
       "unifesspa.uniplus.selecao.domain": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },


### PR DESCRIPTION
## Sumário

Implementa a Story **#459** (US-F4-01) da Feature **#444** (Sprint 3):
- `PredicadoObrigatoriedade` como discriminated union de 8 variantes
  (`sealed abstract record` + 8 records derivados) com `JsonPolymorphic`
  (discriminator `$tipo`) e `JsonNamingPolicy.CamelCase`.
- `ValidadorConformidadeEdital` como pure domain service com pattern
  match exhaustive + fitness reflectivo de variantes.
- `ObrigatoriedadeLegal` placeholder mínimo (forma plena em #460).
- `ResultadoConformidade` + `RegraAvaliada` + `EditalConformidadeView`
  (projeção do agregado para o avaliador).

Conforme [ADR-0058](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0058-obrigatoriedade-legal-validacao-data-driven.md) §"Discriminated union" + §"válvula de escape".

## Critérios de aceite

- [x] **CA-01**: 8 variantes em `PredicadoObrigatoriedade.cs` —
  `EtapaObrigatoria`, `ModalidadesMinimas`, `DesempateDeveIncluir`,
  `DocumentoObrigatorioParaModalidade`, `BonusObrigatorio`,
  `AtendimentoDisponivel`, `ConcorrenciaDuplaObrigatoria`, `Customizado`.
- [x] **CA-02**: `[JsonPolymorphic(TypeDiscriminatorPropertyName = "$tipo")]`
  + 8 `[JsonDerivedType]` — round-trip JSON coberto por teste Theory.
  Persistência jsonb concreta entra em #460 com `ValueObjectConverter`.
- [x] **CA-03**: `ValidadorConformidadeEdital.Evaluate(Edital, regras, ILogger?)`
  + sobrecarga `Evaluate(EditalConformidadeView, regras, ILogger?)`.
  `ObrigatoriedadeLegal` introduzida como placeholder mínimo conforme
  o item permite — vide bloco "Fronteira com #460" abaixo.
- [x] **CA-04**: `ResultadoConformidade(IReadOnlyList<RegraAvaliada>, IReadOnlyList<string> Avisos)`;
  `RegraAvaliada(RegraCodigo, Aprovada, BaseLegal, PortariaInterna,
  DescricaoHumana, Hash)`. Pattern match cobre as 8 variantes.
  Exhaustividade real é exercitada por
  `ValidadorConformidadeEditalExhaustividadeTests.TodasVariantesAvaliadasSemFallback`,
  que itera reflectivamente todos os derivados.
- [x] **CA-05**: `Customizado` emite warning via `[LoggerMessage]` source
  generator (`LogCustomizadoEmUso`). Aviso também propagado de forma
  estruturada via `ResultadoConformidade.Avisos`.
- [x] **CA-06**: Unit tests
  - 4 variantes core × 3 cenários (Aprovada/Reprovada/Malformada) = 12 testes.
  - 4 variantes não-core × 1 smoke cada = 4 testes.
  - Edge cases adicionais: lista só-whitespace = malformada,
    round-trip JSON, guards de argumento, projeção `From(Edital)`.
  - Cobertura exaustiva das 4 não-core: follow-up #TBD (link no comment
    pós-criação).
- [x] **CA-07**: Domain service infrastructure-free. Única dep adicional:
  `Microsoft.Extensions.Logging.Abstractions` (interface pura — não viola
  ADR-0013 "pure domain services"). Fitness `Stage1ArchitectureRulesTests.R2`
  permanece verde (R2 protege contra `Wolverine.*`).

## Decisões de design (não-óbvias)

### Catch-all do switch + fitness reflectivo

C# não oferece discriminated union fechado nativamente — `record abstract` +
derivados `sealed` não emite `CS8509` quando todos os casos concretos estão
cobertos. Mantemos catch-all `_ => throw InvalidOperationException` para
proteger runtime, e a garantia substantiva de exhaustividade vive em
`ValidadorConformidadeEditalExhaustividadeTests`, que itera por reflection
os derivados e exige que o avaliador responda sem cair no fallback.

### `EditalConformidadeView` em vez de inflar `Edital`

O agregado `Edital` ainda não modela critérios de desempate, documentos
obrigatórios por modalidade, atendimentos PcD nem concorrência dupla.
A projeção tipada via `EditalConformidadeView.From(Edital)` permite cobrir
as 4 variantes core sem expandir o agregado fora do escopo desta Story —
testes que precisam exercitar variantes não-suportadas pelo agregado
constroem a view diretamente. Quando o agregado evoluir, `From` se
estende sem mudança de assinatura pública.

### Customizado avalia conservadoramente

ADR-0058 define `Customizado` como "válvula de escape". O avaliador
retorna `Aprovada=false` em vez de aprovar otimisticamente, para evitar
falso positivo legal: o admin que adotou `Customizado` precisa
substituir por variante tipada ou anexar parecer manual. Sinal de uso
sai por dois canais: `ILogger` (warning) **e**
`ResultadoConformidade.Avisos`.

### `JsonElement` em `Customizado` (não `JsonDocument`)

ADR-0058 texto descritivo diz "JsonDocument parametros". Adotamos
`JsonElement` (struct, não `IDisposable`) por ergonomia em value objects
imutáveis — semântica preservada, sem mudança em discriminated union.

### Hash em V1 é placeholder

`HashPlaceholder` computa SHA-256 sobre payload textual + JSON polimórfico
do predicado. Diferencia regras com mesmo `RegraCodigo` mas predicados
distintos, mas **não** é o hash canônico determinístico exigido pelo
snapshot RN08 — esse vem em **#460** (CA-05 daquela Story).

## Fronteira com #460 (US-F4-02)

Esta Story criou `ObrigatoriedadeLegal` como `sealed record` placeholder
com apenas os campos exigidos pela avaliação:
`RegraCodigo`, `Predicado`, `BaseLegal`, `DescricaoHumana`,
`PortariaInternaCodigo?`. **#460 promove o placeholder para entity plena**
(herda `EntityBase`, ganha `Vigencia`, `Categoria`, `TipoEditalCodigo`,
governance `IAreaScopedEntity`, `Hash` canônico, audit interceptor) e
substitui o `HashPlaceholder` por hash canônico determinístico do JSON
completo. **Alinhar no PR review** se algum revisor preferir ajustar a
forma do placeholder antes do merge.

## Test plan

- [x] `dotnet build UniPlus.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test --filter '!IntegrationTests'` — unit + arch verdes.
- [x] `Stage1ArchitectureRulesTests.R2` verde (Domain sem Wolverine).
- [x] `ContractV1FitnessTestsTests.Codes_DeDomainError_EstaoRegistradosNoMapper`
  verde — 4 novos códigos adicionados a `SelecaoDomainErrorRegistration`.
- [x] Fitness reflectivo de exhaustividade verde.
- [ ] CI completo (Build + Unit+arch + Integration + Coverage).
- [ ] Codex AI review pós-push.

## Riscos remanescentes

1. Hash placeholder (substituído em #460).
2. Avaliação de `Customizado` é conservadora — admin deve substituir.
3. Quatro variantes (Bonus/Atendimento/Concorrência/Customizado) recebem
   smoke + edge cases nesta Story; cobertura exaustiva é follow-up.

Closes #459
Refs #444