### PR TITLE
fix(logging): silencia logs Information do OidcDiscoveryHealthCheck

### DIFF
--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/appsettings.json
@@ -26,7 +26,8 @@
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
-        "Microsoft.EntityFrameworkCore": "Warning"
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System.Net.Http.HttpClient.OidcDiscoveryHealthCheck": "Warning"
       }
     }
   },

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/appsettings.json
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/appsettings.json
@@ -22,17 +22,14 @@
     "Enabled": true
   },
   "Serilog": {
-    "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
-        "Microsoft.EntityFrameworkCore": "Warning"
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System.Net.Http.HttpClient.OidcDiscoveryHealthCheck": "Warning"
       }
-    },
-    "WriteTo": [
-      { "Name": "Console" }
-    ]
+    }
   },
   "AllowedHosts": "*"
 }

--- a/src/parametrizacao/Unifesspa.UniPlus.Parametrizacao.API/appsettings.json
+++ b/src/parametrizacao/Unifesspa.UniPlus.Parametrizacao.API/appsettings.json
@@ -22,17 +22,14 @@
     "Enabled": true
   },
   "Serilog": {
-    "Using": ["Serilog.Sinks.Console"],
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
-        "Microsoft.EntityFrameworkCore": "Warning"
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System.Net.Http.HttpClient.OidcDiscoveryHealthCheck": "Warning"
       }
-    },
-    "WriteTo": [
-      { "Name": "Console" }
-    ]
+    }
   },
   "AllowedHosts": "*"
 }

--- a/src/portal/Unifesspa.UniPlus.Portal.API/appsettings.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/appsettings.json
@@ -26,7 +26,8 @@
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
-        "Microsoft.EntityFrameworkCore": "Warning"
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System.Net.Http.HttpClient.OidcDiscoveryHealthCheck": "Warning"
       }
     }
   },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/appsettings.json
@@ -26,7 +26,8 @@
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
-        "Microsoft.EntityFrameworkCore": "Warning"
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "System.Net.Http.HttpClient.OidcDiscoveryHealthCheck": "Warning"
       }
     }
   },


### PR DESCRIPTION
## Problema

O health check OIDC (`OidcDiscoveryHealthCheck`) consulta o Keycloak em `/.well-known/openid-configuration` a cada probe do K8s (~10s), gerando **4 logs `Information`** por ciclo por serviço:

```
SourceContext: System.Net.Http.HttpClient.OidcDiscoveryHealthCheck.LogicalHandler
SourceContext: System.Net.Http.HttpClient.OidcDiscoveryHealthCheck.ClientHandler
```

**Impacto medido:** ~96 logs/min por serviço = **70% do volume total de logs** no cluster.

O override `"Microsoft": "Warning"` não cobria `System.Net.Http.*` — namespace diferente.

## Fix

Adiciona override nos `appsettings.json` dos 3 módulos:

```json
"System.Net.Http.HttpClient.OidcDiscoveryHealthCheck": "Warning"
```

Nível `Warning` preserva alertas de degradação do OIDC; apenas a telemetria operacional normal é suprimida.

## Verificação

Após deploy (v0.3.13), consultar Loki:

```logql
{k8s_namespace_name="uniplus"} |~ "OidcDiscoveryHealthCheck"
```

Deve retornar zero resultados em condição normal.

Closes #518