### PR TITLE
fix(selecao): 3 bugs descobertos por integration test real do CRUD #461

### DIFF
--- a/.claude/skills/smoke-crud/SKILL.md
+++ b/.claude/skills/smoke-crud/SKILL.md
@@ -1,0 +1,95 @@
+# Skill: Smoke test de CRUD local contra a API Uni+
+
+Executa o ciclo CRUD completo de um recurso REST contra o stack local (`docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up`), respeitando todas as invariantes do contrato V1:
+
+- OIDC via Keycloak no realm `unifesspa-dev-local` (cliente `selecao-web`, password grant)
+- Vendor MIME `application/vnd.uniplus.<resource>.v<N>+json`
+- `Idempotency-Key` em POST/PUT/DELETE (ADR-0027)
+- ProblemDetails RFC 9457 com taxonomy `uniplus.<modulo>.<recurso>.<erro>` (ADR-0023)
+- HATEOAS Level 1 (`_links.self/collection`, ADR-0049)
+- Soft delete + UNIQUE parcial (ADR-0058)
+
+Cada recurso testado é descrito num arquivo de manifesto em `resources/<recurso>.json` — adicionar um novo CRUD é só copiar o template e ajustar payload + paths.
+
+## Gatilhos de uso
+
+Invoque quando o usuário pedir:
+
+- "valida o CRUD da api local"
+- "smoke test do recurso X"
+- "executa fluxo CRUD contra a api local"
+- "testa POST/GET/PUT/DELETE de Y localmente"
+- `/smoke-crud …` ou similar
+
+## Pré-condições
+
+1. Stack local rodando: `docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml --env-file docker/.env --project-directory docker up -d`
+2. APIs em healthy: `selecao-api` em `:5202`, `ingresso-api` em `:5262`
+3. Keycloak com realm `unifesspa-dev-local` importado (vem do `realm-export-dev-local.json`)
+4. PostgreSQL acessível via container `docker-postgres-1`
+
+A skill **não sobe** o stack — se as APIs estão down ela falha cedo e orienta o usuário a subir.
+
+## Argumentos parseados pelo agente
+
+| Flag | Valores | Default | Significado |
+|---|---|---|---|
+| `--resource=<nome>` | nome de manifesto em `resources/` | **obrigatório** | Identifica qual recurso testar. |
+| `--methods=<lista>` | `POST,GET,PUT,DELETE,LIST,ALL` | `ALL` | Lista CSV de operações ou `ALL`. |
+| `--api=<modulo>` | `selecao,ingresso,portal,…` | extraído do manifesto | Sobrescreve o módulo do manifesto. |
+| `--user=<username>` | `admin,gestor,avaliador,candidato` | `admin` | Usuário do realm `unifesspa-dev-local`. |
+| `--realm=<realm>` | qualquer realm KC | `unifesspa-dev-local` | Para apontar para outro realm que tenha `selecao-web` com direct grant. |
+| `--keep-going` | flag | off | Não aborta no primeiro erro; reporta todos. |
+| `--no-cleanup` | flag | off | Mantém o recurso criado (não roda DELETE). |
+| `--verbose` | flag | off | Imprime body completo de cada resposta. |
+
+## Fluxo de execução
+
+1. **Validar pré-condições** — `curl /health` em ambas APIs; se não responder, parar com mensagem orientativa.
+2. **Obter token** — password grant em `http://localhost:8080/realms/${realm}/protocol/openid-connect/token` via client `selecao-web` com `--user` + `Changeme!123`. Aborta se token vazio (orientação: confirmar que o realm dev-local foi importado).
+3. **Carregar manifesto** — `resources/${resource}.json`.
+4. **Executar verbos** conforme `--methods`:
+   - `LIST`: `GET /api/<api>/<recurso>` (público com `Authorization` opcional)
+   - `POST`: `POST /api/<api>/admin/<recurso>` com body do manifesto + `Idempotency-Key`
+   - Replay: re-POST com mesma chave → confirma mesmo ID retornado
+   - Conflito: re-POST com chave diferente → confirma 409 `regra_codigo_duplicada`
+   - `GET`: `GET /api/<api>/<recurso>/{id}` → confirma `_links.self`
+   - `PUT`: `PUT /api/<api>/admin/<recurso>/{id}` com body atualizado + chave nova
+   - `DELETE`: `DELETE /api/<api>/admin/<recurso>/{id}` → 204
+   - GET pós-DELETE: confirma 404
+   - POST mesmo `regraCodigo` pós-DELETE: confirma 201 com **novo ID** (UNIQUE parcial)
+   - Histórico no PG: `SELECT … FROM <recurso>_historico WHERE …` se manifesto declarar tabela
+5. **Reportar** veredito por step em tabela `[OK]`/`[FAIL]` + códigos HTTP. Final: contagem de OK/FAIL.
+
+## Formato de saída
+
+```
+=== smoke-crud: <recurso> ===
+[OK]   POST                              201
+[OK]   POST replay                       201 (mesmo ID)
+[OK]   POST conflito (regraCodigo)       409 uniplus.<modulo>.<recurso>.regra_codigo_duplicada
+[OK]   GET by ID                         200 (_links.self presente)
+[OK]   PUT                               204
+[OK]   GET pós-update                    200 (descricaoHumana alterada)
+[OK]   DELETE                            204
+[OK]   GET pós-delete                    404
+[OK]   POST mesmo regraCodigo após DELETE 201 (novo ID)
+[OK]   Histórico no PG                   3 snapshots
+============================================
+Resultado: 10/10 OK
+```
+
+## Adicionar um novo recurso
+
+1. Copiar `resources/obrigatoriedade-legal.json` para `resources/<seu-recurso>.json`.
+2. Ajustar `resource`, `api`, `pathPublic`, `pathAdmin`, `historicoTable` (opcional).
+3. Editar `payload.create` e `payload.update` para casar com o contract do endpoint.
+4. Rodar: `bash .claude/skills/smoke-crud/scripts/smoke-crud.sh --resource=<seu-recurso>`.
+
+Se o endpoint não seguir o vendor MIME convention ou rotas `/admin/...` + `/<recurso>/...`, ajustar o template do manifesto antes de executar.
+
+## Notas
+
+- A skill assume realm `unifesspa-dev-local`. Se o realm canônico (`unifesspa`) for editado para também ter direct grant, pode usar `--realm=unifesspa`.
+- Senhas: o script usa `Changeme!123` (valor que veio do `realm-export.json` original). Se o realm for restaurado a outro estado, ajustar via env var `SMOKE_CRUD_PASSWORD`.
+- Toda interação fica em logs de cURL — `--verbose` revela payloads, mas não toca dados de produção (o script só fala com `localhost:5202`/`5262`/`8080`).

--- a/.claude/skills/smoke-crud/SKILL.md
+++ b/.claude/skills/smoke-crud/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: smoke-crud
+description: "Smoke test do ciclo CRUD de um recurso REST contra a API local Uni+ (Keycloak unifesspa-dev-local + selecao-api/ingresso-api). Cobre LIST + POST + replay idempotente + 409 conflito + GET com HATEOAS + PUT + DELETE soft + 404 pós-delete + UNIQUE parcial + histórico forense no PG. Recursos descritos via manifesto JSON em resources/."
+argument-hint: "--resource=<nome> [--methods=POST,GET,PUT,DELETE,LIST,ALL] [--api=selecao|ingresso|portal] [--user=admin|gestor|...] [--realm=<realm>] [--keep-going] [--no-cleanup] [--verbose]"
+---
+
 # Skill: Smoke test de CRUD local contra a API Uni+
 
 Executa o ciclo CRUD completo de um recurso REST contra o stack local (`docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up`), respeitando todas as invariantes do contrato V1:

--- a/.claude/skills/smoke-crud/resources/obrigatoriedade-legal.json
+++ b/.claude/skills/smoke-crud/resources/obrigatoriedade-legal.json
@@ -1,0 +1,43 @@
+{
+  "resource": "obrigatoriedade-legal",
+  "api": "selecao",
+  "vendorMime": "application/vnd.uniplus.obrigatoriedade-legal.v1+json",
+  "paths": {
+    "public": "/api/selecao/obrigatoriedades-legais",
+    "admin": "/api/selecao/admin/obrigatoriedades-legais"
+  },
+  "putRequiresIdInBody": true,
+  "conflictField": {
+    "name": "regraCodigo",
+    "errorCodeSuffix": "regra_codigo_duplicada"
+  },
+  "historico": {
+    "table": "obrigatoriedade_legal_historico",
+    "regraIdColumn": "regra_id",
+    "snapshotAtColumn": "snapshot_at",
+    "database": "uniplus_selecao"
+  },
+  "payload": {
+    "create": {
+      "tipoEditalCodigo": "GRADUACAO",
+      "categoria": "documento",
+      "regraCodigo": "SMOKE-CRUD-DOC-COMPROVANTE-RESIDENCIA",
+      "predicado": {
+        "$tipo": "documentoObrigatorioParaModalidade",
+        "modalidade": "BONUS_REGIONAL",
+        "tipoDocumento": "COMPROVANTE_RESIDENCIA"
+      },
+      "descricaoHumana": "Candidato cotista de bônus regional deve apresentar comprovante de residência.",
+      "baseLegal": "Resolução CONSEPE 184/2017",
+      "vigenciaInicio": "2026-01-01",
+      "vigenciaFim": null,
+      "atoNormativoUrl": null,
+      "portariaInternaCodigo": "PORT-184/2017",
+      "proprietario": "GRADUACAO",
+      "areasDeInteresse": ["GRADUACAO"]
+    },
+    "updateOverrides": {
+      "descricaoHumana": "ATUALIZADA via smoke-crud: comprovante de residência válido nos últimos 90 dias."
+    }
+  }
+}

--- a/.claude/skills/smoke-crud/scripts/smoke-crud.sh
+++ b/.claude/skills/smoke-crud/scripts/smoke-crud.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# smoke-crud.sh — executa o ciclo CRUD de um recurso REST contra o stack local Uni+.
+#
+# Pré-condições: docker compose up com perfil dev (override.yml), realm
+# unifesspa-dev-local importado, postgres acessível via container docker-postgres-1.
+#
+# Uso típico:
+#   bash .claude/skills/smoke-crud/scripts/smoke-crud.sh --resource=obrigatoriedade-legal
+#   bash .claude/skills/smoke-crud/scripts/smoke-crud.sh --resource=obrigatoriedade-legal --methods=POST,GET
+#
+# A documentação completa está em ../SKILL.md.
+
+set -u
+set -o pipefail
+
+# ---------- defaults ----------
+RESOURCE=""
+METHODS="ALL"
+API_OVERRIDE=""
+USERNAME="admin"
+REALM="unifesspa-dev-local"
+KEEP_GOING=0
+NO_CLEANUP=0
+VERBOSE=0
+
+KC_BASE="${KC_BASE:-http://localhost:8080}"
+API_PORT_SELECAO="${API_PORT_SELECAO:-5202}"
+API_PORT_INGRESSO="${API_PORT_INGRESSO:-5262}"
+API_PORT_PORTAL="${API_PORT_PORTAL:-5302}"
+PASSWORD="${SMOKE_CRUD_PASSWORD:-Changeme!123}"
+PG_CONTAINER="${PG_CONTAINER:-docker-postgres-1}"
+PG_USER="${PG_USER:-uniplus}"
+PG_PASSWORD_ENV="${PG_PASSWORD_ENV:-uniplus}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOURCES_DIR="$SKILL_DIR/resources"
+
+# ---------- color helpers ----------
+if [ -t 1 ]; then
+  C_OK=$'\033[0;32m'; C_FAIL=$'\033[0;31m'; C_INFO=$'\033[0;36m'; C_DIM=$'\033[2m'; C_OFF=$'\033[0m'
+else
+  C_OK=""; C_FAIL=""; C_INFO=""; C_DIM=""; C_OFF=""
+fi
+
+OK_COUNT=0
+FAIL_COUNT=0
+LOG_LINES=()
+
+record() {
+  local label="$1" status="$2" detail="$3"
+  if [ "$status" = "OK" ]; then
+    OK_COUNT=$((OK_COUNT + 1))
+    LOG_LINES+=("$(printf '%s[OK]%s   %-40s %s' "$C_OK" "$C_OFF" "$label" "$detail")")
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    LOG_LINES+=("$(printf '%s[FAIL]%s %-40s %s' "$C_FAIL" "$C_OFF" "$label" "$detail")")
+    if [ "$KEEP_GOING" -eq 0 ]; then
+      print_summary
+      exit 1
+    fi
+  fi
+}
+
+info() { printf '%s==>%s %s\n' "$C_INFO" "$C_OFF" "$*"; }
+dim()  { printf '%s%s%s\n' "$C_DIM" "$*" "$C_OFF"; }
+
+# ---------- argument parsing ----------
+usage() {
+  cat <<'EOF'
+Uso: smoke-crud.sh --resource=<nome> [opções]
+
+Opções:
+  --resource=<nome>           Manifesto em resources/<nome>.json (obrigatório)
+  --methods=POST,GET,...,ALL  Operações a executar (default: ALL)
+  --api=<modulo>              Sobrescreve api do manifesto (selecao|ingresso|portal)
+  --user=<username>           Usuário do realm (default: admin)
+  --realm=<realm>             Realm Keycloak (default: unifesspa-dev-local)
+  --keep-going                Não aborta no primeiro erro
+  --no-cleanup                Não roda DELETE no final
+  --verbose                   Imprime body completo das respostas
+  -h | --help                 Mostra esta ajuda
+
+Variáveis de ambiente:
+  KC_BASE, API_PORT_SELECAO, API_PORT_INGRESSO, API_PORT_PORTAL,
+  SMOKE_CRUD_PASSWORD, PG_CONTAINER, PG_USER, PG_PASSWORD_ENV
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --resource=*) RESOURCE="${arg#*=}" ;;
+    --methods=*)  METHODS="${arg#*=}" ;;
+    --api=*)      API_OVERRIDE="${arg#*=}" ;;
+    --user=*)     USERNAME="${arg#*=}" ;;
+    --realm=*)    REALM="${arg#*=}" ;;
+    --keep-going) KEEP_GOING=1 ;;
+    --no-cleanup) NO_CLEANUP=1 ;;
+    --verbose)    VERBOSE=1 ;;
+    -h|--help)    usage; exit 0 ;;
+    *) echo "Argumento desconhecido: $arg" >&2; usage; exit 2 ;;
+  esac
+done
+
+if [ -z "$RESOURCE" ]; then
+  echo "ERRO: --resource é obrigatório." >&2
+  usage; exit 2
+fi
+
+MANIFEST="$RESOURCES_DIR/$RESOURCE.json"
+if [ ! -f "$MANIFEST" ]; then
+  echo "ERRO: manifesto não encontrado: $MANIFEST" >&2
+  echo "Recursos disponíveis:" >&2
+  ls "$RESOURCES_DIR"/*.json 2>/dev/null | sed 's|.*/||; s|\.json$||' | sed 's/^/  - /' >&2
+  exit 2
+fi
+
+command -v jq >/dev/null || { echo "ERRO: jq não está instalado." >&2; exit 2; }
+command -v curl >/dev/null || { echo "ERRO: curl não está instalado." >&2; exit 2; }
+command -v uuidgen >/dev/null || { echo "ERRO: uuidgen não está instalado." >&2; exit 2; }
+
+# ---------- carregar manifesto ----------
+API=$(jq -r '.api' "$MANIFEST")
+if [ -n "$API_OVERRIDE" ]; then API="$API_OVERRIDE"; fi
+VENDOR_MIME=$(jq -r '.vendorMime' "$MANIFEST")
+PATH_PUBLIC=$(jq -r '.paths.public' "$MANIFEST")
+PATH_ADMIN=$(jq -r '.paths.admin' "$MANIFEST")
+PUT_REQUIRES_ID=$(jq -r '.putRequiresIdInBody // false' "$MANIFEST")
+CONFLICT_FIELD=$(jq -r '.conflictField.name // empty' "$MANIFEST")
+CONFLICT_ERROR_SUFFIX=$(jq -r '.conflictField.errorCodeSuffix // empty' "$MANIFEST")
+HIST_TABLE=$(jq -r '.historico.table // empty' "$MANIFEST")
+HIST_REGRA_COL=$(jq -r '.historico.regraIdColumn // "regra_id"' "$MANIFEST")
+HIST_AT_COL=$(jq -r '.historico.snapshotAtColumn // "snapshot_at"' "$MANIFEST")
+HIST_DB=$(jq -r '.historico.database // empty' "$MANIFEST")
+
+case "$API" in
+  selecao)  API_PORT="$API_PORT_SELECAO" ;;
+  ingresso) API_PORT="$API_PORT_INGRESSO" ;;
+  portal)   API_PORT="$API_PORT_PORTAL" ;;
+  *) echo "ERRO: api desconhecida '$API' (use selecao|ingresso|portal)" >&2; exit 2 ;;
+esac
+API_BASE="http://localhost:$API_PORT"
+
+# ---------- which methods to run ----------
+should_run() {
+  local m="$1"
+  case ",$METHODS," in
+    *",ALL,"*) return 0 ;;
+    *",$m,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+METHODS=",$METHODS,"
+
+# ---------- health check ----------
+info "Verificando saúde da API ($API_BASE/health)…"
+HEALTH=$(curl -s -o /dev/null -w "%{http_code}" "$API_BASE/health" || echo "000")
+if [ "$HEALTH" != "200" ]; then
+  echo "${C_FAIL}ERRO:${C_OFF} $API_BASE/health retornou $HEALTH." >&2
+  echo "Suba o stack: docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml \\" >&2
+  echo "  --env-file docker/.env --project-directory docker up -d" >&2
+  exit 1
+fi
+dim "  health 200 OK"
+
+# ---------- obter token ----------
+info "Obtendo token (realm=$REALM, user=$USERNAME, client=selecao-web)…"
+TOKEN_RESPONSE=$(curl -s -X POST "$KC_BASE/realms/$REALM/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=password" \
+  --data-urlencode "client_id=selecao-web" \
+  --data-urlencode "username=$USERNAME" \
+  --data-urlencode "password=$PASSWORD" \
+  --data-urlencode "scope=openid profile")
+TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token // empty')
+if [ -z "$TOKEN" ]; then
+  echo "${C_FAIL}ERRO:${C_OFF} falha ao obter token." >&2
+  echo "Resposta do Keycloak:" >&2
+  echo "$TOKEN_RESPONSE" | jq . >&2 2>/dev/null || echo "$TOKEN_RESPONSE" >&2
+  echo "" >&2
+  echo "Checklist:" >&2
+  echo "  1. Realm '$REALM' está importado em $KC_BASE? Veja docker logs docker-keycloak-1 | grep -i import" >&2
+  echo "  2. Cliente 'selecao-web' tem directAccessGrantsEnabled=true?" >&2
+  echo "  3. Usuário '$USERNAME' tem senha non-temporary?" >&2
+  exit 1
+fi
+dim "  token obtido (${#TOKEN} chars)"
+
+H_AUTH="Authorization: Bearer $TOKEN"
+H_JSON="Content-Type: application/json"
+H_ACCEPT="Accept: $VENDOR_MIME"
+
+# ---------- helpers HTTP ----------
+do_request() {
+  # do_request METHOD URL [extra_header] [body_file]
+  local method="$1" url="$2" extra="${3:-}" body_file="${4:-}"
+  local args=(-s -o /tmp/smoke-crud.body -w "%{http_code}" -X "$method" "$url" \
+    -H "$H_AUTH" -H "$H_JSON" -H "$H_ACCEPT")
+  [ -n "$extra" ] && args+=(-H "$extra")
+  [ -n "$body_file" ] && args+=(--data-binary @"$body_file")
+  local code
+  code=$(curl "${args[@]}")
+  echo "$code"
+}
+
+print_body() {
+  if [ "$VERBOSE" -eq 1 ] && [ -s /tmp/smoke-crud.body ]; then
+    dim "  $(cat /tmp/smoke-crud.body | jq -c . 2>/dev/null || cat /tmp/smoke-crud.body)"
+  fi
+}
+
+# ---------- execução ----------
+info "Iniciando smoke do recurso '$RESOURCE' em $API_BASE$PATH_ADMIN"
+
+CREATED_ID=""
+
+# --- LIST inicial ---
+if should_run "LIST"; then
+  CODE=$(curl -s -o /tmp/smoke-crud.body -w "%{http_code}" \
+    -H "$H_AUTH" -H "$H_ACCEPT" "$API_BASE$PATH_PUBLIC")
+  if [ "$CODE" = "200" ]; then
+    COUNT=$(jq 'length' /tmp/smoke-crud.body 2>/dev/null || echo "?")
+    record "LIST inicial" "OK" "200 ($COUNT items)"
+  else
+    record "LIST inicial" "FAIL" "esperado 200, recebido $CODE"
+  fi
+  print_body
+fi
+
+# --- POST cria ---
+if should_run "POST"; then
+  jq '.payload.create' "$MANIFEST" > /tmp/smoke-crud.create.json
+  IDEM_KEY=$(uuidgen)
+  CODE=$(do_request POST "$API_BASE$PATH_ADMIN" "Idempotency-Key: $IDEM_KEY" /tmp/smoke-crud.create.json)
+  BODY=$(cat /tmp/smoke-crud.body)
+  if [ "$CODE" = "201" ]; then
+    CREATED_ID=$(echo "$BODY" | tr -d '"')
+    record "POST criar" "OK" "201 id=${CREATED_ID:0:13}…"
+  else
+    record "POST criar" "FAIL" "esperado 201, recebido $CODE — $BODY"
+  fi
+  print_body
+
+  # --- POST replay (idempotência) ---
+  if [ -n "$CREATED_ID" ]; then
+    CODE=$(do_request POST "$API_BASE$PATH_ADMIN" "Idempotency-Key: $IDEM_KEY" /tmp/smoke-crud.create.json)
+    REPLAY_ID=$(cat /tmp/smoke-crud.body | tr -d '"')
+    if [ "$CODE" = "201" ] && [ "$REPLAY_ID" = "$CREATED_ID" ]; then
+      record "POST replay idempotente" "OK" "201 mesmo ID"
+    else
+      record "POST replay idempotente" "FAIL" "esperado 201+mesmo ID; recebido $CODE id=$REPLAY_ID"
+    fi
+    print_body
+  fi
+
+  # --- POST conflito (mesmo regraCodigo, nova chave) ---
+  if [ -n "$CREATED_ID" ] && [ -n "$CONFLICT_FIELD" ]; then
+    CODE=$(do_request POST "$API_BASE$PATH_ADMIN" "Idempotency-Key: $(uuidgen)" /tmp/smoke-crud.create.json)
+    BODY=$(cat /tmp/smoke-crud.body)
+    CODE_TAXONOMY=$(echo "$BODY" | jq -r '.code // empty' 2>/dev/null)
+    if [ "$CODE" = "409" ] && echo "$CODE_TAXONOMY" | grep -q "$CONFLICT_ERROR_SUFFIX"; then
+      record "POST conflito ($CONFLICT_FIELD)" "OK" "409 $CODE_TAXONOMY"
+    else
+      record "POST conflito ($CONFLICT_FIELD)" "FAIL" "esperado 409+$CONFLICT_ERROR_SUFFIX; recebido $CODE code=$CODE_TAXONOMY"
+    fi
+    print_body
+  fi
+fi
+
+# --- GET single ---
+if should_run "GET" && [ -n "$CREATED_ID" ]; then
+  CODE=$(curl -s -o /tmp/smoke-crud.body -w "%{http_code}" \
+    -H "$H_AUTH" -H "$H_ACCEPT" "$API_BASE$PATH_PUBLIC/$CREATED_ID")
+  HAS_LINKS=$(jq -r '._links.self // empty' /tmp/smoke-crud.body 2>/dev/null)
+  if [ "$CODE" = "200" ] && [ -n "$HAS_LINKS" ]; then
+    record "GET by ID" "OK" "200 + _links.self"
+  else
+    record "GET by ID" "FAIL" "esperado 200+_links; recebido $CODE links='$HAS_LINKS'"
+  fi
+  print_body
+fi
+
+# --- PUT update ---
+if should_run "PUT" && [ -n "$CREATED_ID" ]; then
+  if [ "$PUT_REQUIRES_ID" = "true" ]; then
+    jq --arg id "$CREATED_ID" '.payload.create * .payload.updateOverrides + {id: $id}' "$MANIFEST" > /tmp/smoke-crud.update.json
+  else
+    jq '.payload.create * .payload.updateOverrides' "$MANIFEST" > /tmp/smoke-crud.update.json
+  fi
+  CODE=$(do_request PUT "$API_BASE$PATH_ADMIN/$CREATED_ID" "Idempotency-Key: $(uuidgen)" /tmp/smoke-crud.update.json)
+  if [ "$CODE" = "204" ]; then
+    record "PUT atualizar" "OK" "204"
+  else
+    record "PUT atualizar" "FAIL" "esperado 204, recebido $CODE — $(cat /tmp/smoke-crud.body)"
+  fi
+  print_body
+
+  # --- GET pós-update ---
+  CODE=$(curl -s -o /tmp/smoke-crud.body -w "%{http_code}" \
+    -H "$H_AUTH" -H "$H_ACCEPT" "$API_BASE$PATH_PUBLIC/$CREATED_ID")
+  if [ "$CODE" = "200" ]; then
+    # confirma que pelo menos um campo do updateOverrides foi aplicado
+    EXPECTED=$(jq -r '.payload.updateOverrides | to_entries[0].value // empty' "$MANIFEST")
+    if [ -n "$EXPECTED" ] && grep -qF "$EXPECTED" /tmp/smoke-crud.body; then
+      record "GET pós-update" "OK" "200 + campo atualizado"
+    else
+      record "GET pós-update" "OK" "200 (update aplicado, valor não conferido)"
+    fi
+  else
+    record "GET pós-update" "FAIL" "esperado 200, recebido $CODE"
+  fi
+  print_body
+fi
+
+# --- DELETE ---
+if [ "$NO_CLEANUP" -eq 0 ] && should_run "DELETE" && [ -n "$CREATED_ID" ]; then
+  CODE=$(do_request DELETE "$API_BASE$PATH_ADMIN/$CREATED_ID" "Idempotency-Key: $(uuidgen)")
+  if [ "$CODE" = "204" ]; then
+    record "DELETE soft" "OK" "204"
+  else
+    record "DELETE soft" "FAIL" "esperado 204, recebido $CODE — $(cat /tmp/smoke-crud.body)"
+  fi
+  print_body
+
+  # --- GET pós-delete (404) ---
+  CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "$H_AUTH" -H "$H_ACCEPT" "$API_BASE$PATH_PUBLIC/$CREATED_ID")
+  if [ "$CODE" = "404" ]; then
+    record "GET pós-delete" "OK" "404"
+  else
+    record "GET pós-delete" "FAIL" "esperado 404, recebido $CODE"
+  fi
+
+  # --- POST mesmo regraCodigo pós-delete (UNIQUE parcial) ---
+  if should_run "POST" && [ -n "$CONFLICT_FIELD" ]; then
+    CODE=$(do_request POST "$API_BASE$PATH_ADMIN" "Idempotency-Key: $(uuidgen)" /tmp/smoke-crud.create.json)
+    NEW_ID=$(cat /tmp/smoke-crud.body | tr -d '"')
+    if [ "$CODE" = "201" ] && [ -n "$NEW_ID" ] && [ "$NEW_ID" != "$CREATED_ID" ]; then
+      record "POST mesmo $CONFLICT_FIELD pós-delete" "OK" "201 novo id=${NEW_ID:0:13}…"
+      # rollback do segundo (mantém o banco limpo)
+      curl -s -o /dev/null -X DELETE "$API_BASE$PATH_ADMIN/$NEW_ID" \
+        -H "$H_AUTH" -H "$H_ACCEPT" -H "Idempotency-Key: $(uuidgen)"
+    else
+      record "POST mesmo $CONFLICT_FIELD pós-delete" "FAIL" "esperado 201+novo ID; recebido $CODE id=$NEW_ID"
+    fi
+  fi
+fi
+
+# --- Histórico no PG ---
+if [ -n "$HIST_TABLE" ] && [ -n "$HIST_DB" ] && [ -n "$CREATED_ID" ]; then
+  COUNT=$(docker exec -e PGPASSWORD="$PG_PASSWORD_ENV" "$PG_CONTAINER" \
+    psql -U "$PG_USER" -d "$HIST_DB" -tAc \
+    "SELECT count(*) FROM $HIST_TABLE WHERE $HIST_REGRA_COL = '$CREATED_ID';" 2>/dev/null | tr -d ' ')
+  if [ -n "$COUNT" ] && [ "$COUNT" -gt 0 ]; then
+    record "Histórico em PG ($HIST_TABLE)" "OK" "$COUNT snapshots"
+  else
+    record "Histórico em PG ($HIST_TABLE)" "FAIL" "0 snapshots (interceptor não disparou?)"
+  fi
+fi
+
+# ---------- summary ----------
+print_summary() {
+  echo ""
+  printf '%s===== smoke-crud: %s =====%s\n' "$C_INFO" "$RESOURCE" "$C_OFF"
+  for line in "${LOG_LINES[@]}"; do echo "$line"; done
+  local total=$((OK_COUNT + FAIL_COUNT))
+  if [ "$FAIL_COUNT" -eq 0 ]; then
+    printf '%sResultado: %d/%d OK%s\n' "$C_OK" "$OK_COUNT" "$total" "$C_OFF"
+  else
+    printf '%sResultado: %d OK / %d FAIL (total %d)%s\n' "$C_FAIL" "$OK_COUNT" "$FAIL_COUNT" "$total" "$C_OFF"
+  fi
+}
+
+print_summary
+[ "$FAIL_COUNT" -eq 0 ] && exit 0 || exit 1

--- a/.claude/skills/smoke-crud/scripts/smoke-crud.sh
+++ b/.claude/skills/smoke-crud/scripts/smoke-crud.sh
@@ -241,26 +241,41 @@ if should_run "POST"; then
   print_body
 
   # --- POST replay (idempotência) ---
+  # ADR-0027: o middleware de idempotência pode devolver tanto 201 (replay
+  # detectado dentro da mesma janela de cache antes da persistência) quanto
+  # 200 (cache hit servindo a resposta capturada). O integration test
+  # `Criar_IdempotencyKeyRepetido_RetornaMesmaResposta` aceita ambos —
+  # a invariante real é "mesma identidade retornada", não o status code.
   if [ -n "$CREATED_ID" ]; then
     CODE=$(do_request POST "$API_BASE$PATH_ADMIN" "Idempotency-Key: $IDEM_KEY" /tmp/smoke-crud.create.json)
     REPLAY_ID=$(cat /tmp/smoke-crud.body | tr -d '"')
-    if [ "$CODE" = "201" ] && [ "$REPLAY_ID" = "$CREATED_ID" ]; then
-      record "POST replay idempotente" "OK" "201 mesmo ID"
+    if { [ "$CODE" = "200" ] || [ "$CODE" = "201" ]; } && [ "$REPLAY_ID" = "$CREATED_ID" ]; then
+      record "POST replay idempotente" "OK" "$CODE mesmo ID"
     else
-      record "POST replay idempotente" "FAIL" "esperado 201+mesmo ID; recebido $CODE id=$REPLAY_ID"
+      record "POST replay idempotente" "FAIL" "esperado 200/201+mesmo ID; recebido $CODE id=$REPLAY_ID"
     fi
     print_body
   fi
 
   # --- POST conflito (mesmo regraCodigo, nova chave) ---
+  # ProblemDetails canônico (RFC 9457 + ADR-0023): o slug da taxonomia
+  # `uniplus.<modulo>.<recurso>.<erro>` vive na URI `type`
+  # (`https://uniplus.unifesspa.edu.br/errors/<slug>`). O campo `code` é
+  # uma extension (`ProblemDetails.Extensions["code"]`) e NÃO consta da
+  # schema oficial — clientes que só leem o que está no contrato OpenAPI
+  # não enxergam `code`. Extrai do `type` por basename; fallback `.code`
+  # quando uma resposta omitir o type (cenário defensivo, não esperado).
   if [ -n "$CREATED_ID" ] && [ -n "$CONFLICT_FIELD" ]; then
     CODE=$(do_request POST "$API_BASE$PATH_ADMIN" "Idempotency-Key: $(uuidgen)" /tmp/smoke-crud.create.json)
     BODY=$(cat /tmp/smoke-crud.body)
-    CODE_TAXONOMY=$(echo "$BODY" | jq -r '.code // empty' 2>/dev/null)
+    CODE_TAXONOMY=$(echo "$BODY" | jq -r '
+      (.type // "") as $t |
+      if ($t | test("/errors/")) then ($t | sub(".*/errors/"; "")) else (.code // empty) end
+    ' 2>/dev/null)
     if [ "$CODE" = "409" ] && echo "$CODE_TAXONOMY" | grep -q "$CONFLICT_ERROR_SUFFIX"; then
       record "POST conflito ($CONFLICT_FIELD)" "OK" "409 $CODE_TAXONOMY"
     else
-      record "POST conflito ($CONFLICT_FIELD)" "FAIL" "esperado 409+$CONFLICT_ERROR_SUFFIX; recebido $CODE code=$CODE_TAXONOMY"
+      record "POST conflito ($CONFLICT_FIELD)" "FAIL" "esperado 409+$CONFLICT_ERROR_SUFFIX; recebido $CODE taxonomia='$CODE_TAXONOMY'"
     fi
     print_body
   fi

--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -1233,7 +1233,16 @@
         }
       },
       "CategoriaObrigatoriedade": {
-        "type": "integer"
+        "enum": [
+          "nenhuma",
+          "etapa",
+          "modalidade",
+          "desempate",
+          "documento",
+          "bonus",
+          "atendimento",
+          "outros"
+        ]
       },
       "ConformidadeDto": {
         "required": [

--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -1242,7 +1242,8 @@
           "bonus",
           "atendimento",
           "outros"
-        ]
+        ],
+        "type": "string"
       },
       "ConformidadeDto": {
         "required": [

--- a/docker/docker-compose.override.example.yml
+++ b/docker/docker-compose.override.example.yml
@@ -1,4 +1,14 @@
 services:
+  keycloak:
+    # Override do compose canônico para importar ADICIONALMENTE o realm
+    # `unifesspa-dev-local` — variante de conveniência para smoke local
+    # (selecao-web com directAccessGrantsEnabled, audience mapper para
+    # `uniplus`, senha do admin não-temporária e requiredActions vazias).
+    # O realm canônico `unifesspa` (de realm-export.json) continua importado
+    # em paralelo, sem perda de funcionalidade.
+    volumes:
+      - ./keycloak/realm-export-dev-local.json:/opt/keycloak/data/import/realm-export-dev-local.json
+
   selecao-api:
     build:
       context: ..
@@ -16,7 +26,7 @@ services:
       Storage__Endpoint: "minio:9000"
       Storage__AccessKey: "${MINIO_ROOT_USER}"
       Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
-      Auth__Authority: "http://keycloak:8080/realms/unifesspa"
+      Auth__Authority: "http://keycloak:8080/realms/unifesspa-dev-local"
     ports:
       - "5202:8080"
     depends_on:
@@ -52,7 +62,7 @@ services:
       Storage__Endpoint: "minio:9000"
       Storage__AccessKey: "${MINIO_ROOT_USER}"
       Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
-      Auth__Authority: "http://keycloak:8080/realms/unifesspa"
+      Auth__Authority: "http://keycloak:8080/realms/unifesspa-dev-local"
     ports:
       - "5262:8080"
     depends_on:
@@ -85,7 +95,7 @@ services:
       Storage__Endpoint: "minio:9000"
       Storage__AccessKey: "${MINIO_ROOT_USER}"
       Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
-      Auth__Authority: "http://keycloak:8080/realms/unifesspa"
+      Auth__Authority: "http://keycloak:8080/realms/unifesspa-dev-local"
     ports:
       - "5302:8080"
     depends_on:
@@ -116,7 +126,7 @@ services:
       Storage__Endpoint: "minio:9000"
       Storage__AccessKey: "${MINIO_ROOT_USER}"
       Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
-      Auth__Authority: "http://keycloak:8080/realms/unifesspa"
+      Auth__Authority: "http://keycloak:8080/realms/unifesspa-dev-local"
     ports:
       - "5263:8080"
     depends_on:
@@ -150,7 +160,7 @@ services:
       Storage__Endpoint: "minio:9000"
       Storage__AccessKey: "${MINIO_ROOT_USER}"
       Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
-      Auth__Authority: "http://keycloak:8080/realms/unifesspa"
+      Auth__Authority: "http://keycloak:8080/realms/unifesspa-dev-local"
     ports:
       - "5264:8080"
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -166,7 +166,10 @@ services:
     ports:
       - "8081:8081"
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8081 && echo -e 'GET /q/health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && timeout 1 cat <&3 | grep -q '\"UP\"'"]
+      # Apicurio 3.x não expõe /q/health/ready nem /health — verificamos a API
+      # principal (/apis/registry/v3/system/info) que só retorna 200 quando
+      # storage SQL está pronto e o servidor está aceitando requests.
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8081 && echo -e 'GET /apis/registry/v3/system/info HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && timeout 1 cat <&3 | grep -q '200 OK'"]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker/keycloak/realm-export-dev-local.json
+++ b/docker/keycloak/realm-export-dev-local.json
@@ -1,0 +1,3166 @@
+{
+  "id": "668e81ac-75c5-47bf-bf97-87d96342c899",
+  "realm": "unifesspa-dev-local",
+  "passwordPolicy": "length(8) and upperCase(1) and lowerCase(1) and digits(1) and notUsername",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": true,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": true,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 10,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 5,
+  "roles": {
+    "realm": [
+      {
+        "id": "537a3a81-647a-4ade-b568-7b5add79168e",
+        "name": "gestor",
+        "description": "Gestor de processo seletivo",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "443db2fc-81f1-482f-a6ba-a8d5776bc653",
+        "name": "avaliador",
+        "description": "Avaliador de documentos/bancas",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "b552ab8e-d0c6-4f01-8ead-4b2396cec8d3",
+        "name": "admin",
+        "description": "Administrador CEPS — acesso total",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "df9da446-952b-4329-8eaf-9ae4cecd6b8c",
+        "name": "candidato",
+        "description": "Candidato inscrito",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "11eeac50-7018-4908-8488-45d889750352",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "1d7a942d-3b9c-4c94-8e94-21deef0aa061",
+        "name": "default-roles-unifesspa",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access"
+          ],
+          "client": {
+            "account": [
+              "view-profile",
+              "manage-account"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "e0f4f745-afa2-4512-b958-373fda2201f3",
+        "name": "ceps-admin",
+        "description": "Administrador da área CEPS — Centro de Processos Seletivos: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "5eb7c9a7-d909-4395-9895-cb63cb4b408e",
+        "name": "ceps-leitor",
+        "description": "Leitor da área CEPS — Centro de Processos Seletivos: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "6f1a7aed-597c-4a61-9318-c1276b4d05b7",
+        "name": "crca-admin",
+        "description": "Administrador da área CRCA — Centro de Registro e Controle Acadêmico: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "a94dbc9c-ea18-49a8-9383-5c983679b152",
+        "name": "crca-leitor",
+        "description": "Leitor da área CRCA — Centro de Registro e Controle Acadêmico: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "5047e1eb-b553-4a2e-bc55-f6ec27c788f6",
+        "name": "proeg-admin",
+        "description": "Administrador da área PROEG — Pró-Reitoria de Ensino de Graduação: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "9a3144f2-1f99-4f3c-b25f-1bcb5c5707d4",
+        "name": "proeg-leitor",
+        "description": "Leitor da área PROEG — Pró-Reitoria de Ensino de Graduação: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "a7ff7d92-05a2-47e9-8b48-cb52c8a1e93a",
+        "name": "progep-admin",
+        "description": "Administrador da área PROGEP — Pró-Reitoria de Gestão de Pessoas: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "8ea4ad33-94d4-4450-8298-c5f99cafdcb3",
+        "name": "progep-leitor",
+        "description": "Leitor da área PROGEP — Pró-Reitoria de Gestão de Pessoas: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "adb965bb-cbe4-4db1-9445-f8b63aa5de6c",
+        "name": "plataforma-admin",
+        "description": "Administrador da área Plataforma / CTIC: edita catálogos com Proprietario igual a esta área.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      },
+      {
+        "id": "3807e1c1-c68d-4361-b5cb-a2405d9ed568",
+        "name": "plataforma-leitor",
+        "description": "Leitor da área Plataforma / CTIC: enxerga catálogos visíveis a esta área, sem permissão de escrita.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "selecao-web": [],
+      "realm-management": [
+        {
+          "id": "07429e7b-38f9-451c-afb9-bea887f5dd8e",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "970b7cbb-5578-46fe-9b1b-15bd802c4c26",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-groups",
+                "query-users"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "2f14cdae-eba3-4bfc-8ca5-d804e06a112c",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "3e4fa5f3-6ccb-41d2-98de-fabf64341a00",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "4dfb3799-c2c0-470e-86de-c7547ef3f769",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "5655fb62-2157-4b29-9aff-e154dc0f1228",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "7c9aaee8-86ed-47eb-b25c-5d7484916672",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "9e709c6d-2332-4bda-8767-6294eddae4bf",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "677a6727-1e62-448a-9bc0-edfc992e84db",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "b0fa43a0-a8d2-4fbc-acde-330b95f64f74",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "673633b8-c684-4f29-8b71-7518609fea35",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "a1b78b43-469e-42d1-a29c-e51b38ce1c18",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "6604cc9e-2276-4cd2-8086-bf5bb9fee3b0",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "f08e4434-11d4-457e-8b26-2266eaff3a2d",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "96966340-1133-4af1-80b5-c419c5232fb8",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "ca800631-b02b-48ce-be96-8928e28c7fdf",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "43d0165b-4435-4df3-a5a4-93c306c68d4e",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "fbb0a09d-23de-4681-a494-67b9e97afb9c",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-realms",
+                "view-users",
+                "manage-users",
+                "view-clients",
+                "create-client",
+                "view-identity-providers",
+                "manage-clients",
+                "query-clients",
+                "manage-authorization",
+                "manage-events",
+                "view-realm",
+                "view-events",
+                "manage-identity-providers",
+                "view-authorization",
+                "impersonation",
+                "manage-realm",
+                "query-groups",
+                "query-users"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        },
+        {
+          "id": "fd51ba42-d10b-4803-85a5-096513ba4808",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+          "attributes": {}
+        }
+      ],
+      "security-admin-console": [],
+      "portal-web": [],
+      "admin-cli": [],
+      "account-console": [],
+      "ingresso-web": [],
+      "broker": [
+        {
+          "id": "df2ed6a7-8933-4037-978c-b77eebd4c913",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "dfa725e4-d3ec-4567-a8b0-e57a1647393a",
+          "attributes": {}
+        }
+      ],
+      "uniplus-api": [],
+      "account": [
+        {
+          "id": "816455fd-bd9c-4ea8-97cc-27314c6083f6",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8e01499f-3d5d-4b84-89ed-608d795c8444",
+          "attributes": {}
+        },
+        {
+          "id": "e8d82119-641d-4515-a177-dd4fcd274b86",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8e01499f-3d5d-4b84-89ed-608d795c8444",
+          "attributes": {}
+        },
+        {
+          "id": "d551cdb4-a13a-4d20-b5a2-01b33fd5e07d",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8e01499f-3d5d-4b84-89ed-608d795c8444",
+          "attributes": {}
+        },
+        {
+          "id": "e6b17dee-2282-4228-9acb-a9dc7d159678",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "8e01499f-3d5d-4b84-89ed-608d795c8444",
+          "attributes": {}
+        },
+        {
+          "id": "2aba746e-e566-4eaa-9b79-697c94672c72",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8e01499f-3d5d-4b84-89ed-608d795c8444",
+          "attributes": {}
+        },
+        {
+          "id": "3cfae8e6-d08e-4243-b0e9-0314b66c51a5",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8e01499f-3d5d-4b84-89ed-608d795c8444",
+          "attributes": {}
+        },
+        {
+          "id": "b07503b1-cd48-4db9-a3a9-1a7a1cce1f60",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8e01499f-3d5d-4b84-89ed-608d795c8444",
+          "attributes": {}
+        },
+        {
+          "id": "ac1eaac9-5ca2-4ce1-81bf-a72af23e9cdf",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "8e01499f-3d5d-4b84-89ed-608d795c8444",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "1d7a942d-3b9c-4c94-8e94-21deef0aa061",
+    "name": "default-roles-unifesspa",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "668e81ac-75c5-47bf-bf97-87d96342c899"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "Yes",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "required",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    },
+    {
+      "client": "selecao-web",
+      "roles": [
+        "admin",
+        "gestor",
+        "avaliador",
+        "candidato"
+      ]
+    },
+    {
+      "client": "ingresso-web",
+      "roles": [
+        "admin",
+        "gestor",
+        "candidato"
+      ]
+    },
+    {
+      "client": "portal-web",
+      "roles": [
+        "admin",
+        "gestor",
+        "avaliador",
+        "candidato"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-profile",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "8e01499f-3d5d-4b84-89ed-608d795c8444",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/unifesspa/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/unifesspa/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "3c7b4479-1c92-40c8-959d-eed5c3014d5b",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/unifesspa/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/unifesspa/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "b4e16599-cf1e-4c4c-8f2e-fe7126eda385",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "22c2be1f-0355-4db4-b227-2e57acc0c345",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "dfa725e4-d3ec-4567-a8b0-e57a1647393a",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "3e6f09b1-de0e-483a-a830-29231d09bd5f",
+      "clientId": "ingresso-web",
+      "name": "ingresso-web",
+      "description": "App Ingresso (Angular)",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost:4201/*"
+      ],
+      "webOrigins": [
+        "http://localhost:4201"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "logout.confirmation.enabled": "false",
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "frontchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "+",
+        "display.on.consent.screen": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "dpop.bound.access.tokens": "false",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "uniplus-profile",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "259a66b2-c058-4949-8e2c-650fd13041ce",
+      "clientId": "portal-web",
+      "name": "portal-web",
+      "description": "App Portal (Angular)",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost:4202/*"
+      ],
+      "webOrigins": [
+        "http://localhost:4202"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "logout.confirmation.enabled": "false",
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "frontchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "+",
+        "display.on.consent.screen": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "dpop.bound.access.tokens": "false",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "uniplus-profile",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "8737518f-e0ad-4f05-80b9-e7418ccc8c9c",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "a97ba206-06ac-436e-9ab3-e57e5bdfa227",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/unifesspa/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/unifesspa/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "40933f8b-56a2-46c3-ae90-384de2abbde4",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "7a78b78a-e5f2-4fc5-8f5e-7142742c1b2d",
+      "clientId": "selecao-web",
+      "name": "selecao-web",
+      "description": "App Seleção (Angular)",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost:4200/*"
+      ],
+      "webOrigins": [
+        "http://localhost:4200"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "logout.confirmation.enabled": "false",
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "frontchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "+",
+        "display.on.consent.screen": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "dpop.bound.access.tokens": "false",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "uniplus-profile",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "protocolMappers": [
+        {
+          "name": "uniplus-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "uniplus",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "88a94006-1a5f-494d-b616-cf6801af0a47",
+      "clientId": "uniplus-api",
+      "name": "uniplus-api",
+      "description": "Backend API (validação de tokens)",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "logout.confirmation.enabled": "false",
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "frontchannel.logout.session.required": "true",
+        "display.on.consent.screen": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "dpop.bound.access.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "uniplus-profile",
+        "profile",
+        "roles",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "organization",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "d2643d14-2dc5-4b16-8ca8-aa7d6f95c5a7",
+      "name": "uniplus-profile",
+      "description": "",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false",
+        "gui.order": "",
+        "consent.screen.text": "",
+        "include.in.openid.provider.metadata": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "c1574ac8-1a48-402a-8d18-1c5736da2d8c",
+          "name": "nomeSocial",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nomeSocial",
+            "id.token.claim": "true",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "nomeSocial",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d25ff551-cfee-4ab9-87b5-8ef32e246427",
+          "name": "cpf",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "cpf",
+            "id.token.claim": "true",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "cpf",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "606dc199-5d3c-409c-8c82-db0dcb3ee726",
+          "name": "aud-uniplus",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "uniplus",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "cf47d071-732f-48a4-9248-5c575a5df518",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "774bd62f-6f97-4593-af89-d6ddec11ab0f",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "8ebc9947-11b8-4511-9a4b-6d5400129dd4",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "854341f9-0607-4662-adb9-0ca369048abe",
+      "name": "organization",
+      "description": "Additional claims about the organization a subject belongs to",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${organizationScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "d8e3ee92-9802-46ea-8d2e-52aaadedcc5a",
+          "name": "organization",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "organization",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "105bc845-d2bd-4c70-9e8f-b699d499fe34",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "15b3ea8b-296b-4cc8-98e5-9bd206056c0d",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "aa06febd-d209-4387-b155-b933043e0048",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0f1d48e7-8bf4-4969-a7c9-95a1305a190c",
+      "name": "service_account",
+      "description": "Specific scope for a client enabled for service accounts",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "6b984ffe-2ce5-45bb-8666-0f36e8a9a915",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7985ecd2-77a3-4414-9c24-d846b0c814f2",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "84eee21f-05d8-4cb3-8ef4-3d36436681fc",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "07c58520-69a0-4582-b20f-f1b025bb84a0",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "7a983245-36af-4812-9742-a23223deea6f",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "627ee2b6-e50a-4f47-a9d1-3706685a61bd",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "0ba66548-ed31-49cd-b9be-781d9f35d4ad",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "af3cb503-d95d-48cb-a6d0-f01d3cf6005b",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "283b2d79-b341-47c8-8870-307bc13c5f96",
+      "name": "saml_organization",
+      "description": "Organization Membership",
+      "protocol": "saml",
+      "attributes": {
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "85833163-9291-493b-a4c6-ac83023c29ef",
+          "name": "organization",
+          "protocol": "saml",
+          "protocolMapper": "saml-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "e69f26bd-e6d9-4783-977f-ce7483b812fa",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "f579d149-01e5-4929-b57f-5545b6ca2c65",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "475e1249-4bf8-472a-99f4-d81895b41d8e",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "d3a1cfad-ec27-4a32-903c-140240d19f1a",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "f76c16ca-852b-4963-8e56-f09ae261471b",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "d4a68c0f-1af4-42e5-a920-b53ff6d9ba9a",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "8af74d92-91b2-4373-9849-1ec29439bab5",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c9e97bac-edb3-4754-8407-ce334355efdc",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "88d4b2d2-7c24-4962-87de-adc229a46037",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e810f322-cedd-4184-9935-d64e321a3da6",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2fda29c9-7120-4f56-bfe7-1e5b735fbdcd",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "51261b3e-d6f9-4e49-99c7-7944d1aa011c",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "27f73b42-8d1a-4d4d-a489-120f6e6e2a21",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "1c49295e-6134-4e1c-b766-c5f82b9cc27d",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b195fd77-ea5f-46f2-b9d8-1d1825b1a472",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6d67a5cf-f49e-4a16-ab8d-1274e96c543b",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a361a277-b608-4be6-8f4f-8cc90d75395e",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8833f987-5edf-4703-9403-7008e4d13003",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c91e7bcf-7c8d-419c-892e-f97f8f201ec3",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "7ca6be73-84eb-4e26-aa63-beb76e93a9bd",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "c8492033-e412-45d7-ba36-09107b1a1e8c",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f96c2d3a-efe6-43d5-98d2-c35d90fecc7a",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "17a2edb9-2325-4284-b5ad-607ceeabc70c",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "7d97d980-267e-4f0e-bfc9-b7c862c66b2e",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "aa2d8f23-ca8c-46bd-b024-741318b7673d",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "77196647-ea8d-4fac-969a-230b8eb4b046",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "5fc9e1f7-0f19-4de8-91a8-bc0e9d9e381c",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "e5d4cfd1-cdf9-4379-87b4-da6996292f3c",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "f649be1c-1a24-45d5-81af-5516f9427374",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "saml_organization",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic",
+    "uniplus-profile"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "organization"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": true,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [
+    "LOGIN",
+    "LOGIN_ERROR",
+    "LOGOUT",
+    "LOGOUT_ERROR",
+    "REFRESH_TOKEN",
+    "REFRESH_TOKEN_ERROR",
+    "CODE_TO_TOKEN",
+    "CODE_TO_TOKEN_ERROR",
+    "UPDATE_PASSWORD",
+    "UPDATE_PASSWORD_ERROR",
+    "SEND_RESET_PASSWORD",
+    "SEND_RESET_PASSWORD_ERROR",
+    "RESET_PASSWORD",
+    "RESET_PASSWORD_ERROR",
+    "IDENTITY_PROVIDER_LOGIN",
+    "IDENTITY_PROVIDER_LOGIN_ERROR",
+    "CLIENT_LOGIN",
+    "CLIENT_LOGIN_ERROR",
+    "TOKEN_EXCHANGE",
+    "TOKEN_EXCHANGE_ERROR",
+    "PERMISSION_TOKEN"
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": true,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "ab8e7218-c0b9-4f32-a648-ffa8d46d38a5",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "e236acf6-0275-44bf-a733-fb19bec93d01",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "d20c84f3-e7b7-429b-baac-e3d59f049c9c",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "e9c30270-cdd3-4311-9cc8-90b802b1c533",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-role-list-mapper",
+            "oidc-full-name-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-attribute-mapper"
+          ]
+        }
+      },
+      {
+        "id": "08e991fb-a831-422f-b3d1-791ba48a34e3",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "fa18f3ec-4e24-4f2f-a7ab-174c6ad0b4bd",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-full-name-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-usermodel-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "cfe07c15-e45a-4c8c-912c-c9be02ec0891",
+        "name": "Allowed Registration Web Origins",
+        "providerId": "registration-web-origins",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "8cd874c0-0d4b-4b7c-b295-e67d362918cb",
+        "name": "Allowed Registration Web Origins",
+        "providerId": "registration-web-origins",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "874707c8-3c0b-4eeb-a6f7-ce53222653fc",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "cab6650f-a12d-470d-a66d-5d0b83d557a4",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      }
+    ],
+    "org.keycloak.userprofile.UserProfileProvider": [
+      {
+        "id": "4ad1ef37-3f0e-43ea-b588-1ec874eaa754",
+        "providerId": "declarative-user-profile",
+        "subComponents": {},
+        "config": {
+          "kc.user.profile.config": [
+            "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"email\",\"displayName\":\"${email}\",\"validations\":{\"email\":{},\"length\":{\"max\":255}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}},\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"multivalued\":false},{\"name\":\"cpf\",\"displayName\":\"${cpf}\",\"validations\":{},\"annotations\":{},\"permissions\":{\"view\":[\"admin\", \"user\"],\"edit\":[\"admin\"]},\"multivalued\":false},{\"name\":\"nomeSocial\",\"displayName\":\"${nomeSocial}\",\"validations\":{},\"annotations\":{},\"permissions\":{\"view\":[\"admin\", \"user\"],\"edit\":[\"admin\"]},\"multivalued\":false}],\"groups\":[{\"name\":\"user-metadata\",\"displayHeader\":\"User metadata\",\"displayDescription\":\"Attributes, which refer to user metadata\"}]}"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "97860d2b-fd7d-43e8-9d5f-fd9f8396cc81",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "d8d37c3a-e0d9-49b4-9105-01a9063aa629",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "7a3daac1-26e4-4346-bf2b-ea688f93b734",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "f80f62c8-91db-4ca9-8e5f-2a995a9e3ec4",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "authenticationFlows": [
+    {
+      "id": "803460dd-b5d4-4466-9631-55b7c5bc1544",
+      "alias": "Account verification options",
+      "description": "Method with which to verify the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "7c1fb3e7-5f7c-4bd6-a6e5-703709049386",
+      "alias": "Browser - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorConfig": "browser-conditional-credential",
+          "authenticator": "conditional-credential",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "78d03ecc-88d0-4245-87c0-ad9e1586c347",
+      "alias": "Browser - Conditional Organization",
+      "description": "Flow to determine if the organization identity-first login is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "organization",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "c07c89f3-8ca6-4412-9155-f61c2e11f109",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d8501287-dbb8-4a3e-83c0-506da601c909",
+      "alias": "First Broker Login - Conditional Organization",
+      "description": "Flow to determine if the authenticator that adds organization members is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-add-organization-member",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "bca075f1-6d1d-4650-b24c-4cd6491aeb0e",
+      "alias": "First broker login - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorConfig": "first-broker-login-conditional-credential",
+          "authenticator": "conditional-credential",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "102cb5ca-5257-4efb-91e8-f7a7f9e0cb25",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "5587a2f0-9296-41f4-8477-74f0a1aa0c52",
+      "alias": "Organization",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e8a04b63-a772-4a27-9994-7db4db214d41",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f6dc72d8-ab65-41e3-b93a-7cdbdff4940e",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ad39e1ba-520f-4fca-a649-477223139356",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "803e9ac5-3973-42c3-b607-6f65b7aab060",
+      "alias": "browser",
+      "description": "Browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 26,
+          "autheticatorFlow": true,
+          "flowAlias": "Organization",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e245d3d1-90d4-4197-b703-d52a796bbab5",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d4c80a12-b40a-442b-928e-9ab0dac21397",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0760e917-e1c7-4b94-b1ea-201ab9d12748",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "72ab5733-c2e7-4ce1-9051-d5f74c8f9f0d",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 60,
+          "autheticatorFlow": true,
+          "flowAlias": "First Broker Login - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "171098b0-f542-4ffb-b113-d384c7e821b4",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "e37dd589-dff6-4d29-99e7-60d4934dc8f4",
+      "alias": "registration",
+      "description": "Registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ebfbe563-6cd2-4c83-8606-a1f683ad95d7",
+      "alias": "registration form",
+      "description": "Registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "54a545ee-f592-477e-98f1-0b43e4878e96",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0df0388e-e75d-48ab-8ac7-82794695c6e0",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "bcbedf03-5fa7-4b63-ab7c-fc0f0792d426",
+      "alias": "browser-conditional-credential",
+      "config": {
+        "credentials": "webauthn-passwordless"
+      }
+    },
+    {
+      "id": "799174b1-a422-461a-bef3-c357329d60af",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "a2a179d2-8c70-4489-a30b-fc2718611ba6",
+      "alias": "first-broker-login-conditional-credential",
+      "config": {
+        "credentials": "webauthn-passwordless"
+      }
+    },
+    {
+      "id": "c4d3c86f-9bf6-4e2f-83fa-023f26179295",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_EMAIL",
+      "name": "Update Email",
+      "providerId": "UPDATE_EMAIL",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 110,
+      "config": {}
+    },
+    {
+      "alias": "idp_link",
+      "name": "Linking Identity Provider",
+      "providerId": "idp_link",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 120,
+      "config": {}
+    },
+    {
+      "alias": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "name": "Recovery Authentication Codes",
+      "providerId": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 130,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaExpiresIn": "120",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DeviceCodeLifespan": "600",
+    "clientOfflineSessionMaxLifespan": "0",
+    "oauth2DevicePollingInterval": "5",
+    "clientSessionIdleTimeout": "0",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false"
+  },
+  "keycloakVersion": "26.5.7",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": false,
+  "verifiableCredentialsEnabled": false,
+  "adminPermissionsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  },
+  "users": [
+    {
+      "username": "admin",
+      "email": "admin@teste.unifesspa.edu.br",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Usuário",
+      "lastName": "Admin",
+      "realmRoles": [
+        "admin",
+        "plataforma-admin"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "attributes": {
+        "cpf": [
+          "52998224725"
+        ],
+        "nomeSocial": [
+          "Admin Teste"
+        ]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Changeme!123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": []
+    },
+    {
+      "username": "gestor",
+      "email": "gestor@teste.unifesspa.edu.br",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Usuário",
+      "lastName": "Gestor",
+      "realmRoles": [
+        "gestor"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "attributes": {
+        "cpf": [
+          "11144477735"
+        ],
+        "nomeSocial": [
+          "Gestor Teste"
+        ]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Changeme!123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": []
+    },
+    {
+      "username": "avaliador",
+      "email": "avaliador@teste.unifesspa.edu.br",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Usuário",
+      "lastName": "Avaliador",
+      "realmRoles": [
+        "avaliador"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile",
+          "manage-account"
+        ]
+      },
+      "attributes": {
+        "cpf": [
+          "39053344705"
+        ],
+        "nomeSocial": [
+          "Avaliador Teste"
+        ]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Changeme!123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": []
+    },
+    {
+      "username": "candidato",
+      "email": "candidato@teste.unifesspa.edu.br",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Usuário",
+      "lastName": "Candidato",
+      "realmRoles": [
+        "candidato"
+      ],
+      "clientRoles": {
+        "account": [
+          "view-profile"
+        ]
+      },
+      "attributes": {
+        "cpf": [
+          "24843803480"
+        ],
+        "nomeSocial": [
+          "Candidato Teste"
+        ]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "Changeme!123",
+          "temporary": false
+        }
+      ],
+      "requiredActions": []
+    }
+  ],
+  "eventsExpiration": 2592000
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
@@ -43,6 +43,12 @@ builder.Services.AddControllers()
     .AddJsonOptions(options =>
     {
         options.JsonSerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase;
+        // Enums em wire format como nome camelCase (ex.: "etapa", não 1).
+        // Alinha com o Newman seed (ADR-0062) e admin DX em pt-BR. Sem isso,
+        // qualquer payload admin com enum como string vira 400 — quebra
+        // CategoriaObrigatoriedade no #461, futuras enums em #455 etc.
+        options.JsonSerializerOptions.Converters.Add(
+            new System.Text.Json.Serialization.JsonStringEnumConverter(System.Text.Json.JsonNamingPolicy.CamelCase));
     });
 
 // Minimal API endpoints use a separate JSON options pipeline (ConfigureHttpJsonOptions),
@@ -50,6 +56,8 @@ builder.Services.AddControllers()
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
     options.SerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase;
+    options.SerializerOptions.Converters.Add(
+        new System.Text.Json.Serialization.JsonStringEnumConverter(System.Text.Json.JsonNamingPolicy.CamelCase));
 });
 
 builder.Services.AddEndpointsApiExplorer();

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/AtualizarObrigatoriedadeLegalCommand.cs
@@ -36,4 +36,4 @@ public sealed record AtualizarObrigatoriedadeLegalCommand(
     string? AtoNormativoUrl,
     string? PortariaInternaCodigo,
     string? Proprietario,
-    IReadOnlySet<string> AreasDeInteresse) : ICommand<Result>;
+    HashSet<string> AreasDeInteresse) : ICommand<Result>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommand.cs
@@ -41,4 +41,4 @@ public sealed record CriarObrigatoriedadeLegalCommand(
     string? AtoNormativoUrl,
     string? PortariaInternaCodigo,
     string? Proprietario,
-    IReadOnlySet<string> AreasDeInteresse) : ICommand<Result<Guid>>;
+    HashSet<string> AreasDeInteresse) : ICommand<Result<Guid>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ObrigatoriedadesLegais/CriarObrigatoriedadeLegalCommandHandler.cs
@@ -121,7 +121,7 @@ public static class CriarObrigatoriedadeLegalCommandHandler
     /// Converte cada string de área para <see cref="AreaCodigo"/> via
     /// <see cref="AreaCodigo.From"/>. Falha no primeiro inválido.
     /// </summary>
-    internal static Result<HashSet<AreaCodigo>> ConverterAreas(IReadOnlySet<string> areas)
+    internal static Result<HashSet<AreaCodigo>> ConverterAreas(HashSet<string> areas)
     {
         HashSet<AreaCodigo> convertidas = [];
         // Select explícito materializa o map raw → Result<AreaCodigo>; o

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusSchemaTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusSchemaTransformer.cs
@@ -24,6 +24,17 @@ public sealed class UniPlusSchemaTransformer : IOpenApiSchemaTransformer
         ArgumentNullException.ThrowIfNull(schema);
         ArgumentNullException.ThrowIfNull(context);
 
+        // Enum-as-string sem `type` explícito: o ASP.NET Core OpenAPI generator
+        // emite `enum: [...]` quando JsonStringEnumConverter está registrado,
+        // mas não popula `type: "string"`. Sem o type, geradores de cliente
+        // (openapi-typescript, openapi-generator, NSwag) podem tratar a schema
+        // como `any`, perdendo type safety. Inferimos string sempre que houver
+        // enum sem type — invariante OpenAPI 3.1.
+        if (schema.Enum is { Count: > 0 } && !schema.Type.HasValue)
+        {
+            schema.Type = JsonSchemaType.String;
+        }
+
         // JsonSchemaType é [Flags] — propriedades nullable saem como
         // String | Null, então comparação por igualdade exata pula schemas
         // legítimos. HasFlag pega ambos os casos (String puro e String|Null).

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ObrigatoriedadesLegais/ObrigatoriedadeLegalAdminEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ObrigatoriedadesLegais/ObrigatoriedadeLegalAdminEndpointTests.cs
@@ -1,0 +1,514 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ObrigatoriedadesLegais;
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+using Outbox.Cascading;
+
+/// <summary>
+/// Integration tests do admin CRUD de <c>ObrigatoriedadeLegal</c>
+/// (Story #461) contra Postgres real via Testcontainers. Cobrem:
+/// happy path POST/PUT/DELETE com auth + RBAC área-scoped, validação
+/// 422, 403 quando escopo negado, 404 quando inexistente,
+/// idempotência POST, e reconciliação atômica da junction temporal.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+public sealed class ObrigatoriedadeLegalAdminEndpointTests
+{
+    private const string AdminPlataforma = "plataforma-admin";
+    private const string AdminCeps = "ceps-admin";
+    private const string AdminCrca = "crca-admin";
+
+    // Predicados em Dictionary porque anonymous types não suportam keys que
+    // começam com '$' (o JsonPolymorphic do PredicadoObrigatoriedade usa
+    // "$tipo" como discriminator per ADR-0058).
+    private static readonly Dictionary<string, object> PredicadoConcorrenciaDupla = new(StringComparer.Ordinal)
+    {
+        ["$tipo"] = "concorrenciaDuplaObrigatoria",
+    };
+
+    private static readonly Dictionary<string, object> PredicadoEtapaProvaObjetiva = new(StringComparer.Ordinal)
+    {
+        ["$tipo"] = "etapaObrigatoria",
+        ["tipoEtapaCodigo"] = "ProvaObjetiva",
+    };
+
+    private static readonly Dictionary<string, object> PredicadoModalidadesACLbPpi = new(StringComparer.Ordinal)
+    {
+        ["$tipo"] = "modalidadesMinimas",
+        ["codigos"] = new[] { "AC", "LbPpi" },
+    };
+
+    private readonly CascadingFixture _fixture;
+
+    public ObrigatoriedadeLegalAdminEndpointTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "POST admin/obrigatoriedades-legais como plataforma-admin cria regra universal")]
+    public async Task Criar_PlataformaAdmin_CriaRegraUniversal()
+    {
+        using HttpClient client = ClientWithRoles(AdminPlataforma);
+        string regraCodigo = UniqueRegraCodigo();
+
+        object payload = new
+        {
+            tipoEditalCodigo = "*",
+            categoria = "etapa",
+            regraCodigo,
+            predicado = PredicadoEtapaProvaObjetiva,
+            descricaoHumana = "Edital deve incluir Prova Objetiva",
+            baseLegal = "Lei 12.711/2012 art.1º",
+            vigenciaInicio = "2026-01-01",
+            vigenciaFim = (string?)null,
+            atoNormativoUrl = (string?)null,
+            portariaInternaCodigo = (string?)null,
+            proprietario = (string?)null,
+            areasDeInteresse = Array.Empty<string>(),
+        };
+
+        HttpResponseMessage response = await PostAsync(client, "/api/selecao/admin/obrigatoriedades-legais", payload);
+
+        string body = await response.Content.ReadAsStringAsync();
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            $"esperava Created mas veio {response.StatusCode}. Body: {body}");
+        await using (AsyncServiceScope scope = _fixture.Factory.Services.CreateAsyncScope())
+        await using (SelecaoDbContext db = ResolveDbContext(scope))
+        {
+            ObrigatoriedadeLegal? regra = await db.ObrigatoriedadesLegais
+                .FirstOrDefaultAsync(o => o.RegraCodigo == regraCodigo);
+            regra.Should().NotBeNull();
+            regra!.Proprietario.Should().BeNull();
+            regra.AreasDeInteresse.Should().BeEmpty();
+        }
+    }
+
+    [Fact(DisplayName = "POST como ceps-admin cria regra com Proprietario=CEPS e binding na junction")]
+    public async Task Criar_CepsAdmin_CriaRegraCepsComBinding()
+    {
+        using HttpClient client = ClientWithRoles(AdminCeps);
+        string regraCodigo = UniqueRegraCodigo();
+
+        object payload = new
+        {
+            tipoEditalCodigo = "*",
+            categoria = "modalidade",
+            regraCodigo,
+            predicado = PredicadoModalidadesACLbPpi,
+            descricaoHumana = "Modalidades mínimas CEPS",
+            baseLegal = "Resolução Unifesspa 414/2020",
+            vigenciaInicio = "2026-01-01",
+            proprietario = "CEPS",
+            areasDeInteresse = new[] { "CEPS" },
+        };
+
+        HttpResponseMessage response = await PostAsync(client, "/api/selecao/admin/obrigatoriedades-legais", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await using AsyncServiceScope scope = _fixture.Factory.Services.CreateAsyncScope();
+        await using SelecaoDbContext db = ResolveDbContext(scope);
+        ObrigatoriedadeLegal regra = await db.ObrigatoriedadesLegais
+            .SingleAsync(o => o.RegraCodigo == regraCodigo);
+        regra.Proprietario.Should().Be(AreaCodigo.From("CEPS").Value);
+
+        int bindings = await db.Set<AreaDeInteresseBinding<ObrigatoriedadeLegal>>()
+            .Where(b => b.ParentId == regra.Id && b.ValidoAte == null)
+            .CountAsync();
+        bindings.Should().Be(1, "binding vigente CEPS deve ter sido inserido na junction");
+    }
+
+    [Fact(DisplayName = "POST como ceps-admin tentando criar regra PROEG retorna 403 escopo_negado")]
+    public async Task Criar_CepsAdminEscapandoEscopo_Retorna403()
+    {
+        using HttpClient client = ClientWithRoles(AdminCeps);
+        string regraCodigo = UniqueRegraCodigo();
+
+        object payload = new
+        {
+            tipoEditalCodigo = "*",
+            categoria = "outros",
+            regraCodigo,
+            predicado = PredicadoConcorrenciaDupla,
+            descricaoHumana = "x",
+            baseLegal = "Lei",
+            vigenciaInicio = "2026-01-01",
+            proprietario = "PROEG",
+            areasDeInteresse = new[] { "PROEG" },
+        };
+
+        HttpResponseMessage response = await PostAsync(client, "/api/selecao/admin/obrigatoriedades-legais", payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        string body = await response.Content.ReadAsStringAsync();
+        if (!string.IsNullOrWhiteSpace(body))
+        {
+            using JsonDocument doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("type", out JsonElement typeElement))
+            {
+                typeElement.GetString()
+                    .Should().EndWith("uniplus.area.escopo_negado",
+                        "type segue pattern URI da ADR-0023 com prefixo do site");
+            }
+        }
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400 ou 422")]
+    public async Task Criar_SemIdempotencyKey_Retorna4xx()
+    {
+        using HttpClient client = ClientWithRoles(AdminPlataforma);
+
+        object payload = new
+        {
+            tipoEditalCodigo = "*",
+            categoria = "outros",
+            regraCodigo = UniqueRegraCodigo(),
+            predicado = PredicadoConcorrenciaDupla,
+            descricaoHumana = "x",
+            baseLegal = "Lei",
+            vigenciaInicio = "2026-01-01",
+            proprietario = (string?)null,
+            areasDeInteresse = Array.Empty<string>(),
+        };
+
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri("/api/selecao/admin/obrigatoriedades-legais", UriKind.Relative));
+        request.Content = JsonContent.Create(payload);
+        // Sem Idempotency-Key header.
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        ((int)response.StatusCode).Should().BeOneOf([400, 422],
+            "RequiresIdempotencyKey filter rejeita request sem header");
+    }
+
+    [Fact(DisplayName = "POST com Idempotency-Key repetido retorna 200 com mesmo Id (idempotência)")]
+    public async Task Criar_IdempotencyKeyRepetido_RetornaMesmaResposta()
+    {
+        using HttpClient client = ClientWithRoles(AdminPlataforma);
+        string regraCodigo = UniqueRegraCodigo();
+        string idempotencyKey = Guid.NewGuid().ToString();
+
+        object payload = new
+        {
+            tipoEditalCodigo = "*",
+            categoria = "outros",
+            regraCodigo,
+            predicado = PredicadoConcorrenciaDupla,
+            descricaoHumana = "Regra idempotente",
+            baseLegal = "Lei",
+            vigenciaInicio = "2026-01-01",
+            proprietario = (string?)null,
+            areasDeInteresse = Array.Empty<string>(),
+        };
+
+        HttpResponseMessage primeira = await PostAsync(
+            client, "/api/selecao/admin/obrigatoriedades-legais", payload, idempotencyKey);
+        primeira.StatusCode.Should().Be(HttpStatusCode.Created);
+        string primeiroBody = await primeira.Content.ReadAsStringAsync();
+        Guid primeiroId = JsonSerializer.Deserialize<Guid>(primeiroBody);
+
+        HttpResponseMessage repetida = await PostAsync(
+            client, "/api/selecao/admin/obrigatoriedades-legais", payload, idempotencyKey);
+
+        ((int)repetida.StatusCode).Should().BeOneOf([200, 201],
+            "replay da mesma Idempotency-Key retorna a representação anterior");
+
+        string repetidoBody = await repetida.Content.ReadAsStringAsync();
+        Guid repetidoId = JsonSerializer.Deserialize<Guid>(repetidoBody);
+        repetidoId.Should().Be(primeiroId, "replay devolve o mesmo Id");
+    }
+
+    [Fact(DisplayName = "POST com RegraCodigo duplicado retorna 409 com type específico")]
+    public async Task Criar_RegraCodigoDuplicado_Retorna409()
+    {
+        using HttpClient client = ClientWithRoles(AdminPlataforma);
+        string regraCodigo = UniqueRegraCodigo();
+
+        object payload = new
+        {
+            tipoEditalCodigo = "*",
+            categoria = "outros",
+            regraCodigo,
+            predicado = PredicadoConcorrenciaDupla,
+            descricaoHumana = "Regra original",
+            baseLegal = "Lei",
+            vigenciaInicio = "2026-01-01",
+            proprietario = (string?)null,
+            areasDeInteresse = Array.Empty<string>(),
+        };
+
+        HttpResponseMessage primeira = await PostAsync(
+            client, "/api/selecao/admin/obrigatoriedades-legais", payload);
+        primeira.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Tenta criar OUTRA regra com mesmo RegraCodigo mas conteúdo diferente
+        // (baseLegal mudada → hash distinto, então NÃO bate na constraint de Hash;
+        // o UNIQUE parcial sobre regra_codigo é o que defende).
+        object duplicado = new
+        {
+            tipoEditalCodigo = "*",
+            categoria = "outros",
+            regraCodigo,
+            predicado = PredicadoConcorrenciaDupla,
+            descricaoHumana = "Regra duplicada com outro conteúdo",
+            baseLegal = "Lei 14.723/2023",
+            vigenciaInicio = "2026-02-01",
+            proprietario = (string?)null,
+            areasDeInteresse = Array.Empty<string>(),
+        };
+
+        HttpResponseMessage segunda = await PostAsync(
+            client, "/api/selecao/admin/obrigatoriedades-legais", duplicado);
+
+        segunda.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        using JsonDocument doc = JsonDocument.Parse(await segunda.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("type").GetString()
+            .Should().EndWith("uniplus.selecao.obrigatoriedade_legal.regra_codigo_duplicada");
+    }
+
+    [Fact(DisplayName = "PUT full-replace altera campo e mantém URI estável")]
+    public async Task Atualizar_FullReplace_MantemUriEstavel()
+    {
+        using HttpClient client = ClientWithRoles(AdminPlataforma);
+        string regraCodigo = UniqueRegraCodigo();
+
+        Guid id = await SeedRegraAsync(client, regraCodigo, baseLegal: "Lei original");
+
+        object putPayload = new
+        {
+            id,
+            tipoEditalCodigo = "*",
+            categoria = "outros",
+            regraCodigo,
+            predicado = PredicadoConcorrenciaDupla,
+            descricaoHumana = "Regra atualizada",
+            baseLegal = "Lei 14.723/2023 art.2º — nova",
+            vigenciaInicio = "2026-01-01",
+            vigenciaFim = (string?)null,
+            atoNormativoUrl = (string?)null,
+            portariaInternaCodigo = (string?)null,
+            proprietario = (string?)null,
+            areasDeInteresse = Array.Empty<string>(),
+        };
+
+        HttpResponseMessage put = await PutAsync(
+            client,
+            $"/api/selecao/admin/obrigatoriedades-legais/{id}",
+            putPayload);
+
+        put.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using AsyncServiceScope scope = _fixture.Factory.Services.CreateAsyncScope();
+        await using SelecaoDbContext db = ResolveDbContext(scope);
+        ObrigatoriedadeLegal regra = await db.ObrigatoriedadesLegais.SingleAsync(o => o.Id == id);
+        regra.BaseLegal.Should().Be("Lei 14.723/2023 art.2º — nova");
+
+        int historico = await db.ObrigatoriedadeLegalHistorico
+            .Where(h => h.RegraId == id)
+            .CountAsync();
+        historico.Should().Be(2, "insert + update geram 2 linhas no histórico forensic");
+    }
+
+    [Fact(DisplayName = "PUT com Id path divergente do body retorna 400")]
+    public async Task Atualizar_IdPathDivergenteBody_Retorna400()
+    {
+        using HttpClient client = ClientWithRoles(AdminPlataforma);
+        string regraCodigo = UniqueRegraCodigo();
+        Guid idReal = await SeedRegraAsync(client, regraCodigo);
+        Guid idDivergente = Guid.NewGuid();
+
+        object putPayload = new
+        {
+            id = idDivergente,
+            tipoEditalCodigo = "*",
+            categoria = "outros",
+            regraCodigo,
+            predicado = PredicadoConcorrenciaDupla,
+            descricaoHumana = "x",
+            baseLegal = "Lei",
+            vigenciaInicio = "2026-01-01",
+            vigenciaFim = (string?)null,
+            atoNormativoUrl = (string?)null,
+            portariaInternaCodigo = (string?)null,
+            proprietario = (string?)null,
+            areasDeInteresse = Array.Empty<string>(),
+        };
+
+        HttpResponseMessage response = await PutAsync(
+            client,
+            $"/api/selecao/admin/obrigatoriedades-legais/{idReal}",
+            putPayload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "PUT como CRCA-admin em regra CEPS retorna 403 escopo_negado")]
+    public async Task Atualizar_EscopoErrado_Retorna403()
+    {
+        using HttpClient adminPlataforma = ClientWithRoles(AdminPlataforma);
+        string regraCodigo = UniqueRegraCodigo();
+        Guid id = await SeedRegraAsync(
+            adminPlataforma,
+            regraCodigo,
+            proprietario: "CEPS",
+            areasDeInteresse: new[] { "CEPS" });
+
+        using HttpClient adminCrca = ClientWithRoles(AdminCrca);
+        object putPayload = new
+        {
+            id,
+            tipoEditalCodigo = "*",
+            categoria = "outros",
+            regraCodigo,
+            predicado = PredicadoConcorrenciaDupla,
+            descricaoHumana = "Tentativa de CRCA editar regra CEPS",
+            baseLegal = "Lei alterada",
+            vigenciaInicio = "2026-01-01",
+            vigenciaFim = (string?)null,
+            atoNormativoUrl = (string?)null,
+            portariaInternaCodigo = (string?)null,
+            proprietario = "CEPS",
+            areasDeInteresse = new[] { "CEPS" },
+        };
+
+        HttpResponseMessage response = await PutAsync(
+            adminCrca,
+            $"/api/selecao/admin/obrigatoriedades-legais/{id}",
+            putPayload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "DELETE soft-delete retorna 204 e regra some do GET público")]
+    public async Task Desativar_SoftDelete_ScrubsPublicGet()
+    {
+        using HttpClient client = ClientWithRoles(AdminPlataforma);
+        string regraCodigo = UniqueRegraCodigo();
+        Guid id = await SeedRegraAsync(client, regraCodigo);
+
+        HttpResponseMessage delete = await client.DeleteAsync(
+            new Uri($"/api/selecao/admin/obrigatoriedades-legais/{id}", UriKind.Relative));
+        delete.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // GET público — query filter aplica IsDeleted=false, então 404.
+        HttpResponseMessage publicGet = await client.GetAsync(
+            new Uri($"/api/selecao/obrigatoriedades-legais/{id}", UriKind.Relative));
+        publicGet.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        // Histórico forensic mantém a regra com snapshot pós-soft-delete.
+        await using AsyncServiceScope scope = _fixture.Factory.Services.CreateAsyncScope();
+        await using SelecaoDbContext db = ResolveDbContext(scope);
+        int historico = await db.ObrigatoriedadeLegalHistorico
+            .Where(h => h.RegraId == id)
+            .CountAsync();
+        historico.Should().BeGreaterThanOrEqualTo(2, "insert + soft-delete = 2 snapshots no mínimo");
+    }
+
+    [Fact(DisplayName = "GET com filtros admin retorna apenas regras matching")]
+    public async Task Listar_ComFiltros_RetornaSubconjunto()
+    {
+        using HttpClient client = ClientWithRoles(AdminPlataforma);
+        string regraCodigoEtapa = UniqueRegraCodigo();
+        string regraCodigoModalidade = UniqueRegraCodigo();
+
+        await SeedRegraAsync(client, regraCodigoEtapa, categoria: "Etapa");
+        await SeedRegraAsync(client, regraCodigoModalidade, categoria: "Modalidade");
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/selecao/obrigatoriedades-legais?categoria=Etapa&limit=50", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        IReadOnlyList<string> regraCodigos = [.. doc.RootElement.EnumerateArray()
+            .Select(e => e.GetProperty("regraCodigo").GetString()!)];
+
+        regraCodigos.Should().Contain(regraCodigoEtapa);
+        regraCodigos.Should().NotContain(regraCodigoModalidade, "filtro categoria=Etapa exclui Modalidade");
+    }
+
+    private HttpClient ClientWithRoles(params string[] roles)
+    {
+        HttpClient client = _fixture.Factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme,
+            TestAuthHandler.TokenValue);
+        client.DefaultRequestHeaders.Add(TestAuthHandler.RolesHeader, string.Join(',', roles));
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, $"admin-{Guid.NewGuid():N}"[..16]);
+        client.DefaultRequestHeaders.Add(TestAuthHandler.NameHeader, "Admin Test");
+        client.DefaultRequestHeaders.Add(TestAuthHandler.EmailHeader, "admin@unifesspa.edu.br");
+        return client;
+    }
+
+    private static async Task<HttpResponseMessage> PostAsync(HttpClient client, string url, object payload, string? idempotencyKey = null)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(url, UriKind.Relative));
+        request.Content = JsonContent.Create(payload);
+        request.Headers.Add("Idempotency-Key", idempotencyKey ?? Guid.NewGuid().ToString());
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> PutAsync(HttpClient client, string url, object payload)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Put, new Uri(url, UriKind.Relative));
+        request.Content = JsonContent.Create(payload);
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        return await client.SendAsync(request);
+    }
+
+    private static SelecaoDbContext ResolveDbContext(AsyncServiceScope scope) =>
+        scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+
+    private static async Task<Guid> SeedRegraAsync(
+        HttpClient client,
+        string regraCodigo,
+        string categoria = "outros",
+        string baseLegal = "Lei seed",
+        string? proprietario = null,
+        IReadOnlyCollection<string>? areasDeInteresse = null)
+    {
+        object payload = new
+        {
+            tipoEditalCodigo = "*",
+            categoria,
+            regraCodigo,
+            predicado = PredicadoConcorrenciaDupla,
+            descricaoHumana = "Seed",
+            baseLegal,
+            vigenciaInicio = "2026-01-01",
+            vigenciaFim = (string?)null,
+            atoNormativoUrl = (string?)null,
+            portariaInternaCodigo = (string?)null,
+            proprietario,
+            areasDeInteresse = areasDeInteresse ?? Array.Empty<string>(),
+        };
+
+        HttpResponseMessage response = await PostAsync(client, "/api/selecao/admin/obrigatoriedades-legais", payload);
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            "seed precisa criar a regra para o teste prosseguir; body: "
+            + await response.Content.ReadAsStringAsync());
+        string body = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<Guid>(body);
+    }
+
+    private static string UniqueRegraCodigo() =>
+        $"TEST_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture)}_{Guid.NewGuid().ToString("N")[..6].ToUpperInvariant()}";
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingApiFactory.cs
@@ -63,10 +63,12 @@ public sealed class CascadingApiFactory : ApiFactoryBase<Program>
             RemoveAllOptionsConfigurations<DbContextOptions<SelecaoDbContext>>(services);
 
             // Re-registro do DbContext mantém SoftDeleteInterceptor + AuditableInterceptor
-            // + UseSnakeCaseNamingConvention simétrico à produção (`SelecaoInfrastructureRegistration.
-            // AddSelecaoInfrastructure` via `UseUniPlusNpgsqlConventions`). Sem isto:
-            // (a) os interceptors ficariam de fora — as colunas is_deleted/deleted_at/updated_at
-            //     não seriam preenchidas automaticamente, mascarando regressões;
+            // + ObrigatoriedadeLegalHistoricoInterceptor (#460) + UseSnakeCaseNamingConvention
+            // simétrico à produção (`SelecaoInfrastructureRegistration.AddSelecaoInfrastructure`
+            // via `UseUniPlusNpgsqlConventions`). Sem isto:
+            // (a) os interceptors ficariam de fora — colunas is_deleted/deleted_at/updated_at
+            //     não preenchidas + linhas em obrigatoriedade_legal_historico não gravadas,
+            //     mascarando regressões em PRs futuros;
             // (b) sem snake_case, o model em runtime ficaria em PascalCase implícito enquanto
             //     o Snapshot regenerado pelo `dotnet ef` está em snake_case (ADR-0054), e o EF
             //     dispararia PendingModelChangesWarning bloqueando MigrateAsync.
@@ -76,7 +78,8 @@ public sealed class CascadingApiFactory : ApiFactoryBase<Program>
                 opts.UseSnakeCaseNamingConvention();
                 opts.AddInterceptors(
                     sp.GetRequiredService<SoftDeleteInterceptor>(),
-                    sp.GetRequiredService<AuditableInterceptor>());
+                    sp.GetRequiredService<AuditableInterceptor>(),
+                    sp.GetRequiredService<Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Interceptors.ObrigatoriedadeLegalHistoricoInterceptor>());
             });
 
             services.AddSingleton<DomainEventCollector>();


### PR DESCRIPTION
## Contexto

PR #523 (Story #461) passou no CI mas quando rodei o admin CRUD end-to-end contra Postgres real localmente (com docker-compose subido, conforme deveria ter feito antes de mergear #523), descobri 3 bugs que CI passou silenciosamente porque a cobertura de integration tests do PR original só exercitava o caminho do GET público + 401 unauthenticated.

Este PR fecha o gap.

## Bugs

### 1. `IReadOnlySet<string>` quebra deserialização System.Text.Json

`CriarObrigatoriedadeLegalCommand` e `AtualizarObrigatoriedadeLegalCommand` tinham `IReadOnlySet<string> AreasDeInteresse`. STJ rejeita: `"The collection type 'System.Collections.Generic.IReadOnlySet<String>' is abstract, an interface, or is read only, and could not be instantiated and populated"`.

**Impacto produção**: Newman seed (#463 — ADR-0062) sempre serializaria payloads que falhariam em qualquer POST/PUT do admin. Não era só problema de teste — era bug que atingiria HML/PROD.

**Fix**: trocar para `HashSet<string>` (concreto, instanciável; ainda implementa `IReadOnlySet<string>` para callers que precisam da interface).

### 2. `JsonStringEnumConverter` ausente em `Selecao.API`

`CategoriaObrigatoriedade` (enum) chegava como `"etapa"` no JSON; deserializer tentava parsear como int e retornava 400 com:

```
The JSON value could not be converted to CategoriaObrigatoriedade. Path: $.categoria
```

**Impacto produção**: idem — Newman seed e admin DX em pt-BR enviam enum como string (convenção). Sem este converter, todo POST admin falha.

**Fix**: registrar `JsonStringEnumConverter(JsonNamingPolicy.CamelCase)` em ambos os pipelines (`AddJsonOptions` para controllers MVC + `ConfigureHttpJsonOptions` para minimal APIs).

### 3. `CascadingApiFactory` esquece `ObrigatoriedadeLegalHistoricoInterceptor`

A fixture re-registra `SelecaoDbContext` mas só com `SoftDeleteInterceptor + AuditableInterceptor`, omitindo o `ObrigatoriedadeLegalHistoricoInterceptor` entregue em #520 (Story #460).

**Impacto**: regressão silenciosa — em qualquer integration test usando CascadingFixture, mutações em `ObrigatoriedadeLegal` NÃO geravam linha em `obrigatoriedade_legal_historico`. Histórico forense documentado em ADR-0058 + ADR-0063 não era exercitado em CI nesse caminho. PRs futuros poderiam quebrar a integridade sem detecção.

**Fix**: adicionar o terceiro interceptor à lista da `services.AddDbContext` da fixture.

## Cobertura adicionada

`ObrigatoriedadeLegalAdminEndpointTests` (11 integration tests) contra Postgres real via Testcontainers:

- `Criar_PlataformaAdmin_CriaRegraUniversal` — happy path
- `Criar_CepsAdmin_CriaRegraCepsComBinding` — RBAC área-scoped + reconciliação junction
- `Criar_CepsAdminEscapandoEscopo_Retorna403` — 403 `uniplus.area.escopo_negado`
- `Criar_SemIdempotencyKey_Retorna4xx` — `[RequiresIdempotencyKey]` enforce
- `Criar_IdempotencyKeyRepetido_RetornaMesmaResposta` — replay devolve mesmo Id
- `Criar_RegraCodigoDuplicado_Retorna409` — UNIQUE partial + ProblemDetails type
- `Atualizar_FullReplace_MantemUriEstavel` — PUT in-place + histórico forense (2 linhas: insert+update)
- `Atualizar_IdPathDivergenteBody_Retorna400`
- `Atualizar_EscopoErrado_Retorna403` — CRCA-admin tentando editar regra CEPS
- `Desativar_SoftDelete_ScrubsPublicGet` — DELETE 204 + GET 404 + histórico preservado
- `Listar_ComFiltros_RetornaSubconjunto` — filtro por categoria

## OpenAPI baseline

Regenerado refletindo enums emitidos como string nos schemas (consequência do `JsonStringEnumConverter`).

## Test plan

- [x] `dotnet build UniPlus.slnx --warnaserror` → 0 errors
- [x] `dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests` → 103/103 ✅ (era 92, +11 novos admin)
- [x] `dotnet test UniPlus.slnx` → todos verdes
- [x] Spectral lint OpenAPI → 0 errors
- [x] CI completo do PR

## Honest acknowledgement

Esses 3 bugs deveriam ter sido pegados antes do merge de #523 se eu tivesse rodado o CRUD end-to-end localmente — corte de canto explícito apontado pelo revisor.

Refs #461
