### PR TITLE
refactor(selecao): remove dependência de logging do Domain

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ValidadorConformidadeEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ValidadorConformidadeEdital.cs
@@ -4,8 +4,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 
-using Microsoft.Extensions.Logging;
-
 using Entities;
 using ValueObjects;
 
@@ -13,31 +11,27 @@ using ValueObjects;
 /// Domain service puro que avalia um conjunto de
 /// <see cref="ObrigatoriedadeLegal"/> contra um <see cref="Edital"/>
 /// (ou sua projeção <see cref="EditalConformidadeView"/>), conforme
-/// ADR-0058. Sem dependência de infraestrutura: o avaliador é função pura
-/// modulo o logger opcional usado para a variante
-/// <see cref="Customizado"/>.
+/// ADR-0058. <strong>Sem dependência de infraestrutura nem de
+/// abstrações de logging</strong>: ADR-0013 mantido estrito.
 /// </summary>
 /// <remarks>
 /// <para>Pattern match: 8 cases concretos + catch-all <c>_ => throw</c>
-/// (C# não suporta union fechado; CS8509 só dispararia se removêssemos
-/// o catch-all, o que silenciaria variantes futuras). A garantia
-/// substantiva de exhaustividade vive no fitness reflectivo
+/// (C# não suporta union fechado nativamente). A garantia substantiva de
+/// exhaustividade vive no fitness reflectivo
 /// <c>ValidadorConformidadeEditalExhaustividadeTests</c> em
 /// <c>Selecao.Domain.UnitTests</c>: ele itera por reflection cada tipo
 /// derivado e exige que o avaliador responda sem cair no catch-all.</para>
 /// <para>Comparações textuais usam <see cref="StringComparison.OrdinalIgnoreCase"/>
-/// com <c>Trim()</c> nos inputs (admin UI pode chegar com capitalização
-/// inconsistente). Predicados cujas listas obrigatórias só contêm
-/// whitespace/null são tratados como <em>malformados</em> e reprovam com
-/// motivo explícito — não como "tudo presente, lista vazia equivale a
-/// nenhum requisito".</para>
-/// <para>Avisos diagnósticos (uso de <see cref="Customizado"/>, por
-/// exemplo) são propagados via <see cref="ResultadoConformidade.Avisos"/>
-/// E também via <see cref="ILogger"/> opcional quando o caller passa um.
-/// Application layers que quiserem manter Domain ainda mais frio podem
-/// consumir só <see cref="ResultadoConformidade.Avisos"/>.</para>
+/// com <c>Trim()</c> nos inputs. Predicados cujas listas obrigatórias só
+/// contêm whitespace/null são tratados como <em>malformados</em> e
+/// reprovam com motivo explícito.</para>
+/// <para>Sinais diagnósticos (uso de <see cref="Customizado"/>) saem
+/// pela coleção estruturada <see cref="ResultadoConformidade.Avisos"/>.
+/// O caller — Application/API — consome a coleção e roteia para o
+/// pipeline de logging local (<c>[LoggerMessage]</c> idiomático lá).
+/// O domain não emite logs.</para>
 /// </remarks>
-public static partial class ValidadorConformidadeEdital
+public static class ValidadorConformidadeEdital
 {
     /// <summary>
     /// Avalia as regras contra o agregado <see cref="Edital"/>. Internamente
@@ -46,13 +40,12 @@ public static partial class ValidadorConformidadeEdital
     /// </summary>
     public static ResultadoConformidade Evaluate(
         Edital edital,
-        IReadOnlyList<ObrigatoriedadeLegal> regras,
-        ILogger? logger = null)
+        IReadOnlyList<ObrigatoriedadeLegal> regras)
     {
         ArgumentNullException.ThrowIfNull(edital);
         ArgumentNullException.ThrowIfNull(regras);
 
-        return Evaluate(EditalConformidadeView.From(edital), regras, logger);
+        return Evaluate(EditalConformidadeView.From(edital), regras);
     }
 
     /// <summary>
@@ -61,8 +54,7 @@ public static partial class ValidadorConformidadeEdital
     /// </summary>
     public static ResultadoConformidade Evaluate(
         EditalConformidadeView view,
-        IReadOnlyList<ObrigatoriedadeLegal> regras,
-        ILogger? logger = null)
+        IReadOnlyList<ObrigatoriedadeLegal> regras)
     {
         ArgumentNullException.ThrowIfNull(view);
         ArgumentNullException.ThrowIfNull(regras);
@@ -71,7 +63,7 @@ public static partial class ValidadorConformidadeEdital
         List<string> avisos = [];
         foreach (ObrigatoriedadeLegal regra in regras)
         {
-            avaliadas.Add(Avaliar(regra, view, logger, avisos));
+            avaliadas.Add(Avaliar(regra, view, avisos));
         }
 
         return new ResultadoConformidade(avaliadas, avisos);
@@ -80,7 +72,6 @@ public static partial class ValidadorConformidadeEdital
     private static RegraAvaliada Avaliar(
         ObrigatoriedadeLegal regra,
         EditalConformidadeView view,
-        ILogger? logger,
         List<string> avisos)
     {
         ArgumentNullException.ThrowIfNull(regra);
@@ -94,7 +85,7 @@ public static partial class ValidadorConformidadeEdital
             BonusObrigatorio p => AvaliarBonus(p, view),
             AtendimentoDisponivel p => AvaliarAtendimento(p, view),
             ConcorrenciaDuplaObrigatoria => AvaliarConcorrenciaDupla(view),
-            Customizado p => AvaliarCustomizado(p, regra, logger, avisos),
+            Customizado p => AvaliarCustomizado(p, regra, avisos),
             _ => throw new InvalidOperationException(
                 $"Variante PredicadoObrigatoriedade não suportada: {regra.Predicado.GetType().Name}. "
                 + "Adicione um case explícito em ValidadorConformidadeEdital.Avaliar."),
@@ -212,21 +203,19 @@ public static partial class ValidadorConformidadeEdital
     /// a integridade da evidência legal, a avaliação é <strong>conservadora
     /// (Aprovada=false)</strong> — o admin que adotou Customizado precisa
     /// substituir por variante tipada ou anexar parecer manual.
-    /// Aviso estruturado é propagado via <see cref="ResultadoConformidade.Avisos"/>
-    /// e (quando logger fornecido) via <see cref="ILogger"/> warning,
-    /// rastreável em telemetria.
+    /// O sinal de uso é propagado via
+    /// <see cref="ResultadoConformidade.Avisos"/>; a Application consome a
+    /// coleção e roteia para o pipeline de logging local
+    /// (<c>[LoggerMessage]</c> idiomático no handler de
+    /// <c>ObterConformidadeQuery</c>, planejado para a Story #461).
     /// </summary>
     private static (bool, string) AvaliarCustomizado(
         Customizado p,
         ObrigatoriedadeLegal regra,
-        ILogger? logger,
         List<string> avisos)
     {
-        string aviso = $"Predicado.Customizado em uso — RegraCodigo={regra.RegraCodigo} BaseLegal={regra.BaseLegal}. Considere variante tipada.";
-        avisos.Add(aviso);
-
-        if (logger is not null)
-            LogCustomizadoEmUso(logger, regra.RegraCodigo, regra.BaseLegal);
+        avisos.Add(
+            $"Predicado.Customizado em uso — RegraCodigo={regra.RegraCodigo} BaseLegal={regra.BaseLegal}. Considere variante tipada.");
 
         // p.Parametros é preservado na regra para snapshot/auditoria; nesta
         // V1 não tentamos interpretar conteúdo arbitrário.
@@ -287,12 +276,4 @@ public static partial class ValidadorConformidadeEdital
         // Convert.ToHexString já produz uppercase — aceitamos para evitar CA1308.
         return Convert.ToHexString(bytes);
     }
-
-    [LoggerMessage(
-        Level = LogLevel.Warning,
-        Message = "Predicado.Customizado em uso — considerar variante tipada. RegraCodigo={RegraCodigo} BaseLegal={BaseLegal}")]
-    private static partial void LogCustomizadoEmUso(
-        ILogger logger,
-        string regraCodigo,
-        string baseLegal);
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Unifesspa.UniPlus.Selecao.Domain.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Unifesspa.UniPlus.Selecao.Domain.csproj
@@ -1,15 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <!--
-      Microsoft.Extensions.Logging.Abstractions é abstração pura (interfaces +
-      LoggerMessage source generator). Usada exclusivamente pelo domain service
-      ValidadorConformidadeEdital para emitir warning na variante
-      PredicadoObrigatoriedade.Customizado (ADR-0058 §"válvula de escape").
-      Não viola ADR-0013 "pure domain services" — é dependency invertida,
-      não infraestrutura concreta.
-    -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <ProjectReference Include="..\..\shared\Unifesspa.UniPlus.Kernel\Unifesspa.UniPlus.Kernel.csproj" />
   </ItemGroup>
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/packages.lock.json
@@ -2,20 +2,6 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
-      "Microsoft.Extensions.Logging.Abstractions": {
-        "type": "Direct",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
-        }
-      },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
-        "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
-      },
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorConformidadeEditalTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorConformidadeEditalTests.cs
@@ -4,9 +4,6 @@ using System.Text.Json;
 
 using AwesomeAssertions;
 
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
 using Unifesspa.UniPlus.Selecao.Domain.Services;
 using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
@@ -264,25 +261,22 @@ public sealed class ValidadorConformidadeEditalTests
         resultado.Regras[0].Aprovada.Should().BeTrue();
     }
 
-    [Fact(DisplayName = "Customizado reprova conservadoramente e emite warning + aviso estruturado")]
+    [Fact(DisplayName = "Customizado reprova conservadoramente e propaga aviso estruturado")]
     public void Customizado_Smoke_Reprova_E_Avisa()
     {
         using JsonDocument doc = JsonDocument.Parse("{\"campoArbitrario\":\"valor\"}");
         ObrigatoriedadeLegal regra = NovaRegra(new Customizado(doc.RootElement.Clone()));
-        RecordingLogger logger = new();
 
         ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(
             ViewVazia(),
-            [regra],
-            logger);
+            [regra]);
 
         resultado.Regras[0].Aprovada.Should().BeFalse(
             "ADR-0058 §válvula de escape: avaliação manual é exigida para preservar evidência legal");
         resultado.Regras[0].DescricaoHumana.Should().Contain("Customizado");
-        resultado.Avisos.Should().Contain(a => a.Contains("Customizado em uso", StringComparison.Ordinal));
-        logger.Records.Should().Contain(r =>
-            r.Level == LogLevel.Warning &&
-            r.Message.Contains("Customizado em uso", StringComparison.Ordinal));
+        resultado.Avisos.Should().Contain(a =>
+            a.Contains("Customizado em uso", StringComparison.Ordinal) &&
+            a.Contains(regra.RegraCodigo, StringComparison.Ordinal));
     }
 
     // ─── Round-trip JSON polimórfico (P3 Codex) ─────────────────────────
@@ -362,47 +356,6 @@ public sealed class ValidadorConformidadeEditalTests
         return r.Value!;
     }
 
-    /// <summary>
-    /// Coletor minimal de logs em memória; substitui NSubstitute para evitar
-    /// dependência adicional no projeto de testes de domínio.
-    /// </summary>
-    private sealed class RecordingLogger : ILogger
-    {
-        public List<(LogLevel Level, string Message)> Records { get; } = [];
-
-        public IDisposable BeginScope<TState>(TState state) where TState : notnull
-            => NullScope.Instance;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-            ArgumentNullException.ThrowIfNull(formatter);
-            Records.Add((logLevel, formatter(state, exception)));
-        }
-
-        private sealed class NullScope : IDisposable
-        {
-            public static readonly NullScope Instance = new();
-            public void Dispose() { }
-        }
-    }
-
-    [Fact(DisplayName = "Evaluate sem logger ainda funciona para Customizado (não lança)")]
-    public void Customizado_SemLogger_NaoLanca()
-    {
-        using JsonDocument doc = JsonDocument.Parse("{\"x\":1}");
-        ObrigatoriedadeLegal regra = NovaRegra(new Customizado(doc.RootElement.Clone()));
-
-        Action act = () => ValidadorConformidadeEdital.Evaluate(ViewVazia(), [regra], logger: null);
-        act.Should().NotThrow();
-    }
-
     [Fact(DisplayName = "Evaluate com Edital agregado projeta para view via From e funciona")]
     public void Evaluate_ComEdital_FuncionaViaProjecao()
     {
@@ -414,10 +367,7 @@ public sealed class ValidadorConformidadeEditalTests
         Edital edital = Edital.Criar(numero.Value!, "Edital de teste");
         ObrigatoriedadeLegal regra = NovaRegra(new EtapaObrigatoria("ProvaObjetiva"));
 
-        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(
-            edital,
-            [regra],
-            NullLogger.Instance);
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(edital, [regra]);
 
         // Edital sem etapas → EtapaObrigatoria reprova.
         resultado.Regras[0].Aprovada.Should().BeFalse();
@@ -465,10 +415,7 @@ public sealed class ValidadorConformidadeEditalExhaustividadeTests
                 descricaoHumana: "Fitness");
             regra.IsSuccess.Should().BeTrue();
 
-            Action act = () => ValidadorConformidadeEdital.Evaluate(
-                view,
-                [regra.Value!],
-                NullLogger.Instance);
+            Action act = () => ValidadorConformidadeEdital.Evaluate(view, [regra.Value!]);
 
             act.Should().NotThrow(
                 $"variante {derivado.Name} precisa ter case explícito em ValidadorConformidadeEdital.Avaliar");


### PR DESCRIPTION
## Sumário

Ajuste cirúrgico no follow-up de #459 / PR #510: remover a dependência
`Microsoft.Extensions.Logging.Abstractions` que o `Selecao.Domain`
ganhou para emitir warning na variante `PredicadoObrigatoriedade.Customizado`.

A motivação original era CA-05 da #459 ("emite log nível Warning via
`[LoggerMessage]`"). Mas durante a review #510 já introduzimos
`ResultadoConformidade.Avisos[]` — canal estruturado para o mesmo sinal.
Com isso o `ILogger?` no Domain virou redundante e contradiz ADR-0013
("pure domain services, zero dependências de infraestrutura").

## Mudanças

- `Selecao.Domain.csproj`: remove `<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />`. Volta ao estado pré-#459 (só `ProjectReference` do Kernel).
- `ValidadorConformidadeEdital.cs`:
  - Remove parâmetro `ILogger? logger = null` das duas sobrecargas
    `Evaluate(...)`.
  - Remove o `partial method` com `[LoggerMessage]` `LogCustomizadoEmUso`.
  - `AvaliarCustomizado` propaga o aviso apenas via
    `ResultadoConformidade.Avisos` (que já carrega `RegraCodigo` +
    `BaseLegal`).
  - Classe deixa de ser `partial` (não precisa mais).
- Testes:
  - Remove a inner class `RecordingLogger`.
  - Remove `using Microsoft.Extensions.Logging` / `...Abstractions`.
  - `Customizado_Smoke_Reprova_E_Avisa` valida apenas `Avisos`
    (inclui assert de `RegraCodigo` na mensagem).
  - Remove o teste `Customizado_SemLogger_NaoLanca` (não há mais
    parâmetro logger).
  - `Evaluate_ComEdital_FuncionaViaProjecao` e fitness reflectivo
    deixam de usar `NullLogger.Instance`.

## CA-05 ainda honrado?

Sim, no espírito: o `[LoggerMessage]` source generator continua sendo
o pattern obrigatório do projeto — apenas migra de camada. Quando a
Story #461 trouxer o admin CRUD + endpoint
`GET /api/editais/{id}/conformidade`, o handler em
`Selecao.Application` lê `ResultadoConformidade.Avisos` e emite o
warning com `[LoggerMessage]` idiomático lá (onde
`Microsoft.Extensions.Logging.Abstractions` é dependência natural via
`Application.Abstractions`).

Documentei o handoff no XML doc de `AvaliarCustomizado`.

## Test plan

- [x] `dotnet build UniPlus.slnx` — 0 warnings, 0 errors.
- [x] `dotnet test --filter '!IntegrationTests'` — unit + arch verdes
  (34 testes no Selecao.Domain.UnitTests, suíte completa estável).
- [x] `Stage1ArchitectureRulesTests.R2` continua verde — Domain sem
  `Wolverine.*`.
- [ ] CI completo.

## Risco

Nenhum funcional: o sinal de uso de `Customizado` continua sendo
propagado de forma estruturada e visível. A diferença é que o Domain
agora não emite log diretamente — Application emite quando consumir.

Refs #459, PR #510