### PR TITLE
docs(adr): convenção de roteamento path-based + reconciliação de vocabulário Sprint 3

### DIFF
--- a/docs/adrs/0058-obrigatoriedade-legal-validacao-data-driven.md
+++ b/docs/adrs/0058-obrigatoriedade-legal-validacao-data-driven.md
@@ -215,6 +215,73 @@ Vendor MIME: `application/vnd.uniplus.obrigatoriedade-legal.v1+json`.
 - **Prós**: Discussão acima.
 - **Contras**: Discussão acima.
 
+## Emenda 1 (2026-05-16) — vocabulário, URL path-based e semântica do PUT
+
+Durante a auditoria pré-implementação de #461, três pontos desta ADR foram
+reconciliados com (a) a diretriz sponsor sobre vocabulário, (b) a convenção
+de roteamento formalizada na ADR-0064 (path-based com prefixo de módulo,
+otimizada para Traefik) e (c) o que foi efetivamente entregue em #520
+(Story #460):
+
+### 1.1 — URLs com prefixo de módulo (`/api/selecao/...`) sem "catálogos"
+
+A seção §"REST surface" usava `/api/catalogos/obrigatoriedades`. O termo
+"catálogo" fica reservado para um futuro conceito de domínio (Catálogo de
+Serviços ou equivalente); o que estamos construindo é parametrização. E,
+per ADR-0064, recursos REST seguem `/api/{modulo}/{recurso}` para permitir
+roteamento path-prefix simples no Traefik (1 subdomain, 1 cert TLS, 1
+origin CORS).
+
+Mapeamento canônico:
+
+| Antigo (desta ADR) | Novo (per ADR-0064) |
+|---|---|
+| `GET /api/catalogos/obrigatoriedades?tipoEdital={codigo}` | `GET /api/selecao/obrigatoriedades-legais?tipoEdital={codigo}` |
+| `GET /api/catalogos/obrigatoriedades/{id:guid}` | `GET /api/selecao/obrigatoriedades-legais/{id:guid}` |
+| `POST /api/admin/catalogos/obrigatoriedades` | `POST /api/selecao/admin/obrigatoriedades-legais` |
+| `PUT /api/admin/catalogos/obrigatoriedades/{id:guid}` | `PUT /api/selecao/admin/obrigatoriedades-legais/{id:guid}` |
+| `DELETE /api/admin/catalogos/obrigatoriedades/{id:guid}` | `DELETE /api/selecao/admin/obrigatoriedades-legais/{id:guid}` |
+| `GET /api/editais/{id:guid}/conformidade` | `GET /api/selecao/editais/{id:guid}/conformidade` |
+| `GET /api/editais/{id:guid}/conformidade-historica` | `GET /api/selecao/editais/{id:guid}/conformidade-historica` |
+
+Logs estruturados, OpenAPI tags e códigos de erro continuam usando o nome
+da entidade (`obrigatoriedade_legal`, `ObrigatoriedadeLegal`), nunca
+"catálogo".
+
+### 1.2 — Semântica do PUT é in-place full-replace
+
+A seção §"REST surface" descreveu PUT como "soft-delete a versão anterior,
+insere nova (hash muda)". A entrega em #520 (Story #460) convergiu para
+**in-place full-replace** com auditoria via tabela append-only
+`obrigatoriedade_legal_historico`:
+
+- O método `ObrigatoriedadeLegal.Atualizar(...)` aplica todos os campos
+  literalmente sobre a entidade existente (mantém o `Id`).
+- O `ObrigatoriedadeLegalHistoricoInterceptor` grava uma linha no histórico
+  com o `Hash` recomputado e o conteúdo canônico — invariante atômico
+  garantido por estar dentro do mesmo `SaveChangesAsync`.
+- A URI do recurso é estável: `GET /api/obrigatoriedades-legais/{id}`
+  sempre retorna a versão vigente; reconstrução histórica é via
+  `obrigatoriedade_legal_historico` ou via `EditalGovernanceSnapshot`
+  (quando a regra foi vinculada a um edital publicado).
+- Editais já publicados antes da edição mantêm seu `EditalGovernanceSnapshot`
+  original — o hash difere do hash atual da regra; é exatamente isso que
+  preserva a evidência forense.
+- O `Atualizar` exige **todos os campos explicitamente** (full-replace
+  semantics — defaults `null` removidos da assinatura per Codex P1 em #520).
+
+Esta semântica é mais simples, preserva URI stability e dispensa lógica de
+"reativação" de versões soft-deleted — o snapshot histórico já cumpre o
+papel de evidência da versão anterior.
+
+### 1.3 — `EditalGovernanceSnapshot` é `IForensicEntity`
+
+A seção §"Snapshot-on-bind" referia-se a `ObrigatoriedadesSnapshot` como
+nome conceitual. A entrega em #520 nomeou-o `EditalGovernanceSnapshot` e
+o classificou como `IForensicEntity` (ADR-0063) — append-only, sem
+soft-delete, com FK `RESTRICT` para `editais` (em #461) e para
+`obrigatoriedades_legais` quando relevante.
+
 ## Mais informações
 
 - [ADR-0013](0013-motor-de-classificacao-como-servicos-de-dominio-puros.md) — Motor de classificação como pure domain services (precedent para evaluator data-driven sem DSL).
@@ -225,3 +292,5 @@ Vendor MIME: `application/vnd.uniplus.obrigatoriedade-legal.v1+json`.
 - [ADR-0055](0055-organizacao-institucional-bounded-context.md) — OrganizacaoInstitucional bounded context.
 - [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) — Módulo Parametrizacao e carve-out read-side.
 - [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) — RBAC por áreas com snapshot, histórico, invariantes.
+- [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md) — Entidades forensics append-only isentas de soft-delete.
+- [ADR-0064](0064-convencao-roteamento-path-based-com-prefixo-modulo.md) — Convenção de roteamento path-based com prefixo de módulo.

--- a/docs/adrs/0058-obrigatoriedade-legal-validacao-data-driven.md
+++ b/docs/adrs/0058-obrigatoriedade-legal-validacao-data-driven.md
@@ -260,7 +260,7 @@ insere nova (hash muda)". A entrega em #520 (Story #460) convergiu para
 - O `ObrigatoriedadeLegalHistoricoInterceptor` grava uma linha no histórico
   com o `Hash` recomputado e o conteúdo canônico — invariante atômico
   garantido por estar dentro do mesmo `SaveChangesAsync`.
-- A URI do recurso é estável: `GET /api/obrigatoriedades-legais/{id}`
+- A URI do recurso é estável: `GET /api/selecao/obrigatoriedades-legais/{id}`
   sempre retorna a versão vigente; reconstrução histórica é via
   `obrigatoriedade_legal_historico` ou via `EditalGovernanceSnapshot`
   (quando a regra foi vinculada a um edital publicado).

--- a/docs/adrs/0062-seed-de-catalogos-via-newman-e-endpoints-admin.md
+++ b/docs/adrs/0062-seed-de-catalogos-via-newman-e-endpoints-admin.md
@@ -211,6 +211,40 @@ Decisão por classe de teste durante a implementação. Call sites mais simples 
 - **Prós**: discussão acima.
 - **Contras**: discussão acima.
 
+## Emenda 1 (2026-05-16) — vocabulário e URLs path-based
+
+A diretriz sponsor reservou o termo "catálogo" para um futuro conceito de
+domínio. O que esta ADR descreve são **entidades de parametrização** (per
+ADR-0056). E, per ADR-0064, todos os endpoints admin seguem o padrão
+path-based com prefixo de módulo. O conteúdo técnico (Newman, idempotência,
+audit, fitness test de roster) permanece válido — apenas os nomes e
+URLs mudam:
+
+| Antigo | Novo |
+|---|---|
+| "10 catálogos" | "10 entidades de parametrização" |
+| `tools/seeds/seed-catalogos.postman_collection.json` | `tools/seeds/seed-parametrizacao.postman_collection.json` |
+| variável `${CATALOG}` no `run.sh` | `${ENTIDADE}` |
+| Folder Postman "AreasOrganizacionais (catálogo)" | "AreasOrganizacionais" (sem qualificador) |
+
+As URLs admin alvo dos POSTs do Newman seguem a ADR-0064:
+
+| Recurso | URL admin |
+|---|---|
+| Modalidade | `POST /api/parametrizacao/admin/modalidades` |
+| NecessidadeEspecial | `POST /api/parametrizacao/admin/necessidades-especiais` |
+| TipoDocumento | `POST /api/parametrizacao/admin/tipos-documento` |
+| Endereco | `POST /api/parametrizacao/admin/enderecos` |
+| AreaOrganizacional | `POST /api/organizacao/admin/areas-organizacionais` |
+| TipoEdital | `POST /api/selecao/admin/tipos-edital` |
+| TipoEtapa | `POST /api/selecao/admin/tipos-etapa` |
+| CriterioDesempate | `POST /api/selecao/admin/criterios-desempate` |
+| LocalProva | `POST /api/selecao/admin/locais-prova` |
+| ObrigatoriedadeLegal | `POST /api/selecao/admin/obrigatoriedades-legais` |
+
+`docs/guia-banco-de-dados.md` e `seeds/README.md` (quando criado em #463)
+devem refletir o novo vocabulário e os paths atualizados.
+
 ## Mais informações
 
 - [ADR-0023](0023-problemdetails-rfc-9457.md) — ProblemDetails RFC 9457 (Newman tests checam contra).

--- a/docs/adrs/0064-convencao-roteamento-path-based-com-prefixo-modulo.md
+++ b/docs/adrs/0064-convencao-roteamento-path-based-com-prefixo-modulo.md
@@ -1,0 +1,300 @@
+---
+status: "accepted"
+date: "2026-05-16"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+  - "DevOps (DIRSI)"
+---
+
+# ADR-0064: Convenção de roteamento — path-based com prefixo de módulo
+
+## Contexto e enunciado do problema
+
+O `uniplus-api` é um monolito modular composto por 5 APIs ASP.NET independentes,
+cada uma compilada em container Docker próprio e implantada como serviço
+separado:
+
+| API | Bounded context | Container |
+|---|---|---|
+| `Selecao.API` | Editais, inscrições, classificação (CEPS) | `uniplus-selecao` |
+| `Ingresso.API` | Chamadas, convocações, matrículas (CRCA) | `uniplus-ingresso` |
+| `OrganizacaoInstitucional.API` | `AreaOrganizacional` (roster fechado per ADR-0055) | `uniplus-organizacao` |
+| `Parametrizacao.API` | Entidades cross-cutting (Modalidade, NecessidadeEspecial, TipoDocumento, Endereco) | `uniplus-parametrizacao` |
+| `Portal.API` | Landing público + auth gateway | `uniplus-portal` |
+
+Em HML/PROD as 5 APIs são expostas atrás de um **Traefik (ou Ingress
+Kubernetes equivalente)** definido em `uniplus-infra`. O frontend Angular
+no `uniplus-web` consome HTTP a partir de um único origin. Surge a
+pergunta de como o reverse proxy roteia as requisições para a API correta.
+
+Os controllers iniciais convergiram para dois padrões inconsistentes:
+
+- `EditalController` (Selecao) declara `[Route("api/editais")]` — recurso
+  direto sob `/api/`.
+- `AreasOrganizacionaisController` (OrganizacaoInstitucional) declara
+  `[Route("api")]` com paths `/api/areas-organizacionais` e
+  `/api/admin/areas-organizacionais` — também sem prefixo de módulo.
+- `PingController` (Portal) declara `[Route("api/portal/ping")]` — único
+  caso com prefixo de módulo.
+
+ADRs antigas (ADR-0058 §"REST surface", ADR-0062) propunham
+`/api/catalogos/...` como prefixo de agrupamento — vocabulário rejeitado
+pelo sponsor (o termo "catálogo" fica reservado a um futuro conceito de
+domínio).
+
+Falta uma convenção explícita que reconcilie (a) o pattern dos controllers
+existentes, (b) o vocabulário sponsor e (c) o custo operacional de
+configurar Traefik + DNS + TLS.
+
+## Drivers da decisão
+
+- **Operação do Traefik em HML/PROD**: regra de roteamento mais simples
+  possível, idealmente um único subdomain com path matchers.
+- **TLS gerenciado**: minimizar quantidade de certificados (Let's Encrypt
+  HTTP-01 challenge é simples para 1 domain, exige DNS-01 para wildcard).
+- **Frontend Angular**: um único `API_URL` configurado por ambiente, sem
+  precisar diferenciar 5 origins distintos no `environment.ts`.
+- **CORS**: um único origin liberado nos controllers, sem multiplicar
+  whitelist por API.
+- **Movimentação de recursos entre módulos**: ADR-0058 documenta critérios
+  para promover `ObrigatoriedadeLegal` para um futuro módulo `Normativos` —
+  decisão arquitetural rara (anos), proporcional a uma URL change.
+- **Vocabulário sponsor**: nem "catálogos" nem "parametrização" devem
+  aparecer como segmento de URL como **categoria genérica**, mas o nome do
+  **bounded context** (`selecao`, `parametrizacao`, `ingresso`, `organizacao`,
+  `portal`) é descritivo arquitetural válido — não conflita com a diretriz.
+
+## Opções consideradas
+
+- **A**: `/api/{recurso}` sem prefixo de módulo, separação cross-API via
+  **host/subdomain** (`selecao.api.uniplus.unifesspa.edu.br`, etc).
+- **B**: `/api/{modulo}/{recurso}` com prefixo de módulo, separação
+  cross-API via **path prefix** sob um único host (escolhida).
+- **C**: `/api/{recurso}` em todas APIs, gateway agregador dedicado
+  (Ocelot, YARP) que multiplexa para os 5 backends.
+- **D**: Híbrido — recursos canônicos sem prefix; admin endpoints com
+  prefix de módulo.
+
+## Resultado da decisão
+
+**Escolhida:** "B — path-based com prefixo de módulo, sob um único host",
+porque é o pattern idiomático do Traefik (`PathPrefix(/api/selecao)`),
+exige apenas 1 subdomain DNS e 1 certificado TLS, simplifica CORS para o
+frontend a um único origin, e mantém uniformidade entre APIs sem custo
+operacional adicional.
+
+### Forma concreta
+
+Cada controller declara `[Route("api/{modulo}/{recurso-plural-kebab}")]` ou
+`[Route("api/{modulo}")]` com paths action-level quando há split
+público/admin:
+
+```csharp
+[ApiController]
+[Route("api/selecao/obrigatoriedades-legais")]
+public sealed class ObrigatoriedadeLegalController : ControllerBase { ... }
+```
+
+Para split público/admin no mesmo controller:
+
+```csharp
+[ApiController]
+[Route("api/selecao")]
+public sealed class ObrigatoriedadeLegalController : ControllerBase
+{
+    [HttpGet("obrigatoriedades-legais")]
+    public Task<IActionResult> Listar(...) { ... }
+
+    [HttpPost("admin/obrigatoriedades-legais")]
+    public Task<IActionResult> Criar(...) { ... }
+}
+```
+
+### Naming convention
+
+- **Segmento de módulo** em minúsculas, sem hífen interno, refletindo o
+  bounded context: `selecao`, `parametrizacao`, `ingresso`, `organizacao`
+  (encurtado de `organizacao-institucional` para legibilidade), `portal`.
+- **Segmento de recurso**: plural kebab-case (`obrigatoriedades-legais`,
+  `areas-organizacionais`, `necessidades-especiais`, `tipos-documento`).
+- **Admin endpoints**: `{recurso}` ganha sufixo de path `admin/` (com
+  módulo já no prefix): `/api/selecao/admin/obrigatoriedades-legais`,
+  `/api/parametrizacao/admin/modalidades`. RBAC restrito por
+  `AreaScopedAuthorizationHandler` (ADR-0057).
+- **Sub-recursos**: `/api/{modulo}/{recurso-pai}/{id}/{sub-recurso}` —
+  ex.: `/api/selecao/editais/{id}/conformidade`.
+
+### Endpoints operacionais
+
+Endpoints sem semântica REST de recurso (health, readiness, ping, metrics)
+seguem o mesmo padrão: `/api/{modulo}/health`, `/api/{modulo}/ping`. Não
+suportam vendor MIME nem aparecem no OpenAPI público. `PingController` em
+Portal (`/api/portal/ping`) já segue.
+
+### Roteamento Traefik / Ingress
+
+Em HML/PROD, um único host (`api.uniplus.unifesspa.edu.br`) com regras
+path-prefix:
+
+```text
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/selecao`)       → uniplus-selecao
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/ingresso`)      → uniplus-ingresso
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/parametrizacao`)→ uniplus-parametrizacao
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/organizacao`)   → uniplus-organizacao
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/portal`)        → uniplus-portal
+```
+
+Um único certificado TLS para `api.uniplus.unifesspa.edu.br` (HTTP-01
+challenge funciona — não exige wildcard). CORS configurado para um único
+origin (`uniplus.unifesspa.edu.br` em PROD).
+
+Em DEV (`docker-compose`), cada API expõe porta distinta; o frontend
+local pode rodar com `API_URL=http://localhost:7080` apontando para
+qualquer reverse proxy local (ou portas diretas durante debug).
+
+Recursos REST entre APIs nunca colidem porque o segmento de módulo
+diferencia. Consumo cross-API in-process usa `IXxxReader` (ADR-0056), não
+HTTP.
+
+### Mapeamento canônico Sprint 3
+
+| Recurso | API hospedeira | URL público | URL admin | Vendor MIME |
+|---|---|---|---|---|
+| Edital | Selecao | `/api/selecao/editais` | `/api/selecao/admin/editais` | `vnd.uniplus.edital.v1+json` |
+| ObrigatoriedadeLegal | Selecao | `/api/selecao/obrigatoriedades-legais` | `/api/selecao/admin/obrigatoriedades-legais` | `vnd.uniplus.obrigatoriedade-legal.v1+json` |
+| TipoEdital | Selecao | `/api/selecao/tipos-edital` | `/api/selecao/admin/tipos-edital` | `vnd.uniplus.tipo-edital.v1+json` |
+| TipoEtapa | Selecao | `/api/selecao/tipos-etapa` | `/api/selecao/admin/tipos-etapa` | `vnd.uniplus.tipo-etapa.v1+json` |
+| CriterioDesempate | Selecao | `/api/selecao/criterios-desempate` | `/api/selecao/admin/criterios-desempate` | `vnd.uniplus.criterio-desempate.v1+json` |
+| LocalProva | Selecao | `/api/selecao/locais-prova` | `/api/selecao/admin/locais-prova` | `vnd.uniplus.local-prova.v1+json` |
+| Modalidade | Parametrizacao | `/api/parametrizacao/modalidades` | `/api/parametrizacao/admin/modalidades` | `vnd.uniplus.modalidade.v1+json` |
+| NecessidadeEspecial | Parametrizacao | `/api/parametrizacao/necessidades-especiais` | `/api/parametrizacao/admin/necessidades-especiais` | `vnd.uniplus.necessidade-especial.v1+json` |
+| TipoDocumento | Parametrizacao | `/api/parametrizacao/tipos-documento` | `/api/parametrizacao/admin/tipos-documento` | `vnd.uniplus.tipo-documento.v1+json` |
+| Endereco | Parametrizacao | `/api/parametrizacao/enderecos` | `/api/parametrizacao/admin/enderecos` | `vnd.uniplus.endereco.v1+json` |
+| AreaOrganizacional | OrganizacaoInstitucional | `/api/organizacao/areas-organizacionais` | `/api/organizacao/admin/areas-organizacionais` | `vnd.uniplus.area-organizacional.v1+json` |
+
+### Migração dos endpoints já em main
+
+Dois controllers em main usam o padrão antigo sem prefix de módulo:
+
+- `EditalController` em `Selecao.API`: `[Route("api/editais")]` →
+  `[Route("api/selecao/editais")]`.
+- `AreasOrganizacionaisController` em `OrganizacaoInstitucional.API`:
+  `[Route("api")]` com paths `/api/areas-organizacionais` e
+  `/api/admin/areas-organizacionais` → `[Route("api/organizacao")]` com
+  paths `/api/organizacao/areas-organizacionais` e
+  `/api/organizacao/admin/areas-organizacionais`.
+
+A migração é breaking change para clientes, mas o projeto está em fase
+**pré-HML sem consumers reais** — momento adequado. A migração será
+feita em PRs separados, fora do escopo desta ADR (cada controller
+afetado tem sua própria PR de cutover acompanhada por atualização do
+respectivo OpenAPI spec).
+
+### Vocabulário sponsor preservado
+
+Os segmentos de módulo (`selecao`, `parametrizacao`, etc) são **nomes de
+bounded contexts arquiteturais**, não rótulos genéricos como "catálogo"
+ou "parametrização (do recurso X)". A diretriz sponsor de reservar
+"catálogo" a um futuro conceito de domínio continua honrada — nenhum path
+usa `/catalogos/` ou rótulo categoria-genérica.
+
+## Consequências
+
+### Positivas
+
+- **Operação Traefik trivial**: regras `PathPrefix(/api/{modulo})` por
+  API, 1 subdomain, 1 certificado TLS, 1 origin CORS.
+- **DNS simples**: um único registro A para `api.uniplus.unifesspa.edu.br`,
+  sem necessidade de wildcard ou múltiplos subdomains.
+- **Frontend simples**: um `API_URL` único no `environment.ts`; todos os
+  recursos navegam por path relativo (`/api/selecao/...`).
+- **OpenAPI per-resource (ADR-0028) preservado**: cada API tem seu próprio
+  doc, com base path `/api/{modulo}`.
+- **Uniformidade**: todo recurso de negócio tem `/api/{modulo}/{recurso}`,
+  sem exceções; endpoints operacionais idem.
+- **Bounded context explícito na URL**: dev/admin/cliente identifica o
+  módulo dono pela URL sem precisar de doc paralelo.
+
+### Negativas
+
+- **URLs mais verbosas**: `/api/selecao/editais` em vez de `/api/editais`.
+  Custo cosmético — frontend usa interpolação ou helper, dev raramente
+  digita à mão.
+- **Movimentação de recurso entre módulos é breaking change**: se
+  `ObrigatoriedadeLegal` for promovida para um módulo `Normativos` (per
+  critérios em ADR-0058), a URL muda de `/api/selecao/obrigatoriedades-legais`
+  para `/api/normativos/obrigatoriedades-legais`. Mitigado por (a) ser
+  decisão arquitetural rara (anos), (b) versionamento per-resource
+  (ADR-0028) permitir deprecation graceful, (c) ingress poder manter
+  rewrite temporário durante migração.
+- **Migração dos 2 controllers em main**: cutover precisa ser executado
+  antes que mais clientes consumam os paths antigos. Trabalho one-time.
+
+### Neutras
+
+- O segmento de módulo na URL é descritivo, mas semanticamente redundante
+  com o host (em ambientes onde o ingress já isolou as APIs por path).
+  Aceitável — torna a URL self-documenting.
+
+## Confirmação
+
+- **Fitness test (futuro)**: análise estática que verifica em
+  `*.API/Controllers/*.cs` que `[Route(...)]` segue `api/{modulo}` ou
+  `api/{modulo}/{recurso-kebab}`. Implementado quando o terceiro recurso
+  novo (post-#461) entrar.
+- **Manifest do Traefik/Ingress** em `uniplus-infra` deve listar as 5
+  rules de PathPrefix por API. PR de cutover dos controllers em main
+  acompanha a configuração de ingress equivalente.
+- **Code review obrigatório**: qualquer PR que introduza controller sem
+  prefix de módulo na rota precisa amendment desta ADR.
+
+## Prós e contras das opções
+
+### A — Host-based (`Host(selecao.api.…)`)
+
+- **Bom**: URLs curtas (`/api/editais`); promoção de recurso entre
+  módulos não muda URL.
+- **Ruim**: 5 subdomains DNS + 5 certificados TLS (ou wildcard com DNS-01
+  challenge mais complexo); 5 origins CORS no frontend; precisa env var
+  por API no frontend.
+
+### B — Path-based (escolhida)
+
+- **Bom**: 1 subdomain, 1 cert, 1 origin CORS, 1 env var no frontend;
+  pattern idiomático do Traefik; bounded context explícito na URL.
+- **Ruim**: URLs mais verbosas; promoção de recurso entre módulos é
+  breaking change.
+
+### C — Gateway agregador (Ocelot/YARP)
+
+- **Bom**: cliente vê API monolítica; recursos podem ser remapeados sem
+  breaking change.
+- **Ruim**: adiciona infra extra (gateway dedicado, latência, ponto de
+  falha) sem benefício proporcional para 5 APIs.
+
+### D — Híbrido (recurso direto + admin com prefix)
+
+- **Bom**: nenhum claro.
+- **Ruim**: inconsistência por design; cada PR decide caso a caso.
+
+## Mais informações
+
+- [ADR-0001](0001-monolito-modular-como-estilo-arquitetural.md) — Monolito
+  modular, cross-módulo via Kafka apenas (write) ou IXxxReader (read).
+- [ADR-0028](0028-versionamento-per-resource-content-negotiation.md) —
+  Vendor MIME per resource.
+- [ADR-0049](0049-hateoas-level-1-recurso-canonico.md) — HATEOAS Level 1
+  (links sempre relativos).
+- [ADR-0055](0055-organizacao-institucional-bounded-context.md) — APIs
+  por bounded context.
+- [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) —
+  Carve-out cross-módulo via `IXxxReader`.
+- [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md) — Emenda
+  1 aplica as URLs com prefixo de módulo desta ADR.
+- [ADR-0062](0062-seed-de-catalogos-via-newman-e-endpoints-admin.md) —
+  Emenda 1 aplica as URLs admin com prefixo de módulo.
+- Documentação Traefik PathPrefix —
+  <https://doc.traefik.io/traefik/routing/routers/#rule>.

--- a/docs/adrs/0064-convencao-roteamento-path-based-com-prefixo-modulo.md
+++ b/docs/adrs/0064-convencao-roteamento-path-based-com-prefixo-modulo.md
@@ -134,15 +134,17 @@ public sealed class ObrigatoriedadeLegalController : ControllerBase
 em main em todas as 5 APIs (via `app.MapHealthChecks(...)` em `Program.cs`)
 e alinha com a convenção Kubernetes — probes (`livenessProbe`,
 `readinessProbe`) são configuradas direto contra o pod IP, frequentemente
-bypassando o ingress. Manter `/health*` na raiz preserva esse caminho
-operacional sem precisar de regra extra no Traefik.
+bypassando o ingress. Health checks são registrados pelo framework
+(`MapHealthChecks`), não por Controller; **não entram no OpenAPI** e não
+suportam vendor MIME — são endpoints de infra.
 
-**Outros endpoints operacionais** sem semântica REST de recurso (ping,
-metrics, info) seguem `/api/{modulo}/{endpoint}` — ex.: `/api/portal/ping`.
-São endpoints "lógicos" da API e fazem sentido dentro do prefix de módulo.
-
-Em todos os casos: não suportam vendor MIME, não aparecem no OpenAPI
-público.
+**Outros endpoints operacionais** sem semântica REST de recurso de
+domínio (ping, info, status) seguem `/api/{modulo}/{endpoint}` —
+ex.: `/api/portal/ping`. São Controllers regulares que **aparecem no
+OpenAPI** (e isso é desejável — `PingController` em Portal existe
+justamente para validar o pipeline de transformers OpenAPI 3.1 do
+esqueleto inicial da API). Não suportam vendor MIME porque o response
+shape é simples e não-versionado por design.
 
 ### Roteamento Traefik / Ingress
 

--- a/docs/adrs/0064-convencao-roteamento-path-based-com-prefixo-modulo.md
+++ b/docs/adrs/0064-convencao-roteamento-path-based-com-prefixo-modulo.md
@@ -129,23 +129,43 @@ public sealed class ObrigatoriedadeLegalController : ControllerBase
 
 ### Endpoints operacionais
 
-Endpoints sem semântica REST de recurso (health, readiness, ping, metrics)
-seguem o mesmo padrão: `/api/{modulo}/health`, `/api/{modulo}/ping`. Não
-suportam vendor MIME nem aparecem no OpenAPI público. `PingController` em
-Portal (`/api/portal/ping`) já segue.
+**Health checks** (`/health`, `/health/live`, `/health/ready`) ficam na
+**raiz de cada API**, sem prefixo `/api/{modulo}/`. Esse é o pattern já
+em main em todas as 5 APIs (via `app.MapHealthChecks(...)` em `Program.cs`)
+e alinha com a convenção Kubernetes — probes (`livenessProbe`,
+`readinessProbe`) são configuradas direto contra o pod IP, frequentemente
+bypassando o ingress. Manter `/health*` na raiz preserva esse caminho
+operacional sem precisar de regra extra no Traefik.
+
+**Outros endpoints operacionais** sem semântica REST de recurso (ping,
+metrics, info) seguem `/api/{modulo}/{endpoint}` — ex.: `/api/portal/ping`.
+São endpoints "lógicos" da API e fazem sentido dentro do prefix de módulo.
+
+Em todos os casos: não suportam vendor MIME, não aparecem no OpenAPI
+público.
 
 ### Roteamento Traefik / Ingress
 
 Em HML/PROD, um único host (`api.uniplus.unifesspa.edu.br`) com regras
-path-prefix:
+de path-prefix usando **trailing slash explícita** para garantir limite
+de segmento de caminho (sem essa precaução, `PathPrefix(/api/selecao)`
+em Traefik também casaria `/api/selecao-foo`, gerando colisão potencial):
 
 ```text
-Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/selecao`)       → uniplus-selecao
-Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/ingresso`)      → uniplus-ingresso
-Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/parametrizacao`)→ uniplus-parametrizacao
-Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/organizacao`)   → uniplus-organizacao
-Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/portal`)        → uniplus-portal
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/selecao/`)        → uniplus-selecao
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/ingresso/`)       → uniplus-ingresso
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/parametrizacao/`) → uniplus-parametrizacao
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/organizacao/`)    → uniplus-organizacao
+Host(`api.uniplus.unifesspa.edu.br`) && PathPrefix(`/api/portal/`)         → uniplus-portal
 ```
+
+Como nenhum controller expõe endpoint em exatamente `/api/{modulo}` (sem
+sub-path), a trailing slash no matcher é suficiente. Caso futuro precise
+de endpoint na raiz do módulo, usar `Path(\`/api/{modulo}\`) || PathPrefix(\`/api/{modulo}/\`)`.
+
+Para os health checks na raiz, regra separada por host (não path) ou,
+preferencialmente, configurar a probe Kubernetes direto contra o pod IP
+bypassando o ingress (pattern padrão).
 
 Um único certificado TLS para `api.uniplus.unifesspa.edu.br` (HTTP-01
 challenge funciona — não exige wildcard). CORS configurado para um único

--- a/docs/adrs/0064-convencao-roteamento-path-based-com-prefixo-modulo.md
+++ b/docs/adrs/0064-convencao-roteamento-path-based-com-prefixo-modulo.md
@@ -165,9 +165,17 @@ Como nenhum controller expõe endpoint em exatamente `/api/{modulo}` (sem
 sub-path), a trailing slash no matcher é suficiente. Caso futuro precise
 de endpoint na raiz do módulo, usar `Path(\`/api/{modulo}\`) || PathPrefix(\`/api/{modulo}/\`)`.
 
-Para os health checks na raiz, regra separada por host (não path) ou,
-preferencialmente, configurar a probe Kubernetes direto contra o pod IP
-bypassando o ingress (pattern padrão).
+Para os health checks na raiz (`/health`, `/health/live`, `/health/ready`),
+**o ingress não consegue desambiguar a API alvo** — todas as 5 APIs
+expõem os mesmos paths sob o mesmo host compartilhado
+`api.uniplus.unifesspa.edu.br`. Tentar rotear por host apenas mandaria
+todas as probes para um único backend (o que casar a regra de maior
+prioridade), quebrando as probes das demais APIs. Por isso, as probes
+Kubernetes **devem** ser configuradas direto contra o pod IP (ou contra
+o `Service` interno do cluster) — bypassando o ingress. Esse é o pattern
+canônico (`livenessProbe` / `readinessProbe` no manifest do `Deployment`)
+e o que `uniplus-infra` aplica. Acesso externo a `/health*` via ingress
+não é suportado por design.
 
 Um único certificado TLS para `api.uniplus.unifesspa.edu.br` (HTTP-01
 challenge funciona — não exige wildcard). CORS configurado para um único

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -91,6 +91,8 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0060](0060-junction-tables-por-entidade-com-view-unificada.md) | Junction tables por entidade para `AreasDeInteresse` + view unificada por DbContext para leituras cross-catálogo | accepted | 2026-05-14 |
 | [0061](0061-referencia-cross-modulo-via-snapshot-copy.md) | Referência cross-módulo via snapshot-copy (value object embedded) com `OrigemId` opcional sem FK | accepted | 2026-05-14 |
 | [0062](0062-seed-de-catalogos-via-newman-e-endpoints-admin.md) | Seed de catálogos via Newman + endpoints admin (sem auto-seeder, audit captura usuário real) | accepted | 2026-05-14 |
+| [0063](0063-entidades-forensics-isentas-de-soft-delete.md) | Entidades forensics append-only (`IForensicEntity`) isentas de soft-delete, mutuamente exclusivas com `EntityBase` | accepted | 2026-05-16 |
+| [0064](0064-convencao-roteamento-path-based-com-prefixo-modulo.md) | Convenção de roteamento — path-based com prefixo de módulo (`/api/{modulo}/{recurso}`), separação cross-API via PathPrefix no Traefik | accepted | 2026-05-16 |
 
 ## Como adicionar um novo ADR
 


### PR DESCRIPTION
## Resumo

PR docs-only que (a) formaliza a convenção de roteamento REST do uniplus-api otimizada para Traefik (path-based com prefixo de módulo) e (b) reconcilia inconsistências de vocabulário e semântica entre ADRs antigas, código em main e diretriz sponsor — antes de iniciar o desenvolvimento de #461 e #462.

## Decisão central: roteamento path-based

Todas as 5 APIs (Selecao, Ingresso, Parametrizacao, OrganizacaoInstitucional, Portal) expõem recursos sob `/api/{modulo}/{recurso-plural-kebab}`. Em HML/PROD um único host (`api.uniplus.unifesspa.edu.br`) com regras Traefik `PathPrefix(/api/{modulo})` roteia para cada API. Trade-offs:

| Aspecto | Path-based (escolhido) | Host-based (rejeitado) |
|---|---|---|
| DNS | 1 subdomain | 5 subdomains |
| TLS | 1 cert via HTTP-01 | 5 certs ou wildcard via DNS-01 |
| CORS frontend | 1 origin | 5 origins |
| Env var Angular | 1 `API_URL` | 5 env vars |
| Traefik rule | `PathPrefix(/api/{modulo})` idiomático | `Host(\`x.api.…\`)` + `PathPrefix(/api)` |
| Verbosidade URL | `/api/selecao/editais` | `/api/editais` |

URLs verbosas é o único custo; tudo o mais é simplificação operacional.

## Mudanças

### Nova ADR

- **ADR-0064** — Convenção de roteamento path-based com prefixo de módulo. Inclui mapeamento canônico dos 11 recursos da Sprint 3 e nota sobre cutover dos 2 controllers em main (`EditalController` `/api/editais` → `/api/selecao/editais`; `AreasOrganizacionaisController` `/api/areas-organizacionais` → `/api/organizacao/areas-organizacionais`).

### Emendas datadas

- **ADR-0058 Emenda 1** — três reconciliações com o que foi entregue em #520 (Story #460):
  1. URLs `/api/selecao/obrigatoriedades-legais` (path-based + sem segmento "catálogos")
  2. PUT é in-place full-replace com auditoria via `obrigatoriedade_legal_historico` (não versionamento)
  3. `EditalGovernanceSnapshot` classificado como `IForensicEntity` per ADR-0063

- **ADR-0062 Emenda 1** — vocabulário Newman alinhado ("10 entidades de parametrização") e paths admin path-based (`POST /api/{modulo}/admin/{recurso}`).

### Índice

- README ganha entradas para ADR-0063 (faltava) e ADR-0064.

## Por que reconciliar agora

- O termo "catálogo" foi reservado pelo sponsor para um futuro conceito de domínio; as ADRs 0058 e 0062 foram escritas antes dessa diretriz e usavam o termo em URLs.
- A convenção de roteamento não estava formalizada — `EditalController` e `AreasOrganizacionaisController` divergiam entre si, e Traefik exige uniformidade na configuração de ingress.
- A semântica do PUT na ADR-0058 (versionamento por novo Id) divergia do que foi entregue em #520 (in-place full-replace com histórico via interceptor). Reconciliar agora evita herdar a divergência em #461.

## Próximos passos

- Issue #521 fechada por este PR.
- Issues #461 e #462 já tiveram corpos refinados (`gh issue edit`) com as URLs path-based.
- Issues #449-#452, #453, #458 retituladas + comentários alinhando vocabulário.
- Cutover dos 2 controllers em main (`EditalController`, `AreasOrganizacionaisController`) será feito em PRs separados, fora do escopo deste PR docs-only — issues serão abertas após o merge.

## Não toca código

PR é exclusivamente docs. Validado pelo `tools/adr-lint/validate.sh` (MADR 4.0 + markdownlint-cli2).

## Test plan

- [x] ADR lint local verde
- [x] markdownlint local verde
- [ ] ADR lint CI verde
- [ ] markdownlint CI verde

Closes #521
