### PR TITLE
docs(adrs): ADRs 0078-0088 da frente de Autorização (PBAC + ABAC)

### DIFF
--- a/docs/adrs/0078-modelo-de-autorizacao-pbac-abac.md
+++ b/docs/adrs/0078-modelo-de-autorizacao-pbac-abac.md
@@ -1,0 +1,137 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0078: Modelo de autorização PBAC + ABAC com ponto de decisão único
+
+## Contexto e enunciado do problema
+
+A autorização administrativa do `uniplus-api` foi modelada na [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) como um modelo por papéis fixos por Unidade: papéis globais (administrador / leitor) sobre um identificador de Unidade, com visibilidade por interseção de conjuntos de Unidades. Esse modelo decide o acesso a partir do **papel** do solicitante e do conjunto de Unidades que ele administra.
+
+Um papel global não é suficiente para o domínio do Uni+. A permissão real de uma operação depende de muito mais que o papel:
+
+- de qual módulo se trata (Seleção, Ingresso, Configuração, Organização);
+- de qual unidade organizacional o solicitante atua;
+- de qual processo seletivo, edital, etapa, banca, chamada ou matrícula está em jogo;
+- de qual fase do fluxo está aberta e qual o estado do recurso;
+- da classificação do dado retornado (público, interno, pessoal, sensível) e da base legal aplicável (LGPD);
+- da preferência de identificação do candidato (nome social vs. nome civil);
+- de o solicitante ter recebido uma concessão excepcional fora do seu grupo padrão;
+- de o solicitante estar operando em sessão delegada (atuação institucional em nome de uma unidade).
+
+Espalhar essas condições por verificações ad hoc nos controllers — por exemplo, `[Authorize(Policy = "...")]` com lógica de negócio embutida — produz autorização inconsistente, não auditável e difícil de evoluir. O problema é **decidir o acesso de forma uniforme, sensível ao contexto, com um único ponto de decisão e um sujeito explícito**.
+
+## Drivers da decisão
+
+- Autorização sensível a **atributos de contexto**, não apenas ao papel.
+- **Um único ponto de decisão** — toda decisão de acesso passa pelo mesmo contrato, para ser auditável e testável.
+- **Sujeito explícito** na assinatura da decisão — nunca inferido do ambiente (thread estático, header solto, estado global).
+- LGPD-by-design: a decisão precisa poder considerar a classificação do dado e a base legal (detalhado em ADR própria desta frente).
+- Concessões fora do papel padrão (excepcional, sessão delegada) avaliadas no servidor, sem depender do conteúdo do token.
+- Substituir o modelo por papéis fixos por Unidade da ADR-0057, que não acompanha a complexidade real e tende à proliferação de papéis.
+
+## Opções consideradas
+
+- **A**: Manter o modelo por papéis fixos por Unidade (ADR-0057) — papéis globais por Unidade.
+- **B**: **PBAC** (baseado em permissão — *o que* pode ser feito) **+ ABAC** (baseado em atributos de contexto — *em que circunstância*) com um **ponto de decisão único** e **sujeito explícito**.
+- **C**: ReBAC / motor externo de políticas (Cedar, OPA, OpenFGA) como sidecar.
+
+## Resultado da decisão
+
+**Escolhida:** "B — PBAC + ABAC com ponto de decisão único", porque combina permissões granulares com atributos de contexto num contrato formal único, auditável e testável, sem o acoplamento operacional de um motor externo nesta fase.
+
+### Ponto de decisão único
+
+Toda decisão de acesso passa por um serviço único, `IAuthorizationDecisionService`, com a assinatura:
+
+```csharp
+Task<AuthorizationDecision> DecideAsync(
+    AuthorizationSubject subject,        // quem — explícito
+    PermissionRequirement requirement,   // o que — permissão + metadados
+    ResourceContext resource,            // sobre qual recurso — atributos do alvo
+    AuthorizationRequestContext request, // em que requisição — contexto da chamada
+    CancellationToken ct);
+```
+
+`[Authorize(Policy = ...)]` fica restrito à autenticação básica; **regra de negócio de autorização não vive em atributo de controller** — vive no serviço de decisão.
+
+### Sujeito explícito e concessões efetivas
+
+O sujeito é passado explicitamente como `AuthorizationSubject`, carregando: a identidade (`UsuarioRef`, com emissor + *subject* do token — nunca um `Guid` representando o *subject*), os grupos do token, as unidades administradas (derivadas no servidor), e a lista de **concessões efetivas** (`EffectiveGrant`).
+
+Uma concessão efetiva **unifica três fontes possíveis** — o token OIDC, o vínculo de grupo definido pela aplicação e a concessão excepcional — cada uma com **fonte rastreável**. A decisão pergunta apenas se o sujeito tem **ao menos uma** concessão aplicável ao recurso, considerando escopo e validade. Não exige que a permissão esteja no token *antes* de considerar uma concessão de outra fonte — uma concessão excepcional avaliada no servidor é uma concessão válida, apenas com origem distinta.
+
+### Algoritmo de decisão (forma canônica)
+
+1. Se a permissão exige autenticação multifator e o sujeito não a satisfez → negar (motivo registrado).
+2. Se a permissão exige dupla aprovação e a requisição não a apresenta válida e não usada → negar.
+3. Selecionar as concessões efetivas aplicáveis: mesma permissão, dentro da validade, com escopo que inclui o recurso (unidade, processo, chamada, tipo de recurso).
+4. Se nenhuma concessão aplicável → negar (sem concessão aplicável).
+5. Executar as verificações declarativas de contexto exigidas pela permissão; se alguma falha → negar com o motivo correspondente.
+6. Se o dado é pessoal ou sensível → confirmar a base legal aplicável.
+7. Conceder, registrando **qual concessão (e qual fonte) foi usada** para autorizar.
+
+O resultado (`AuthorizationDecision`) carrega o veredito, o motivo de negativa quando aplicável (`DenyReason`, sem dados pessoais) e a concessão usada para fins de auditoria.
+
+### Verificações declarativas de contexto
+
+Cada permissão declara as verificações de contexto obrigatórias (por exemplo: fase aberta, estado do recurso compatível, escopo de auditoria ativo, base legal aplicável, MFA satisfeito, dupla aprovação registrada, equipe ativa no processo, atribuição documental ativa). O serviço de decisão orquestra a sequência declarada; **cada verificação é uma unidade testável** (`IPermissaoCheck`), não código espalhado.
+
+### O que esta ADR não decide
+
+Em respeito à regra "1 ADR = 1 decisão", esta ADR fixa **apenas** o modelo de decisão (PBAC + ABAC, ponto único, sujeito explícito, concessão efetiva). Decisões correlatas têm ADR própria desta frente de autorização: o catálogo declarativo de permissões e a geração de artefatos; a **hierarquia institucional sem herança de permissão** (ADR seguinte); a proteção de dado por permissão (LGPD-by-design); os grupos OIDC e seu provisionamento; a concessão excepcional e a sessão delegada; o cache e a revogação de concessões; a trilha de auditoria de autorização; e o banco isolado de autorização.
+
+## Consequências
+
+### Positivas
+
+- Decisão de acesso **uniforme, auditável e testável** — um único ponto de decisão.
+- Sensível a contexto **sem** espalhar lógica de autorização pelos controllers.
+- Sujeito explícito elimina a dependência de estado ambiental e torna a decisão reproduzível em teste.
+- Concessões fora do papel padrão (excepcional, sessão delegada) integradas à decisão sem inflar o token.
+- A negativa explica-se por um motivo estável e sem dados pessoais, útil para diagnóstico e auditoria.
+
+### Negativas
+
+- Mais peças (tipos formais e verificações) do que um simples atributo de papel.
+- Cada nova condição de contexto é uma verificação a implementar e testar.
+- Curva de aprendizado para a equipe acostumada ao modelo por papéis fixos.
+
+### Neutras
+
+- Não fecha a porta para um motor externo de políticas (Cedar/OPA/OpenFGA) no futuro — fica como avaliação posterior, caso a complexidade das políticas justifique.
+
+## Confirmação
+
+- **Fitness test**: nenhuma rota de negócio usa `[Authorize(Policy = ...)]` para regra de autorização; toda permissão referenciada em uma decisão existe no catálogo de permissões; o sujeito é parâmetro explícito do serviço de decisão.
+- **Golden authorization tests**: cobertura de conceder e de **negar** por escopo de unidade, fase fechada, estado de recurso incompatível e validade expirada — com prova negativa e contraprova positiva.
+
+## Prós e contras das opções
+
+### A — Modelo por papéis fixos por Unidade (manter ADR-0057)
+
+- Bom, porque é simples e já modelado.
+- Ruim, porque decide só por papel; condições reais (fase, estado, unidade, classificação do dado, base legal) não cabem no papel e acabam espalhadas pelos controllers; tende à proliferação de papéis.
+
+### B — PBAC + ABAC com ponto de decisão único (escolhida)
+
+- Bom, porque decide por permissão + atributos de contexto num contrato único, auditável e testável, com sujeito explícito.
+- Ruim, porque exige tipos formais e verificações declaradas — mais peças que um atributo de papel.
+
+### C — Motor externo de políticas (Cedar/OPA/OpenFGA)
+
+- Bom, porque externaliza a linguagem de políticas e escala para regras complexas.
+- Ruim, porque adiciona um componente de runtime e uma linguagem própria sem necessidade comprovada nesta fase; acoplamento operacional alto para o ganho atual.
+
+## Mais informações
+
+- **Supersede** a [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) (modelo por papéis fixos por Unidade): o eixo de decisão deixa de ser o papel por Unidade e passa a ser permissão + atributos de contexto, com escopo por Unidade.
+- **Refina** a [ADR-0055](0055-organizacao-institucional-bounded-context.md) (Organização como bounded context): a Unidade permanece o escopo institucional, mas a autorização sobre ela passa a ser PBAC + ABAC, não papel global por Unidade.
+- Relaciona-se com: [ADR-0033](0033-icurrentuser-abstraction-via-iusercontext.md) (`IUserContext`, estendido para expor o sujeito), [ADR-0010](0010-audience-unica-uniplus-em-tokens-oidc.md) (audience OIDC), [ADR-0034](0034-problemdetails-em-401-403-via-jwtbearer-events.md) (ProblemDetails em 401/403), [ADR-0019](0019-proibir-pii-em-path-segments-de-url.md) (sem dado pessoal em URL) e [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md) (trilha forense isenta de soft-delete).
+- A **hierarquia institucional sem herança de permissão** (unidades irmãs; auditoria explícita) é decidida na ADR seguinte desta frente; o catálogo de permissões, a proteção de dado por permissão e o provisionamento OIDC seguem em ADRs próprias.

--- a/docs/adrs/0079-hierarquia-institucional-sem-heranca-de-permissao.md
+++ b/docs/adrs/0079-hierarquia-institucional-sem-heranca-de-permissao.md
@@ -1,0 +1,91 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0079: Hierarquia institucional sem herança de permissão
+
+## Contexto e enunciado do problema
+
+A estrutura organizacional da Unifesspa é hierárquica: a instituição tem pró-reitorias e centros como filhos diretos, e estes têm divisões, coordenações e núcleos abaixo. No modelo de dados, cada `Unidade` aponta para a sua unidade superior (`UnidadeSuperiorId`).
+
+A [ADR-0055](0055-organizacao-institucional-bounded-context.md) tratou a PROEG como **supervisora** sobre o CEPS e o CRCA, e a [ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md) modelou visibilidade entre Unidades. Isso deixa em aberto uma pergunta de autorização: **estar acima na hierarquia institucional concede, automaticamente, acesso ao que está abaixo?**
+
+Estrutura e autoridade de acesso são eixos distintos. Uma pró-reitoria figurar como superior de um centro descreve a organização administrativa; não significa que ela opere — nem deva enxergar por padrão — os dados operacionais daquele centro (inscrições, documentos de candidatos, pareceres de banca). Se a hierarquia propagasse permissão, três efeitos indesejados surgiriam: (1) acesso amplo viraria efeito colateral da posição na árvore, não uma decisão; (2) a auditoria não conseguiria atribuir "quem podia ver isto" a uma concessão explícita; (3) reorganizar a árvore (mudar o pai de uma Unidade por portaria) concederia ou removeria acessos silenciosamente.
+
+O problema é decidir se a hierarquia institucional propaga permissão por herança, ou se o acesso é sempre concessão explícita.
+
+## Drivers da decisão
+
+- **Menor privilégio**: acesso amplo deve ser concessão deliberada, não consequência da posição hierárquica.
+- **Auditabilidade**: "quem podia ver ou editar isto, e por quê" deve resolver para uma concessão explícita, não para a topologia da árvore.
+- **Realidade institucional**: supervisão administrativa não equivale a acesso operacional aos dados; a PROEG não conduz o backlog diário do CEPS.
+- **Sem escalonamento implícito**: reorganização institucional (mudança de unidade superior) não pode alterar acessos sem um ato explícito.
+
+## Opções consideradas
+
+- **A**: Herança por hierarquia — a unidade superior herda o acesso das inferiores (interpretação da supervisão da ADR-0055).
+- **B**: **Sem herança** — unidades são irmãs para fins de autorização; visibilidade ampla exige um escopo de auditoria explícito, formal e temporal.
+- **C**: Herança opcional, configurável por unidade.
+
+## Resultado da decisão
+
+**Escolhida:** "B — sem herança de permissão por hierarquia", porque preserva o menor privilégio, mantém a autorização auditável a concessões explícitas e desacopla a estrutura institucional da autoridade de acesso.
+
+A hierarquia (`UnidadeSuperiorId`) descreve a estrutura organizacional e **não** propaga permissão nem visibilidade. Para fins de autorização, **PROEG, CEPS e CRCA são unidades irmãs** (filhas diretas da instituição), não mãe e filhas. Nenhuma unidade enxerga ou administra o que pertence a outra por estar acima dela na árvore.
+
+A visibilidade ampla legítima — por exemplo, uma pró-reitoria acompanhar o que ocorre nas unidades a ela vinculadas — é concedida por um **escopo de auditoria explícito**: uma concessão formal, **temporal** (com validade), com **base legal** registrada, materializada na entidade de escopo de auditoria e exercida por permissões de auditoria (`:auditar`). Não é um efeito da hierarquia; é um ato de concessão rastreável.
+
+A resolução de acesso, portanto, **não consulta `UnidadeSuperiorId`** para conceder. A hierarquia permanece disponível para apresentação e navegação institucional, não para decisão de autorização.
+
+## Consequências
+
+### Positivas
+
+- Menor privilégio por padrão; nenhum acesso amplo surge como efeito colateral da árvore.
+- Toda visibilidade entre unidades é rastreável a uma concessão explícita, temporal e fundamentada — auditoria responde "por quê".
+- Reorganização institucional (mudar a unidade superior) não altera acessos silenciosamente.
+- Estrutura e autoridade ficam desacopladas; a árvore pode evoluir sem consequências de segurança implícitas.
+
+### Negativas
+
+- Visibilidade ampla exige um ato explícito (escopo de auditoria), em vez de "vir de graça" pela posição — passo administrativo a mais.
+- Contraintuitivo para quem espera que "a unidade superior vê tudo o que está abaixo".
+
+### Neutras
+
+- A hierarquia continua modelada e útil para apresentação/navegação; apenas não participa da decisão de acesso.
+
+## Confirmação
+
+- **Fitness test**: a resolução de autorização não usa `UnidadeSuperiorId` para conceder acesso; toda visibilidade entre unidades passa por um escopo de auditoria ativo.
+- **Golden authorization test**: uma unidade superior **não** enxerga, por padrão, recursos de uma unidade subordinada; passa a enxergar somente mediante escopo de auditoria válido e dentro da validade.
+
+## Prós e contras das opções
+
+### A — Herança por hierarquia
+
+- Bom, porque é simples e intuitivo ("o superior vê tudo").
+- Ruim, porque viola o menor privilégio, torna o acesso não auditável a uma concessão explícita e faz a reorganização da árvore alterar acessos silenciosamente.
+
+### B — Sem herança; visibilidade por escopo de auditoria explícito (escolhida)
+
+- Bom, porque preserva o menor privilégio, mantém a autorização auditável e desacopla estrutura de autoridade.
+- Ruim, porque exige um ato explícito para conceder visibilidade ampla.
+
+### C — Herança opcional configurável
+
+- Bom, porque permite ajustar caso a caso.
+- Ruim, porque reintroduz a herança como caminho de acesso (com os mesmos riscos de auditoria e escalonamento implícito), agora de forma inconsistente entre unidades.
+
+## Mais informações
+
+- **Refina** a [ADR-0055](0055-organizacao-institucional-bounded-context.md): a relação de **supervisão** da PROEG sobre CEPS/CRCA, ali enunciada, é revista — para fins de autorização essas unidades são **irmãs**; supervisão administrativa não implica acesso operacional.
+- A visibilidade entre Unidades, que o modelo anterior ([ADR-0057](0057-areas-rbac-snapshot-historia-invariantes.md)) — superseded pela [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md) — tratava como propriedade dos papéis, passa a depender de concessão de auditoria explícita.
+- Depende do modelo de decisão da [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md) (a concessão de auditoria é uma das fontes consideradas pelo ponto de decisão).
+- A entidade de escopo de auditoria, sua expiração e seus índices são detalhados nas specs de implementação desta frente; esta ADR fixa apenas o princípio de **não herança**.

--- a/docs/adrs/0080-catalogo-declarativo-de-permissoes-e-codegen.md
+++ b/docs/adrs/0080-catalogo-declarativo-de-permissoes-e-codegen.md
@@ -1,0 +1,99 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0080: Catálogo declarativo de permissões como fonte única e geração de artefatos
+
+## Contexto e enunciado do problema
+
+O modelo de autorização da [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md) decide o acesso a partir de **permissões** (o que pode ser feito) combinadas com atributos de contexto. Essas permissões são referenciadas em vários pontos do sistema, em repositórios diferentes:
+
+- no backend .NET, para exigir a permissão na decisão de acesso;
+- no frontend, para habilitar ou esconder ações na interface;
+- no provisionamento de grupos do provedor de identidade, para empacotar permissões em perfis;
+- no inventário de proteção de dados (LGPD), para saber qual a sensibilidade e a base legal de cada operação;
+- na documentação para desenvolvedores.
+
+Se cada um desses pontos declara as permissões por conta própria, eles divergem: uma permissão renomeada no backend não se reflete no frontend nem no provisionamento; uma permissão sensível pode ficar sem base legal registrada; o conjunto efetivo de permissões de um perfil deixa de ser conhecido. O problema é manter **uma única fonte de verdade** para o catálogo de permissões e **derivar dela**, de forma verificável, todos os artefatos que dependem dele.
+
+## Drivers da decisão
+
+- **Fonte única de verdade** — evitar divergência entre backend, frontend e provedor de identidade.
+- **Metadados ricos por permissão** — sensibilidade, base legal, escopo de contexto exigido, verificações obrigatórias, quem pode receber a permissão.
+- **Artefatos derivados e consistentes** — constantes de código, manifesto de provisionamento, inventário LGPD, relatório de permissões efetivas.
+- **Travas contra deriva** — o desvio entre a fonte e os artefatos gerados deve falhar a integração contínua.
+
+## Opções consideradas
+
+- **A**: Permissões declaradas em código .NET (constantes), espalhadas e referenciadas onde necessário.
+- **B**: **Catálogo declarativo único de permissões** (um arquivo versionado), do qual um gerador produz os artefatos, com testes de conformidade travando a deriva.
+- **C**: Catálogo de permissões mantido no banco de dados, lido em runtime.
+
+## Resultado da decisão
+
+**Escolhida:** "B — catálogo declarativo único de permissões com geração de artefatos", porque centraliza a verdade num único arquivo versionado, carrega os metadados ricos que a decisão de acesso e a LGPD exigem, e permite gerar artefatos consistentes com travas automáticas contra deriva.
+
+O catálogo de permissões é um arquivo declarativo único (`permissions.yml`) no `uniplus-api`. Cada permissão declara, além do código (`{módulo}:{recurso}:{ação}`), os metadados: sensibilidade, base legal padrão, se exige autenticação multifator ou dupla aprovação, o escopo de contexto obrigatório, quem pode recebê-la e quais verificações de contexto são exigidas na decisão.
+
+Um gerador (codegen) produz, a partir desse arquivo:
+
+- as **constantes .NET** consumidas pelo backend;
+- as **constantes de frontend**, para consumo pelo `uniplus-web` (a forma de publicação e o versionamento desse contrato entre repositórios são decididos em ADR própria desta frente, não aqui);
+- o **manifesto de provisionamento** dos grupos no provedor de identidade;
+- o **inventário LGPD** (classificação e base legal por operação);
+- o **relatório de permissões efetivas** (o que cada perfil concede).
+
+Testes de conformidade (fitness tests) garantem que: toda permissão referenciada no código existe no catálogo de permissões; os artefatos gerados estão sincronizados com a fonte (sem deriva); toda permissão sensível tem base legal; os nomes de verificação de contexto declarados existem no backend. O catálogo de permissões é a fonte; o código não declara permissões fora dele.
+
+## Consequências
+
+### Positivas
+
+- Uma única fonte de verdade; os artefatos para backend, frontend e provedor de identidade ficam consistentes por construção.
+- Metadados de sensibilidade e base legal ficam ao lado da permissão — o inventário LGPD é derivado, não mantido à parte.
+- A deriva entre fonte e artefatos é detectada pela integração contínua, não em produção.
+- A geração das constantes de frontend a partir da mesma fonte elimina a divergência manual entre backend e frontend.
+
+### Negativas
+
+- O gerador e os testes de conformidade são infraestrutura a manter.
+- Toda mudança de permissão exige regenerar os artefatos e revisar o resultado.
+
+### Neutras
+
+- A forma concreta do arquivo (estrutura dos campos) evolui com a frente; esta ADR fixa que **existe uma fonte declarativa única e artefatos gerados**, não o detalhe de cada campo.
+
+## Confirmação
+
+- **Fitness test**: nenhuma permissão é referenciada no código sem existir no catálogo de permissões; os artefatos gerados conferem com a fonte (regenerar não produz diferença); permissões sensíveis têm base legal.
+- **Regeneração determinística**: rodar o gerador sobre o catálogo de permissões não produz diferença em relação aos artefatos versionados (qualquer divergência falha a integração contínua).
+
+## Prós e contras das opções
+
+### A — Permissões em constantes de código espalhadas
+
+- Bom, porque não exige gerador nem arquivo novo.
+- Ruim, porque diverge entre backend, frontend e provedor de identidade; os metadados (sensibilidade, base legal) não têm lugar único; o conjunto efetivo de um perfil deixa de ser conhecido.
+
+### B — Catálogo declarativo único de permissões com codegen (escolhida)
+
+- Bom, porque há uma fonte de verdade, metadados ricos centralizados e artefatos consistentes com travas contra deriva.
+- Ruim, porque adiciona um gerador e testes de conformidade a manter.
+
+### C — Catálogo de permissões no banco em runtime
+
+- Bom, porque permite alterar permissões sem novo build.
+- Ruim, porque a referência em tempo de compilação (constantes tipadas) se perde e a geração determinística de artefatos para outros repositórios deixa de ser possível.
+
+## Mais informações
+
+- Ancora no modelo de decisão da [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md): o catálogo de permissões é o vocabulário que o ponto de decisão exige.
+- O manifesto de provisionamento liga-se à estratégia de grupos do provedor de identidade e o inventário LGPD liga-se à proteção de dado por permissão — ambos detalhados em ADRs próprias desta frente.
+- **A publicação e o versionamento do contrato gerado para o frontend (entre repositórios) são uma decisão à parte, objeto de ADR própria desta frente** — esta ADR decide apenas a existência da fonte única e do gerador.
+- A forma de roteamento e a separação por módulo seguem a [ADR-0064](0064-convencao-roteamento-path-based-com-prefixo-modulo.md); os códigos de permissão usam o mesmo prefixo de módulo.

--- a/docs/adrs/0081-lgpd-by-design-dto-por-permissao.md
+++ b/docs/adrs/0081-lgpd-by-design-dto-por-permissao.md
@@ -1,0 +1,94 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted:
+  - "Encarregada de Proteção de Dados (DPO) — validação pendente"
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0081: LGPD-by-design — projeção por permissão como controle primário de proteção de dado pessoal
+
+> **Status:** a decisão estrutural (projeção por permissão como controle primário) está proposta; a **classificação de cada dado e a base legal de cada tratamento** descritas abaixo ficam **pendentes de validação da Encarregada de Proteção de Dados (DPO)** antes da aceitação formal desta ADR.
+
+## Contexto e enunciado do problema
+
+O Uni+ trata dados pessoais e sensíveis de candidatos: CPF, raça/cor, condição de deficiência, renda familiar, entre outros. As respostas da API que carregam esses dados precisam expor **apenas o que a permissão do solicitante autoriza** — um resultado público não pode conter CPF nem raça/cor; um perfil operacional vê os campos que sua permissão comporta; um auditor vê sob escopo e base legal.
+
+A tentação é resolver isso com **mascaramento na serialização**: um conversor que, ao escrever o JSON, substitui o valor de um campo sensível por uma máscara quando o solicitante não tem acesso. Esse mecanismo é **frágil como controle primário**: é contornado por uma projeção customizada, por *streaming*, por exportação, por um objeto aninhado, por um novo endpoint que serializa de outra forma. Quando o controle de proteção depende de um passo opcional na borda de saída, qualquer caminho que não passe por ele vaza o dado.
+
+O problema é garantir, por construção, que cada resposta exponha somente os campos que a permissão autoriza, com a classificação e a base legal de cada dado conhecidas.
+
+## Drivers da decisão
+
+- **LGPD-by-design**: cada campo pessoal/sensível tem classificação (público, interno, pessoal, sensível) e base legal; a decisão de exposição é parte do desenho, não um filtro de saída.
+- **Controle primário robusto** — não contornável por caminhos alternativos de serialização.
+- **Defesa em profundidade** — um segundo mecanismo (mascaramento) cobre o que escapar do primeiro.
+- **Verificabilidade** — é possível testar que um DTO público não vaza dado pessoal.
+
+## Opções consideradas
+
+- **A**: Mascaramento na serialização como controle primário (um conversor que mascara campos conforme o solicitante).
+- **B**: **Projeção por permissão** (DTO específico por permissão) como controle primário; mascaramento como defesa secundária; classificação e base legal por campo; testes de exposição (BOPLA).
+- **C**: Filtro genérico por papel aplicado a uma entidade única de saída.
+
+## Resultado da decisão
+
+**Escolhida:** "B — projeção por permissão como controle primário", porque o que não é projetado não pode vazar: o controle vive no formato da resposta, não num passo opcional de saída.
+
+Cada permissão que retorna dado pessoal tem um **DTO específico**, projetado no servidor, contendo **apenas** os campos que aquela permissão autoriza. Um resultado público projeta um DTO sem CPF, sem raça/cor, sem identificador interno; um perfil operacional projeta um DTO com os campos que sua permissão comporta; um auditor projeta um DTO sob escopo de auditoria e base legal. A projeção é o **controle primário**.
+
+Como **defesa secundária**, prevê-se um **mascaramento na serialização da resposta**: um campo classificado que, por engano, chegue a um DTO indevido seria mascarado na saída. É rede de segurança, não o controle primário — e é **distinto** do mascaramento de dados pessoais já aplicado aos logs (que permanece em vigor).
+
+Cada campo de dado pessoal/sensível carrega sua **classificação** e a **base legal** de tratamento. Permissões que retornam dado sensível exigem base legal aplicável na decisão de acesso (modelo da ADR-0078).
+
+A conformidade é verificada por **testes de exposição** (Broken Object Property Level Authorization): para cada DTO com dado pessoal, um teste confirma que a serialização para um solicitante sem acesso não contém o campo protegido — incluindo o teste da projeção real (não apenas do tipo).
+
+## Consequências
+
+### Positivas
+
+- O dado não projetado não vaza — o controle é estrutural, não um passo opcional na borda.
+- Classificação e base legal por campo tornam o inventário de tratamento derivável e auditável.
+- A defesa em profundidade (projeção + mascaramento) cobre erro humano.
+- A exposição é testável por DTO, com prova negativa (não vaza) e contraprova positiva (projeta o permitido).
+
+### Negativas
+
+- Mais DTOs a manter (um por cenário de permissão), em vez de uma entidade de saída única.
+- Disciplina exigida: criar um DTO específico para cada nova permissão que retorna dado pessoal.
+
+### Neutras
+
+- A forma concreta dos atributos de classificação e do conversor de mascaramento evolui com a frente; esta ADR fixa a **ordem de precedência** (projeção primeiro, mascaramento depois), não o detalhe de cada atributo.
+
+## Confirmação
+
+- **Fitness test**: nenhum DTO marcado como público contém campo classificado como pessoal/sensível; todo campo sensível tem base legal declarada.
+- **Golden BOPLA test por DTO**: a serialização para um solicitante sem acesso não contém o campo protegido, validando a projeção real (não só o tipo declarado).
+
+## Prós e contras das opções
+
+### A — Mascaramento na serialização como controle primário
+
+- Bom, porque é centralizado num único conversor.
+- Ruim, porque é contornável por projeção customizada, streaming, exportação ou objeto aninhado; um caminho que não passe pelo conversor vaza o dado.
+
+### B — Projeção por permissão como controle primário (escolhida)
+
+- Bom, porque o dado não projetado não pode vazar; classificação e base legal ficam explícitas; é testável.
+- Ruim, porque exige um DTO por cenário de permissão e disciplina para mantê-los.
+
+### C — Filtro genérico por papel sobre entidade única
+
+- Bom, porque há um só tipo de saída.
+- Ruim, porque o filtro por papel não acompanha a granularidade real (a exposição depende de permissão + contexto, não só do papel) e reincide na fragilidade do controle de saída.
+
+## Mais informações
+
+- Ancora no modelo de decisão da [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md): a permissão determina qual DTO é projetado e se a base legal é exigida.
+- Relaciona-se com a [ADR-0019](0019-proibir-pii-em-path-segments-de-url.md) (sem dado pessoal em URL) e a [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md) (trilha forense).
+- A classificação específica do **nome social e do nome civil** (quando cada um é público ou pessoal) é decidida na ADR seguinte desta frente, por tocar dignidade e legislação própria.
+- A base legal de cada tratamento e a classificação de cada dado são **validadas com a Encarregada de Proteção de Dados (DPO)** da instituição — **validação pendente** antes da aceitação formal desta ADR.

--- a/docs/adrs/0082-nome-social-publico-nome-civil-pessoal.md
+++ b/docs/adrs/0082-nome-social-publico-nome-civil-pessoal.md
@@ -1,0 +1,96 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted:
+  - "Encarregada de Proteção de Dados (DPO) — validação pendente"
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0082: Nome social como dado público e nome civil como dado pessoal protegido
+
+> **Status:** proposta **pendente de validação da Encarregada de Proteção de Dados (DPO)** antes de ser aceita. A classificação de dados e a regra de exibição abaixo tocam dignidade da pessoa e legislação específica; a aceitação formal depende do parecer da DPO.
+
+## Contexto e enunciado do problema
+
+Um candidato pode registrar um **nome social**. Em pontos públicos do processo — listas de resultado, convocações, classificação — exibir o **nome civil** de quem optou pelo nome social contraria o **Decreto 8.727/2016** (uso do nome social na administração pública federal) e o princípio da **dignidade da pessoa humana** (Constituição, art. 1º, III).
+
+Há uma inversão em relação à intuição comum sobre proteção de dados. O **nome social**, quando é a forma de identificação preferida pelo candidato, é a identificação que **deve** aparecer publicamente — é dado **público** nesse contexto. O **nome civil**, ao contrário, é dado **pessoal** (LGPD) e **não** pode aparecer em local público quando contraria a preferência do titular.
+
+O problema é classificar o nome social e o nome civil, definir como a preferência de identificação é determinada e estabelecer a regra de exibição pública.
+
+## Drivers da decisão
+
+- **Decreto 8.727/2016** — uso do nome social na administração pública federal.
+- **Dignidade da pessoa humana** — Constituição, art. 1º, III.
+- **LGPD** — o nome civil é dado pessoal; sua divulgação tem base legal e finalidade.
+- **Preferência explícita** — a escolha do candidato deve ser persistida e inequívoca, não inferida por heurística.
+
+## Opções consideradas
+
+- **A**: Tratar o nome social como dado protegido (PII) e usar o nome civil nas listas públicas.
+- **B**: **Nome social (quando preferido) é dado público; nome civil é dado pessoal** e nunca aparece em local público contra a preferência; a preferência de identificação é **persistida**.
+- **C**: Inferir a preferência pela presença do nome social (sem persistir uma escolha explícita).
+
+## Resultado da decisão
+
+**Escolhida:** "B — nome social público quando preferido; nome civil pessoal e protegido", porque é o que respeita o Decreto 8.727/2016 e a dignidade do titular, e porque a preferência precisa ser uma escolha registrada, não uma adivinhação.
+
+- **Listas de classificação e de resultado (públicas):** a identificação é feita pelo **número de inscrição** acompanhado de uma **forma abreviada do nome** — as iniciais dos primeiros nomes seguidas do último sobrenome por extenso (por exemplo, "M. L. Almeida" para "Maria Lima Almeida") —, derivada do **nome social** quando o candidato o prefere. O **nome completo não é exibido** nessas listas (minimização — LGPD, art. 6º, III).
+- **Pontos de identificação nominal** (convocação nominal, documento de identificação do candidato, atendimento): usa-se o **nome social** quando o candidato indicou um nome social; usa-se o **nome civil** quando não há nome social ou a preferência é pelo civil. O **nome civil nunca aparece em local público contra a preferência** do titular.
+- O **nome social preferido** é classificado como dado **público** (a forma de identificação que o titular escolheu tornar pública).
+- O **nome civil** completo é dado **pessoal** (LGPD): visível ao próprio titular, a atores com permissão operacional explícita e a auditores sob escopo e base legal — **nunca** em exposição pública contra a preferência.
+- A **preferência de identificação** (social ou civil) é **persistida** como atributo do candidato, **não inferida** pela presença ou ausência do nome social.
+
+Invariantes da preferência:
+
+- se o candidato não tem nome social, a preferência só pode ser **civil**;
+- se a preferência é **social**, o nome social não pode estar vazio;
+- a transição entre preferências é um ato explícito do titular, registrado.
+
+## Consequências
+
+### Positivas
+
+- Conformidade com o Decreto 8.727/2016 e respeito à dignidade do titular.
+- A exposição pública usa sempre a identificação que o titular escolheu; o nome civil fica protegido onde deve.
+- A preferência é inequívoca e auditável, por ser persistida.
+
+### Negativas
+
+- Exige uma migração/backfill para atribuir a preferência aos candidatos já cadastrados.
+- As projeções públicas precisam usar a identificação derivada, nunca o nome civil diretamente — disciplina nas consultas.
+
+### Neutras
+
+- A forma concreta da persistência da preferência e da identificação derivada é detalhada na spec de implementação; esta ADR fixa a **classificação** e a **regra de exibição**.
+
+## Confirmação
+
+- **Fitness/golden BOPLA test**: uma lista pública de classificação/resultado expõe o número de inscrição e o nome abreviado (iniciais + último sobrenome), nunca o nome completo; um DTO público de candidato **não** contém o nome civil quando a preferência é social; nos pontos de identificação nominal, resolve para o nome social quando há indicação dele.
+- **Teste de invariante**: a preferência social exige nome social não vazio; sem nome social, a preferência é civil; a transição é coberta por teste.
+
+## Prós e contras das opções
+
+### A — Nome social protegido como PII; nome civil em listas públicas
+
+- Bom, porque segue a intuição comum de "nome social é dado sensível a ocultar".
+- Ruim, porque expõe o nome civil contra a preferência do titular, violando o Decreto 8.727/2016 e a dignidade da pessoa.
+
+### B — Nome social público quando preferido; nome civil pessoal; preferência persistida (escolhida)
+
+- Bom, porque respeita a legislação e a dignidade, e torna a preferência inequívoca e auditável.
+- Ruim, porque exige backfill da preferência e disciplina nas projeções públicas.
+
+### C — Inferir a preferência pela presença do nome social
+
+- Bom, porque dispensa um campo de preferência.
+- Ruim, porque a inferência é ambígua (um nome social cadastrado não significa que o titular quer usá-lo em tudo) e não registra uma escolha — frágil para um direito do titular.
+
+## Mais informações
+
+- Ancora na [ADR-0081](0081-lgpd-by-design-dto-por-permissao.md): esta é a classificação específica do nome social/civil dentro do controle de proteção por projeção.
+- Base legal e normativa: Decreto 8.727/2016; Constituição art. 1º, III; LGPD (Lei 13.709/2018).
+- **Validação pendente da DPO** da instituição antes da aceitação formal desta ADR.

--- a/docs/adrs/0083-grupos-oidc-governados-pela-aplicacao.md
+++ b/docs/adrs/0083-grupos-oidc-governados-pela-aplicacao.md
@@ -1,0 +1,91 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0083: Grupos OIDC governados pela aplicação, com marca de propriedade e sincronização não-destrutiva
+
+## Contexto e enunciado do problema
+
+As permissões do Uni+ são empacotadas em **perfis administrativos**. O provedor de identidade (OIDC) organiza os usuários em **grupos**, e cada grupo, ao ser atribuído a um usuário, deve conceder um conjunto de permissões. Surgem duas perguntas: **quem é a fonte da verdade sobre o que cada grupo concede** e **como a aplicação provisiona e mantém esses grupos no provedor sem causar dano**.
+
+O provedor de identidade do Uni+ é compartilhado com outros sistemas institucionais. Hoje são poucos sistemas e poucos perfis, de modo que o impacto de um descuido seria limitado. Ainda assim, um processo de sincronização ingênuo — que liste todos os grupos do provedor e os ajuste ao estado desejado da aplicação — poderia **criar, renomear ou apagar grupos que pertencem a outros sistemas**. É um erro evitável com pouco esforço, e a proteção deve estar pronta antes de o número de sistemas e perfis crescer.
+
+O problema é a aplicação governar **apenas os grupos que ela define**, mantendo o vínculo grupo→permissões, sem jamais tocar o que não é seu.
+
+## Drivers da decisão
+
+- **Fonte da verdade na aplicação**: o que cada grupo concede é definido pela aplicação (registro no banco); o provedor reflete.
+- **Provider-agnostic**: o vocabulário de domínio não embute o nome do produto de identidade; os caminhos de grupo seguem o *slug* da Unidade.
+- **Propriedade explícita**: a aplicação só opera grupos marcados como dela.
+- **Não destrutivo por padrão**: a sincronização observa e relata; qualquer alteração exige um plano aprovado.
+- **Isolamento em provedor de identidade compartilhado**: grupos de outros sistemas são invisíveis ao processo de sincronização.
+
+## Opções consideradas
+
+- **A**: Sincronização automática bidirecional — a aplicação cria, renomeia e remove grupos no provedor para casar com o estado desejado.
+- **B**: **Vínculo no banco** (registro que define o que cada grupo concede) + **marca de propriedade** em cada grupo provisionado + **filtro de prefixo e de propriedade** + **sincronização somente-leitura por padrão**, com alteração apenas via plano aprovado.
+- **C**: Grupos apenas no provedor, sem vínculo no banco.
+
+## Resultado da decisão
+
+**Escolhida:** "B — grupos governados por vínculo no banco, com marca de propriedade e sincronização não-destrutiva", porque mantém a aplicação como fonte da verdade sobre as concessões e impede, por construção, que a sincronização toque grupos que não são da aplicação no provedor compartilhado.
+
+- A aplicação mantém um **vínculo** que define, para cada grupo, o conjunto de permissões concedidas, o perfil e a Unidade associada. Esse vínculo é a fonte da verdade; o provedor reflete.
+- Os **caminhos de grupo** seguem o *slug* da Unidade, num espaço de nomes próprio da aplicação (prefixo dedicado), de forma independente do produto de identidade.
+- Cada grupo provisionado pela aplicação carrega uma **marca de propriedade** (um atributo que identifica a aplicação como dona).
+- O processo de **sincronização opera somente sobre grupos** que satisfaçam, ao mesmo tempo, o **prefixo** da aplicação **e** a **marca de propriedade**. Qualquer grupo fora desses dois filtros é **invisível**: não é listado, não é alterado, não é renomeado, não é removido, nem reportado como divergência.
+- O **modo padrão é somente-leitura**: a sincronização observa e relata diferenças. Criar, renomear ou remover grupos exige um **plano aprovado** explicitamente. Uma colisão de caminho com um grupo sem a marca de propriedade é **bloqueada** (nunca sobrescrita), com alerta.
+- Concessões **dinâmicas** (por processo, edital, banca) **não** viram grupo no provedor — seu tratamento é decidido em ADR própria desta frente.
+
+## Consequências
+
+### Positivas
+
+- A possibilidade de a sincronização tocar grupos de outros sistemas é eliminada por construção (filtro de prefixo + propriedade).
+- A aplicação é a fonte auditável do que cada grupo concede; o provedor é um reflexo.
+- O vocabulário permanece independente do produto de identidade.
+- A sincronização não-destrutiva por padrão evita remoções acidentais.
+
+### Negativas
+
+- Operações de alteração de grupo exigem um plano aprovado — passo a mais, deliberado.
+- A marca de propriedade e o vínculo no banco são estado adicional a manter.
+
+### Neutras
+
+- A forma concreta do registro de vínculo, do atributo de propriedade e do fluxo de aprovação do plano é detalhada na spec de implementação; esta ADR fixa o **modelo de governança** (fonte na aplicação, propriedade, filtro, não-destrutivo).
+
+## Confirmação
+
+- **Teste de isolamento**: um grupo fora do prefixo/propriedade da aplicação nunca entra no plano de sincronização; em modo de aplicação, um plano que o contenha aborta (defesa em profundidade).
+- **Teste de não-destrutividade**: o modo padrão lista zero ações de escrita; criar/renomear/remover só ocorre com plano aprovado; colisão de caminho sem marca de propriedade é bloqueada.
+
+## Prós e contras das opções
+
+### A — Sincronização automática bidirecional
+
+- Bom, porque mantém o provedor sempre alinhado sem intervenção.
+- Ruim, porque, num provedor compartilhado, pode criar/renomear/remover grupos de outros sistemas — impacto hoje limitado pelo número pequeno de sistemas, mas indesejável e facilmente evitável.
+
+### B — Vínculo + marca de propriedade + sincronização não-destrutiva (escolhida)
+
+- Bom, porque isola o que é da aplicação, mantém a fonte da verdade no banco e evita dano a terceiros.
+- Ruim, porque exige plano aprovado para alterações e estado adicional (vínculo + marca).
+
+### C — Grupos só no provedor, sem vínculo no banco
+
+- Bom, porque não há estado duplicado.
+- Ruim, porque a aplicação perde a fonte auditável do que cada grupo concede e a junção com metadados de perfil/Unidade para relatórios e decisões.
+
+## Mais informações
+
+- Ancora no modelo de decisão da [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md): um grupo é uma das fontes de concessão efetiva consideradas na decisão.
+- O **manifesto de provisionamento** dos grupos é um dos artefatos gerados a partir do catálogo de permissões ([ADR-0080](0080-catalogo-declarativo-de-permissoes-e-codegen.md)).
+- A hierarquia institucional **não** se reflete em grupos aninhados ([ADR-0079](0079-hierarquia-institucional-sem-heranca-de-permissao.md)): a árvore de unidades não propaga concessão.
+- As concessões contextuais (excepcional, sessão delegada, equipes e bancas) são decididas em ADR própria desta frente e **não** viram grupo no provedor.

--- a/docs/adrs/0084-concessao-excepcional-e-atuacao-institucional-server-side.md
+++ b/docs/adrs/0084-concessao-excepcional-e-atuacao-institucional-server-side.md
@@ -1,0 +1,92 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0084: Concessão excepcional e atuação institucional avaliadas no servidor
+
+## Contexto e enunciado do problema
+
+Além das permissões empacotadas em grupos ([ADR-0083](0083-grupos-oidc-governados-pela-aplicacao.md)), o Uni+ precisa de dois mecanismos de concessão fora do perfil padrão:
+
+1. **Concessão excepcional** — conceder a um usuário específico uma permissão que seu grupo não dá, de forma **temporária** e **escopada** (a uma unidade, processo, chamada ou tipo de recurso). Exemplo: liberar, por um período, que um servidor auxilie em um processo específico de outra unidade.
+2. **Atuação institucional** (sessão delegada) — permitir que um administrador de plataforma **opere em nome de uma unidade** por um motivo registrado e por tempo limitado, para resolver uma situação pontual.
+
+A tentação é colocar essas concessões **no token** (via um mapeador do provedor de identidade). Isso é problemático: o token vive por um tempo e não reflete uma revogação imediata (token velho continua concedendo); acopla a decisão de autorização ao ciclo de emissão do token; e dificulta carregar o **escopo** da concessão.
+
+O problema é conceder permissões fora do perfil padrão e operar sessão delegada de forma **temporal, escopada, revogável e auditável**, sem depender do conteúdo do token.
+
+## Drivers da decisão
+
+- **Revogação imediata** — retirar uma concessão deve ter efeito no ato, não ao expirar o token.
+- **Escopo e validade explícitos** — toda concessão excepcional é limitada a um recurso e a um período.
+- **Sessão delegada auditável** — quem atua em nome de quem, por quê e por quanto tempo, fica registrado.
+- **Operações sensíveis sob dupla aprovação** — atuar em nome de outra unidade em operação sensível exige um segundo aprovador.
+
+## Opções consideradas
+
+- **A**: Injetar a concessão excepcional **no token**, via mapeador do provedor de identidade.
+- **B**: **Concessão excepcional e atuação institucional como entidades no servidor**, consultadas na decisão de acesso, com escopo e validade obrigatórios e dupla aprovação para operações sensíveis.
+- **C**: Conceder via um **grupo OIDC temporário** criado e removido no provedor.
+
+## Resultado da decisão
+
+**Escolhida:** "B — concessões avaliadas no servidor", porque é o único caminho que dá revogação imediata, escopo explícito e auditoria, sem prender a decisão ao ciclo do token.
+
+- A **concessão excepcional** é registrada no servidor com: a permissão concedida, um **escopo obrigatório** (unidade, processo, chamada ou tipo de recurso — ao menos um), uma **validade obrigatória** (com teto), a justificativa e a aprovação. É **consultada na decisão de acesso** (modelo da ADR-0078), não embutida no token; a revogação tem **efeito imediato**.
+- A **atuação institucional** (sessão delegada) é registrada no servidor com: quem atua, em nome de qual unidade, o motivo, o instante de início e o de expiração (com teto). A decisão de acesso considera a atuação ativa como contexto.
+- **Operações sensíveis em sessão delegada exigem dupla aprovação**: a operação só prossegue com um segundo aprovador distinto do solicitante.
+- A **concessão excepcional** é uma **fonte de concessão efetiva** considerada pelo ponto de decisão, com **origem rastreável** (a decisão registra de qual fonte veio a autorização). A **atuação institucional** é considerada **contexto** de sessão delegada (não é fonte de concessão efetiva); seu uso fica rastreável na trilha de auditoria.
+
+## Consequências
+
+### Positivas
+
+- Revogação tem efeito imediato — não há janela de token velho concedendo acesso retirado.
+- Toda concessão fora do padrão tem escopo e validade explícitos e aprovação registrada.
+- A sessão delegada é auditável (quem, em nome de quem, por quê, por quanto tempo).
+- Operações sensíveis delegadas ficam protegidas por dupla aprovação.
+
+### Negativas
+
+- A decisão consulta o servidor para essas concessões; a estratégia que concilia essa consulta com desempenho e revogação imediata é decidida em ADR própria desta frente.
+- Há um processo de aprovação (e, no caso sensível, de dupla aprovação) a operar.
+
+### Neutras
+
+- A forma concreta das entidades (campos, constraints de escopo e validade, consumo atômico da dupla aprovação) é detalhada na spec de implementação; esta ADR fixa que essas concessões são **avaliadas no servidor**, **escopadas**, **temporais** e **revogáveis no ato**.
+
+## Confirmação
+
+- **Teste de escopo e validade**: uma concessão excepcional sem escopo é rejeitada; uma concessão expirada não concede.
+- **Teste de revogação**: revogar uma concessão tem efeito na decisão seguinte (sem janela de token velho).
+- **Teste de dupla aprovação**: uma operação sensível em sessão delegada sem um segundo aprovador distinto é negada.
+
+## Prós e contras das opções
+
+### A — Concessão excepcional no token
+
+- Bom, porque a decisão lê tudo do token, sem consulta adicional.
+- Ruim, porque o token vive por um tempo (revogação não é imediata), acopla a autorização ao ciclo de emissão e dificulta carregar o escopo da concessão.
+
+### B — Concessões avaliadas no servidor (escolhida)
+
+- Bom, porque dá revogação imediata, escopo e validade explícitos e auditoria.
+- Ruim, porque consulta o servidor na decisão e exige processo de aprovação.
+
+### C — Grupo OIDC temporário
+
+- Bom, porque reaproveita o mecanismo de grupos.
+- Ruim, porque cria e remove grupos para concessões efêmeras (poluindo o provedor), não carrega escopo fino por recurso e mistura concessão pontual com perfil administrativo estável.
+
+## Mais informações
+
+- Ancora no modelo de decisão da [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md): a concessão excepcional é fonte de concessão efetiva e a atuação institucional é contexto de sessão delegada, ambas com origem/uso rastreável.
+- Contrasta com os grupos da [ADR-0083](0083-grupos-oidc-governados-pela-aplicacao.md): estas concessões são **dinâmicas** e **não** viram grupo no provedor.
+- O **cache e a revogação imediata** (como o efeito imediato é garantido sob cache) são decididos em ADR própria desta frente.
+- A **trilha de auditoria** que registra o uso dessas concessões é decidida em ADR própria desta frente.

--- a/docs/adrs/0085-cache-e-revogacao-diferenciados-por-sensibilidade.md
+++ b/docs/adrs/0085-cache-e-revogacao-diferenciados-por-sensibilidade.md
@@ -1,0 +1,82 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0085: Cache de decisão e revogação diferenciados por sensibilidade
+
+## Contexto e enunciado do problema
+
+A decisão de acesso ([ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md)) consulta as concessões do solicitante, parte delas avaliada no servidor ([ADR-0084](0084-concessao-excepcional-e-atuacao-institucional-server-side.md)). Consultar o estado de concessões a cada decisão tem custo; um cache reduz esse custo. Mas o cache cria uma **janela** entre o que ele guarda e uma **revogação**: depois que uma concessão é retirada, um acesso a dado sensível **não pode** ser autorizado por um cache desatualizado.
+
+Tratar todas as decisões com o mesmo cache força uma escolha ruim: ou o cache é tão curto que perde a utilidade, ou é longo o bastante para autorizar, por instantes, um acesso já revogado a dado sensível. O problema é equilibrar desempenho e revogação imediata **de acordo com a sensibilidade** do que está sendo acessado, e degradar de forma segura quando o mecanismo de revogação falha.
+
+## Drivers da decisão
+
+- **Revogação com efeito imediato** para dado sensível e exportação.
+- **Desempenho aceitável** no caso comum (dado público/interno).
+- **Degradação segura** (fail-closed): se o mecanismo que propaga revogações atrasar, o sistema fica mais restritivo, não mais permissivo.
+
+## Opções consideradas
+
+- **A**: Cache uniforme com tempo de vida fixo para toda decisão.
+- **B**: **Cache diferenciado por sensibilidade** — público/interno com tempo de vida curto; pessoal com tempo de vida muito curto; sensível, exportação e dupla aprovação **sem cache** (consulta direta); uma marca de revogação versionada para invalidar; **fail-closed** quando a propagação de revogações atrasa.
+- **C**: Sem cache — consulta direta sempre.
+
+## Resultado da decisão
+
+**Escolhida:** "B — cache diferenciado por sensibilidade com fail-closed", porque ajusta o risco à sensibilidade: economiza no caso comum e nunca deixa o cache autorizar um acesso sensível já revogado.
+
+- O cache da decisão é **diferenciado pela sensibilidade** da permissão: dado **público/interno** tolera um tempo de vida curto; dado **pessoal** usa um tempo de vida muito curto; dado **sensível**, **exportação** e operações de **dupla aprovação** **não usam cache** — a decisão consulta o estado diretamente.
+- Uma **marca de revogação versionada** registra que as concessões de um sujeito (ou de um grupo, ou de uma concessão específica) mudaram; a decisão compara a versão em cache com a versão corrente e invalida o cache quando divergem.
+- O mecanismo que propaga revogações é **monitorado**. Se o seu atraso ultrapassar um limite, o sistema entra em **modo de segurança elevada**: as decisões sobre dado sensível passam a consultar diretamente e as **exportações são negadas** até a recuperação. A degradação é **fail-closed** — sob incerteza, nega-se.
+
+## Consequências
+
+### Positivas
+
+- Revogação tem efeito imediato onde mais importa (dado sensível, exportação), sem janela de cache.
+- O caso comum mantém desempenho com cache curto.
+- A falha do mecanismo de revogação leva a negar, não a liberar — postura segura.
+
+### Negativas
+
+- O cache diferenciado é mais complexo que um tempo de vida único.
+- Exige monitorar o mecanismo de propagação de revogações e operar o modo de segurança elevada.
+
+### Neutras
+
+- Os tempos de vida concretos por sensibilidade e os limites de atraso são parâmetros de operação ajustados na implementação; esta ADR fixa a **política** (diferenciar por sensibilidade; sensível sem cache; fail-closed).
+
+## Confirmação
+
+- **Teste de revogação imediata**: revogar uma concessão e, em seguida, acessar uma permissão sensível resulta em negação (a decisão não usa cache para sensível).
+- **Teste de fail-closed**: com o mecanismo de propagação de revogações parado além do limite, uma exportação é negada até a recuperação.
+
+## Prós e contras das opções
+
+### A — Cache uniforme com tempo de vida fixo
+
+- Bom, porque é simples.
+- Ruim, porque obriga a escolher entre cache inútil (curto demais) e janela insegura para dado sensível (longo demais).
+
+### B — Cache diferenciado por sensibilidade com fail-closed (escolhida)
+
+- Bom, porque ajusta o risco à sensibilidade e nunca autoriza acesso sensível por cache velho.
+- Ruim, porque é mais complexo e exige monitorar o mecanismo de revogação.
+
+### C — Sem cache
+
+- Bom, porque a revogação é sempre imediata.
+- Ruim, porque consulta o estado a cada decisão, inclusive no caso comum de dado público/interno, com custo desnecessário.
+
+## Mais informações
+
+- Ancora no modelo de decisão da [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md): o cache e a revogação operam sobre a decisão de acesso.
+- A sensibilidade de cada permissão vem do catálogo de permissões ([ADR-0080](0080-catalogo-declarativo-de-permissoes-e-codegen.md)).
+- As concessões cujo efeito de revogação esta ADR garante são as da [ADR-0084](0084-concessao-excepcional-e-atuacao-institucional-server-side.md).

--- a/docs/adrs/0086-trilha-de-auditoria-com-hmac-e-cofre.md
+++ b/docs/adrs/0086-trilha-de-auditoria-com-hmac-e-cofre.md
@@ -1,0 +1,88 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0086: Trilha de auditoria de autorização com integridade verificável
+
+## Contexto e enunciado do problema
+
+As decisões de autorização sobre dados pessoais e sensíveis — visualizar um detalhe sensível, listar um conjunto, exportar, gerar relatório — precisam de uma **trilha de auditoria**. Essa trilha responde, depois do fato, "quem acessou o quê, quando, sob qual base legal e com qual resultado", e serve como prova em situações de fiscalização ou litígio.
+
+Para ter valor probatório, a trilha precisa ser **íntegra**: uma alteração posterior de um registro deve ser detectável. Um *hash* simples do registro não basta — qualquer um que consiga reescrever o registro reescreve também o *hash*. Além disso, a verificação precisa continuar possível **depois** de a chave usada ter sido rotacionada.
+
+O problema é registrar a trilha de auditoria de autorização de forma **íntegra e verificável ao longo do tempo**, sem expor dados pessoais na própria trilha nem na observabilidade.
+
+## Drivers da decisão
+
+- **Integridade verificável** — adulteração de um registro deve ser detectável.
+- **Verificação após rotação de chave** — registros antigos continuam verificáveis.
+- **Append-only** — a trilha é forense; não se sobrescreve nem se apaga.
+- **Sem dado pessoal** na trilha estruturada e na observabilidade.
+
+## Opções consideradas
+
+- **A**: *Hash* simples (por exemplo, SHA-256) do conteúdo do registro.
+- **B**: **Código de autenticação de mensagem (HMAC)** com chave rotacionável guardada em cofre, calculado sobre uma forma canônica determinística do conteúdo, com a versão da chave registrada em cada entrada; trilha append-only.
+- **C**: Sem proteção de integridade — confiar apenas no controle de acesso ao banco.
+
+## Resultado da decisão
+
+**Escolhida:** "B — HMAC com chave em cofre, rotacionável e versionada", porque um *hash* simples não autentica (qualquer reescrita do registro reescreve o *hash*), enquanto um código de autenticação com chave secreta torna a adulteração detectável e a verificação reproduzível ao longo do tempo.
+
+- Cada registro de auditoria de autorização carrega um **código de autenticação de mensagem (HMAC)** calculado sobre uma **forma canônica determinística** do seu conteúdo (uma serialização estável, para que o mesmo conteúdo produza sempre o mesmo código).
+- A chave do código é guardada em **cofre** e é **rotacionável**. Cada registro guarda a **versão da chave** usada, de modo que um registro antigo permanece verificável com a versão correspondente, mesmo após a rotação.
+- A trilha é **append-only** ([ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md)): correções entram como um **novo fato**, nunca sobrescrevem ou apagam um registro anterior.
+- A **observabilidade** (logs, métricas, painéis) da autorização **não** expõe dados pessoais; registra eventos e identificadores não sensíveis.
+
+## Consequências
+
+### Positivas
+
+- Adulteração de um registro é detectável — a trilha tem valor probatório.
+- Registros antigos continuam verificáveis após a rotação de chave (a versão é registrada).
+- A natureza append-only preserva o histórico íntegro.
+- A ausência de dado pessoal na trilha/observabilidade reduz a superfície de exposição.
+
+### Negativas
+
+- Exige gestão de chaves no cofre (rotação, retenção das versões para verificação).
+- A forma canônica determinística do conteúdo precisa ser mantida estável ao longo do tempo.
+
+### Neutras
+
+- O algoritmo concreto, a periodicidade de rotação e a retenção das versões de chave são parâmetros de operação detalhados na implementação; esta ADR fixa o **mecanismo** (código de autenticação com chave em cofre, rotacionável, versionada por registro, sobre forma canônica, em trilha append-only).
+
+## Confirmação
+
+- **Teste de integridade**: alterar um registro faz a verificação do código de autenticação falhar.
+- **Teste de rotação**: um registro gravado antes de uma rotação permanece verificável com a versão de chave correspondente.
+- **Teste de privacidade**: nenhum dado pessoal aparece na trilha estruturada nem nos painéis/logs de observabilidade.
+
+## Prós e contras das opções
+
+### A — *Hash* simples do registro
+
+- Bom, porque é trivial de calcular.
+- Ruim, porque não autentica: quem reescreve o registro reescreve o *hash*; não detecta adulteração por quem tem acesso de escrita.
+
+### B — Código de autenticação com chave em cofre, rotacionável e versionada (escolhida)
+
+- Bom, porque detecta adulteração e permite verificação reproduzível ao longo do tempo, inclusive após rotação.
+- Ruim, porque exige gestão de chaves e uma forma canônica estável.
+
+### C — Sem proteção de integridade
+
+- Bom, porque não há nada a manter.
+- Ruim, porque a trilha perde valor probatório: nada distingue um registro íntegro de um adulterado.
+
+## Mais informações
+
+- A trilha é forense e append-only conforme a [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md).
+- Registra o uso das concessões da [ADR-0084](0084-concessao-excepcional-e-atuacao-institucional-server-side.md) e o resultado das decisões da [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md), sem expor dado pessoal.
+- A verificação de integridade dos registros (recálculo do código com a versão de chave registrada) é uma capacidade de uso interno da auditoria, detalhada na spec de implementação.

--- a/docs/adrs/0087-banco-isolado-para-o-contexto-de-autorizacao.md
+++ b/docs/adrs/0087-banco-isolado-para-o-contexto-de-autorizacao.md
@@ -1,0 +1,84 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0087: Banco isolado para o contexto de autorização
+
+## Contexto e enunciado do problema
+
+A [ADR-0054](0054-naming-convention-e-strategy-migrations.md) estabeleceu bancos PostgreSQL **isolados por módulo**: cada bounded context tem o seu banco, e referências entre contextos não cruzam o limite por chave estrangeira.
+
+A autorização, nesta frente, ganha um conjunto próprio de entidades persistidas: concessões excepcionais, escopos de auditoria, atuação institucional, vínculos de grupo, base legal de tratamento e a trilha de auditoria. A autorização **não é um módulo de domínio** como Seleção ou Ingresso — é um contexto **transversal** (cross-cutting), consumido por todos os módulos. A pergunta é **onde essas entidades persistem**: espalhadas pelos bancos dos módulos de domínio, num *schema* dentro de um banco compartilhado, ou num banco próprio.
+
+## Drivers da decisão
+
+- **Isolamento por contexto** — coerência com a ADR-0054 (cada contexto, seu banco).
+- **Autz é transversal** — não pertence a nenhum módulo de domínio específico.
+- **Integridade referencial intra-contexto** — as entidades de autorização se relacionam entre si por chave estrangeira.
+- **Isolamento de segurança** — dados de autorização e a trilha de auditoria com fronteira própria.
+
+## Opções consideradas
+
+- **A**: Distribuir as entidades de autorização pelos bancos dos módulos de domínio.
+- **B**: **Banco isolado dedicado** para o contexto de autorização.
+- **C**: *Schema* dedicado dentro de um banco compartilhado.
+
+## Resultado da decisão
+
+**Escolhida:** "B — banco isolado dedicado de autorização", porque é a aplicação direta do isolamento por contexto da ADR-0054 a um contexto que é transversal e tem entidades próprias com integridade referencial entre si.
+
+- As entidades de autorização vivem em um **banco isolado** dedicado ao contexto. As chaves estrangeiras **entre elas** são intra-banco (normais).
+- Referências a entidades de **outros contextos** — `Unidade`, `Candidato` — entram por **identificador** (Guid v7), resolvidas por **leitor read-side** ([ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md)), **sem** chave estrangeira cruzando banco (conforme ADR-0054).
+- A **trilha de auditoria forense** ([ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md)) reside nesse banco, com a fronteira de isolamento própria do contexto.
+
+## Consequências
+
+### Positivas
+
+- Topologia coerente com o isolamento por contexto já adotado no projeto.
+- Integridade referencial entre as entidades de autorização é garantida intra-banco.
+- A fronteira própria facilita o controle de acesso e a operação da trilha de auditoria.
+
+### Negativas
+
+- Um banco a mais para provisionar, migrar e operar.
+- Referências a `Unidade`/`Candidato` são por identificador (via leitor), não por chave estrangeira — consistência garantida na aplicação, não pelo banco.
+
+### Neutras
+
+- A nomenclatura do banco, as migrations e a configuração seguem a própria ADR-0054; esta ADR fixa apenas **que** o contexto de autorização tem **banco isolado**.
+
+## Confirmação
+
+- **Fitness test**: nenhuma entidade de autorização tem chave estrangeira para tabela de outro banco; referências externas são por identificador, resolvidas por leitor read-side.
+- **Teste de migração**: o banco de autorização é criado e migrado isoladamente, sem dependência de schema de outro contexto.
+
+## Prós e contras das opções
+
+### A — Distribuir nas bases dos módulos de domínio
+
+- Bom, porque reaproveita bancos existentes.
+- Ruim, porque a autorização é transversal e não cabe em um módulo; espalhar suas entidades quebra a coesão do contexto e dificulta a integridade referencial entre elas.
+
+### B — Banco isolado dedicado (escolhida)
+
+- Bom, porque aplica o isolamento por contexto, garante integridade intra-contexto e dá fronteira própria à trilha de auditoria.
+- Ruim, porque é mais um banco a operar e as referências externas passam a ser por identificador.
+
+### C — *Schema* dentro de um banco compartilhado
+
+- Bom, porque evita provisionar um banco novo.
+- Ruim, porque tensiona o isolamento por contexto da ADR-0054 e mistura, num mesmo banco, dados de contextos que a decisão de isolamento quis separar.
+
+## Mais informações
+
+- Aplica a [ADR-0054](0054-naming-convention-e-strategy-migrations.md) (bancos isolados por módulo) ao contexto transversal de autorização.
+- As referências cross-contexto seguem a [ADR-0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) (leitor read-side) e a regra de não-FK cross-banco da ADR-0054.
+- A trilha de auditoria forense isolada segue a [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md).
+- Este banco persiste as entidades decididas na [ADR-0084](0084-concessao-excepcional-e-atuacao-institucional-server-side.md) e na [ADR-0086](0086-trilha-de-auditoria-com-hmac-e-cofre.md), entre outras desta frente.

--- a/docs/adrs/0088-versionamento-cross-repo-do-contrato-de-permissoes.md
+++ b/docs/adrs/0088-versionamento-cross-repo-do-contrato-de-permissoes.md
@@ -1,0 +1,83 @@
+---
+status: "proposed"
+date: "2026-06-02"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0088: Versionamento e publicação cross-repo do contrato de permissões
+
+## Contexto e enunciado do problema
+
+O catálogo declarativo de permissões ([ADR-0080](0080-catalogo-declarativo-de-permissoes-e-codegen.md)) gera, entre outros artefatos, as **constantes de permissão consumidas pelo frontend** (`uniplus-web`). Backend (`uniplus-api`) e frontend são **repositórios distintos**.
+
+Se o frontend consome esse contrato sem disciplina de versão, uma mudança no catálogo de permissões do backend pode **quebrar o frontend silenciosamente** (uma permissão renomeada ou removida) ou deixá-lo **dessincronizado** (o frontend referencia permissões que não existem mais, ou ignora permissões novas). O problema é **como o contrato gerado é publicado e versionado** para que o frontend o consuma de forma **estável e verificável**.
+
+> Esta é uma decisão **distinta** da existência da fonte única e do gerador (ADR-0080), em respeito à regra "1 ADR = 1 decisão": a 0080 decide que o contrato **é gerado**; esta ADR decide **como ele é publicado e versionado entre repositórios**.
+
+## Drivers da decisão
+
+- **Consumo estável** pelo frontend — sem quebra silenciosa por mudança no backend.
+- **Mudança incompatível visível** — uma alteração que quebra o contrato precisa ser explícita.
+- **Verificação de sincronização** — detectar, na integração contínua, que o frontend está desalinhado do contrato publicado.
+
+## Opções consideradas
+
+- **A**: O frontend copia as constantes manualmente do backend.
+- **B**: O contrato é publicado como **pacote versionado** (versionamento semântico); o frontend o consome com **versão fixa**; a integração contínua valida o casamento entre o que o frontend consome e o que o backend publicou.
+- **C**: O frontend referencia o arquivo do backend diretamente (submódulo ou caminho compartilhado).
+
+## Resultado da decisão
+
+**Escolhida:** "B — contrato publicado como pacote versionado, consumido com versão fixa, validado na integração contínua", porque torna a evolução do contrato explícita e detectável, sem acoplar fisicamente os dois repositórios.
+
+- O contrato gerado é publicado como um **pacote versionado**, seguindo **versionamento semântico**: uma mudança incompatível (remover ou renomear uma permissão) é um **salto de versão maior**, visível.
+- O frontend consome o pacote com **versão fixa** (sem faixa aberta), de modo que atualizar o contrato é um **ato deliberado** — uma mudança no backend não chega ao frontend sem revisão.
+- A **integração contínua valida** que a versão do contrato consumida pelo frontend corresponde à versão publicada pelo backend, detectando deriva entre os repositórios.
+
+## Consequências
+
+### Positivas
+
+- O frontend consome um contrato estável; mudanças no backend não o quebram sem aviso.
+- Uma mudança incompatível é explícita (salto de versão maior), não silenciosa.
+- A deriva entre os repositórios é detectada pela integração contínua.
+
+### Negativas
+
+- Há um fluxo de publicação e versionamento do pacote a operar.
+- A atualização do frontend para uma versão nova do contrato é um passo deliberado, não automático.
+
+### Neutras
+
+- O ecossistema de empacotamento, o nome do pacote e o mecanismo concreto de publicação são detalhes de implementação; esta ADR fixa a **disciplina** (pacote versionado por versionamento semântico, consumo com versão fixa, validação na integração contínua).
+
+## Confirmação
+
+- **Validação na integração contínua (cross-repo)**: a versão do contrato consumida pelo frontend bate com a versão publicada pelo backend; divergência falha a verificação.
+- **Política de versão**: uma mudança incompatível no catálogo de permissões exige um salto de versão maior; o frontend só passa a consumi-la ao atualizar a versão fixa deliberadamente.
+
+## Prós e contras das opções
+
+### A — Cópia manual das constantes
+
+- Bom, porque não exige publicação de pacote.
+- Ruim, porque a cópia se desatualiza sem aviso e não há verificação de sincronização — a divergência é descoberta tarde.
+
+### B — Pacote versionado, versão fixa, validação na integração contínua (escolhida)
+
+- Bom, porque torna a evolução explícita e detectável, sem acoplar fisicamente os repositórios.
+- Ruim, porque exige operar a publicação e tratar a atualização do frontend como ato deliberado.
+
+### C — Referência direta ao arquivo do backend (submódulo/caminho)
+
+- Bom, porque há uma única cópia do contrato.
+- Ruim, porque acopla fisicamente os repositórios, dificulta a versão fixa e mistura os ciclos de build dos dois projetos.
+
+## Mais informações
+
+- O artefato versionado é um dos produtos do gerador decidido na [ADR-0080](0080-catalogo-declarativo-de-permissoes-e-codegen.md); esta ADR cobre **apenas** a sua publicação e versionamento entre repositórios.
+- O consumo desse contrato pelo frontend é implementado no repositório `uniplus-web`.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -105,10 +105,24 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0074](0074-base-legal-exigencia-1n-validacao-publicacao.md) | A base legal da exigência documental é 1:N e enforçada por uma validação de publicação | accepted | 2026-05-31 |
 | [0075](0075-snapshot-do-ato-resolvido-no-instante.md) | O snapshot que governa um ato é resolvido deterministicamente no instante do ato e gravado nele | accepted | 2026-05-31 |
 | [0076](0076-contrato-snapshot-runtime-espelha-publicacao.md) | A validação do snapshot lido em runtime reproduz, integralmente, a validação aplicada à configuração na publicação | accepted | 2026-05-31 |
+| 0077 | Identidade institucional canônica de `Unidade` (identificadores únicos, alias não-único, histórico) — **reservada**, a publicar (ver issue unifesspa-edu-br/uniplus-api#595) | reserved | — |
+| [0078](0078-modelo-de-autorizacao-pbac-abac.md) | Modelo de autorização PBAC + ABAC com ponto de decisão único — supersede 0057, refina 0055 | proposed | 2026-06-02 |
+| [0079](0079-hierarquia-institucional-sem-heranca-de-permissao.md) | Hierarquia institucional sem herança de permissão (unidades irmãs; visibilidade por escopo de auditoria explícito) — refina 0055 | proposed | 2026-06-02 |
+| [0080](0080-catalogo-declarativo-de-permissoes-e-codegen.md) | Catálogo declarativo de permissões como fonte única + geração de artefatos (codegen, fitness contra deriva) | proposed | 2026-06-02 |
+| [0081](0081-lgpd-by-design-dto-por-permissao.md) | LGPD-by-design — projeção por permissão como controle primário de proteção de dado pessoal (mascaramento secundário; BOPLA) — **classificação/base legal pendente de validação DPO** | proposed | 2026-06-02 |
+| [0082](0082-nome-social-publico-nome-civil-pessoal.md) | Nome social como dado público e nome civil como dado pessoal protegido (Decreto 8.727/2016) — **pendente validação DPO** | proposed | 2026-06-02 |
+| [0083](0083-grupos-oidc-governados-pela-aplicacao.md) | Grupos OIDC governados pela aplicação — vínculo no banco, marca de propriedade e sincronização não-destrutiva | proposed | 2026-06-02 |
+| [0084](0084-concessao-excepcional-e-atuacao-institucional-server-side.md) | Concessão excepcional e atuação institucional avaliadas no servidor (escopadas, temporais, revogáveis; dupla aprovação para sensível) | proposed | 2026-06-02 |
+| [0085](0085-cache-e-revogacao-diferenciados-por-sensibilidade.md) | Cache de decisão e revogação diferenciados por sensibilidade (sensível sem cache; fail-closed) | proposed | 2026-06-02 |
+| [0086](0086-trilha-de-auditoria-com-hmac-e-cofre.md) | Trilha de auditoria de autorização com integridade verificável (código de autenticação com chave em cofre, rotacionável; append-only) | proposed | 2026-06-02 |
+| [0087](0087-banco-isolado-para-o-contexto-de-autorizacao.md) | Banco isolado para o contexto de autorização (aplica ADR-0054; referências externas por identificador via leitor) | proposed | 2026-06-02 |
+| [0088](0088-versionamento-cross-repo-do-contrato-de-permissoes.md) | Versionamento e publicação cross-repo do contrato de permissões (pacote versionado; versão fixa no frontend; validação na CI) | proposed | 2026-06-02 |
+
+> **Nota de numeração:** a `0077` está **reservada** para a identidade de `Unidade` (origem na Camada 0 de cadastros, issue #595) e ainda não tem arquivo publicado; por isso o índice salta de `0076` para `0078`. Ao adicionar uma ADR nova, use `0089+` (não reocupe a `0077`).
 
 ## Como adicionar um novo ADR
 
-1. Identifique o próximo número sequencial (`ls docs/adrs/[0-9]*.md | wc -l`).
+1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0089`). **Não** use `ls | wc -l` — a contagem de arquivos não é confiável quando há número **reservado sem arquivo** (a `0077` está reservada). Confira a coluna de número da tabela para não reocupar uma entrada reservada.
 2. Copie [`_template.md`](_template.md).
 3. Renomeie para `NNNN-titulo-em-slug.md` (slug ASCII em minúsculas, hífens como separador).
 4. Preencha frontmatter, contexto, drivers, opções, resultado da decisão (única), consequências.


### PR DESCRIPTION
## O que

Promove as **11 ADRs (0078–0088)** da frente de **Autorização e acesso (PBAC + ABAC, OIDC, LGPD-by-design)** para `docs/adrs/`, com o índice atualizado.

Relaciona-se ao Epic #600 (Autorização e acesso — PBAC + ABAC) e às Features/Stories #601–616.

## ADRs

| ADR | Decisão |
|---|---|
| 0078 | Modelo PBAC + ABAC com ponto de decisão único — **supersede 0057**, refina 0055 |
| 0079 | Hierarquia institucional sem herança de permissão — refina 0055 |
| 0080 | Catálogo de permissões declarativo + geração de artefatos |
| 0081 | LGPD-by-design: projeção por permissão como controle primário |
| 0082 | Nome social público / nome civil pessoal (Decreto 8.727/2016) |
| 0083 | Grupos OIDC governados pela aplicação |
| 0084 | Concessão excepcional e atuação institucional no servidor |
| 0085 | Cache e revogação diferenciados por sensibilidade |
| 0086 | Trilha de auditoria com integridade verificável (HMAC + cofre) |
| 0087 | Banco isolado para o contexto de autorização |
| 0088 | Versionamento cross-repo do contrato de permissões |

## Status e pendências

- Entram como **`proposed`**.
- **0081** (classificação/base legal LGPD) e **0082** (nome social/civil) ficam **pendentes de parecer da Encarregada de Proteção de Dados (DPO)** antes da aceitação formal.

## Revisão

- Conteúdo revisado nas fases de especificação; **redação pública revisada com Codex (2 rodadas)** antes deste PR — escopo por **Unidade** (não "área"), "catálogo de permissões" sempre qualificado, sem jargão de processo interno.

## Follow-up (frente separada, fora deste PR)

- Marcar a **ADR-0057** como `superseded` quando a 0078 for aceita.
- Renomear os **slugs legados** 0056/0057 (frente Área→Unidade / Parametrização→Configuração); os links para esses arquivos permanecem válidos até lá.
