### PR TITLE
feat(organizacao): cadastro de Unidade com identidade rica e hierarquia

### DIFF
--- a/UniPlus.slnx
+++ b/UniPlus.slnx
@@ -52,5 +52,6 @@
     <Project Path="tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Unifesspa.UniPlus.Selecao.IntegrationTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.csproj" />
   </Folder>
 </Solution>

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
@@ -1,0 +1,184 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Unidades;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/unidades</c>,
+/// <c>GET /api/unidades/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/admin/unidades</c>) restritos a
+/// <c>plataforma-admin</c>.
+/// </summary>
+/// <remarks>
+/// Rotas público/admin em caminhos distintos — o controller declara
+/// <c>[Route("api")]</c> e cada action especifica seu caminho.
+/// </remarks>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class UnidadesController : ControllerBase
+{
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<UnidadeDto> _linksBuilder;
+
+    public UnidadesController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<UnidadeDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista todas as unidades organizacionais ativas. Sem cursor — catálogo é
+    /// reference data bounded (exceção deliberada a ADR-0026).
+    /// </summary>
+    [HttpGet("unidades")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "unidade", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<UnidadeDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> Listar(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<UnidadeDto> unidades = await _queryBus
+            .Send(new ListarUnidadesAtivasQuery(), cancellationToken)
+            .ConfigureAwait(false);
+        return Ok(unidades);
+    }
+
+    /// <summary>
+    /// Obtém uma unidade pelo Id. Retorna 404 quando inexistente.
+    /// </summary>
+    [HttpGet("unidades/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "unidade", Versions = [1])]
+    [ProducesResponseType(typeof(UnidadeDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        UnidadeDto? unidade = await _queryBus
+            .Send(new ObterUnidadePorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (unidade is null)
+        {
+            return NotFound();
+        }
+
+        UnidadeDto comLinks = unidade with { Links = _linksBuilder.Build(unidade) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>
+    /// Cria uma nova unidade organizacional. Restrito a <c>plataforma-admin</c>.
+    /// Idempotency-Key obrigatório (ADR-0027).
+    /// </summary>
+    [HttpPost("admin/unidades")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarUnidadeCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Atualiza uma unidade organizacional existente. Restrito a
+    /// <c>plataforma-admin</c>.
+    /// </summary>
+    [HttpPut("admin/unidades/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarUnidadeCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Remove (soft-delete) uma unidade organizacional. Restrito a
+    /// <c>plataforma-admin</c>.
+    /// </summary>
+    [HttpDelete("admin/unidades/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverUnidadeCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
@@ -10,6 +10,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
 using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
@@ -33,6 +34,8 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Unidades;
     Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
 public sealed class UnidadesController : ControllerBase
 {
+    private const string ResourceTag = "unidades";
+
     private readonly ICommandBus _commandBus;
     private readonly IQueryBus _queryBus;
     private readonly IDomainErrorMapper _mapper;
@@ -51,20 +54,34 @@ public sealed class UnidadesController : ControllerBase
     }
 
     /// <summary>
-    /// Lista todas as unidades organizacionais ativas. Sem cursor — catálogo é
-    /// reference data bounded (exceção deliberada a ADR-0026).
+    /// Lista as unidades organizacionais ativas, paginadas por cursor opaco
+    /// (ADR-0026). Navegação via header <c>Link</c> (RFC 5988/8288); cada item
+    /// carrega seu <c>_links.self</c> (ADR-0029 §"Coleção").
     /// </summary>
     [HttpGet("unidades")]
     [AllowAnonymous]
     [VendorMediaType(Resource = "unidade", Versions = [1])]
     [ProducesResponseType(typeof(IEnumerable<UnidadeDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
-    public async Task<IActionResult> Listar(CancellationToken cancellationToken)
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
     {
-        IReadOnlyList<UnidadeDto> unidades = await _queryBus
-            .Send(new ListarUnidadesAtivasQuery(), cancellationToken)
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarUnidadesAtivasResult resultado = await _queryBus
+            .Send(new ListarUnidadesAtivasQuery(page.AfterId, page.Limit), cancellationToken)
             .ConfigureAwait(false);
-        return Ok(unidades);
+
+        // HATEOAS Level 1 (ADR-0029 §"Coleção"): cada item carrega seu _links.self.
+        UnidadeDto[] comLinks = [.. resultado.Items.Select(u => u with { Links = _linksBuilder.Build(u) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
@@ -131,6 +131,7 @@ public sealed class UnidadesController : ControllerBase
     /// </summary>
     [HttpPut("admin/unidades/{id:guid}")]
     [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Errors/OrganizacaoDomainErrorRegistration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Errors/OrganizacaoDomainErrorRegistration.cs
@@ -76,5 +76,132 @@ internal sealed class OrganizacaoDomainErrorRegistration : IDomainErrorRegistrat
                 StatusCodes.Status422UnprocessableEntity,
                 "uniplus.organizacao.area_codigo.invalido",
                 "Código de área inválido")),
+
+        // ── Unidade ──────────────────────────────────────────────────────
+        new(UnidadeErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.nome_obrigatorio",
+                "Nome da unidade é obrigatório")),
+
+        new(UnidadeErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.nome_tamanho",
+                "Tamanho do nome da unidade inválido")),
+
+        new(UnidadeErrorCodes.SiglaObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.sigla_obrigatoria",
+                "Sigla da unidade é obrigatória")),
+
+        new(UnidadeErrorCodes.SiglaTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.sigla_tamanho",
+                "Tamanho da sigla da unidade inválido")),
+
+        new(UnidadeErrorCodes.SiglaJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.organizacao.unidade.sigla_ja_existe",
+                "Já existe uma unidade ativa com esta sigla")),
+
+        new(UnidadeErrorCodes.CodigoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.codigo_obrigatorio",
+                "Código da unidade é obrigatório")),
+
+        new(UnidadeErrorCodes.CodigoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.codigo_tamanho",
+                "Tamanho do código da unidade inválido")),
+
+        new(UnidadeErrorCodes.CodigoJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.organizacao.unidade.codigo_ja_existe",
+                "Já existe uma unidade ativa com este código")),
+
+        new(UnidadeErrorCodes.SlugObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.slug_obrigatorio",
+                "Slug da unidade é obrigatório")),
+
+        new(UnidadeErrorCodes.SlugTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.slug_tamanho",
+                "Tamanho do slug da unidade inválido")),
+
+        new(UnidadeErrorCodes.SlugFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.slug_formato_invalido",
+                "Slug deve estar no formato kebab-case (ex.: ceps, faculdade-de-ciencias)")),
+
+        new(UnidadeErrorCodes.SlugJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.organizacao.unidade.slug_ja_existe",
+                "Já existe uma unidade ativa com este slug")),
+
+        new(UnidadeErrorCodes.AliasTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.alias_tamanho",
+                "Tamanho do alias da unidade inválido")),
+
+        new(UnidadeErrorCodes.TipoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.tipo_invalido",
+                "Tipo de unidade inválido")),
+
+        new(UnidadeErrorCodes.OrigemInvalida,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.origem_invalida",
+                "Origem da unidade inválida")),
+
+        new(UnidadeErrorCodes.VigenciaFimAnteriorAoInicio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.vigencia_fim_anterior_ao_inicio",
+                "Data de encerramento de vigência não pode ser anterior à data de início")),
+
+        new(UnidadeErrorCodes.SuperiorNaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.superior_nao_encontrado",
+                "Unidade superior informada não encontrada")),
+
+        new(UnidadeErrorCodes.SuperiorFormaCiclo,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.unidade.superior_forma_ciclo",
+                "A unidade superior informada formaria ciclo na hierarquia")),
+
+        new(UnidadeErrorCodes.NaoEncontrada,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.organizacao.unidade.nao_encontrada",
+                "Unidade não encontrada")),
+
+        new(UnidadeErrorCodes.RemocaoBloqueadaPorSubordinadas,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.organizacao.unidade.remocao_bloqueada_por_subordinadas",
+                "Não é possível remover uma unidade que possui subordinadas ativas")),
+
+        new(UnidadeErrorCodes.RemocaoBloqueadaPorInstituicao,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.organizacao.unidade.remocao_bloqueada_por_instituicao",
+                "Não é possível remover uma unidade que é raiz de uma instituição")),
     ];
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Hateoas/UnidadeLinksBuilder.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Hateoas/UnidadeLinksBuilder.cs
@@ -1,0 +1,74 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.API.Controllers;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029/0049) para
+/// <see cref="UnidadeDto"/>.
+/// </summary>
+/// <remarks>
+/// Relações em V1: <c>self</c> (URI canônica) e <c>collection</c> (listagem).
+/// Action links nunca aparecem aqui (ADR-0029 §"Esta ADR não decide").
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<UnidadeDto>, UnidadeLinksBuilder>().")]
+internal sealed class UnidadeLinksBuilder : IResourceLinksBuilder<UnidadeDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public UnidadeLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(UnidadeDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        string controllerName = NomeControllerSemSufixo();
+
+        string self = ResolverPath(httpContext, nameof(UnidadesController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(httpContext, nameof(UnidadesController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+
+    private static string NomeControllerSemSufixo()
+    {
+        const string sufixo = "Controller";
+        string nome = nameof(UnidadesController);
+        return nome.EndsWith(sufixo, StringComparison.Ordinal)
+            ? nome[..^sufixo.Length]
+            : nome;
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Program.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Program.cs
@@ -46,8 +46,9 @@ builder.Services.AddUniPlusOpenApi("organizacao", builder.Configuration);
 builder.Services.AddSingleton<IDomainErrorRegistration, OrganizacaoDomainErrorRegistration>();
 builder.Services.AddDomainErrorMapper();
 
-// HATEOAS Level 1 (ADR-0029/0049) — builder de _links para AreaOrganizacionalDto.
+// HATEOAS Level 1 (ADR-0029/0049) — builders de _links.
 builder.Services.AddSingleton<IResourceLinksBuilder<AreaOrganizacionalDto>, AreaOrganizacionalLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<UnidadeDto>, UnidadeLinksBuilder>();
 
 // Criptografia (Idempotency response cipher) + Idempotency-Key (ADR-0027).
 // AddIdempotency injeta o filter de MVC que ativa-se em endpoints com

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Program.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Program.cs
@@ -55,6 +55,9 @@ builder.Services.AddSingleton<IResourceLinksBuilder<UnidadeDto>, UnidadeLinksBui
 // [RequiresIdempotencyKey], usando o DbContext do módulo para persistir
 // entries cifradas at-rest.
 builder.Services.AddUniPlusEncryption(builder.Configuration);
+// Cursor pagination (ADR-0026) — CursorEncoder, PageRequestModelBinder e o hook
+// que traduz falhas do binder para 400/410/422; usado por GET /api/unidades.
+builder.Services.AddCursorPagination(builder.Configuration);
 builder.Services.AddIdempotency<OrganizacaoInstitucionalDbContext>(builder.Configuration);
 
 builder.Services.AddOidcAuthentication(builder.Configuration, builder.Environment);

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Program.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Program.cs
@@ -80,7 +80,16 @@ builder.Services.AddDbContextMigrationsOnStartup<OrganizacaoInstitucionalDbConte
 // específico — o módulo não emite eventos Kafka em V1 (D4 do plano #447); o
 // wire-up básico permanece para que ICommandBus/IQueryBus funcionem com
 // middleware de validação e logging.
-builder.Host.UseWolverineOutboxCascading(builder.Configuration, connectionStringName: "OrganizacaoDb");
+builder.Host.UseWolverineOutboxCascading(
+    builder.Configuration,
+    connectionStringName: "OrganizacaoDb",
+    configureRouting: opts =>
+    {
+        // Wolverine escaneia o entry assembly (OrganizacaoInstitucional.API) por padrão;
+        // handlers produtivos vivem em OrganizacaoInstitucional.Application —
+        // incluir explicitamente para que os command/query handlers sejam descobertos.
+        opts.Discovery.IncludeAssembly(typeof(OrganizacaoInstitucionalApplicationServiceRegistration).Assembly);
+    });
 builder.Services.AddWolverineMessaging();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Abstractions/IUnidadeCacheInvalidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Abstractions/IUnidadeCacheInvalidator.cs
@@ -1,0 +1,10 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+
+/// <summary>
+/// Invalida o cache do reader cross-módulo de <c>Unidade</c> após operações
+/// de escrita (ADR-0056). Chamada pós-commit, best-effort.
+/// </summary>
+public interface IUnidadeCacheInvalidator
+{
+    Task InvalidarAsync(CancellationToken cancellationToken = default);
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommand.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommand.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+
+public sealed record AtualizarUnidadeCommand(
+    Guid Id,
+    string Nome,
+    string? Alias,
+    string Slug,
+    string Sigla,
+    string Codigo,
+    Guid? UnidadeSuperiorId,
+    TipoUnidade Tipo,
+    bool UnidadeAcademica,
+    DateOnly? VigenciaFim,
+    /// <summary>Motivo da mudança de identificador (Slug/Sigla/Codigo/Alias), se aplicável.</summary>
+    string? MotivoMudancaIdentificador = null) : ICommand<Result>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommandHandler.cs
@@ -56,7 +56,10 @@ public static class AtualizarUnidadeCommandHandler
                 $"Já existe uma Unidade viva com a sigla '{command.Sigla}'."));
         }
 
-        if (!string.Equals(command.Codigo, unidade.Codigo, StringComparison.OrdinalIgnoreCase)
+        // Codigo é case-sensitive (o agregado preserva a caixa e o índice único é
+        // case-sensitive) — compara com Ordinal para que ABC→abc conte como
+        // mudança e dispare a checagem, em vez de estourar no índice (500).
+        if (!string.Equals(command.Codigo.Trim(), unidade.Codigo, StringComparison.Ordinal)
             && await repository.CodigoExisteEntreLivosAsync(command.Codigo, command.Id, cancellationToken).ConfigureAwait(false))
         {
             return Result.Failure(new DomainError(

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommandHandler.cs
@@ -83,7 +83,8 @@ public static class AtualizarUnidadeCommandHandler
                     "A Unidade superior informada não foi encontrada."));
             }
 
-            if (await repository.FormariaCicloAsync(command.Id, command.UnidadeSuperiorId.Value, cancellationToken).ConfigureAwait(false))
+            // Ciclo: o superior proposto é descendente da própria unidade editada.
+            if (await repository.EhDescendenteAsync(command.UnidadeSuperiorId.Value, command.Id, cancellationToken).ConfigureAwait(false))
             {
                 return Result.Failure(new DomainError(
                     UnidadeErrorCodes.SuperiorFormaCiclo,

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommandHandler.cs
@@ -1,0 +1,119 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+public static class AtualizarUnidadeCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarUnidadeCommand command,
+        IUnidadeRepository repository,
+        IUnitOfWork unitOfWork,
+        IUnidadeCacheInvalidator cacheInvalidator,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(cacheInvalidator);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        Unidade? unidade = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (unidade is null)
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.NaoEncontrada,
+                "Unidade não encontrada."));
+        }
+
+        Result<Slug> slugResult = Slug.From(command.Slug);
+        if (slugResult.IsFailure)
+        {
+            return Result.Failure(slugResult.Error!);
+        }
+
+        Slug slug = slugResult.Value!;
+
+        if (!string.Equals(slug.Valor, unidade.Slug.Valor, StringComparison.OrdinalIgnoreCase)
+            && await repository.SlugExisteEntreLivosAsync(slug, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.SlugJaExiste,
+                $"Já existe uma Unidade viva com o slug '{slug}'."));
+        }
+
+        if (!string.Equals(command.Sigla, unidade.Sigla, StringComparison.OrdinalIgnoreCase)
+            && await repository.SiglaExisteEntreLivosAsync(command.Sigla, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.SiglaJaExiste,
+                $"Já existe uma Unidade viva com a sigla '{command.Sigla}'."));
+        }
+
+        if (!string.Equals(command.Codigo, unidade.Codigo, StringComparison.OrdinalIgnoreCase)
+            && await repository.CodigoExisteEntreLivosAsync(command.Codigo, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.CodigoJaExiste,
+                $"Já existe uma Unidade viva com o código '{command.Codigo}'."));
+        }
+
+        if (command.UnidadeSuperiorId.HasValue)
+        {
+            if (command.UnidadeSuperiorId.Value == command.Id)
+            {
+                return Result.Failure(new DomainError(
+                    UnidadeErrorCodes.SuperiorFormaCiclo,
+                    "Uma Unidade não pode ser superior de si mesma."));
+            }
+
+            Unidade? superior = await repository.ObterPorIdAsync(
+                command.UnidadeSuperiorId.Value, cancellationToken).ConfigureAwait(false);
+
+            if (superior is null)
+            {
+                return Result.Failure(new DomainError(
+                    UnidadeErrorCodes.SuperiorNaoEncontrado,
+                    "A Unidade superior informada não foi encontrada."));
+            }
+
+            if (await repository.FormariaCicloAsync(command.Id, command.UnidadeSuperiorId.Value, cancellationToken).ConfigureAwait(false))
+            {
+                return Result.Failure(new DomainError(
+                    UnidadeErrorCodes.SuperiorFormaCiclo,
+                    "A Unidade superior informada é descendente da Unidade sendo editada — formaria ciclo na hierarquia."));
+            }
+        }
+
+        DateOnly dataAtual = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime);
+
+        Result atualizarResult = unidade.Atualizar(
+            command.Nome,
+            command.Alias,
+            slug,
+            command.Sigla,
+            command.Codigo,
+            command.UnidadeSuperiorId,
+            command.Tipo,
+            command.UnidadeAcademica,
+            command.VigenciaFim,
+            dataAtual,
+            command.MotivoMudancaIdentificador);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidarAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommandValidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/AtualizarUnidadeCommandValidator.cs
@@ -1,0 +1,38 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+
+public sealed class AtualizarUnidadeCommandValidator : AbstractValidator<AtualizarUnidadeCommand>
+{
+    public AtualizarUnidadeCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id da Unidade é obrigatório.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome da Unidade é obrigatório.")
+            .MinimumLength(2).WithMessage("Nome da Unidade deve ter ao menos 2 caracteres.")
+            .MaximumLength(250).WithMessage("Nome da Unidade deve ter no máximo 250 caracteres.");
+
+        RuleFor(x => x.Slug)
+            .NotEmpty().WithMessage("Slug da Unidade é obrigatório.");
+
+        RuleFor(x => x.Sigla)
+            .NotEmpty().WithMessage("Sigla da Unidade é obrigatória.")
+            .MaximumLength(50).WithMessage("Sigla da Unidade deve ter no máximo 50 caracteres.");
+
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código da Unidade é obrigatório.")
+            .MaximumLength(50).WithMessage("Código da Unidade deve ter no máximo 50 caracteres.");
+
+        RuleFor(x => x.Alias)
+            .MaximumLength(100).WithMessage("Alias da Unidade deve ter no máximo 100 caracteres.")
+            .When(x => x.Alias is not null);
+
+        RuleFor(x => x.Tipo)
+            .Must(t => Enum.IsDefined(t) && t != TipoUnidade.Nenhum)
+            .WithMessage("Tipo de Unidade inválido.");
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/CriarUnidadeCommand.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/CriarUnidadeCommand.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+
+public sealed record CriarUnidadeCommand(
+    string Nome,
+    string? Alias,
+    string Slug,
+    string Sigla,
+    string Codigo,
+    Guid? UnidadeSuperiorId,
+    TipoUnidade Tipo,
+    bool UnidadeAcademica,
+    DateOnly VigenciaInicio,
+    DateOnly? VigenciaFim,
+    OrigemUnidade Origem) : ICommand<Result<Guid>>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/CriarUnidadeCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/CriarUnidadeCommandHandler.cs
@@ -1,0 +1,107 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+/// <summary>
+/// Handler do <see cref="CriarUnidadeCommand"/>. Convention-based para Wolverine
+/// — método estático <c>Handle</c> com dependências por parâmetro.
+/// </summary>
+/// <remarks>
+/// Sequência:
+/// <list type="number">
+///   <item>Valida o Slug via <see cref="Slug.From"/>;</item>
+///   <item>Confirma unicidade de Slug, Sigla e Codigo entre unidades vivas;</item>
+///   <item>Valida hierarquia (superior existe e não forma ciclo), se informado;</item>
+///   <item>Cria o agregado via <see cref="Unidade.Criar"/>;</item>
+///   <item>Persiste + commit;</item>
+///   <item>Invalida o cache do reader cross-módulo (ADR-0056).</item>
+/// </list>
+/// </remarks>
+public static class CriarUnidadeCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarUnidadeCommand command,
+        IUnidadeRepository repository,
+        IUnitOfWork unitOfWork,
+        IUnidadeCacheInvalidator cacheInvalidator,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(cacheInvalidator);
+
+        Result<Slug> slugResult = Slug.From(command.Slug);
+        if (slugResult.IsFailure)
+        {
+            return Result<Guid>.Failure(slugResult.Error!);
+        }
+
+        Slug slug = slugResult.Value!;
+
+        if (await repository.SlugExisteEntreLivosAsync(slug, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(new DomainError(
+                UnidadeErrorCodes.SlugJaExiste,
+                $"Já existe uma Unidade viva com o slug '{slug}'."));
+        }
+
+        if (await repository.SiglaExisteEntreLivosAsync(command.Sigla, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(new DomainError(
+                UnidadeErrorCodes.SiglaJaExiste,
+                $"Já existe uma Unidade viva com a sigla '{command.Sigla}'."));
+        }
+
+        if (await repository.CodigoExisteEntreLivosAsync(command.Codigo, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(new DomainError(
+                UnidadeErrorCodes.CodigoJaExiste,
+                $"Já existe uma Unidade viva com o código '{command.Codigo}'."));
+        }
+
+        if (command.UnidadeSuperiorId.HasValue)
+        {
+            Unidade? superior = await repository.ObterPorIdAsync(
+                command.UnidadeSuperiorId.Value, cancellationToken).ConfigureAwait(false);
+
+            if (superior is null)
+            {
+                return Result<Guid>.Failure(new DomainError(
+                    UnidadeErrorCodes.SuperiorNaoEncontrado,
+                    "A Unidade superior informada não foi encontrada."));
+            }
+        }
+
+        Result<Unidade> unidadeResult = Unidade.Criar(
+            command.Nome,
+            command.Alias,
+            slug,
+            command.Sigla,
+            command.Codigo,
+            command.UnidadeSuperiorId,
+            command.Tipo,
+            command.UnidadeAcademica,
+            command.VigenciaInicio,
+            command.VigenciaFim,
+            command.Origem);
+
+        if (unidadeResult.IsFailure)
+        {
+            return Result<Guid>.Failure(unidadeResult.Error!);
+        }
+
+        Unidade unidade = unidadeResult.Value!;
+        await repository.AdicionarAsync(unidade, cancellationToken).ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidarAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<Guid>.Success(unidade.Id);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/CriarUnidadeCommandValidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/CriarUnidadeCommandValidator.cs
@@ -33,7 +33,7 @@ public sealed class CriarUnidadeCommandValidator : AbstractValidator<CriarUnidad
             .WithMessage("Tipo de Unidade inválido.");
 
         RuleFor(x => x.Origem)
-            .Must(o => Enum.IsDefined(o))
+            .Must(o => Enum.IsDefined(o) && o != OrigemUnidade.Nenhum)
             .WithMessage("Origem da Unidade inválida.");
 
         RuleFor(x => x.VigenciaFim)

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/CriarUnidadeCommandValidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/CriarUnidadeCommandValidator.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+
+public sealed class CriarUnidadeCommandValidator : AbstractValidator<CriarUnidadeCommand>
+{
+    public CriarUnidadeCommandValidator()
+    {
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome da Unidade é obrigatório.")
+            .MinimumLength(2).WithMessage("Nome da Unidade deve ter ao menos 2 caracteres.")
+            .MaximumLength(250).WithMessage("Nome da Unidade deve ter no máximo 250 caracteres.");
+
+        RuleFor(x => x.Slug)
+            .NotEmpty().WithMessage("Slug da Unidade é obrigatório.");
+
+        RuleFor(x => x.Sigla)
+            .NotEmpty().WithMessage("Sigla da Unidade é obrigatória.")
+            .MaximumLength(50).WithMessage("Sigla da Unidade deve ter no máximo 50 caracteres.");
+
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código da Unidade é obrigatório.")
+            .MaximumLength(50).WithMessage("Código da Unidade deve ter no máximo 50 caracteres.");
+
+        RuleFor(x => x.Alias)
+            .MaximumLength(100).WithMessage("Alias da Unidade deve ter no máximo 100 caracteres.")
+            .When(x => x.Alias is not null);
+
+        RuleFor(x => x.Tipo)
+            .Must(t => Enum.IsDefined(t) && t != TipoUnidade.Nenhum)
+            .WithMessage("Tipo de Unidade inválido.");
+
+        RuleFor(x => x.Origem)
+            .Must(o => Enum.IsDefined(o))
+            .WithMessage("Origem da Unidade inválida.");
+
+        RuleFor(x => x.VigenciaFim)
+            .GreaterThanOrEqualTo(x => x.VigenciaInicio)
+            .WithMessage("Data de encerramento deve ser igual ou posterior à data de início.")
+            .When(x => x.VigenciaFim.HasValue);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/RemoverUnidadeCommand.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/RemoverUnidadeCommand.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed record RemoverUnidadeCommand(Guid Id) : ICommand<Result>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/RemoverUnidadeCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/RemoverUnidadeCommandHandler.cs
@@ -1,0 +1,58 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+/// <summary>
+/// Handler do <see cref="RemoverUnidadeCommand"/>. Executa soft-delete via
+/// <c>SoftDeleteInterceptor</c> — bloqueia se a unidade for superior de outra
+/// unidade viva.
+/// </summary>
+/// <remarks>
+/// O bloqueio por <c>instituicao.unidade_raiz_id</c> (CA-06 §"raiz da
+/// Instituição") será adicionado quando o agregado Instituicao for implementado
+/// (issue #585), que depende desta Story.
+/// </remarks>
+public static class RemoverUnidadeCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverUnidadeCommand command,
+        IUnidadeRepository repository,
+        IUnitOfWork unitOfWork,
+        IUnidadeCacheInvalidator cacheInvalidator,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(cacheInvalidator);
+
+        Unidade? unidade = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (unidade is null)
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.NaoEncontrada,
+                "Unidade não encontrada."));
+        }
+
+        if (await repository.PossuiSubordinadasVivasAsync(command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.RemocaoBloqueadaPorSubordinadas,
+                "Não é possível remover uma Unidade que possui unidades subordinadas ativas."));
+        }
+
+        // SoftDeleteInterceptor converte EntityState.Deleted em soft-delete
+        // preenchendo DeletedBy/DeletedAt a partir de IUserContext + TimeProvider.
+        repository.Remover(unidade);
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidarAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/DTOs/UnidadeDto.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/DTOs/UnidadeDto.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>Unidade</c>. Exposto pelos endpoints do
+/// controller; suporta HATEOAS Level 1 via <c>_links</c>.
+/// </summary>
+public sealed record UnidadeDto(
+    Guid Id,
+    string Nome,
+    string? Alias,
+    string Slug,
+    string Sigla,
+    string Codigo,
+    Guid? UnidadeSuperiorId,
+    string Tipo,
+    bool UnidadeAcademica,
+    DateOnly VigenciaInicio,
+    DateOnly? VigenciaFim,
+    string Origem,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Mappings/UnidadeMapping.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Mappings/UnidadeMapping.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Mappings;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+
+public static class UnidadeMapping
+{
+    public static UnidadeDto ToDto(this Unidade unidade)
+    {
+        ArgumentNullException.ThrowIfNull(unidade);
+        return new UnidadeDto(
+            unidade.Id,
+            unidade.Nome,
+            unidade.Alias,
+            unidade.Slug.Valor,
+            unidade.Sigla,
+            unidade.Codigo,
+            unidade.UnidadeSuperiorId,
+            unidade.Tipo.ToString(),
+            unidade.UnidadeAcademica,
+            unidade.VigenciaInicio,
+            unidade.VigenciaFim,
+            unidade.Origem.ToString(),
+            unidade.CreatedAt);
+    }
+
+    public static UnidadeView ToView(this Unidade unidade)
+    {
+        ArgumentNullException.ThrowIfNull(unidade);
+        return new UnidadeView(
+            unidade.Id,
+            unidade.Sigla,
+            unidade.Slug.Valor,
+            unidade.Nome,
+            unidade.Alias,
+            unidade.Tipo.ToString(),
+            unidade.UnidadeAcademica,
+            unidade.UnidadeSuperiorId);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQuery.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Unidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+
+public sealed record ListarUnidadesAtivasQuery : IQuery<IReadOnlyList<UnidadeDto>>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQuery.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQuery.cs
@@ -1,6 +1,13 @@
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Unidades;
 
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
-using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
 
-public sealed record ListarUnidadesAtivasQuery : IQuery<IReadOnlyList<UnidadeDto>>;
+/// <summary>
+/// Lista unidades ativas paginadas por cursor (ADR-0026). Os parâmetros já
+/// chegam decodificados — o controller decifra o cursor opaco e valida o
+/// <c>limit</c> antes de despachar a query, mantendo <c>Application</c>
+/// independente de <c>Infrastructure.Core</c>.
+/// </summary>
+/// <param name="AfterId">Identificador do último item da página anterior; <c>null</c> retorna a primeira janela.</param>
+/// <param name="Limit">Tamanho máximo da página a retornar.</param>
+public sealed record ListarUnidadesAtivasQuery(Guid? AfterId, int Limit) : IQuery<ListarUnidadesAtivasResult>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQueryHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQueryHandler.cs
@@ -5,9 +5,15 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Mappings;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
 
+/// <summary>
+/// Handler convention-based de <see cref="ListarUnidadesAtivasQuery"/>:
+/// paginação keyset-based (cursor) sobre o agregado <c>Unidade</c>, ordenando
+/// pelo identificador para garantir estabilidade da janela. Solicita
+/// <c>limit + 1</c> itens para detectar a próxima página sem COUNT (ADR-0026).
+/// </summary>
 public static class ListarUnidadesAtivasQueryHandler
 {
-    public static async Task<IReadOnlyList<UnidadeDto>> Handle(
+    public static async Task<ListarUnidadesAtivasResult> Handle(
         ListarUnidadesAtivasQuery query,
         IUnidadeRepository repository,
         CancellationToken cancellationToken)
@@ -15,10 +21,19 @@ public static class ListarUnidadesAtivasQueryHandler
         ArgumentNullException.ThrowIfNull(query);
         ArgumentNullException.ThrowIfNull(repository);
 
-        IReadOnlyList<Unidade> unidades = await repository
-            .ListarAtivasAsync(cancellationToken)
+        IReadOnlyList<Unidade> page = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit + 1, cancellationToken)
             .ConfigureAwait(false);
 
-        return [.. unidades.Select(u => u.ToDto())];
+        // Defesa contra Limit <= 0 (config inconsistente): Take(0) devolveria
+        // array vazio e limited[^1] lançaria IndexOutOfRangeException.
+        if (page.Count > query.Limit && query.Limit > 0)
+        {
+            UnidadeDto[] limited = [.. page.Take(query.Limit).Select(u => u.ToDto())];
+            return new ListarUnidadesAtivasResult(limited, limited[^1].Id);
+        }
+
+        UnidadeDto[] items = [.. page.Select(u => u.ToDto())];
+        return new ListarUnidadesAtivasResult(items, ProximoAfterId: null);
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQueryHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Unidades;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Mappings;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+public static class ListarUnidadesAtivasQueryHandler
+{
+    public static async Task<IReadOnlyList<UnidadeDto>> Handle(
+        ListarUnidadesAtivasQuery query,
+        IUnidadeRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        IReadOnlyList<Unidade> unidades = await repository
+            .ListarAtivasAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. unidades.Select(u => u.ToDto())];
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasResult.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Unidades;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarUnidadesAtivasQuery"/>: lote de unidades já
+/// projetadas + identificador opcional do último item para o controller
+/// construir o cursor da próxima página (ADR-0026). Não vaza entidades de
+/// domínio.
+/// </summary>
+/// <param name="Items">Unidades da página corrente, ordenadas pelo identificador.</param>
+/// <param name="ProximoAfterId">Id do último item da janela quando há mais páginas; <c>null</c> sinaliza fim da coleção.</param>
+public sealed record ListarUnidadesAtivasResult(IReadOnlyList<UnidadeDto> Items, Guid? ProximoAfterId);

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ObterUnidadePorIdQuery.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ObterUnidadePorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Unidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+
+public sealed record ObterUnidadePorIdQuery(Guid Id) : IQuery<UnidadeDto?>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ObterUnidadePorIdQueryHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ObterUnidadePorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Unidades;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Mappings;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+public static class ObterUnidadePorIdQueryHandler
+{
+    public static async Task<UnidadeDto?> Handle(
+        ObterUnidadePorIdQuery query,
+        IUnidadeRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        Unidade? unidade = await repository
+            .ObterPorIdAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return unidade?.ToDto();
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ObterUnidadePorIdQueryHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ObterUnidadePorIdQueryHandler.cs
@@ -16,7 +16,7 @@ public static class ObterUnidadePorIdQueryHandler
         ArgumentNullException.ThrowIfNull(repository);
 
         Unidade? unidade = await repository
-            .ObterPorIdAsync(query.Id, cancellationToken)
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
             .ConfigureAwait(false);
 
         return unidade?.ToDto();

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Unidade.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Unidade.cs
@@ -177,8 +177,11 @@ public sealed class Unidade : EntityBase, IAuditableEntity
         DateOnly dataAtual,
         string? motivo)
     {
-        // Nenhuma mudança — sem histórico.
-        if (string.Equals(valorAtual, novoValor, StringComparison.OrdinalIgnoreCase))
+        // Nenhuma mudança — sem histórico. Comparação Ordinal (case-sensitive):
+        // os valores chegam já normalizados (Slug lowercase, Sigla uppercase), e
+        // Codigo/Alias preservam a caixa — então uma troca só na caixa (ABC→abc)
+        // conta como mudança e gera entrada de histórico (CA-04).
+        if (string.Equals(valorAtual, novoValor, StringComparison.Ordinal))
         {
             return;
         }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Unidade.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Unidade.cs
@@ -183,8 +183,8 @@ public sealed class Unidade : EntityBase, IAuditableEntity
             return;
         }
 
-        // Caso especial: Alias pode ir de null para valor ou vice-versa.
-        bool valorAtualNulo = valorAtual is null;
+        // Caso especial: Alias pode ir de null para valor ou vice-versa — só
+        // abrimos nova entrada quando o novo valor é não nulo.
         bool novoValorNulo = novoValor is null;
 
         // Fecha entrada aberta do identificador.

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Unidade.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Unidade.cs
@@ -1,0 +1,285 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+/// <summary>
+/// Unidade organizacional da Unifesspa: reitoria, pró-reitorias, centros,
+/// institutos, faculdades, departamentos, coordenações, diretorias, divisões
+/// e núcleos (ADR-0055). Agregado raiz com identidade rica (Slug, Sigla,
+/// Codigo, Alias) e histórico de identificadores para auditoria temporal.
+/// </summary>
+/// <remarks>
+/// <para>Slug, Sigla e Codigo são únicos entre unidades vivas. Alias não é
+/// único — serve como agrupamento popular. A unicidade entre vivos é validada
+/// pelo handler via repositório antes de chamar a factory ou Atualizar; a
+/// restrição de banco (índice parcial) é a segunda linha de defesa.</para>
+/// <para>Alterações nos identificadores únicos (Slug, Sigla, Codigo) e no
+/// Alias geram entradas em <see cref="UnidadeIdentificadorHistorico"/> — a
+/// data de abertura da nova vigência é o <paramref name="dataAtual"/> passado
+/// pelo handler. O domínio não consulta relógio diretamente.</para>
+/// <para>Detecção de ciclo na hierarquia é responsabilidade do handler (via
+/// repositório); este agregado recebe o ID do superior já validado.</para>
+/// </remarks>
+public sealed class Unidade : EntityBase, IAuditableEntity
+{
+    private const int NomeMaxLength = 250;
+    private const int NomeMinLength = 2;
+    private const int SiglaMaxLength = 50;
+    private const int SiglaMinLength = 1;
+    private const int CodigoMaxLength = 50;
+    private const int CodigoMinLength = 1;
+    private const int AliasMaxLength = 100;
+
+    private readonly List<UnidadeIdentificadorHistorico> _historico = [];
+
+    public string Nome { get; private set; } = string.Empty;
+    public string? Alias { get; private set; }
+    public Slug Slug { get; private set; }
+    public string Sigla { get; private set; } = string.Empty;
+    public string Codigo { get; private set; } = string.Empty;
+    public Guid? UnidadeSuperiorId { get; private set; }
+    public TipoUnidade Tipo { get; private set; }
+    public bool UnidadeAcademica { get; private set; }
+    public DateOnly VigenciaInicio { get; private set; }
+    public DateOnly? VigenciaFim { get; private set; }
+    public OrigemUnidade Origem { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    public IReadOnlyList<UnidadeIdentificadorHistorico> Historico =>
+        _historico.AsReadOnly();
+
+    // EF Core materialization
+    private Unidade()
+    {
+    }
+
+    /// <summary>
+    /// Cria uma nova Unidade com identidade rica. Os handlers de unicidade
+    /// (Slug/Sigla/Codigo) e de detecção de ciclo na hierarquia são
+    /// responsabilidade do handler chamador — esta factory valida apenas
+    /// formato e domínio local.
+    /// </summary>
+    public static Result<Unidade> Criar(
+        string nome,
+        string? alias,
+        Slug slug,
+        string sigla,
+        string codigo,
+        Guid? unidadeSuperiorId,
+        TipoUnidade tipo,
+        bool unidadeAcademica,
+        DateOnly vigenciaInicio,
+        DateOnly? vigenciaFim,
+        OrigemUnidade origem)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(sigla);
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        Result validacao = ValidarCampos(nome, alias, sigla, codigo, tipo, origem, vigenciaInicio, vigenciaFim);
+        if (validacao.IsFailure)
+        {
+            return Result<Unidade>.Failure(validacao.Error!);
+        }
+
+        var unidade = new Unidade
+        {
+            Nome = nome.Trim(),
+            Alias = alias?.Trim(),
+            Slug = slug,
+            Sigla = sigla.Trim().ToUpperInvariant(),
+            Codigo = codigo.Trim(),
+            UnidadeSuperiorId = unidadeSuperiorId,
+            Tipo = tipo,
+            UnidadeAcademica = unidadeAcademica,
+            VigenciaInicio = vigenciaInicio,
+            VigenciaFim = vigenciaFim,
+            Origem = origem,
+        };
+
+        // Abre histórico inicial para identificadores com variação temporal.
+        unidade._historico.Add(
+            UnidadeIdentificadorHistorico.Abrir(unidade.Id, TipoIdentificador.Slug, slug.Valor, vigenciaInicio));
+        unidade._historico.Add(
+            UnidadeIdentificadorHistorico.Abrir(unidade.Id, TipoIdentificador.Sigla, unidade.Sigla, vigenciaInicio));
+        unidade._historico.Add(
+            UnidadeIdentificadorHistorico.Abrir(unidade.Id, TipoIdentificador.Codigo, unidade.Codigo, vigenciaInicio));
+        if (unidade.Alias is not null)
+        {
+            unidade._historico.Add(
+                UnidadeIdentificadorHistorico.Abrir(unidade.Id, TipoIdentificador.Alias, unidade.Alias, vigenciaInicio));
+        }
+
+        return Result<Unidade>.Success(unidade);
+    }
+
+    /// <summary>
+    /// Atualiza atributos da Unidade. Mudanças em Slug, Sigla, Codigo ou Alias
+    /// encerram a vigência do valor anterior e abrem nova entrada de histórico.
+    /// A data de mudança é o <paramref name="dataAtual"/> fornecido pelo handler.
+    /// </summary>
+    public Result Atualizar(
+        string nome,
+        string? alias,
+        Slug slug,
+        string sigla,
+        string codigo,
+        Guid? unidadeSuperiorId,
+        TipoUnidade tipo,
+        bool unidadeAcademica,
+        DateOnly? vigenciaFim,
+        DateOnly dataAtual,
+        string? motivoMudancaIdentificador = null)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(sigla);
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        Result validacao = ValidarCampos(nome, alias, sigla, codigo, tipo, Origem, VigenciaInicio, vigenciaFim);
+        if (validacao.IsFailure)
+        {
+            return validacao;
+        }
+
+        string siglaNormalizada = sigla.Trim().ToUpperInvariant();
+        string codigoNormalizado = codigo.Trim();
+        string? aliasNormalizado = alias?.Trim();
+
+        RenomearIdentificadorSeNecessario(TipoIdentificador.Slug, Slug.Valor, slug.Valor, dataAtual, motivoMudancaIdentificador);
+        RenomearIdentificadorSeNecessario(TipoIdentificador.Sigla, Sigla, siglaNormalizada, dataAtual, motivoMudancaIdentificador);
+        RenomearIdentificadorSeNecessario(TipoIdentificador.Codigo, Codigo, codigoNormalizado, dataAtual, motivoMudancaIdentificador);
+        RenomearIdentificadorSeNecessario(TipoIdentificador.Alias, Alias, aliasNormalizado, dataAtual, motivoMudancaIdentificador);
+
+        Nome = nome.Trim();
+        Alias = aliasNormalizado;
+        Slug = slug;
+        Sigla = siglaNormalizada;
+        Codigo = codigoNormalizado;
+        UnidadeSuperiorId = unidadeSuperiorId;
+        Tipo = tipo;
+        UnidadeAcademica = unidadeAcademica;
+        VigenciaFim = vigenciaFim;
+
+        return Result.Success();
+    }
+
+    private void RenomearIdentificadorSeNecessario(
+        TipoIdentificador tipoIdentificador,
+        string? valorAtual,
+        string? novoValor,
+        DateOnly dataAtual,
+        string? motivo)
+    {
+        // Nenhuma mudança — sem histórico.
+        if (string.Equals(valorAtual, novoValor, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        // Caso especial: Alias pode ir de null para valor ou vice-versa.
+        bool valorAtualNulo = valorAtual is null;
+        bool novoValorNulo = novoValor is null;
+
+        // Fecha entrada aberta do identificador.
+        UnidadeIdentificadorHistorico? entradaAberta = _historico
+            .FirstOrDefault(h => h.TipoIdentificador == tipoIdentificador && h.VigenciaFim is null);
+        entradaAberta?.FecharVigencia(dataAtual);
+
+        // Abre nova entrada apenas se o novo valor é não nulo.
+        if (!novoValorNulo)
+        {
+            _historico.Add(
+                UnidadeIdentificadorHistorico.Abrir(Id, tipoIdentificador, novoValor!, dataAtual, motivo));
+        }
+    }
+
+    private static Result ValidarCampos(
+        string nome,
+        string? alias,
+        string sigla,
+        string codigo,
+        TipoUnidade tipo,
+        OrigemUnidade origem,
+        DateOnly vigenciaInicio,
+        DateOnly? vigenciaFim)
+    {
+        if (!Enum.IsDefined(tipo) || tipo == TipoUnidade.Nenhum)
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.TipoInvalido,
+                "Tipo de Unidade inválido — use um valor definido em TipoUnidade, diferente de Nenhum."));
+        }
+
+        if (!Enum.IsDefined(origem) || origem == OrigemUnidade.Nenhum)
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.OrigemInvalida,
+                "Origem da Unidade inválida."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.NomeObrigatorio,
+                "Nome da Unidade é obrigatório."));
+        }
+
+        if (nome.Trim().Length is < NomeMinLength or > NomeMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.NomeTamanho,
+                $"Nome da Unidade deve ter entre {NomeMinLength} e {NomeMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(sigla))
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.SiglaObrigatoria,
+                "Sigla da Unidade é obrigatória."));
+        }
+
+        if (sigla.Trim().Length is < SiglaMinLength or > SiglaMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.SiglaTamanho,
+                $"Sigla da Unidade deve ter entre {SiglaMinLength} e {SiglaMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.CodigoObrigatorio,
+                "Código da Unidade é obrigatório."));
+        }
+
+        if (codigo.Trim().Length is < CodigoMinLength or > CodigoMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.CodigoTamanho,
+                $"Código da Unidade deve ter entre {CodigoMinLength} e {CodigoMaxLength} caracteres."));
+        }
+
+        if (alias is not null && alias.Trim().Length > AliasMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.AliasTamanho,
+                $"Alias da Unidade não pode ter mais que {AliasMaxLength} caracteres."));
+        }
+
+        if (vigenciaFim.HasValue && vigenciaFim.Value < vigenciaInicio)
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.VigenciaFimAnteriorAoInicio,
+                "Data de encerramento da vigência deve ser igual ou posterior à data de início."));
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/UnidadeIdentificadorHistorico.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/UnidadeIdentificadorHistorico.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+
+/// <summary>
+/// Registro histórico de um identificador (<see cref="TipoIdentificador"/>) de
+/// uma <see cref="Unidade"/>. Cada vez que Slug, Sigla, Codigo ou Alias muda,
+/// a vigência do valor anterior é encerrada e uma nova entrada é aberta — o
+/// histórico responde à pergunta "qual sigla esta unidade tinha na data D".
+/// </summary>
+/// <remarks>
+/// Entidade interna ao agregado <see cref="Unidade"/>; criada apenas por
+/// métodos do agregado. Construtor privado mantém o invariante.
+/// Soft-delete herdado de <see cref="EntityBase"/> não se aplica: o histórico
+/// é imutável (append-only). Entradas fechadas não são deletadas — mantidas
+/// para auditoria.
+/// </remarks>
+public sealed class UnidadeIdentificadorHistorico : EntityBase
+{
+    public Guid UnidadeId { get; private set; }
+    public TipoIdentificador TipoIdentificador { get; private set; }
+    public string Valor { get; private set; } = string.Empty;
+    public DateOnly VigenciaInicio { get; private set; }
+    public DateOnly? VigenciaFim { get; private set; }
+    public string? MotivoMudanca { get; private set; }
+
+    // EF Core materialization
+    private UnidadeIdentificadorHistorico()
+    {
+    }
+
+    internal static UnidadeIdentificadorHistorico Abrir(
+        Guid unidadeId,
+        TipoIdentificador tipo,
+        string valor,
+        DateOnly vigenciaInicio,
+        string? motivoMudanca = null)
+    {
+        return new UnidadeIdentificadorHistorico
+        {
+            UnidadeId = unidadeId,
+            TipoIdentificador = tipo,
+            Valor = valor,
+            VigenciaInicio = vigenciaInicio,
+            VigenciaFim = null,
+            MotivoMudanca = motivoMudanca,
+        };
+    }
+
+    // Encerra a vigência desta entrada — chamado pelo agregado ao renomear.
+    internal void FecharVigencia(DateOnly dataFechamento)
+    {
+        VigenciaFim = dataFechamento;
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Enums/OrigemUnidade.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Enums/OrigemUnidade.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+
+/// <summary>
+/// Indica como o registro de Unidade foi gerado no sistema.
+/// </summary>
+public enum OrigemUnidade
+{
+    Nenhum = 0,
+    LegadoCoc = 1,
+    CriadoNoUniPlus = 2,
+    ImportadoSiorg = 3,
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Enums/TipoIdentificador.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Enums/TipoIdentificador.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+
+/// <summary>
+/// Tipo do identificador cujo histórico está sendo registrado em
+/// <c>UnidadeIdentificadorHistorico</c>. Slug, Sigla e Codigo são únicos entre
+/// Unidades vivas; Alias não é único.
+/// </summary>
+public enum TipoIdentificador
+{
+    Nenhum = 0,
+    Slug = 1,
+    Sigla = 2,
+    Codigo = 3,
+    Alias = 4,
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Enums/TipoUnidade.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Enums/TipoUnidade.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+
+/// <summary>
+/// Classificação organizacional de uma Unidade institucional da Unifesspa (ADR-0055).
+/// Roster fechado de 11 valores — novos tipos exigem deliberação do Tech Lead.
+/// O valor numérico faz parte do contrato: nunca renumerar existentes.
+/// </summary>
+public enum TipoUnidade
+{
+    Nenhum = 0,        // Sentinel — indica corrupção se encontrado em runtime
+    Reitoria = 1,
+    ProReitoria = 2,
+    Centro = 3,
+    Instituto = 4,
+    Faculdade = 5,
+    Departamento = 6,
+    Coordenacao = 7,
+    Diretoria = 8,
+    Divisao = 9,
+    Nucleo = 10,
+    Outro = 11,
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Errors/UnidadeErrorCodes.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Errors/UnidadeErrorCodes.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+
+public static class UnidadeErrorCodes
+{
+    public const string NomeObrigatorio = "Unidade.NomeObrigatorio";
+    public const string NomeTamanho = "Unidade.NomeTamanho";
+    public const string SiglaObrigatoria = "Unidade.SiglaObrigatoria";
+    public const string SiglaTamanho = "Unidade.SiglaTamanho";
+    public const string SiglaJaExiste = "Unidade.SiglaJaExiste";
+    public const string CodigoObrigatorio = "Unidade.CodigoObrigatorio";
+    public const string CodigoTamanho = "Unidade.CodigoTamanho";
+    public const string CodigoJaExiste = "Unidade.CodigoJaExiste";
+    public const string SlugObrigatorio = "Unidade.SlugObrigatorio";
+    public const string SlugTamanho = "Unidade.SlugTamanho";
+    public const string SlugFormatoInvalido = "Unidade.SlugFormatoInvalido";
+    public const string SlugJaExiste = "Unidade.SlugJaExiste";
+    public const string AliasTamanho = "Unidade.AliasTamanho";
+    public const string TipoInvalido = "Unidade.TipoInvalido";
+    public const string OrigemInvalida = "Unidade.OrigemInvalida";
+    public const string VigenciaFimAnteriorAoInicio = "Unidade.VigenciaFimAnteriorAoInicio";
+    public const string SuperiorNaoEncontrado = "Unidade.SuperiorNaoEncontrado";
+    public const string SuperiorFormaCiclo = "Unidade.SuperiorFormaCiclo";
+    public const string NaoEncontrada = "Unidade.NaoEncontrada";
+    public const string RemocaoBloqueadaPorSubordinadas = "Unidade.RemocaoBloqueadaPorSubordinadas";
+    public const string RemocaoBloqueadaPorInstituicao = "Unidade.RemocaoBloqueadaPorInstituicao";
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
@@ -10,7 +10,19 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
 /// </summary>
 public interface IUnidadeRepository
 {
+    /// <summary>
+    /// Carrega a unidade com o histórico de identificadores incluído, rastreada
+    /// pelo contexto — para mutação (atualização que renomeia identificadores) e
+    /// verificações que dependem do agregado completo.
+    /// </summary>
     Task<Unidade?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Carrega a unidade para leitura (<c>AsNoTracking</c>, sem o histórico de
+    /// identificadores) — para projeção em DTO. Evita o over-fetch da coleção de
+    /// histórico em caminhos que não a expõem.
+    /// </summary>
+    Task<Unidade?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
 
     Task<IReadOnlyList<Unidade>> ListarAtivasAsync(CancellationToken cancellationToken);
 

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
@@ -24,7 +24,13 @@ public interface IUnidadeRepository
     /// </summary>
     Task<Unidade?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
 
-    Task<IReadOnlyList<Unidade>> ListarAtivasAsync(CancellationToken cancellationToken);
+    /// <summary>
+    /// Lista unidades ativas paginadas por cursor keyset (ADR-0026): ordena por
+    /// <c>Id</c> (Guid v7, ADR-0032 — ordem cronológica) e retorna até
+    /// <paramref name="take"/> itens com <c>Id</c> maior que
+    /// <paramref name="afterId"/> (ou a primeira janela quando <c>null</c>).
+    /// </summary>
+    Task<IReadOnlyList<Unidade>> ListarPaginadoAsync(Guid? afterId, int take, CancellationToken cancellationToken);
 
     Task AdicionarAsync(Unidade unidade, CancellationToken cancellationToken);
 

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
@@ -1,0 +1,45 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+/// <summary>
+/// Repositório da entidade <see cref="Unidade"/> (ADR-0054: banco isolado de
+/// Organização). Todas as operações de leitura excluem registros soft-deleted
+/// via query filter do EF Core.
+/// </summary>
+public interface IUnidadeRepository
+{
+    Task<Unidade?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<Unidade>> ListarAtivasAsync(CancellationToken cancellationToken);
+
+    Task AdicionarAsync(Unidade unidade, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca a unidade para remoção no contexto EF. O
+    /// <c>SoftDeleteInterceptor</c> converte automaticamente para soft-delete
+    /// preenchendo <c>DeletedBy</c>/<c>DeletedAt</c> a partir do
+    /// <c>IUserContext</c> e do <c>TimeProvider</c>.
+    /// </summary>
+    void Remover(Unidade unidade);
+
+    /// <summary>Verifica se existe unidade viva com o slug informado, excluindo opcionalmente um Id.</summary>
+    Task<bool> SlugExisteEntreLivosAsync(Slug slug, Guid? excluirId, CancellationToken cancellationToken);
+
+    /// <summary>Verifica se existe unidade viva com a sigla informada (case-insensitive), excluindo opcionalmente um Id.</summary>
+    Task<bool> SiglaExisteEntreLivosAsync(string sigla, Guid? excluirId, CancellationToken cancellationToken);
+
+    /// <summary>Verifica se existe unidade viva com o código informado, excluindo opcionalmente um Id.</summary>
+    Task<bool> CodigoExisteEntreLivosAsync(string codigo, Guid? excluirId, CancellationToken cancellationToken);
+
+    /// <summary>Verifica se a unidade tem subordinadas vivas (impede remoção).</summary>
+    Task<bool> PossuiSubordinadasVivasAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Verifica se definir <paramref name="candidatoSuperiorId"/> como superior de
+    /// <paramref name="unidadeId"/> formaria ciclo na hierarquia (o candidato é
+    /// descendente ou igual à unidade).
+    /// </summary>
+    Task<bool> FormariaCicloAsync(Guid unidadeId, Guid candidatoSuperiorId, CancellationToken cancellationToken);
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
@@ -55,9 +55,10 @@ public interface IUnidadeRepository
     Task<bool> PossuiSubordinadasVivasAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Verifica se definir <paramref name="candidatoSuperiorId"/> como superior de
-    /// <paramref name="unidadeId"/> formaria ciclo na hierarquia (o candidato é
-    /// descendente ou igual à unidade).
+    /// Indica se <paramref name="possivelDescendenteId"/> é descendente (ou igual)
+    /// de <paramref name="possivelAncestralId"/> na hierarquia, percorrendo a
+    /// cadeia de superiores. O handler usa isto para barrar a atribuição de um
+    /// superior que formaria ciclo (superior que é descendente da própria unidade).
     /// </summary>
-    Task<bool> FormariaCicloAsync(Guid unidadeId, Guid candidatoSuperiorId, CancellationToken cancellationToken);
+    Task<bool> EhDescendenteAsync(Guid possivelDescendenteId, Guid possivelAncestralId, CancellationToken cancellationToken);
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/ValueObjects/Slug.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/ValueObjects/Slug.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+using System.Text.RegularExpressions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+
+/// <summary>
+/// Identificador kebab-case normalizado de uma Unidade, usado em caminhos de
+/// URL e integrações de identidade. Slug é escolhido e revisado no cadastro —
+/// não derivado automaticamente da sigla (siglas reais têm caixa mista e
+/// pontos, e há colisões de normalização que exigem decisão humana).
+/// </summary>
+/// <remarks>
+/// Formato: <c>^[a-z][a-z0-9-]{1,62}[a-z0-9]$</c> — inicia com letra
+/// minúscula, termina com letra minúscula ou dígito, comprimento 3-64 chars.
+/// O valor normalizado é armazenado em lowercase, sem espaços ou acentos.
+/// </remarks>
+public readonly partial record struct Slug
+{
+    private const int ComprimentoMinimo = 3;
+    private const int ComprimentoMaximo = 64;
+
+    public string Valor { get; }
+
+    private Slug(string valor) => Valor = valor;
+
+    public static Result<Slug> From(string? valor)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return Result<Slug>.Failure(new DomainError(
+                UnidadeErrorCodes.SlugObrigatorio,
+                "Slug da Unidade é obrigatório."));
+        }
+
+        string normalizado = valor.Trim();
+
+        if (normalizado.Length < ComprimentoMinimo || normalizado.Length > ComprimentoMaximo)
+        {
+            return Result<Slug>.Failure(new DomainError(
+                UnidadeErrorCodes.SlugTamanho,
+                $"Slug deve ter entre {ComprimentoMinimo} e {ComprimentoMaximo} caracteres."));
+        }
+
+        if (!FormatoValido().IsMatch(normalizado))
+        {
+            return Result<Slug>.Failure(new DomainError(
+                UnidadeErrorCodes.SlugFormatoInvalido,
+                "Slug deve estar no formato kebab-case: iniciar com letra minúscula, "
+                + "conter apenas letras minúsculas, dígitos e hífens, e terminar com "
+                + "letra minúscula ou dígito (ex.: ceps, faculdade-de-ciencias)."));
+        }
+
+        return Result<Slug>.Success(new Slug(normalizado));
+    }
+
+    public override string ToString() => Valor ?? string.Empty;
+
+    [GeneratedRegex(@"^[a-z][a-z0-9-]{1,62}[a-z0-9]$", RegexOptions.CultureInvariant)]
+    private static partial Regex FormatoValido();
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/ValueObjects/Slug.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/ValueObjects/Slug.cs
@@ -12,9 +12,11 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
 /// pontos, e há colisões de normalização que exigem decisão humana).
 /// </summary>
 /// <remarks>
-/// Formato: <c>^[a-z][a-z0-9-]{1,62}[a-z0-9]$</c> — inicia com letra
-/// minúscula, termina com letra minúscula ou dígito, comprimento 3-64 chars.
-/// O valor normalizado é armazenado em lowercase, sem espaços ou acentos.
+/// Formato: <c>^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$</c> — inicia com letra
+/// minúscula, segmentos separados por hífen único (sem hífens consecutivos nem
+/// nas pontas), termina com letra minúscula ou dígito. O comprimento (3-64) é
+/// validado à parte em <see cref="From"/>. O valor normalizado é armazenado em
+/// lowercase, sem espaços ou acentos.
 /// </remarks>
 public readonly partial record struct Slug
 {
@@ -57,6 +59,6 @@ public readonly partial record struct Slug
 
     public override string ToString() => Valor ?? string.Empty;
 
-    [GeneratedRegex(@"^[a-z][a-z0-9-]{1,62}[a-z0-9]$", RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$", RegexOptions.CultureInvariant)]
     private static partial Regex FormatoValido();
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Caching/UnidadeCacheInvalidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Caching/UnidadeCacheInvalidator.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Caching;
+
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em OrganizacaoInstitucionalInfrastructureRegistration.")]
+internal sealed partial class UnidadeCacheInvalidator : IUnidadeCacheInvalidator
+{
+    private readonly ICacheService _cache;
+    private readonly ILogger<UnidadeCacheInvalidator> _logger;
+
+    public UnidadeCacheInvalidator(ICacheService cache, ILogger<UnidadeCacheInvalidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(logger);
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task InvalidarAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _cache.RemoverAsync(UnidadeCacheKeys.TodasAsUnidadesAtivas, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogFalhaInvalidacao(_logger, ex);
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Falha ao invalidar cache de unidades ativas após mutação — cache stale até TTL natural (5 min).")]
+    private static partial void LogFalhaInvalidacao(ILogger logger, Exception exception);
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Caching/UnidadeCacheKeys.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Caching/UnidadeCacheKeys.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Caching;
+
+internal static class UnidadeCacheKeys
+{
+    public const string TodasAsUnidadesAtivas = "organizacao:unidades:ativas";
+    public const string LeaseTodasAsUnidadesAtivas = "organizacao:unidades:ativas:lease";
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/DependencyInjection.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/DependencyInjection.cs
@@ -36,12 +36,14 @@ public static class OrganizacaoInstitucionalInfrastructureRegistration
             serviceProvider.GetRequiredService<OrganizacaoInstitucionalDbContext>());
 
         services.AddScoped<IAreaOrganizacionalRepository, AreaOrganizacionalRepository>();
+        services.AddScoped<IUnidadeRepository, UnidadeRepository>();
 
-        // Reader cross-módulo (ADR-0055/0056) + cache invalidator. Ambos Scoped:
-        // dependem de ICacheService (Scoped) e DbContext (Scoped). Singleton causaria
-        // captive dependency e exceção em Development com ValidateScopes=true.
+        // Readers cross-módulo (ADR-0056) + cache invalidators. Scoped porque
+        // dependem de ICacheService (Scoped) e DbContext (Scoped).
         services.AddScoped<IAreaOrganizacionalReader, AreaOrganizacionalReader>();
         services.AddScoped<IAreaOrganizacionalCacheInvalidator, AreaOrganizacionalCacheInvalidator>();
+        services.AddScoped<IUnidadeReader, UnidadeReader>();
+        services.AddScoped<IUnidadeCacheInvalidator, UnidadeCacheInvalidator>();
 
         return services;
     }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/UnidadeConfiguration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/UnidadeConfiguration.cs
@@ -1,0 +1,79 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Converters;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class UnidadeConfiguration : IEntityTypeConfiguration<Unidade>
+{
+    public void Configure(EntityTypeBuilder<Unidade> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("unidade");
+        builder.HasKey(u => u.Id);
+
+        builder.Property(u => u.Nome).HasMaxLength(250).IsRequired();
+        builder.Property(u => u.Alias).HasMaxLength(100);
+        builder.Property(u => u.Slug)
+            .HasConversion(new SlugValueConverter())
+            .HasMaxLength(64)
+            .IsRequired();
+        builder.Property(u => u.Sigla).HasMaxLength(50).IsRequired();
+        builder.Property(u => u.Codigo).HasMaxLength(50).IsRequired();
+        builder.Property(u => u.Tipo).HasConversion<string>().HasMaxLength(30).IsRequired();
+        builder.Property(u => u.Origem).HasConversion<string>().HasMaxLength(30).IsRequired();
+        builder.Property(u => u.UnidadeAcademica).IsRequired();
+        builder.Property(u => u.VigenciaInicio).IsRequired();
+        builder.Property(u => u.VigenciaFim);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(u => u.CreatedBy).HasMaxLength(255);
+        builder.Property(u => u.UpdatedBy).HasMaxLength(255);
+
+        // Hierarquia: auto-referência intra-banco (ADR-0054)
+        builder.HasOne<Unidade>()
+            .WithMany()
+            .HasForeignKey(u => u.UnidadeSuperiorId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Histórico de identificadores — coleção owned dentro do agregado
+        builder.HasMany(u => u.Historico)
+            .WithOne()
+            .HasForeignKey(h => h.UnidadeId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Índices únicos parciais (WHERE is_deleted = false) — unicidade entre vivos
+        builder.HasIndex(u => u.Slug)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_unidade_slug_vivo");
+
+        builder.HasIndex(u => u.Sigla)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_unidade_sigla_vivo");
+
+        builder.HasIndex(u => u.Codigo)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_unidade_codigo_vivo");
+
+        // Alias: índice não-único (para agrupamento/busca)
+        builder.HasIndex(u => u.Alias)
+            .HasDatabaseName("ix_unidade_alias");
+
+        // Hierarquia: índice para busca de subordinadas
+        builder.HasIndex(u => u.UnidadeSuperiorId)
+            .HasDatabaseName("ix_unidade_superior_id");
+
+        builder.HasQueryFilter(u => !u.IsDeleted);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/UnidadeIdentificadorHistoricoConfiguration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/UnidadeIdentificadorHistoricoConfiguration.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class UnidadeIdentificadorHistoricoConfiguration
+    : IEntityTypeConfiguration<UnidadeIdentificadorHistorico>
+{
+    public void Configure(EntityTypeBuilder<UnidadeIdentificadorHistorico> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("unidade_identificador_historico");
+        builder.HasKey(h => h.Id);
+
+        builder.Property(h => h.UnidadeId).IsRequired();
+        builder.Property(h => h.TipoIdentificador).HasConversion<string>().HasMaxLength(20).IsRequired();
+        builder.Property(h => h.Valor).HasMaxLength(100).IsRequired();
+        builder.Property(h => h.VigenciaInicio).IsRequired();
+        builder.Property(h => h.VigenciaFim);
+        builder.Property(h => h.MotivoMudanca).HasMaxLength(500);
+
+        // Índice para consultas históricas por unidade + tipo + período
+        builder.HasIndex(h => new { h.UnidadeId, h.TipoIdentificador, h.VigenciaInicio })
+            .HasDatabaseName("ix_uid_hist_unidade_tipo_inicio");
+
+        // Histórico é append-only — sem query filter de soft-delete
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Converters/SlugValueConverter.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Converters/SlugValueConverter.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+// Mapeia Slug <-> string no banco com fail-fast nos dois sentidos.
+// Slug inválido no banco indica corrupção — falha alto via InvalidOperationException.
+public sealed class SlugValueConverter : ValueConverter<Slug, string>
+{
+    public SlugValueConverter()
+        : base(
+            slug => slug.Valor,
+            valor => Reidratar(valor))
+    {
+    }
+
+    private static Slug Reidratar(string valor)
+    {
+        Result<Slug> resultado = Slug.From(valor);
+        if (resultado.IsFailure)
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar Slug: '{valor}' "
+                + $"({resultado.Error!.Code}). "
+                + "Verifique se houve alteração manual da coluna.");
+        }
+
+        return resultado.Value!;
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260608164735_AddUnidade.Designer.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260608164735_AddUnidade.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(OrganizacaoInstitucionalDbContext))]
-    partial class OrganizacaoInstitucionalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260608164735_AddUnidade")]
+    partial class AddUnidade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260608164735_AddUnidade.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260608164735_AddUnidade.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUnidade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "unidade",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    nome = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    alias = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    slug = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    sigla = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    codigo = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    unidade_superior_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    tipo = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    unidade_academica = table.Column<bool>(type: "boolean", nullable: false),
+                    vigencia_inicio = table.Column<DateOnly>(type: "date", nullable: false),
+                    vigencia_fim = table.Column<DateOnly>(type: "date", nullable: true),
+                    origem = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_unidade", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_unidade_unidade_unidade_superior_id",
+                        column: x => x.unidade_superior_id,
+                        principalTable: "unidade",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "unidade_identificador_historico",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    unidade_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tipo_identificador = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    valor = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    vigencia_inicio = table.Column<DateOnly>(type: "date", nullable: false),
+                    vigencia_fim = table.Column<DateOnly>(type: "date", nullable: true),
+                    motivo_mudanca = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_unidade_identificador_historico", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_unidade_identificador_historico_unidade_unidade_id",
+                        column: x => x.unidade_id,
+                        principalTable: "unidade",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_unidade_alias",
+                table: "unidade",
+                column: "alias");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_unidade_codigo_vivo",
+                table: "unidade",
+                column: "codigo",
+                unique: true,
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_unidade_sigla_vivo",
+                table: "unidade",
+                column: "sigla",
+                unique: true,
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_unidade_slug_vivo",
+                table: "unidade",
+                column: "slug",
+                unique: true,
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_unidade_superior_id",
+                table: "unidade",
+                column: "unidade_superior_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_uid_hist_unidade_tipo_inicio",
+                table: "unidade_identificador_historico",
+                columns: new[] { "unidade_id", "tipo_identificador", "vigencia_inicio" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "unidade_identificador_historico");
+
+            migrationBuilder.DropTable(
+                name: "unidade");
+        }
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260608164735_AddUnidade.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260608164735_AddUnidade.cs
@@ -114,11 +114,11 @@ namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(
-                name: "unidade_identificador_historico");
-
-            migrationBuilder.DropTable(
-                name: "unidade");
+            // Forward-only per ADR-0054 §J: nova migration "Reverte..." é o
+            // mecanismo canônico de revert. Dropar as tabelas aqui induziria
+            // um `database update <baseline>` a destruir unidade/historico em
+            // staging/prod sem audit trail — caminho proibido.
+            throw new NotSupportedException("Forward-only migration per ADR-0054 §J.");
         }
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/OrganizacaoInstitucionalDbContext.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/OrganizacaoInstitucionalDbContext.cs
@@ -21,6 +21,11 @@ public sealed class OrganizacaoInstitucionalDbContext : DbContext, IUnitOfWork
 
     public DbSet<AreaOrganizacional> AreasOrganizacionais => Set<AreaOrganizacional>();
 
+    public DbSet<Unidade> Unidades => Set<Unidade>();
+
+    public DbSet<UnidadeIdentificadorHistorico> UnidadesIdentificadoresHistorico =>
+        Set<UnidadeIdentificadorHistorico>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do agregado
     /// para permitir gravação adjacente no outbox; entries cifradas at-rest

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
@@ -27,6 +27,13 @@ internal sealed class UnidadeRepository : IUnidadeRepository
             .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
     }
 
+    public Task<Unidade?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Unidades
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
+    }
+
     public async Task<IReadOnlyList<Unidade>> ListarAtivasAsync(CancellationToken cancellationToken)
     {
         List<Unidade> unidades = await _dbContext.Unidades

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
@@ -103,20 +103,20 @@ internal sealed class UnidadeRepository : IUnidadeRepository
     }
 
     /// <summary>
-    /// Determina se definir <paramref name="candidatoSuperiorId"/> como superior de
-    /// <paramref name="unidadeId"/> formaria ciclo, percorrendo os ancestrais do
-    /// candidato até a raiz. A operação é O(profundidade) — na prática ≤6 níveis
-    /// na Unifesspa.
+    /// Indica se <paramref name="possivelDescendenteId"/> é descendente (ou igual)
+    /// de <paramref name="possivelAncestralId"/>, percorrendo a cadeia de
+    /// superiores do possível descendente até a raiz. A operação é O(profundidade)
+    /// — na prática ≤6 níveis na Unifesspa.
     /// </summary>
-    public async Task<bool> FormariaCicloAsync(
-        Guid unidadeId,
-        Guid candidatoSuperiorId,
+    public async Task<bool> EhDescendenteAsync(
+        Guid possivelDescendenteId,
+        Guid possivelAncestralId,
         CancellationToken cancellationToken)
     {
-        Guid? atual = candidatoSuperiorId;
+        Guid? atual = possivelDescendenteId;
         while (atual.HasValue)
         {
-            if (atual.Value == unidadeId)
+            if (atual.Value == possivelAncestralId)
             {
                 return true;
             }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
@@ -1,0 +1,115 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em OrganizacaoInstitucionalInfrastructureRegistration.")]
+internal sealed class UnidadeRepository : IUnidadeRepository
+{
+    private readonly OrganizacaoInstitucionalDbContext _dbContext;
+
+    public UnidadeRepository(OrganizacaoInstitucionalDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<Unidade?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Unidades
+            .Include(u => u.Historico)
+            .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Unidade>> ListarAtivasAsync(CancellationToken cancellationToken)
+    {
+        List<Unidade> unidades = await _dbContext.Unidades
+            .AsNoTracking()
+            .OrderBy(u => u.Sigla)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return unidades;
+    }
+
+    public async Task AdicionarAsync(Unidade unidade, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(unidade);
+        await _dbContext.Unidades.AddAsync(unidade, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(Unidade unidade)
+    {
+        ArgumentNullException.ThrowIfNull(unidade);
+        _dbContext.Unidades.Remove(unidade);
+    }
+
+    public Task<bool> SlugExisteEntreLivosAsync(Slug slug, Guid? excluirId, CancellationToken cancellationToken)
+    {
+        return _dbContext.Unidades
+            .AsNoTracking()
+            .Where(u => excluirId == null || u.Id != excluirId)
+            .AnyAsync(u => u.Slug == slug, cancellationToken);
+    }
+
+    public Task<bool> SiglaExisteEntreLivosAsync(string sigla, Guid? excluirId, CancellationToken cancellationToken)
+    {
+        string siglaNorm = sigla.ToUpperInvariant();
+        return _dbContext.Unidades
+            .AsNoTracking()
+            .Where(u => excluirId == null || u.Id != excluirId)
+            .AnyAsync(u => u.Sigla == siglaNorm, cancellationToken);
+    }
+
+    public Task<bool> CodigoExisteEntreLivosAsync(string codigo, Guid? excluirId, CancellationToken cancellationToken)
+    {
+        return _dbContext.Unidades
+            .AsNoTracking()
+            .Where(u => excluirId == null || u.Id != excluirId)
+            .AnyAsync(u => u.Codigo == codigo, cancellationToken);
+    }
+
+    public Task<bool> PossuiSubordinadasVivasAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Unidades
+            .AsNoTracking()
+            .AnyAsync(u => u.UnidadeSuperiorId == id, cancellationToken);
+    }
+
+    /// <summary>
+    /// Determina se definir <paramref name="candidatoSuperiorId"/> como superior de
+    /// <paramref name="unidadeId"/> formaria ciclo, percorrendo os ancestrais do
+    /// candidato até a raiz. A operação é O(profundidade) — na prática ≤6 níveis
+    /// na Unifesspa.
+    /// </summary>
+    public async Task<bool> FormariaCicloAsync(
+        Guid unidadeId,
+        Guid candidatoSuperiorId,
+        CancellationToken cancellationToken)
+    {
+        Guid? atual = candidatoSuperiorId;
+        while (atual.HasValue)
+        {
+            if (atual.Value == unidadeId)
+            {
+                return true;
+            }
+
+            Guid? superiorDoAtual = await _dbContext.Unidades
+                .AsNoTracking()
+                .Where(u => u.Id == atual.Value)
+                .Select(u => u.UnidadeSuperiorId)
+                .FirstOrDefaultAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            atual = superiorDoAtual;
+        }
+
+        return false;
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
@@ -34,14 +34,28 @@ internal sealed class UnidadeRepository : IUnidadeRepository
             .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<Unidade>> ListarAtivasAsync(CancellationToken cancellationToken)
+    public async Task<IReadOnlyList<Unidade>> ListarPaginadoAsync(
+        Guid? afterId,
+        int take,
+        CancellationToken cancellationToken)
     {
-        List<Unidade> unidades = await _dbContext.Unidades
+        IQueryable<Unidade> query = _dbContext.Unidades
             .AsNoTracking()
-            .OrderBy(u => u.Sigla)
+            .OrderBy(u => u.Id);
+
+        if (afterId is { } cursor)
+        {
+            // Keyset coerente server-side (ADR-0026 + ADR-0032): Npgsql traduz
+            // Guid.CompareTo para o operador uuid > nativo do PG — mesmo
+            // comparador do OrderBy(Id). Com Guid v7, a ordem por Id reflete a
+            // criação temporal.
+            query = query.Where(u => u.Id.CompareTo(cursor) > 0);
+        }
+
+        return await query
+            .Take(take)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
-        return unidades;
     }
 
     public async Task AdicionarAsync(Unidade unidade, CancellationToken cancellationToken)

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
@@ -80,7 +80,10 @@ internal sealed class UnidadeRepository : IUnidadeRepository
 
     public Task<bool> SiglaExisteEntreLivosAsync(string sigla, Guid? excluirId, CancellationToken cancellationToken)
     {
-        string siglaNorm = sigla.ToUpperInvariant();
+        // Espelha a normalização do agregado (Trim + ToUpperInvariant) para que
+        // " abc " case com o "ABC" persistido — senão a checagem erra e a colisão
+        // só estoura no índice único (500 em vez do 409 SiglaJaExiste).
+        string siglaNorm = sigla.Trim().ToUpperInvariant();
         return _dbContext.Unidades
             .AsNoTracking()
             .Where(u => excluirId == null || u.Id != excluirId)
@@ -89,10 +92,12 @@ internal sealed class UnidadeRepository : IUnidadeRepository
 
     public Task<bool> CodigoExisteEntreLivosAsync(string codigo, Guid? excluirId, CancellationToken cancellationToken)
     {
+        // Espelha o Trim do agregado (mesma razão da Sigla).
+        string codigoNorm = codigo.Trim();
         return _dbContext.Unidades
             .AsNoTracking()
             .Where(u => excluirId == null || u.Id != excluirId)
-            .AnyAsync(u => u.Codigo == codigo, cancellationToken);
+            .AnyAsync(u => u.Codigo == codigoNorm, cancellationToken);
     }
 
     public Task<bool> PossuiSubordinadasVivasAsync(Guid id, CancellationToken cancellationToken)
@@ -116,14 +121,15 @@ internal sealed class UnidadeRepository : IUnidadeRepository
         Guid? atual = possivelDescendenteId;
         while (atual.HasValue)
         {
-            if (atual.Value == possivelAncestralId)
+            Guid atualId = atual.Value;
+            if (atualId == possivelAncestralId)
             {
                 return true;
             }
 
             Guid? superiorDoAtual = await _dbContext.Unidades
                 .AsNoTracking()
-                .Where(u => u.Id == atual.Value)
+                .Where(u => u.Id == atualId)
                 .Select(u => u.UnidadeSuperiorId)
                 .FirstOrDefaultAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Readers/UnidadeReader.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Readers/UnidadeReader.cs
@@ -1,0 +1,182 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Mappings;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Caching;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação canônica de <see cref="IUnidadeReader"/>:
+/// cache Redis (TTL 5 min) + stampede protection via lease ~2s
+/// (ADR-0057 Pattern 4).
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em OrganizacaoInstitucionalInfrastructureRegistration.")]
+internal sealed partial class UnidadeReader : IUnidadeReader
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan LeaseTtl = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan EsperaCurta = TimeSpan.FromMilliseconds(100);
+    private const int TentativasDeRecheck = 25;
+
+    internal static TimeSpan DelayAntesDoSourceParaTeste { get; set; } = TimeSpan.Zero;
+
+    private readonly ICacheService _cache;
+    private readonly OrganizacaoInstitucionalDbContext _dbContext;
+    private readonly ILogger<UnidadeReader> _logger;
+
+    public UnidadeReader(
+        ICacheService cache,
+        OrganizacaoInstitucionalDbContext dbContext,
+        ILogger<UnidadeReader> logger)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(logger);
+        _cache = cache;
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<UnidadeView>> ListarAtivasAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        List<UnidadeView>? cacheado = await ObterDoCacheAsync(cancellationToken).ConfigureAwait(false);
+        if (cacheado is not null)
+        {
+            return cacheado;
+        }
+
+        IAsyncDisposable? lease = null;
+        bool leaseIndisponivelPorOutage = false;
+        try
+        {
+            lease = await _cache
+                .AcquireLeaseAsync(UnidadeCacheKeys.LeaseTodasAsUnidadesAtivas, LeaseTtl, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogFalhaAdquirirLease(_logger, ex);
+            leaseIndisponivelPorOutage = true;
+        }
+
+        try
+        {
+            if (!leaseIndisponivelPorOutage && lease is null)
+            {
+                for (int tentativa = 0; tentativa < TentativasDeRecheck; tentativa++)
+                {
+                    await Task.Delay(EsperaCurta, cancellationToken).ConfigureAwait(false);
+                    cacheado = await ObterDoCacheAsync(cancellationToken).ConfigureAwait(false);
+                    if (cacheado is not null)
+                    {
+                        return cacheado;
+                    }
+                }
+
+                LogLeaseEsgotouSemPopular(_logger, UnidadeCacheKeys.TodasAsUnidadesAtivas);
+            }
+            else if (lease is not null)
+            {
+                cacheado = await ObterDoCacheAsync(cancellationToken).ConfigureAwait(false);
+                if (cacheado is not null)
+                {
+                    return cacheado;
+                }
+            }
+
+            IReadOnlyList<UnidadeView> views = await CarregarDoSourceAsync(cancellationToken).ConfigureAwait(false);
+
+            try
+            {
+                await _cache.DefinirAsync(
+                    UnidadeCacheKeys.TodasAsUnidadesAtivas,
+                    views,
+                    CacheTtl,
+                    cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                LogFalhaPopularCache(_logger, ex);
+            }
+
+            return views;
+        }
+        finally
+        {
+            if (lease is not null)
+            {
+                await lease.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    public async Task<UnidadeView?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<UnidadeView> todas = await ListarAtivasAsync(cancellationToken).ConfigureAwait(false);
+        return todas.FirstOrDefault(u => u.Id == id);
+    }
+
+    private async Task<List<UnidadeView>?> ObterDoCacheAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _cache.ObterAsync<List<UnidadeView>>(
+                UnidadeCacheKeys.TodasAsUnidadesAtivas,
+                cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogFalhaLerCache(_logger, ex);
+            return null;
+        }
+    }
+
+    private async Task<IReadOnlyList<UnidadeView>> CarregarDoSourceAsync(CancellationToken cancellationToken)
+    {
+        if (DelayAntesDoSourceParaTeste > TimeSpan.Zero)
+        {
+            await Task.Delay(DelayAntesDoSourceParaTeste, cancellationToken).ConfigureAwait(false);
+        }
+
+        List<Unidade> entidades = await _dbContext.Unidades
+            .AsNoTracking()
+            .OrderBy(u => u.Sigla)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(u => u.ToView())];
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Lease para chave {ChaveLease} esgotou sem cache popular — caindo à fonte direta (fail-open).")]
+    private static partial void LogLeaseEsgotouSemPopular(ILogger logger, string chaveLease);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Falha ao popular cache de unidades ativas após carregar da fonte.")]
+    private static partial void LogFalhaPopularCache(ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Falha ao ler cache de unidades ativas; usando fonte direta.")]
+    private static partial void LogFalhaLerCache(ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Falha ao adquirir lease de stampede protection para unidades; seguindo sem coordenação (cache fail-open).")]
+    private static partial void LogFalhaAdquirirLease(ILogger logger, Exception exception);
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.csproj
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.csproj
@@ -11,4 +11,10 @@
     <ProjectReference Include="..\Unifesspa.UniPlus.OrganizacaoInstitucional.Application\Unifesspa.UniPlus.OrganizacaoInstitucional.Application.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expõe internals (ex.: UnidadeRepository) aos testes de integração —
+         mesmo padrão de Infrastructure.Core. -->
+    <InternalsVisibleTo Include="Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/IUnidadeReader.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/IUnidadeReader.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>Unidade</c> (ADR-0056). Expõe o estado vivo da
+/// Unidade para consumo por outros bounded contexts (ex.: Seleção, Configuração)
+/// sem acesso direto ao banco de Organização (ADR-0054).
+/// </summary>
+/// <remarks>
+/// A implementação canônica é respaldada por cache Redis (TTL ~5 min) com
+/// stampede protection (ADR-0057 Pattern 4). Cada API que precisa de Unidade
+/// hospeda sua própria instância via
+/// <c>AddOrganizacaoInstitucionalInfrastructure()</c>.
+/// </remarks>
+public interface IUnidadeReader
+{
+    /// <summary>
+    /// Lista todas as Unidades ativas (não soft-deleted), ordenadas por sigla
+    /// ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<UnidadeView>> ListarAtivasAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém uma Unidade pelo <paramref name="id"/>, ou
+    /// <see langword="null"/> se inexistente / soft-deleted.
+    /// </summary>
+    Task<UnidadeView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/UnidadeView.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/UnidadeView.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>Unidade</c> para consumo cross-módulo via
+/// <see cref="IUnidadeReader"/> (ADR-0056). Expõe apenas os campos
+/// necessários para vinculação e exibição — sem dados de auditoria interna
+/// nem histórico de identificadores.
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="Sigla">Sigla corrente da Unidade (uppercase).</param>
+/// <param name="Slug">Identificador kebab-case da Unidade.</param>
+/// <param name="Nome">Nome formal da Unidade.</param>
+/// <param name="Alias">Nome popular de agrupamento, ou <see langword="null"/> se não informado.</param>
+/// <param name="Tipo">Classificação organizacional como string (desacoplado do enum interno).</param>
+/// <param name="UnidadeAcademica">Indica se é uma unidade acadêmica.</param>
+/// <param name="UnidadeSuperiorId">Id da Unidade superior, ou <see langword="null"/> para a raiz.</param>
+public sealed record UnidadeView(
+    Guid Id,
+    string Sigla,
+    string Slug,
+    string Nome,
+    string? Alias,
+    string Tipo,
+    bool UnidadeAcademica,
+    Guid? UnidadeSuperiorId);

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarUnidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarUnidadeCommandHandlerTests.cs
@@ -144,7 +144,7 @@ public sealed class AtualizarUnidadeCommandHandlerTests
         await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
     }
 
-    [Fact(DisplayName = "Handle com superior que é descendente retorna SuperiorFormaCiclo (via FormariaCicloAsync)")]
+    [Fact(DisplayName = "Handle com superior que é descendente retorna SuperiorFormaCiclo (via EhDescendenteAsync)")]
     public async Task Handle_ComSuperiorDescendente_RetornaSuperiorFormaCiclo()
     {
         (IUnidadeRepository repo, IUnitOfWork uow, IUnidadeCacheInvalidator cache) = Mocks();
@@ -153,7 +153,7 @@ public sealed class AtualizarUnidadeCommandHandlerTests
         Guid superiorId = Guid.NewGuid();
         repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
         repo.ObterPorIdAsync(superiorId, Arg.Any<CancellationToken>()).Returns(superior);
-        repo.FormariaCicloAsync(existente.Id, superiorId, Arg.Any<CancellationToken>()).Returns(true);
+        repo.EhDescendenteAsync(superiorId, existente.Id, Arg.Any<CancellationToken>()).Returns(true);
 
         AtualizarUnidadeCommand command =
             CommandSemMudancaDeIdentificador(existente.Id) with { UnidadeSuperiorId = superiorId };

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarUnidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarUnidadeCommandHandlerTests.cs
@@ -1,0 +1,183 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+public sealed class AtualizarUnidadeCommandHandlerTests
+{
+    private static readonly DateOnly DataInicio = new(2026, 1, 1);
+
+    private static Unidade UnidadeExistente() => Unidade.Criar(
+        "Centro de Processos Seletivos",
+        null,
+        Slug.From("ceps").Value!,
+        "CEPS",
+        "0001",
+        null,
+        TipoUnidade.Centro,
+        false,
+        DataInicio,
+        null,
+        OrigemUnidade.CriadoNoUniPlus).Value!;
+
+    // Command que reapresenta os mesmos identificadores da unidade existente —
+    // as verificações de unicidade são puladas (não houve mudança).
+    private static AtualizarUnidadeCommand CommandSemMudancaDeIdentificador(Guid id) => new(
+        id,
+        "Centro de Processos Seletivos (novo nome)",
+        null,
+        "ceps",
+        "CEPS",
+        "0001",
+        null,
+        TipoUnidade.Centro,
+        false,
+        null);
+
+    private static (IUnidadeRepository Repo, IUnitOfWork Uow, IUnidadeCacheInvalidator Cache) Mocks()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        repo.SlugExisteEntreLivosAsync(Arg.Any<Slug>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>()).Returns(false);
+        repo.SiglaExisteEntreLivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>()).Returns(false);
+        repo.CodigoExisteEntreLivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>()).Returns(false);
+        return (repo, Substitute.For<IUnitOfWork>(), Substitute.For<IUnidadeCacheInvalidator>());
+    }
+
+    [Fact(DisplayName = "Handle com unidade inexistente retorna NaoEncontrada e NÃO persiste")]
+    public async Task Handle_ComUnidadeInexistente_RetornaNaoEncontrada()
+    {
+        (IUnidadeRepository repo, IUnitOfWork uow, IUnidadeCacheInvalidator cache) = Mocks();
+        Guid id = Guid.NewGuid();
+        repo.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((Unidade?)null);
+
+        Result resultado = await AtualizarUnidadeCommandHandler.Handle(
+            CommandSemMudancaDeIdentificador(id), repo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.NaoEncontrada);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.DidNotReceive().InvalidarAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle trocando slug para um já existente entre vivos retorna SlugJaExiste")]
+    public async Task Handle_ComSlugDuplicadoExcluindoSelf_RetornaSlugJaExiste()
+    {
+        (IUnidadeRepository repo, IUnitOfWork uow, IUnidadeCacheInvalidator cache) = Mocks();
+        Unidade existente = UnidadeExistente();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        repo.SlugExisteEntreLivosAsync(Arg.Any<Slug>(), existente.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        AtualizarUnidadeCommand command = CommandSemMudancaDeIdentificador(existente.Id) with { Slug = "crca" };
+
+        Result resultado = await AtualizarUnidadeCommandHandler.Handle(
+            command, repo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SlugJaExiste);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle trocando sigla para uma já existente entre vivos retorna SiglaJaExiste")]
+    public async Task Handle_ComSiglaDuplicadaExcluindoSelf_RetornaSiglaJaExiste()
+    {
+        (IUnidadeRepository repo, IUnitOfWork uow, IUnidadeCacheInvalidator cache) = Mocks();
+        Unidade existente = UnidadeExistente();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        repo.SiglaExisteEntreLivosAsync("CRCA", existente.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        AtualizarUnidadeCommand command = CommandSemMudancaDeIdentificador(existente.Id) with { Sigla = "CRCA" };
+
+        Result resultado = await AtualizarUnidadeCommandHandler.Handle(
+            command, repo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SiglaJaExiste);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com superior igual à própria unidade retorna SuperiorFormaCiclo")]
+    public async Task Handle_ComSuperiorIgualAoProprio_RetornaSuperiorFormaCiclo()
+    {
+        (IUnidadeRepository repo, IUnitOfWork uow, IUnidadeCacheInvalidator cache) = Mocks();
+        Unidade existente = UnidadeExistente();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        AtualizarUnidadeCommand command =
+            CommandSemMudancaDeIdentificador(existente.Id) with { UnidadeSuperiorId = existente.Id };
+
+        Result resultado = await AtualizarUnidadeCommandHandler.Handle(
+            command, repo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SuperiorFormaCiclo);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com superior inexistente retorna SuperiorNaoEncontrado")]
+    public async Task Handle_ComSuperiorInexistente_RetornaSuperiorNaoEncontrado()
+    {
+        (IUnidadeRepository repo, IUnitOfWork uow, IUnidadeCacheInvalidator cache) = Mocks();
+        Unidade existente = UnidadeExistente();
+        Guid superiorId = Guid.NewGuid();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        repo.ObterPorIdAsync(superiorId, Arg.Any<CancellationToken>()).Returns((Unidade?)null);
+
+        AtualizarUnidadeCommand command =
+            CommandSemMudancaDeIdentificador(existente.Id) with { UnidadeSuperiorId = superiorId };
+
+        Result resultado = await AtualizarUnidadeCommandHandler.Handle(
+            command, repo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SuperiorNaoEncontrado);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com superior que é descendente retorna SuperiorFormaCiclo (via FormariaCicloAsync)")]
+    public async Task Handle_ComSuperiorDescendente_RetornaSuperiorFormaCiclo()
+    {
+        (IUnidadeRepository repo, IUnitOfWork uow, IUnidadeCacheInvalidator cache) = Mocks();
+        Unidade existente = UnidadeExistente();
+        Unidade superior = UnidadeExistente();
+        Guid superiorId = Guid.NewGuid();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        repo.ObterPorIdAsync(superiorId, Arg.Any<CancellationToken>()).Returns(superior);
+        repo.FormariaCicloAsync(existente.Id, superiorId, Arg.Any<CancellationToken>()).Returns(true);
+
+        AtualizarUnidadeCommand command =
+            CommandSemMudancaDeIdentificador(existente.Id) with { UnidadeSuperiorId = superiorId };
+
+        Result resultado = await AtualizarUnidadeCommandHandler.Handle(
+            command, repo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SuperiorFormaCiclo);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com command válido persiste e invalida cache")]
+    public async Task Handle_ComCommandValido_PersisteEInvalidaCache()
+    {
+        (IUnidadeRepository repo, IUnitOfWork uow, IUnidadeCacheInvalidator cache) = Mocks();
+        Unidade existente = UnidadeExistente();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarUnidadeCommandHandler.Handle(
+            CommandSemMudancaDeIdentificador(existente.Id), repo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await uow.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.Received(1).InvalidarAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarUnidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarUnidadeCommandHandlerTests.cs
@@ -166,6 +166,36 @@ public sealed class AtualizarUnidadeCommandHandlerTests
         await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
     }
 
+    [Fact(DisplayName = "Handle trocando Codigo só na caixa (ABC→abc) detecta mudança e checa unicidade")]
+    public async Task Handle_ComCodigoMudandoApenasCaixa_RodaChecagemDeUnicidade()
+    {
+        (IUnidadeRepository repo, IUnitOfWork uow, IUnidadeCacheInvalidator cache) = Mocks();
+        Unidade existente = Unidade.Criar(
+            "Centro de Processos Seletivos",
+            null,
+            Slug.From("ceps").Value!,
+            "CEPS",
+            "ABC",
+            null,
+            TipoUnidade.Centro,
+            false,
+            DataInicio,
+            null,
+            OrigemUnidade.CriadoNoUniPlus).Value!;
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        repo.CodigoExisteEntreLivosAsync("abc", existente.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        // Mesmos Slug/Sigla (pulam a checagem); só o Codigo muda de "ABC" para "abc".
+        AtualizarUnidadeCommand command = CommandSemMudancaDeIdentificador(existente.Id) with { Codigo = "abc" };
+
+        Result resultado = await AtualizarUnidadeCommandHandler.Handle(
+            command, repo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.CodigoJaExiste);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
     [Fact(DisplayName = "Handle com command válido persiste e invalida cache")]
     public async Task Handle_ComCommandValido_PersisteEInvalidaCache()
     {

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/CriarUnidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/CriarUnidadeCommandHandlerTests.cs
@@ -1,0 +1,137 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+public sealed class CriarUnidadeCommandHandlerTests
+{
+    private static readonly DateOnly DataInicio = new(2026, 1, 1);
+
+    private static CriarUnidadeCommand CommandValido() => new(
+        "Centro de Processos Seletivos",
+        null,
+        "ceps",
+        "CEPS",
+        "0001",
+        null,
+        TipoUnidade.Centro,
+        false,
+        DataInicio,
+        null,
+        OrigemUnidade.CriadoNoUniPlus);
+
+    [Fact(DisplayName = "Handle com command válido persiste e invalida cache")]
+    public async Task Handle_ComCommandValido_PersisteEInvalidaCache()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
+        repo.SlugExisteEntreLivosAsync(Arg.Any<Slug>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        repo.SiglaExisteEntreLivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        repo.CodigoExisteEntreLivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarUnidadeCommandHandler.Handle(
+            CommandValido(), repo, uow, cache, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBeEmpty();
+        await repo.Received(1).AdicionarAsync(Arg.Any<Unidade>(), Arg.Any<CancellationToken>());
+        await uow.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.Received(1).InvalidarAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com slug duplicado retorna SlugJaExiste e NÃO persiste")]
+    public async Task Handle_ComSlugDuplicado_RetornaSlugJaExiste()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
+        repo.SlugExisteEntreLivosAsync(Arg.Any<Slug>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarUnidadeCommandHandler.Handle(
+            CommandValido(), repo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SlugJaExiste);
+        await repo.DidNotReceive().AdicionarAsync(Arg.Any<Unidade>(), Arg.Any<CancellationToken>());
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.DidNotReceive().InvalidarAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com sigla duplicada retorna SiglaJaExiste e NÃO persiste")]
+    public async Task Handle_ComSiglaDuplicada_RetornaSiglaJaExiste()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
+        repo.SlugExisteEntreLivosAsync(Arg.Any<Slug>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        repo.SiglaExisteEntreLivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarUnidadeCommandHandler.Handle(
+            CommandValido(), repo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SiglaJaExiste);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com slug inválido retorna SlugFormatoInvalido (Slug.From falha)")]
+    public async Task Handle_ComSlugInvalido_RetornaSlugFormatoInvalido()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
+        CriarUnidadeCommand command = CommandValido() with { Slug = "SLUG-COM-MAIUSCULAS" };
+
+        Result<Guid> resultado = await CriarUnidadeCommandHandler.Handle(
+            command, repo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SlugFormatoInvalido);
+        await repo.DidNotReceive().SlugExisteEntreLivosAsync(
+            Arg.Any<Slug>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com superior inexistente retorna SuperiorNaoEncontrado")]
+    public async Task Handle_ComSuperiorInexistente_RetornaSuperiorNaoEncontrado()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
+        repo.SlugExisteEntreLivosAsync(Arg.Any<Slug>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        repo.SiglaExisteEntreLivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        repo.CodigoExisteEntreLivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        Guid superiorId = Guid.NewGuid();
+        repo.ObterPorIdAsync(superiorId, Arg.Any<CancellationToken>())
+            .Returns((Unidade?)null);
+
+        CriarUnidadeCommand command = CommandValido() with { UnidadeSuperiorId = superiorId };
+
+        Result<Guid> resultado = await CriarUnidadeCommandHandler.Handle(
+            command, repo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SuperiorNaoEncontrado);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/RemoverUnidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/RemoverUnidadeCommandHandlerTests.cs
@@ -1,0 +1,89 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Unidades;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+public sealed class RemoverUnidadeCommandHandlerTests
+{
+    private static Unidade CriarUnidade() =>
+        Unidade.Criar(
+            "Centro de Processos Seletivos",
+            null,
+            Slug.From("ceps").Value!,
+            "CEPS",
+            "0001",
+            null,
+            TipoUnidade.Centro,
+            false,
+            new DateOnly(2026, 1, 1),
+            null,
+            OrigemUnidade.CriadoNoUniPlus).Value!;
+
+    [Fact(DisplayName = "Handle com unidade válida e sem subordinadas remove e invalida cache")]
+    public async Task Handle_ComUnidadeValida_RemoveEInvalidaCache()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
+
+        Unidade unidade = CriarUnidade();
+        repo.ObterPorIdAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(unidade);
+        repo.PossuiSubordinadasVivasAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result resultado = await RemoverUnidadeCommandHandler.Handle(
+            new RemoverUnidadeCommand(unidade.Id), repo, uow, cache, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        repo.Received(1).Remover(unidade);
+        await uow.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.Received(1).InvalidarAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com unidade inexistente retorna NaoEncontrada e NÃO persiste")]
+    public async Task Handle_ComUnidadeInexistente_RetornaNaoEncontrada()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
+        repo.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Unidade?)null);
+
+        Result resultado = await RemoverUnidadeCommandHandler.Handle(
+            new RemoverUnidadeCommand(Guid.NewGuid()), repo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.NaoEncontrada);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.DidNotReceive().InvalidarAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com subordinadas vivas retorna RemocaoBloqueadaPorSubordinadas e NÃO persiste")]
+    public async Task Handle_ComSubordinadasVivas_RetornaBloqueio()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
+
+        Unidade unidade = CriarUnidade();
+        repo.ObterPorIdAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(unidade);
+        repo.PossuiSubordinadasVivasAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result resultado = await RemoverUnidadeCommandHandler.Handle(
+            new RemoverUnidadeCommand(unidade.Id), repo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.RemocaoBloqueadaPorSubordinadas);
+        repo.DidNotReceive().Remover(Arg.Any<Unidade>());
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/UnidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/UnidadeTests.cs
@@ -1,0 +1,248 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+public sealed class UnidadeTests
+{
+    private static readonly DateOnly DataInicio = new(2026, 1, 1);
+    private static readonly Slug SlugValido = Slug.From("ceps").Value!;
+
+    private static Unidade CriarUnidadeValida(string? alias = null, Guid? superiorId = null) =>
+        Unidade.Criar(
+            "Centro de Processos Seletivos",
+            alias,
+            SlugValido,
+            "CEPS",
+            "0001",
+            superiorId,
+            TipoUnidade.Centro,
+            false,
+            DataInicio,
+            null,
+            OrigemUnidade.CriadoNoUniPlus).Value!;
+
+    // ── Criar ──────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Criar com dados válidos retorna Success com agregado preenchido")]
+    public void Criar_ComDadosValidos_DeveRetornarSuccessComAgregadoPreenchido()
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            "Centro de Processos Seletivos",
+            null,
+            SlugValido,
+            "CEPS",
+            "0001",
+            null,
+            TipoUnidade.Centro,
+            false,
+            DataInicio,
+            null,
+            OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsSuccess.Should().BeTrue();
+        Unidade u = resultado.Value!;
+        u.Nome.Should().Be("Centro de Processos Seletivos");
+        u.Slug.Should().Be(SlugValido);
+        u.Sigla.Should().Be("CEPS");
+        u.Codigo.Should().Be("0001");
+        u.Tipo.Should().Be(TipoUnidade.Centro);
+        u.Origem.Should().Be(OrigemUnidade.CriadoNoUniPlus);
+        u.Id.Should().NotBeEmpty("ADR-0032 exige Guid v7 via EntityBase");
+        u.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar abre histórico inicial para Slug, Sigla e Codigo")]
+    public void Criar_ComDadosValidos_AbreHistoricoInicialParaIdentificadores()
+    {
+        Unidade unidade = CriarUnidadeValida();
+
+        unidade.Historico.Should().HaveCount(3);
+        unidade.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Slug && h.Valor == "ceps" && h.VigenciaFim == null);
+        unidade.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Sigla && h.Valor == "CEPS" && h.VigenciaFim == null);
+        unidade.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Codigo && h.Valor == "0001" && h.VigenciaFim == null);
+    }
+
+    [Fact(DisplayName = "Criar com alias abre histórico adicional para Alias")]
+    public void Criar_ComAlias_AbreHistoricoParaAlias()
+    {
+        Unidade unidade = CriarUnidadeValida(alias: "Centro Seletivos");
+
+        unidade.Historico.Should().HaveCount(4);
+        unidade.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Alias && h.Valor == "Centro Seletivos" && h.VigenciaFim == null);
+    }
+
+    [Theory(DisplayName = "Criar com nome vazio/whitespace retorna NomeObrigatorio")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_ComNomeVazio_DeveRetornarNomeObrigatorio(string nomeInvalido)
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            nomeInvalido, null, SlugValido, "CEPS", "0001", null,
+            TipoUnidade.Centro, false, DataInicio, null, OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.NomeObrigatorio);
+    }
+
+    [Fact(DisplayName = "Criar com nome com 1 char retorna NomeTamanho (limite inferior)")]
+    public void Criar_ComNomeMuitoCurto_DeveRetornarNomeTamanho()
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            "a", null, SlugValido, "CEPS", "0001", null,
+            TipoUnidade.Centro, false, DataInicio, null, OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.NomeTamanho);
+    }
+
+    [Fact(DisplayName = "Criar com sigla vazia retorna SiglaObrigatoria")]
+    public void Criar_ComSiglaVazia_DeveRetornarSiglaObrigatoria()
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            "Nome valido", null, SlugValido, "  ", "0001", null,
+            TipoUnidade.Centro, false, DataInicio, null, OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SiglaObrigatoria);
+    }
+
+    [Fact(DisplayName = "Criar com sigla > 50 chars retorna SiglaTamanho")]
+    public void Criar_ComSiglaMuitoLonga_DeveRetornarSiglaTamanho()
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            "Nome valido", null, SlugValido, new string('A', 51), "0001", null,
+            TipoUnidade.Centro, false, DataInicio, null, OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SiglaTamanho);
+    }
+
+    [Fact(DisplayName = "Criar com código vazio retorna CodigoObrigatorio")]
+    public void Criar_ComCodigoVazio_DeveRetornarCodigoObrigatorio()
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            "Nome valido", null, SlugValido, "CEPS", "  ", null,
+            TipoUnidade.Centro, false, DataInicio, null, OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.CodigoObrigatorio);
+    }
+
+    [Fact(DisplayName = "Criar com alias > 100 chars retorna AliasTamanho")]
+    public void Criar_ComAliasMuitoLongo_DeveRetornarAliasTamanho()
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            "Nome valido", new string('a', 101), SlugValido, "CEPS", "0001", null,
+            TipoUnidade.Centro, false, DataInicio, null, OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.AliasTamanho);
+    }
+
+    [Theory(DisplayName = "Criar com TipoUnidade.Nenhum ou cast inválido retorna TipoInvalido")]
+    [InlineData(TipoUnidade.Nenhum)]
+    [InlineData((TipoUnidade)99)]
+    public void Criar_ComTipoInvalido_DeveRetornarTipoInvalido(TipoUnidade tipoInvalido)
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            "Nome valido", null, SlugValido, "CEPS", "0001", null,
+            tipoInvalido, false, DataInicio, null, OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.TipoInvalido);
+    }
+
+    [Theory(DisplayName = "Criar com OrigemUnidade.Nenhum ou cast inválido retorna OrigemInvalida")]
+    [InlineData(OrigemUnidade.Nenhum)]
+    [InlineData((OrigemUnidade)99)]
+    public void Criar_ComOrigemInvalida_DeveRetornarOrigemInvalida(OrigemUnidade origemInvalida)
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            "Nome valido", null, SlugValido, "CEPS", "0001", null,
+            TipoUnidade.Centro, false, DataInicio, null, origemInvalida);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.OrigemInvalida);
+    }
+
+    [Fact(DisplayName = "Criar com vigenciaFim anterior ao início retorna VigenciaFimAnteriorAoInicio")]
+    public void Criar_ComVigenciaFimAntesDoInicio_DeveRetornarVigenciaFimAnteriorAoInicio()
+    {
+        DateOnly fimAnterior = DataInicio.AddDays(-1);
+
+        Result<Unidade> resultado = Unidade.Criar(
+            "Nome valido", null, SlugValido, "CEPS", "0001", null,
+            TipoUnidade.Centro, false, DataInicio, fimAnterior, OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.VigenciaFimAnteriorAoInicio);
+    }
+
+    // ── Atualizar ──────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Atualizar com dados válidos altera campos e não toca histórico sem mudança de identificadores")]
+    public void Atualizar_SemMudancaDeIdentificadores_NaoAdicionaHistorico()
+    {
+        Unidade unidade = CriarUnidadeValida();
+        int historicoAntes = unidade.Historico.Count;
+        DateOnly dataAtual = DataInicio.AddMonths(1);
+
+        Result resultado = unidade.Atualizar(
+            "Centro de Processos Seletivos Alterado",
+            null, SlugValido, "CEPS", "0001", null,
+            TipoUnidade.Centro, true, null, dataAtual);
+
+        resultado.IsSuccess.Should().BeTrue();
+        unidade.Nome.Should().Be("Centro de Processos Seletivos Alterado");
+        unidade.UnidadeAcademica.Should().BeTrue();
+        unidade.Historico.Should().HaveCount(historicoAntes, "nenhum identificador mudou");
+    }
+
+    [Fact(DisplayName = "Atualizar com novo Slug fecha vigência antiga e abre nova entrada de histórico")]
+    public void Atualizar_ComNovoSlug_AdicionaEntradaDeHistorico()
+    {
+        Unidade unidade = CriarUnidadeValida();
+        Slug novoSlug = Slug.From("ceps-unifesspa").Value!;
+        DateOnly dataAtual = DataInicio.AddMonths(1);
+
+        Result resultado = unidade.Atualizar(
+            unidade.Nome, null, novoSlug, "CEPS", "0001", null,
+            TipoUnidade.Centro, false, null, dataAtual, "Adequação de naming");
+
+        resultado.IsSuccess.Should().BeTrue();
+        unidade.Slug.Should().Be(novoSlug);
+
+        // Entrada antiga fechada
+        unidade.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Slug &&
+            h.Valor == "ceps" &&
+            h.VigenciaFim == dataAtual);
+
+        // Nova entrada aberta
+        unidade.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Slug &&
+            h.Valor == "ceps-unifesspa" &&
+            h.VigenciaFim == null);
+    }
+
+    [Fact(DisplayName = "Sigla é normalizada para uppercase no Criar")]
+    public void Criar_SiglaEhNormalizadaParaUppercase()
+    {
+        Result<Unidade> resultado = Unidade.Criar(
+            "Nome valido", null, SlugValido, "ceps", "0001", null,
+            TipoUnidade.Centro, false, DataInicio, null, OrigemUnidade.CriadoNoUniPlus);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Sigla.Should().Be("CEPS");
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/UnidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/UnidadeTests.cs
@@ -235,6 +235,31 @@ public sealed class UnidadeTests
             h.VigenciaFim == null);
     }
 
+    [Fact(DisplayName = "Atualizar troca de Codigo só na caixa (ABC→abc) registra histórico")]
+    public void Atualizar_ComCodigoMudandoApenasCaixa_AdicionaEntradaDeHistorico()
+    {
+        Unidade unidade = Unidade.Criar(
+            "Centro de Processos Seletivos", null, SlugValido, "CEPS", "ABC", null,
+            TipoUnidade.Centro, false, DataInicio, null, OrigemUnidade.CriadoNoUniPlus).Value!;
+        DateOnly dataAtual = DataInicio.AddMonths(1);
+
+        Result resultado = unidade.Atualizar(
+            unidade.Nome, null, SlugValido, "CEPS", "abc", null,
+            TipoUnidade.Centro, false, null, dataAtual, "Correção de caixa");
+
+        resultado.IsSuccess.Should().BeTrue();
+        unidade.Codigo.Should().Be("abc");
+
+        // Entrada antiga "ABC" fechada na data da mudança.
+        unidade.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Codigo &&
+            h.Valor == "ABC" && h.VigenciaFim == dataAtual);
+        // Nova entrada "abc" aberta.
+        unidade.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Codigo &&
+            h.Valor == "abc" && h.VigenciaFim == null);
+    }
+
     [Fact(DisplayName = "Sigla é normalizada para uppercase no Criar")]
     public void Criar_SiglaEhNormalizadaParaUppercase()
     {

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/ValueObjects/SlugTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/ValueObjects/SlugTests.cs
@@ -1,0 +1,87 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+public sealed class SlugTests
+{
+    [Theory(DisplayName = "Slug válido retorna Success com valor preservado")]
+    [InlineData("ceps")]
+    [InlineData("ceps-unifesspa")]
+    [InlineData("faculdade-de-ciencias")]
+    [InlineData("a1b")]
+    [InlineData("abc123")]
+    public void From_ComSlugValido_DeveRetornarSuccess(string valor)
+    {
+        Result<Slug> resultado = Slug.From(valor);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Valor.Should().Be(valor);
+    }
+
+    [Theory(DisplayName = "Slug nulo ou vazio retorna SlugObrigatorio")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void From_ComSlugVazioOuNulo_DeveRetornarSlugObrigatorio(string? valor)
+    {
+        Result<Slug> resultado = Slug.From(valor);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SlugObrigatorio);
+    }
+
+    [Fact(DisplayName = "Slug com 2 chars retorna SlugTamanho (abaixo do mínimo)")]
+    public void From_ComSlugDe2Chars_DeveRetornarSlugTamanho()
+    {
+        Result<Slug> resultado = Slug.From("ab");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SlugTamanho);
+    }
+
+    [Fact(DisplayName = "Slug com 65 chars retorna SlugTamanho (acima do máximo)")]
+    public void From_ComSlug65Chars_DeveRetornarSlugTamanho()
+    {
+        string valor65 = "a" + new string('b', 63) + "c"; // 65 chars
+        Result<Slug> resultado = Slug.From(valor65);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SlugTamanho);
+    }
+
+    [Theory(DisplayName = "Slug em formato inválido retorna SlugFormatoInvalido")]
+    [InlineData("1ceps")]          // começa com dígito
+    [InlineData("-ceps")]          // começa com hífen
+    [InlineData("CEPS")]           // maiúsculas
+    [InlineData("ceps-")]          // termina com hífen
+    [InlineData("ceps unifesspa")] // espaço
+    public void From_ComFormatoInvalido_DeveRetornarSlugFormatoInvalido(string valor)
+    {
+        Result<Slug> resultado = Slug.From(valor);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.SlugFormatoInvalido);
+    }
+
+    [Fact(DisplayName = "ToString retorna o Valor")]
+    public void ToString_DeveRetornarOValor()
+    {
+        Slug slug = Slug.From("ceps").Value!;
+
+        slug.ToString().Should().Be("ceps");
+    }
+
+    [Fact(DisplayName = "Igualdade estrutural: mesmos valores são iguais")]
+    public void Equality_ComMesmosValores_DevemSerIguais()
+    {
+        Slug a = Slug.From("ceps").Value!;
+        Slug b = Slug.From("ceps").Value!;
+
+        (a == b).Should().BeTrue();
+        a.Equals(b).Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/ValueObjects/SlugTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/ValueObjects/SlugTests.cs
@@ -59,6 +59,7 @@ public sealed class SlugTests
     [InlineData("CEPS")]           // maiúsculas
     [InlineData("ceps-")]          // termina com hífen
     [InlineData("ceps unifesspa")] // espaço
+    [InlineData("ceps--unifesspa")] // hífens consecutivos
     public void From_ComFormatoInvalido_DeveRetornarSlugFormatoInvalido(string valor)
     {
         Result<Slug> resultado = Slug.From(valor);

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Infrastructure/OrganizacaoApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Infrastructure/OrganizacaoApiFactory.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x IClassFixture<T> requires the fixture type to be public.")]
+public sealed class OrganizacaoApiFactory : ApiFactoryBase<Program>
+{
+    protected override IEnumerable<KeyValuePair<string, string?>> GetConfigurationOverrides() =>
+    [
+        new("ConnectionStrings:OrganizacaoDb", "Host=localhost;Port=5432;Database=uniplus_tests;Username=uniplus;Password=uniplus_dev"),
+        new("Auth:Authority", "http://localhost/test-realm"),
+        new("Auth:Audience", "uniplus"),
+    ];
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Infrastructure/OrganizacaoEndpointApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Infrastructure/OrganizacaoEndpointApiFactory.cs
@@ -1,0 +1,100 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+
+/// <summary>
+/// <see cref="Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory{TEntryPoint}"/> que sobe
+/// o Program.cs produtivo do módulo OrganizacaoInstitucional apontando para o
+/// Postgres efêmero da fixture. Re-registra o DbContext sem
+/// <c>EnableRetryOnFailure</c> (incompatível com transações explícitas do
+/// Wolverine).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "WebApplicationFactory<T> derivative used as collection fixture state.")]
+public sealed class OrganizacaoEndpointApiFactory : ApiFactoryBase<Program>
+{
+    private readonly string _connectionString;
+
+    public OrganizacaoEndpointApiFactory(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        _connectionString = connectionString;
+    }
+
+    // Esta suite valida o pipeline HTTP completo com Wolverine rodando.
+    // A fixture provisiona Postgres efêmero, então o WolverineRuntime
+    // não pode ser removido.
+    protected override bool DisableWolverineRuntimeForTests => false;
+
+    protected override IEnumerable<KeyValuePair<string, string?>> GetConfigurationOverrides() =>
+    [
+        new("ConnectionStrings:OrganizacaoDb", _connectionString),
+        new("Auth:Authority", "http://localhost/test-realm"),
+        new("Auth:Audience", "uniplus"),
+    ];
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureTestServices(services =>
+        {
+            // Remove o registro do DbContext produtivo (com EnableRetryOnFailure)
+            // e re-registra apontando para o container efêmero sem retry —
+            // o retry é incompatível com transações user-initiated do Wolverine.
+            services.RemoveAll<DbContextOptions<OrganizacaoInstitucionalDbContext>>();
+            services.RemoveAll<DbContextOptions>();
+            services.RemoveAll<OrganizacaoInstitucionalDbContext>();
+            services.RemoveAll<IDbContextOptionsConfiguration<OrganizacaoInstitucionalDbContext>>();
+            RemoveAllOptionsConfigurations<DbContextOptions<OrganizacaoInstitucionalDbContext>>(services);
+
+            services.AddDbContext<OrganizacaoInstitucionalDbContext>((sp, opts) =>
+            {
+                opts.UseNpgsql(_connectionString);
+                opts.UseSnakeCaseNamingConvention();
+                opts.AddInterceptors(
+                    sp.GetRequiredService<SoftDeleteInterceptor>(),
+                    sp.GetRequiredService<AuditableInterceptor>());
+            });
+        });
+    }
+
+    private static void RemoveAllOptionsConfigurations<TOptions>(IServiceCollection services)
+        where TOptions : class
+    {
+        Type[] configurationTypes =
+        [
+            typeof(IConfigureOptions<TOptions>),
+            typeof(IPostConfigureOptions<TOptions>),
+            typeof(IConfigureNamedOptions<TOptions>),
+            typeof(IOptionsChangeTokenSource<TOptions>),
+        ];
+
+        foreach (Type type in configurationTypes)
+        {
+            for (int i = services.Count - 1; i >= 0; i--)
+            {
+                if (services[i].ServiceType == type)
+                {
+                    services.RemoveAt(i);
+                }
+            }
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Infrastructure/OrganizacaoEndpointCollection.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Infrastructure/OrganizacaoEndpointCollection.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+// DisableParallelization=true protege a env var ConnectionStrings__OrganizacaoDb
+// contra interleaving com outras coleções de teste no mesmo processo.
+[CollectionDefinition(Name, DisableParallelization = true)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit ICollectionFixture<T> requires the collection definition type to be public.")]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção de nome de coleção xUnit termina com 'Collection'.")]
+public sealed class OrganizacaoEndpointCollection : ICollectionFixture<OrganizacaoEndpointFixture>
+{
+    public const string Name = "organizacao-endpoint";
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Infrastructure/OrganizacaoEndpointFixture.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Infrastructure/OrganizacaoEndpointFixture.cs
@@ -1,0 +1,90 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Testcontainers.PostgreSql;
+
+/// <summary>
+/// Fixture de coleção xUnit que provisiona um Postgres efêmero (Testcontainers)
+/// e sobe o <see cref="OrganizacaoEndpointApiFactory"/> com Wolverine habilitado
+/// — necessário para exercitar endpoints que chamam o query/command bus.
+/// </summary>
+/// <remarks>
+/// Segue o padrão de <c>CascadingFixture</c> do módulo Seleção. A connection
+/// string é injetada via env var (duplo underscore) porque overrides via
+/// <c>ConfigureAppConfiguration</c> chegam tarde demais no minimal hosting
+/// (o <c>Program.cs</c> já leu a config antes do <c>Build()</c>).
+/// <c>DisableParallelization=true</c> em <see cref="OrganizacaoEndpointCollection"/>
+/// protege a env var contra interleaving com outras coleções no mesmo processo.
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit ICollectionFixture<T> requires the fixture type to be public.")]
+[SuppressMessage(
+    "Reliability",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Disposable resources released by IAsyncLifetime.DisposeAsync — xUnit invoca deterministicamente.")]
+public sealed class OrganizacaoEndpointFixture : IAsyncLifetime
+{
+    private const string ConnectionStringEnvVar = "ConnectionStrings__OrganizacaoDb";
+    private const string KafkaBootstrapEnvVar = "Kafka__BootstrapServers";
+
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_organizacao_endpoint_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    private string? _connectionStringEnvVarPrevio;
+    private string? _kafkaEnvVarPrevio;
+    private OrganizacaoEndpointApiFactory? _factory;
+
+    public string ConnectionString => _postgres.GetConnectionString();
+
+    public OrganizacaoEndpointApiFactory Factory =>
+        _factory ?? throw new InvalidOperationException(
+            "Factory ainda não inicializada. InitializeAsync deve rodar antes do primeiro teste.");
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync().ConfigureAwait(false);
+
+        // Schema provisionado pelo MigrationHostedService<OrganizacaoInstitucionalDbContext>
+        // registrado no Program.cs antes do UseWolverineOutboxCascading (invariante issue #419).
+        // Schema do Wolverine (`wolverine.*`) provisionado pelo framework via
+        // AutoBuildMessageStorageOnStartup.
+
+        _connectionStringEnvVarPrevio = Environment.GetEnvironmentVariable(ConnectionStringEnvVar);
+        _kafkaEnvVarPrevio = Environment.GetEnvironmentVariable(KafkaBootstrapEnvVar);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(ConnectionStringEnvVar, ConnectionString);
+            // Espaço em vez de string.Empty: em runtimes < .NET 9, string.Empty apaga
+            // a variável, fazendo o appsettings voltar a ser consultado.
+            Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, " ");
+
+            _factory = new OrganizacaoEndpointApiFactory(ConnectionString);
+        }
+        catch
+        {
+            Environment.SetEnvironmentVariable(ConnectionStringEnvVar, _connectionStringEnvVarPrevio);
+            Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, _kafkaEnvVarPrevio);
+            throw;
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync().ConfigureAwait(false);
+        }
+
+        Environment.SetEnvironmentVariable(ConnectionStringEnvVar, _connectionStringEnvVarPrevio);
+        Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, _kafkaEnvVarPrevio);
+
+        await _postgres.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/StubUserContext.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/StubUserContext.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Unidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// Stub mínimo de <see cref="IUserContext"/> para testes de persistência da
+/// Story #586. Suporta apenas o caminho "autenticado com <c>sub</c> fixo"
+/// usado pelos interceptors (created_by, updated_by, deleted_by).
+/// </summary>
+internal sealed class StubUserContext : IUserContext
+{
+    public StubUserContext(string userId)
+    {
+        UserId = userId;
+    }
+
+    public bool IsAuthenticated => true;
+    public string? UserId { get; }
+    public string? Name => null;
+    public string? Email => null;
+    public string? Cpf => null;
+    public string? NomeSocial => null;
+    public IReadOnlyList<string> Roles => [];
+    public bool HasRole(string role) => false;
+    public IReadOnlyList<string> GetResourceRoles(string resourceName) => [];
+    public IReadOnlyCollection<AreaCodigo> AreasAdministradas => [];
+    public bool IsPlataformaAdmin => false;
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeDbFixture.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeDbFixture.cs
@@ -1,0 +1,80 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Unidades;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Testcontainers.PostgreSql;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+
+/// <summary>
+/// Fixture xUnit que provisiona um Postgres efêmero (Testcontainers) com o
+/// schema do <see cref="OrganizacaoInstitucionalDbContext"/> aplicado via
+/// <c>MigrateAsync</c>, e expõe uma factory de DbContext com os MESMOS
+/// interceptors da produção (SoftDelete + Auditable).
+/// </summary>
+/// <remarks>
+/// Story #586 — valida ponta-a-ponta:
+/// <list type="bullet">
+///   <item>UNIQUE parcial sobre slug/sigla/codigo (WHERE is_deleted = false).</item>
+///   <item>Soft-delete via SoftDeleteInterceptor liberta o slot único.</item>
+///   <item>Histórico de identificadores criado no Insert via EF.</item>
+///   <item>Audit trail (created_by / updated_by) preenchido pelo AuditableInterceptor.</item>
+///   <item>FK hierárquica unidade_superior_id com ReferentialAction.Restrict.</item>
+/// </list>
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IAsyncLifetime + IClassFixture<T> exigem tipo público.")]
+[SuppressMessage(
+    "Reliability",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Disposable resources released by IAsyncLifetime.DisposeAsync — xUnit invoca deterministicamente.")]
+public sealed class UnidadeDbFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_unidade_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    public string ConnectionString => _postgres.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync().ConfigureAwait(false);
+
+        await using OrganizacaoInstitucionalDbContext context = CreateDbContext(userId: null);
+        await context.Database.MigrateAsync().ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _postgres.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Constrói um <see cref="OrganizacaoInstitucionalDbContext"/> com os
+    /// interceptors de produção. Quando <paramref name="userId"/> é informado,
+    /// simula um <c>IUserContext</c> autenticado — caso contrário, os
+    /// interceptors usam o fallback <c>"system"</c>.
+    /// </summary>
+    public OrganizacaoInstitucionalDbContext CreateDbContext(string? userId)
+    {
+        StubUserContext? userContext = userId is null ? null : new StubUserContext(userId);
+
+        DbContextOptions<OrganizacaoInstitucionalDbContext> options =
+            new DbContextOptionsBuilder<OrganizacaoInstitucionalDbContext>()
+                .UseNpgsql(ConnectionString)
+                .UseSnakeCaseNamingConvention()
+                .AddInterceptors(
+                    new SoftDeleteInterceptor(TimeProvider.System, userContext),
+                    new AuditableInterceptor(TimeProvider.System, userContext))
+                .Options;
+
+        return new OrganizacaoInstitucionalDbContext(options);
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeEndpointTests.cs
@@ -1,0 +1,110 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Unidades;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Smoke tests dos endpoints de <c>Unidade</c> introduzidos na Story #586.
+/// Verificam wiring do controller (routing, vendor media type, HATEOAS),
+/// aplicação de autenticação/autorização e resposta 404 para recursos
+/// inexistentes — sem dependência de banco de dados real.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IClassFixture<T> exige tipo de teste público.")]
+public sealed class UnidadeEndpointTests : IClassFixture<OrganizacaoApiFactory>
+{
+    private readonly OrganizacaoApiFactory _factory;
+
+    public UnidadeEndpointTests(OrganizacaoApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact(DisplayName = "GET /api/unidades retorna 200 com Content-Type vendor MIME de unidade")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/unidades", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.unidade.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/unidades retorna array JSON (catálogo vazio)")]
+    public async Task Listar_RetornaArrayJson()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/unidades", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [Fact(DisplayName = "GET /api/unidades/{id} retorna 404 quando unidade inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/unidades/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/admin/unidades sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _factory.CreateClient();
+        using StringContent content = new("{}", Encoding.UTF8, "application/json");
+
+        // TestAuthHandler injeta user autenticado como plataforma-admin.
+        HttpResponseMessage response = await client.PostAsync(
+            new Uri("/api/admin/unidades", UriKind.Relative), content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "Idempotency-Key é obrigatório — sem ela o filter retorna 400");
+    }
+
+    [Fact(DisplayName = "POST /api/admin/unidades sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        // Factory sem autenticação — CreateDefaultClient não injeta o TestAuthHandler.
+        using HttpClient client = _factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Post,
+            new Uri("/api/admin/unidades", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "DELETE /api/admin/unidades/{id} sem autenticação retorna 401")]
+    public async Task Remover_SemAuth_Retorna401()
+    {
+        using HttpClient client = _factory.CreateDefaultClient();
+
+        HttpResponseMessage response = await client.DeleteAsync(
+            new Uri($"/api/admin/unidades/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeEndpointTests.cs
@@ -7,31 +7,32 @@ using System.Text.Json;
 
 using AwesomeAssertions;
 
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Infrastructure;
 
 /// <summary>
-/// Smoke tests dos endpoints de <c>Unidade</c> introduzidos na Story #586.
-/// Verificam wiring do controller (routing, vendor media type, HATEOAS),
-/// aplicação de autenticação/autorização e resposta 404 para recursos
-/// inexistentes — sem dependência de banco de dados real.
+/// Smoke tests dos endpoints de <c>Unidade</c> (Story #586). Verificam
+/// routing, vendor media type, HATEOAS, autenticação e autorização com
+/// Wolverine rodando contra Postgres efêmero (<see cref="OrganizacaoEndpointFixture"/>).
 /// </summary>
+[Collection(OrganizacaoEndpointCollection.Name)]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",
-    Justification = "xUnit IClassFixture<T> exige tipo de teste público.")]
-public sealed class UnidadeEndpointTests : IClassFixture<OrganizacaoApiFactory>
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class UnidadeEndpointTests
 {
-    private readonly OrganizacaoApiFactory _factory;
+    private readonly OrganizacaoEndpointFixture _fixture;
 
-    public UnidadeEndpointTests(OrganizacaoApiFactory factory)
+    public UnidadeEndpointTests(OrganizacaoEndpointFixture fixture)
     {
-        _factory = factory;
+        _fixture = fixture;
     }
 
     [Fact(DisplayName = "GET /api/unidades retorna 200 com Content-Type vendor MIME de unidade")]
     public async Task Listar_Retorna200ComVendorMime()
     {
-        using HttpClient client = _factory.CreateClient();
+        using HttpClient client = _fixture.Factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(
             new Uri("/api/unidades", UriKind.Relative));
@@ -44,7 +45,7 @@ public sealed class UnidadeEndpointTests : IClassFixture<OrganizacaoApiFactory>
     [Fact(DisplayName = "GET /api/unidades retorna array JSON (catálogo vazio)")]
     public async Task Listar_RetornaArrayJson()
     {
-        using HttpClient client = _factory.CreateClient();
+        using HttpClient client = _fixture.Factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(
             new Uri("/api/unidades", UriKind.Relative));
@@ -59,7 +60,7 @@ public sealed class UnidadeEndpointTests : IClassFixture<OrganizacaoApiFactory>
     [Fact(DisplayName = "GET /api/unidades/{id} retorna 404 quando unidade inexistente")]
     public async Task ObterPorId_NaoExiste_Retorna404()
     {
-        using HttpClient client = _factory.CreateClient();
+        using HttpClient client = _fixture.Factory.CreateClient();
 
         HttpResponseMessage response = await client.GetAsync(
             new Uri($"/api/unidades/{Guid.NewGuid()}", UriKind.Relative));
@@ -70,22 +71,28 @@ public sealed class UnidadeEndpointTests : IClassFixture<OrganizacaoApiFactory>
     [Fact(DisplayName = "POST /api/admin/unidades sem Idempotency-Key retorna 400")]
     public async Task Criar_SemIdempotencyKey_Retorna400()
     {
-        using HttpClient client = _factory.CreateClient();
-        using StringContent content = new("{}", Encoding.UTF8, "application/json");
+        // Auth precisa passar (Authorize roda antes dos filtros MVC).
+        // [RequiresIdempotencyKey] é um filtro MVC — retorna 400 antes de
+        // atingir o action quando o header está ausente.
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Post,
+            new Uri("/api/admin/unidades", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        // Sem Idempotency-Key — esperamos 400 do filtro.
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
 
-        // TestAuthHandler injeta user autenticado como plataforma-admin.
-        HttpResponseMessage response = await client.PostAsync(
-            new Uri("/api/admin/unidades", UriKind.Relative), content);
+        HttpResponseMessage response = await client.SendAsync(request);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "Idempotency-Key é obrigatório — sem ela o filter retorna 400");
+            "Idempotency-Key é obrigatório — sem ela o filtro retorna 400 antes do action");
     }
 
     [Fact(DisplayName = "POST /api/admin/unidades sem autenticação retorna 401")]
     public async Task Criar_SemAuth_Retorna401()
     {
-        // Factory sem autenticação — CreateDefaultClient não injeta o TestAuthHandler.
-        using HttpClient client = _factory.CreateDefaultClient();
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
         using HttpRequestMessage request = new(
             HttpMethod.Post,
             new Uri("/api/admin/unidades", UriKind.Relative));
@@ -100,7 +107,7 @@ public sealed class UnidadeEndpointTests : IClassFixture<OrganizacaoApiFactory>
     [Fact(DisplayName = "DELETE /api/admin/unidades/{id} sem autenticação retorna 401")]
     public async Task Remover_SemAuth_Retorna401()
     {
-        using HttpClient client = _factory.CreateDefaultClient();
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
 
         HttpResponseMessage response = await client.DeleteAsync(
             new Uri($"/api/admin/unidades/{Guid.NewGuid()}", UriKind.Relative));

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadePersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadePersistenceTests.cs
@@ -1,0 +1,271 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Unidades;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+
+/// <summary>
+/// Integração ponta-a-ponta da Story #586 contra Postgres real. Cobre os
+/// cenários de persistência da <see cref="Unidade"/>:
+/// UNIQUE parcial slug/sigla/codigo, soft-delete liberando slot único,
+/// histórico de identificadores, audit trail e FK hierárquica.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IClassFixture<T> exige tipo de teste público.")]
+public sealed class UnidadePersistenceTests : IClassFixture<UnidadeDbFixture>
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private static readonly DateOnly DataInicio = new(2026, 1, 1);
+
+    private readonly UnidadeDbFixture _fixture;
+
+    public UnidadePersistenceTests(UnidadeDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Insert persiste Unidade e cria 3 entradas de histórico (Slug, Sigla, Codigo)")]
+    public async Task Insert_PersistUnidadeECriaHistoricoDeIdentificadores()
+    {
+        Unidade unidade = NovaUnidade("insert-basico", "CEPS-INS", "INS001");
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(unidade);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext readCtx = _fixture.CreateDbContext(userId: null);
+
+        Unidade persistida = await readCtx.Unidades
+            .Include(u => u.Historico)
+            .SingleAsync(u => u.Id == unidade.Id);
+
+        persistida.Slug.Should().Be(Slug.From("insert-basico").Value!);
+        persistida.Sigla.Should().Be("CEPS-INS");
+        persistida.Codigo.Should().Be("INS001");
+        persistida.IsDeleted.Should().BeFalse();
+
+        persistida.Historico.Should().HaveCount(3);
+        persistida.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Slug && h.Valor == "insert-basico" && h.VigenciaFim == null);
+        persistida.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Sigla && h.Valor == "CEPS-INS" && h.VigenciaFim == null);
+        persistida.Historico.Should().Contain(h =>
+            h.TipoIdentificador == TipoIdentificador.Codigo && h.Valor == "INS001" && h.VigenciaFim == null);
+    }
+
+    [Fact(DisplayName = "AuditableInterceptor preenche created_by com o UserId do contexto")]
+    public async Task Insert_PreencheCreatedByViaAuditableInterceptor()
+    {
+        Unidade unidade = NovaUnidade("audit-trail", "AUDIT", "AUD001");
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(unidade);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext readCtx = _fixture.CreateDbContext(userId: null);
+
+        Unidade persistida = await readCtx.Unidades
+            .SingleAsync(u => u.Id == unidade.Id);
+
+        persistida.CreatedBy.Should().Be(AdminA);
+        persistida.UpdatedBy.Should().BeNull("apenas criação — sem update ainda");
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial (slug) rejeita segunda Unidade ativa com mesmo slug")]
+    public async Task UniquePartial_Slug_RejeitaDuplicataAtiva()
+    {
+        Unidade primeira = NovaUnidade("slug-unico", "SU01", "SUC001");
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(primeira);
+            await ctx.SaveChangesAsync();
+        }
+
+        Unidade segunda = NovaUnidade("slug-unico", "SU02", "SUC002");
+        await using OrganizacaoInstitucionalDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.Unidades.Add(segunda);
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>()
+            .WithInnerException(typeof(Npgsql.PostgresException));
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial (sigla) rejeita segunda Unidade ativa com mesma sigla")]
+    public async Task UniquePartial_Sigla_RejeitaDuplicataAtiva()
+    {
+        Unidade primeira = NovaUnidade("sigla-unica-a", "SIGDUP", "SGDUP001");
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(primeira);
+            await ctx.SaveChangesAsync();
+        }
+
+        Unidade segunda = NovaUnidade("sigla-unica-b", "SIGDUP", "SGDUP002");
+        await using OrganizacaoInstitucionalDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.Unidades.Add(segunda);
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>()
+            .WithInnerException(typeof(Npgsql.PostgresException));
+    }
+
+    [Fact(DisplayName = "Soft-delete liberta o slot da UNIQUE parcial — novo slug é aceito após exclusão")]
+    public async Task SoftDelete_LibertaUniquePartialSlug()
+    {
+        Unidade unidade = NovaUnidade("slug-reciclado", "RCSL", "REC001");
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(unidade);
+            await ctx.SaveChangesAsync();
+        }
+
+        // Soft-delete via SoftDeleteInterceptor.
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            Unidade tracked = await ctx.Unidades.SingleAsync(u => u.Id == unidade.Id);
+            ctx.Unidades.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        // Confirma que is_deleted = true via IgnoreQueryFilters.
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            Unidade excluida = await ctx.Unidades
+                .IgnoreQueryFilters()
+                .SingleAsync(u => u.Id == unidade.Id);
+            excluida.IsDeleted.Should().BeTrue();
+        }
+
+        // Nova Unidade com mesmo slug é aceita — UNIQUE parcial WHERE is_deleted = false.
+        Unidade nova = NovaUnidade("slug-reciclado", "RCSL2", "REC002");
+        await using OrganizacaoInstitucionalDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.Unidades.Add(nova);
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync("slot liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "SoftDeleteInterceptor preenche deleted_by e deleted_at")]
+    public async Task SoftDelete_PreencheDeletedByEDeletedAt()
+    {
+        Unidade unidade = NovaUnidade("soft-del-audit", "SDA", "SDA001");
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(unidade);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            Unidade tracked = await ctx.Unidades.SingleAsync(u => u.Id == unidade.Id);
+            ctx.Unidades.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        Unidade excluida = await readCtx.Unidades
+            .IgnoreQueryFilters()
+            .SingleAsync(u => u.Id == unidade.Id);
+
+        excluida.IsDeleted.Should().BeTrue();
+        excluida.DeletedAt.Should().NotBeNull();
+        excluida.DeletedBy.Should().Be(AdminB);
+    }
+
+    [Fact(DisplayName = "FK unidade_superior_id aceita hierarquia válida pai → filho")]
+    public async Task Hierarquia_FkAceitaPaiFilhoValido()
+    {
+        Unidade pai = NovaUnidade("reitoria", "REIT", "REIT001");
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(pai);
+            await ctx.SaveChangesAsync();
+        }
+
+        Unidade filho = NovaUnidade("proeg", "PROEG", "PROEG001", superiorId: pai.Id);
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(filho);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext readCtx = _fixture.CreateDbContext(userId: null);
+
+        Unidade persistido = await readCtx.Unidades.SingleAsync(u => u.Id == filho.Id);
+
+        persistido.UnidadeSuperiorId.Should().Be(pai.Id);
+    }
+
+    [Fact(DisplayName = "FK unidade_superior_id com RESTRICT bloqueia DELETE físico do pai quando há filhos")]
+    public async Task Hierarquia_FkRestrictBloqueiaDeleteFisicoDoSuperior()
+    {
+        // O SoftDeleteInterceptor converte EntityState.Deleted → UPDATE is_deleted=true,
+        // portanto não emite DELETE SQL e não aciona o RESTRICT. Para testar a constraint
+        // de banco em si, emitimos DELETE físico via SQL bruto.
+        Unidade pai = NovaUnidade("pai-restrict", "PRST", "PRS001");
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(pai);
+            await ctx.SaveChangesAsync();
+        }
+
+        Unidade filho = NovaUnidade("filho-restrict", "FRST", "FRS001", superiorId: pai.Id);
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(filho);
+            await ctx.SaveChangesAsync();
+        }
+
+        // Tenta DELETE físico do pai com filho ativo — deve violar FK RESTRICT.
+        await using OrganizacaoInstitucionalDbContext rawCtx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () =>
+            await rawCtx.Database.ExecuteSqlAsync(
+                $"DELETE FROM unidade WHERE id = {pai.Id}");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "FK unidade_superior_id com RESTRICT deve impedir DELETE físico de unidade pai que possui filhos referenciando-a");
+    }
+
+    // ── Factory helper ───────────────────────────────────────────────────
+
+    private static Unidade NovaUnidade(
+        string slug,
+        string sigla,
+        string codigo,
+        Guid? superiorId = null) =>
+        Unidade.Criar(
+            nome: $"Unidade {sigla}",
+            alias: null,
+            slug: Slug.From(slug).Value!,
+            sigla: sigla,
+            codigo: codigo,
+            unidadeSuperiorId: superiorId,
+            tipo: TipoUnidade.Centro,
+            unidadeAcademica: false,
+            vigenciaInicio: DataInicio,
+            vigenciaFim: null,
+            origem: OrigemUnidade.CriadoNoUniPlus).Value!;
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadePersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadePersistenceTests.cs
@@ -10,6 +10,7 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Repositories;
 
 /// <summary>
 /// Integração ponta-a-ponta da Story #586 contra Postgres real. Cobre os
@@ -247,6 +248,43 @@ public sealed class UnidadePersistenceTests : IClassFixture<UnidadeDbFixture>
 
         await act.Should().ThrowAsync<Npgsql.PostgresException>(
             "FK unidade_superior_id com RESTRICT deve impedir DELETE físico de unidade pai que possui filhos referenciando-a");
+    }
+
+    [Fact(DisplayName = "EhDescendenteAsync percorre a cadeia de superiores e ignora não-relacionados")]
+    public async Task EhDescendenteAsync_PercorreAncestraisContraPostgresReal()
+    {
+        // Hierarquia A → B → C (A superior de B, B superior de C) + D solta.
+        Unidade a = NovaUnidade("hier-a", "HIERA", "HRA001");
+        Unidade b = NovaUnidade("hier-b", "HIERB", "HRB001", a.Id);
+        Unidade c = NovaUnidade("hier-c", "HIERC", "HRC001", b.Id);
+        Unidade d = NovaUnidade("hier-d", "HIERD", "HRD001");
+
+        await using (OrganizacaoInstitucionalDbContext seed = _fixture.CreateDbContext(AdminA))
+        {
+            // Saves sequenciais respeitam a FK auto-referencial (pai antes do filho).
+            seed.Unidades.Add(a);
+            await seed.SaveChangesAsync();
+            seed.Unidades.Add(b);
+            await seed.SaveChangesAsync();
+            seed.Unidades.Add(c);
+            await seed.SaveChangesAsync();
+            seed.Unidades.Add(d);
+            await seed.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var repository = new UnidadeRepository(ctx);
+
+        // C é descendente de A (A→B→C): tornar C superior de A formaria ciclo.
+        (await repository.EhDescendenteAsync(c.Id, a.Id, CancellationToken.None)).Should().BeTrue();
+        // B é descendente direto de A.
+        (await repository.EhDescendenteAsync(b.Id, a.Id, CancellationToken.None)).Should().BeTrue();
+        // A não é descendente de C: reapontar A para sob C é válido (sem ciclo).
+        (await repository.EhDescendenteAsync(a.Id, c.Id, CancellationToken.None)).Should().BeFalse();
+        // Igualdade conta como descendente — barra a auto-referência.
+        (await repository.EhDescendenteAsync(a.Id, a.Id, CancellationToken.None)).Should().BeTrue();
+        // D não tem vínculo com A.
+        (await repository.EhDescendenteAsync(d.Id, a.Id, CancellationToken.None)).Should().BeFalse();
     }
 
     // ── Factory helper ───────────────────────────────────────────────────

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadePersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadePersistenceTests.cs
@@ -287,6 +287,25 @@ public sealed class UnidadePersistenceTests : IClassFixture<UnidadeDbFixture>
         (await repository.EhDescendenteAsync(d.Id, a.Id, CancellationToken.None)).Should().BeFalse();
     }
 
+    [Fact(DisplayName = "Checagens de unicidade normalizam (Trim) Sigla e Codigo do argumento")]
+    public async Task ChecagensDeUnicidade_NormalizamArgumentoComEspacos()
+    {
+        Unidade existente = NovaUnidade("trim-check", "TRIMSIG", "TRIMCOD");
+        await using (OrganizacaoInstitucionalDbContext seed = _fixture.CreateDbContext(AdminA))
+        {
+            seed.Unidades.Add(existente);
+            await seed.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var repository = new UnidadeRepository(ctx);
+
+        // " trimsig " deve casar com "TRIMSIG" persistido (Trim + ToUpperInvariant).
+        (await repository.SiglaExisteEntreLivosAsync(" trimsig ", null, CancellationToken.None)).Should().BeTrue();
+        // " TRIMCOD " deve casar com "TRIMCOD" persistido (Trim).
+        (await repository.CodigoExisteEntreLivosAsync(" TRIMCOD ", null, CancellationToken.None)).Should().BeTrue();
+    }
+
     // ── Factory helper ───────────────────────────────────────────────────
 
     private static Unidade NovaUnidade(

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="WolverineFx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Unifesspa.UniPlus.OrganizacaoInstitucional.API.csproj" />
+    <ProjectReference Include="../Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
@@ -1,0 +1,1570 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.4.0, )",
+        "resolved": "9.4.0",
+        "contentHash": "dJxkWiQ8D+xT6Gr2sSL83+Mar+Vpy2JTcUPxFcckpPJ8VYBfSgnk+zqpS6t7kcGnjz8NLyF14qfuoL4bKzzoew=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Hosting": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.InMemory": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "RAns8RTPymM9GsIdY5Y8wWdpdMEXputTl24+95WhYzqF4HhT0i+jFmNgDxBTy386vU9ruoUC5gcPAiuJr8SZxg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
+      },
+      "WolverineFx": {
+        "type": "Direct",
+        "requested": "[5.39.0, )",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
+        "dependencies": {
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
+          "JasperFx.RuntimeCompiler": "4.5.0",
+          "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "CommunityToolkit.HighPerformance": {
+        "type": "Transitive",
+        "resolved": "8.4.0",
+        "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
+      },
+      "Confluent.SchemaRegistry.Serdes.Json": {
+        "type": "Transitive",
+        "resolved": "2.14.0",
+        "contentHash": "rymTRDrwEIzfFCDEcoV6ZvDatlVrwmMWXT93sERMLHZiEOhOCR53Jiwa9bk/OyjIRqRxiIFHOwys2qJgfN6rQQ==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0",
+          "NJsonSchema.NewtonsoftJson": "11.0.2"
+        }
+      },
+      "DistributedLock.Core": {
+        "type": "Transitive",
+        "resolved": "1.0.8",
+        "contentHash": "LAOsY8WxX8JU/n3lfXFz+f2pfnv0+4bHkCrOO3bwa28u9HrS3DlxSG6jf+u76SqesKs+KehZi0CndkfaUXBKvg=="
+      },
+      "DistributedLock.Postgres": {
+        "type": "Transitive",
+        "resolved": "1.3.0",
+        "contentHash": "CyjXmbhFgG30qPg4DwGnsmZO63y5DBRo+PI2xW0NwtFrsYsMVt/T1RcEUlb36JMKhDkf+euhnkanv/nU+W35qA==",
+        "dependencies": {
+          "DistributedLock.Core": "[1.0.8, 1.1.0)",
+          "Npgsql": "8.0.6"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
+      },
+      "FastExpressionCompiler": {
+        "type": "Transitive",
+        "resolved": "5.3.0",
+        "contentHash": "XRmGW48Gdm7B70WUtTJJUnmuc8jRDmOhhjG/a3rix/nXChnrkETaSvA0j2VrcsH4MNeYLe60LA5o5JABmbneag=="
+      },
+      "Google.Protobuf": {
+        "type": "Transitive",
+        "resolved": "3.30.1",
+        "contentHash": "HeWXDQBabQn/sCGicbeLJ0HMunknfC4FdLrOQOsaMJHcpqx3HVIpyyJqTrqJlWnza870twhOb+rBcaTiC/TlNA=="
+      },
+      "Grpc.Core.Api": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "66UotvWcSIq41oiQhLWcQACyKPM4umxXNiht5DQTLZJfNwEswWOcS7Z0xIEHyNIBE7ZpjotH22bEjTkvhPxmVw=="
+      },
+      "Grpc.Net.Client": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "xNv0FFCVJa5S1beUtye82WFCxKThuE1jbN8DO1x1Rj8VSIWXLBUmfSID5a1fGzsU2R/EMfwPoWclJ2RMfQuGXw==",
+        "dependencies": {
+          "Grpc.Net.Common": "2.70.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+        }
+      },
+      "Grpc.Net.Common": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "rBdEUMyCwa+iB8mqC6JKyPbj3SBHHkReJj/yy/XKJI63GcG6w9DJMMGTVcYHqq4Ci2W4m0HT4jt2pFfFscar8g==",
+        "dependencies": {
+          "Grpc.Core.Api": "2.70.0"
+        }
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "ImTools": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "dms0JfLKC9AQbQX/EdpRjn59EjEvaCxIgv1z9YxbEQb5SiOVoo7vlIKdEySeEwUkWhN05rZnNpUpG+aw5VqPVQ=="
+      },
+      "JasperFx": {
+        "type": "Transitive",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
+        "dependencies": {
+          "FastExpressionCompiler": "5.3.0",
+          "ImTools": "4.0.0",
+          "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
+          "Polly.Core": "8.6.5",
+          "Spectre.Console": "0.55.0"
+        }
+      },
+      "JasperFx.Events": {
+        "type": "Transitive",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
+        "dependencies": {
+          "JasperFx": "1.31.0"
+        }
+      },
+      "JasperFx.RuntimeCompiler": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "SGJlU1kD8lX8A5p0hBWTPDV7dvPzoUB37IZjprWgA+L5yZZNyBElpn6UPNo7ZuXLKKwlSSt8BWTr99vxpxT3JA==",
+        "dependencies": {
+          "JasperFx": "1.28.0",
+          "Microsoft.CodeAnalysis": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "JasperFx.SourceGeneration": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "yIOaiA/OrlXQLGPjxFDubHnOU8MCzPTz465xBGRITMm4fDf7DbWKogb2SZC2jYLWEj27q3smTz1Z7lU4h1KkOQ=="
+      },
+      "librdkafka.redist": {
+        "type": "Transitive",
+        "resolved": "2.14.0",
+        "contentHash": "jqmYswYUiW9So5lce1Upo/zm5V7p/kWaqnUqkP5Lar1Ekq2yLrORoDCJ1JIiVLD3xdVkavwqW9iFKHBfkTsS7w=="
+      },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bUubrBD6tRJE3V1kvRloYc6NymH3R5oFKjAS9e0ELNx6u0ZR+zjps9dDQyjgqN/rArzl7f+21KGszj3YRN7F2Q=="
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "18.0.2",
+        "contentHash": "sOSb+0J4G/jCBW/YqmRuL0eOMXgfw1KQLdC9TkbvfA5xs7uNm+PBQXJCOzSJGXtZcZrtXozcwxPmUiRUbmd7FA=="
+      },
+      "Microsoft.CodeAnalysis": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "X7vItpZDkGm4NS2wp4P1S07Z1e61LaBWDW5tPXE1c6z5/x9KbF2RymhAPoYg7Qoiyk7odEZ6EjBEJ47p3dBpYQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1sGloRYbG3743ut/+vuXy9/WaRQTm7mDtp71rBaVSmKpFntvo5Hcro1ubg6/3SeeLtiFYJl7V3Dk0Fo3CGlnHA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Scripting.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/KgZdm6kRTrR/O2jqXxU5GWREYhtVmqcNWczyPt8hsQkFGFK/C6CrLWfG44FCUn0aPHGDRBHYjXlGosQ/H8oXw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Scripting": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "XTulByMNxqXGCgMeODUoG2h4oK4/nLv1BcawRVcjv+UZHMpoaymtdaq3cJqlNrEvYEcbU48g5swJ3RhY1m3fBg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "sUBWvHs2HgHGA+b716dgjS7JiXGen5ntyohAurPLR1ZiZzFp3FlnVA7GrMTqVGdVJTVqiC3c4K8k1bk0gj6IPg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Nom4UuZVEZGaV6Qa+joJR/BawXZMtflvQJFKc0SaUc3LrZr/8LmRY5cn8mbvLOWIVfwWkQz+cVE6eQKu9qa65g==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.MSBuild": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/G+LVoAGMz6Ae8nm+PGLxSw+F5RjYx/J7irbTO5uKAPw1bxHyQJLc/YOnpDxt+EpPtYxvC9wvBsg/kETZp1F9Q==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "17.11.31",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "Microsoft.Extensions.DependencyInjection": "9.0.0",
+          "Microsoft.Extensions.Logging": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Options": "9.0.0",
+          "Microsoft.Extensions.Primitives": "9.0.0",
+          "Microsoft.VisualStudio.SolutionPersistence": "1.0.52",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "3lNjglxfFxOzI9zG+3HSg/YSGqo//8Fqw6u6iuIamZb4JCorbA3JLaeWOpfKTAPi2UJwaispOXWx14dUqcGz4A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TWto3imA+mJMLZI+5sbgLiFFoOFNFkizQYNaC5jTuiHKn3diwm1RN7mWDOEZN9kG2bixw7IvgpvtUG5/teSRzA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "qbZLvLsoTdArSloEnSxs21P781YUmwVmHc5NJPQD/ezAreQ7884z+6QfAZVKi86WAZtzx83jK2uC4itxOM44gQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "64dimvyyKk0dbUbrLg/YCv4ugJ4sVz2aXLwfvZwR1EC4tJqW9ru/oVRcXwoJRa2lQGXtYtlpk4maWOeIb48tQw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YqVIICoIdl0016wkeO2WQS+uEbEXbUhMLKdC5rZNl1X3nu59F+nwaAHdHjq/4OK+Cx31DYmNUSFh+MUot8qSDw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "zhgWg/i0ECj5v0jLFBSZHplvc5ygCI91DR4nne+BP4XAKF5ycz0pEKnFiTw8C1jCABJEZsnBZh6pXAvn71kFmw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "NTUspqB+vH9g4wAD6KPOBx01xqYuKXR/cHXm449zpbq1GqfjdAxBmg7eJXrNsPw7SKwIdT2cJ05GxYVvc+lvsA=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "M/vBpfWcschvS2EUeq7cHfscsxabiGTptXwV7GeSueovGiSoNjyo1j5PMcWuOAAQrRW3nRqxZk8NeumrmpzUBg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.7",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Logging.Console": "10.0.7",
+          "Microsoft.Extensions.Logging.Debug": "10.0.7",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.7",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "7BBnoGF37USiu7j434put9mDp7EjdlNDIZsR4vHfC1FbLZeLqiWjgJbeEtF0p59Ryqt8AtraHawf0ZKbe5jibg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "DA++Es6v6W0HfrOrw+K8WyN6jNnZHp640PDdEvl8yfeVmgflKdn6vSSFvufNUSOuY+M2ZaSUgfY+jUKtNpXcCw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Y6DSt/JZApunYWKqTtqbdsR6iqAvHx3D0tavbNJ1rnC24MUpF+3XO/VKgFi+9PFqMyvQ2GHBBGb8H3cLSw7rDg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "1C8eTuxF6BLncNSJ1HCfmaBcjpUSqQDPlBVdYTlet9oldHTPpNh9iatxSJLs8TOqdp/FOpH+nSLdBve7fu9mTQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "System.Diagnostics.EventLog": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YWfndnDX1jVMGCN8d5T+rO+BO8sDw6BkYlUk0BYui+WP7+HhlWx8QLdA4yUDjrkGVb3AQxIWWEPVKw5Nnfj5GQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "OtlIWcyX01olfdevPKZdIPfBEvbcioDyBiE/Z2lHsopsMD7twcKtlN9kMevHmI5IIPhFpfwCIiR6qHQz1WHUIw=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "s6++gF9x0rQApQzOBbSyp4jUaAlwm+DroKfL8gdOHxs83k8SJfUXhuc46rDB3rNXBQ1MVRxqKUrqFhO/M0E97g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "UCPF2exZqBXe7v/6sGNiM6zCQOUXXQ9+v5VTb9gPB8ZSUPnX53BxlN78v2jsbIvK9Dq4GovQxo23x8JgWvm/Qg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "uA2vpKqU3I2mBBEaeJAWPTjT9v1TZrGWKdgK6G5qJd03CLx83kdiqO9cmiK8/n1erkHzFBwU/RphP83aAe3i3g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "kDimB6Dkd3nkW2oZPDkMkVHfQt3IDqO5gL0oa8WVy3OP4uE8Ij+8TXnqg9TOd9ufjsY3IDiGz7pCUbnfL18tjg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.VisualStudio.SolutionPersistence": {
+        "type": "Transitive",
+        "resolved": "1.0.52",
+        "contentHash": "oNv2JtYXhpdJrX63nibx1JT3uCESOBQ1LAk7Dtz/sr0+laW0KRM6eKp4CZ3MHDR2siIkKsY8MmUkeP5DKkQQ5w=="
+      },
+      "Mono.TextTemplating": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "YqueG52R/Xej4VVbKuRIodjiAhV0HR/XVbLbNrJhCZnzjnSjgMJ/dCdV0akQQxavX6hp/LC6rqLGLcXeQYU7XA==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Namotion.Reflection": {
+        "type": "Transitive",
+        "resolved": "3.1.1",
+        "contentHash": "Qn0wM7u9TpSpja2x8UVexr2bLHb1DGMNhD2TCz3woklxaY1oH+Sitrw9fg/4YbNoNtczeH2jf+yPdXMQlgvFlQ=="
+      },
+      "NetTopologySuite": {
+        "type": "Transitive",
+        "resolved": "2.5.0",
+        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
+      },
+      "NetTopologySuite.IO.PostGis": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "3W8XTFz8iP6GQ5jDXK1/LANHiU+988k1kmmuPWNKcJLpmSg6CvFpbTpz+s4+LBzkAp64wHGOldSlkSuzYfrIKA==",
+        "dependencies": {
+          "NetTopologySuite": "[2.0.0, 3.0.0-A)"
+        }
+      },
+      "NewId": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "jegBasNndmG21G3BmT51suFDCIz/sLN81j+IxmkZ4iWoaDi8LygeHiyNnYbXz5OQh9nCRJFIx1+PJrlYi1Gc9Q=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NJsonSchema": {
+        "type": "Transitive",
+        "resolved": "11.0.2",
+        "contentHash": "BOgw+TOd1w7BSRIEWwkiSgHlKWC2eu0DHsSsb1LIwlC1Hq26A0ARZiMjsCsqfXqXdr7hLf1m4M84Z7LW1wmCGA==",
+        "dependencies": {
+          "NJsonSchema.Annotations": "11.0.2",
+          "Namotion.Reflection": "3.1.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "NJsonSchema.Annotations": {
+        "type": "Transitive",
+        "resolved": "11.0.2",
+        "contentHash": "VbA0fmxVyqloGXYz863g6QHyojM1tgejwPQr9LjXdubs9YJt5YfRPCQOV/hnzpP2Bqd7nZFpDn9MCImmLAmqCw=="
+      },
+      "NJsonSchema.NewtonsoftJson": {
+        "type": "Transitive",
+        "resolved": "11.0.2",
+        "contentHash": "tTVG8h7qfw6anxlhXGx3oUz7f3ig+t9jO3yrho73ypvMZ7DCyFtiaF5gG3GqBDZXM49ONogDmTZ+8HTG6AKaNQ==",
+        "dependencies": {
+          "NJsonSchema": "11.0.2",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Npgsql.NetTopologySuite": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "7AwBLPz8EPmgAXveZ55K0Tz/9bNb8j4VI4pkTOQjyHrce8wWfAA9pefm3REidy+Kt2UFiAWef34YVi7sb/kB4A==",
+        "dependencies": {
+          "NetTopologySuite": "2.5.0",
+          "NetTopologySuite.IO.PostGIS": "2.1.0",
+          "Npgsql": "9.0.4"
+        }
+      },
+      "OpenTelemetry": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "N0i6WjPoHPbZyms1ugbDIFAJFuGlpeExJMU/+XSL0lQRUkg/D0utFkDoLXf8Z1km5B+xVZ2GyMXXiX8qdeNmPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "OpenTelemetry.Api.ProviderBuilderExtensions": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "SYn0lqYDwLMWhv/zlNGsQcl2yX++yTumanX46bmOZE/ZDOd1WjPBO2kZaZgKLEZTZk48pavIFGJ6vOvxXgWVFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "OpenTelemetry.Api": "1.15.3"
+        }
+      },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.8",
+        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.5",
+        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+      },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "Serilog.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Serilog.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Formatting.Compact": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "wQsv14w9cqlfB5FX2MZpNsTawckN4a8dryuNGbebB/3Nh1pXnROHZov3swtu3Nj5oNG7Ba+xdu7Et/ulAUPanQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Serilog": "4.3.0"
+        }
+      },
+      "Serilog.Sinks.Console": {
+        "type": "Transitive",
+        "resolved": "6.1.1",
+        "contentHash": "8jbqgjUyZlfCuSTaJk6lOca465OndqOz3KZP6Cryt/IqZYybyBu7GP0fE/AXBzrrQB3EBmQntBFAvMVz1COvAA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.File": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "WTlRjL6KWIMr/pAaq3rYqh0TJlzpouaQ/W1eelssHgtlwHAH25jXTkUphTYx9HaIIf7XA6qs/0+YhtLEQRkJ+Q=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
+      },
+      "System.Reactive": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "rHaWtKDwCi9qJ3ObKo8LHPMuuwv33YbmQi7TcUK1C264V3MFnOr5Im7QgCTdLniztP3GJyeiSg5x8NqYJFqRmg=="
+      },
+      "Weasel.Core": {
+        "type": "Transitive",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
+        "dependencies": {
+          "JasperFx": "1.26.0"
+        }
+      },
+      "Weasel.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
+          "Weasel.Core": "8.15.1"
+        }
+      },
+      "Weasel.Postgresql": {
+        "type": "Transitive",
+        "resolved": "8.15.1",
+        "contentHash": "YD/3CWlqCCX5dBVMZmIYvR8/flwcgDHPQq4EtUHJOlFnPrmQX4Lfd5rmFCIW3n/3F53qxMXl2HaJnxGI1Twtsw==",
+        "dependencies": {
+          "DistributedLock.Postgres": "1.3.0",
+          "Npgsql": "9.0.4",
+          "Npgsql.NetTopologySuite": "9.0.4",
+          "Weasel.Core": "8.15.1"
+        }
+      },
+      "WolverineFx.RDBMS": {
+        "type": "Transitive",
+        "resolved": "5.39.0",
+        "contentHash": "qLwcwCaQzkbcJpX3MFftHDLVXDTUFl+8XRFwLDZPwLHAf4FeRfRE/u/eOnrWyrQ/sv189WDZx5UmoEdxnRynTw==",
+        "dependencies": {
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.39.0"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "unifesspa.uniplus.application.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.infrastructure.core": {
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.7, )",
+          "Minio": "[7.0.0, )",
+          "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
+          "OpenTelemetry.Instrumentation.EntityFrameworkCore": "[1.15.1-beta.1, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
+          "StackExchange.Redis": "[2.12.14, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "VaultSharp": "[1.17.5.1, )",
+          "WolverineFx": "[5.39.0, )",
+          "WolverineFx.EntityFrameworkCore": "[5.39.0, )",
+          "WolverineFx.Kafka": "[5.39.0, )",
+          "WolverineFx.Postgresql": "[5.39.0, )"
+        }
+      },
+      "unifesspa.uniplus.integrationtests.fixtures": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.0.7, )",
+          "Testcontainers": "[4.11.0, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "WolverineFx": "[5.39.0, )",
+          "xunit": "[2.9.3, )"
+        }
+      },
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      },
+      "unifesspa.uniplus.organizacaoinstitucional.api": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.OrganizacaoInstitucional.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Postgresql": "[5.39.0, )"
+        }
+      },
+      "unifesspa.uniplus.organizacaoinstitucional.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.OrganizacaoInstitucional.Domain": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.organizacaoinstitucional.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.organizacaoinstitucional.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.7, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.7, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.OrganizacaoInstitucional.Application": "[1.0.0, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
+      "Confluent.Kafka": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
+        "dependencies": {
+          "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Design": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.2",
+        "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "18.0.2",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
+          "Microsoft.Extensions.Caching.Memory": "10.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.DependencyModel": "10.0.2",
+          "Microsoft.Extensions.Logging": "10.0.2",
+          "Mono.TextTemplating": "3.0.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Minio": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "GiCD0koYBM8/VCXRkrfSzOtySEmrA2ngceJuxRO5H+/uGodiTX+XPaUHQq9/1DpaeBxWnkmrgqu52dwuZqIYgw==",
+        "dependencies": {
+          "CommunityToolkit.HighPerformance": "8.4.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.4",
+          "Microsoft.Extensions.Logging": "9.0.4",
+          "System.IO.Hashing": "9.0.4",
+          "System.Reactive": "6.0.1"
+        }
+      },
+      "Npgsql": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.2, )",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.3, )",
+        "resolved": "1.15.3",
+        "contentHash": "FEXJepcseTGbATiCkUfP7ipoFEYYfl/0UmmUwi0KxCPg9PaUA8ab2P1LGopK+/HExasJ1ZutFhZrN6WvUIR23g==",
+        "dependencies": {
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.3, )",
+        "resolved": "1.15.3",
+        "contentHash": "u8n/W8yIlqv0BXZmvId1iVaeWXG42tGKdTkuLYg5g57Y/r9CeUNzqtrSHNdG5IoO8iPX79w3v+WsbAHgUQbfeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Instrumentation.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.2, )",
+        "resolved": "1.15.2",
+        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "dependencies": {
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.1-beta.1, )",
+        "resolved": "1.15.1-beta.1",
+        "contentHash": "NmtYLk3HJUUkV0g2VnFLs67/PGIVbI8JXtu0g4f9bk2ZaInp211/AL2+Qcbgkb9ih/uOi8loN6E1Aw2o0YIWag==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Http": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.1, )",
+        "resolved": "1.15.1",
+        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Runtime": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.1, )",
+        "resolved": "1.15.1",
+        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "dependencies": {
+          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+        }
+      },
+      "Serilog.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "a/cNa1mY4On1oJlfGG1wAvxjp5g7OEzk/Jf/nm7NF9cWoE7KlZw1GldrifUBWm9oKibHkR7Lg/l5jy3y7ACR8w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Console": "6.1.1",
+          "Serilog.Sinks.Debug": "3.0.0",
+          "Serilog.Sinks.File": "7.0.0"
+        }
+      },
+      "Serilog.Sinks.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "PzMCyE5G19tjr5IZEi5qg+4UU5QrxBEoBEMu/hhYybTrGKXqUDiSGWKZNUDBgelaVKqLADlsmlJVyKce5SyPrg==",
+        "dependencies": {
+          "Google.Protobuf": "3.30.1",
+          "Grpc.Net.Client": "2.70.0",
+          "Serilog": "4.2.0"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.12.14, )",
+        "resolved": "2.12.14",
+        "contentHash": "QiAQg40OP4Owem6/PjIbjEKq2+uIeQYeZ1TCMUnx/QvKugOPxOfC96wjlnBjWHi4Wq9pv9+fDlXGT06XkRZ6Ig==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Pipelines.Sockets.Unofficial": "2.2.8",
+          "System.IO.Hashing": "10.0.2"
+        }
+      },
+      "Testcontainers": {
+        "type": "CentralTransitive",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "VaultSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.17.5.1, )",
+        "resolved": "1.17.5.1",
+        "contentHash": "1O/F+AQCkyK4K709pBDYEbDDfJ12OlaE5lnOs9dffq+KxqrnPxh8FIdQtEst9yBJmC7I0BptftzTJyRSwhZR/A=="
+      },
+      "WolverineFx.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[5.39.0, )",
+        "resolved": "5.39.0",
+        "contentHash": "xD31lMm3aud+YL2WVy9xTEKWEOt2F4a6sYBYlRLNzgSECZUnG/1vWwCivmxMQy3YraSjB9cfqRchRTKqtN9lfA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.2",
+          "Microsoft.EntityFrameworkCore.Design": "10.0.2",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
+        }
+      },
+      "WolverineFx.Kafka": {
+        "type": "CentralTransitive",
+        "requested": "[5.39.0, )",
+        "resolved": "5.39.0",
+        "contentHash": "FqtGEBFPT7MCWmJXCPfLZqd7LzOTpL1pO2BVHVmu2tioQajAIqsngIekUYMVlxSEoIRj3/DCLKV0gbtq1fkf/A==",
+        "dependencies": {
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.14.0",
+          "Confluent.SchemaRegistry.Serdes.Json": "2.14.0",
+          "WolverineFx": "5.39.0"
+        }
+      },
+      "WolverineFx.Postgresql": {
+        "type": "CentralTransitive",
+        "requested": "[5.39.0, )",
+        "resolved": "5.39.0",
+        "contentHash": "lwKbD6hdg2sSmX+kNMfqSp6LCY8iO8s21qhn0ZxcUUx7pxMzZHC42uRxU79UPHUxTVG4QJ+lZmkHFPaz6vGBow==",
+        "dependencies": {
+          "Weasel.Postgresql": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Resumo

Implementa a entidade `Unidade` organizacional no bounded context de Organização (ADR-0055) com **identidade rica** — `Sigla`, `Slug`, `Codigo`, `Alias`, `TipoUnidade`, hierarquia e **histórico de identificadores** — e entrega o CRUD administrativo completo.

Fecha #586.

## Mudanças

### Domínio (`OrganizacaoInstitucional.Domain`)
- `Unidade` — agregado com identidade rica, hierarquia, soft-delete, guard anti-ciclo e guard de remoção por referência intra-banco (superior de outra unidade viva e raiz da Instituição)
- `UnidadeIdentificadorHistorico` — entidade de histórico: renomear `Slug`/`Sigla`/`Codigo`/`Alias` fecha a vigência anterior e abre nova entrada
- Enums: `TipoUnidade` (11), `OrigemUnidade` (3), `TipoIdentificador` (4)
- VO `Slug` — valida regex kebab-case (`^[a-z][a-z0-9-]{1,62}[a-z0-9]$`)
- `IUnidadeRepository` + `IUnidadeReader` (ADR-0056 — leitura cross-módulo via leitor read-side)

### Aplicação (`OrganizacaoInstitucional.Application`)
- Commands: `CriarUnidade`, `AtualizarUnidade`, `RemoverUnidade` + handlers estáticos Wolverine
- Validators FluentValidation: unicidade por índice parcial, regex slug, coerência de vigência, ciclo na hierarquia
- Queries: `ListarUnidadesAtivas`, `ObterUnidadePorId`
- `IUnidadeCacheInvalidator`

### Infraestrutura (`OrganizacaoInstitucional.Infrastructure`)
- `UnidadeConfiguration` + `UnidadeIdentificadorHistoricoConfiguration` (EF Core) — índices únicos parciais (`WHERE is_deleted = false`) em `slug`, `sigla`, `codigo`; índice não-único em `alias`
- `UnidadeRepository`, `UnidadeReader`, `UnidadeCacheInvalidator`
- Migration `20260608164735_AddUnidade`
- `SlugValueConverter`

### API (`OrganizacaoInstitucional.API`)
- `UnidadesController` — endpoints REST CRUD com HATEOAS links (`UnidadeLinksBuilder`)
- `OrganizacaoDomainErrorRegistration` — mapeamento de erros de domínio para RFC 9457

### Testes
- Unitários: `UnidadeTests` (248 linhas), `SlugTests`, `CriarUnidadeCommandHandlerTests`, `RemoverUnidadeCommandHandlerTests`
- Integração (Testcontainers): `UnidadePersistenceTests` (271 linhas), `UnidadeEndpointTests`
- Novo projeto `Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests`

## Testes

- Unitários: todos passando
- Integração: todos passando (Testcontainers + PostgreSQL real)

## Checklist

- [x] Build sem errors
- [x] Testes passando
- [x] Migration forward-only (sem `Down()` — ADR-0054)
- [x] Soft-delete + auditoria em todas as entidades
- [x] HATEOAS links no controller
- [x] Sem FK cross-banco (ADR-0054 / ADR-0061)
- [x] Leitor read-side registrado (ADR-0056)