### PR TITLE
docs(adr): vocabulário canônico na ADR-0069 (catálogo/parametrização → Configuração)

### DIFF
--- a/docs/adrs/0069-event-sourcing-seletivo-marten-contextos-criticos.md
+++ b/docs/adrs/0069-event-sourcing-seletivo-marten-contextos-criticos.md
@@ -19,7 +19,7 @@ informed: []
 > **Topologia decidida:** **EF Core/Postgres permanece o message store `main`** (plano
 > operacional, preserva a ADR-0004) e **o Marten entra como store `ancillary`**
 > (`AddMartenStore<…>().IntegrateWithWolverine()`), **por-API e apenas onde há agregado
-> event-sourced** (Seleção e Ingresso); APIs CRUD (Parametrização, Organização
+> event-sourced** (Seleção e Ingresso); APIs CRUD (Configuração, Organização
 > Institucional, Portal) não recebem Marten. **Não** adotar Marten como `main`.
 > Piloto = homologação documental. Condições e topologia detalhadas em
 > [`docs/spikes/adr-0069-coexistencia-marten-efcore-proposta.md`](../spikes/adr-0069-coexistencia-marten-efcore-proposta.md)
@@ -82,7 +82,7 @@ suficiente.
 - Coerência com a stack existente: Wolverine e Marten pertencem ao ecossistema
   JasperFx, com integração nativa entre command handling, event store e outbox.
 - Adoção seletiva e justificada por agregado, sem contaminar cadastros,
-  catálogos, RBAC, parametrização, templates e demais CRUDs auxiliares.
+  configuração, RBAC, templates e demais CRUDs auxiliares.
 
 ## Opções consideradas
 
@@ -279,7 +279,7 @@ Itens que devem permanecer CRUD em V1:
 
 - cadastros auxiliares;
 - RBAC e permissões;
-- parametrização e catálogos;
+- configuração;
 - templates e conteúdo administrativo;
 - endpoints técnicos e smoke tests;
 - read models e projeções derivadas.

--- a/docs/spikes/adr-0069-event-sourcing-findings.md
+++ b/docs/spikes/adr-0069-event-sourcing-findings.md
@@ -87,6 +87,6 @@ A viabilidade técnica está **comprovada** em todos os gates, incluindo coabita
 **Veredito (decisão de gate, 2026-05-25):** a ADR-0069 foi promovida a **`accepted`**. Adoção:
 
 - **Marten como store `ancillary` (auxiliar)** — `AddMartenStore<…>().IntegrateWithWolverine()` — **por-API e apenas onde há agregado event-sourced** (Seleção e Ingresso). **EF Core/Postgres permanece o message store `main`** (plano operacional, preserva a ADR-0004). **Não** adotar Marten como `main`.
-- APIs CRUD (Parametrização, Organização Institucional, Portal) **não recebem Marten**.
+- APIs CRUD (Configuração, Organização Institucional, Portal) **não recebem Marten**.
 - **Piloto: homologação documental.** Antes de produção, fechar o hardening pendente (⟳ no relatório/proposta): externalização de chaves (Vault/KMS), eliminação da correlação pseudônima residual, recovery pós-crash, DLQ/replay e posse de migrations.
 - Reavaliar "Marten como `main`" apenas se algum serviço futuro nascer **event-first** (maioria dos agregados event-sourced).


### PR DESCRIPTION
## Contexto

A **ADR-0069** (Event Sourcing seletivo com Marten) e o relatório do spike #540 ainda carregavam os termos **banidos** "catálogo" e "parametrização" em listas de exemplo de módulos CRUD. O glossário do projeto adota vocabulário canônico (regra R6: **Parametrização → Configuração**; "catálogo" descartado em favor de "Configuração").

## Mudanças (errata de vocabulário — sem alterar a decisão)

- **ADR-0069**: drivers, escopo de adoção e lista de itens que permanecem CRUD passam a usar "Configuração"; a API de exemplo "Parametrização" vira "Configuração".
- **docs/spikes/adr-0069-event-sourcing-findings.md**: idem na lista de APIs CRUD que não recebem Marten.

Nenhuma mudança semântica: topologia (Marten `ancillary`, EF Core `main`), agregados candidatos e o veredito do gate permanecem idênticos.

## Validação

- `grep` confirma zero ocorrências de catálogo/parametrização nos arquivos.
- `bash tools/adr-lint/validate.sh` → 0 erros · `markdownlint-cli2` → 0 erros.