### PR TITLE
ci(publish): habilita manifest list multi-arch (amd64+arm64) no GHCR

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -19,6 +19,15 @@ name: Publish Images
 #   - ghcr.io/<owner>/uniplus-api-selecao
 #   - ghcr.io/<owner>/uniplus-api-ingresso
 #   - ghcr.io/<owner>/uniplus-api-portal
+#
+# Multi-arch: cada tag acima é publicada como manifest list cobrindo
+#   - linux/amd64  (cluster legacy GRU/E5)
+#   - linux/arm64  (cluster IAD/A1 ARM Ampere, Epic uniplus-infra#317)
+# O smoke test estrutural roda apenas no build amd64 — invariantes
+# validadas (usuário não-root, entrypoint, runtime) são idênticas em ambas
+# arquiteturas, então emular arm64 só repete o mesmo cheque com overhead
+# de QEMU. Smoke runtime real (com sidecar Postgres/Kafka/Redis) acontece
+# em compose/Helm pós-publish.
 
 on:
   push:
@@ -105,6 +114,16 @@ jobs:
           fi
           echo "✓ Tag aponta para commit em main: $TAG_COMMIT"
 
+      - name: Set up QEMU
+        # Habilita cross-build linux/arm64 no runner amd64 do GitHub
+        # Actions registrando os binfmt_misc handlers para emulação
+        # user-mode. Buildx delega para QEMU quando a plataforma alvo
+        # não bate com a do runner. Smoke roda em amd64 (nativo); push
+        # multi-arch usa esta capability para compilar o layer arm64.
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -159,14 +178,22 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.${{ matrix.module }}
+          # Smoke fica amd64 apenas: o `load: true` do buildx só funciona
+          # com uma plataforma por vez (carrega no daemon Docker local
+          # para `docker create`/`docker run`). As invariantes que o smoke
+          # valida (usuário não-root, entrypoint, runtime .NET responde)
+          # são identicas entre arquiteturas — repetir com arm64 emulado
+          # via QEMU não acrescenta cobertura, só overhead.
           platforms: linux/amd64
           push: false
           load: true
           tags: smoke/uniplus-api-${{ matrix.module }}:ci
-          # Cache scoped por módulo: builds independentes não invalidam cache uns
-          # dos outros (cada Dockerfile copia src/<module>/ separadamente).
-          cache-from: type=gha,scope=${{ matrix.module }}
-          cache-to: type=gha,scope=${{ matrix.module }},mode=max
+          # Cache scoped por módulo + arch amd64: builds independentes
+          # não invalidam cache uns dos outros, e o cache amd64 deste
+          # smoke é reaproveitado integralmente pelo layer amd64 do
+          # push multi-arch a seguir.
+          cache-from: type=gha,scope=${{ matrix.module }}-amd64
+          cache-to: type=gha,scope=${{ matrix.module }}-amd64,mode=max
 
       - name: Smoke test — validação estrutural da imagem
         # Smoke runtime (/health/live) não é viável em CI puro: Wolverine valida
@@ -222,20 +249,33 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.${{ matrix.module }}
-          platforms: linux/amd64
+          # Manifest list multi-arch: ArgoCD em cluster amd64 (GRU/E5)
+          # ou arm64 (IAD/A1) puxa o layer correto automaticamente do
+          # mesmo `ghcr.io/.../uniplus-api-<module>:vX.Y.Z`. Layer amd64
+          # reusa cache integral do step smoke; layer arm64 compila via
+          # QEMU emulation (~2-3x mais lento que nativo, aceitável para
+          # release explícito em tag).
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Reusa o cache do build_local — segundo build é praticamente
-          # instantâneo (apenas resolve manifest e push das layers já em cache).
-          cache-from: type=gha,scope=${{ matrix.module }}
+          # Cache amd64 vem do smoke (cache-to amd64-only); cache arm64
+          # é populado neste push e fica disponível para releases futuras
+          # do mesmo módulo. Scopes separados por arch evitam invalidação
+          # cruzada quando só uma arquitetura tem mudança de base image.
+          cache-from: |
+            type=gha,scope=${{ matrix.module }}-amd64
+            type=gha,scope=${{ matrix.module }}-arm64
+          cache-to: type=gha,scope=${{ matrix.module }}-arm64,mode=max
 
       - name: Resumo
         if: always()
         run: |
           echo "### Publish: \`uniplus-api-${{ matrix.module }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Tags publicadas:**" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Plataformas:** \`linux/amd64\`, \`linux/arm64\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Tags publicadas (manifest list multi-arch):**" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           echo "${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/docs/adrs/0050-registry-ghcr-e-tagging.md
+++ b/docs/adrs/0050-registry-ghcr-e-tagging.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted — emendado em 2026-05-17 (multi-arch habilitado)"
+status: "accepted"
 date: "2026-05-08"
 decision-makers:
   - "Tech Lead"

--- a/docs/adrs/0050-registry-ghcr-e-tagging.md
+++ b/docs/adrs/0050-registry-ghcr-e-tagging.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: "accepted — emendado em 2026-05-17 (multi-arch habilitado)"
 date: "2026-05-08"
 decision-makers:
   - "Tech Lead"
@@ -10,6 +10,19 @@ informed:
 ---
 
 # ADR-0050: GitHub Container Registry e estratégia de tagging das imagens da `uniplus-api`
+
+> **Emenda de 2026-05-17 — multi-arch (`linux/arm64`) habilitado**
+>
+> A decisão original deferia `linux/arm64` "até existir cluster ARM ou demanda concreta de Apple Silicon em CI" (seção "Resultado da decisão"). O primeiro gatilho acaba de disparar: a Epic [`uniplus-infra#317`](https://github.com/unifesspa-edu-br/uniplus-infra/issues/317) provisiona o lab Uni+ em `us-ashburn-1` sobre `VM.Standard.A1.Flex` (ARM Ampere) — alvo de migração do lab atual `standalone` (`sa-saopaulo-1`/E5 AMD) antes do trial OCI expirar em 2026-06-03.
+>
+> **O que muda:**
+>
+> - `publish-images.yml` passa a produzir manifest list multi-arch (`linux/amd64,linux/arm64`) por release. ArgoCD em cluster amd64 ou arm64 consome a mesma tag `vX.Y.Z`; o daemon Docker resolve o digest correto pela plataforma do nó.
+> - Smoke test estrutural permanece em `linux/amd64` apenas: as invariantes validadas (usuário não-root, entrypoint, runtime .NET responde) são idênticas entre arquiteturas, então emular arm64 via QEMU só repete o mesmo cheque com overhead. Smoke runtime real (sidecars Postgres/Kafka/Redis) continua deferido para compose/Helm pós-publish.
+> - Layer arm64 é compilado via QEMU emulation no runner amd64 do GitHub Actions (`docker/setup-qemu-action` registra os handlers `binfmt_misc`). Custo: ~2–3× mais lento por release. Aceitável porque o trigger continua sendo tag explícita (lockstep raro, não rolling tag).
+> - SBOM e attestation cosign keyless seguem parqueados (mesma posição da decisão original).
+>
+> **O que permanece válido:** registry (GHCR), naming `uniplus-api-<modulo>`, estratégia lockstep semver, gates de validação (formato semver, tag em commit em `main`), smoke estrutural pré-push. A emenda toca apenas a cláusula de plataformas.
 
 ## Contexto e enunciado do problema
 


### PR DESCRIPTION
## Resumo

Adapta `.github/workflows/publish-images.yml` para produzir manifest list multi-arch (`linux/amd64,linux/arm64`) por release no GHCR e emenda a ADR-0050 documentando que o gatilho de revisão da cláusula "linux/arm64 deferido" disparou: a Epic `unifesspa-edu-br/uniplus-infra#317` provisiona cluster ARM destino (`us-ashburn-1` sobre `VM.Standard.A1.Flex`) antes do trial OCI expirar em 2026-06-03.

Atende Story `unifesspa-edu-br/uniplus-infra#335` (S2.1 — buildx multi-arch no CI do uniplus-api), que cobre os 3 services hoje publicados (`selecao`, `ingresso`, `portal`). Os 2 Dockerfiles adicionais existentes (`organizacao`, `parametrizacao`) não estão na matriz do workflow e ficam fora deste PR.

## O que muda

### `publish-images.yml` (+49 / −9)

| Step | Mudança |
|---|---|
| Header docstring | Documenta multi-arch e por que smoke fica em amd64 |
| **NOVO**: Set up QEMU | `docker/setup-qemu-action@v3` com `platforms: arm64` antes do `setup-buildx-action`. Registra binfmt_misc handlers para emulação user-mode da arch não-nativa do runner |
| Build local (smoke) | Permanece `linux/amd64` (`load: true` exige single platform). Cache scope passa a ser `${{ matrix.module }}-amd64` |
| Push para GHCR | `platforms: linux/amd64,linux/arm64`. Layer amd64 reusa cache do smoke; layer arm64 compila sob QEMU. Cache scopes separados por arch para evitar invalidação cruzada |
| Resumo | Linha extra mostrando `Plataformas: linux/amd64, linux/arm64` |

**Smoke continua amd64-only** porque as invariantes que valida (usuário não-root, entrypoint, runtime .NET) são idênticas entre arquiteturas — emular arm64 só repete o cheque com overhead.

### `docs/adrs/0050-registry-ghcr-e-tagging.md` (+14 / −1)

- Status frontmatter: `accepted` → `accepted — emendado em 2026-05-17 (multi-arch habilitado)`
- Bloco "Emenda de 2026-05-17" no topo do ADR descrevendo:
  - **Trigger**: cluster ARM via `uniplus-infra#317`
  - **O que muda**: workflow + smoke amd64-only + emulação QEMU + cache scopes
  - **O que permanece**: registry GHCR, naming, lockstep semver, gates, smoke estrutural pré-push
  - **O que segue parqueado**: SBOM e attestation cosign

A redação histórica da cláusula "Multi-arch fica restrito a `linux/amd64` neste momento" permanece no corpo como contexto da decisão original — superada pela emenda no topo.

## Validação local

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-images.yml'))"   # OK
yamllint .github/workflows/publish-images.yml                                              # exit=0
```

Pré-revisão via `/up-coder-revisar` (qwen2.5-coder:14b + uniplus-rag): **LIMPO**.

Cruzamento manual de 7 cenários verificados:
- `setup-qemu-action@v3` com `platforms: arm64` — uso padrão da action ✓
- Ordem `setup-qemu` → `setup-buildx` — obrigatória (buildx detecta plataformas via binfmt no startup) ✓
- Cache scopes `${{ matrix.module }}-amd64` / `-arm64` — pattern recomendado pelo Docker Buildx para multi-arch ✓
- `cache-from: |` com 2 linhas — sintaxe válida em `docker/build-push-action@v5` (newline-separated) ✓
- `load: true` + multi-platform — inviável (`load` exige single platform); smoke amd64 é a única opção ✓
- Push multi-arch com `setup-qemu` só `arm64` — amd64 é nativo do runner, só não-nativo precisa registrar ✓
- Tom da emenda ADR — trigger + o-que-muda + o-que-permanece, consistente com o texto histórico ✓

## Como confirmar pós-merge

1. **Próxima tag `v*.*.*` aplicada a commit em main** dispara o workflow
2. `gh run watch` deve mostrar:
   - Smoke amd64 passando como antes (sem regressão)
   - Push final consumindo ~2-3× mais tempo no layer arm64 (QEMU)
3. `docker manifest inspect ghcr.io/unifesspa-edu-br/uniplus-api-selecao:vX.Y.Z` deve listar 2 entries:
   ```json
   [
     {"platform": {"architecture": "amd64", "os": "linux"}, "digest": "sha256:..."},
     {"platform": {"architecture": "arm64", "os": "linux"}, "digest": "sha256:..."}
   ]
   ```
4. ArgoCD em cluster amd64 ou arm64 puxa o digest correto automaticamente

## Notas

- Não toca em Dockerfiles — todos já usam imagens base multi-arch (`mcr.microsoft.com/dotnet/sdk:10.0.100`, `aspnet:10.0`) sem `RUN` arch-specific
- Não inclui smoke runtime real (sidecars Postgres/Kafka/Redis); essa cobertura permanece em compose/Helm pós-publish
- Não inclui SBOM/attestation cosign — seguem deferidos como na decisão original

Refs unifesspa-edu-br/uniplus-infra#317
Refs unifesspa-edu-br/uniplus-infra#335