### PR TITLE
docs(adrs): supersessão proposta da ADR-0057 pela ADR-0078

### DIFF
--- a/docs/adrs/0057-areas-rbac-snapshot-historia-invariantes.md
+++ b/docs/adrs/0057-areas-rbac-snapshot-historia-invariantes.md
@@ -10,6 +10,8 @@ informed:
 
 # ADR-0057: RBAC por áreas com snapshot, histórico e invariantes auditáveis
 
+> **Supersessão proposta:** o modelo de autorização desta ADR está sendo superseded pela [ADR-0078](0078-modelo-de-autorizacao-pbac-abac.md) (PBAC + ABAC com ponto de decisão único). Enquanto a ADR-0078 está em avaliação (`proposed`), esta ADR permanece `accepted` como registro do modelo vigente; passa a `superseded` quando a ADR-0078 for aceita.
+
 ## Contexto e enunciado do problema
 
 Toda entidade admin-editável dos catálogos cross-cutting de Parametrizacao e dos catálogos domain-specific de Selecao carrega dois campos de governança:

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -85,7 +85,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0054](0054-naming-convention-e-strategy-migrations.md) | Convenção de nomenclatura `snake_case` via `EFCore.NamingConventions` + isolamento por banco e estratégia de migrations | accepted | 2026-05-13 |
 | [0055](0055-organizacao-institucional-bounded-context.md) | `OrganizacaoInstitucional` como bounded context para áreas (CEPS, CRCA, PROEG, PROGEP, PLATAFORMA) com roster fechado | accepted | 2026-05-14 |
 | [0056](0056-parametrizacao-modulo-e-read-side-carve-out.md) | Módulo `Parametrizacao` para catálogos cross-cutting + carve-out read-side cross-módulo via `IXxxReader` | accepted | 2026-05-14 |
-| [0057](0057-areas-rbac-snapshot-historia-invariantes.md) | RBAC por áreas com snapshot na publicação, histórico SCD Type 2 e invariantes de governança | accepted | 2026-05-14 |
+| [0057](0057-areas-rbac-snapshot-historia-invariantes.md) | RBAC por áreas com snapshot na publicação, histórico SCD Type 2 e invariantes de governança — **supersessão proposta pela ADR-0078** | accepted | 2026-05-14 |
 | [0058](0058-obrigatoriedade-legal-validacao-data-driven.md) | `ObrigatoriedadeLegal` como validação data-driven com citação legal e snapshot-on-bind | accepted | 2026-05-14 |
 | [0059](0059-sprint-3-decomposicao-estrategia-paralela.md) | Decomposição da Sprint 3 — foundation primeiro, depois 3 lanes paralelas | accepted | 2026-05-14 |
 | [0060](0060-junction-tables-por-entidade-com-view-unificada.md) | Junction tables por entidade para `AreasDeInteresse` + view unificada por DbContext para leituras cross-catálogo | accepted | 2026-05-14 |


### PR DESCRIPTION
## O que

Marca na **ADR-0057** (modelo anterior de autorização) a **supersessão proposta pela [ADR-0078](docs/adrs/0078-modelo-de-autorizacao-pbac-abac.md)** (PBAC + ABAC), fechando o lado da 0057 da relação que a 0078 já declara.

Relaciona-se ao Epic #600 (Autorização e acesso — PBAC + ABAC).

## Detalhe de lifecycle

- A ADR-0078 entrou como `proposed` (PR #617). Enquanto está em avaliação, a 0057 **permanece `accepted`** como registro do modelo vigente, com uma **nota de supersessão proposta** (corpo + índice).
- A 0057 passa a `superseded` quando a 0078 for aceita.

## Fora de escopo

- **Não renomeia o slug da 0057** — `0057-areas-rbac-...` descreve corretamente o modelo histórico que a ADR documenta.
- O rename **Parametrização → Configuração** (módulo 0056) é refactor de código de verdade (33 arquivos + DbContext + schema + rotas + cache) — tratado em issue própria.
