### PR TITLE
docs(adr): modelagem de domínio do Módulo Configuração de Edital (0065–0067)

### DIFF
--- a/docs/adrs/0065-localoferta-flat-um-por-endereco-emec.md
+++ b/docs/adrs/0065-localoferta-flat-um-por-endereco-emec.md
@@ -1,0 +1,80 @@
+---
+status: "accepted"
+date: "2026-05-19"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0065: LocalOferta como entidade flat, uma entrada por local de oferta (endereço e-MEC)
+
+## Contexto e enunciado do problema
+
+O wizard de Configuração de Edital precisa de um catálogo de **locais onde os cursos são ofertados** — campi sede, unidades fora de sede e ofertas por convênio de interiorização. O protótipo legado tratava "campus" e "cidade" como o mesmo achatado, o que não reflete a realidade regulatória: a Unifesspa (IES 18440) opera múltiplos endereços por município, cada um com cadastro próprio no e-MEC.
+
+A modelagem deste catálogo influencia diretamente o que o edital aponta como local de oferta de cada vaga e como a auditoria reconstrói, anos depois, onde uma vaga foi ofertada. A pergunta concreta da deliberação foi: o local de oferta deve ser **uma entrada por endereço cadastrado** (espelhando o e-MEC), **uma entrada por campus com subunidades aninhadas**, ou uma **hierarquia entre locais**?
+
+A evidência canônica (cadastro e-MEC da IES 18440, consultado em 2026-05-19) refutou a hipótese inicial de "ato único por campus": a IES lista **13 endereços distintos**, cada um com código próprio — Marabá com 3 endereços (`1064323` Unidade I com `Polo=A`, `1066314` Unidade II, `1072603` Unidade III), Santana do Araguaia com 3, Xinguara com 2, e os demais municípios (Rondon do Pará, São Félix do Xingu, Canaã dos Carajás, Jacundá, Parauapebas) com 1 cada. Cada Unidade é um endereço regulatório irmão sob a IES, não uma subunidade aninhada.
+
+## Drivers da decisão
+
+- **Espelhar o cadastro regulatório**: o modelo deve refletir o e-MEC, fonte de verdade do MEC, sem inventar agregações que o cadastro não declara.
+- **Rastreabilidade**: cada local de oferta precisa ser rastreável diretamente a um código de cadastro federal quando existir.
+- **Forward-compat com Ingresso e módulos futuros**: o catálogo é cross-módulo (usado por Seleção hoje, Ingresso depois) e deve viver em local neutro.
+- **Evitar overengineering**: hierarquia entre locais não tem suporte no e-MEC (todos os endereços são irmãos sob a IES) e adicionaria complexidade sem ganho.
+
+## Opções consideradas
+
+- **Entidade flat, uma entrada por endereço e-MEC** — cada endereço cadastrado vira um `LocalOferta`; a agregação visual ("Campus de Marabá ▸ Unidades I/II/III") é responsabilidade da camada de apresentação.
+- **Uma entrada por campus com subunidades aninhadas** — um `LocalOferta` "Campus de Marabá" contendo Unidades I/II/III como filhos.
+- **Hierarquia recursiva entre locais** — `LocalOferta` com auto-referência multinível (campus → unidade → sala).
+
+## Resultado da decisão
+
+**Escolhida:** "Entidade flat, uma entrada por local de oferta", porque espelha exatamente o cadastro e-MEC da IES 18440, mantém rastreabilidade direta ao código federal e evita inventar uma hierarquia que o cadastro regulatório não declara.
+
+`LocalOferta` é catálogo cross-módulo e, por consistência com a [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md), vive no módulo **Parametrizacao**. O endereço físico é modelado como o value object `Endereco` da [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md), embedded na entidade. Forma da entidade (em termos de domínio):
+
+- `Codigo` — slug interno estável (`MARABA_UI`, `MARABA_UII`, …).
+- `CodigoEmec` — código do endereço no e-MEC, **opcional**: presente nos endereços cadastrados (sede e fora de sede), ausente nas ofertas por convênio que herdam o código do campus responsável via `OfertaCurso`.
+- `Nome` — rótulo institucional (`"Campus de Marabá — Unidade I"`).
+- `Tipo` — discriminador `TipoLocalOferta`: `CampusSede`, `CampusForaDeSede`, `CursoForaDeSede`, `PoloEad`, `ConvenioInteriorizacao`, `Outro`.
+- `Endereco` — value object da ADR-0056 (logradouro, CEP, latitude/longitude quando disponíveis).
+- `CidadeId` — referência ao município (vários `LocalOferta` podem compartilhar a mesma cidade).
+- `CampusResponsavelId` — auto-referência opcional ao campus responsável (null para o campus sede principal).
+- `PrincipalEmMunicipio` — flag que marca o endereço com `Polo=A` no e-MEC (ex.: Unidade I em Marabá).
+- `AtoRegulatorioMec`, `BaseLegal` — referências regulatórias opcionais.
+
+A agregação de apresentação ("Campus de Marabá" agrupando suas Unidades) é um `GROUP BY CidadeId + PrincipalEmMunicipio` na camada de leitura, **não** uma estrutura no modelo de escrita. O rótulo canônico de UI do catálogo é **"Locais de Oferta"** — técnico-neutro, cobre os seis tipos sem colidir com "Polo" (regulatório EaD) ou "Unidade" (entidade institucional da [ADR-0055](0055-organizacao-institucional-bounded-context.md)).
+
+## Consequências
+
+### Positivas
+
+- O catálogo é uma cópia 1:1 do cadastro e-MEC nos endereços com código, com rastreabilidade direta via `CodigoEmec`.
+- Sem hierarquia no modelo de escrita: leitura e migração são simples; cada local evolui de forma independente.
+- Ofertas por convênio de interiorização (Jacundá, Parauapebas, Canaã não-Pepeti) entram como `ConvenioInteriorizacao`, sem forçar um código e-MEC inexistente.
+- Catálogo em Parametrizacao fica disponível para Ingresso e módulos futuros sem reescrita.
+
+### Negativas
+
+- A agregação "campus com suas unidades" passa a ser responsabilidade da apresentação — exige consistência nas telas que listam locais por município.
+- O significado exato de `Polo=A` no e-MEC ainda não foi confirmado institucionalmente (ver pendências).
+
+### Neutras
+
+- A flag `PrincipalEmMunicipio` adiciona uma coluna cuja semântica final depende de confirmação da PROEG.
+
+## Confirmação
+
+- Seed inicial do catálogo reproduz os endereços e-MEC da IES 18440 (com `CodigoEmec` preenchido) mais os locais de convênio de interiorização.
+- Nenhuma entidade `LocalOferta` referencia outra como pai a não ser via `CampusResponsavelId` (auto-referência simples, sem multinível).
+
+## Mais informações
+
+- Relaciona-se com a [ADR-0066](0066-ofertacurso-modelo-tres-niveis-emec-por-campus.md) — `OfertaCurso.LocalOfertaId` aponta sempre para um `LocalOferta` específico.
+- Endereço físico via value object `Endereco` da [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md); referência de município segue o catálogo `Cidade`.
+- **Pendências a confirmar com PROEG/Procuradoria (não bloqueiam o modelo):** significado de `Polo=A` no e-MEC; classificação regulatória (`Tipo`) definitiva de Jacundá/Parauapebas/Canaã (provisoriamente `ConvenioInteriorizacao`).
+- **Origem:** deliberação técnica de modelagem do Módulo Configuração de Edital conduzida pelo Tech Lead (2026-05-19), validada contra o cadastro e-MEC da IES 18440 e confirmada com a equipe CTIC com conhecimento operacional dos sistemas legados; rascunhos de trabalho não publicados.

--- a/docs/adrs/0066-ofertacurso-modelo-tres-niveis-emec-por-campus.md
+++ b/docs/adrs/0066-ofertacurso-modelo-tres-niveis-emec-por-campus.md
@@ -47,7 +47,7 @@ Como catálogo cross-módulo, `Curso` e `OfertaCurso` vivem no módulo **Paramet
 - `CargaHorariaTotal`, `DuracaoSemestresPadrao`, `DescricaoCurricular`, `Ativo`.
 - **Sem `e_mec_codigo`.**
 
-**`OfertaCurso` — instância regulatória (~95 entradas reais):**
+**`OfertaCurso` — instância regulatória (cerca de uma centena de entradas reais):**
 
 - `CursoId` — referência à matriz curricular.
 - `LocalOfertaId` — referência ao `LocalOferta` específico ([ADR-0065](0065-localoferta-flat-um-por-endereco-emec.md)).
@@ -56,7 +56,7 @@ Como catálogo cross-módulo, `Curso` e `OfertaCurso` vivem no módulo **Paramet
 - `FormatoPedagogico` — `Presencial` (default, não-nulo), `Semipresencial`, `Ead`.
 - `Turno` — `Matutino`, `Vespertino`, `Noturno`, `Integral`.
 - `EMecCodigo` — código e-MEC **por campus-sede** (do registro de diploma/COC), herdado pelos convênios do mesmo campus.
-- `CodigoSga` — código no Sistema de Gestão Acadêmica (do `cod_curso` do SIGAA). Nome **vendor-neutral** ([ver convenção](#mais-informações)) para não acoplar o domínio ao SIGAA.
+- `CodigoSga` — código no Sistema de Gestão Acadêmica (do `cod_curso` do SIGAA). Nome **vendor-neutral** (ver a convenção de nome na seção "Mais informações") para não acoplar o domínio ao SIGAA.
 - `VagasAnuaisAutorizadas`.
 - `BaseLegal` — **obrigatório quando `Modalidade != Regular`** (programa-mãe, ex.: "Convênio Forma Pará nº 004/2020").
 - `AtoAutorizacaoMec` — **opcional** (ato específico da oferta, ex.: "Carta de aceite Prefeitura de Almeirim 2024").
@@ -79,7 +79,7 @@ A pesquisa sobre os programas itinerantes confirmou um padrão **híbrido nos qu
 
 ### Negativas
 
-- Migração dos dados legados exige separar ~40 cursos curriculares de ~95 ofertas, com matching COC↔SIGAA imperfeito (parte das ofertas ainda sem `CodigoSga`).
+- Migração dos dados legados exige separar cerca de 40 cursos curriculares das ofertas regulatórias, com matching COC↔SIGAA imperfeito (parte das ofertas ainda sem `CodigoSga`).
 - Snapshot-copy da unidade ofertante ([ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md)) exige disciplina de rebinding quando a unidade muda — trade-off já assumido pela ADR-0061.
 
 ### Neutras

--- a/docs/adrs/0066-ofertacurso-modelo-tres-niveis-emec-por-campus.md
+++ b/docs/adrs/0066-ofertacurso-modelo-tres-niveis-emec-por-campus.md
@@ -1,0 +1,101 @@
+---
+status: "accepted"
+date: "2026-05-19"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0066: Modelo de oferta em três níveis — Curso curricular, OfertaCurso regulatória e código e-MEC por campus
+
+## Contexto e enunciado do problema
+
+O wizard de Configuração de Edital precisa expressar **quais cursos têm vagas em quais locais, sob qual modalidade**. O protótipo legado misturava num único conceito de "curso" três coisas distintas: a matriz curricular, a instância regulatória (onde/como o curso é ofertado) e o registro nacional (código e-MEC). Essa mistura gera inconsistências reais: "Engenharia Civil" é ofertada em Marabá (instituto IGE) e em Santana do Araguaia (instituto IEA) — mesmo nome de curso, unidades ofertantes diferentes, e códigos e-MEC diferentes.
+
+A deliberação precisou responder a duas perguntas acopladas:
+
+1. Qual a granularidade do "curso" que o edital referencia — a matriz curricular ou a oferta concreta?
+2. Onde vive o `e_mec_codigo` — é atributo estável do curso, ou varia por local de oferta?
+
+Quatro fontes institucionais autoritativas (endereços e-MEC da IES 18440; campo `codigoIES` do COC; campos `cod_curso`/`nome_oficial`/`unidade` do SIGAA; campo `cod_emec` do registro de diploma) foram cruzadas em 2026-05-19. Elas provaram que o código e-MEC **varia por campus-sede** e é herdado pelos convênios: Engenharia Civil → `1262444` (Marabá/IGE) e `1276153` (Santana/IEA); História Licenciatura → `1262485` (Marabá) e `1270446` (Xinguara); Matemática Licenciatura → `12037` (Marabá) e `1270326` (Santana).
+
+## Drivers da decisão
+
+- **Consistência regulatória**: o edital deve apontar para uma oferta estável e auditável, não para um conceito ambíguo que confunde matriz, local e código.
+- **Granularidade mista real**: a unidade ofertante (instituto acadêmico responsável) varia por local para o mesmo curso — isso é característica da oferta, não inconsistência do curso.
+- **Evidência sobre inferência**: a localização do `e_mec_codigo` deve seguir as quatro fontes legadas, não suposição.
+- **Forward-compat**: novos formatos pedagógicos, turnos e polos devem tocar apenas a oferta, mantendo a matriz curricular estável.
+
+## Opções consideradas
+
+- **Modelo de dois níveis** — `Curso` carregando local, modalidade e `e_mec_codigo`, com uma linha por combinação. Foi o ponto de partida do protótipo.
+- **Modelo de três níveis com `e_mec_codigo` no Curso** — separar `Curso` (curricular) de `OfertaCurso` (regulatória), mantendo o código e-MEC como atributo único do curso.
+- **Modelo de três níveis com `e_mec_codigo` na OfertaCurso** — separar curricular de regulatório e mover o código e-MEC para a oferta, refletindo a variação por campus comprovada nas fontes.
+
+## Resultado da decisão
+
+**Escolhida:** "Modelo de três níveis com `e_mec_codigo` na OfertaCurso" (`Curso → OfertaCurso → Turma`), porque é o único que reconcilia a granularidade mista observada (mesmo curso, institutos e códigos e-MEC diferentes por campus) com a estabilidade da matriz curricular.
+
+Como catálogo cross-módulo, `Curso` e `OfertaCurso` vivem no módulo **Parametrizacao** ([ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md)). A referência de `OfertaCurso` à `Unidade` ofertante atravessa o bounded context `OrganizacaoInstitucional` ([ADR-0055](0055-organizacao-institucional-bounded-context.md)) e, por isso, segue o snapshot-copy da [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md) (cópia imutável dos dados relevantes da unidade, sem FK cross-banco).
+
+**`Curso` — curricular puro (~40 entradas):**
+
+- `Codigo`, `Nome`, `Grau`.
+- Opcionalmente `TitulacaoFeminino`/`TitulacaoMasculino` (do SIGAA, para diploma e para a RN02 de `docs/visao-do-projeto.md` — nome social).
+- `CargaHorariaTotal`, `DuracaoSemestresPadrao`, `DescricaoCurricular`, `Ativo`.
+- **Sem `e_mec_codigo`.**
+
+**`OfertaCurso` — instância regulatória (~95 entradas reais):**
+
+- `CursoId` — referência à matriz curricular.
+- `LocalOfertaId` — referência ao `LocalOferta` específico ([ADR-0065](0065-localoferta-flat-um-por-endereco-emec.md)).
+- `UnidadeOfertante` — snapshot-copy ([ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md)) do instituto/faculdade responsável (varia por campus — granularidade mista confirmada pelo campo `unidade` do SIGAA).
+- `Modalidade` — `Regular`, `FormaPara`, `Parfor`, `Pronera`, `Pepeti`, `ConvenioOutro`, `Outro`.
+- `FormatoPedagogico` — `Presencial` (default, não-nulo), `Semipresencial`, `Ead`.
+- `Turno` — `Matutino`, `Vespertino`, `Noturno`, `Integral`.
+- `EMecCodigo` — código e-MEC **por campus-sede** (do registro de diploma/COC), herdado pelos convênios do mesmo campus.
+- `CodigoSga` — código no Sistema de Gestão Acadêmica (do `cod_curso` do SIGAA). Nome **vendor-neutral** ([ver convenção](#mais-informações)) para não acoplar o domínio ao SIGAA.
+- `VagasAnuaisAutorizadas`.
+- `BaseLegal` — **obrigatório quando `Modalidade != Regular`** (programa-mãe, ex.: "Convênio Forma Pará nº 004/2020").
+- `AtoAutorizacaoMec` — **opcional** (ato específico da oferta, ex.: "Carta de aceite Prefeitura de Almeirim 2024").
+- `VigenciaInicio`, `VigenciaFim`, `Ativo`.
+
+**`Turma`** é o terceiro nível e fica **fora do MVP** (integração SIGAA futura).
+
+O edital referencia `OfertaCurso` (estável entre semestres), não `Curso`. A junção edital↔oferta carrega `VagasOfertadas ≤ OfertaCurso.VagasAnuaisAutorizadas`.
+
+A pesquisa sobre os programas itinerantes confirmou um padrão **híbrido nos quatro** (Forma Pará, PARFOR, Pronera, Pepeti): sempre há um programa-mãe (guarda-chuva, em `BaseLegal`) mais um ato específico por oferta (opcional, em `AtoAutorizacaoMec`). O `e_mec_codigo` permanece atributo do registro nacional por campus; a oferta adiciona o local de funcionamento.
+
+## Consequências
+
+### Positivas
+
+- A granularidade mista (institutos diferentes por campus para o mesmo curso) deixa de ser inconsistência e vira característica da oferta.
+- O `e_mec_codigo` reflete as quatro fontes legadas (varia por campus-sede), eliminando a contradição de tratá-lo como único por curso.
+- O edital aponta para algo estável (`OfertaCurso`); novos formatos/turnos/polos tocam só a oferta.
+- As quatro fontes legadas cruzadas tornam-se base de migração de dados para produção.
+
+### Negativas
+
+- Migração dos dados legados exige separar ~40 cursos curriculares de ~95 ofertas, com matching COC↔SIGAA imperfeito (parte das ofertas ainda sem `CodigoSga`).
+- Snapshot-copy da unidade ofertante ([ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md)) exige disciplina de rebinding quando a unidade muda — trade-off já assumido pela ADR-0061.
+
+### Neutras
+
+- O terceiro nível (`Turma`) fica reservado mas não implementado no MVP.
+
+## Confirmação
+
+- `e_mec_codigo` **não** existe em `Curso`; existe em `OfertaCurso`. Verificável por inspeção do modelo e por teste de migração que confirma códigos distintos para o mesmo curso em campi diferentes (ex.: Engenharia Civil `1262444` vs `1276153`).
+- `BaseLegal` é obrigatório sempre que `Modalidade != Regular` — candidato a invariante validado no domínio.
+- `OfertaCurso.UnidadeOfertante` é value object (snapshot), não FK cross-banco ([ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md)).
+
+## Mais informações
+
+- **Convenção de nome vendor-neutral:** `e_mec_codigo` mantém nome próprio (registro nacional estável), mas `CodigoSga` (SGA = Sistema de Gestão Acadêmica) é genérico para não acoplar o domínio ao SIGAA.
+- Os sete cursos que a busca pública não localizou foram completados pelo registro de diploma (Biologia Lic. `1442854`, Jornalismo `1276154`, Engenharia Florestal `1457294`, Arquitetura `1483808`, Zootecnia `1276151`, Medicina Veterinária `1276152`).
+- Refina a [ADR-0065](0065-localoferta-flat-um-por-endereco-emec.md): convênios de interiorização (Jacundá, Parauapebas, Canaã não-Pepeti) têm `LocalOferta.Tipo = ConvenioInteriorizacao`, com o vínculo acadêmico em `OfertaCurso.UnidadeOfertante`.
+- **Pendências a confirmar com PROEG/Procuradoria (não bloqueiam):** granularidade exata da autorização PARFOR (turma vs lote de edital); Pronera (1 projeto = 1 ou N turmas); financiador do Pepeti.
+- **Origem:** deliberação técnica de modelagem do Módulo Configuração de Edital conduzida pelo Tech Lead (2026-05-19), com confirmação operacional da equipe CTIC sobre os legados COC/UDOCS, validada contra quatro fontes institucionais (endereços e-MEC da IES 18440, COC, SIGAA, registro de diploma); rascunhos de trabalho não publicados.

--- a/docs/adrs/0067-aninhamento-tipodeficiencia-sob-pcd.md
+++ b/docs/adrs/0067-aninhamento-tipodeficiencia-sob-pcd.md
@@ -51,14 +51,14 @@ AtendimentoEspecializadoOferta {
 
 **Invariantes estruturais** (o modelo não admite estado inválido):
 
-- `PCD ∈ condicoesAceitas` ⟺ `detalhesPcd.tiposDeficiencia.Count ≥ 1`
+- `PCD ∈ condicoesAceitas` ⟺ `detalhesPcd.tiposDeficiencia` contém ao menos um item
 - `PCD ∉ condicoesAceitas` ⟹ `detalhesPcd` é null/ausente
 - `TipoDeficiencia` jamais aparece fora de `detalhesPcd`
 
 **Mapeamento para o `uniplus-api`:**
 
 - `detalhesPcd` é um **value object** (sem identidade própria).
-- `TipoDeficiencia` é uma **entidade dependente** — não tem identidade fora do contexto da oferta PCD; o catálogo de tipos vive em Parametrizacao (junto a `NecessidadeEspecial`/`RecursoAcessibilidade`, [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md)), mas no edital só aparece aninhado.
+- `TipoDeficiencia` é uma **entidade dependente** — não tem identidade fora do contexto da oferta PCD; o catálogo de tipos vive em Parametrizacao, junto aos catálogos de acessibilidade da [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) (lá nomeado `NecessidadeEspecial`, nome anterior à adoção do vocabulário "atendimento especializado" — a reconciliação terminológica fica como pendência registrada, candidata a ADR futura), mas no edital só aparece aninhado.
 - A invariante `OBRIGATORIEDADE_PCD_COERENTE` é validada no domínio na construção/edição da oferta.
 - **Snapshot RN08**: na publicação do edital, `detalhesPcd.tiposDeficiencia` é denormalizado no snapshot de governança (consistente com [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md)), preservando a integridade mesmo que um `TipoDeficiencia` seja inativado depois.
 

--- a/docs/adrs/0067-aninhamento-tipodeficiencia-sob-pcd.md
+++ b/docs/adrs/0067-aninhamento-tipodeficiencia-sob-pcd.md
@@ -1,0 +1,92 @@
+---
+status: "accepted"
+date: "2026-05-19"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0067: Aninhamento de TipoDeficiencia sob a condição PCD na oferta de atendimento especializado
+
+## Contexto e enunciado do problema
+
+Ao configurar um edital, o CEPS define qual **atendimento especializado** o processo oferece. Essa oferta tem três dimensões distintas que o protótipo legado tratava de forma plana e ambígua:
+
+1. As **condições** aceitas para solicitar atendimento (PCD, dislexia, TDAH, lactante, etc.).
+2. Os **tipos de deficiência** reconhecidos — que só fazem sentido **dentro** da condição PCD.
+3. Os **recursos de acessibilidade** oferecidos (ledor, prova ampliada, intérprete de Libras, tempo adicional, etc.), independentes das condições.
+
+O termo institucional adotado no Uni+ é **"atendimento especializado"** (alinhado ao INEP / Edital ENEM 52/2025), descartando "atendimento diferenciado/especial" e "necessidade especial". Há três entidades de domínio distintas no tema: `TipoDeficiencia`, `RecursoAcessibilidade` e `SolicitacaoAtendimentoEspecializado` (esta última no lado do candidato, na inscrição).
+
+O problema de modelagem: `TipoDeficiencia` é uma **dimensão ortogonal** à lista de condições (cada uma é uma entidade independente), ou é um **sub-detalhamento da condição PCD** (só existe quando PCD é aceita)? A escolha errada permite estados inválidos — por exemplo, tipos de deficiência selecionados sem que PCD seja uma condição aceita, ou PCD aceita sem nenhum tipo de deficiência reconhecido.
+
+## Drivers da decisão
+
+- **Impossibilitar estado inválido por construção**, em vez de depender de validação defensiva espalhada.
+- **Alinhamento com modelos brasileiros consolidados** de atendimento especializado em processos seletivos.
+- **UX coerente**: a tela não deve pedir ao operador que mantenha duas listas sincronizadas manualmente.
+- **Integridade de auditoria (RN08)**: o que foi ofertado precisa ser reconstruível na publicação do edital.
+
+## Opções consideradas
+
+- **PCD derivada dos tipos de deficiência** — a condição PCD é inferida quando há ao menos um tipo de deficiência selecionado; não existe flag PCD própria.
+- **TipoDeficiencia como dimensão ortogonal** — lista de tipos de deficiência independente da lista de condições, com validação cruzada garantindo coerência.
+- **TipoDeficiencia aninhada sob PCD** — os tipos de deficiência vivem dentro de um bloco `detalhes_pcd` que só existe quando PCD está entre as condições aceitas.
+
+## Resultado da decisão
+
+**Escolhida:** "TipoDeficiencia aninhada sob PCD", porque torna o estado inválido **inalcançável por construção** e alinha-se aos modelos brasileiros de referência (INEP/ENEM, banca Cebraspe/UnB e a estrutura da LBI — Lei 13.146/2015).
+
+Forma canônica da oferta de atendimento especializado do edital:
+
+```text
+AtendimentoEspecializadoOferta {
+  condicoesAceitas: CondicaoAtendimentoEspecializado[]   // ex.: PCD, DISLEXIA, TDAH, LACTANTE…
+  detalhesPcd: { tiposDeficiencia: TipoDeficiencia[] } | null   // existe apenas se PCD ∈ condicoesAceitas
+  recursosOferecidos: RecursoAcessibilidade[]            // independentes das condições
+}
+```
+
+**Invariantes estruturais** (o modelo não admite estado inválido):
+
+- `PCD ∈ condicoesAceitas` ⟺ `detalhesPcd.tiposDeficiencia.Count ≥ 1`
+- `PCD ∉ condicoesAceitas` ⟹ `detalhesPcd` é null/ausente
+- `TipoDeficiencia` jamais aparece fora de `detalhesPcd`
+
+**Mapeamento para o `uniplus-api`:**
+
+- `detalhesPcd` é um **value object** (sem identidade própria).
+- `TipoDeficiencia` é uma **entidade dependente** — não tem identidade fora do contexto da oferta PCD; o catálogo de tipos vive em Parametrizacao (junto a `NecessidadeEspecial`/`RecursoAcessibilidade`, [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md)), mas no edital só aparece aninhado.
+- A invariante `OBRIGATORIEDADE_PCD_COERENTE` é validada no domínio na construção/edição da oferta.
+- **Snapshot RN08**: na publicação do edital, `detalhesPcd.tiposDeficiencia` é denormalizado no snapshot de governança (consistente com [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md)), preservando a integridade mesmo que um `TipoDeficiencia` seja inativado depois.
+
+## Consequências
+
+### Positivas
+
+- Estado inválido (tipos sem PCD, ou PCD sem tipos) é inalcançável — elimina uma classe inteira de validação defensiva.
+- A tela de configuração renderiza um sub-bloco condicional sob PCD, sem listas paralelas a sincronizar.
+- O snapshot na publicação mantém a oferta reproduzível para auditoria retrospectiva.
+
+### Negativas
+
+- A migração de dados legados precisa tratar o caso patológico "PCD marcado sem tipos": registra-se uma observação de migração e um banner de pendência — **nunca** se preenche tipo arbitrariamente.
+- Atrela a evolução de `TipoDeficiencia` ao contexto PCD; um eventual uso de tipos de deficiência fora de PCD exigiria reabrir esta decisão.
+
+### Neutras
+
+- `RecursoAcessibilidade` permanece uma lista independente, sem acoplamento às condições.
+
+## Confirmação
+
+- Invariante de domínio `OBRIGATORIEDADE_PCD_COERENTE` (teste de unidade cobrindo os três casos: PCD com tipos, PCD sem tipos rejeitada, tipos sem PCD rejeitados).
+- Inspeção do modelo confirma que `TipoDeficiencia` só é alcançável via `detalhesPcd`.
+
+## Mais informações
+
+- Vocabulário canônico: **"atendimento especializado"** (INEP/Edital ENEM 52/2025); três entidades distintas — `TipoDeficiencia`, `RecursoAcessibilidade`, `SolicitacaoAtendimentoEspecializado`.
+- Catálogos de referência em Parametrizacao: ver [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md).
+- Snapshot na publicação: ver [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md) e RN08 de `docs/visao-do-projeto.md`.
+- **Origem:** deliberação técnica de modelagem do Módulo Configuração de Edital conduzida pelo Tech Lead (2026-05-19), fundamentada em pesquisa sobre modelos brasileiros de atendimento especializado (INEP/ENEM, Cebraspe/UnB, LBI Lei 13.146/2015); rascunhos de trabalho não publicados.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -93,6 +93,9 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0062](0062-seed-de-catalogos-via-newman-e-endpoints-admin.md) | Seed de catálogos via Newman + endpoints admin (sem auto-seeder, audit captura usuário real) | accepted | 2026-05-14 |
 | [0063](0063-entidades-forensics-isentas-de-soft-delete.md) | Entidades forensics append-only (`IForensicEntity`) isentas de soft-delete, mutuamente exclusivas com `EntityBase` | accepted | 2026-05-16 |
 | [0064](0064-convencao-roteamento-path-based-com-prefixo-modulo.md) | Convenção de roteamento — path-based com prefixo de módulo (`/api/{modulo}/{recurso}`), separação cross-API via PathPrefix no Traefik | accepted | 2026-05-16 |
+| [0065](0065-localoferta-flat-um-por-endereco-emec.md) | LocalOferta como entidade flat, uma entrada por local de oferta (endereço e-MEC) | accepted | 2026-05-19 |
+| [0066](0066-ofertacurso-modelo-tres-niveis-emec-por-campus.md) | Modelo de oferta em três níveis — Curso curricular, OfertaCurso regulatória e código e-MEC por campus | accepted | 2026-05-19 |
+| [0067](0067-aninhamento-tipodeficiencia-sob-pcd.md) | Aninhamento de TipoDeficiencia sob a condição PCD na oferta de atendimento especializado | accepted | 2026-05-19 |
 
 ## Como adicionar um novo ADR
 


### PR DESCRIPTION
## Objetivo

Promover para o acervo MADR oficial (`docs/adrs/`) as decisões binding de modelagem de domínio do **Módulo Configuração de Edital**, fechadas no gate de modelagem de 2026-05-19 e validadas contra quatro fontes institucionais (endereços e-MEC da IES 18440, COC, SIGAA, registro de diploma).

Closes #534

## ADRs adicionados

| ADR | Decisão |
|-----|---------|
| **0065** | `LocalOferta` como entidade **flat**, uma entrada por local de oferta (endereço e-MEC), no módulo Parametrizacao. Espelha o cadastro do MEC (13 endereços sob a IES 18440) sem inventar hierarquia. Rótulo de UI "Locais de Oferta". |
| **0066** | Modelo de oferta em **três níveis** (`Curso` curricular → `OfertaCurso` regulatória → `Turma`). Correção evidence-locked: o código e-MEC **varia por campus-sede** e vive em `OfertaCurso`, não em `Curso`. Unidade ofertante via snapshot-copy (ADR-0061); `BaseLegal` obrigatório quando `Modalidade != Regular`. |
| **0067** | Aninhamento de `TipoDeficiencia` sob a condição **PCD** na oferta de atendimento especializado. A invariante torna o estado inválido inalcançável por construção; snapshot RN08 na publicação. |

## Encaixe na arquitetura existente

- Catálogos cross-módulo (`Curso`/`OfertaCurso`/`LocalOferta`) no módulo **Parametrizacao** — consistente com [ADR-0056](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0056-parametrizacao-modulo-e-read-side-carve-out.md).
- Referência `OfertaCurso → Unidade` atravessa o bounded context **OrganizacaoInstitucional** ([ADR-0055](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0055-organizacao-institucional-bounded-context.md)) via **snapshot-copy** ([ADR-0061](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0061-referencia-cross-modulo-via-snapshot-copy.md)), não FK cross-banco.
- Endereço físico via value object `Endereco` (ADR-0056); snapshot na publicação alinhado à RN08.

## Critérios de aceite (Story #534)

- [x] **ADR A** (0067) — aninhamento PCD com invariante; vocabulário canônico "atendimento especializado" + 3 entidades distintas.
- [x] **ADR B** (0065) — `LocalOferta` como entidade com `Tipo`; vínculo acadêmico em `OfertaCurso.UnidadeOfertante`.
- [x] **ADR C** (0066) — separação `Curso`/`OfertaCurso`; `e_mec_codigo` em OfertaCurso com as 4 fontes; `codigo_sga` vendor-neutral; `base_legal`.
- [x] Numeração MADR sequencial (0065–0067); índice `docs/adrs/README.md` atualizado.
- [x] Linter de ADR (`tools/adr-lint/validate.sh`) + `markdownlint-cli2` passando.
- [x] Conteúdo pt-BR com acentuação; títulos sem notação de deliberação.

> ADRs opcionais D (`Unidade.tipo`) e E (snapshot RN08) seguem como follow-up na Feature #533.

## Validação

```
67 ADR(s) validados sem erros (frontmatter MADR 4.0).
markdownlint-cli2: 0 error(s)
```