### PR TITLE
fix(logging): remove Console sink duplicado dos appsettings

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.json
@@ -22,17 +22,13 @@
     "Enabled": true
   },
   "Serilog": {
-    "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore": "Warning"
       }
-    },
-    "WriteTo": [
-      { "Name": "Console" }
-    ]
+    }
   },
   "AllowedHosts": "*"
 }

--- a/src/portal/Unifesspa.UniPlus.Portal.API/appsettings.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/appsettings.json
@@ -22,17 +22,13 @@
     "Enabled": true
   },
   "Serilog": {
-    "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore": "Warning"
       }
-    },
-    "WriteTo": [
-      { "Name": "Console" }
-    ]
+    }
   },
   "AllowedHosts": "*"
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.json
@@ -22,17 +22,13 @@
     "Enabled": true
   },
   "Serilog": {
-    "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore": "Warning"
       }
-    },
-    "WriteTo": [
-      { "Name": "Console" }
-    ]
+    }
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Problema

Pós-deploy v0.3.11, logs ainda apareciam duplicados no stdout dos pods:

```
[14:39:44 Information] End processing HTTP request... {Properties:j} TraceId=... SpanId=...
[14:39:44 INF] End processing HTTP request...
```

A linha `INF` persistia no Loki como `unknown` (2161 entradas na janela de 5min vs 1034 `Information`).

## Causa raiz

`appsettings.json` dos 3 APIs declarava `"WriteTo": [{"Name": "Console"}]`, que é carregado pelo `.ReadFrom.Configuration()` em `ConfigurarSerilog` e cria um Console sink com o **template padrão** do Serilog (`{Level:u3}` → `INF`). O código adiciona um segundo Console sink com o `ConsoleOutputTemplate` correto (`{Level}` → `Information`).

Resultado: cada evento é emitido duas vezes — uma pelo sink JSON (unknown no Loki) e outra pelo sink de código (information).

## Fix

Removido `"Using"` e `"WriteTo"` da seção `Serilog` dos 3 `appsettings.json`. O `MinimumLevel` permanece para que `.ReadFrom.Configuration` continue configurando níveis mínimos e overrides.

## Arquivos alterados

- `src/selecao/.../appsettings.json`
- `src/ingresso/.../appsettings.json`
- `src/portal/.../appsettings.json`

Closes #516
Refs #513