### PR TITLE
US-F4-03: admin CRUD ObrigatoriedadeLegal + endpoints de conformidade

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -162,7 +162,7 @@
         }
       }
     },
-    "/api/editais": {
+    "/api/selecao/editais": {
       "post": {
         "tags": [
           "Edital"
@@ -370,7 +370,7 @@
         "x-uniplus-paginated": true
       }
     },
-    "/api/editais/{id}": {
+    "/api/selecao/editais/{id}": {
       "get": {
         "tags": [
           "Edital"
@@ -430,7 +430,7 @@
         }
       }
     },
-    "/api/editais/{id}/publicar": {
+    "/api/selecao/editais/{id}/publicar": {
       "post": {
         "tags": [
           "Edital"
@@ -505,10 +505,693 @@
         },
         "x-uniplus-idempotent": true
       }
+    },
+    "/api/selecao/editais/{id}/conformidade": {
+      "get": {
+        "tags": [
+          "Edital"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConformidadeDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConformidadeDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConformidadeDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/selecao/editais/{id}/conformidade-historica": {
+      "get": {
+        "tags": [
+          "Edital"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConformidadeDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConformidadeDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConformidadeDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/selecao/obrigatoriedades-legais": {
+      "get": {
+        "tags": [
+          "ObrigatoriedadeLegal"
+        ],
+        "parameters": [
+          {
+            "name": "tipoEdital",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "categoria",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/CategoriaObrigatoriedade"
+            }
+          },
+          {
+            "name": "proprietario",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vigentes",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022next\u0022 s\u00F3 quando h\u00E1 pr\u00F3xima p\u00E1gina. Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/selecao/obrigatoriedades-legais/{id}": {
+      "get": {
+        "tags": [
+          "ObrigatoriedadeLegal"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/selecao/admin/obrigatoriedades-legais": {
+      "post": {
+        "tags": [
+          "ObrigatoriedadeLegal"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarObrigatoriedadeLegalCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarObrigatoriedadeLegalCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarObrigatoriedadeLegalCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/selecao/admin/obrigatoriedades-legais/{id}": {
+      "put": {
+        "tags": [
+          "ObrigatoriedadeLegal"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarObrigatoriedadeLegalCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarObrigatoriedadeLegalCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarObrigatoriedadeLegalCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "ObrigatoriedadeLegal"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "AtualizarObrigatoriedadeLegalCommand": {
+        "required": [
+          "id",
+          "tipoEditalCodigo",
+          "categoria",
+          "regraCodigo",
+          "predicado",
+          "descricaoHumana",
+          "baseLegal",
+          "vigenciaInicio",
+          "vigenciaFim",
+          "atoNormativoUrl",
+          "portariaInternaCodigo",
+          "proprietario",
+          "areasDeInteresse"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tipoEditalCodigo": {
+            "type": "string"
+          },
+          "categoria": {
+            "$ref": "#/components/schemas/CategoriaObrigatoriedade"
+          },
+          "regraCodigo": {
+            "type": "string"
+          },
+          "predicado": {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedade"
+          },
+          "descricaoHumana": {
+            "type": "string"
+          },
+          "baseLegal": {
+            "type": "string"
+          },
+          "vigenciaInicio": {
+            "type": "string",
+            "format": "date"
+          },
+          "vigenciaFim": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
+          },
+          "atoNormativoUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "portariaInternaCodigo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "proprietario": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "areasDeInteresse": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "AuthenticatedUserResponse": {
         "required": [
           "userId",
@@ -546,6 +1229,37 @@
           "timestamp": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "CategoriaObrigatoriedade": {
+        "type": "integer"
+      },
+      "ConformidadeDto": {
+        "required": [
+          "editalId",
+          "regras"
+        ],
+        "type": "object",
+        "properties": {
+          "editalId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "regras": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RegraAvaliadaDto"
+            }
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },
@@ -591,6 +1305,78 @@
             ],
             "format": "int32",
             "default": 1
+          }
+        }
+      },
+      "CriarObrigatoriedadeLegalCommand": {
+        "required": [
+          "tipoEditalCodigo",
+          "categoria",
+          "regraCodigo",
+          "predicado",
+          "descricaoHumana",
+          "baseLegal",
+          "vigenciaInicio",
+          "vigenciaFim",
+          "atoNormativoUrl",
+          "portariaInternaCodigo",
+          "proprietario",
+          "areasDeInteresse"
+        ],
+        "type": "object",
+        "properties": {
+          "tipoEditalCodigo": {
+            "type": "string"
+          },
+          "categoria": {
+            "$ref": "#/components/schemas/CategoriaObrigatoriedade"
+          },
+          "regraCodigo": {
+            "type": "string"
+          },
+          "predicado": {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedade"
+          },
+          "descricaoHumana": {
+            "type": "string"
+          },
+          "baseLegal": {
+            "type": "string"
+          },
+          "vigenciaInicio": {
+            "type": "string",
+            "format": "date"
+          },
+          "vigenciaFim": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
+          },
+          "atoNormativoUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "portariaInternaCodigo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "proprietario": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "areasDeInteresse": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -657,6 +1443,281 @@
         "type": "string",
         "format": "binary"
       },
+      "JsonElement": {},
+      "ObrigatoriedadeLegalDto": {
+        "required": [
+          "id",
+          "tipoEditalCodigo",
+          "categoria",
+          "regraCodigo",
+          "predicado",
+          "descricaoHumana",
+          "baseLegal",
+          "atoNormativoUrl",
+          "portariaInternaCodigo",
+          "vigenciaInicio",
+          "vigenciaFim",
+          "hash",
+          "proprietario",
+          "areasDeInteresse",
+          "isDeleted"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tipoEditalCodigo": {
+            "type": "string"
+          },
+          "categoria": {
+            "$ref": "#/components/schemas/CategoriaObrigatoriedade"
+          },
+          "regraCodigo": {
+            "type": "string"
+          },
+          "predicado": {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedade"
+          },
+          "descricaoHumana": {
+            "type": "string"
+          },
+          "baseLegal": {
+            "type": "string"
+          },
+          "atoNormativoUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "portariaInternaCodigo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "vigenciaInicio": {
+            "type": "string",
+            "format": "date"
+          },
+          "vigenciaFim": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "proprietario": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "areasDeInteresse": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PredicadoObrigatoriedade": {
+        "required": [
+          "$tipo"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedadeEtapaObrigatoria"
+          },
+          {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedadeModalidadesMinimas"
+          },
+          {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedadeDesempateDeveIncluir"
+          },
+          {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedadeDocumentoObrigatorioParaModalidade"
+          },
+          {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedadeBonusObrigatorio"
+          },
+          {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedadeAtendimentoDisponivel"
+          },
+          {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedadeConcorrenciaDuplaObrigatoria"
+          },
+          {
+            "$ref": "#/components/schemas/PredicadoObrigatoriedadeCustomizado"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "$tipo",
+          "mapping": {
+            "etapaObrigatoria": "#/components/schemas/PredicadoObrigatoriedadeEtapaObrigatoria",
+            "modalidadesMinimas": "#/components/schemas/PredicadoObrigatoriedadeModalidadesMinimas",
+            "desempateDeveIncluir": "#/components/schemas/PredicadoObrigatoriedadeDesempateDeveIncluir",
+            "documentoObrigatorioParaModalidade": "#/components/schemas/PredicadoObrigatoriedadeDocumentoObrigatorioParaModalidade",
+            "bonusObrigatorio": "#/components/schemas/PredicadoObrigatoriedadeBonusObrigatorio",
+            "atendimentoDisponivel": "#/components/schemas/PredicadoObrigatoriedadeAtendimentoDisponivel",
+            "concorrenciaDuplaObrigatoria": "#/components/schemas/PredicadoObrigatoriedadeConcorrenciaDuplaObrigatoria",
+            "customizado": "#/components/schemas/PredicadoObrigatoriedadeCustomizado"
+          }
+        }
+      },
+      "PredicadoObrigatoriedadeAtendimentoDisponivel": {
+        "required": [
+          "necessidades"
+        ],
+        "properties": {
+          "$tipo": {
+            "enum": [
+              "atendimentoDisponivel"
+            ],
+            "type": "string"
+          },
+          "necessidades": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PredicadoObrigatoriedadeBonusObrigatorio": {
+        "required": [
+          "modalidadesAplicaveis"
+        ],
+        "properties": {
+          "$tipo": {
+            "enum": [
+              "bonusObrigatorio"
+            ],
+            "type": "string"
+          },
+          "modalidadesAplicaveis": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PredicadoObrigatoriedadeConcorrenciaDuplaObrigatoria": {
+        "properties": {
+          "$tipo": {
+            "enum": [
+              "concorrenciaDuplaObrigatoria"
+            ],
+            "type": "string"
+          }
+        }
+      },
+      "PredicadoObrigatoriedadeCustomizado": {
+        "required": [
+          "parametros"
+        ],
+        "properties": {
+          "$tipo": {
+            "enum": [
+              "customizado"
+            ],
+            "type": "string"
+          },
+          "parametros": {
+            "$ref": "#/components/schemas/JsonElement"
+          }
+        }
+      },
+      "PredicadoObrigatoriedadeDesempateDeveIncluir": {
+        "required": [
+          "criterio"
+        ],
+        "properties": {
+          "$tipo": {
+            "enum": [
+              "desempateDeveIncluir"
+            ],
+            "type": "string"
+          },
+          "criterio": {
+            "type": "string"
+          }
+        }
+      },
+      "PredicadoObrigatoriedadeDocumentoObrigatorioParaModalidade": {
+        "required": [
+          "modalidade",
+          "tipoDocumento"
+        ],
+        "properties": {
+          "$tipo": {
+            "enum": [
+              "documentoObrigatorioParaModalidade"
+            ],
+            "type": "string"
+          },
+          "modalidade": {
+            "type": "string"
+          },
+          "tipoDocumento": {
+            "type": "string"
+          }
+        }
+      },
+      "PredicadoObrigatoriedadeEtapaObrigatoria": {
+        "required": [
+          "tipoEtapaCodigo"
+        ],
+        "properties": {
+          "$tipo": {
+            "enum": [
+              "etapaObrigatoria"
+            ],
+            "type": "string"
+          },
+          "tipoEtapaCodigo": {
+            "type": "string"
+          }
+        }
+      },
+      "PredicadoObrigatoriedadeModalidadesMinimas": {
+        "required": [
+          "codigos"
+        ],
+        "properties": {
+          "$tipo": {
+            "enum": [
+              "modalidadesMinimas"
+            ],
+            "type": "string"
+          },
+          "codigos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "ProblemDetails": {
         "type": "object",
         "properties": {
@@ -692,6 +1753,65 @@
               "null",
               "string"
             ]
+          }
+        }
+      },
+      "RegraAvaliadaDto": {
+        "required": [
+          "regraId",
+          "regraCodigo",
+          "aprovada",
+          "baseLegal",
+          "portariaInternaCodigo",
+          "atoNormativoUrl",
+          "descricaoHumana",
+          "hash",
+          "vigenciaInicio",
+          "vigenciaFim"
+        ],
+        "type": "object",
+        "properties": {
+          "regraId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "regraCodigo": {
+            "type": "string"
+          },
+          "aprovada": {
+            "type": "boolean"
+          },
+          "baseLegal": {
+            "type": "string"
+          },
+          "portariaInternaCodigo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "atoNormativoUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descricaoHumana": {
+            "type": "string"
+          },
+          "hash": {
+            "type": "string"
+          },
+          "vigenciaInicio": {
+            "type": "string",
+            "format": "date"
+          },
+          "vigenciaFim": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
           }
         }
       },
@@ -765,6 +1885,9 @@
     },
     {
       "name": "Edital"
+    },
+    {
+      "name": "ObrigatoriedadeLegal"
     }
   ]
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
@@ -14,9 +14,10 @@ using Unifesspa.UniPlus.Kernel.Results;
 using Application.Commands.Editais;
 using Application.DTOs;
 using Application.Queries.Editais;
+using Application.Queries.ObrigatoriedadesLegais;
 
 [ApiController]
-[Route("api/editais")]
+[Route("api/selecao/editais")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",
@@ -115,5 +116,87 @@ public sealed class EditalController : ControllerBase
         if (resultado.IsSuccess)
             return NoContent();
         return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Conformidade atual: avalia <c>ValidadorConformidadeEdital</c> contra
+    /// o ruleset vigente filtrado por tipo de edital, retornando lista de
+    /// regras com veredicto <c>Aprovada/Reprovada</c>. Consumido pelo wizard
+    /// no passo de revisão (ADR-0058). HATEOAS <c>_links.self</c> sempre
+    /// presente.
+    /// </summary>
+    [HttpGet("{id:guid}/conformidade")]
+    [VendorMediaType(Resource = "conformidade", Versions = [1])]
+    [ProducesResponseType(typeof(ConformidadeDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterConformidade(Guid id, CancellationToken cancellationToken)
+    {
+        ConformidadeDto? conformidade = await _queryBus
+            .Send(new ObterConformidadeAtualQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+        if (conformidade is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(conformidade with
+        {
+            Links = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["self"] = Url.Action(
+                    nameof(ObterConformidade),
+                    "Edital",
+                    new { id })
+                    ?? $"/api/selecao/editais/{id}/conformidade",
+            },
+        });
+    }
+
+    /// <summary>
+    /// Conformidade histórica: retorna o snapshot imutável persistido em
+    /// <c>edital_governance_snapshot.regras_json</c> no momento de
+    /// <c>Edital.Publicar()</c>. Retorna <c>404 Not Found</c> com
+    /// <c>uniplus.selecao.conformidade.snapshot_nao_disponivel</c> quando
+    /// o edital ainda não foi publicado (snapshot inexistente — preenchimento
+    /// pela Story #462).
+    /// </summary>
+    [HttpGet("{id:guid}/conformidade-historica")]
+    [VendorMediaType(Resource = "conformidade", Versions = [1])]
+    [ProducesResponseType(typeof(ConformidadeDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterConformidadeHistorica(Guid id, CancellationToken cancellationToken)
+    {
+        ConformidadeDto? historico = await _queryBus
+            .Send(new ObterConformidadeHistoricaQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+        if (historico is null)
+        {
+            // ProblemDetails específico (ADR-0023): type matching com o code
+            // registrado em SelecaoDomainErrorRegistration. Não construímos
+            // DomainError aqui — controllers não dependem dele (fitness test
+            // F3 — ADR-0024).
+            return NotFound(new ProblemDetails
+            {
+                Title = "Snapshot de conformidade indisponível",
+                Status = StatusCodes.Status404NotFound,
+                Type = "uniplus.selecao.conformidade.snapshot_nao_disponivel",
+                Detail = $"Snapshot de conformidade indisponível para o edital {id} — "
+                    + "o edital pode estar em rascunho ou nunca ter sido publicado.",
+            });
+        }
+
+        return Ok(historico with
+        {
+            Links = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["self"] = Url.Action(
+                    nameof(ObterConformidadeHistorica),
+                    "Edital",
+                    new { id })
+                    ?? $"/api/selecao/editais/{id}/conformidade-historica",
+            },
+        });
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ObrigatoriedadeLegalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ObrigatoriedadeLegalController.cs
@@ -1,0 +1,209 @@
+namespace Unifesspa.UniPlus.Selecao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Admin CRUD + leitura pública de <c>ObrigatoriedadeLegal</c>
+/// (Story #461, ADR-0058 Emenda 1). Paths path-based per ADR-0064:
+/// público sob <c>/api/selecao/obrigatoriedades-legais</c>, admin sob
+/// <c>/api/selecao/admin/obrigatoriedades-legais</c>. RBAC área-scoped
+/// (ADR-0057) é verificado pelos handlers via <c>IUserContext.AreasAdministradas</c>
+/// — controller mantém apenas a authentication gate.
+/// </summary>
+[ApiController]
+[Route("api/selecao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public; sem isso o MVC ignora a classe.")]
+public sealed class ObrigatoriedadeLegalController : ControllerBase
+{
+    private const string ResourceTag = "obrigatoriedades-legais";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<ObrigatoriedadeLegalDto> _linksBuilder;
+
+    public ObrigatoriedadeLegalController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<ObrigatoriedadeLegalDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista paginada (cursor) com filtros admin. Leitura pública —
+    /// <c>vigentes=true</c> por default.
+    /// </summary>
+    [HttpGet("obrigatoriedades-legais")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "obrigatoriedade-legal", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<ObrigatoriedadeLegalDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        [FromQuery] string? tipoEdital,
+        [FromQuery] CategoriaObrigatoriedade? categoria,
+        [FromQuery] string? proprietario,
+        [FromQuery] bool vigentes = true,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarObrigatoriedadesLegaisResult resultado = await _queryBus.Send(
+            new ListarObrigatoriedadesLegaisQuery(
+                page.AfterId,
+                page.Limit,
+                tipoEdital,
+                categoria,
+                proprietario,
+                vigentes),
+            cancellationToken).ConfigureAwait(false);
+
+        return await this.OkPaginatedAsync(
+            resultado.Items,
+            resultado.ProximoAfterId,
+            page,
+            ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Obtém uma regra pelo Id. HATEOAS Level 1 com <c>_links.self/collection</c>.
+    /// </summary>
+    [HttpGet("obrigatoriedades-legais/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "obrigatoriedade-legal", Versions = [1])]
+    [ProducesResponseType(typeof(ObrigatoriedadeLegalDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        ObrigatoriedadeLegalDto? dto = await _queryBus
+            .Send(new ObterObrigatoriedadeLegalQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+        if (dto is null)
+        {
+            return NotFound();
+        }
+
+        ObrigatoriedadeLegalDto comLinks = dto with { Links = _linksBuilder.Build(dto) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>
+    /// Cria uma nova <c>ObrigatoriedadeLegal</c>. Restrito a admin
+    /// área-scoped (ADR-0057) — checagem no handler com base no
+    /// <c>Proprietario</c> do payload. <c>Idempotency-Key</c> obrigatório
+    /// (ADR-0027).
+    /// </summary>
+    [HttpPost("admin/obrigatoriedades-legais")]
+    [Authorize]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarObrigatoriedadeLegalCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(nameof(ObterPorId), new { id = resultado.Value }, resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Atualiza in-place (full-replace per ADR-0058 Emenda 1). Caller deve
+    /// repassar todos os campos. <c>Idempotency-Key</c> obrigatório.
+    /// </summary>
+    [HttpPut("admin/obrigatoriedades-legais/{id:guid}")]
+    [Authorize]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarObrigatoriedadeLegalCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (command.Id != id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id do path não bate com Id do body",
+                Status = StatusCodes.Status400BadRequest,
+                Type = "uniplus.contract.id_path_body_divergente",
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Desativa (soft-delete) a regra. FK <c>RESTRICT</c> de
+    /// <c>obrigatoriedade_legal_historico</c> protege contra hard-delete
+    /// acidental; soft-delete (Modified+IsDeleted=true) não dispara RESTRICT
+    /// e libera o slot do <c>UNIQUE</c> parcial sobre <c>Hash</c> (ADR-0063).
+    /// </summary>
+    [HttpDelete("admin/obrigatoriedades-legais/{id:guid}")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Desativar(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new DesativarObrigatoriedadeLegalCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -40,6 +40,11 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("ObrigatoriedadeLegal.HashColisao", new DomainErrorMapping(StatusCodes.Status409Conflict, "uniplus.selecao.obrigatoriedade_legal.hash_colisao", "Colisão de hash de regra ativa")),
         new("ObrigatoriedadeLegal.ProprietarioForaDeAreasDeInteresse", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.obrigatoriedade_legal.proprietario_fora_de_areas_de_interesse", "Proprietario deve estar em AreasDeInteresse")),
         new("ObrigatoriedadeLegal.ProprietarioObrigatorioComAreas", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.obrigatoriedade_legal.proprietario_obrigatorio_com_areas", "Proprietario obrigatório quando há AreasDeInteresse")),
+        new("ObrigatoriedadeLegal.NaoEncontrada", new DomainErrorMapping(StatusCodes.Status404NotFound, "uniplus.selecao.obrigatoriedade_legal.nao_encontrada", "ObrigatoriedadeLegal não encontrada")),
+        new("AreaCodigo.Invalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.governance.area_codigo.invalido", "AreaCodigo inválido (uppercase ASCII, 2..32 chars)")),
+        new("Area.EscopoNegado", new DomainErrorMapping(StatusCodes.Status403Forbidden, "uniplus.area.escopo_negado", "Caller não administra a área proprietária do recurso")),
+        // Conformidade (Story #461). Snapshot ausente em edital não publicado.
+        new("Conformidade.SnapshotNaoDisponivel", new DomainErrorMapping(StatusCodes.Status404NotFound, "uniplus.selecao.conformidade.snapshot_nao_disponivel", "Snapshot de conformidade indisponível — edital não publicado")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Hateoas/ObrigatoriedadeLegalLinksBuilder.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Hateoas/ObrigatoriedadeLegalLinksBuilder.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.Selecao.API.Hateoas;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Selecao.API.Controllers;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+/// <summary>
+/// Constrói <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029 + ADR-0049)
+/// para <see cref="ObrigatoriedadeLegalDto"/>. Action links (publicar,
+/// desativar, etc.) NÃO entram aqui — são descobertos via OpenAPI (ADR-0030).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<ObrigatoriedadeLegalDto>, ...>().")]
+internal sealed class ObrigatoriedadeLegalLinksBuilder : IResourceLinksBuilder<ObrigatoriedadeLegalDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public ObrigatoriedadeLegalLinksBuilder(
+        LinkGenerator linkGenerator,
+        IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(ObrigatoriedadeLegalDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "ObrigatoriedadeLegal";
+
+        string self = ResolverPath(
+            httpContext,
+            nameof(ObrigatoriedadeLegalController.ObterPorId),
+            controllerName,
+            new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext,
+            nameof(ObrigatoriedadeLegalController.Listar),
+            controllerName,
+            values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -63,6 +63,7 @@ builder.Services.AddDomainErrorMapper();
 // HATEOAS Level 1 (ADR-0029) — builder de _links por recurso. Singleton
 // porque encapsula apenas um LinkGenerator (também singleton); função pura.
 builder.Services.AddSingleton<IResourceLinksBuilder<Unifesspa.UniPlus.Selecao.Application.DTOs.EditalDto>, EditalLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<Unifesspa.UniPlus.Selecao.Application.DTOs.ObrigatoriedadeLegalDto>, ObrigatoriedadeLegalLinksBuilder>();
 
 // Criptografia + cursor pagination usados pelos endpoints de listagem
 // (ADR-0026 + ADR-0031). AddUniPlusEncryption: provider 'local' AES-GCM 256

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AreaScopedAuthorization.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AreaScopedAuthorization.cs
@@ -1,0 +1,39 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Verificação imperativa de RBAC área-scoped (ADR-0057) ao nível de handler.
+/// Replica a lógica do <c>AreaScopedAuthorizationHandler</c> de
+/// <c>Infrastructure.Core/Authorization</c> em forma <c>Result&lt;T&gt;</c>
+/// — Application não depende de <c>IAuthorizationService</c>/<c>HttpContext</c>.
+/// </summary>
+internal static class AreaScopedAuthorization
+{
+    /// <summary>
+    /// Autoriza a operação sobre a regra dado o <paramref name="proprietario"/>
+    /// dela. <c>plataforma-admin</c> sempre passa (ADR-0057 §"bypass
+    /// platform-wide"); admin da área dona passa; demais casos falham com
+    /// <c>Area.EscopoNegado</c>.
+    /// </summary>
+    public static Result Autorizar(IUserContext userContext, AreaCodigo? proprietario)
+    {
+        ArgumentNullException.ThrowIfNull(userContext);
+
+        if (userContext.IsPlataformaAdmin)
+        {
+            return Result.Success();
+        }
+
+        if (proprietario is { } prop && userContext.AreasAdministradas.Contains(prop))
+        {
+            return Result.Success();
+        }
+
+        return Result.Failure(new DomainError(
+            "Area.EscopoNegado",
+            "O caller não administra a área proprietária do recurso e não é plataforma-admin."));
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommand.cs
@@ -1,0 +1,39 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Command que atualiza uma <c>ObrigatoriedadeLegal</c> existente. Semântica
+/// full-replace (ADR-0058 Emenda 1): todos os campos são aplicados
+/// literalmente — caller deve repassar valores correntes dos opcionais que
+/// quer preservar. URI estável (mesmo <see cref="Id"/>); auditoria via
+/// <c>obrigatoriedade_legal_historico</c>.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1056:URI-like properties should not be strings",
+    Justification = "AtoNormativoUrl é payload textual de citação normativa.")]
+[SuppressMessage(
+    "Design",
+    "CA1054:URI-like parameters should not be strings",
+    Justification = "Construtor do record propaga o tipo string do payload — ver justificativa acima.")]
+public sealed record AtualizarObrigatoriedadeLegalCommand(
+    Guid Id,
+    string TipoEditalCodigo,
+    CategoriaObrigatoriedade Categoria,
+    string RegraCodigo,
+    PredicadoObrigatoriedade Predicado,
+    string DescricaoHumana,
+    string BaseLegal,
+    DateOnly VigenciaInicio,
+    DateOnly? VigenciaFim,
+    string? AtoNormativoUrl,
+    string? PortariaInternaCodigo,
+    string? Proprietario,
+    IReadOnlySet<string> AreasDeInteresse) : ICommand<Result>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommandHandler.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
 
 using System.Collections.Generic;
 
+using Microsoft.EntityFrameworkCore;
+
 using Unifesspa.UniPlus.Application.Abstractions.Authentication;
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Governance.Contracts;
@@ -107,7 +109,30 @@ public static class AtualizarObrigatoriedadeLegalCommandHandler
             userContext.UserId ?? "system",
             cancellationToken).ConfigureAwait(false);
 
-        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex)
+        {
+            // Mesmo tratamento do Criar: race entre o ExisteRegraCodigoAtivoAsync
+            // e o UPDATE (caller troca RegraCodigo para um valor que outra escrita
+            // concorrente acabou de assumir) dispara a constraint do banco.
+            string? constraint = UniqueConstraintViolation.GetViolatedConstraint(ex);
+            if (UniqueConstraintViolation.IsRegraCodigoConflict(constraint))
+            {
+                return Result.Failure(new DomainError(
+                    "ObrigatoriedadeLegal.RegraCodigoDuplicada",
+                    $"Já existe outra regra ativa com RegraCodigo '{command.RegraCodigo}'."));
+            }
+            if (UniqueConstraintViolation.IsHashConflict(constraint))
+            {
+                return Result.Failure(new DomainError(
+                    "ObrigatoriedadeLegal.HashColisao",
+                    "Já existe regra ativa com o mesmo conteúdo canônico após esta atualização."));
+            }
+            throw;
+        }
 
         return Result.Success();
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommandHandler.cs
@@ -1,0 +1,114 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+
+using System.Collections.Generic;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+/// <summary>
+/// Handler convention-based do <see cref="AtualizarObrigatoriedadeLegalCommand"/>.
+/// Semântica full-replace (ADR-0058 Emenda 1) + RBAC área-scoped: o caller
+/// deve administrar a área <strong>atual</strong> da regra E a área
+/// <strong>nova</strong> (impede transferência cross-área por admin não
+/// platform-wide). Reconciliação da junction temporal pelo repositório.
+/// </summary>
+public static class AtualizarObrigatoriedadeLegalCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarObrigatoriedadeLegalCommand command,
+        IObrigatoriedadeLegalRepository repository,
+        IUnitOfWork unitOfWork,
+        IUserContext userContext,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(userContext);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        ObrigatoriedadeLegal? regra = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (regra is null)
+        {
+            return Result.Failure(new DomainError(
+                "ObrigatoriedadeLegal.NaoEncontrada",
+                $"ObrigatoriedadeLegal {command.Id} não encontrada."));
+        }
+
+        Result authzAtual = AreaScopedAuthorization.Autorizar(userContext, regra.Proprietario);
+        if (authzAtual.IsFailure)
+        {
+            return authzAtual;
+        }
+
+        Result<HashSet<AreaCodigo>> areasResult =
+            CriarObrigatoriedadeLegalCommandHandler.ConverterAreas(command.AreasDeInteresse);
+        if (areasResult.IsFailure)
+        {
+            return Result.Failure(areasResult.Error!);
+        }
+
+        Result<AreaCodigo?> proprietarioResult =
+            CriarObrigatoriedadeLegalCommandHandler.ConverterProprietario(command.Proprietario);
+        if (proprietarioResult.IsFailure)
+        {
+            return Result.Failure(proprietarioResult.Error!);
+        }
+
+        if (regra.Proprietario != proprietarioResult.Value)
+        {
+            Result authzNovo = AreaScopedAuthorization.Autorizar(userContext, proprietarioResult.Value);
+            if (authzNovo.IsFailure)
+            {
+                return authzNovo;
+            }
+        }
+
+        bool duplicado = await repository.ExisteRegraCodigoAtivoAsync(
+            command.RegraCodigo,
+            excluirId: command.Id,
+            cancellationToken).ConfigureAwait(false);
+        if (duplicado)
+        {
+            return Result.Failure(new DomainError(
+                "ObrigatoriedadeLegal.RegraCodigoDuplicada",
+                $"Já existe outra regra ativa com RegraCodigo '{command.RegraCodigo}'."));
+        }
+
+        Result atualizado = regra.Atualizar(
+            tipoEditalCodigo: command.TipoEditalCodigo,
+            categoria: command.Categoria,
+            regraCodigo: command.RegraCodigo,
+            predicado: command.Predicado,
+            descricaoHumana: command.DescricaoHumana,
+            baseLegal: command.BaseLegal,
+            vigenciaInicio: command.VigenciaInicio,
+            vigenciaFim: command.VigenciaFim,
+            atoNormativoUrl: command.AtoNormativoUrl,
+            portariaInternaCodigo: command.PortariaInternaCodigo,
+            proprietario: proprietarioResult.Value,
+            areasDeInteresse: areasResult.Value);
+        if (atualizado.IsFailure)
+        {
+            return atualizado;
+        }
+
+        await repository.ReconciliarBindingsAsync(
+            regra,
+            areasResult.Value!,
+            timeProvider.GetUtcNow(),
+            userContext.UserId ?? "system",
+            cancellationToken).ConfigureAwait(false);
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommandHandler.cs
@@ -2,8 +2,6 @@ namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
 
 using System.Collections.Generic;
 
-using Microsoft.EntityFrameworkCore;
-
 using Unifesspa.UniPlus.Application.Abstractions.Authentication;
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Governance.Contracts;
@@ -113,12 +111,11 @@ public static class AtualizarObrigatoriedadeLegalCommandHandler
         {
             await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (DbUpdateException ex)
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint)
         {
             // Mesmo tratamento do Criar: race entre o ExisteRegraCodigoAtivoAsync
             // e o UPDATE (caller troca RegraCodigo para um valor que outra escrita
             // concorrente acabou de assumir) dispara a constraint do banco.
-            string? constraint = UniqueConstraintViolation.GetViolatedConstraint(ex);
             if (UniqueConstraintViolation.IsRegraCodigoConflict(constraint))
             {
                 return Result.Failure(new DomainError(

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommand.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Command que cria uma <c>ObrigatoriedadeLegal</c> a partir do payload do
+/// <c>POST /api/selecao/admin/obrigatoriedades-legais</c>. Reflete o input
+/// integral da forma plena (ADR-0058 + Emenda 1) — full-replace por design.
+/// </summary>
+/// <remarks>
+/// <see cref="AreasDeInteresse"/> usa <c>IReadOnlySet&lt;string&gt;</c> de
+/// códigos uppercase ASCII; o handler converte para
+/// <c>HashSet&lt;AreaCodigo&gt;</c> via <c>AreaCodigo.From</c>, validando
+/// shape no caminho. Ambos vazios (sem proprietário, sem áreas) modelam
+/// regra universal/global.
+/// </remarks>
+[SuppressMessage(
+    "Design",
+    "CA1056:URI-like properties should not be strings",
+    Justification = "AtoNormativoUrl é payload textual de citação normativa "
+        + "(DOI, URN, IRI) — preserva fidelidade do valor original.")]
+[SuppressMessage(
+    "Design",
+    "CA1054:URI-like parameters should not be strings",
+    Justification = "Construtor do record propaga o tipo string do payload — ver justificativa acima.")]
+public sealed record CriarObrigatoriedadeLegalCommand(
+    string TipoEditalCodigo,
+    CategoriaObrigatoriedade Categoria,
+    string RegraCodigo,
+    PredicadoObrigatoriedade Predicado,
+    string DescricaoHumana,
+    string BaseLegal,
+    DateOnly VigenciaInicio,
+    DateOnly? VigenciaFim,
+    string? AtoNormativoUrl,
+    string? PortariaInternaCodigo,
+    string? Proprietario,
+    IReadOnlySet<string> AreasDeInteresse) : ICommand<Result<Guid>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
@@ -100,9 +100,11 @@ public static class CriarObrigatoriedadeLegalCommandHandler
     internal static Result<HashSet<AreaCodigo>> ConverterAreas(IReadOnlySet<string> areas)
     {
         HashSet<AreaCodigo> convertidas = [];
-        foreach (string raw in areas)
+        // Select explícito materializa o map raw → Result<AreaCodigo>; o
+        // loop só carrega a lógica de fail-fast (early-return no primeiro
+        // inválido) e agregação no HashSet.
+        foreach (Result<AreaCodigo> resultado in areas.Select(AreaCodigo.From))
         {
-            Result<AreaCodigo> resultado = AreaCodigo.From(raw);
             if (resultado.IsFailure)
             {
                 return Result<HashSet<AreaCodigo>>.Failure(resultado.Error!);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
 
 using System.Collections.Generic;
 
+using Microsoft.EntityFrameworkCore;
+
 using Unifesspa.UniPlus.Application.Abstractions.Authentication;
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Governance.Contracts;
@@ -88,7 +90,30 @@ public static class CriarObrigatoriedadeLegalCommandHandler
             userContext.UserId ?? "system",
             cancellationToken).ConfigureAwait(false);
 
-        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex)
+        {
+            // Race entre ExisteRegraCodigoAtivoAsync e o INSERT (check-then-act):
+            // a constraint UNIQUE parcial sobre regra_codigo/hash dispara 23505,
+            // viramos 409 ProblemDetails consistente com o caminho não-race.
+            string? constraint = UniqueConstraintViolation.GetViolatedConstraint(ex);
+            if (UniqueConstraintViolation.IsRegraCodigoConflict(constraint))
+            {
+                return Result<Guid>.Failure(new DomainError(
+                    "ObrigatoriedadeLegal.RegraCodigoDuplicada",
+                    $"Já existe regra ativa com RegraCodigo '{command.RegraCodigo}'."));
+            }
+            if (UniqueConstraintViolation.IsHashConflict(constraint))
+            {
+                return Result<Guid>.Failure(new DomainError(
+                    "ObrigatoriedadeLegal.HashColisao",
+                    "Já existe regra ativa com o mesmo conteúdo canônico."));
+            }
+            throw;
+        }
 
         return Result<Guid>.Success(regra.Id);
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
@@ -1,0 +1,127 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+
+using System.Collections.Generic;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+/// <summary>
+/// Handler convention-based do <see cref="CriarObrigatoriedadeLegalCommand"/>.
+/// Converte códigos de área para <c>AreaCodigo</c>, autoriza por RBAC
+/// área-scoped (ADR-0057), checa colisão de <c>RegraCodigo</c>, chama a
+/// factory canônica da entity e persiste via repositório com reconciliação
+/// atômica da junction temporal (ADR-0060).
+/// </summary>
+public static class CriarObrigatoriedadeLegalCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarObrigatoriedadeLegalCommand command,
+        IObrigatoriedadeLegalRepository repository,
+        IUnitOfWork unitOfWork,
+        IUserContext userContext,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(userContext);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        Result<HashSet<AreaCodigo>> areasResult = ConverterAreas(command.AreasDeInteresse);
+        if (areasResult.IsFailure)
+        {
+            return Result<Guid>.Failure(areasResult.Error!);
+        }
+
+        Result<AreaCodigo?> proprietarioResult = ConverterProprietario(command.Proprietario);
+        if (proprietarioResult.IsFailure)
+        {
+            return Result<Guid>.Failure(proprietarioResult.Error!);
+        }
+
+        Result authz = AreaScopedAuthorization.Autorizar(userContext, proprietarioResult.Value);
+        if (authz.IsFailure)
+        {
+            return Result<Guid>.Failure(authz.Error!);
+        }
+
+        bool duplicado = await repository.ExisteRegraCodigoAtivoAsync(
+            command.RegraCodigo,
+            excluirId: null,
+            cancellationToken).ConfigureAwait(false);
+        if (duplicado)
+        {
+            return Result<Guid>.Failure(new DomainError(
+                "ObrigatoriedadeLegal.RegraCodigoDuplicada",
+                $"Já existe regra ativa com RegraCodigo '{command.RegraCodigo}'."));
+        }
+
+        Result<ObrigatoriedadeLegal> regraResult = ObrigatoriedadeLegal.Criar(
+            tipoEditalCodigo: command.TipoEditalCodigo,
+            categoria: command.Categoria,
+            regraCodigo: command.RegraCodigo,
+            predicado: command.Predicado,
+            descricaoHumana: command.DescricaoHumana,
+            baseLegal: command.BaseLegal,
+            vigenciaInicio: command.VigenciaInicio,
+            vigenciaFim: command.VigenciaFim,
+            atoNormativoUrl: command.AtoNormativoUrl,
+            portariaInternaCodigo: command.PortariaInternaCodigo,
+            proprietario: proprietarioResult.Value,
+            areasDeInteresse: areasResult.Value);
+        if (regraResult.IsFailure)
+        {
+            return Result<Guid>.Failure(regraResult.Error!);
+        }
+
+        ObrigatoriedadeLegal regra = regraResult.Value!;
+
+        await repository.AdicionarComBindingsAsync(
+            regra,
+            areasResult.Value!,
+            timeProvider.GetUtcNow(),
+            userContext.UserId ?? "system",
+            cancellationToken).ConfigureAwait(false);
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<Guid>.Success(regra.Id);
+    }
+
+    /// <summary>
+    /// Converte cada string de área para <see cref="AreaCodigo"/> via
+    /// <see cref="AreaCodigo.From"/>. Falha no primeiro inválido.
+    /// </summary>
+    internal static Result<HashSet<AreaCodigo>> ConverterAreas(IReadOnlySet<string> areas)
+    {
+        HashSet<AreaCodigo> convertidas = [];
+        foreach (string raw in areas)
+        {
+            Result<AreaCodigo> resultado = AreaCodigo.From(raw);
+            if (resultado.IsFailure)
+            {
+                return Result<HashSet<AreaCodigo>>.Failure(resultado.Error!);
+            }
+            convertidas.Add(resultado.Value);
+        }
+        return Result<HashSet<AreaCodigo>>.Success(convertidas);
+    }
+
+    internal static Result<AreaCodigo?> ConverterProprietario(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return Result<AreaCodigo?>.Success(null);
+        }
+
+        Result<AreaCodigo> resultado = AreaCodigo.From(raw);
+        return resultado.IsFailure
+            ? Result<AreaCodigo?>.Failure(resultado.Error!)
+            : Result<AreaCodigo?>.Success(resultado.Value);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
@@ -2,8 +2,6 @@ namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
 
 using System.Collections.Generic;
 
-using Microsoft.EntityFrameworkCore;
-
 using Unifesspa.UniPlus.Application.Abstractions.Authentication;
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Governance.Contracts;
@@ -94,12 +92,13 @@ public static class CriarObrigatoriedadeLegalCommandHandler
         {
             await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (DbUpdateException ex)
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint)
         {
             // Race entre ExisteRegraCodigoAtivoAsync e o INSERT (check-then-act):
             // a constraint UNIQUE parcial sobre regra_codigo/hash dispara 23505,
             // viramos 409 ProblemDetails consistente com o caminho não-race.
-            string? constraint = UniqueConstraintViolation.GetViolatedConstraint(ex);
+            // Filtro do `when` garante que outras exceções não-23505 propagam
+            // intactas (não engolimos falhas inesperadas).
             if (UniqueConstraintViolation.IsRegraCodigoConflict(constraint))
             {
                 return Result<Guid>.Failure(new DomainError(

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/DesativarObrigatoriedadeLegalCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/DesativarObrigatoriedadeLegalCommand.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Command que desativa uma <c>ObrigatoriedadeLegal</c> via soft-delete.
+/// O ciclo append-only do <c>obrigatoriedade_legal_historico</c> preserva
+/// o estado pré-desativação para evidência forense (ADR-0058 + ADR-0063).
+/// O <c>UNIQUE</c> parcial sobre <c>Hash</c> libera o slot para reciclar a
+/// regra após o soft-delete (ADR-0060 + entrega #520).
+/// </summary>
+public sealed record DesativarObrigatoriedadeLegalCommand(Guid Id) : ICommand<Result>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/DesativarObrigatoriedadeLegalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/DesativarObrigatoriedadeLegalCommandHandler.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+/// <summary>
+/// Handler convention-based do <see cref="DesativarObrigatoriedadeLegalCommand"/>.
+/// Marca a regra para soft-delete via <c>SoftDeleteInterceptor</c> — o EF
+/// converte <c>EntityState.Deleted</c> em <c>Modified + IsDeleted = true</c>,
+/// e o <c>ObrigatoriedadeLegalHistoricoInterceptor</c> grava o snapshot da
+/// desativação (ADR-0058 Emenda 1 + ADR-0063). Junction temporal é
+/// preservada — os bindings continuam ativos até que o admin emita um PUT
+/// reciclando a regra com novo Hash.
+/// </summary>
+public static class DesativarObrigatoriedadeLegalCommandHandler
+{
+    public static async Task<Result> Handle(
+        DesativarObrigatoriedadeLegalCommand command,
+        IObrigatoriedadeLegalRepository repository,
+        IUnitOfWork unitOfWork,
+        IUserContext userContext,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(userContext);
+
+        ObrigatoriedadeLegal? regra = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (regra is null)
+        {
+            return Result.Failure(new DomainError(
+                "ObrigatoriedadeLegal.NaoEncontrada",
+                $"ObrigatoriedadeLegal {command.Id} não encontrada."));
+        }
+
+        Result authz = AreaScopedAuthorization.Autorizar(userContext, regra.Proprietario);
+        if (authz.IsFailure)
+        {
+            return authz;
+        }
+
+        repository.Remover(regra);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/UniqueConstraintViolation.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/UniqueConstraintViolation.cs
@@ -1,16 +1,17 @@
 namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
 
-using Microsoft.EntityFrameworkCore;
-
 /// <summary>
 /// Helper para mapear violações 23505 de índice UNIQUE parcial para
-/// <c>DomainError</c> apropriado, sem depender diretamente do package
-/// concreto do provider (Npgsql) na camada Application. Acessa
-/// <c>SqlState</c> e <c>ConstraintName</c> via reflection no inner
-/// exception — o shape é estável na API pública do
-/// <c>Npgsql.PostgresException</c>. Mapping centralizado para 23505
-/// cross-cutting permanece como #504 (escopo separado); este helper
-/// cobre o caso específico das constraints que esta Story introduz.
+/// <c>DomainError</c> apropriado. Acessa <c>SqlState</c> e
+/// <c>ConstraintName</c> via reflection no inner exception — o shape é
+/// estável na API pública do <c>Npgsql.PostgresException</c>. Inspeção
+/// do tipo da exceção por nome via <see cref="System.Type.FullName"/>
+/// evita dependência direta do <c>Microsoft.EntityFrameworkCore</c>
+/// package na camada Application (mantém Clean Arch — Application
+/// referencia apenas Domain + SharedKernel + abstrações). Mapping
+/// centralizado para 23505 cross-cutting permanece como #504 (escopo
+/// separado); este helper cobre o caso específico das constraints que
+/// esta Story introduz.
 /// </summary>
 internal static class UniqueConstraintViolation
 {
@@ -20,15 +21,22 @@ internal static class UniqueConstraintViolation
 
     private const string HashConstraint = "ux_obrigatoriedades_legais_hash_ativos";
 
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
     /// <summary>
     /// Retorna o nome da constraint violada quando a exceção é uma
     /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
     /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário —
     /// o caller deve propagar a exceção.
     /// </summary>
-    public static string? GetViolatedConstraint(DbUpdateException ex)
+    public static string? GetViolatedConstraint(Exception ex)
     {
         ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
 
         Exception? inner = ex.InnerException;
         if (inner is null)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/UniqueConstraintViolation.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/UniqueConstraintViolation.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Helper para mapear violações 23505 de índice UNIQUE parcial para
+/// <c>DomainError</c> apropriado, sem depender diretamente do package
+/// concreto do provider (Npgsql) na camada Application. Acessa
+/// <c>SqlState</c> e <c>ConstraintName</c> via reflection no inner
+/// exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. Mapping centralizado para 23505
+/// cross-cutting permanece como #504 (escopo separado); este helper
+/// cobre o caso específico das constraints que esta Story introduz.
+/// </summary>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string RegraCodigoConstraint = "ux_obrigatoriedades_legais_regra_codigo_ativos";
+
+    private const string HashConstraint = "ux_obrigatoriedades_legais_hash_ativos";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário —
+    /// o caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(DbUpdateException ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é a do
+    /// <c>RegraCodigo</c> ativo.
+    /// </summary>
+    public static bool IsRegraCodigoConflict(string? constraint) =>
+        string.Equals(constraint, RegraCodigoConstraint, StringComparison.Ordinal);
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é a do
+    /// <c>Hash</c> canônico de regra ativa.
+    /// </summary>
+    public static bool IsHashConflict(string? constraint) =>
+        string.Equals(constraint, HashConstraint, StringComparison.Ordinal);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ConformidadeDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ConformidadeDto.cs
@@ -1,0 +1,50 @@
+namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Resultado da avaliação de conformidade de um edital — payload do
+/// <c>GET /api/selecao/editais/{id}/conformidade</c> (estado atual) e do
+/// <c>GET /api/selecao/editais/{id}/conformidade-historica</c> (snapshot
+/// publicado, lido de <c>EditalGovernanceSnapshot.RegrasJson</c>).
+/// </summary>
+public sealed record ConformidadeDto(
+    Guid EditalId,
+    IReadOnlyList<RegraAvaliadaDto> Regras)
+{
+    /// <summary>
+    /// Links HATEOAS Level 1 — sempre carregam <c>self</c> apontando para o
+    /// próprio endpoint que produziu a resposta.
+    /// </summary>
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}
+
+/// <summary>
+/// Item individual da lista de regras avaliadas. Reflete o que o
+/// <c>ValidadorConformidadeEdital</c> produz: code da regra, aprovação,
+/// citação legal, descrição humana, hash do snapshot.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1056:URI-like properties should not be strings",
+    Justification = "AtoNormativoUrl é payload textual de citação normativa "
+        + "(DOI, URN, IRI) — preserva fidelidade do valor original informado pelo admin.")]
+[SuppressMessage(
+    "Design",
+    "CA1054:URI-like parameters should not be strings",
+    Justification = "Construtor do record propaga o tipo string do payload — ver justificativa acima.")]
+public sealed record RegraAvaliadaDto(
+    Guid RegraId,
+    string RegraCodigo,
+    bool Aprovada,
+    string BaseLegal,
+    string? PortariaInternaCodigo,
+    string? AtoNormativoUrl,
+    string DescricaoHumana,
+    string Hash,
+    DateOnly VigenciaInicio,
+    DateOnly? VigenciaFim);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ObrigatoriedadeLegalDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ObrigatoriedadeLegalDto.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// DTO de leitura de <c>ObrigatoriedadeLegal</c> exposto pela camada API.
+/// Reflete o estado atual da regra após qualquer mutação in-place (ADR-0058
+/// Emenda 1) — a reconstrução de versões anteriores é via
+/// <c>obrigatoriedade_legal_historico</c>.
+/// </summary>
+[SuppressMessage(
+    "Design",
+    "CA1056:URI-like properties should not be strings",
+    Justification = "AtoNormativoUrl é payload textual exibido para auditoria — pode incluir DOI, "
+        + "URN ou identificadores não-HTTP. Espelha a propriedade homônima da entidade.")]
+[SuppressMessage(
+    "Design",
+    "CA1054:URI-like parameters should not be strings",
+    Justification = "Construtor do record propaga o tipo string do payload — ver justificativa acima.")]
+public sealed record ObrigatoriedadeLegalDto(
+    Guid Id,
+    string TipoEditalCodigo,
+    CategoriaObrigatoriedade Categoria,
+    string RegraCodigo,
+    PredicadoObrigatoriedade Predicado,
+    string DescricaoHumana,
+    string BaseLegal,
+    string? AtoNormativoUrl,
+    string? PortariaInternaCodigo,
+    DateOnly VigenciaInicio,
+    DateOnly? VigenciaFim,
+    string Hash,
+    string? Proprietario,
+    IReadOnlyList<string> AreasDeInteresse,
+    bool IsDeleted)
+{
+    /// <summary>
+    /// Hypermedia links (HATEOAS Level 1) — opt-in, populado pelo
+    /// <c>IResourceLinksBuilder&lt;ObrigatoriedadeLegalDto&gt;</c> no boundary
+    /// HTTP para respostas single. Coleções não carregam — navegação via
+    /// header <c>Link</c> (ADR-0026).
+    /// </summary>
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Mappings/ObrigatoriedadeLegalMapping.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Mappings/ObrigatoriedadeLegalMapping.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Mappings;
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+/// <summary>
+/// Mapeamento <c>ObrigatoriedadeLegal</c> → <c>ObrigatoriedadeLegalDto</c>.
+/// <c>AreasDeInteresse</c> chega via batch lookup do repositório
+/// (<c>ObterAreasVigentesPorIdsAsync</c>) — a entity em si não carrega
+/// nav property para a junction (ADR-0060).
+/// </summary>
+public static class ObrigatoriedadeLegalMapping
+{
+    public static ObrigatoriedadeLegalDto ToDto(
+        ObrigatoriedadeLegal regra,
+        IReadOnlySet<AreaCodigo> areasVigentes)
+    {
+        ArgumentNullException.ThrowIfNull(regra);
+        ArgumentNullException.ThrowIfNull(areasVigentes);
+
+        return new ObrigatoriedadeLegalDto(
+            Id: regra.Id,
+            TipoEditalCodigo: regra.TipoEditalCodigo,
+            Categoria: regra.Categoria,
+            RegraCodigo: regra.RegraCodigo,
+            Predicado: regra.Predicado,
+            DescricaoHumana: regra.DescricaoHumana,
+            BaseLegal: regra.BaseLegal,
+            AtoNormativoUrl: regra.AtoNormativoUrl,
+            PortariaInternaCodigo: regra.PortariaInternaCodigo,
+            VigenciaInicio: regra.VigenciaInicio,
+            VigenciaFim: regra.VigenciaFim,
+            Hash: regra.Hash,
+            Proprietario: regra.Proprietario?.Value,
+            AreasDeInteresse: [.. areasVigentes
+                .Select(a => a.Value)
+                .OrderBy(v => v, StringComparer.Ordinal)],
+            IsDeleted: regra.IsDeleted);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Mappings/ObrigatoriedadeLegalMapping.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Mappings/ObrigatoriedadeLegalMapping.cs
@@ -35,7 +35,10 @@ public static class ObrigatoriedadeLegalMapping
             VigenciaInicio: regra.VigenciaInicio,
             VigenciaFim: regra.VigenciaFim,
             Hash: regra.Hash,
-            Proprietario: regra.Proprietario?.Value,
+            // Pattern matching no nullable record struct — elimina o
+            // dereference de `?.` que o analisador flagra como ambíguo
+            // (mesmo padrão aplicado no interceptor de #520).
+            Proprietario: regra.Proprietario is { } prop ? prop.Value : null,
             AreasDeInteresse: [.. areasVigentes
                 .Select(a => a.Value)
                 .OrderBy(v => v, StringComparer.Ordinal)],

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisQuery.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisQuery.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Query paginada por cursor (ADR-0026) com filtros admin. <c>Vigentes</c>
+/// default <see langword="true"/> — leitura pública padrão; admin pode
+/// passar <see langword="false"/> para incluir regras com
+/// <c>VigenciaFim</c> passada.
+/// </summary>
+public sealed record ListarObrigatoriedadesLegaisQuery(
+    Guid? AfterId,
+    int Take,
+    string? TipoEditalCodigo,
+    CategoriaObrigatoriedade? Categoria,
+    string? Proprietario,
+    bool Vigentes) : IQuery<ListarObrigatoriedadesLegaisResult>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisQueryHandler.cs
@@ -1,0 +1,76 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Application.Mappings;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+/// <summary>
+/// Handler convention-based de <see cref="ListarObrigatoriedadesLegaisQuery"/>.
+/// Paginação keyset por <c>Id</c> (ADR-0026 + Guid v7) com lookup batch de
+/// bindings vigentes (sem N+1). Solicita <c>take + 1</c> para detectar
+/// próxima página sem COUNT — mesma estratégia do <c>ListarEditaisQueryHandler</c>.
+/// </summary>
+public static class ListarObrigatoriedadesLegaisQueryHandler
+{
+    public static async Task<ListarObrigatoriedadesLegaisResult> Handle(
+        ListarObrigatoriedadesLegaisQuery query,
+        IObrigatoriedadeLegalRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        AreaCodigo? proprietarioFiltro = null;
+        if (!string.IsNullOrWhiteSpace(query.Proprietario))
+        {
+            Result<AreaCodigo> conv = AreaCodigo.From(query.Proprietario);
+            if (conv.IsFailure)
+            {
+                // Filtro inválido — retorna vazio em vez de 500; lista admin
+                // não vaza detalhes do shape do código de área.
+                return new ListarObrigatoriedadesLegaisResult([], ProximoAfterId: null);
+            }
+            proprietarioFiltro = conv.Value;
+        }
+
+        IReadOnlyList<ObrigatoriedadeLegal> page = await repository.ListarPaginadoAsync(
+            query.AfterId,
+            query.Take + 1,
+            query.TipoEditalCodigo,
+            query.Categoria,
+            proprietarioFiltro,
+            query.Vigentes,
+            cancellationToken).ConfigureAwait(false);
+
+        if (page.Count == 0)
+        {
+            return new ListarObrigatoriedadesLegaisResult([], ProximoAfterId: null);
+        }
+
+        bool temProxima = page.Count > query.Take && query.Take > 0;
+        IReadOnlyList<ObrigatoriedadeLegal> visiveis = temProxima
+            ? [.. page.Take(query.Take)]
+            : page;
+
+        IReadOnlyDictionary<Guid, IReadOnlySet<AreaCodigo>> areasPorRegra =
+            await repository.ObterAreasVigentesPorIdsAsync(
+                [.. visiveis.Select(r => r.Id)],
+                cancellationToken).ConfigureAwait(false);
+
+        ObrigatoriedadeLegalDto[] items = [.. visiveis.Select(regra =>
+            ObrigatoriedadeLegalMapping.ToDto(
+                regra,
+                areasPorRegra.TryGetValue(regra.Id, out IReadOnlySet<AreaCodigo>? areas)
+                    ? areas
+                    : new HashSet<AreaCodigo>()))];
+
+        Guid? proximo = temProxima ? items[^1].Id : null;
+        return new ListarObrigatoriedadesLegaisResult(items, proximo);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisResult.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisResult.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+
+using System.Collections.Generic;
+
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+/// <summary>
+/// Resultado paginado do <see cref="ListarObrigatoriedadesLegaisQuery"/>.
+/// <see cref="ProximoAfterId"/> é o último <c>Id</c> da janela retornada
+/// quando houve <c>take</c> itens — controller emite o cursor encriptado
+/// + header <c>Link</c> de next.
+/// </summary>
+public sealed record ListarObrigatoriedadesLegaisResult(
+    IReadOnlyList<ObrigatoriedadeLegalDto> Items,
+    Guid? ProximoAfterId);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeAtualQuery.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeAtualQuery.cs
@@ -1,0 +1,11 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+/// <summary>
+/// Avalia a conformidade do edital contra o ruleset atual (regras vigentes
+/// aplicáveis ao tipo). Endpoint <c>GET /api/selecao/editais/{id}/conformidade</c>
+/// — consumido pelo wizard de edital para o passo 12 (Revisão) per ADR-0058.
+/// </summary>
+public sealed record ObterConformidadeAtualQuery(Guid EditalId) : IQuery<ConformidadeDto?>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeAtualQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeAtualQueryHandler.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.Services;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Handler convention-based de <see cref="ObterConformidadeAtualQuery"/>.
+/// Carrega o edital com etapas/cotas (necessárias para o evaluator), busca
+/// as regras vigentes aplicáveis ao tipo (universal + específico) na data
+/// de hoje, roda o <see cref="ValidadorConformidadeEdital"/> e mapeia o
+/// resultado para <see cref="ConformidadeDto"/>. Retorna <see langword="null"/>
+/// quando o edital não existe — controller traduz para 404.
+/// </summary>
+public static class ObterConformidadeAtualQueryHandler
+{
+    public static async Task<ConformidadeDto?> Handle(
+        ObterConformidadeAtualQuery query,
+        IEditalRepository editalRepository,
+        IObrigatoriedadeLegalRepository regraRepository,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(editalRepository);
+        ArgumentNullException.ThrowIfNull(regraRepository);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        Edital? edital = await editalRepository
+            .ObterComEtapasECotasAsync(query.EditalId, cancellationToken)
+            .ConfigureAwait(false);
+        if (edital is null)
+        {
+            return null;
+        }
+
+        DateOnly hoje = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime.Date);
+        string tipoEditalCodigo = edital.TipoEditalId?.ToString() ?? ObrigatoriedadeLegal.TipoEditalUniversal;
+
+        IReadOnlyList<ObrigatoriedadeLegal> regras = await regraRepository
+            .ObterVigentesParaTipoEditalAsync(tipoEditalCodigo, hoje, cancellationToken)
+            .ConfigureAwait(false);
+
+        ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(edital, regras);
+
+        RegraAvaliadaDto[] regrasAvaliadas = [.. resultado.Regras.Select(avaliada =>
+        {
+            ObrigatoriedadeLegal? fonte = regras.FirstOrDefault(r => r.RegraCodigo == avaliada.RegraCodigo);
+            return new RegraAvaliadaDto(
+                RegraId: fonte?.Id ?? Guid.Empty,
+                RegraCodigo: avaliada.RegraCodigo,
+                Aprovada: avaliada.Aprovada,
+                BaseLegal: avaliada.BaseLegal,
+                PortariaInternaCodigo: avaliada.PortariaInterna,
+                AtoNormativoUrl: fonte?.AtoNormativoUrl,
+                DescricaoHumana: avaliada.DescricaoHumana,
+                Hash: avaliada.Hash,
+                VigenciaInicio: fonte?.VigenciaInicio ?? hoje,
+                VigenciaFim: fonte?.VigenciaFim);
+        })];
+
+        return new ConformidadeDto(edital.Id, regrasAvaliadas);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeAtualQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeAtualQueryHandler.cs
@@ -48,6 +48,13 @@ public static class ObterConformidadeAtualQueryHandler
 
         ResultadoConformidade resultado = ValidadorConformidadeEdital.Evaluate(edital, regras);
 
+        // Hash do payload precisa ser o canônico persistido em
+        // ObrigatoriedadeLegal.Hash (HashCanonicalComputer per #460) — não o
+        // placeholder textual emitido pelo ValidadorConformidadeEdital
+        // (que vem do código #459 anterior à forma plena). Sem isso o
+        // hash retornado por GET /conformidade divergiria do hash do
+        // snapshot histórico e do catálogo admin, quebrando correlação
+        // client-side (Codex P1).
         RegraAvaliadaDto[] regrasAvaliadas = [.. resultado.Regras.Select(avaliada =>
         {
             ObrigatoriedadeLegal? fonte = regras.FirstOrDefault(r => r.RegraCodigo == avaliada.RegraCodigo);
@@ -59,7 +66,7 @@ public static class ObterConformidadeAtualQueryHandler
                 PortariaInternaCodigo: avaliada.PortariaInterna,
                 AtoNormativoUrl: fonte?.AtoNormativoUrl,
                 DescricaoHumana: avaliada.DescricaoHumana,
-                Hash: avaliada.Hash,
+                Hash: fonte?.Hash ?? avaliada.Hash,
                 VigenciaInicio: fonte?.VigenciaInicio ?? hoje,
                 VigenciaFim: fonte?.VigenciaFim);
         })];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeAtualQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeAtualQueryHandler.cs
@@ -40,7 +40,19 @@ public static class ObterConformidadeAtualQueryHandler
         }
 
         DateOnly hoje = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime.Date);
-        string tipoEditalCodigo = edital.TipoEditalId?.ToString() ?? ObrigatoriedadeLegal.TipoEditalUniversal;
+
+        // V1: TipoEdital ainda é Guid (entity vem só com a promoção
+        // enum → entidade em #455). Até lá, o lookup case-sensitive de
+        // TipoEditalCodigo nunca casa um Guid contra um código textual
+        // tipo "PSIQ"/"SISU" — então só as regras universais (TipoEditalCodigo
+        // = "*") são aplicadas na prática. Quando #455 mergeie, basta trocar
+        // a resolução abaixo para tipoEdital.Codigo carregado pelo repositório
+        // de TipoEdital. Mantemos o ToUpperInvariant pelo invariante de
+        // normalização do PayloadNormalizer (uppercase ASCII canônico) —
+        // evita falso-negativo se o admin seedar a regra com o mesmo Guid
+        // que está em edital.TipoEditalId.
+        string tipoEditalCodigo = edital.TipoEditalId?.ToString().ToUpperInvariant()
+            ?? ObrigatoriedadeLegal.TipoEditalUniversal;
 
         IReadOnlyList<ObrigatoriedadeLegal> regras = await regraRepository
             .ObterVigentesParaTipoEditalAsync(tipoEditalCodigo, hoje, cancellationToken)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeHistoricaQuery.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeHistoricaQuery.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+/// <summary>
+/// Lê o snapshot imutável de conformidade gravado em
+/// <c>edital_governance_snapshot.regras_json</c> no momento de
+/// <c>Edital.Publicar()</c> (ADR-0058 §"Snapshot-on-bind"). Endpoint
+/// <c>GET /api/selecao/editais/{id}/conformidade-historica</c>.
+/// </summary>
+public sealed record ObterConformidadeHistoricaQuery(Guid EditalId) : IQuery<ConformidadeDto?>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeHistoricaQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterConformidadeHistoricaQueryHandler.cs
@@ -1,0 +1,81 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+
+using System.Text.Json;
+
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Handler convention-based de <see cref="ObterConformidadeHistoricaQuery"/>.
+/// Lê <c>RegrasJson</c> do <c>EditalGovernanceSnapshot</c> e deserializa
+/// para <see cref="ConformidadeDto"/>. Retorna <see langword="null"/> quando
+/// o snapshot inexiste — controller traduz para 404 com ProblemDetails
+/// <c>uniplus.selecao.conformidade.snapshot_nao_disponivel</c>.
+/// </summary>
+/// <remarks>
+/// O JSON do snapshot é byte-equivalente ao formato canônico emitido pelo
+/// <c>HashCanonicalComputer</c> (ADR-0058 + #460): array de regra-objects
+/// com <c>id</c>, <c>hash</c>, <c>baseLegal</c>, <c>portariaInternaCodigo</c>,
+/// <c>vigenciaInicio/Fim</c>, <c>predicado</c> etc. Todas as regras no
+/// snapshot foram <c>Aprovada = true</c> pelo evaluator no momento da
+/// publicação — caso contrário <c>Edital.Publicar()</c> teria falhado e o
+/// snapshot nunca seria gravado (#462).
+/// </remarks>
+public static class ObterConformidadeHistoricaQueryHandler
+{
+    public static async Task<ConformidadeDto?> Handle(
+        ObterConformidadeHistoricaQuery query,
+        IObrigatoriedadeLegalRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        string? json = await repository
+            .ObterSnapshotConformidadeJsonAsync(query.EditalId, cancellationToken)
+            .ConfigureAwait(false);
+        if (json is null)
+        {
+            return null;
+        }
+
+        SnapshotRegraItem[] itens = JsonSerializer.Deserialize<SnapshotRegraItem[]>(
+            json,
+            HashCanonicalComputer.CanonicalOptions) ?? [];
+
+        RegraAvaliadaDto[] regras = [.. itens.Select(item => new RegraAvaliadaDto(
+            RegraId: item.Id,
+            RegraCodigo: item.RegraCodigo,
+            Aprovada: true,
+            BaseLegal: item.BaseLegal,
+            PortariaInternaCodigo: item.PortariaInternaCodigo,
+            AtoNormativoUrl: item.AtoNormativoUrl,
+            DescricaoHumana: item.DescricaoHumana,
+            Hash: item.Hash,
+            VigenciaInicio: item.VigenciaInicio,
+            VigenciaFim: item.VigenciaFim))];
+
+        return new ConformidadeDto(query.EditalId, regras);
+    }
+
+    /// <summary>
+    /// Shape de cada item do array <c>RegrasJson</c> persistido pelo
+    /// <c>Edital.Publicar()</c> em #462. Sub-conjunto do payload canônico
+    /// suficiente para reconstruir <see cref="RegraAvaliadaDto"/>.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciado por reflection pelo JsonSerializer.Deserialize.")]
+    private sealed record SnapshotRegraItem(
+        Guid Id,
+        string RegraCodigo,
+        string BaseLegal,
+        string DescricaoHumana,
+        string Hash,
+        DateOnly VigenciaInicio,
+        DateOnly? VigenciaFim,
+        string? PortariaInternaCodigo,
+        string? AtoNormativoUrl);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterObrigatoriedadeLegalQuery.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterObrigatoriedadeLegalQuery.cs
@@ -1,0 +1,11 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+/// <summary>
+/// Lê uma <c>ObrigatoriedadeLegal</c> ativa pelo Id. Retorna
+/// <see langword="null"/> quando não existe ou foi soft-deleted —
+/// controller traduz para <c>404 Not Found</c>.
+/// </summary>
+public sealed record ObterObrigatoriedadeLegalQuery(Guid Id) : IQuery<ObrigatoriedadeLegalDto?>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterObrigatoriedadeLegalQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ObterObrigatoriedadeLegalQueryHandler.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
+
+using System.Collections.Generic;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Application.Mappings;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+/// <summary>
+/// Handler convention-based de <see cref="ObterObrigatoriedadeLegalQuery"/>.
+/// Carrega a regra (filtrada por soft-delete via query filter padrão) e
+/// hidrata <c>AreasDeInteresse</c> a partir da junction temporal — entity
+/// não tem nav property (ADR-0060), o set in-memory vem vazio após carga
+/// EF fresca.
+/// </summary>
+public static class ObterObrigatoriedadeLegalQueryHandler
+{
+    public static async Task<ObrigatoriedadeLegalDto?> Handle(
+        ObterObrigatoriedadeLegalQuery query,
+        IObrigatoriedadeLegalRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        ObrigatoriedadeLegal? regra = await repository
+            .ObterPorIdAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (regra is null)
+        {
+            return null;
+        }
+
+        IReadOnlySet<AreaCodigo> areas = await repository
+            .ObterAreasVigentesAsync(regra.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return ObrigatoriedadeLegalMapping.ToDto(regra, areas);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/AtualizarObrigatoriedadeLegalCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/AtualizarObrigatoriedadeLegalCommandValidator.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Validators;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Validação de fronteira HTTP do <see cref="AtualizarObrigatoriedadeLegalCommand"/>.
+/// Mesmas regras de shape do <see cref="CriarObrigatoriedadeLegalCommandValidator"/>
+/// + obrigatoriedade de <see cref="AtualizarObrigatoriedadeLegalCommand.Id"/>
+/// não-vazio.
+/// </summary>
+public sealed class AtualizarObrigatoriedadeLegalCommandValidator
+    : AbstractValidator<AtualizarObrigatoriedadeLegalCommand>
+{
+    public AtualizarObrigatoriedadeLegalCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEqual(Guid.Empty)
+            .WithMessage("Id é obrigatório.");
+
+        RuleFor(x => x.TipoEditalCodigo)
+            .NotEmpty()
+            .WithMessage("TipoEditalCodigo é obrigatório.")
+            .MaximumLength(64);
+
+        RuleFor(x => x.Categoria)
+            .NotEqual(CategoriaObrigatoriedade.Nenhuma)
+            .WithMessage("Categoria não pode ser Nenhuma.")
+            .IsInEnum();
+
+        RuleFor(x => x.RegraCodigo)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Predicado)
+            .NotNull();
+
+        RuleFor(x => x.DescricaoHumana)
+            .NotEmpty()
+            .MaximumLength(1000);
+
+        RuleFor(x => x.BaseLegal)
+            .NotEmpty()
+            .MaximumLength(500);
+
+        RuleFor(x => x.AtoNormativoUrl)
+            .MaximumLength(1000)
+            .When(x => !string.IsNullOrWhiteSpace(x.AtoNormativoUrl));
+
+        RuleFor(x => x.PortariaInternaCodigo)
+            .MaximumLength(128)
+            .When(x => !string.IsNullOrWhiteSpace(x.PortariaInternaCodigo));
+
+        RuleFor(x => x)
+            .Must(x => x.VigenciaFim is null || x.VigenciaFim.Value > x.VigenciaInicio)
+            .WithName(nameof(AtualizarObrigatoriedadeLegalCommand.VigenciaFim))
+            .WithMessage("VigenciaFim deve ser estritamente posterior a VigenciaInicio.");
+
+        RuleFor(x => x.AreasDeInteresse)
+            .NotNull()
+            .WithMessage("AreasDeInteresse é obrigatório (passe coleção vazia para regra global).");
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/CriarObrigatoriedadeLegalCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/CriarObrigatoriedadeLegalCommandValidator.cs
@@ -1,0 +1,68 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Validators;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Selecao.Application.Commands.ObrigatoriedadesLegais;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Validação de fronteira HTTP do <see cref="CriarObrigatoriedadeLegalCommand"/>.
+/// Erros de shape básico (campos vazios, comprimento, vigência inconsistente)
+/// retornam 422 ProblemDetails antes do command chegar ao handler. Regras de
+/// domínio (governance Invariante 1 do ADR-0057, hash colision, regra
+/// duplicada) são verificadas pelo handler — geram <see cref="Kernel.Results.DomainError"/>
+/// específico.
+/// </summary>
+public sealed class CriarObrigatoriedadeLegalCommandValidator
+    : AbstractValidator<CriarObrigatoriedadeLegalCommand>
+{
+    public CriarObrigatoriedadeLegalCommandValidator()
+    {
+        RuleFor(x => x.TipoEditalCodigo)
+            .NotEmpty()
+            .WithMessage("TipoEditalCodigo é obrigatório — use \"*\" para regras universais.")
+            .MaximumLength(64);
+
+        RuleFor(x => x.Categoria)
+            .NotEqual(CategoriaObrigatoriedade.Nenhuma)
+            .WithMessage("Categoria não pode ser Nenhuma (sentinel default).")
+            .IsInEnum()
+            .WithMessage("Categoria inválida.");
+
+        RuleFor(x => x.RegraCodigo)
+            .NotEmpty()
+            .WithMessage("RegraCodigo é obrigatório.")
+            .MaximumLength(128);
+
+        RuleFor(x => x.Predicado)
+            .NotNull()
+            .WithMessage("Predicado é obrigatório.");
+
+        RuleFor(x => x.DescricaoHumana)
+            .NotEmpty()
+            .WithMessage("DescricaoHumana é obrigatória.")
+            .MaximumLength(1000);
+
+        RuleFor(x => x.BaseLegal)
+            .NotEmpty()
+            .WithMessage("BaseLegal é obrigatória.")
+            .MaximumLength(500);
+
+        RuleFor(x => x.AtoNormativoUrl)
+            .MaximumLength(1000)
+            .When(x => !string.IsNullOrWhiteSpace(x.AtoNormativoUrl));
+
+        RuleFor(x => x.PortariaInternaCodigo)
+            .MaximumLength(128)
+            .When(x => !string.IsNullOrWhiteSpace(x.PortariaInternaCodigo));
+
+        RuleFor(x => x)
+            .Must(x => x.VigenciaFim is null || x.VigenciaFim.Value > x.VigenciaInicio)
+            .WithName(nameof(CriarObrigatoriedadeLegalCommand.VigenciaFim))
+            .WithMessage("VigenciaFim deve ser estritamente posterior a VigenciaInicio.");
+
+        RuleFor(x => x.AreasDeInteresse)
+            .NotNull()
+            .WithMessage("AreasDeInteresse é obrigatório — passe coleção vazia para regra global.");
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IObrigatoriedadeLegalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IObrigatoriedadeLegalRepository.cs
@@ -1,0 +1,114 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+using System.Collections.Generic;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Repositório de <see cref="ObrigatoriedadeLegal"/> + reconciliação atômica
+/// da junction temporal <c>obrigatoriedade_legal_areas_de_interesse</c>
+/// (ADR-0060). O repositório é o único ponto que escreve nessa junction —
+/// o template <c>AreaVisibilityConfiguration</c> não tem nav property no
+/// modelo EF.
+/// </summary>
+/// <remarks>
+/// Listagem paginada por chave (ADR-0026) com filtros admin
+/// (<c>tipoEditalCodigo</c>, <c>categoria</c>, <c>proprietario</c>,
+/// <c>vigentes</c>). Consultas para o motor de conformidade
+/// (<c>ObterVigentesParaTipoEditalAsync</c>) carregam regras universais
+/// (<c>"*"</c>) + específicas do tipo.
+/// </remarks>
+public interface IObrigatoriedadeLegalRepository : IRepository<ObrigatoriedadeLegal>
+{
+    /// <summary>
+    /// Lista regras paginadas com filtros admin. Ordenação estável por
+    /// <c>Id</c> (Guid v7 cronológico). <paramref name="afterId"/> aplica
+    /// keyset; <paramref name="take"/> limita a janela.
+    /// </summary>
+    Task<IReadOnlyList<ObrigatoriedadeLegal>> ListarPaginadoAsync(
+        Guid? afterId,
+        int take,
+        string? tipoEditalCodigo,
+        CategoriaObrigatoriedade? categoria,
+        AreaCodigo? proprietario,
+        bool vigentes,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lê o conjunto de regras vigentes aplicáveis ao tipo de edital
+    /// (filtra <c>TipoEditalCodigo = '*' OR tipo</c>, vigência ativa,
+    /// não soft-deleted). Caminho do motor de conformidade.
+    /// </summary>
+    Task<IReadOnlyList<ObrigatoriedadeLegal>> ObterVigentesParaTipoEditalAsync(
+        string tipoEditalCodigo,
+        DateOnly hoje,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persiste uma nova regra junto com seus bindings temporais. POST do
+    /// admin CRUD — bindings recebem <c>ValidoDe = now</c>, <c>ValidoAte = null</c>.
+    /// </summary>
+    Task AdicionarComBindingsAsync(
+        ObrigatoriedadeLegal regra,
+        IReadOnlySet<AreaCodigo> areasDeInteresse,
+        DateTimeOffset agora,
+        string adicionadoPor,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Diff-aplica novo conjunto de bindings: insere novos
+    /// (<c>ValidoDe = now</c>); fecha removidos (<c>ValidoAte = now</c>);
+    /// preserva intactos. PUT do admin CRUD respeitando histórico temporal
+    /// da junction (ADR-0060).
+    /// </summary>
+    Task ReconciliarBindingsAsync(
+        ObrigatoriedadeLegal regra,
+        IReadOnlySet<AreaCodigo> novasAreasDeInteresse,
+        DateTimeOffset agora,
+        string adicionadoPor,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lê o set vigente de áreas para a regra (bindings com
+    /// <c>ValidoAte IS NULL</c>). Usado pelo handler do PUT para reidratar
+    /// o set in-memory antes do <c>Atualizar()</c> da entity (semântica
+    /// full-replace exige caller passar valores correntes).
+    /// </summary>
+    Task<IReadOnlySet<AreaCodigo>> ObterAreasVigentesAsync(
+        Guid regraId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Carrega o map id → áreas vigentes em batch para um conjunto de regras —
+    /// evita N+1 quando o handler do <c>GET</c> paginado precisa hidratar
+    /// <c>AreasDeInteresse</c> do DTO de cada item.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, IReadOnlySet<AreaCodigo>>> ObterAreasVigentesPorIdsAsync(
+        IReadOnlyCollection<Guid> regraIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Verifica colisão de <c>RegraCodigo</c> ativo (não soft-deleted).
+    /// Usado para emitir <c>409 Conflict</c> com
+    /// <c>uniplus.selecao.obrigatoriedade_legal.regra_codigo_duplicada</c>
+    /// antes de tentar a INSERT que dispararia a <c>UNIQUE</c> parcial.
+    /// </summary>
+    Task<bool> ExisteRegraCodigoAtivoAsync(
+        string regraCodigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lê o <c>RegrasJson</c> do <c>EditalGovernanceSnapshot</c> de um edital
+    /// publicado (ADR-0058 §"Snapshot-on-bind"). Retorna <see langword="null"/>
+    /// quando o edital ainda não foi publicado — <c>GET /conformidade-historica</c>
+    /// emite 404 com <c>uniplus.selecao.conformidade.snapshot_nao_disponivel</c>.
+    /// O preenchimento da tabela é responsabilidade de #462 (US-F4-04).
+    /// </summary>
+    Task<string?> ObterSnapshotConformidadeJsonAsync(
+        Guid editalId,
+        CancellationToken cancellationToken = default);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -49,6 +49,7 @@ public static class SelecaoInfrastructureRegistration
 
         services.AddScoped<IEditalRepository, EditalRepository>();
         services.AddScoped<IInscricaoRepository, InscricaoRepository>();
+        services.AddScoped<IObrigatoriedadeLegalRepository, ObrigatoriedadeLegalRepository>();
         services.AddScoped<IGovBrAuthService, GovBrAuthService>();
 
         return services;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ObrigatoriedadeLegalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ObrigatoriedadeLegalConfiguration.cs
@@ -132,6 +132,20 @@ internal sealed class ObrigatoriedadeLegalConfiguration()
             .HasFilter("is_deleted = false")
             .HasDatabaseName("ux_obrigatoriedades_legais_hash_ativos");
 
+        // UNIQUE parcial sobre RegraCodigo entre regras ativas (Codex P1 de
+        // #461). O ExisteRegraCodigoAtivoAsync no handler é check-then-act
+        // não-atômico — duas escritas concorrentes com o mesmo RegraCodigo
+        // poderiam ambas passar a checagem e commitar, criando o cenário
+        // ambíguo de "duas regras vigentes com mesmo código simbólico"
+        // mesmo que seus hashes canônicos divirjam por um campo qualquer
+        // (vigência, base legal). Constraint do banco é a única defesa
+        // realmente atômica; o ExisteRegraCodigoAtivoAsync vira fast path
+        // pra emitir 409 ProblemDetails antes do INSERT em casos não-race.
+        builder.HasIndex(o => o.RegraCodigo)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ux_obrigatoriedades_legais_regra_codigo_ativos");
+
         ConfigureAreaVisibility(builder);
     }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260516225949_AddObrigatoriedadeLegalRegraCodigoUniquePartial.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260516225949_AddObrigatoriedadeLegalRegraCodigoUniquePartial.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516225949_AddObrigatoriedadeLegalRegraCodigoUniquePartial")]
+    partial class AddObrigatoriedadeLegalRegraCodigoUniquePartial
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260516225949_AddObrigatoriedadeLegalRegraCodigoUniquePartial.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260516225949_AddObrigatoriedadeLegalRegraCodigoUniquePartial.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddObrigatoriedadeLegalRegraCodigoUniquePartial : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ux_obrigatoriedades_legais_regra_codigo_ativos",
+                table: "obrigatoriedades_legais",
+                column: "regra_codigo",
+                unique: true,
+                filter: "is_deleted = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ux_obrigatoriedades_legais_regra_codigo_ativos",
+                table: "obrigatoriedades_legais");
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
@@ -183,26 +183,20 @@ public sealed class ObrigatoriedadeLegalRepository : IObrigatoriedadeLegalReposi
 
         HashSet<AreaCodigo> vigentesCodigos = [.. vigentes.Select(b => b.AreaCodigo)];
 
-        // Encerra bindings que sumiram do novo set.
-        foreach (AreaDeInteresseBinding<ObrigatoriedadeLegal> binding in vigentes)
+        // Encerra bindings que sumiram do novo set — filtro explícito com
+        // Where torna a intenção visível na origem da iteração.
+        foreach (AreaDeInteresseBinding<ObrigatoriedadeLegal> binding in
+            vigentes.Where(b => !novasAreasDeInteresse.Contains(b.AreaCodigo)))
         {
-            if (!novasAreasDeInteresse.Contains(binding.AreaCodigo))
-            {
-                binding.Encerrar(agora);
-            }
+            binding.Encerrar(agora);
         }
 
         // Insere bindings que não existiam na junção. Strict greater-than no
         // ValidoDe versus o ValidoAte recém-fechado preserva o invariante de
         // janela do exclusion GIST.
         DateTimeOffset proximoValidoDe = agora.AddTicks(1);
-        foreach (AreaCodigo nova in novasAreasDeInteresse)
+        foreach (AreaCodigo nova in novasAreasDeInteresse.Where(a => !vigentesCodigos.Contains(a)))
         {
-            if (vigentesCodigos.Contains(nova))
-            {
-                continue;
-            }
-
             await junction.AddAsync(
                 AreaDeInteresseBinding<ObrigatoriedadeLegal>.Criar(
                     regra.Id, nova, proximoValidoDe, adicionadoPor),

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
@@ -1,0 +1,288 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+/// <summary>
+/// Repositório de <see cref="ObrigatoriedadeLegal"/> + reconciliação atômica
+/// da junction <c>obrigatoriedade_legal_areas_de_interesse</c> (ADR-0060).
+/// </summary>
+/// <remarks>
+/// Reconciliação temporal (<see cref="ReconciliarBindingsAsync"/>): bindings
+/// vigentes (<c>ValidoAte IS NULL</c>) cujo <c>AreaCodigo</c> some do novo
+/// set são encerrados com <c>ValidoAte = agora</c>; bindings novos são
+/// inseridos com <c>ValidoDe = agora</c>; bindings já vigentes que
+/// permanecem no novo set ficam intactos. Tudo dentro do mesmo
+/// <c>SaveChangesAsync</c> — atomicidade write+histórico via
+/// <c>ObrigatoriedadeLegalHistoricoInterceptor</c>.
+/// </remarks>
+public sealed class ObrigatoriedadeLegalRepository : IObrigatoriedadeLegalRepository
+{
+    private readonly SelecaoDbContext _context;
+
+    public ObrigatoriedadeLegalRepository(SelecaoDbContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    public async Task<ObrigatoriedadeLegal?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        return await _context.ObrigatoriedadesLegais
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<ObrigatoriedadeLegal>> ObterTodosAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return await _context.ObrigatoriedadesLegais
+            .AsNoTracking()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task AdicionarAsync(
+        ObrigatoriedadeLegal entity,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        await _context.ObrigatoriedadesLegais.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Atualizar(ObrigatoriedadeLegal entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        _context.ObrigatoriedadesLegais.Update(entity);
+    }
+
+    public void Remover(ObrigatoriedadeLegal entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        // SoftDeleteInterceptor converte Deleted → Modified + IsDeleted=true.
+        // ObrigatoriedadeLegalHistoricoInterceptor grava a linha do snapshot
+        // refletindo o estado pós-desativação.
+        _context.ObrigatoriedadesLegais.Remove(entity);
+    }
+
+    public async Task<IReadOnlyList<ObrigatoriedadeLegal>> ListarPaginadoAsync(
+        Guid? afterId,
+        int take,
+        string? tipoEditalCodigo,
+        CategoriaObrigatoriedade? categoria,
+        AreaCodigo? proprietario,
+        bool vigentes,
+        CancellationToken cancellationToken = default)
+    {
+        IQueryable<ObrigatoriedadeLegal> query = _context.ObrigatoriedadesLegais
+            .AsNoTracking()
+            .OrderBy(o => o.Id);
+
+        if (!string.IsNullOrWhiteSpace(tipoEditalCodigo))
+        {
+            string normalizado = tipoEditalCodigo.Trim();
+            query = query.Where(o => o.TipoEditalCodigo == normalizado);
+        }
+
+        if (categoria is { } cat)
+        {
+            query = query.Where(o => o.Categoria == cat);
+        }
+
+        if (proprietario is { } prop)
+        {
+            query = query.Where(o => o.Proprietario == prop);
+        }
+
+        if (vigentes)
+        {
+            DateOnly hoje = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime.Date);
+            query = query.Where(o =>
+                o.VigenciaInicio <= hoje
+                && (o.VigenciaFim == null || o.VigenciaFim > hoje));
+        }
+
+        if (afterId is { } cursor)
+        {
+            query = query.Where(o => o.Id.CompareTo(cursor) > 0);
+        }
+
+        return await query.Take(take).ToListAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<ObrigatoriedadeLegal>> ObterVigentesParaTipoEditalAsync(
+        string tipoEditalCodigo,
+        DateOnly hoje,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tipoEditalCodigo);
+
+        return await _context.ObrigatoriedadesLegais
+            .AsNoTracking()
+            .Where(o =>
+                (o.TipoEditalCodigo == ObrigatoriedadeLegal.TipoEditalUniversal
+                    || o.TipoEditalCodigo == tipoEditalCodigo)
+                && o.VigenciaInicio <= hoje
+                && (o.VigenciaFim == null || o.VigenciaFim > hoje))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task AdicionarComBindingsAsync(
+        ObrigatoriedadeLegal regra,
+        IReadOnlySet<AreaCodigo> areasDeInteresse,
+        DateTimeOffset agora,
+        string adicionadoPor,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(regra);
+        ArgumentNullException.ThrowIfNull(areasDeInteresse);
+        ArgumentException.ThrowIfNullOrWhiteSpace(adicionadoPor);
+
+        await _context.ObrigatoriedadesLegais.AddAsync(regra, cancellationToken).ConfigureAwait(false);
+
+        DbSet<AreaDeInteresseBinding<ObrigatoriedadeLegal>> junction =
+            _context.Set<AreaDeInteresseBinding<ObrigatoriedadeLegal>>();
+
+        foreach (AreaCodigo area in areasDeInteresse)
+        {
+            await junction.AddAsync(
+                AreaDeInteresseBinding<ObrigatoriedadeLegal>.Criar(regra.Id, area, agora, adicionadoPor),
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task ReconciliarBindingsAsync(
+        ObrigatoriedadeLegal regra,
+        IReadOnlySet<AreaCodigo> novasAreasDeInteresse,
+        DateTimeOffset agora,
+        string adicionadoPor,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(regra);
+        ArgumentNullException.ThrowIfNull(novasAreasDeInteresse);
+        ArgumentException.ThrowIfNullOrWhiteSpace(adicionadoPor);
+
+        DbSet<AreaDeInteresseBinding<ObrigatoriedadeLegal>> junction =
+            _context.Set<AreaDeInteresseBinding<ObrigatoriedadeLegal>>();
+
+        List<AreaDeInteresseBinding<ObrigatoriedadeLegal>> vigentes = await junction
+            .Where(b => b.ParentId == regra.Id && b.ValidoAte == null)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        HashSet<AreaCodigo> vigentesCodigos = [.. vigentes.Select(b => b.AreaCodigo)];
+
+        // Encerra bindings que sumiram do novo set.
+        foreach (AreaDeInteresseBinding<ObrigatoriedadeLegal> binding in vigentes)
+        {
+            if (!novasAreasDeInteresse.Contains(binding.AreaCodigo))
+            {
+                binding.Encerrar(agora);
+            }
+        }
+
+        // Insere bindings que não existiam na junção. Strict greater-than no
+        // ValidoDe versus o ValidoAte recém-fechado preserva o invariante de
+        // janela do exclusion GIST.
+        DateTimeOffset proximoValidoDe = agora.AddTicks(1);
+        foreach (AreaCodigo nova in novasAreasDeInteresse)
+        {
+            if (vigentesCodigos.Contains(nova))
+            {
+                continue;
+            }
+
+            await junction.AddAsync(
+                AreaDeInteresseBinding<ObrigatoriedadeLegal>.Criar(
+                    regra.Id, nova, proximoValidoDe, adicionadoPor),
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async Task<IReadOnlySet<AreaCodigo>> ObterAreasVigentesAsync(
+        Guid regraId,
+        CancellationToken cancellationToken = default)
+    {
+        List<AreaCodigo> codigos = await _context
+            .Set<AreaDeInteresseBinding<ObrigatoriedadeLegal>>()
+            .AsNoTracking()
+            .Where(b => b.ParentId == regraId && b.ValidoAte == null)
+            .Select(b => b.AreaCodigo)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return codigos.ToHashSet();
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, IReadOnlySet<AreaCodigo>>> ObterAreasVigentesPorIdsAsync(
+        IReadOnlyCollection<Guid> regraIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(regraIds);
+
+        if (regraIds.Count == 0)
+        {
+            return new Dictionary<Guid, IReadOnlySet<AreaCodigo>>();
+        }
+
+        var bindings = await _context
+            .Set<AreaDeInteresseBinding<ObrigatoriedadeLegal>>()
+            .AsNoTracking()
+            .Where(b => regraIds.Contains(b.ParentId) && b.ValidoAte == null)
+            .Select(b => new { b.ParentId, b.AreaCodigo })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Dictionary<Guid, IReadOnlySet<AreaCodigo>> map = bindings
+            .GroupBy(b => b.ParentId)
+            .ToDictionary(
+                g => g.Key,
+                g => (IReadOnlySet<AreaCodigo>)g.Select(x => x.AreaCodigo).ToHashSet());
+
+        return map;
+    }
+
+    public async Task<bool> ExisteRegraCodigoAtivoAsync(
+        string regraCodigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(regraCodigo);
+
+        string normalizado = regraCodigo.Trim();
+        IQueryable<ObrigatoriedadeLegal> query = _context.ObrigatoriedadesLegais
+            .AsNoTracking()
+            .Where(o => o.RegraCodigo == normalizado);
+
+        if (excluirId is { } id)
+        {
+            query = query.Where(o => o.Id != id);
+        }
+
+        return await query.AnyAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<string?> ObterSnapshotConformidadeJsonAsync(
+        Guid editalId,
+        CancellationToken cancellationToken = default)
+    {
+        return await _context.EditalGovernanceSnapshots
+            .AsNoTracking()
+            .Where(s => s.EditalId == editalId)
+            .OrderByDescending(s => s.SnapshottedAt)
+            .Select(s => s.RegrasJson)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
@@ -127,11 +127,18 @@ public sealed class ObrigatoriedadeLegalRepository : IObrigatoriedadeLegalReposi
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(tipoEditalCodigo);
 
+        // Comparação case-insensitive defensiva (Codex P2 round 2): mesmo
+        // que o caller já passe o lookup uppercased, a persistência aceita
+        // caixa livre — divergências de caixa entre Criar/Atualizar e o
+        // lookup quebrariam silenciosamente a conformidade. `EF.Functions.ILike`
+        // traduz para o operador case-insensitive nativo do PostgreSQL.
+        // Universal "*" segue por igualdade direta — sentinela ASCII sem
+        // letras.
         return await _context.ObrigatoriedadesLegais
             .AsNoTracking()
             .Where(o =>
                 (o.TipoEditalCodigo == ObrigatoriedadeLegal.TipoEditalUniversal
-                    || o.TipoEditalCodigo == tipoEditalCodigo)
+                    || EF.Functions.ILike(o.TipoEditalCodigo, tipoEditalCodigo))
                 && o.VigenciaInicio <= hoje
                 && (o.VigenciaFim == null || o.VigenciaFim > hoje))
             .ToListAsync(cancellationToken)

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ListarEditaisEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ListarEditaisEndpointTests.cs
@@ -26,13 +26,13 @@ public sealed class ListarEditaisEndpointTests
         _fixture = fixture;
     }
 
-    [Fact(DisplayName = "GET /api/editais retorna 200, body JSON array, header Link com rel=\"self\"")]
+    [Fact(DisplayName = "GET /api/selecao/editais retorna 200, body JSON array, header Link com rel=\"self\"")]
     public async Task Listar_SemCursor_RetornaArrayJsonComLinkSelf()
     {
         await SemearEditaisAsync(_fixture.Factory, quantidade: 2);
         using HttpClient client = _fixture.Factory.CreateClient();
 
-        HttpResponseMessage response = await client.GetAsync(new Uri("/api/editais?limit=10", UriKind.Relative));
+        HttpResponseMessage response = await client.GetAsync(new Uri("/api/selecao/editais?limit=10", UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/vnd.uniplus.edital.v1+json");
@@ -48,13 +48,13 @@ public sealed class ListarEditaisEndpointTests
         await response.AssertNoPiiAsync();
     }
 
-    [Fact(DisplayName = "GET /api/editais com cursor adulterado retorna 400 cursor_invalido")]
+    [Fact(DisplayName = "GET /api/selecao/editais com cursor adulterado retorna 400 cursor_invalido")]
     public async Task Listar_CursorAdulterado_Retorna400()
     {
         using HttpClient client = _fixture.Factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(
-            new Uri("/api/editais?cursor=AAAA-cursor-invalido-AAAA", UriKind.Relative));
+            new Uri("/api/selecao/editais?cursor=AAAA-cursor-invalido-AAAA", UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
@@ -63,11 +63,11 @@ public sealed class ListarEditaisEndpointTests
         await response.AssertNoPiiAsync();
     }
 
-    [Fact(DisplayName = "GET /api/editais com Accept de versao inexistente retorna 406 + available_versions")]
+    [Fact(DisplayName = "GET /api/selecao/editais com Accept de versao inexistente retorna 406 + available_versions")]
     public async Task Listar_AcceptVersaoInexistente_Retorna406()
     {
         using HttpClient client = _fixture.Factory.CreateClient();
-        using HttpRequestMessage request = new(HttpMethod.Get, new Uri("/api/editais", UriKind.Relative));
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri("/api/selecao/editais", UriKind.Relative));
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.edital.v9+json"));
 
         HttpResponseMessage response = await client.SendAsync(request);
@@ -82,32 +82,32 @@ public sealed class ListarEditaisEndpointTests
         await response.AssertNoPiiAsync();
     }
 
-    [Fact(DisplayName = "GET /api/editais com limit fora de faixa retorna 422 cursor_limit_invalido")]
+    [Fact(DisplayName = "GET /api/selecao/editais com limit fora de faixa retorna 422 cursor_limit_invalido")]
     public async Task Listar_LimitInvalido_Retorna422()
     {
         using HttpClient client = _fixture.Factory.CreateClient();
 
-        HttpResponseMessage response = await client.GetAsync(new Uri("/api/editais?limit=999", UriKind.Relative));
+        HttpResponseMessage response = await client.GetAsync(new Uri("/api/selecao/editais?limit=999", UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         doc.RootElement.GetProperty("code").GetString().Should().Be("uniplus.cursor.limit_invalido");
     }
 
-    [Fact(DisplayName = "GET /api/editais ?limit do query string vence sobre limit do cursor")]
+    [Fact(DisplayName = "GET /api/selecao/editais ?limit do query string vence sobre limit do cursor")]
     public async Task Listar_LimitDoQueryStringVencePrecedencia()
     {
         await SemearEditaisAsync(_fixture.Factory, quantidade: 6);
         using HttpClient client = _fixture.Factory.CreateClient();
 
         // Primeira página com limit=2 — emite cursor com Limit=2 embutido.
-        HttpResponseMessage paginaUm = await client.GetAsync(new Uri("/api/editais?limit=2", UriKind.Relative));
+        HttpResponseMessage paginaUm = await client.GetAsync(new Uri("/api/selecao/editais?limit=2", UriKind.Relative));
         paginaUm.StatusCode.Should().Be(HttpStatusCode.OK);
         string nextCursor = ExtrairCursorNext(paginaUm);
 
         // Reutiliza o cursor mas pede explicitamente limit=4 — query string deve vencer.
         HttpResponseMessage paginaDois = await client.GetAsync(
-            new Uri($"/api/editais?cursor={Uri.EscapeDataString(nextCursor)}&limit=4", UriKind.Relative));
+            new Uri($"/api/selecao/editais?cursor={Uri.EscapeDataString(nextCursor)}&limit=4", UriKind.Relative));
         paginaDois.StatusCode.Should().Be(HttpStatusCode.OK);
 
         IReadOnlyList<Guid> ids = await ExtrairIdsAsync(paginaDois);
@@ -116,7 +116,7 @@ public sealed class ListarEditaisEndpointTests
             "limit=4 do query string venceu sobre Limit=2 herdado do cursor");
     }
 
-    [Fact(DisplayName = "GET /api/editais navega cursor sem duplicar nem omitir itens")]
+    [Fact(DisplayName = "GET /api/selecao/editais navega cursor sem duplicar nem omitir itens")]
     public async Task Listar_CursorNavegacao_PreservaJanela()
     {
         // Seed garante volume mínimo; o DB pode ter editais residuais de outros
@@ -125,7 +125,7 @@ public sealed class ListarEditaisEndpointTests
         await SemearEditaisAsync(_fixture.Factory, quantidade: 5);
         using HttpClient client = _fixture.Factory.CreateClient();
 
-        HttpResponseMessage paginaUm = await client.GetAsync(new Uri("/api/editais?limit=2", UriKind.Relative));
+        HttpResponseMessage paginaUm = await client.GetAsync(new Uri("/api/selecao/editais?limit=2", UriKind.Relative));
         paginaUm.StatusCode.Should().Be(HttpStatusCode.OK);
         IReadOnlyList<Guid> idsPagina1 = await ExtrairIdsAsync(paginaUm);
 
@@ -133,7 +133,7 @@ public sealed class ListarEditaisEndpointTests
         nextCursor.Should().NotBeNullOrEmpty();
 
         HttpResponseMessage paginaDois = await client.GetAsync(
-            new Uri($"/api/editais?cursor={Uri.EscapeDataString(nextCursor)}", UriKind.Relative));
+            new Uri($"/api/selecao/editais?cursor={Uri.EscapeDataString(nextCursor)}", UriKind.Relative));
         paginaDois.StatusCode.Should().Be(HttpStatusCode.OK);
         IReadOnlyList<Guid> idsPagina2 = await ExtrairIdsAsync(paginaDois);
 
@@ -153,7 +153,7 @@ public sealed class ListarEditaisEndpointTests
     private static string ExtrairCursorNext(HttpResponseMessage response)
     {
         string linkHeader = string.Join(',', response.Headers.GetValues("Link"));
-        // Formato: <https://.../api/editais?cursor=ABC&limit=2>; rel="next", <...>; rel="self"
+        // Formato: <https://.../api/selecao/editais?cursor=ABC&limit=2>; rel="next", <...>; rel="self"
         int relIndex = linkHeader.IndexOf("rel=\"next\"", StringComparison.Ordinal);
         relIndex.Should().BeGreaterThan(-1);
         int urlEnd = linkHeader.LastIndexOf('>', relIndex);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ObterEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Editais/ObterEditalEndpointTests.cs
@@ -16,7 +16,7 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 using Outbox.Cascading;
 
 /// <summary>
-/// Cobertura de <c>GET /api/editais/{id}</c> em runtime real, focando em
+/// Cobertura de <c>GET /api/selecao/editais/{id}</c> em runtime real, focando em
 /// HATEOAS Level 1 (ADR-0029): body inclui <c>_links.self</c> sempre, e
 /// <c>_links.collection</c>; nenhum action link (<c>publicar</c>, etc.) per
 /// vedação explícita da ADR-0029.
@@ -32,14 +32,14 @@ public sealed class ObterEditalEndpointTests
         _fixture = fixture;
     }
 
-    [Fact(DisplayName = "GET /api/editais/{id} retorna 200 + body com _links.self e _links.collection (ADR-0029)")]
+    [Fact(DisplayName = "GET /api/selecao/editais/{id} retorna 200 + body com _links.self e _links.collection (ADR-0029)")]
     public async Task ObterPorId_EditalExistente_RetornaBodyComLinks()
     {
         Edital seeded = await SemearEditalAsync(_fixture.Factory);
         using HttpClient client = _fixture.Factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(
-            new Uri($"/api/editais/{seeded.Id}", UriKind.Relative));
+            new Uri($"/api/selecao/editais/{seeded.Id}", UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
@@ -53,13 +53,13 @@ public sealed class ObterEditalEndpointTests
         // _links.self obrigatório, URI relativa apontando para o próprio recurso.
         string self = links.GetProperty("self").GetString()!;
         self.Should().Be(
-            $"/api/editais/{seeded.Id.ToString("D", CultureInfo.InvariantCulture)}",
+            $"/api/selecao/editais/{seeded.Id.ToString("D", CultureInfo.InvariantCulture)}",
             "ADR-0029 §'URIs relativas': self é URI relativa à raiz da API");
 
         // _links.collection navega de volta para a coleção.
         string collection = links.GetProperty("collection").GetString()!;
         collection.Should().Be(
-            "/api/editais",
+            "/api/selecao/editais",
             "ADR-0029 §'Forma do _links': collection aponta para o endpoint de listagem");
 
         // Action links (publicar etc.) NÃO aparecem em V1 — ADR-0029 §'Esta ADR não decide'.
@@ -76,13 +76,13 @@ public sealed class ObterEditalEndpointTests
         await response.AssertNoPiiAsync();
     }
 
-    [Fact(DisplayName = "GET /api/editais/{id} para id inexistente retorna 404 sem body de _links")]
+    [Fact(DisplayName = "GET /api/selecao/editais/{id} para id inexistente retorna 404 sem body de _links")]
     public async Task ObterPorId_EditalInexistente_Retorna404()
     {
         using HttpClient client = _fixture.Factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(
-            new Uri($"/api/editais/{Guid.NewGuid()}", UriKind.Relative));
+            new Uri($"/api/selecao/editais/{Guid.NewGuid()}", UriKind.Relative));
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ObrigatoriedadesLegais/ObrigatoriedadeLegalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ObrigatoriedadesLegais/ObrigatoriedadeLegalEndpointTests.cs
@@ -1,0 +1,102 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ObrigatoriedadesLegais;
+
+using System.Net;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Outbox.Cascading;
+
+/// <summary>
+/// Smoke tests do contrato dos endpoints introduzidos em #461. Cobrem o
+/// caminho público sem autenticação para confirmar:
+/// (a) wiring do controller (Route, VendorMediaType, HATEOAS),
+/// (b) shape do ProblemDetails específico para conformidade-historica 404.
+///
+/// Testes que exigem authenticated admin context (POST/PUT/DELETE com RBAC
+/// área-scoped) ficam fora deste smoke — entram em follow-up dedicado com
+/// fixture de TestAuthHandler ajustada para popular AreasAdministradas.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+public sealed class ObrigatoriedadeLegalEndpointTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public ObrigatoriedadeLegalEndpointTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/selecao/obrigatoriedades-legais retorna 200 com array vazio quando catálogo vazio")]
+    public async Task Listar_RetornaArrayJsonVazio()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/selecao/obrigatoriedades-legais?limit=10", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.obrigatoriedade-legal.v1+json");
+
+        string body = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [Fact(DisplayName = "GET /api/selecao/obrigatoriedades-legais/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/selecao/obrigatoriedades-legais/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "GET /api/selecao/editais/{id}/conformidade-historica retorna 404 com type específico quando sem snapshot")]
+    public async Task ConformidadeHistorica_SemSnapshot_Retorna404ComProblemDetailsEspecifico()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // Edital inexistente (ou existente sem snapshot ainda) — em V1 a tabela
+        // edital_governance_snapshot está vazia per #460 (INSERT diferido para
+        // #462). O endpoint precisa retornar 404 com type
+        // uniplus.selecao.conformidade.snapshot_nao_disponivel.
+        Guid editalId = Guid.NewGuid();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/selecao/editais/{editalId}/conformidade-historica", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        string body = await response.Content.ReadAsStringAsync();
+        if (!string.IsNullOrWhiteSpace(body))
+        {
+            using JsonDocument doc = JsonDocument.Parse(body);
+            // ProblemDetails RFC 9457 — type é a URI canônica do erro.
+            if (doc.RootElement.TryGetProperty("type", out JsonElement typeElement))
+            {
+                typeElement.GetString()
+                    .Should().Be("uniplus.selecao.conformidade.snapshot_nao_disponivel");
+            }
+        }
+    }
+
+    [Fact(DisplayName = "POST /api/selecao/admin/obrigatoriedades-legais sem auth retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Post,
+            new Uri("/api/selecao/admin/obrigatoriedades-legais", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalEndpointTests.cs
@@ -17,8 +17,8 @@ using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
 /// <summary>
-/// Cobertura HTTP direta de <c>POST /api/editais</c> (criação) e
-/// <c>GET /api/editais/{id}</c> (consulta) — endpoints que ganharam
+/// Cobertura HTTP direta de <c>POST /api/selecao/editais</c> (criação) e
+/// <c>GET /api/selecao/editais/{id}</c> (consulta) — endpoints que ganharam
 /// roteamento pelo fix de #173 mas não tinham testes HTTP dedicados.
 /// Issue #202.
 /// </summary>
@@ -42,14 +42,14 @@ public sealed class EditalEndpointTests
 
     public EditalEndpointTests(CascadingFixture fixture) => _fixture = fixture;
 
-    [Fact(DisplayName = "POST /api/editais retorna 201 + Location quando o command é válido")]
+    [Fact(DisplayName = "POST /api/selecao/editais retorna 201 + Location quando o command é válido")]
     public async Task CriarEdital_DeveRetornar201()
     {
         CascadingApiFactory api = _fixture.Factory;
         using HttpClient client = api.CreateClient();
 
         int numero = NextNumeroSeed();
-        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/selecao/editais", UriKind.Relative))
         {
             Content = JsonContent.Create(new
             {
@@ -73,7 +73,7 @@ public sealed class EditalEndpointTests
         editalId.Should().NotBe(Guid.Empty);
     }
 
-    [Fact(DisplayName = "POST /api/editais com tipoEditalId Guid v7 persiste e GET retorna o mesmo valor")]
+    [Fact(DisplayName = "POST /api/selecao/editais com tipoEditalId Guid v7 persiste e GET retorna o mesmo valor")]
     public async Task CriarEdital_ComTipoEditalIdInformado_PersisteEReflete()
     {
         CascadingApiFactory api = _fixture.Factory;
@@ -82,7 +82,7 @@ public sealed class EditalEndpointTests
         Guid tipoEditalId = Guid.CreateVersion7();
         int numero = NextNumeroSeed();
 
-        using HttpRequestMessage post = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        using HttpRequestMessage post = new(HttpMethod.Post, new Uri("/api/selecao/editais", UriKind.Relative))
         {
             Content = JsonContent.Create(new
             {
@@ -101,7 +101,7 @@ public sealed class EditalEndpointTests
         Guid editalId = JsonDocument.Parse(await created.Content.ReadAsStringAsync()).RootElement.GetGuid();
 
         using HttpRequestMessage get = new(HttpMethod.Get,
-            new Uri($"/api/editais/{editalId}", UriKind.Relative));
+            new Uri($"/api/selecao/editais/{editalId}", UriKind.Relative));
         AppendTestAuth(get);
         get.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.edital.v1+json"));
 
@@ -112,14 +112,14 @@ public sealed class EditalEndpointTests
         body.RootElement.GetProperty("tipoEditalId").GetGuid().Should().Be(tipoEditalId);
     }
 
-    [Fact(DisplayName = "POST /api/editais com tipoEditalId = Guid.Empty retorna 422 (validator)")]
+    [Fact(DisplayName = "POST /api/selecao/editais com tipoEditalId = Guid.Empty retorna 422 (validator)")]
     public async Task CriarEdital_ComTipoEditalIdEmpty_Retorna422()
     {
         CascadingApiFactory api = _fixture.Factory;
         using HttpClient client = api.CreateClient();
 
         int numero = NextNumeroSeed();
-        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/selecao/editais", UriKind.Relative))
         {
             Content = JsonContent.Create(new
             {
@@ -137,7 +137,7 @@ public sealed class EditalEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
     }
 
-    [Fact(DisplayName = "GET /api/editais/{id} retorna 200 quando o edital existe")]
+    [Fact(DisplayName = "GET /api/selecao/editais/{id} retorna 200 quando o edital existe")]
     public async Task ObterEdital_DeveRetornar200_QuandoExiste()
     {
         CascadingApiFactory api = _fixture.Factory;
@@ -146,7 +146,7 @@ public sealed class EditalEndpointTests
         Edital edital = await SemearEditalAsync(api);
 
         using HttpRequestMessage request = new(HttpMethod.Get,
-            new Uri($"/api/editais/{edital.Id}", UriKind.Relative));
+            new Uri($"/api/selecao/editais/{edital.Id}", UriKind.Relative));
         AppendTestAuth(request);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.edital.v1+json"));
 
@@ -157,7 +157,7 @@ public sealed class EditalEndpointTests
         doc.RootElement.GetProperty("id").GetGuid().Should().Be(edital.Id);
     }
 
-    [Fact(DisplayName = "GET /api/editais/{id} retorna 404 quando o edital não existe")]
+    [Fact(DisplayName = "GET /api/selecao/editais/{id} retorna 404 quando o edital não existe")]
     public async Task ObterEdital_DeveRetornar404_QuandoNaoExiste()
     {
         CascadingApiFactory api = _fixture.Factory;
@@ -165,7 +165,7 @@ public sealed class EditalEndpointTests
 
         Guid inexistente = Guid.CreateVersion7();
         using HttpRequestMessage request = new(HttpMethod.Get,
-            new Uri($"/api/editais/{inexistente}", UriKind.Relative));
+            new Uri($"/api/selecao/editais/{inexistente}", UriKind.Relative));
         AppendTestAuth(request);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.edital.v1+json"));
 
@@ -174,7 +174,7 @@ public sealed class EditalEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
-    [Fact(DisplayName = "GET /api/editais retorna Link e X-Page-Size headers (RFC 5988/8288, ADR-0026)")]
+    [Fact(DisplayName = "GET /api/selecao/editais retorna Link e X-Page-Size headers (RFC 5988/8288, ADR-0026)")]
     public async Task ListarEditais_DeveExporLinkEXPageSizeHeaders()
     {
         CascadingApiFactory api = _fixture.Factory;
@@ -185,7 +185,7 @@ public sealed class EditalEndpointTests
         await SemearEditalAsync(api);
 
         using HttpRequestMessage request = new(HttpMethod.Get,
-            new Uri("/api/editais?limit=1", UriKind.Relative));
+            new Uri("/api/selecao/editais?limit=1", UriKind.Relative));
         AppendTestAuth(request);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.edital.v1+json"));
 

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarEditalEndpointTests.cs
@@ -151,7 +151,7 @@ public sealed class PublicarEditalEndpointTests
         using HttpClient client = api.CreateClient();
 
         HttpResponseMessage response = await client.PostAsync(
-            new Uri($"/api/editais/{Guid.CreateVersion7()}/publicar", UriKind.Relative), content: null);
+            new Uri($"/api/selecao/editais/{Guid.CreateVersion7()}/publicar", UriKind.Relative), content: null);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
@@ -167,7 +167,7 @@ public sealed class PublicarEditalEndpointTests
         using HttpClient client = api.CreateClient();
 
         using HttpRequestMessage request = new(HttpMethod.Post,
-            new Uri($"/api/editais/{Guid.CreateVersion7()}/publicar", UriKind.Relative));
+            new Uri($"/api/selecao/editais/{Guid.CreateVersion7()}/publicar", UriKind.Relative));
         request.Headers.TryAddWithoutValidation("Idempotency-Key", "invalid key with spaces");
 
         HttpResponseMessage response = await client.SendAsync(request);
@@ -188,7 +188,7 @@ public sealed class PublicarEditalEndpointTests
         using HttpClient client = api.CreateClient();
 
         using HttpRequestMessage request = new(HttpMethod.Post,
-            new Uri($"/api/editais/{Guid.CreateVersion7()}/publicar", UriKind.Relative));
+            new Uri($"/api/selecao/editais/{Guid.CreateVersion7()}/publicar", UriKind.Relative));
         request.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
         // Sem AppendTestAuth — request anonymous deliberada.
 
@@ -212,7 +212,7 @@ public sealed class PublicarEditalEndpointTests
         int numero2 = NextNumeroSeed(); // body diferente garantido (incrementos sequenciais)
 
         // Primeira request: cria edital normalmente.
-        using HttpRequestMessage primeiraReq = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        using HttpRequestMessage primeiraReq = new(HttpMethod.Post, new Uri("/api/selecao/editais", UriKind.Relative))
         {
             Content = JsonContent.Create(new
             {
@@ -227,7 +227,7 @@ public sealed class PublicarEditalEndpointTests
         primeira.StatusCode.Should().Be(HttpStatusCode.Created);
 
         // Segunda request: mesma key, body diferente (numero2).
-        using HttpRequestMessage segundaReq = new(HttpMethod.Post, new Uri("/api/editais", UriKind.Relative))
+        using HttpRequestMessage segundaReq = new(HttpMethod.Post, new Uri("/api/selecao/editais", UriKind.Relative))
         {
             Content = JsonContent.Create(new
             {
@@ -249,7 +249,7 @@ public sealed class PublicarEditalEndpointTests
     private static async Task<HttpResponseMessage> PostPublicarAsync(HttpClient client, Guid editalId, string idempotencyKey)
     {
         using HttpRequestMessage request = new(HttpMethod.Post,
-            new Uri($"/api/editais/{editalId}/publicar", UriKind.Relative));
+            new Uri($"/api/selecao/editais/{editalId}/publicar", UriKind.Relative));
         AppendTestAuth(request);
         request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
         return await client.SendAsync(request).ConfigureAwait(false);


### PR DESCRIPTION
## Resumo

Implementa #461 (admin CRUD ObrigatoriedadeLegal + conformidade) per ADR-0058 Emenda 1 (URLs path-based, PUT in-place full-replace) + ADR-0063 (DELETE soft-delete + FK forensic) + ADR-0064 (roteamento path-based com prefixo de módulo).

## O que muda

### Application slice (`Selecao.Application`)

- DTOs: `ObrigatoriedadeLegalDto`, `ConformidadeDto`, `RegraAvaliadaDto` (com Links HATEOAS Level 1 opt-in).
- Commands: `CriarObrigatoriedadeLegalCommand`, `AtualizarObrigatoriedadeLegalCommand`, `DesativarObrigatoriedadeLegalCommand` (todos `ICommand<Result<>>` e full-replace).
- Queries: `ListarObrigatoriedadesLegaisQuery` (cursor + filtros), `ObterObrigatoriedadeLegalQuery`, `ObterConformidadeAtualQuery`, `ObterConformidadeHistoricaQuery`.
- Handlers convention-based (Wolverine) + Validators FluentValidation.
- `AreaScopedAuthorization` — verificação RBAC área-scoped imperativa em forma `Result` (sem dependência de `IAuthorizationService`/`HttpContext`).
- `ObrigatoriedadeLegalMapping` — mapping centralizado entity → DTO com bindings vigentes.

### Domain + Infrastructure

- `IObrigatoriedadeLegalRepository` em Domain com 9 métodos (incluindo reconciliação atômica da junction temporal `obrigatoriedade_legal_areas_de_interesse` per ADR-0060).
- `ObrigatoriedadeLegalRepository` implementa: keyset pagination com filtros, batch lookup de bindings (sem N+1), diff temporal (`encerrar removidos + inserir novos`), leitura do `EditalGovernanceSnapshot.RegrasJson`.
- DI: registrado scoped adjacente aos demais repositórios.

### API surface (`Selecao.API`)

- `ObrigatoriedadeLegalController` com 5 actions sob `/api/selecao/{public,admin}/obrigatoriedades-legais`.
- `ObrigatoriedadeLegalLinksBuilder` HATEOAS Level 1.
- `EditalController` ganha 2 sub-recursos: `GET /conformidade` e `GET /conformidade-historica`.
- **Cutover do `EditalController`** para `[Route("api/selecao/editais")]` per ADR-0064 — primeira aplicação produtiva da convenção.
- 4 novos códigos de erro mapeados em `SelecaoDomainErrorRegistration` (`ObrigatoriedadeLegal.NaoEncontrada`, `AreaCodigo.Invalido`, `Area.EscopoNegado`, `Conformidade.SnapshotNaoDisponivel`).

### Tests

- Migração de path nos 4 integration tests existentes do EditalController (sed em massa).
- `ObrigatoriedadeLegalEndpointTests` smoke cobrindo wiring, vendor MIME, 404 sem ID, 404 do conformidade-historica com `type` específico, 401 sem auth.
- Domain unit tests + ArchTests 100% verdes locais.

### OpenAPI baseline

`contracts/openapi.selecao.json` regenerado via `UPDATE_OPENAPI_BASELINE=1`. Spectral lint local: 0 errors, 22 warnings (description/operationId — segue padrão dos endpoints existentes).

## CAs atendidos

| CA | Status | Observação |
|---|---|---|
| CA-01 — paths sem `/catalogos/` | ✅ | `[Route("api/selecao")]` |
| CA-02 — vendor MIME `obrigatoriedade-legal.v1` | ✅ | `[VendorMediaType]` aplicado |
| CA-03 — HATEOAS Level 1 em GETs | ✅ | LinksBuilder padrão `EditalLinksBuilder` |
| CA-04 — cursor pagination com filtros | ✅ | `[FromCursor]` + `OkPaginatedAsync` |
| CA-05 — `GET /editais/{id}/conformidade` | ✅ | `EditalController.ObterConformidade` |
| CA-06 — `GET /editais/{id}/conformidade-historica` 404 com PD type | ✅ | `uniplus.selecao.conformidade.snapshot_nao_disponivel` |
| CA-07 — `IObrigatoriedadeLegalRepository` com reconciliação junction | ✅ | `ReconciliarBindingsAsync` diff temporal |
| CA-08 — Application via Repository + UoW | ✅ | Handlers Wolverine convention-based |
| CA-09 — Idempotency-Key POST + PUT | ✅ | `[RequiresIdempotencyKey]` |
| CA-10 — DELETE soft-delete com FK forensic RESTRICT | ✅ | Repository.Remover + interceptor |
| CA-11 — RBAC área-scoped | ✅ | `AreaScopedAuthorization` no handler (3 commands) |
| CA-12 — Filtros admin + leitura pública | ✅ | `?tipoEdital`, `?categoria`, `?proprietario`, `?vigentes` |
| CA-13 — OpenAPI 3.1 atualizado | ✅ | Baseline regenerado |
| CA-14 — Latência targets | 🟡 | Validação via CI; medição p95 fica para smoke teste pós-deploy |

## Cutover do `EditalController`

A task técnica explícita no body de #461 (cutover do EditalController para `/api/selecao/editais`) está incluída neste PR. Integration tests existentes migrados via `sed` em massa. `AreasOrganizacionaisController` (`/api/areas-organizacionais` → `/api/organizacao/areas-organizacionais`) **permanece fora do escopo** — issue separada será aberta após merge.

## Test plan

- [x] `dotnet build UniPlus.slnx --warnaserror` → 0 warnings, 0 errors
- [x] `dotnet test Selecao.Domain.UnitTests` → 63/63
- [x] `dotnet test ArchTests` → 21/21
- [x] `dotnet test Selecao.ArchTests` → 6/6 (incluindo F3 — controllers não dependem de DomainError)
- [x] Spectral lint OpenAPI baseline → 0 errors
- [x] `git rebase --exec dotnet build` → 5/5 commits verdes
- [ ] CI completo (workflows do PR)
- [ ] Cobertura ≥80% nos arquivos novos (validação do CI)
- [ ] Integration tests Testcontainers — auth-required tests entram em follow-up dedicado

## Fronteiras com Stories vizinhas

- **#462** (US-F4-04): `Edital.Publicar()` populará `EditalGovernanceSnapshot`. Endpoint `GET /conformidade-historica` lerá dele; até #462 mergear, retorna 404 com ProblemDetails type específico (`uniplus.selecao.conformidade.snapshot_nao_disponivel`).
- **#460** (mergeada via #520): entidade plena `ObrigatoriedadeLegal`, histórico forensic, interceptor de snapshot — tudo já em main, consumido por este PR.

Closes #461
