### PR TITLE
docs(adr): liga ADR-0003/0004/0005 à emenda de event sourcing (ADR-0069)

### DIFF
--- a/docs/adrs/0003-wolverine-como-backbone-cqrs.md
+++ b/docs/adrs/0003-wolverine-como-backbone-cqrs.md
@@ -65,6 +65,8 @@ A drenagem de domain events não passa por dispatcher injetado: handlers que mut
 
 Capacidades avançadas (sagas, process managers, scheduled messages, event sourcing) ficam **deliberadamente fora** desta decisão e só entram no projeto quando um caso de uso concreto exigir, com emenda a esta ADR.
 
+> **Emenda (2026-05-25):** a [ADR-0069](0069-event-sourcing-seletivo-marten-contextos-criticos.md) ativou a exceção de **event sourcing** para agregados críticos (Seleção e Ingresso), com Marten como store `ancillary` sobre o PostgreSQL existente. As demais capacidades permanecem fora até justificativa própria. As abstrações `ICommandBus`/`IQueryBus` continuam sendo a entrada da Application — handlers event-sourced ficam na Infrastructure para não acoplar a camada a `Wolverine.*`.
+
 ## Consequências
 
 ### Positivas
@@ -117,6 +119,7 @@ Capacidades avançadas (sagas, process managers, scheduled messages, event sourc
 
 - ADR-0004 define o outbox transacional sobre Wolverine + EF Core.
 - ADR-0005 define a estratégia de drenagem de domain events via cascading messages.
+- ADR-0069 ativa a exceção de event sourcing seletivo (Marten como store `ancillary`) prevista por esta ADR.
 - ADR-0012 define ArchUnitNET como ferramenta de enforcement.
 - ADR-0018 define OpenTelemetry como observabilidade obrigatória.
 - [Wolverine documentation](https://wolverinefx.net/)

--- a/docs/adrs/0004-outbox-transacional-via-wolverine.md
+++ b/docs/adrs/0004-outbox-transacional-via-wolverine.md
@@ -97,6 +97,7 @@ Decisões contratuais derivadas:
 - ADR-0014 define Kafka como bus inter-módulo.
 - ADR-0007 define PostgreSQL como banco primário (provedor da persistência outbox).
 - ADR-0018 define OpenTelemetry como observabilidade obrigatória — métricas e alertas Wolverine ficam ali.
+- ADR-0069 define que, em agregados event-sourced, o envelope do outbox é persistido na mesma unidade transacional do *append* no Marten via integração Marten/Wolverine; o EF Core/Postgres permanece o message store `main` e a invariante deste outbox é preservada.
 - [Wolverine — Durable Outbox](https://wolverinefx.net/guide/durability/)
 - [JasperFx/wolverine#2586 — fix do DomainEventScraper](https://github.com/JasperFx/wolverine/pull/2586)
 - **Origem:** revisão da ADR interna Uni+ ADR-025 (não publicada). A ADR interna ADR-024, que documentou a primeira tentativa reprovada, permanece como histórico interno e não é canonizada aqui — só o estado atual.

--- a/docs/adrs/0005-cascading-messages-para-drenagem-de-domain-events.md
+++ b/docs/adrs/0005-cascading-messages-para-drenagem-de-domain-events.md
@@ -95,6 +95,7 @@ Convenções:
 
 - ADR-0003 define Wolverine como backbone CQRS.
 - ADR-0004 define o outbox transacional (configuração de transport, persistence, retenção de dead letters).
+- ADR-0069 mantém esta invariante nos contextos event-sourced: `PublishDomainEventsFromEntityFrameworkCore` permanece desabilitado e não há scraper EF para streams Marten; contextos CRUD seguem com cascading messages explícitas, como hoje.
 - [Wolverine — Cascading Messages](https://wolverinefx.net/guide/handlers/cascading.html)
 - [JasperFx/wolverine#2585 — thread upstream com recomendação do maintainer](https://github.com/JasperFx/wolverine/issues/2585)
 - **Origem:** revisão da ADR interna Uni+ ADR-026 (não publicada).


### PR DESCRIPTION
## Contexto

A **ADR-0069 — Event Sourcing seletivo com Marten** foi promovida a `accepted` (gate cumprido pelo spike #540, PR #542 mergeado). Este PR fecha o **loop de rastreabilidade** nas ADRs que originalmente deixaram event sourcing fora do escopo.

## Mudanças

- **ADR-0003** (Wolverine como backbone CQRS): deixou event sourcing *deliberadamente fora* da decisão inicial. Agora registra explicitamente a **emenda** que a ADR-0069 representa, reafirmando que `ICommandBus`/`IQueryBus` seguem como entrada da Application e que handlers event-sourced ficam na Infrastructure. Bullet no índice "Mais informações".
- **ADR-0004** (outbox transacional): nota cruzada — em agregados event-sourced o envelope do outbox é persistido na mesma transação do *append* no Marten; EF Core/Postgres permanece o store `main` e a invariante do outbox é preservada.
- **ADR-0005** (cascading messages): nota cruzada — `PublishDomainEventsFromEntityFrameworkCore` permanece desabilitado, sem scraper EF para streams Marten; contextos CRUD seguem com cascading messages explícitas.

Apenas notas/índices — nenhuma decisão alterada.

## Validação

- `bash tools/adr-lint/validate.sh` → 69 ADRs OK
- `npx markdownlint-cli2 'docs/adrs/**/*.md'` → 0 erros