### PR TITLE
refactor(shared): relógio via TimeProvider injetado obrigatório (ADR-0068)

### DIFF
--- a/docs/adrs/0068-relogio-via-timeprovider-injetado.md
+++ b/docs/adrs/0068-relogio-via-timeprovider-injetado.md
@@ -1,0 +1,86 @@
+---
+status: "proposed"
+date: "2026-05-24"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0068: Relógio via TimeProvider injetado, obrigatório em todo o `src/`
+
+## Contexto e enunciado do problema
+
+Parte do código novo do `uniplus-api` já lê o relógio de forma testável via `System.TimeProvider` (BCL .NET 8+): idempotência ([ADR-0027](0027-idempotency-key-store-postgresql.md)), cursor pagination ([ADR-0026](0026-paginacao-cursor-opaco-cifrado.md) — `CursorEncoder`), a entidade `ObrigatoriedadeLegal` ([ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md)) e vários handlers. A convenção existia de facto, mas **não estava declarada nem enforçada**, e a fundação a contradizia.
+
+A fundação e os interceptors de auditoria — anteriores a essa convenção — liam o relógio estático direto: `EntityBase.CreatedAt = DateTimeOffset.UtcNow` (inicializador), `EntityBase.MarkAsDeleted` (instante interno), `DomainEventBase.OccurredOn = DateTimeOffset.UtcNow`, `AuditableInterceptor`/`SoftDeleteInterceptor`, geração de protocolos (`Inscricao`, `ProtocoloConvocacao`), e o cache de token do Schema Registry. Resultado: três efeitos colaterais — (1) `CreatedAt` tinha duas fontes (o inicializador do domínio **e** o `AuditableInterceptor`, que o sobrescreve no `Added`); (2) `OccurredOn` e tempos de negócio eram não-determinísticos em teste; (3) nada impedia o próximo `DateTimeOffset.UtcNow` de entrar.
+
+A questão a decidir é: **como tornar o acesso a relógio uniforme, testável e à prova de regressão em todo o `src/`** — e, decidido isso, **se o `TimeProvider` deve ser obrigatório (injetado sempre) ou opcional com fallback `TimeProvider.System`**.
+
+## Drivers da decisão
+
+- **Determinismo de teste.** Tempos de negócio (`OccurredOn`, `DataManifestacao`, prefixo de protocolo, vigência) e timestamps de auditoria precisam ser fixáveis via um `TimeProvider` fixo em teste (test double, ou `FakeTimeProvider` quando for preciso simular avanço) sem `Thread.Sleep`/tolerância de janela.
+- **Fonte única por timestamp.** `CreatedAt`/`UpdatedAt`/`DeletedAt` são audit trail de persistência; ter o domínio e o interceptor ambos escrevendo o instante é ambíguo.
+- **Coerência interna.** O projeto já padronizou `TimeProvider`; falta declarar e generalizar — espelha a postura de "padrão único" da [ADR-0032](0032-guid-v7-para-identidade-de-entidades.md) e da abstração canônica única da [ADR-0033](0033-iusercontext-como-abstracao-de-autenticacao.md).
+- **À prova de regressão.** A convenção não pode depender de disciplina de revisão; precisa de enforcement automático no build, como a fitness function de `Guid.NewGuid()`.
+- **Clean Architecture.** A solução não pode arrastar dependência de infraestrutura para o domínio — `TimeProvider` é primitivo de BCL (como `DateTimeOffset`), então pode residir no domínio sem violar a regra de dependência.
+
+## Opções consideradas
+
+- **A. `TimeProvider` injetado e obrigatório** — sem default `null`, sem fallback `TimeProvider.System` em código de negócio; relógio sempre fornecido pelo caller; fitness test bane leitura estática.
+- **B. `TimeProvider` injetado, opcional com fallback `System`** — `TimeProvider? clock = null` → `clock ?? TimeProvider.System`; baixo churn, mas mantém um caminho de não-determinismo.
+- **C. Abstração própria `IDateTimeProvider`/`IClock`** — interface custom registrada na DI.
+- **D. Manter `DateTimeOffset.UtcNow` inline** — status quo; descartado de antemão por não ser testável nem determinístico.
+
+## Resultado da decisão
+
+**Escolhida:** "A — `TimeProvider` injetado e obrigatório", porque é a única opção que fecha o backdoor de não-determinismo sem reintroduzir dívida.
+
+**Sem exceções, sem fallback escondido.** Todo método de negócio que lê o relógio recebe `TimeProvider clock` obrigatório (com `ArgumentNullException.ThrowIfNull`) — entidades (`Edital.Publicar`, `Inscricao.Criar/Confirmar`, `Convocacao.Criar/Aceitar/Recusar`, `Matricula.Efetivar`), value objects (`ProtocoloConvocacao.Gerar`), factories de conveniência (`ObrigatoriedadeLegal.Criar`) e serviços de infraestrutura (interceptors, repositórios, `OAuthBearerAuthenticationHeaderValueProvider`, endpoints smoke). A opção B foi rejeitada explicitamente: `clock ?? TimeProvider.System` compila para qualquer caller que passe `null`, e um teste que esqueça o relógio passa silenciosamente a depender do relógio real — exatamente o que se quer eliminar.
+
+**Fonte única de auditoria nos interceptors.** `EntityBase.CreatedAt` perde o inicializador e passa a ser carimbado exclusivamente pelo `AuditableInterceptor` no `SaveChanges` (estado `Added`) a partir do `TimeProvider` injetado; `UpdatedAt` idem no `Modified`; `MarkAsDeleted(string, DateTimeOffset)` recebe o instante do `SoftDeleteInterceptor`. Uma entidade transiente (pré-persistência) tem `CreatedAt` default — comportamento correto: ela ainda não foi criada do ponto de vista do audit trail.
+
+**`OccurredOn` é instante de negócio, fornecido na origem.** `DomainEventBase(DateTimeOffset OccurredOn)` torna o campo parâmetro obrigatório do construtor; o método de entidade que levanta o evento passa `clock.GetUtcNow()`.
+
+**`TimeProvider` do BCL, não abstração própria (rejeita C).** `TimeProvider` (.NET 8+) é o ponto Schelling da plataforma: tem `FakeTimeProvider` oficial (`Microsoft.Extensions.TimeProvider.Testing`), cobre relógio, timers e timestamps de alta resolução, e o projeto já o usa. Uma interface custom seria reinvenção com menos capacidade e mais carga de manutenção.
+
+**`TimeProvider.System` só em composition roots.** Permanece permitido apenas onde a composição acontece e não há `IServiceProvider` para resolver: registrations de DI (`services.TryAddSingleton(TimeProvider.System)` em `AddUniPlusEfInterceptors`, paginação e idempotência) e o callback de configuração do Wolverine (`SchemaRegistryServiceCollectionExtensions.CreateClient`, que roda antes de `builder.Build()`). Em código de teste, `TimeProvider.System` (ou um `FakeTimeProvider`) é escolha explícita do teste, não default de produção.
+
+### Esta ADR não decide
+
+- **Identidade determinística (UUIDv7).** `EntityBase.Id` e `DomainEventBase.EventId` continuam gerados por `Guid.CreateVersion7()` internamente — tornar a identidade determinística é escopo da [ADR-0032](0032-guid-v7-para-identidade-de-entidades.md), não desta convenção. O leak de timestamp embutido no UUIDv7 já foi avaliado lá.
+- **Migração de medições de duração.** Usos de `Stopwatch.GetTimestamp()` (ex.: `RequestLoggingMiddleware`) medem *elapsed*, não *wall-clock*; ficam fora desta convenção.
+- **Tornar determinísticos os testes que hoje passam `TimeProvider.System`.** Migrar suítes para `FakeTimeProvider` e assertar instantes exatos é melhoria incremental de qualidade de teste, não requisito desta decisão.
+
+## Consequências
+
+### Positivas
+
+- **Determinismo de relógio disponível em todo o domínio e infra** — qualquer cenário (vigência, expiração de cursor/idempotência, `OccurredOn`, protocolo) é fixável por um `TimeProvider` fixo em teste; os interceptors de auditoria já têm testes determinísticos assertando o instante exato.
+- **`CreatedAt`/`UpdatedAt`/`DeletedAt` com fonte única** — o `AuditableInterceptor`/`SoftDeleteInterceptor` é a autoridade; some a ambiguidade domínio×interceptor.
+- **Convenção à prova de regressão** — o fitness test falha o build no primeiro `DateTimeOffset.UtcNow` cru reintroduzido em `src/`.
+- **Coerência com o stack** — `TimeProvider` do BCL, zero dependência nova; alinhado ao padrão emergente da plataforma.
+
+### Negativas
+
+- **Assinaturas de domínio carregam `TimeProvider`** — métodos que antes não tinham parâmetro agora recebem o relógio; o ganho de testabilidade justifica.
+- **Churn de call-sites de teste** — testes que construíam interceptors/entidades sem relógio passam a fornecer `TimeProvider.System` ou um fake explícito.
+- **`CreatedAt` default em entidade transiente** — código que lê `CreatedAt` antes do `SaveChanges` vê `default`; correto semanticamente, mas exige atenção (após persistir, o interceptor já carimbou a instância rastreada).
+
+### Neutras
+
+- **`TimeProvider.System` segue presente em composition roots** — é o lugar legítimo do relógio real; não é exceção à regra, é a fronteira dela.
+
+## Confirmação
+
+1. **Fitness test solution-wide** — `RelogioViaTimeProviderTests` em `tests/Unifesspa.UniPlus.ArchTests/SolutionRules/` varre por regex os arquivos `.cs` de `src/` (excluindo `obj/`/`bin/`, com strip de comentários) e falha o build ao encontrar `DateTime`/`DateTimeOffset` `.UtcNow`/`.Now`. Espelha `DominioNaoUsaGuidNewGuidTests` ([ADR-0032](0032-guid-v7-para-identidade-de-entidades.md)) — mesma abordagem textual, justificada porque ArchUnitNET enxerga dependência de tipo, não chamada de membro.
+2. **Compilador** — `TimeProvider` obrigatório (sem default) faz o build falhar em qualquer caller que omita o relógio; `ArgumentNullException.ThrowIfNull(clock)` cobre passagem de `null` em runtime.
+3. **Code review** — revisor confirma que código novo recebe `TimeProvider` por injeção e que `TimeProvider.System` aparece apenas em composition roots ou em teste.
+
+## Mais informações
+
+- [ADR-0032](0032-guid-v7-para-identidade-de-entidades.md) — fitness function irmã (`Guid.NewGuid()`); a identidade UUIDv7 fica fora desta convenção.
+- [ADR-0033](0033-iusercontext-como-abstracao-de-autenticacao.md) — mesma postura de "abstração canônica única" para um cross-cutting concern.
+- [ADR-0004](0004-outbox-transacional-via-wolverine.md) / [ADR-0005](0005-cascading-messages-para-drenagem-de-domain-events.md) — `OccurredOn` viaja no envelope do outbox; agora com instante de negócio determinístico.
+- [ADR-0027](0027-idempotency-key-store-postgresql.md) / [ADR-0026](0026-paginacao-cursor-opaco-cifrado.md) — já consumiam `TimeProvider`; esta ADR generaliza o padrão.
+- [TimeProvider — Microsoft Learn](https://learn.microsoft.com/dotnet/api/system.timeprovider) — API oficial (BCL .NET 8+).
+- [Microsoft.Extensions.TimeProvider.Testing — FakeTimeProvider](https://learn.microsoft.com/dotnet/core/extensions/timeprovider) — controle de tempo em teste.
+- Issues #127 / #390 (uniplus-api) — origem do `SoftDeleteInterceptor`/`AuditableInterceptor` cujo carimbo de tempo passa a ser injetado.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -96,6 +96,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0065](0065-localoferta-flat-um-por-endereco-emec.md) | LocalOferta como entidade flat, uma entrada por local de oferta (endereço e-MEC) | accepted | 2026-05-19 |
 | [0066](0066-ofertacurso-modelo-tres-niveis-emec-por-campus.md) | Modelo de oferta em três níveis — Curso curricular, OfertaCurso regulatória e código e-MEC por campus | accepted | 2026-05-19 |
 | [0067](0067-aninhamento-tipodeficiencia-sob-pcd.md) | Aninhamento de TipoDeficiencia sob a condição PCD na oferta de atendimento especializado | accepted | 2026-05-19 |
+| [0068](0068-relogio-via-timeprovider-injetado.md) | Relógio via TimeProvider injetado, obrigatório em todo o `src/` | proposed | 2026-05-24 |
 
 ## Como adicionar um novo ADR
 

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Convocacao.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Convocacao.cs
@@ -18,9 +18,10 @@ public sealed class Convocacao : EntityBase
 
     private Convocacao() { }
 
-    public static Convocacao Criar(Guid chamadaId, Guid inscricaoId, Guid candidatoId, ProtocoloConvocacao protocolo, int posicao, string codigoCurso)
+    public static Convocacao Criar(Guid chamadaId, Guid inscricaoId, Guid candidatoId, ProtocoloConvocacao protocolo, int posicao, string codigoCurso, TimeProvider clock)
     {
         ArgumentNullException.ThrowIfNull(protocolo);
+        ArgumentNullException.ThrowIfNull(clock);
 
         var convocacao = new Convocacao
         {
@@ -33,21 +34,28 @@ public sealed class Convocacao : EntityBase
             CodigoCurso = codigoCurso
         };
 
-        convocacao.AddDomainEvent(new CandidatoConvocadoEvent(inscricaoId, candidatoId, chamadaId, protocolo.Valor));
+        convocacao.AddDomainEvent(new CandidatoConvocadoEvent(
+            inscricaoId,
+            candidatoId,
+            chamadaId,
+            protocolo.Valor,
+            clock.GetUtcNow()));
 
         return convocacao;
     }
 
-    public void Aceitar()
+    public void Aceitar(TimeProvider clock)
     {
+        ArgumentNullException.ThrowIfNull(clock);
         Status = StatusConvocacao.Aceita;
-        DataManifestacao = DateTimeOffset.UtcNow;
+        DataManifestacao = clock.GetUtcNow();
     }
 
-    public void Recusar()
+    public void Recusar(TimeProvider clock)
     {
+        ArgumentNullException.ThrowIfNull(clock);
         Status = StatusConvocacao.Recusada;
-        DataManifestacao = DateTimeOffset.UtcNow;
+        DataManifestacao = clock.GetUtcNow();
     }
 
     public void MarcarComoNaoCompareceu() =>

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Matricula.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Matricula.cs
@@ -49,9 +49,14 @@ public sealed class Matricula : EntityBase
         Observacoes = observacoes;
     }
 
-    public void Efetivar()
+    public void Efetivar(TimeProvider clock)
     {
+        ArgumentNullException.ThrowIfNull(clock);
         Status = StatusMatricula.Efetivada;
-        AddDomainEvent(new MatriculaEfetivadaEvent(Id, CandidatoId, CodigoCurso));
+        AddDomainEvent(new MatriculaEfetivadaEvent(
+            Id,
+            CandidatoId,
+            CodigoCurso,
+            clock.GetUtcNow()));
     }
 }

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Events/CandidatoConvocadoEvent.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Events/CandidatoConvocadoEvent.cs
@@ -2,4 +2,5 @@ namespace Unifesspa.UniPlus.Ingresso.Domain.Events;
 
 using Unifesspa.UniPlus.Kernel.Domain.Events;
 
-public sealed record CandidatoConvocadoEvent(Guid InscricaoId, Guid CandidatoId, Guid ChamadaId, string Protocolo) : DomainEventBase;
+public sealed record CandidatoConvocadoEvent(Guid InscricaoId, Guid CandidatoId, Guid ChamadaId, string Protocolo, DateTimeOffset OccurredOn)
+    : DomainEventBase(OccurredOn);

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Events/MatriculaEfetivadaEvent.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Events/MatriculaEfetivadaEvent.cs
@@ -2,4 +2,5 @@ namespace Unifesspa.UniPlus.Ingresso.Domain.Events;
 
 using Unifesspa.UniPlus.Kernel.Domain.Events;
 
-public sealed record MatriculaEfetivadaEvent(Guid MatriculaId, Guid CandidatoId, string CodigoCurso) : DomainEventBase;
+public sealed record MatriculaEfetivadaEvent(Guid MatriculaId, Guid CandidatoId, string CodigoCurso, DateTimeOffset OccurredOn)
+    : DomainEventBase(OccurredOn);

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/ValueObjects/ProtocoloConvocacao.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/ValueObjects/ProtocoloConvocacao.cs
@@ -8,9 +8,12 @@ public sealed record ProtocoloConvocacao
 
     private ProtocoloConvocacao(string valor) => Valor = valor;
 
-    public static ProtocoloConvocacao Gerar(int numeroChamada, int sequencial)
+    public static ProtocoloConvocacao Gerar(int numeroChamada, int sequencial, TimeProvider clock)
     {
-        string protocolo = $"CONV-{DateTimeOffset.UtcNow:yyyyMMdd}-{numeroChamada:D2}-{sequencial:D5}";
+        ArgumentNullException.ThrowIfNull(clock);
+        // Prefixo de data vem do TimeProvider injetado (obrigatório, nunca
+        // DateTimeOffset.UtcNow): determinístico sob um TimeProvider fixo em testes.
+        string protocolo = $"CONV-{clock.GetUtcNow():yyyyMMdd}-{numeroChamada:D2}-{sequencial:D5}";
         return new ProtocoloConvocacao(protocolo);
     }
 

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Repositories/ChamadaRepository.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Repositories/ChamadaRepository.cs
@@ -8,10 +8,12 @@ using Domain.Interfaces;
 public sealed class ChamadaRepository : IChamadaRepository
 {
     private readonly IngressoDbContext _context;
+    private readonly TimeProvider _timeProvider;
 
-    public ChamadaRepository(IngressoDbContext context)
+    public ChamadaRepository(IngressoDbContext context, TimeProvider timeProvider)
     {
         _context = context;
+        _timeProvider = timeProvider;
     }
 
     public async Task<Chamada?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken = default)
@@ -43,7 +45,7 @@ public sealed class ChamadaRepository : IChamadaRepository
     public void Remover(Chamada entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
-        entity.MarkAsDeleted("system");
+        entity.MarkAsDeleted("system", _timeProvider.GetUtcNow());
     }
 
     public async Task<Chamada?> ObterComConvocacoesAsync(Guid id, CancellationToken cancellationToken = default)

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Repositories/MatriculaRepository.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Repositories/MatriculaRepository.cs
@@ -8,10 +8,12 @@ using Domain.Interfaces;
 public sealed class MatriculaRepository : IMatriculaRepository
 {
     private readonly IngressoDbContext _context;
+    private readonly TimeProvider _timeProvider;
 
-    public MatriculaRepository(IngressoDbContext context)
+    public MatriculaRepository(IngressoDbContext context, TimeProvider timeProvider)
     {
         _context = context;
+        _timeProvider = timeProvider;
     }
 
     public async Task<Matricula?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken = default)
@@ -43,7 +45,7 @@ public sealed class MatriculaRepository : IMatriculaRepository
     public void Remover(Matricula entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
-        entity.MarkAsDeleted("system");
+        entity.MarkAsDeleted("system", _timeProvider.GetUtcNow());
     }
 
     public async Task<Matricula?> ObterComDocumentosAsync(Guid id, CancellationToken cancellationToken = default)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/PublicarEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/PublicarEditalCommandHandler.cs
@@ -39,11 +39,13 @@ public sealed class PublicarEditalCommandHandler
         PublicarEditalCommand command,
         IEditalRepository editalRepository,
         IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(editalRepository);
         ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
         Edital? edital = await editalRepository.ObterPorIdAsync(command.EditalId, cancellationToken).ConfigureAwait(false);
         if (edital is null)
@@ -60,7 +62,7 @@ public sealed class PublicarEditalCommandHandler
                 []);
         }
 
-        edital.Publicar();
+        edital.Publicar(timeProvider);
         editalRepository.Atualizar(edital);
         await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
@@ -67,9 +67,17 @@ public sealed class Edital : EntityBase
 
     public void AdicionarCota(Cota cota) => _cotas.Add(cota);
 
-    public void Publicar()
+    // clock é obrigatório (sem default): o relógio sempre é injetado — handlers
+    // de produção passam o TimeProvider da DI, testes passam um TimeProvider fixo.
+    // Não há fallback TimeProvider.System aqui para não reintroduzir leitura de
+    // relógio não-determinística. OccurredOn é o instante de negócio da publicação.
+    public void Publicar(TimeProvider clock)
     {
+        ArgumentNullException.ThrowIfNull(clock);
         Status = StatusEdital.Publicado;
-        AddDomainEvent(new EditalPublicadoEvent(Id, NumeroEdital.ToString()));
+        AddDomainEvent(new EditalPublicadoEvent(
+            Id,
+            NumeroEdital.ToString(),
+            clock.GetUtcNow()));
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Inscricao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Inscricao.cs
@@ -20,8 +20,9 @@ public sealed class Inscricao : EntityBase
 
     private Inscricao() { }
 
-    public static Result<Inscricao> Criar(Guid candidatoId, Guid editalId, ModalidadeConcorrencia modalidade, string codigoCursoPrimeiraOpcao)
+    public static Result<Inscricao> Criar(Guid candidatoId, Guid editalId, ModalidadeConcorrencia modalidade, string codigoCursoPrimeiraOpcao, TimeProvider clock)
     {
+        ArgumentNullException.ThrowIfNull(clock);
         var inscricao = new Inscricao
         {
             CandidatoId = candidatoId,
@@ -29,19 +30,20 @@ public sealed class Inscricao : EntityBase
             Modalidade = modalidade,
             Status = StatusInscricao.Rascunho,
             CodigoCursoPrimeiraOpcao = codigoCursoPrimeiraOpcao,
-            NumeroInscricao = GerarNumeroInscricao()
+            NumeroInscricao = GerarNumeroInscricao(clock)
         };
 
         return Result<Inscricao>.Success(inscricao);
     }
 
-    public Result<Inscricao> Confirmar()
+    public Result<Inscricao> Confirmar(TimeProvider clock)
     {
+        ArgumentNullException.ThrowIfNull(clock);
         if (Status != StatusInscricao.Rascunho)
             return Result<Inscricao>.Failure(new DomainError("Inscricao.StatusInvalido", "Somente inscrições em rascunho podem ser confirmadas."));
 
         Status = StatusInscricao.Confirmada;
-        AddDomainEvent(new InscricaoRealizadaEvent(Id, CandidatoId, EditalId));
+        AddDomainEvent(new InscricaoRealizadaEvent(Id, CandidatoId, EditalId, clock.GetUtcNow()));
         return Result<Inscricao>.Success(this);
     }
 
@@ -59,7 +61,8 @@ public sealed class Inscricao : EntityBase
     // Usa RandomNumberGenerator em vez de Guid v4 porque (a) Guid.NewGuid é
     // proibido em domínio (ADR-0032 / fitness test) e (b) Guid v7 não serve
     // aqui — seus primeiros 8 chars são timestamp ms, não random; quem quer
-    // entropia em string curta usa RNG direto.
-    private static string GerarNumeroInscricao() =>
-        $"{DateTimeOffset.UtcNow:yyyyMMdd}-{RandomNumberGenerator.GetHexString(stringLength: 8, lowercase: false)}";
+    // entropia em string curta usa RNG direto. O prefixo de data vem do
+    // TimeProvider injetado (nunca DateTimeOffset.UtcNow), mantendo determinismo.
+    private static string GerarNumeroInscricao(TimeProvider clock) =>
+        $"{clock.GetUtcNow():yyyyMMdd}-{RandomNumberGenerator.GetHexString(stringLength: 8, lowercase: false)}";
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ObrigatoriedadeLegal.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ObrigatoriedadeLegal.cs
@@ -163,20 +163,20 @@ public sealed class ObrigatoriedadeLegal : EntityBase, IAuditableEntity, IAreaSc
     /// Use a sobrecarga completa em código de produção.
     /// </summary>
     /// <param name="clock">
-    /// Fonte de "hoje" para <c>VigenciaInicio</c>. Default
-    /// <see cref="TimeProvider.System"/>; testes determinísticos passam
-    /// um <see cref="TimeProvider"/> fake para isolar o cenário do relógio
-    /// do sistema.
+    /// Fonte de "hoje" para <c>VigenciaInicio</c>. Obrigatório (sem default
+    /// <see cref="TimeProvider.System"/>): a convenção de relógio exige que o
+    /// <see cref="TimeProvider"/> seja sempre injetado. Testes passam um
+    /// <see cref="TimeProvider"/> fake para isolar o cenário do relógio.
     /// </param>
     public static Result<ObrigatoriedadeLegal> Criar(
         string regraCodigo,
         PredicadoObrigatoriedade predicado,
         string baseLegal,
         string descricaoHumana,
-        string? portariaInternaCodigo = null,
-        TimeProvider? clock = null)
+        string? portariaInternaCodigo,
+        TimeProvider clock)
     {
-        TimeProvider effectiveClock = clock ?? TimeProvider.System;
+        ArgumentNullException.ThrowIfNull(clock);
         return Criar(
             tipoEditalCodigo: TipoEditalUniversal,
             categoria: CategoriaObrigatoriedade.Outros,
@@ -184,7 +184,7 @@ public sealed class ObrigatoriedadeLegal : EntityBase, IAuditableEntity, IAreaSc
             predicado: predicado,
             descricaoHumana: descricaoHumana,
             baseLegal: baseLegal,
-            vigenciaInicio: DateOnly.FromDateTime(effectiveClock.GetUtcNow().UtcDateTime.Date),
+            vigenciaInicio: DateOnly.FromDateTime(clock.GetUtcNow().UtcDateTime.Date),
             vigenciaFim: null,
             atoNormativoUrl: null,
             portariaInternaCodigo: portariaInternaCodigo,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/ClassificacaoPublicadaEvent.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/ClassificacaoPublicadaEvent.cs
@@ -2,4 +2,5 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Events;
 
 using Unifesspa.UniPlus.Kernel.Domain.Events;
 
-public sealed record ClassificacaoPublicadaEvent(Guid EditalId, string NumeroEdital) : DomainEventBase;
+public sealed record ClassificacaoPublicadaEvent(Guid EditalId, string NumeroEdital, DateTimeOffset OccurredOn)
+    : DomainEventBase(OccurredOn);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/EditalPublicadoEvent.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/EditalPublicadoEvent.cs
@@ -2,4 +2,5 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Events;
 
 using Unifesspa.UniPlus.Kernel.Domain.Events;
 
-public sealed record EditalPublicadoEvent(Guid EditalId, string NumeroEdital) : DomainEventBase;
+public sealed record EditalPublicadoEvent(Guid EditalId, string NumeroEdital, DateTimeOffset OccurredOn)
+    : DomainEventBase(OccurredOn);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/InscricaoRealizadaEvent.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/InscricaoRealizadaEvent.cs
@@ -2,4 +2,5 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Events;
 
 using Unifesspa.UniPlus.Kernel.Domain.Events;
 
-public sealed record InscricaoRealizadaEvent(Guid InscricaoId, Guid CandidatoId, Guid EditalId) : DomainEventBase;
+public sealed record InscricaoRealizadaEvent(Guid InscricaoId, Guid CandidatoId, Guid EditalId, DateTimeOffset OccurredOn)
+    : DomainEventBase(OccurredOn);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Interceptors/ObrigatoriedadeLegalHistoricoInterceptor.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Interceptors/ObrigatoriedadeLegalHistoricoInterceptor.cs
@@ -50,9 +50,16 @@ public sealed class ObrigatoriedadeLegalHistoricoInterceptor : SaveChangesInterc
     private const string SystemUser = "system";
 
     private readonly IUserContext? _userContext;
+    private readonly TimeProvider _timeProvider;
 
-    public ObrigatoriedadeLegalHistoricoInterceptor(IUserContext? userContext = null)
+    // TimeProvider é obrigatório (sem fallback TimeProvider.System): o relógio
+    // é sempre injetado pela DI (Singleton). IUserContext permanece opcional —
+    // o fallback "system" é regra legítima para fluxos sem principal (jobs,
+    // migrations), não um backdoor de não-determinismo.
+    public ObrigatoriedadeLegalHistoricoInterceptor(TimeProvider timeProvider, IUserContext? userContext = null)
     {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        _timeProvider = timeProvider;
         _userContext = userContext;
     }
 
@@ -83,7 +90,7 @@ public sealed class ObrigatoriedadeLegalHistoricoInterceptor : SaveChangesInterc
 
     private void CapturarHistorico(DbContext context)
     {
-        DateTimeOffset snapshotAt = DateTimeOffset.UtcNow;
+        DateTimeOffset snapshotAt = _timeProvider.GetUtcNow();
         string snapshotBy = ResolveSnapshotBy();
 
         List<EntityEntry<ObrigatoriedadeLegal>> entries = CapturarEntries(context);
@@ -108,7 +115,7 @@ public sealed class ObrigatoriedadeLegalHistoricoInterceptor : SaveChangesInterc
 
     private async ValueTask CapturarHistoricoAsync(DbContext context, CancellationToken cancellationToken)
     {
-        DateTimeOffset snapshotAt = DateTimeOffset.UtcNow;
+        DateTimeOffset snapshotAt = _timeProvider.GetUtcNow();
         string snapshotBy = ResolveSnapshotBy();
 
         List<EntityEntry<ObrigatoriedadeLegal>> entries = CapturarEntries(context);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/EditalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/EditalRepository.cs
@@ -8,10 +8,12 @@ using Domain.Interfaces;
 public sealed class EditalRepository : IEditalRepository
 {
     private readonly SelecaoDbContext _context;
+    private readonly TimeProvider _timeProvider;
 
-    public EditalRepository(SelecaoDbContext context)
+    public EditalRepository(SelecaoDbContext context, TimeProvider timeProvider)
     {
         _context = context;
+        _timeProvider = timeProvider;
     }
 
     public async Task<Edital?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken = default)
@@ -43,7 +45,7 @@ public sealed class EditalRepository : IEditalRepository
     public void Remover(Edital entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
-        entity.MarkAsDeleted("system");
+        entity.MarkAsDeleted("system", _timeProvider.GetUtcNow());
     }
 
     public async Task<Edital?> ObterComEtapasECotasAsync(Guid id, CancellationToken cancellationToken = default)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/InscricaoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/InscricaoRepository.cs
@@ -9,10 +9,12 @@ using Domain.Interfaces;
 public sealed class InscricaoRepository : IInscricaoRepository
 {
     private readonly SelecaoDbContext _context;
+    private readonly TimeProvider _timeProvider;
 
-    public InscricaoRepository(SelecaoDbContext context)
+    public InscricaoRepository(SelecaoDbContext context, TimeProvider timeProvider)
     {
         _context = context;
+        _timeProvider = timeProvider;
     }
 
     public async Task<Inscricao?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken = default)
@@ -44,7 +46,7 @@ public sealed class InscricaoRepository : IInscricaoRepository
     public void Remover(Inscricao entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
-        entity.MarkAsDeleted("system");
+        entity.MarkAsDeleted("system", _timeProvider.GetUtcNow());
     }
 
     public async Task<bool> ExisteInscricaoAtivaAsync(Guid candidatoId, Guid editalId, CancellationToken cancellationToken = default)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
@@ -27,11 +27,14 @@ using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
 public sealed class ObrigatoriedadeLegalRepository : IObrigatoriedadeLegalRepository
 {
     private readonly SelecaoDbContext _context;
+    private readonly TimeProvider _timeProvider;
 
-    public ObrigatoriedadeLegalRepository(SelecaoDbContext context)
+    public ObrigatoriedadeLegalRepository(SelecaoDbContext context, TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(timeProvider);
         _context = context;
+        _timeProvider = timeProvider;
     }
 
     public async Task<ObrigatoriedadeLegal?> ObterPorIdAsync(
@@ -106,7 +109,7 @@ public sealed class ObrigatoriedadeLegalRepository : IObrigatoriedadeLegalReposi
 
         if (vigentes)
         {
-            DateOnly hoje = DateOnly.FromDateTime(DateTimeOffset.UtcNow.UtcDateTime.Date);
+            DateOnly hoje = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime.Date);
             query = query.Where(o =>
                 o.VigenciaInicio <= hoje
                 && (o.VigenciaFim == null || o.VigenciaFim > hoje));

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProvider.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProvider.cs
@@ -41,6 +41,7 @@ public sealed partial class OAuthBearerAuthenticationHeaderValueProvider
     private readonly bool ownsHttpClient;
     private readonly OAuthBearerSettings settings;
     private readonly ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger;
+    private readonly TimeProvider timeProvider;
     private readonly SemaphoreSlim refreshLock = new(initialCount: 1, maxCount: 1);
 
     private string? cachedToken;
@@ -54,8 +55,9 @@ public sealed partial class OAuthBearerAuthenticationHeaderValueProvider
     public OAuthBearerAuthenticationHeaderValueProvider(
         HttpClient httpClient,
         OAuthBearerSettings settings,
-        ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger)
-        : this(httpClient, ownsHttpClient: false, settings, logger)
+        ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger,
+        TimeProvider timeProvider)
+        : this(httpClient, ownsHttpClient: false, settings, logger, timeProvider)
     {
     }
 
@@ -68,16 +70,19 @@ public sealed partial class OAuthBearerAuthenticationHeaderValueProvider
         HttpClient httpClient,
         bool ownsHttpClient,
         OAuthBearerSettings settings,
-        ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger)
+        ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger,
+        TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
         this.httpClient = httpClient;
         this.ownsHttpClient = ownsHttpClient;
         this.settings = settings;
         this.logger = logger;
+        this.timeProvider = timeProvider;
         this.httpClient.Timeout = TimeSpan.FromMilliseconds(settings.RequestTimeoutMs);
     }
 
@@ -92,7 +97,7 @@ public sealed partial class OAuthBearerAuthenticationHeaderValueProvider
 
     private async Task<string> GetOrRefreshTokenAsync(CancellationToken cancellationToken)
     {
-        DateTimeOffset now = DateTimeOffset.UtcNow;
+        DateTimeOffset now = timeProvider.GetUtcNow();
         TimeSpan skew = TimeSpan.FromSeconds(settings.RefreshSkewSeconds);
 
         if (cachedToken is not null && now < cachedTokenExpiresAt - skew)
@@ -104,7 +109,7 @@ public sealed partial class OAuthBearerAuthenticationHeaderValueProvider
         try
         {
             // Re-check após acquire — outro thread pode ter renovado enquanto esperávamos.
-            now = DateTimeOffset.UtcNow;
+            now = timeProvider.GetUtcNow();
             if (cachedToken is not null && now < cachedTokenExpiresAt - skew)
             {
                 return cachedToken;
@@ -113,7 +118,7 @@ public sealed partial class OAuthBearerAuthenticationHeaderValueProvider
             TokenEndpointResponse response = await RequestTokenAsync(cancellationToken).ConfigureAwait(false);
 
             cachedToken = response.AccessToken;
-            cachedTokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(response.ExpiresInSeconds);
+            cachedTokenExpiresAt = timeProvider.GetUtcNow().AddSeconds(response.ExpiresInSeconds);
 
             LogTokenRefreshed(logger, settings.ClientId, response.ExpiresInSeconds);
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
@@ -83,6 +83,10 @@ public static class SchemaRegistryServiceCollectionExtensions
         bool useOAuthBearer = string.Equals(settings.AuthType, "OAuthBearer", StringComparison.OrdinalIgnoreCase);
         if (useOAuthBearer)
         {
+            // Relógio canônico (ADR-0068): registrado aqui para que o provider
+            // resolva via GetRequiredService (fail-fast), coerente com os demais
+            // pontos de DI. TryAdd preserva override de teste.
+            services.TryAddSingleton(TimeProvider.System);
             services.AddHttpClient<OAuthBearerAuthenticationHeaderValueProvider>();
             services.TryAddSingleton<IAuthenticationHeaderValueProvider>(static sp =>
             {
@@ -91,10 +95,12 @@ public static class SchemaRegistryServiceCollectionExtensions
                 ILogger<OAuthBearerAuthenticationHeaderValueProvider> logger = sp
                     .GetRequiredService<ILogger<OAuthBearerAuthenticationHeaderValueProvider>>();
                 HttpClient client = factory.CreateClient(nameof(OAuthBearerAuthenticationHeaderValueProvider));
+                TimeProvider timeProvider = sp.GetRequiredService<TimeProvider>();
                 return new OAuthBearerAuthenticationHeaderValueProvider(
                     client,
                     opts.Value.OAuth,
-                    logger);
+                    logger,
+                    timeProvider);
             });
         }
 
@@ -198,11 +204,15 @@ public static class SchemaRegistryServiceCollectionExtensions
             // — necessário porque CachedSchemaRegistryClient.Dispose não dispõe
             // custom auth providers (Codex P2 na review do PR #359, issue #360).
             HttpClient httpClient = new();
+            // TimeProvider.System explícito: este é um composition root genuíno
+            // (callback do Wolverine que roda antes de builder.Build(), sem
+            // IServiceProvider disponível), não um fallback escondido.
             OAuthBearerAuthenticationHeaderValueProvider authProvider = new(
                 httpClient,
                 ownsHttpClient: true,
                 settings.OAuth,
-                loggerFactory.CreateLogger<OAuthBearerAuthenticationHeaderValueProvider>());
+                loggerFactory.CreateLogger<OAuthBearerAuthenticationHeaderValueProvider>(),
+                TimeProvider.System);
 
             // Registrations:
             // - Singleton(instance) torna o auth provider resolvable via DI (mesma

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/AuditableInterceptor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/AuditableInterceptor.cs
@@ -24,11 +24,16 @@ public sealed class AuditableInterceptor : SaveChangesInterceptor
     private const string SystemUser = "system";
 
     private readonly IUserContext? _userContext;
+    private readonly TimeProvider _timeProvider;
 
-    // Construtor sem args preservado para uso em testes que não exigem
-    // IUserContext (cenário equivalente ao fallback "system").
-    public AuditableInterceptor(IUserContext? userContext = null)
+    // TimeProvider é obrigatório (sem fallback TimeProvider.System): o relógio
+    // é sempre injetado pela DI (Singleton). IUserContext permanece opcional —
+    // o fallback "system" é regra legítima para fluxos sem principal (jobs,
+    // migrations), não um backdoor de não-determinismo.
+    public AuditableInterceptor(TimeProvider timeProvider, IUserContext? userContext = null)
     {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        _timeProvider = timeProvider;
         _userContext = userContext;
     }
 
@@ -59,7 +64,7 @@ public sealed class AuditableInterceptor : SaveChangesInterceptor
 
     private void ApplyAuditFields(DbContext context)
     {
-        DateTimeOffset now = DateTimeOffset.UtcNow;
+        DateTimeOffset now = _timeProvider.GetUtcNow();
         string userBy = ResolveUserBy();
 
         foreach (Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<EntityBase> entry

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs
@@ -21,11 +21,16 @@ public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
     private const string SystemUser = "system";
 
     private readonly IUserContext? _userContext;
+    private readonly TimeProvider _timeProvider;
 
-    // Construtor sem args preservado para uso em testes que não exigem
-    // IUserContext (cenário equivalente ao fallback "system").
-    public SoftDeleteInterceptor(IUserContext? userContext = null)
+    // TimeProvider é obrigatório (sem fallback TimeProvider.System): o relógio
+    // é sempre injetado pela DI (Singleton). IUserContext permanece opcional —
+    // o fallback "system" é regra legítima para fluxos sem principal (jobs,
+    // migrations), não um backdoor de não-determinismo.
+    public SoftDeleteInterceptor(TimeProvider timeProvider, IUserContext? userContext = null)
     {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        _timeProvider = timeProvider;
         _userContext = userContext;
     }
 
@@ -57,6 +62,7 @@ public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
     private void ConvertDeleteToSoftDelete(DbContext context)
     {
         string deletedBy = ResolveDeletedBy();
+        DateTimeOffset deletedAt = _timeProvider.GetUtcNow();
 
         foreach (Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<EntityBase> entry
             in context.ChangeTracker.Entries<EntityBase>())
@@ -64,7 +70,7 @@ public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
             if (entry.State == EntityState.Deleted)
             {
                 entry.State = EntityState.Modified;
-                entry.Entity.MarkAsDeleted(deletedBy);
+                entry.Entity.MarkAsDeleted(deletedBy, deletedAt);
             }
         }
     }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 using Interceptors;
 
@@ -136,6 +137,12 @@ public static class UniPlusDbContextOptionsExtensions
     public static IServiceCollection AddUniPlusEfInterceptors(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
+
+        // Relógio canônico (ADR de convenção de TimeProvider): os interceptors
+        // dependem dele para CreatedAt/UpdatedAt/DeletedAt. TryAdd preserva
+        // overrides de teste (TimeProvider fixo) e é idempotente com os demais
+        // pontos que já registram TimeProvider.System (paginação, idempotência).
+        services.TryAddSingleton(TimeProvider.System);
 
         services.AddScoped<SoftDeleteInterceptor>();
         services.AddScoped<AuditableInterceptor>();

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Smoke/SmokeEndpointsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Smoke/SmokeEndpointsExtensions.cs
@@ -104,15 +104,17 @@ public static class SmokeEndpointsExtensions
     private static async Task<IResult> ProbeSmokeCacheAsync(
         string key,
         IConnectionMultiplexer redis,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
         ArgumentNullException.ThrowIfNull(redis);
+        ArgumentNullException.ThrowIfNull(timeProvider);
         cancellationToken.ThrowIfCancellationRequested();
 
         IDatabase db = redis.GetDatabase();
         string fullKey = SmokeCacheKeyPrefix + key;
-        string value = DateTimeOffset.UtcNow.ToString("O", System.Globalization.CultureInfo.InvariantCulture);
+        string value = timeProvider.GetUtcNow().ToString("O", System.Globalization.CultureInfo.InvariantCulture);
 
         await db.StringSetAsync(fullKey, value, DefaultCacheTtl).ConfigureAwait(false);
         RedisValue retrieved = await db.StringGetAsync(fullKey).ConfigureAwait(false);
@@ -127,11 +129,13 @@ public static class SmokeEndpointsExtensions
 
     private static async Task<IResult> PublishSmokeMessageAsync(
         IMessageBus bus,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(bus);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
-        SmokePingMessage message = new(Guid.NewGuid(), DateTimeOffset.UtcNow);
+        SmokePingMessage message = new(Guid.NewGuid(), timeProvider.GetUtcNow());
         await bus.PublishAsync(message).ConfigureAwait(false);
 
         return Results.Ok(new { id = message.Id, timestamp = message.Timestamp });

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
@@ -15,16 +15,27 @@ public abstract class EntityBase
     // O timestamp leak não cria risco LGPD novo: toda entidade já carrega
     // CreatedAt como audit trail obrigatório, expondo o mesmo dado.
     public Guid Id { get; protected init; } = Guid.CreateVersion7();
-    public DateTimeOffset CreatedAt { get; protected set; } = DateTimeOffset.UtcNow;
+
+    // CreatedAt/UpdatedAt/DeletedAt são audit trail de persistência: a fonte
+    // única do instante é o relógio injetado (TimeProvider) nos interceptors
+    // de Infrastructure (AuditableInterceptor/SoftDeleteInterceptor), nunca
+    // DateTimeOffset.UtcNow lido no domínio. Por isso CreatedAt NÃO tem
+    // inicializador — uma entidade transiente (pré-SaveChanges) tem CreatedAt
+    // default; o AuditableInterceptor o carimba em Added. O fitness test
+    // RelogioViaTimeProviderTests bane leituras diretas de relógio em src/.
+    public DateTimeOffset CreatedAt { get; protected set; }
     public DateTimeOffset? UpdatedAt { get; protected set; }
     public bool IsDeleted { get; private set; }
     public DateTimeOffset? DeletedAt { get; private set; }
     public string? DeletedBy { get; private set; }
 
-    public void MarkAsDeleted(string deletedBy)
+    // O instante é parâmetro, não relógio lido aqui: o caller (SoftDeleteInterceptor
+    // ou repositório) provê deletedAt a partir do TimeProvider injetado, mantendo
+    // o domínio determinístico e a leitura de relógio concentrada em Infrastructure.
+    public void MarkAsDeleted(string deletedBy, DateTimeOffset deletedAt)
     {
         IsDeleted = true;
-        DeletedAt = DateTimeOffset.UtcNow;
+        DeletedAt = deletedAt;
         DeletedBy = deletedBy;
     }
 

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Events/DomainEventBase.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Events/DomainEventBase.cs
@@ -1,9 +1,16 @@
 namespace Unifesspa.UniPlus.Kernel.Domain.Events;
 
-public abstract record DomainEventBase : IDomainEvent
+// OccurredOn é parâmetro obrigatório do construtor (não inicializador com
+// DateTimeOffset.UtcNow): quem levanta o evento provê o instante a partir do
+// TimeProvider, mantendo o domínio determinístico. O fitness test
+// RelogioViaTimeProviderTests bane leituras diretas de relógio em src/.
+// EventId permanece UUID v7 — tornar a IDENTIDADE determinística é escopo
+// separado da ADR-0032, não desta convenção de relógio.
+public abstract record DomainEventBase(DateTimeOffset OccurredOn) : IDomainEvent
 {
     // UUID v7 (ADR-0032) — eventos ganham ordering temporal natural no outbox
-    // e nos consumers, facilitando debug e replay determinístico.
+    // e nos consumers, facilitando debug e replay determinístico. get-only
+    // (sem init): EventId é identidade única por instância — `with` preserva o
+    // valor via copy ctor sem permitir override acidental.
     public Guid EventId { get; } = Guid.CreateVersion7();
-    public DateTimeOffset OccurredOn { get; } = DateTimeOffset.UtcNow;
 }

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Interfaces/ISoftDeletable.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Interfaces/ISoftDeletable.cs
@@ -5,5 +5,5 @@ public interface ISoftDeletable
     bool IsDeleted { get; }
     DateTimeOffset? DeletedAt { get; }
     string? DeletedBy { get; }
-    void MarkAsDeleted(string deletedBy);
+    void MarkAsDeleted(string deletedBy, DateTimeOffset deletedAt);
 }

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/RelogioViaTimeProviderTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/RelogioViaTimeProviderTests.cs
@@ -1,0 +1,114 @@
+namespace Unifesspa.UniPlus.ArchTests.SolutionRules;
+
+using System.IO;
+using System.Text.RegularExpressions;
+
+using AwesomeAssertions;
+
+using TestSupport;
+
+/// <summary>
+/// Fitness function da convenção de relógio: todo acesso a tempo de parede em
+/// <c>src/</c> passa por um <see cref="System.TimeProvider"/> injetado
+/// (<c>TimeProvider.GetUtcNow()</c>), nunca por leituras estáticas diretas
+/// <c>DateTime.UtcNow</c>/<c>DateTime.Now</c>/<c>DateTimeOffset.UtcNow</c>/<c>DateTimeOffset.Now</c>.
+/// Mantém o domínio determinístico (FakeTimeProvider em testes) e concentra a
+/// dependência de relógio nos interceptors/serviços de Infrastructure.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mesma abordagem por inspeção textual de <see cref="DominioNaoUsaGuidNewGuidTests"/>:
+/// ArchUnitNET enxerga dependência de tipo, não chamada de membro específico
+/// (todas as classes dependem de <c>System.DateTimeOffset</c> como tipo).
+/// </para>
+/// <para>
+/// O escopo é TODO <c>src/</c> (não apenas <c>*.Domain</c>): após a refatoração
+/// de relógio, nenhuma camada lê o relógio estático — interceptors, repositórios,
+/// schema registry e endpoints smoke recebem <see cref="System.TimeProvider"/>.
+/// <c>TimeProvider.System</c> permanece permitido (é o acessor legítimo do
+/// relógio real, não uma leitura estática de <c>UtcNow</c>/<c>Now</c>).
+/// </para>
+/// <para>
+/// Falsos positivos tratados: comentários (linha <c>//</c> e bloco <c>/* */</c>)
+/// são removidos antes do match; arquivos gerados em <c>obj/</c>/<c>bin/</c> são
+/// excluídos por path.
+/// </para>
+/// </remarks>
+public sealed partial class RelogioViaTimeProviderTests
+{
+    [GeneratedRegex(@"\b(DateTime|DateTimeOffset)\.(UtcNow|Now)\b")]
+    private static partial Regex RelogioEstaticoPattern();
+
+    [Fact(DisplayName = "Convenção de relógio: nenhum arquivo .cs em src/ lê DateTime(Offset).UtcNow/.Now")]
+    public void Src_NaoLe_RelogioEstatico()
+    {
+        string solutionRoot = SolutionRootLocator.Locate();
+        // Path.Join (não Path.Combine): concatena sem o reset de path rooted,
+        // eliminando o risco de descartar silenciosamente solutionRoot.
+        string srcRoot = Path.Join(solutionRoot, "src");
+
+        List<string> violations = [];
+
+        IEnumerable<string> files = Directory
+            .EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(static p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(static p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+        foreach (string file in files)
+        {
+            string[] lines = File.ReadAllLines(file);
+            bool inBlockComment = false;
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                string trimmed = line.TrimStart();
+
+                // Estado-máquina mínima de comment: rastreia /* ... */ que pode atravessar
+                // múltiplas linhas. Linha que ABRE e FECHA o bloco (/* foo */) sai do estado
+                // dentro do mesmo passo. (Idêntica à de DominioNaoUsaGuidNewGuidTests.)
+                if (inBlockComment)
+                {
+                    int closing = line.IndexOf("*/", StringComparison.Ordinal);
+                    if (closing < 0)
+                        continue;
+                    inBlockComment = false;
+                    line = line[(closing + 2)..];
+                    trimmed = line.TrimStart();
+                    if (trimmed.Length == 0)
+                        continue;
+                }
+
+                if (trimmed.StartsWith("//", StringComparison.Ordinal))
+                    continue;
+
+                int blockStart = line.IndexOf("/*", StringComparison.Ordinal);
+                if (blockStart >= 0)
+                {
+                    int blockEnd = line.IndexOf("*/", blockStart + 2, StringComparison.Ordinal);
+                    if (blockEnd < 0)
+                    {
+                        inBlockComment = true;
+                        line = line[..blockStart];
+                    }
+                    else
+                    {
+                        line = string.Concat(line.AsSpan(0, blockStart), line.AsSpan(blockEnd + 2));
+                    }
+                }
+
+                if (RelogioEstaticoPattern().IsMatch(line))
+                {
+                    string relative = Path.GetRelativePath(solutionRoot, file);
+                    violations.Add($"{relative}:{i + 1}: {lines[i].Trim()}");
+                }
+            }
+        }
+
+        violations.Should().BeEmpty(
+            "a convenção de relógio exige TimeProvider injetado (TimeProvider.GetUtcNow()) em src/. "
+            + "Injete TimeProvider no construtor/handler/endpoint e use clock.GetUtcNow(); em entidades de "
+            + "domínio siga o precedente `TimeProvider? clock = null` e passe (clock ?? TimeProvider.System).GetUtcNow(). "
+            + $"Violações encontradas:\n  - {string.Join("\n  - ", violations)}");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedServiceTests.cs
@@ -35,7 +35,8 @@ public sealed class OAuthBearerAuthProviderDisposeHostedServiceTests
             httpClient: new HttpClient(),
             ownsHttpClient: true,
             settings: new OAuthBearerSettings { ClientId = "x", ClientSecret = "x", TokenEndpoint = "https://x" },
-            logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance);
+            logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance,
+            timeProvider: TimeProvider.System);
     }
 
     /// <summary>Cria provider com stub HTTP que responde 200 OK — útil para
@@ -64,7 +65,8 @@ public sealed class OAuthBearerAuthProviderDisposeHostedServiceTests
                 ClientSecret = "test",
                 TokenEndpoint = "https://kc.test/token",
             },
-            logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance);
+            logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance,
+            timeProvider: TimeProvider.System);
     }
 
     [Fact(DisplayName = "StartAsync é no-op — retorna Task concluída e provider continua funcional")]

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProviderTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/SchemaRegistry/OAuthBearerAuthenticationHeaderValueProviderTests.cs
@@ -53,7 +53,8 @@ public sealed class OAuthBearerAuthenticationHeaderValueProviderTests
             httpClient,
             ownsHttpClient: true,
             settings ?? DefaultSettings(),
-            NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance);
+            NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance,
+            TimeProvider.System);
     }
 
     [Fact(DisplayName = "200 OK retorna Bearer header com access_token + cacheia o token")]
@@ -196,7 +197,8 @@ public sealed class OAuthBearerAuthenticationHeaderValueProviderTests
         using (OAuthBearerAuthenticationHeaderValueProvider sut = new(
             externalClient,
             settings: DefaultSettings(),
-            logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance))
+            logger: NullLogger<OAuthBearerAuthenticationHeaderValueProvider>.Instance,
+            timeProvider: TimeProvider.System))
         {
             sut.GetAuthenticationHeader();
         }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/AuditableInterceptorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/AuditableInterceptorTests.cs
@@ -15,6 +15,17 @@ public sealed class AuditableInterceptorTests
 {
     private const string SystemUser = "system";
 
+    // Instante fixo + relógio determinístico (ADR-0068): o interceptor carimba
+    // CreatedAt/UpdatedAt a partir do TimeProvider injetado, então as asserções
+    // verificam o valor EXATO — prova que a fonte é o relógio injetado, não
+    // DateTimeOffset.UtcNow.
+    private static readonly DateTimeOffset Instante = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+
     private sealed class EntidadeTeste : EntityBase
     {
         public string Nome { get; set; } = string.Empty;
@@ -40,7 +51,7 @@ public sealed class AuditableInterceptorTests
     private static ContextoTeste CriarContexto(IUserContext? userContext = null, string? dbName = null) =>
         new(new DbContextOptionsBuilder<ContextoTeste>()
             .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString())
-            .AddInterceptors(new AuditableInterceptor(userContext))
+            .AddInterceptors(new AuditableInterceptor(new FixedTimeProvider(Instante), userContext))
             .Options);
 
     private static IUserContext UsuarioAutenticado(string userId)
@@ -63,13 +74,12 @@ public sealed class AuditableInterceptorTests
     public void SavingChanges_DadoEntityAdicionada_EntaoDeveDefinirCreatedAt()
     {
         using ContextoTeste contexto = CriarContexto();
-        DateTimeOffset antes = DateTimeOffset.UtcNow.AddSeconds(-1);
         EntidadeTeste entidade = new() { Nome = "teste" };
 
         contexto.Entidades.Add(entidade);
         contexto.SaveChanges();
 
-        entidade.CreatedAt.Should().BeOnOrAfter(antes);
+        entidade.CreatedAt.Should().Be(Instante, "CreatedAt vem do TimeProvider injetado no interceptor");
     }
 
     [Fact]
@@ -81,24 +91,21 @@ public sealed class AuditableInterceptorTests
         contexto.SaveChanges();
 
         entidade.Nome = "modificado";
-        DateTimeOffset antes = DateTimeOffset.UtcNow.AddSeconds(-1);
         contexto.SaveChanges();
 
-        entidade.UpdatedAt.Should().NotBeNull();
-        entidade.UpdatedAt.Should().BeOnOrAfter(antes);
+        entidade.UpdatedAt.Should().Be(Instante, "UpdatedAt vem do TimeProvider injetado no interceptor");
     }
 
     [Fact]
     public async Task SavingChangesAsync_DadoEntityAdicionada_EntaoDeveDefinirCreatedAt()
     {
         await using ContextoTeste contexto = CriarContexto();
-        DateTimeOffset antes = DateTimeOffset.UtcNow.AddSeconds(-1);
         EntidadeTeste entidade = new() { Nome = "teste" };
 
         contexto.Entidades.Add(entidade);
         await contexto.SaveChangesAsync();
 
-        entidade.CreatedAt.Should().BeOnOrAfter(antes);
+        entidade.CreatedAt.Should().Be(Instante, "CreatedAt vem do TimeProvider injetado no interceptor");
     }
 
     [Fact]
@@ -110,11 +117,9 @@ public sealed class AuditableInterceptorTests
         await contexto.SaveChangesAsync();
 
         entidade.Nome = "modificado";
-        DateTimeOffset antes = DateTimeOffset.UtcNow.AddSeconds(-1);
         await contexto.SaveChangesAsync();
 
-        entidade.UpdatedAt.Should().NotBeNull();
-        entidade.UpdatedAt.Should().BeOnOrAfter(antes);
+        entidade.UpdatedAt.Should().Be(Instante, "UpdatedAt vem do TimeProvider injetado no interceptor");
     }
 
     // ───── #390: ramos IAuditableEntity (opt-in) ──────────────────────────
@@ -211,6 +216,6 @@ public sealed class AuditableInterceptorTests
         };
 
         acao.Should().NotThrow();
-        entidade.CreatedAt.Should().BeAfter(DateTimeOffset.UtcNow.AddSeconds(-5));
+        entidade.CreatedAt.Should().Be(Instante, "CreatedAt é carimbado pelo interceptor mesmo em entidade não-auditável");
     }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
@@ -14,6 +14,15 @@ public sealed class SoftDeleteInterceptorTests
 {
     private const string SystemUser = "system";
 
+    // Instante fixo + relógio determinístico (ADR-0068): DeletedAt vem do
+    // TimeProvider injetado, então a asserção verifica o valor EXATO.
+    private static readonly DateTimeOffset Instante = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
+
+    private sealed class FixedTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+
     private sealed class EntidadeTeste : EntityBase
     {
         public string Nome { get; set; } = string.Empty;
@@ -27,7 +36,7 @@ public sealed class SoftDeleteInterceptorTests
     private static ContextoTeste CriarContexto(IUserContext? userContext = null) =>
         new(new DbContextOptionsBuilder<ContextoTeste>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
-            .AddInterceptors(new SoftDeleteInterceptor(userContext))
+            .AddInterceptors(new SoftDeleteInterceptor(new FixedTimeProvider(Instante), userContext))
             .Options);
 
     private static IUserContext UsuarioAutenticado(string userId)
@@ -58,7 +67,7 @@ public sealed class SoftDeleteInterceptorTests
         contexto.SaveChanges();
 
         entidade.IsDeleted.Should().BeTrue();
-        entidade.DeletedAt.Should().NotBeNull();
+        entidade.DeletedAt.Should().Be(Instante, "DeletedAt vem do TimeProvider injetado no interceptor");
         entidade.DeletedBy.Should().Be(SystemUser);
         contexto.Entidades.Find(entidade.Id).Should().NotBeNull();
     }
@@ -75,7 +84,7 @@ public sealed class SoftDeleteInterceptorTests
         await contexto.SaveChangesAsync();
 
         entidade.IsDeleted.Should().BeTrue();
-        entidade.DeletedAt.Should().NotBeNull();
+        entidade.DeletedAt.Should().Be(Instante, "DeletedAt vem do TimeProvider injetado no interceptor");
         entidade.DeletedBy.Should().Be(SystemUser);
         (await contexto.Entidades.FindAsync(entidade.Id)).Should().NotBeNull();
     }

--- a/tests/Unifesspa.UniPlus.Ingresso.Domain.UnitTests/Entities/RelogioObrigatorioTests.cs
+++ b/tests/Unifesspa.UniPlus.Ingresso.Domain.UnitTests/Entities/RelogioObrigatorioTests.cs
@@ -1,0 +1,79 @@
+namespace Unifesspa.UniPlus.Ingresso.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Ingresso.Domain.Entities;
+using Unifesspa.UniPlus.Ingresso.Domain.ValueObjects;
+
+/// <summary>
+/// Pin do contrato da ADR-0068: métodos de domínio que leem o relógio exigem
+/// <see cref="System.TimeProvider"/> — passar <c>null</c> lança
+/// <see cref="System.ArgumentNullException"/>. Cobre os guards introduzidos
+/// junto da convenção (sem default de relógio).
+/// </summary>
+public sealed class RelogioObrigatorioTests
+{
+    private static ProtocoloConvocacao Protocolo() => ProtocoloConvocacao.Gerar(1, 1, TimeProvider.System);
+
+    private static Convocacao NovaConvocacao() => Convocacao.Criar(
+        Guid.NewGuid(),
+        Guid.NewGuid(),
+        Guid.NewGuid(),
+        Protocolo(),
+        posicao: 1,
+        codigoCurso: "CURSO01",
+        clock: TimeProvider.System);
+
+    [Fact(DisplayName = "ProtocoloConvocacao.Gerar exige TimeProvider não-nulo")]
+    public void ProtocoloGerar_ClockNulo_Lanca()
+    {
+        Action act = () => ProtocoloConvocacao.Gerar(1, 1, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "Convocacao.Criar exige TimeProvider não-nulo")]
+    public void ConvocacaoCriar_ClockNulo_Lanca()
+    {
+        Action act = () => Convocacao.Criar(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            Protocolo(),
+            posicao: 1,
+            codigoCurso: "CURSO01",
+            clock: null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "Convocacao.Aceitar exige TimeProvider não-nulo")]
+    public void ConvocacaoAceitar_ClockNulo_Lanca()
+    {
+        Convocacao convocacao = NovaConvocacao();
+
+        Action act = () => convocacao.Aceitar(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "Convocacao.Recusar exige TimeProvider não-nulo")]
+    public void ConvocacaoRecusar_ClockNulo_Lanca()
+    {
+        Convocacao convocacao = NovaConvocacao();
+
+        Action act = () => convocacao.Recusar(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "Matricula.Efetivar exige TimeProvider não-nulo")]
+    public void MatriculaEfetivar_ClockNulo_Lanca()
+    {
+        Matricula matricula = Matricula.Criar(Guid.NewGuid(), Guid.NewGuid(), "CURSO01");
+
+        Action act = () => matricula.Efetivar(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseTests.cs
@@ -28,19 +28,17 @@ public sealed class EntityBaseTests
         a.Id.Should().NotBe(b.Id);
     }
 
-    [Fact(DisplayName = "CreatedAt é preenchido com UtcNow ±5s no momento da criação")]
-    public void CreatedAt_ProximoDoAgoraUtc()
+    [Fact(DisplayName = "CreatedAt nasce default — o AuditableInterceptor o carimba no SaveChanges (fonte única)")]
+    public void CreatedAt_NasceDefault_InterceptorCarimba()
     {
-        DateTimeOffset antes = DateTimeOffset.UtcNow;
-
+        // Convenção de relógio: a fonte única de CreatedAt é o TimeProvider
+        // injetado no AuditableInterceptor (Infrastructure), nunca um
+        // DateTimeOffset.UtcNow lido no domínio. Uma entidade transiente
+        // (pré-persistência) tem CreatedAt default; o carimbo em Added é
+        // coberto por teste de integração do interceptor.
         EntidadeDeTeste entidade = new();
 
-        DateTimeOffset depois = DateTimeOffset.UtcNow;
-
-        entidade.CreatedAt.Should().BeOnOrAfter(antes.AddSeconds(-5));
-        entidade.CreatedAt.Should().BeOnOrBefore(depois.AddSeconds(5));
-        entidade.CreatedAt.Offset.Should().Be(TimeSpan.Zero,
-            "audit trail é normalizado em UTC");
+        entidade.CreatedAt.Should().Be(default);
     }
 
     [Fact(DisplayName = "Entidade recém-criada não tem UpdatedAt, IsDeleted, DeletedAt, DeletedBy")]
@@ -54,21 +52,19 @@ public sealed class EntityBaseTests
         entidade.DeletedBy.Should().BeNull();
     }
 
-    [Fact(DisplayName = "MarkAsDeleted altera IsDeleted, DeletedAt (UtcNow) e DeletedBy")]
+    [Fact(DisplayName = "MarkAsDeleted altera IsDeleted, DeletedAt (instante recebido) e DeletedBy")]
     public void MarkAsDeleted_AlteraFlagsDeSoftDelete()
     {
         EntidadeDeTeste entidade = new();
-        DateTimeOffset antes = DateTimeOffset.UtcNow;
+        // Instante determinístico: o caller (SoftDeleteInterceptor/repositório)
+        // provê deletedAt a partir do TimeProvider; o domínio só o registra.
+        DateTimeOffset instante = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
 
-        entidade.MarkAsDeleted("usuario@exemplo.com");
-
-        DateTimeOffset depois = DateTimeOffset.UtcNow;
+        entidade.MarkAsDeleted("usuario@exemplo.com", instante);
 
         entidade.IsDeleted.Should().BeTrue();
         entidade.DeletedBy.Should().Be("usuario@exemplo.com");
-        entidade.DeletedAt.Should().NotBeNull();
-        entidade.DeletedAt!.Value.Should().BeOnOrAfter(antes.AddSeconds(-1))
-            .And.BeOnOrBefore(depois.AddSeconds(1));
+        entidade.DeletedAt.Should().Be(instante);
         entidade.DeletedAt!.Value.Offset.Should().Be(TimeSpan.Zero);
     }
 
@@ -76,9 +72,10 @@ public sealed class EntityBaseTests
     public void MarkAsDeleted_PodeSerChamadoMaisDeUmaVez()
     {
         EntidadeDeTeste entidade = new();
-        entidade.MarkAsDeleted("primeiro");
+        DateTimeOffset instante = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
+        entidade.MarkAsDeleted("primeiro", instante);
 
-        entidade.MarkAsDeleted("segundo");
+        entidade.MarkAsDeleted("segundo", instante);
 
         entidade.IsDeleted.Should().BeTrue();
         entidade.DeletedBy.Should().Be("segundo");

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Events/DomainEventBaseTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Events/DomainEventBaseTests.cs
@@ -6,11 +6,13 @@ using Unifesspa.UniPlus.Kernel.Domain.Events;
 
 public sealed class DomainEventBaseTests
 {
+    private static readonly DateTimeOffset InstanteFixo = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
+
     [Fact(DisplayName = "DomainEventBase atribui EventId UUID v7 distinto por instância")]
     public void EventId_EhUuidV7Unico()
     {
-        EventoDeTeste a = new("a");
-        EventoDeTeste b = new("b");
+        EventoDeTeste a = new("a", InstanteFixo);
+        EventoDeTeste b = new("b", InstanteFixo);
 
         a.EventId.Should().NotBe(b.EventId);
         ExtrairVersao(a.EventId).Should().Be(7,
@@ -18,17 +20,14 @@ public sealed class DomainEventBaseTests
         ExtrairVersao(b.EventId).Should().Be(7);
     }
 
-    [Fact(DisplayName = "DomainEventBase atribui OccurredOn em UTC próximo de UtcNow")]
-    public void OccurredOn_ProximoUtcNow()
+    [Fact(DisplayName = "DomainEventBase registra o OccurredOn recebido no construtor (determinístico)")]
+    public void OccurredOn_VemDoConstrutor()
     {
-        DateTimeOffset antes = DateTimeOffset.UtcNow;
+        // Convenção de relógio: OccurredOn é parâmetro obrigatório provido por
+        // quem levanta o evento (a partir do TimeProvider), nunca DateTimeOffset.UtcNow.
+        EventoDeTeste evento = new("x", InstanteFixo);
 
-        EventoDeTeste evento = new("x");
-
-        DateTimeOffset depois = DateTimeOffset.UtcNow;
-
-        evento.OccurredOn.Should().BeOnOrAfter(antes.AddSeconds(-5))
-            .And.BeOnOrBefore(depois.AddSeconds(5));
+        evento.OccurredOn.Should().Be(InstanteFixo);
         evento.OccurredOn.Offset.Should().Be(TimeSpan.Zero,
             "OccurredOn é normalizado em UTC para serialização determinística");
     }
@@ -36,7 +35,7 @@ public sealed class DomainEventBaseTests
     [Fact(DisplayName = "DomainEventBase implementa IDomainEvent")]
     public void Implementa_IDomainEvent()
     {
-        EventoDeTeste evento = new("x");
+        EventoDeTeste evento = new("x", InstanteFixo);
 
         evento.Should().BeAssignableTo<IDomainEvent>();
     }
@@ -44,14 +43,13 @@ public sealed class DomainEventBaseTests
     [Fact(DisplayName = "Records de domain event não colidem por payload — EventId e OccurredOn entram na igualdade record-based")]
     public void Records_Igualdade_ConsideraEventIdEOccurredOn()
     {
-        EventoDeTeste a = new("mesmo-payload");
-        EventoDeTeste b = new("mesmo-payload");
+        EventoDeTeste a = new("mesmo-payload", InstanteFixo);
+        EventoDeTeste b = new("mesmo-payload", InstanteFixo);
 
-        // Records do C# comparam todos os campos sintetizados — EventId e
-        // OccurredOn são auto-properties com inicializador, então entram
-        // na igualdade. Resultado: dois eventos com mesmo payload mas
-        // gerados em momentos distintos são naturalmente desiguais.
-        // Propriedade desejável para deduplicação no outbox.
+        // Records do C# comparam todos os campos sintetizados. Mesmo com payload
+        // e OccurredOn idênticos, o EventId (UUID v7 gerado por instância) difere,
+        // tornando os dois eventos desiguais — propriedade desejável para
+        // deduplicação no outbox.
         a.Should().NotBe(b);
         a.EventId.Should().NotBe(b.EventId);
     }
@@ -62,5 +60,5 @@ public sealed class DomainEventBaseTests
         return (bytes[7] & 0xF0) >> 4;
     }
 
-    private sealed record EventoDeTeste(string Payload) : DomainEventBase;
+    private sealed record EventoDeTeste(string Payload, DateTimeOffset OccurredOn) : DomainEventBase(OccurredOn);
 }

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Interfaces/ISoftDeletableContractTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Interfaces/ISoftDeletableContractTests.cs
@@ -23,11 +23,12 @@ public sealed class ISoftDeletableContractTests
         DummySoftDeletable dummy = new();
         ISoftDeletable contrato = dummy;
 
-        contrato.MarkAsDeleted("auditor@exemplo.com");
+        DateTimeOffset instante = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
+        contrato.MarkAsDeleted("auditor@exemplo.com", instante);
 
         contrato.IsDeleted.Should().BeTrue();
         contrato.DeletedBy.Should().Be("auditor@exemplo.com");
-        contrato.DeletedAt.Should().NotBeNull();
+        contrato.DeletedAt.Should().Be(instante);
     }
 
     private sealed class DummySoftDeletable : ISoftDeletable
@@ -36,10 +37,10 @@ public sealed class ISoftDeletableContractTests
         public DateTimeOffset? DeletedAt { get; private set; }
         public string? DeletedBy { get; private set; }
 
-        public void MarkAsDeleted(string deletedBy)
+        public void MarkAsDeleted(string deletedBy, DateTimeOffset deletedAt)
         {
             IsDeleted = true;
-            DeletedAt = DateTimeOffset.UtcNow;
+            DeletedAt = deletedAt;
             DeletedBy = deletedBy;
         }
     }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ObrigatoriedadeLegalCriarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ObrigatoriedadeLegalCriarTests.cs
@@ -293,7 +293,9 @@ public sealed class ObrigatoriedadeLegalCriarTests
             regraCodigo: "REGRA_LEGADA",
             predicado: PredicadoBase,
             baseLegal: "Lei 12.711/2012",
-            descricaoHumana: "Regra retrocompatível.");
+            descricaoHumana: "Regra retrocompatível.",
+            portariaInternaCodigo: null,
+            clock: TimeProvider.System);
 
         r.IsSuccess.Should().BeTrue();
         ObrigatoriedadeLegal regra = r.Value!;

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/RelogioObrigatorioTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/RelogioObrigatorioTests.cs
@@ -1,0 +1,72 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Pin do contrato da ADR-0068: métodos de domínio que leem o relógio exigem
+/// <see cref="System.TimeProvider"/> — passar <c>null</c> lança
+/// <see cref="System.ArgumentNullException"/>. Cobre os guards introduzidos
+/// junto da convenção (sem default de relógio).
+/// </summary>
+public sealed class RelogioObrigatorioTests
+{
+    private static NumeroEdital Numero() => NumeroEdital.Criar(numero: 1, ano: 2026).Value!;
+
+    [Fact(DisplayName = "Edital.Publicar exige TimeProvider não-nulo")]
+    public void EditalPublicar_ClockNulo_Lanca()
+    {
+        Edital edital = Edital.Criar(Numero(), "Edital teste");
+
+        Action act = () => edital.Publicar(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "Inscricao.Criar exige TimeProvider não-nulo")]
+    public void InscricaoCriar_ClockNulo_Lanca()
+    {
+        Action act = () => Inscricao.Criar(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            ModalidadeConcorrencia.AC,
+            "CURSO01",
+            null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "Inscricao.Confirmar exige TimeProvider não-nulo")]
+    public void InscricaoConfirmar_ClockNulo_Lanca()
+    {
+        Inscricao inscricao = Inscricao.Criar(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            ModalidadeConcorrencia.AC,
+            "CURSO01",
+            TimeProvider.System).Value!;
+
+        Action act = () => inscricao.Confirmar(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "ObrigatoriedadeLegal.Criar (conveniência) exige TimeProvider não-nulo")]
+    public void ObrigatoriedadeLegalCriar_ClockNulo_Lanca()
+    {
+        PredicadoObrigatoriedade predicado = new EtapaObrigatoria("ProvaObjetiva");
+
+        Action act = () => ObrigatoriedadeLegal.Criar(
+            regraCodigo: "REGRA",
+            predicado: predicado,
+            baseLegal: "Lei 12.711/2012",
+            descricaoHumana: "desc",
+            portariaInternaCodigo: null,
+            clock: null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorConformidadeEditalTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorConformidadeEditalTests.cs
@@ -382,7 +382,8 @@ public sealed class ValidadorConformidadeEditalTests
             predicado: predicado,
             baseLegal: "Lei 12.711/2012 art.1º",
             descricaoHumana: "Regra de teste",
-            portariaInternaCodigo: "Portaria CTIC 2026/01");
+            portariaInternaCodigo: "Portaria CTIC 2026/01",
+            clock: TimeProvider.System);
 
         r.IsSuccess.Should().BeTrue();
         return r.Value!;
@@ -444,7 +445,9 @@ public sealed class ValidadorConformidadeEditalExhaustividadeTests
                 regraCodigo: $"FITNESS_{derivado.Name}",
                 predicado: predicado,
                 baseLegal: "Lei 12.711/2012",
-                descricaoHumana: "Fitness");
+                descricaoHumana: "Fitness",
+                portariaInternaCodigo: null,
+                clock: TimeProvider.System);
             regra.IsSuccess.Should().BeTrue();
 
             Action act = () => ValidadorConformidadeEdital.Evaluate(view, [regra.Value!]);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Messaging/EditalPublicadoAvroTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Messaging/EditalPublicadoAvroTests.cs
@@ -48,7 +48,8 @@ public sealed class EditalPublicadoAvroTests
     {
         EditalPublicadoEvent evt = new(
             EditalId: Guid.CreateVersion7(),
-            NumeroEdital: "001/2026");
+            NumeroEdital: "001/2026",
+            OccurredOn: new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero));
 
         EditalPublicadoAvro avro = EditalPublicadoToAvroMapper.ToAvro(evt);
 
@@ -73,7 +74,8 @@ public sealed class EditalPublicadoAvroTests
         // qualquer drift entre .avsc e a classe ISpecificRecord falhará aqui.
         EditalPublicadoEvent evt = new(
             EditalId: Guid.CreateVersion7(),
-            NumeroEdital: "042/2026");
+            NumeroEdital: "042/2026",
+            OccurredOn: new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero));
 
         EditalPublicadoAvro original = EditalPublicadoToAvroMapper.ToAvro(evt);
 

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ObrigatoriedadesLegais/ObrigatoriedadeLegalDbFixture.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ObrigatoriedadesLegais/ObrigatoriedadeLegalDbFixture.cs
@@ -87,9 +87,9 @@ public sealed class ObrigatoriedadeLegalDbFixture : IAsyncLifetime
             .UseNpgsql(ConnectionString)
             .UseSnakeCaseNamingConvention()
             .AddInterceptors(
-                new SoftDeleteInterceptor(userContext),
-                new AuditableInterceptor(userContext),
-                new ObrigatoriedadeLegalHistoricoInterceptor(userContext))
+                new SoftDeleteInterceptor(TimeProvider.System, userContext),
+                new AuditableInterceptor(TimeProvider.System, userContext),
+                new ObrigatoriedadeLegalHistoricoInterceptor(TimeProvider.System, userContext))
             .Options;
 
         return new SelecaoDbContext(options);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingHandlerUnitTests.cs
@@ -43,6 +43,7 @@ public sealed class CascadingHandlerUnitTests
         IEnumerable<object> cascading = await PublicarEditalCascadingHandler.Handle(
             command,
             db,
+            TimeProvider.System,
             CancellationToken.None);
 
         IReadOnlyList<object> materialized = [.. cascading];

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
@@ -23,13 +23,15 @@ public sealed class PublicarEditalCascadingHandler
     public static async Task<IEnumerable<object>> Handle(
         PublicarEditalCascadingCommand command,
         SelecaoDbContext db,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
         Edital edital = Edital.Criar(command.Numero, command.Titulo);
-        edital.Publicar();
+        edital.Publicar(timeProvider);
         db.Editais.Add(edital);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -55,13 +57,15 @@ public sealed class FalharAposSaveChangesCascadingHandler
     public static async Task<IEnumerable<object>> Handle(
         FalharAposSaveChangesCascadingCommand command,
         SelecaoDbContext db,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
         Edital edital = Edital.Criar(command.Numero, command.Titulo);
-        edital.Publicar();
+        edital.Publicar(timeProvider);
         db.Editais.Add(edital);
         await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalPublicadoToKafkaCascadeHandlerLoggingTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EditalPublicadoToKafkaCascadeHandlerLoggingTests.cs
@@ -28,7 +28,7 @@ public sealed class EditalPublicadoToKafkaCascadeHandlerLoggingTests
     {
         Guid editalId = Guid.CreateVersion7();
         const string numeroEdital = "42/2026";
-        EditalPublicadoEvent @event = new(editalId, numeroEdital);
+        EditalPublicadoEvent @event = new(editalId, numeroEdital, new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero));
         EstruturalLogger<EditalPublicadoToKafkaCascadeHandler> logger = new();
 
         EditalPublicadoAvro avro = EditalPublicadoToKafkaCascadeHandler.Handle(@event, logger);
@@ -44,7 +44,7 @@ public sealed class EditalPublicadoToKafkaCascadeHandlerLoggingTests
     {
         Guid editalId = Guid.CreateVersion7();
         const string numeroEdital = "99/2030";
-        EditalPublicadoEvent @event = new(editalId, numeroEdital);
+        EditalPublicadoEvent @event = new(editalId, numeroEdital, new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero));
         EstruturalLogger<EditalPublicadoToKafkaCascadeHandler> logger = new();
 
         _ = EditalPublicadoToKafkaCascadeHandler.Handle(@event, logger);
@@ -81,7 +81,7 @@ public sealed class EditalPublicadoToKafkaCascadeHandlerLoggingTests
     [Fact(DisplayName = "Handle lança ArgumentNullException com logger nulo")]
     public void Handle_ComLoggerNulo_LancaArgumentNullException()
     {
-        EditalPublicadoEvent @event = new(Guid.CreateVersion7(), "1/2026");
+        EditalPublicadoEvent @event = new(Guid.CreateVersion7(), "1/2026", new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero));
 
         Action act = () => EditalPublicadoToKafkaCascadeHandler.Handle(@event, null!);
 


### PR DESCRIPTION
Closes #538

## Objetivo

Generaliza e enforça a convenção de relógio do backend: todo código de negócio em `src/` lê o tempo via `System.TimeProvider` **injetado e obrigatório** — sem `DateTimeOffset.UtcNow` direto, sem default `null`, sem fallback `TimeProvider.System` escondido. Decisão registrada na **ADR-0068**.

A convenção já existia de facto (idempotência, cursor pagination, `ObrigatoriedadeLegal`), mas não era declarada nem enforçada, e a fundação a contradizia (dupla fonte de `CreatedAt`, `OccurredOn` não-determinístico, nenhum guardrail).

## Mudanças

**Fundação (Kernel)**
- `EntityBase.CreatedAt` perde o inicializador estático — `AuditableInterceptor`/`SoftDeleteInterceptor` viram **fonte única** de `CreatedAt`/`UpdatedAt`/`DeletedAt` via `TimeProvider` injetado.
- `MarkAsDeleted(string, DateTimeOffset)` recebe o instante; `DomainEventBase` exige `OccurredOn` no construtor (`EventId` UUIDv7 segue interno — escopo da ADR-0032).

**Domínio + Infra**
- Métodos que leem relógio (`Edital.Publicar`, `Inscricao.Criar/Confirmar`, `Convocacao.Criar/Aceitar/Recusar`, `Matricula.Efetivar`, `ProtocoloConvocacao.Gerar`, `ObrigatoriedadeLegal.Criar`) e serviços de infra (interceptors, repositórios, `OAuthBearer`, endpoints smoke) recebem `TimeProvider`, com guard `ArgumentNullException.ThrowIfNull`.
- `TimeProvider.System` restrito a composition roots (registrations de DI e o callback Wolverine `CreateClient`).

**Guardrail + cobertura**
- `RelogioViaTimeProviderTests`: fitness function que varre `src/` e falha o build ao encontrar `DateTime`/`DateTimeOffset` `.UtcNow`/`.Now` (espelha `DominioNaoUsaGuidNewGuidTests` da ADR-0032 — zero dependência nova).
- `RelogioObrigatorioTests` (Selecao + Ingresso): pinam o contrato "clock obrigatório".
- Testes de auditoria determinísticos (instante exato via `TimeProvider` fixo).

## Verificação

- **Build:** 0 erros, 0 avisos (`TreatWarningsAsErrors`).
- **Unit/arch:** 896 testes verdes.
- **Integração (Testcontainers/Postgres+Keycloak):** 141 verdes — Infrastructure.Core 30, Selecao 103, Ingresso 8. Confirmam o carimbo de `CreatedAt`/`OccurredOn`/histórico em banco real (sem regressão de `0001-01-01`).
- **ADR-0068:** `adr-lint` + `markdownlint` 0 erros.

## Commits

1. `docs(adr)` — ADR-0068 (MADR 4.0) + índice.
2. `refactor(shared)` — implementação (src + testes ajustados).
3. `test(shared)` — fitness test + guard tests.

## ADRs relacionadas

ADR-0068 (nova) · relaciona ADR-0032 (Guid v7) · ADR-0033 (IUserContext) · ADR-0004/0005 (outbox/cascading) · ADR-0026/0027 (já consumiam TimeProvider).