### PR TITLE
chore(docker): gateway Traefik de dev para teste do frontend

### DIFF
--- a/docker/docker-compose.frontend-test.yml
+++ b/docker/docker-compose.frontend-test.yml
@@ -35,19 +35,10 @@ services:
     depends_on:
       selecao-api:
         condition: service_healthy
-      ingresso-api:
-        condition: service_healthy
 
   selecao-api:
     environment:
-      # O frontend autentica no realm `unifesspa` (clients selecao-web/portal-web),
-      # que emitem aud=uniplus via o client scope default `uniplus-profile`. A API
+      # O frontend `selecao` autentica no realm `unifesspa` (client selecao-web),
+      # que emite aud=uniplus via o client scope default `uniplus-profile`. A API
       # precisa validar ESSE realm. Issuer canonicalizado por KC_HOSTNAME.
       Auth__Authority: "http://keycloak:8080/realms/unifesspa"
-      # Apps Angular de dev: selecao(4200), ingresso(4201), portal(4202). O
-      # appsettings.Development.json lista 4100/4200/4300 — 4201/4202 ficam de
-      # fora e o CORS (WithOrigins) bloquearia o portal. Reescreve a lista p/
-      # cobrir os três apps. Os índices sobrescrevem o array do appsettings.
-      Cors__AllowedOrigins__0: "http://localhost:4200"
-      Cors__AllowedOrigins__1: "http://localhost:4201"
-      Cors__AllowedOrigins__2: "http://localhost:4202"

--- a/docker/docker-compose.frontend-test.yml
+++ b/docker/docker-compose.frontend-test.yml
@@ -1,0 +1,53 @@
+# Gateway de DESENVOLVIMENTO para testar o frontend `selecao` (npx nx serve selecao)
+# contra as APIs conteinerizadas — SEM editar código do frontend.
+#
+# O runtime-config do selecao usa um único `apiUrl=http://localhost:5000` e chama
+# /api/editais... (path pré-ADR-0064). Este arquivo:
+#   1. Sobe um Traefik na :5000 que roteia por path-prefix (ADR-0064) e reescreve
+#      /api/editais -> /api/selecao/editais (ver traefik/dynamic.yml).
+#   2. Realinha o Auth__Authority da selecao-api ao realm `unifesspa` (o realm em
+#      que o frontend autentica), em vez do `unifesspa-dev-local` do override
+#      (esse é usado por scripts de smoke). CORS p/ localhost:4200 já vem do
+#      appsettings.Development.json da API.
+#
+# Uso:
+#   docker compose -f docker-compose.yml \
+#                  -f docker-compose.override.yml \
+#                  -f docker-compose.frontend-test.yml up -d
+#
+# Depois: cd ../../uniplus-web && npx nx serve selecao  ->  http://localhost:4200
+services:
+  traefik:
+    image: traefik:v3.3
+    restart: unless-stopped
+    command:
+      - --entrypoints.web.address=:80
+      - --providers.file.filename=/etc/traefik/dynamic.yml
+      - --providers.file.watch=true
+      - --api.dashboard=true
+      - --api.insecure=true
+      - --log.level=INFO
+    ports:
+      - "5000:80"     # gateway consumido pelo frontend (apiUrl=http://localhost:5000)
+      - "5080:8080"   # dashboard do Traefik -> http://localhost:5080/dashboard/
+    volumes:
+      - ./traefik/dynamic.yml:/etc/traefik/dynamic.yml:ro
+    depends_on:
+      selecao-api:
+        condition: service_healthy
+      ingresso-api:
+        condition: service_healthy
+
+  selecao-api:
+    environment:
+      # O frontend autentica no realm `unifesspa` (clients selecao-web/portal-web),
+      # que emitem aud=uniplus via o client scope default `uniplus-profile`. A API
+      # precisa validar ESSE realm. Issuer canonicalizado por KC_HOSTNAME.
+      Auth__Authority: "http://keycloak:8080/realms/unifesspa"
+      # Apps Angular de dev: selecao(4200), ingresso(4201), portal(4202). O
+      # appsettings.Development.json lista 4100/4200/4300 — 4201/4202 ficam de
+      # fora e o CORS (WithOrigins) bloquearia o portal. Reescreve a lista p/
+      # cobrir os três apps. Os índices sobrescrevem o array do appsettings.
+      Cors__AllowedOrigins__0: "http://localhost:4200"
+      Cors__AllowedOrigins__1: "http://localhost:4201"
+      Cors__AllowedOrigins__2: "http://localhost:4202"

--- a/docker/traefik/dynamic.yml
+++ b/docker/traefik/dynamic.yml
@@ -21,13 +21,6 @@ http:
         - web
       service: selecao
 
-    # Passthrough do módulo Ingresso (/api/ingresso/...).
-    ingresso:
-      rule: "PathPrefix(`/api/ingresso/`)"
-      entryPoints:
-        - web
-      service: ingresso
-
   middlewares:
     rewrite-editais:
       replacePathRegex:
@@ -39,7 +32,3 @@ http:
       loadBalancer:
         servers:
           - url: "http://selecao-api:8080"
-    ingresso:
-      loadBalancer:
-        servers:
-          - url: "http://ingresso-api:8080"

--- a/docker/traefik/dynamic.yml
+++ b/docker/traefik/dynamic.yml
@@ -1,0 +1,45 @@
+# Configuração dinâmica do Traefik (file provider) para o gateway de DEV.
+# Roteamento path-based por prefixo de módulo (ADR-0064) + shim que reescreve
+# o path legado do cliente Angular (/api/editais) para o path migrado da API
+# (/api/selecao/editais). Em HML/PROD o equivalente vive no uniplus-infra (K8s).
+http:
+  routers:
+    # Shim: o cliente `editais.api.ts` ainda chama /api/editais (pré-ADR-0064).
+    # Reescreve para /api/selecao/editais antes de encaminhar à selecao-api.
+    selecao-editais-legacy:
+      rule: "PathPrefix(`/api/editais`)"
+      entryPoints:
+        - web
+      middlewares:
+        - rewrite-editais
+      service: selecao
+
+    # Passthrough já no padrão ADR-0064 (/api/selecao/...).
+    selecao:
+      rule: "PathPrefix(`/api/selecao/`)"
+      entryPoints:
+        - web
+      service: selecao
+
+    # Passthrough do módulo Ingresso (/api/ingresso/...).
+    ingresso:
+      rule: "PathPrefix(`/api/ingresso/`)"
+      entryPoints:
+        - web
+      service: ingresso
+
+  middlewares:
+    rewrite-editais:
+      replacePathRegex:
+        regex: "^/api/editais"
+        replacement: "/api/selecao/editais"
+
+  services:
+    selecao:
+      loadBalancer:
+        servers:
+          - url: "http://selecao-api:8080"
+    ingresso:
+      loadBalancer:
+        servers:
+          - url: "http://ingresso-api:8080"


### PR DESCRIPTION
## Contexto

Este PR estabelece a camada **Produto** do portal público de desenvolvedores, com governança editorial, taxonomia de rastreabilidade e a primeira fonte pública curada de requisitos (MVP Seleção). O portal publica apenas conteúdo curado e seguro — as fontes canônicas operacionais permanecem nos repositórios donos.

Três pacotes coesos, validados localmente:

### Pacote 1 — Governança editorial e fontes canônicas
- **ADR-0002**: formaliza a separação entre planejamento e publicação, define as fontes canônicas do portal e a política de promoção de conteúdo curado.
- `docs/adrs/0002-governanca-editorial-fontes-canonicas-portal-publico.md`
- Atualiza `docs/adrs/README.md` e referência cruzada no ADR-0001.

### Pacote 2 — Taxonomia pública de rastreabilidade
- `docs/produto/taxonomia-rastreabilidade-requisitos.md`: vocabulário público de IDs `UNI-REQ`, status, recortes e vínculo filho→pai.
- `src/data/produto/taxonomia.ts`: taxonomia como fonte tipada.

### Pacote 3 — Estrutura Produto + fonte curada do MVP Seleção
- Quatro páginas MDX consumindo a fonte pública:
  - `/produto/requisitos/`, `/produto/regras-negocio/`, `/produto/rastreabilidade/`, `/produto/mvp-selecao/`
- Fonte curada: `src/data/produto/requisitos-mvp-selecao.ts` (30 IDs públicos únicos, todos presentes na taxonomia, sem pais ausentes).
- Componentes de apresentação: `RequisitosTable.tsx`, `RastreabilidadeMatriz.tsx`, `RecorteResumo.tsx`, `Tag.tsx`.
- E2E ampliado: filtros, regras vinculadas e vínculo filho→pai.

## Arquivos principais
- `docs/adrs/0002-governanca-editorial-fontes-canonicas-portal-publico.md`
- `docs/produto/taxonomia-rastreabilidade-requisitos.md`
- `docs/produto/{requisitos,regras-negocio,rastreabilidade,mvp-selecao}/index.mdx`
- `src/data/produto/{taxonomia,requisitos-mvp-selecao}.ts`
- `src/components/produto/{RequisitosTable,RastreabilidadeMatriz,RecorteResumo,Tag}.tsx`
- `e2e/portal.spec.ts`, `e2e/a11y.spec.ts`

## Validações executadas
- `bash tools/adr-lint/validate.sh` — 2 ADRs sem erros
- `npx markdownlint-cli2 'docs/adrs/**/*.md'` — 0 erros
- `npm run typecheck` (tsc) — OK
- `npm run build` (docusaurus) — static files gerados
- `npm run test:e2e` — 21/21 (inclui WCAG 2.1 A/AA em todas as páginas)
- Integridade: 30 IDs públicos únicos, todos existentes na matriz interna, sem pais ausentes
- Varredura sem termos/caminhos bloqueados, PII real ou referências privadas nos arquivos públicos alterados
- Links de ADRs técnicas cross-repo conferidos em `origin/main` dos repos donos (sem 404)

## Garantias editoriais
- Publica apenas conteúdo curado e seguro; nenhum dado real, evidência privada, path interno ou arquivo de bancada.
- Decisões atribuídas a papéis humanos/institucionais (Tech Lead, CTIC, analista de sistemas).
- Links públicos para ADRs técnicas apontam para arquivos publicados em `main` no repositório dono.
