### PR TITLE
test(selecao): cobre rejeição de JSON malformado em PredicadoObrigatoriedade

### DIFF
--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorConformidadeEditalTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorConformidadeEditalTests.cs
@@ -311,6 +311,38 @@ public sealed class ValidadorConformidadeEditalTests
         return data;
     }
 
+    [Fact(DisplayName = "PredicadoObrigatoriedade rejeita JSON com discriminator $tipo desconhecido")]
+    public void Deserialize_DiscriminatorDesconhecido_Lanca()
+    {
+        // CA da Task #491: contrato JSON do System.Text.Json com [JsonPolymorphic]
+        // deve rejeitar tipos não registrados via [JsonDerivedType] — proteção
+        // contra row corrompida no jsonb (cenário BDD #459 "Predicado JSON
+        // malformado quebra deserialização").
+        const string jsonComTipoDesconhecido = """{"$tipo":"variantePropostaQueNaoExiste","x":1}""";
+
+        Action act = () => JsonSerializer.Deserialize<PredicadoObrigatoriedade>(
+            jsonComTipoDesconhecido,
+            PredicadoObrigatoriedade.JsonOptions);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact(DisplayName = "PredicadoObrigatoriedade rejeita JSON sem discriminator $tipo")]
+    public void Deserialize_SemDiscriminator_Lanca()
+    {
+        // Reforça a invariante: rows no jsonb sem o campo $tipo (ex.: legado
+        // pré-#459 ou corrupção) não devem deserializar para nenhuma variante.
+        // STJ levanta NotSupportedException por se tratar de tipo abstrato sem
+        // discriminator (vs JsonException para discriminator desconhecido).
+        const string jsonSemDiscriminator = """{"tipoEtapaCodigo":"ProvaObjetiva"}""";
+
+        Action act = () => JsonSerializer.Deserialize<PredicadoObrigatoriedade>(
+            jsonSemDiscriminator,
+            PredicadoObrigatoriedade.JsonOptions);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
     // ─── Guards de argumento ────────────────────────────────────────────
 
     [Fact(DisplayName = "Evaluate com view nula lança ArgumentNullException")]


### PR DESCRIPTION
## Sumário

Adiciona dois testes em `Selecao.Domain.UnitTests` endereçando lacunas de cobertura identificadas no triage das tasks #491/#492 (descendentes da Story #459):

- `Deserialize_DiscriminatorDesconhecido_Lanca` — `JsonException` ao deserializar JSON com `$tipo` não registrado em `[JsonDerivedType]`. **CA explícito** da #491.
- `Deserialize_SemDiscriminator_Lanca` — `NotSupportedException` ao deserializar JSON sem `$tipo` em tipo abstrato (caso STJ distinto, mesma invariante de "rejeitar payload legado/corrompido"). Bônus de robustez.

Os dois cenários reforçam o BDD da #459 ("Predicado JSON malformado quebra deserialização") que estava implicitamente coberto pelo `System.Text.Json` mas sem teste explícito.

## Mudanças

- `tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorConformidadeEditalTests.cs` (+32 linhas)

Sem mudança em source de produção.

## Test plan

- [x] `dotnet test tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/` — 36/36 verdes (era 34, +2 testes novos).
- [ ] CI completo.

## Pós-merge

- Fechar #491 (todos os CAs atendidos).
- Fechar #492 (já estava integralmente atendido em main; apenas atualização de body, sem mudança de código).

Refs #459, #491, #492