### PR TITLE
feat(organizacao): cadastro singleton de Instituição (e-MEC)

### DIFF
--- a/docker/docker-compose.override.example.yml
+++ b/docker/docker-compose.override.example.yml
@@ -120,7 +120,10 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:8080
-      ConnectionStrings__OrganizacaoDb: "Host=postgres;Port=5432;Database=uniplus_organizacao;Username=uniplus_organizacao_app;Password=${POSTGRES_PASSWORD}"
+      # role uniplus_organizacao_app provisionada em docker/init-db.sql com
+      # senha literal 'uniplus_dev' (dev only); POSTGRES_PASSWORD pertence ao
+      # super user `postgres`. Mantém credencial role-specific.
+      ConnectionStrings__OrganizacaoDb: "Host=postgres;Port=5432;Database=uniplus_organizacao;Username=uniplus_organizacao_app;Password=uniplus_dev"
       Redis__ConnectionString: "redis:6379"
       Kafka__BootstrapServers: "kafka:29092"
       Storage__Endpoint: "minio:9000"

--- a/docker/docker-compose.override.example.yml
+++ b/docker/docker-compose.override.example.yml
@@ -38,6 +38,9 @@ services:
         condition: service_healthy
       apicurio:
         condition: service_healthy
+      # Keycloak sobe junto da API (a API valida JWT contra o realm dev-local).
+      keycloak:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
       interval: 10s
@@ -74,6 +77,9 @@ services:
         condition: service_healthy
       apicurio:
         condition: service_healthy
+      # Keycloak sobe junto da API (a API valida JWT contra o realm dev-local).
+      keycloak:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
       interval: 10s
@@ -104,6 +110,9 @@ services:
       redis:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      # Keycloak sobe junto da API (a API valida JWT contra o realm dev-local).
+      keycloak:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
@@ -139,6 +148,11 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      # A API valida JWT contra o realm dev-local do Keycloak; declarar a
+      # dependência garante que o Keycloak suba junto da API e esteja pronto
+      # quando ela aceitar requisições autenticadas (admin CRUD).
+      keycloak:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
       interval: 10s
@@ -172,6 +186,9 @@ services:
       redis:
         condition: service_healthy
       kafka:
+        condition: service_healthy
+      # Keycloak sobe junto da API (a API valida JWT contra o realm dev-local).
+      keycloak:
         condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]

--- a/docs/setup-ambiente-local.md
+++ b/docs/setup-ambiente-local.md
@@ -44,6 +44,7 @@ docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.ym
 | Keycloak 26.5 | 8080 | http://localhost:8080 | `admin` / `admin` |
 | Seleção API | 5202 | http://localhost:5202/health | — |
 | Ingresso API | 5262 | http://localhost:5262/health | — |
+| Organização API | 5263 | http://localhost:5263/health | — |
 
 ## Databases PostgreSQL
 

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/InstituicaoController.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/InstituicaoController.cs
@@ -1,0 +1,160 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Instituicoes;
+
+/// <summary>
+/// Endpoint público de leitura (<c>GET /api/instituicao</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/admin/instituicao</c>) restritos a
+/// <c>plataforma-admin</c>. A Instituição é singleton (ADR-0055) — não há
+/// listagem nem seletor: há a Instituição, criada uma vez e editada ao longo do
+/// tempo.
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class InstituicaoController : ControllerBase
+{
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<InstituicaoDto> _linksBuilder;
+
+    public InstituicaoController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<InstituicaoDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Obtém a Instituição (cabeçalho institucional). Retorna 404 quando nenhuma
+    /// foi cadastrada ainda.
+    /// </summary>
+    [HttpGet("instituicao")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "instituicao", Versions = [1])]
+    [ProducesResponseType(typeof(InstituicaoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> Obter(CancellationToken cancellationToken)
+    {
+        InstituicaoDto? instituicao = await _queryBus
+            .Send(new ObterInstituicaoQuery(), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (instituicao is null)
+        {
+            return NotFound();
+        }
+
+        InstituicaoDto comLinks = instituicao with { Links = _linksBuilder.Build(instituicao) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>
+    /// Cria a Instituição. Restrito a <c>plataforma-admin</c>. Idempotency-Key
+    /// obrigatório (ADR-0027). Retorna 409 se já existe uma Instituição viva
+    /// (singleton — CA-02).
+    /// </summary>
+    [HttpPost("admin/instituicao")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarInstituicaoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(nameof(Obter), routeValues: null, resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Atualiza a Instituição existente. Restrito a <c>plataforma-admin</c>.
+    /// </summary>
+    [HttpPut("admin/instituicao/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarInstituicaoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Remove (soft-delete) a Instituição. Restrito a <c>plataforma-admin</c>.
+    /// </summary>
+    [HttpDelete("admin/instituicao/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverInstituicaoCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Errors/OrganizacaoDomainErrorRegistration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Errors/OrganizacaoDomainErrorRegistration.cs
@@ -203,5 +203,96 @@ internal sealed class OrganizacaoDomainErrorRegistration : IDomainErrorRegistrat
                 StatusCodes.Status409Conflict,
                 "uniplus.organizacao.unidade.remocao_bloqueada_por_instituicao",
                 "Não é possível remover uma unidade que é raiz de uma instituição")),
+
+        // ── Instituicao (singleton e-MEC) ────────────────────────────────
+        new(InstituicaoErrorCodes.CodigoEmecObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.codigo_emec_obrigatorio",
+                "Código e-MEC da instituição é obrigatório")),
+
+        new(InstituicaoErrorCodes.CodigoEmecTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.codigo_emec_tamanho",
+                "Tamanho do código e-MEC da instituição inválido")),
+
+        new(InstituicaoErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.nome_obrigatorio",
+                "Nome da instituição é obrigatório")),
+
+        new(InstituicaoErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.nome_tamanho",
+                "Tamanho do nome da instituição inválido")),
+
+        new(InstituicaoErrorCodes.SiglaObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.sigla_obrigatoria",
+                "Sigla da instituição é obrigatória")),
+
+        new(InstituicaoErrorCodes.SiglaTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.sigla_tamanho",
+                "Tamanho da sigla da instituição inválido")),
+
+        new(InstituicaoErrorCodes.OrganizacaoAcademicaObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.organizacao_academica_obrigatoria",
+                "Organização acadêmica da instituição é obrigatória")),
+
+        new(InstituicaoErrorCodes.OrganizacaoAcademicaTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.organizacao_academica_tamanho",
+                "Tamanho da organização acadêmica da instituição inválido")),
+
+        new(InstituicaoErrorCodes.CategoriaAdministrativaObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.categoria_administrativa_obrigatoria",
+                "Categoria administrativa da instituição é obrigatória")),
+
+        new(InstituicaoErrorCodes.CategoriaAdministrativaTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.categoria_administrativa_tamanho",
+                "Tamanho da categoria administrativa da instituição inválido")),
+
+        new(InstituicaoErrorCodes.CampoOpcionalTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.campo_opcional_tamanho",
+                "Tamanho de um campo opcional da instituição inválido")),
+
+        new(InstituicaoErrorCodes.JaExisteInstituicaoViva,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.organizacao.instituicao.ja_existe",
+                "Já existe uma instituição cadastrada — a plataforma atende uma única instituição")),
+
+        new(InstituicaoErrorCodes.NaoEncontrada,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.organizacao.instituicao.nao_encontrada",
+                "Instituição não encontrada")),
+
+        new(InstituicaoErrorCodes.UnidadeRaizNaoEncontrada,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.unidade_raiz_nao_encontrada",
+                "A unidade informada como raiz não foi encontrada ou foi removida")),
+
+        new(InstituicaoErrorCodes.UnidadeRaizNaoEhReitoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.instituicao.unidade_raiz_nao_eh_reitoria",
+                "A unidade informada como raiz da instituição deve ser do tipo reitoria")),
     ];
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Hateoas/InstituicaoLinksBuilder.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Hateoas/InstituicaoLinksBuilder.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.API.Controllers;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029/0049) para
+/// <see cref="InstituicaoDto"/>.
+/// </summary>
+/// <remarks>
+/// Relação em V1: <c>self</c> (URI canônica do recurso singleton). Sem
+/// <c>collection</c> — a Instituição não tem listagem (ADR-0055). Action links
+/// nunca aparecem aqui (ADR-0029 §"Esta ADR não decide").
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<InstituicaoDto>, InstituicaoLinksBuilder>().")]
+internal sealed class InstituicaoLinksBuilder : IResourceLinksBuilder<InstituicaoDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public InstituicaoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(InstituicaoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        string controllerName = NomeControllerSemSufixo();
+
+        string self = ResolverPath(httpContext, nameof(InstituicaoController.Obter), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+
+    private static string NomeControllerSemSufixo()
+    {
+        const string sufixo = "Controller";
+        string nome = nameof(InstituicaoController);
+        return nome.EndsWith(sufixo, StringComparison.Ordinal)
+            ? nome[..^sufixo.Length]
+            : nome;
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Program.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Program.cs
@@ -49,6 +49,7 @@ builder.Services.AddDomainErrorMapper();
 // HATEOAS Level 1 (ADR-0029/0049) — builders de _links.
 builder.Services.AddSingleton<IResourceLinksBuilder<AreaOrganizacionalDto>, AreaOrganizacionalLinksBuilder>();
 builder.Services.AddSingleton<IResourceLinksBuilder<UnidadeDto>, UnidadeLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<InstituicaoDto>, InstituicaoLinksBuilder>();
 
 // Criptografia (Idempotency response cipher) + Idempotency-Key (ADR-0027).
 // AddIdempotency injeta o filter de MVC que ativa-se em endpoints com

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Unifesspa.UniPlus.OrganizacaoInstitucional.API.csproj
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Unifesspa.UniPlus.OrganizacaoInstitucional.API.csproj
@@ -12,4 +12,12 @@
     <ProjectReference Include="..\Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure\Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.csproj" />
   </ItemGroup>
 
+  <!-- Coleção Postman versionada junto da API (uma por API, não compartilhada),
+       mas fora do output de publish — sem a exclusão o Web SDK copia os .json
+       como Content e leva os artefatos de teste (e credenciais dev do environment)
+       para a imagem de runtime. -->
+  <ItemGroup>
+    <Content Remove="postman/**" />
+  </ItemGroup>
+
 </Project>

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/postman/README.md
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/postman/README.md
@@ -1,0 +1,59 @@
+# Coleção Postman — API de Organização
+
+Testes HTTP do módulo **OrganizacaoInstitucional**, versionados junto da própria
+API (convenção: uma coleção por API, não compartilhada). Exercita o ciclo de
+vida completo da **Instituição** singleton (issue #585) e um smoke de **Unidade**.
+
+## Arquivos
+
+- `organizacao.postman_collection.json` — a coleção (Postman v2.1).
+- `organizacao.postman_environment.json` — ambiente local (dev): URLs, client e
+  credenciais do realm `unifesspa-dev-local`. Valores **dev-only**, idênticos ao
+  `docker/keycloak/realm-export-dev-local.json`.
+
+## Pré-condições
+
+Stack local **completo** rodando — a coleção precisa do Keycloak (`:8080`) para
+obter o token, e o Keycloak não é `depends_on` da `organizacao-api`, então subir
+só a API não basta:
+
+```bash
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml \
+  --env-file docker/.env --project-directory docker up -d
+```
+
+Isso sobe Postgres, Redis, Kafka, MinIO, Keycloak e a `organizacao-api` em
+`:5263`. O Keycloak importa o realm `unifesspa-dev-local` com o usuário `admin`
+(role `plataforma-admin`).
+
+## Rodar (Newman)
+
+```bash
+cd repositories/uniplus-api
+P=src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/postman
+npx newman run "$P/organizacao.postman_collection.json" -e "$P/organizacao.postman_environment.json"
+```
+
+Ou importe ambos os arquivos no Postman e selecione o ambiente.
+
+## O que é coberto
+
+| Cenário | Verbo / rota | Esperado |
+|---|---|---|
+| Token plataforma-admin | `POST` token (Keycloak) | 200 + `access_token` |
+| Limpeza (estado conhecido) | `GET /api/instituicao` (+ `DELETE` se existir) | 200/404 → limpo |
+| Criar sem auth | `POST /api/admin/instituicao` | 401 |
+| Criar sem Idempotency-Key | `POST /api/admin/instituicao` | 400 |
+| Criar sem campo obrigatório | `POST /api/admin/instituicao` | 400/422 |
+| Criar com unidade raiz inexistente | `POST /api/admin/instituicao` | 422 `unidade_raiz_nao_encontrada` |
+| Criar Instituição | `POST /api/admin/instituicao` | 201 + Guid v7 |
+| Obter (vendor MIME + HATEOAS) | `GET /api/instituicao` | 200 + `_links.self` |
+| Singleton: 2ª criação | `POST /api/admin/instituicao` | 409 `ja_existe` |
+| Atualizar | `PUT /api/admin/instituicao/{id}` | 204 |
+| Obter após atualização | `GET /api/instituicao` | 200 + `situacao` Credenciada |
+| Remover (soft-delete) | `DELETE /api/admin/instituicao/{id}` | 204 |
+| Obter pós-remoção (slot liberado) | `GET /api/instituicao` | 404 |
+| Smoke Unidade | `GET /api/unidades` | 200 + vendor MIME + array |
+
+A coleção é **auto-contida e re-executável**: limpa a Instituição no início e
+remove a que cria ao final, deixando o estado limpo.

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/postman/README.md
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/postman/README.md
@@ -13,18 +13,17 @@ vida completo da **Instituição** singleton (issue #585) e um smoke de **Unidad
 
 ## Pré-condições
 
-Stack local **completo** rodando — a coleção precisa do Keycloak (`:8080`) para
-obter o token, e o Keycloak não é `depends_on` da `organizacao-api`, então subir
-só a API não basta:
+A `organizacao-api` declara dependência de Postgres, Redis, Kafka e **Keycloak**,
+então subir a API já traz tudo que a coleção precisa (o token sai do Keycloak):
 
 ```bash
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml \
-  --env-file docker/.env --project-directory docker up -d
+  --env-file docker/.env --project-directory docker up -d organizacao-api
 ```
 
-Isso sobe Postgres, Redis, Kafka, MinIO, Keycloak e a `organizacao-api` em
-`:5263`. O Keycloak importa o realm `unifesspa-dev-local` com o usuário `admin`
-(role `plataforma-admin`).
+Use `up -d` sem o nome do serviço para o stack inteiro (inclui MinIO, Apicurio e
+as demais APIs). A `organizacao-api` fica em `:5263`; o Keycloak importa o realm
+`unifesspa-dev-local` com o usuário `admin` (role `plataforma-admin`).
 
 ## Rodar (Newman)
 

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/postman/organizacao.postman_collection.json
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/postman/organizacao.postman_collection.json
@@ -1,0 +1,298 @@
+{
+  "info": {
+    "name": "Uni+ — Organização API",
+    "description": "Coleção de testes HTTP da API de Organização (módulo OrganizacaoInstitucional). Exercita o ciclo de vida completo da Instituição singleton (#585) — autenticação plataforma-admin via Keycloak (realm unifesspa-dev-local), Idempotency-Key (ADR-0027), vendor MIME por recurso (ADR-0028), ProblemDetails RFC 9457 (ADR-0023/0024), HATEOAS Level 1 (ADR-0029/0049) e soft-delete. Roda contra o stack local (organizacao-api em :5263). Auto-contida e re-executável (limpa o estado no início e ao final).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Obter token plataforma-admin",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "const j = pm.response.json();",
+                  "pm.expect(j.access_token, 'access_token presente').to.be.a('string').and.to.have.length.above(0);",
+                  "pm.environment.set('token', j.access_token);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/x-www-form-urlencoded" }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                { "key": "grant_type", "value": "password" },
+                { "key": "client_id", "value": "{{client_id}}" },
+                { "key": "username", "value": "{{username}}" },
+                { "key": "password", "value": "{{password}}" }
+              ]
+            },
+            "url": "{{keycloak_token_url}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Setup",
+      "item": [
+        {
+          "name": "Limpeza inicial — remover Instituição se existir",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('estado conhecido (200 ou 404)', () => pm.expect(pm.response.code).to.be.oneOf([200, 404]));",
+                  "if (pm.response.code === 200) {",
+                  "  const id = pm.response.json().id;",
+                  "  pm.sendRequest({",
+                  "    url: pm.environment.get('base_url') + '/api/admin/instituicao/' + id,",
+                  "    method: 'DELETE',",
+                  "    header: { Authorization: 'Bearer ' + pm.environment.get('token') }",
+                  "  }, (err, res) => {",
+                  "    pm.test('limpeza: DELETE da Instituição pré-existente → 204', () => {",
+                  "      pm.expect(res.code).to.eql(204);",
+                  "    });",
+                  "  });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/instituicao"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Validações (negativos)",
+      "item": [
+        {
+          "name": "Criar sem autenticação → 401",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('401 Unauthorized', () => pm.response.to.have.status(401));"
+            ] } }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Idempotency-Key", "value": "{{$guid}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": { "mode": "raw", "raw": "{\"codigoEmec\":\"3990\",\"nome\":\"Universidade Federal do Sul e Sudeste do Pará\",\"sigla\":\"Unifesspa\",\"organizacaoAcademica\":\"Universidade\",\"categoriaAdministrativa\":\"Pública Federal\"}" },
+            "url": "{{base_url}}/api/admin/instituicao"
+          }
+        },
+        {
+          "name": "Criar sem Idempotency-Key → 400",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('400 Bad Request', () => pm.response.to.have.status(400));"
+            ] } }
+          ],
+          "request": {
+            "method": "POST",
+            "auth": { "type": "bearer", "bearer": [ { "key": "token", "value": "{{token}}" } ] },
+            "header": [ { "key": "Content-Type", "value": "application/json" } ],
+            "body": { "mode": "raw", "raw": "{}" },
+            "url": "{{base_url}}/api/admin/instituicao"
+          }
+        },
+        {
+          "name": "Criar sem campo obrigatório → 422",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('rejeitado na validação (400 ou 422)', () => pm.expect(pm.response.code).to.be.oneOf([400, 422]));"
+            ] } }
+          ],
+          "request": {
+            "method": "POST",
+            "auth": { "type": "bearer", "bearer": [ { "key": "token", "value": "{{token}}" } ] },
+            "header": [
+              { "key": "Idempotency-Key", "value": "{{$guid}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": { "mode": "raw", "raw": "{\"codigoEmec\":\"\",\"nome\":\"Sem código\",\"sigla\":\"X\",\"organizacaoAcademica\":\"Universidade\",\"categoriaAdministrativa\":\"Pública Federal\"}" },
+            "url": "{{base_url}}/api/admin/instituicao"
+          }
+        },
+        {
+          "name": "Criar com unidade raiz inexistente → 422",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('422 Unprocessable Entity', () => pm.response.to.have.status(422));",
+              "pm.test('code = unidade_raiz_nao_encontrada', () => pm.expect(pm.response.json().code).to.eql('uniplus.organizacao.instituicao.unidade_raiz_nao_encontrada'));"
+            ] } }
+          ],
+          "request": {
+            "method": "POST",
+            "auth": { "type": "bearer", "bearer": [ { "key": "token", "value": "{{token}}" } ] },
+            "header": [
+              { "key": "Idempotency-Key", "value": "{{$guid}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": { "mode": "raw", "raw": "{\"codigoEmec\":\"3990\",\"nome\":\"Universidade\",\"sigla\":\"Unifesspa\",\"organizacaoAcademica\":\"Universidade\",\"categoriaAdministrativa\":\"Pública Federal\",\"unidadeRaizId\":\"{{$guid}}\"}" },
+            "url": "{{base_url}}/api/admin/instituicao"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Ciclo de vida (singleton)",
+      "item": [
+        {
+          "name": "Criar Instituição → 201",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('201 Created', () => pm.response.to.have.status(201));",
+              "const id = pm.response.json();",
+              "pm.test('retorna Id Guid v7', () => { pm.expect(id).to.be.a('string'); pm.expect(id[14]).to.eql('7'); });",
+              "pm.environment.set('instituicao_id', id);"
+            ] } }
+          ],
+          "request": {
+            "method": "POST",
+            "auth": { "type": "bearer", "bearer": [ { "key": "token", "value": "{{token}}" } ] },
+            "header": [
+              { "key": "Idempotency-Key", "value": "{{$guid}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": { "mode": "raw", "raw": "{\"codigoEmec\":\"3990\",\"nome\":\"Universidade Federal do Sul e Sudeste do Pará\",\"sigla\":\"Unifesspa\",\"organizacaoAcademica\":\"Universidade\",\"categoriaAdministrativa\":\"Pública Federal\",\"municipioSede\":\"Marabá\"}" },
+            "url": "{{base_url}}/api/admin/instituicao"
+          }
+        },
+        {
+          "name": "Obter Instituição → 200 (vendor MIME + HATEOAS)",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('vendor MIME instituicao.v1', () => pm.expect(pm.response.headers.get('Content-Type')).to.include('application/vnd.uniplus.instituicao.v1+json'));",
+              "const j = pm.response.json();",
+              "pm.test('dados corretos', () => { pm.expect(j.codigoEmec).to.eql('3990'); pm.expect(j.sigla).to.eql('Unifesspa'); pm.expect(j.municipioSede).to.eql('Marabá'); });",
+              "pm.test('HATEOAS _links.self', () => pm.expect(j._links.self).to.eql('/api/instituicao'));"
+            ] } }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [ { "key": "Accept", "value": "application/vnd.uniplus.instituicao.v1+json" } ],
+            "url": "{{base_url}}/api/instituicao"
+          }
+        },
+        {
+          "name": "Criar segunda Instituição → 409 (singleton, CA-02)",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('409 Conflict', () => pm.response.to.have.status(409));",
+              "pm.test('code = ja_existe', () => pm.expect(pm.response.json().code).to.eql('uniplus.organizacao.instituicao.ja_existe'));"
+            ] } }
+          ],
+          "request": {
+            "method": "POST",
+            "auth": { "type": "bearer", "bearer": [ { "key": "token", "value": "{{token}}" } ] },
+            "header": [
+              { "key": "Idempotency-Key", "value": "{{$guid}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": { "mode": "raw", "raw": "{\"codigoEmec\":\"4000\",\"nome\":\"Outra Instituição\",\"sigla\":\"OUTRA\",\"organizacaoAcademica\":\"Universidade\",\"categoriaAdministrativa\":\"Pública Federal\"}" },
+            "url": "{{base_url}}/api/admin/instituicao"
+          }
+        },
+        {
+          "name": "Atualizar Instituição → 204",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('204 No Content', () => pm.response.to.have.status(204));"
+            ] } }
+          ],
+          "request": {
+            "method": "PUT",
+            "auth": { "type": "bearer", "bearer": [ { "key": "token", "value": "{{token}}" } ] },
+            "header": [
+              { "key": "Idempotency-Key", "value": "{{$guid}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": { "mode": "raw", "raw": "{\"id\":\"{{instituicao_id}}\",\"codigoEmec\":\"3990\",\"nome\":\"Universidade Federal do Sul e Sudeste do Pará\",\"sigla\":\"Unifesspa\",\"organizacaoAcademica\":\"Universidade\",\"categoriaAdministrativa\":\"Pública Federal\",\"situacao\":\"Credenciada\",\"municipioSede\":\"Marabá\"}" },
+            "url": "{{base_url}}/api/admin/instituicao/{{instituicao_id}}"
+          }
+        },
+        {
+          "name": "Obter após atualização → 200 (situacao Credenciada)",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('situacao atualizada', () => pm.expect(pm.response.json().situacao).to.eql('Credenciada'));"
+            ] } }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/instituicao"
+          }
+        },
+        {
+          "name": "Remover Instituição (soft-delete) → 204",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('204 No Content', () => pm.response.to.have.status(204));"
+            ] } }
+          ],
+          "request": {
+            "method": "DELETE",
+            "auth": { "type": "bearer", "bearer": [ { "key": "token", "value": "{{token}}" } ] },
+            "header": [],
+            "url": "{{base_url}}/api/admin/instituicao/{{instituicao_id}}"
+          }
+        },
+        {
+          "name": "Obter após remoção → 404 (slot liberado, CA-05)",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('404 Not Found', () => pm.response.to.have.status(404));"
+            ] } }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/instituicao"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Unidade (smoke)",
+      "item": [
+        {
+          "name": "Listar unidades → 200 (vendor MIME)",
+          "event": [
+            { "listen": "test", "script": { "type": "text/javascript", "exec": [
+              "pm.test('200 OK', () => pm.response.to.have.status(200));",
+              "pm.test('vendor MIME unidade.v1', () => pm.expect(pm.response.headers.get('Content-Type')).to.include('application/vnd.uniplus.unidade.v1+json'));",
+              "pm.test('corpo é array', () => pm.expect(pm.response.json()).to.be.an('array'));"
+            ] } }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/unidades"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/postman/organizacao.postman_environment.json
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/postman/organizacao.postman_environment.json
@@ -1,0 +1,14 @@
+{
+  "id": "8f3a1c20-0a2e-4d51-9c7a-organizacao01",
+  "name": "Uni+ Organização — local (dev)",
+  "values": [
+    { "key": "base_url", "value": "http://localhost:5263", "type": "default", "enabled": true },
+    { "key": "keycloak_token_url", "value": "http://localhost:8080/realms/unifesspa-dev-local/protocol/openid-connect/token", "type": "default", "enabled": true },
+    { "key": "client_id", "value": "selecao-web", "type": "default", "enabled": true },
+    { "key": "username", "value": "admin", "type": "default", "enabled": true },
+    { "key": "password", "value": "Changeme!123", "type": "secret", "enabled": true },
+    { "key": "token", "value": "", "type": "secret", "enabled": true },
+    { "key": "instituicao_id", "value": "", "type": "default", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Abstractions/IInstituicaoCacheInvalidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Abstractions/IInstituicaoCacheInvalidator.cs
@@ -1,0 +1,10 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+
+/// <summary>
+/// Invalida o cache do reader cross-módulo da <c>Instituicao</c> após operações
+/// de escrita (ADR-0056). Chamada pós-commit, best-effort.
+/// </summary>
+public interface IInstituicaoCacheInvalidator
+{
+    Task InvalidarAsync(CancellationToken cancellationToken = default);
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommand.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommand.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Edita os dados regulatórios e o vínculo com a reitoria da Instituição
+/// existente.
+/// </summary>
+public sealed record AtualizarInstituicaoCommand(
+    Guid Id,
+    string CodigoEmec,
+    string Nome,
+    string Sigla,
+    string OrganizacaoAcademica,
+    string CategoriaAdministrativa,
+    string? Cnpj,
+    string? Mantenedora,
+    string? CodigoMantenedoraEmec,
+    string? Situacao,
+    string? AtoCredenciamento,
+    string? AtoRecredenciamento,
+    string? ConceitoInstitucional,
+    string? Igc,
+    string? Website,
+    string? EnderecoSede,
+    string? MunicipioSede,
+    Guid? UnidadeRaizId) : ICommand<Result>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommandHandler.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+public static class AtualizarInstituicaoCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarInstituicaoCommand command,
+        IInstituicaoRepository repository,
+        IUnidadeRepository unidadeRepository,
+        IUnitOfWork unitOfWork,
+        IInstituicaoCacheInvalidator cacheInvalidator,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unidadeRepository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(cacheInvalidator);
+
+        Instituicao? instituicao = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (instituicao is null)
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.NaoEncontrada,
+                "Instituição não encontrada."));
+        }
+
+        DomainError? vinculoInvalido = await InstituicaoUnidadeRaizGuard
+            .ValidarAsync(command.UnidadeRaizId, unidadeRepository, cancellationToken)
+            .ConfigureAwait(false);
+        if (vinculoInvalido is not null)
+        {
+            return Result.Failure(vinculoInvalido);
+        }
+
+        Result atualizarResult = instituicao.Atualizar(
+            command.CodigoEmec,
+            command.Nome,
+            command.Sigla,
+            command.OrganizacaoAcademica,
+            command.CategoriaAdministrativa,
+            command.Cnpj,
+            command.Mantenedora,
+            command.CodigoMantenedoraEmec,
+            command.Situacao,
+            command.AtoCredenciamento,
+            command.AtoRecredenciamento,
+            command.ConceitoInstitucional,
+            command.Igc,
+            command.Website,
+            command.EnderecoSede,
+            command.MunicipioSede,
+            command.UnidadeRaizId);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidarAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommandValidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommandValidator.cs
@@ -1,0 +1,40 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+using FluentValidation;
+
+/// <summary>
+/// Validação de formato dos campos da atualização da Instituição. As regras que
+/// dependem do banco (existência, tipo da Unidade raiz) ficam no handler.
+/// </summary>
+public sealed class AtualizarInstituicaoCommandValidator : AbstractValidator<AtualizarInstituicaoCommand>
+{
+    public AtualizarInstituicaoCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id da Instituição é obrigatório.");
+
+        RuleFor(x => x.CodigoEmec)
+            .NotEmpty().WithMessage("Código e-MEC da Instituição é obrigatório.")
+            .MaximumLength(20).WithMessage("Código e-MEC deve ter no máximo 20 caracteres.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome da Instituição é obrigatório.")
+            .MaximumLength(250).WithMessage("Nome da Instituição deve ter no máximo 250 caracteres.");
+
+        RuleFor(x => x.Sigla)
+            .NotEmpty().WithMessage("Sigla da Instituição é obrigatória.")
+            .MaximumLength(50).WithMessage("Sigla da Instituição deve ter no máximo 50 caracteres.");
+
+        RuleFor(x => x.OrganizacaoAcademica)
+            .NotEmpty().WithMessage("Organização acadêmica da Instituição é obrigatória.")
+            .MaximumLength(100).WithMessage("Organização acadêmica deve ter no máximo 100 caracteres.");
+
+        RuleFor(x => x.CategoriaAdministrativa)
+            .NotEmpty().WithMessage("Categoria administrativa da Instituição é obrigatória.")
+            .MaximumLength(100).WithMessage("Categoria administrativa deve ter no máximo 100 caracteres.");
+
+        RuleFor(x => x.Website)
+            .MaximumLength(255).WithMessage("Website deve ter no máximo 255 caracteres.")
+            .When(x => x.Website is not null);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommand.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommand.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria a Instituição singleton. Rejeitado se já existe uma Instituição viva
+/// (ADR-0055 · CA-02).
+/// </summary>
+public sealed record CriarInstituicaoCommand(
+    string CodigoEmec,
+    string Nome,
+    string Sigla,
+    string OrganizacaoAcademica,
+    string CategoriaAdministrativa,
+    string? Cnpj,
+    string? Mantenedora,
+    string? CodigoMantenedoraEmec,
+    string? Situacao,
+    string? AtoCredenciamento,
+    string? AtoRecredenciamento,
+    string? ConceitoInstitucional,
+    string? Igc,
+    string? Website,
+    string? EnderecoSede,
+    string? MunicipioSede,
+    Guid? UnidadeRaizId) : ICommand<Result<Guid>>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommandHandler.cs
@@ -1,0 +1,104 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+/// <summary>
+/// Handler do <see cref="CriarInstituicaoCommand"/>. Convention-based para
+/// Wolverine — método estático <c>Handle</c> com dependências por parâmetro.
+/// </summary>
+/// <remarks>
+/// Sequência:
+/// <list type="number">
+///   <item>Guard de domínio do singleton: rejeita se já existe Instituição viva (CA-02);</item>
+///   <item>Valida o vínculo com a Unidade raiz (reitoria), se informado (CA-04);</item>
+///   <item>Cria o agregado via <see cref="Instituicao.Criar"/>;</item>
+///   <item>Persiste + commit; uma corrida concorrente que passe pelo guard e
+///   colida no índice único parcial é traduzida para o mesmo erro de singleton (CA-02);</item>
+///   <item>Invalida o cache do reader cross-módulo (ADR-0056).</item>
+/// </list>
+/// </remarks>
+public static class CriarInstituicaoCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarInstituicaoCommand command,
+        IInstituicaoRepository repository,
+        IUnidadeRepository unidadeRepository,
+        IUnitOfWork unitOfWork,
+        IInstituicaoCacheInvalidator cacheInvalidator,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unidadeRepository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(cacheInvalidator);
+
+        if (await repository.ExisteAlgumaVivaAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(new DomainError(
+                InstituicaoErrorCodes.JaExisteInstituicaoViva,
+                "Já existe uma Instituição cadastrada — cada instância da plataforma atende uma única instituição."));
+        }
+
+        DomainError? vinculoInvalido = await InstituicaoUnidadeRaizGuard
+            .ValidarAsync(command.UnidadeRaizId, unidadeRepository, cancellationToken)
+            .ConfigureAwait(false);
+        if (vinculoInvalido is not null)
+        {
+            return Result<Guid>.Failure(vinculoInvalido);
+        }
+
+        Result<Instituicao> instituicaoResult = Instituicao.Criar(
+            command.CodigoEmec,
+            command.Nome,
+            command.Sigla,
+            command.OrganizacaoAcademica,
+            command.CategoriaAdministrativa,
+            command.Cnpj,
+            command.Mantenedora,
+            command.CodigoMantenedoraEmec,
+            command.Situacao,
+            command.AtoCredenciamento,
+            command.AtoRecredenciamento,
+            command.ConceitoInstitucional,
+            command.Igc,
+            command.Website,
+            command.EnderecoSede,
+            command.MunicipioSede,
+            command.UnidadeRaizId);
+
+        if (instituicaoResult.IsFailure)
+        {
+            return Result<Guid>.Failure(instituicaoResult.Error!);
+        }
+
+        Instituicao instituicao = instituicaoResult.Value!;
+        await repository.AdicionarAsync(instituicao, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsSingletonConflict(constraint))
+        {
+            // Corrida entre ExisteAlgumaVivaAsync e o INSERT (check-then-act): o
+            // índice único parcial sentinela dispara 23505 e viramos o mesmo erro
+            // de singleton (CA-02) — 409 consistente com o caminho não-race, em vez
+            // de deixar o DbUpdateException virar 500 no middleware global. O filtro
+            // do `when` garante que outras exceções propagam intactas.
+            return Result<Guid>.Failure(new DomainError(
+                InstituicaoErrorCodes.JaExisteInstituicaoViva,
+                "Já existe uma Instituição cadastrada — cada instância da plataforma atende uma única instituição."));
+        }
+
+        await cacheInvalidator.InvalidarAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<Guid>.Success(instituicao.Id);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommandValidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommandValidator.cs
@@ -1,0 +1,38 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+using FluentValidation;
+
+/// <summary>
+/// Validação de formato dos campos da criação da Instituição (CA-03). As regras
+/// que dependem do banco — singleton (CA-02) e tipo da Unidade raiz (CA-04) —
+/// ficam no handler, espelhando o padrão do cadastro de Unidade.
+/// </summary>
+public sealed class CriarInstituicaoCommandValidator : AbstractValidator<CriarInstituicaoCommand>
+{
+    public CriarInstituicaoCommandValidator()
+    {
+        RuleFor(x => x.CodigoEmec)
+            .NotEmpty().WithMessage("Código e-MEC da Instituição é obrigatório.")
+            .MaximumLength(20).WithMessage("Código e-MEC deve ter no máximo 20 caracteres.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome da Instituição é obrigatório.")
+            .MaximumLength(250).WithMessage("Nome da Instituição deve ter no máximo 250 caracteres.");
+
+        RuleFor(x => x.Sigla)
+            .NotEmpty().WithMessage("Sigla da Instituição é obrigatória.")
+            .MaximumLength(50).WithMessage("Sigla da Instituição deve ter no máximo 50 caracteres.");
+
+        RuleFor(x => x.OrganizacaoAcademica)
+            .NotEmpty().WithMessage("Organização acadêmica da Instituição é obrigatória.")
+            .MaximumLength(100).WithMessage("Organização acadêmica deve ter no máximo 100 caracteres.");
+
+        RuleFor(x => x.CategoriaAdministrativa)
+            .NotEmpty().WithMessage("Categoria administrativa da Instituição é obrigatória.")
+            .MaximumLength(100).WithMessage("Categoria administrativa deve ter no máximo 100 caracteres.");
+
+        RuleFor(x => x.Website)
+            .MaximumLength(255).WithMessage("Website deve ter no máximo 255 caracteres.")
+            .When(x => x.Website is not null);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/InstituicaoUnidadeRaizGuard.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/InstituicaoUnidadeRaizGuard.cs
@@ -1,0 +1,52 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+/// <summary>
+/// Confere a integridade do vínculo <c>unidade_raiz_id</c> da Instituição:
+/// quando informado, deve apontar para uma Unidade viva do tipo reitoria
+/// (UNI-REQ-0007 · CA-04). Compartilhado entre os handlers de criação e
+/// atualização.
+/// </summary>
+internal static class InstituicaoUnidadeRaizGuard
+{
+    /// <summary>
+    /// Retorna <see langword="null"/> quando o vínculo é válido (ou ausente), ou
+    /// o <see cref="DomainError"/> correspondente quando a Unidade referenciada
+    /// não existe / foi removida ou não é do tipo reitoria.
+    /// </summary>
+    public static async Task<DomainError?> ValidarAsync(
+        Guid? unidadeRaizId,
+        IUnidadeRepository unidadeRepository,
+        CancellationToken cancellationToken)
+    {
+        if (unidadeRaizId is not { } id)
+        {
+            return null;
+        }
+
+        Unidade? unidade = await unidadeRepository
+            .ObterPorIdParaLeituraAsync(id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (unidade is null)
+        {
+            return new DomainError(
+                InstituicaoErrorCodes.UnidadeRaizNaoEncontrada,
+                "A Unidade informada como raiz não foi encontrada ou foi removida.");
+        }
+
+        if (unidade.Tipo != TipoUnidade.Reitoria)
+        {
+            return new DomainError(
+                InstituicaoErrorCodes.UnidadeRaizNaoEhReitoria,
+                "A Unidade informada como raiz da Instituição deve ser do tipo reitoria.");
+        }
+
+        return null;
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/RemoverInstituicaoCommand.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/RemoverInstituicaoCommand.cs
@@ -1,0 +1,11 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Remove (soft-delete) a Instituição — recadastramento institucional. Libera a
+/// criação de uma nova Instituição, pois o registro removido não conta para o
+/// limite singleton (CA-05).
+/// </summary>
+public sealed record RemoverInstituicaoCommand(Guid Id) : ICommand<Result>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/RemoverInstituicaoCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/RemoverInstituicaoCommandHandler.cs
@@ -1,0 +1,48 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+/// <summary>
+/// Handler do <see cref="RemoverInstituicaoCommand"/>. Executa soft-delete via
+/// <c>SoftDeleteInterceptor</c>; o registro removido permanece na trilha de
+/// auditoria e deixa de contar para o limite singleton.
+/// </summary>
+public static class RemoverInstituicaoCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverInstituicaoCommand command,
+        IInstituicaoRepository repository,
+        IUnitOfWork unitOfWork,
+        IInstituicaoCacheInvalidator cacheInvalidator,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(cacheInvalidator);
+
+        Instituicao? instituicao = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (instituicao is null)
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.NaoEncontrada,
+                "Instituição não encontrada."));
+        }
+
+        // SoftDeleteInterceptor converte EntityState.Deleted em soft-delete
+        // preenchendo DeletedBy/DeletedAt a partir de IUserContext + TimeProvider.
+        repository.Remover(instituicao);
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        await cacheInvalidator.InvalidarAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/UniqueConstraintViolation.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/UniqueConstraintViolation.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do singleton da
+/// Instituição para o <c>DomainError</c> apropriado. Acessa <c>SqlState</c> e
+/// <c>ConstraintName</c> por reflection no inner exception — o shape é estável
+/// na API pública do <c>Npgsql.PostgresException</c>. A inspeção do tipo da
+/// exceção por <see cref="System.Type.FullName"/> evita dependência direta do
+/// pacote <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém
+/// Clean Arch — Application referencia apenas Domain + SharedKernel + abstrações).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão de <c>UniqueConstraintViolation</c> do módulo Seleção
+/// (ObrigatoriedadesLegais). A tradução cross-cutting de 23505 → 409 via
+/// <c>GlobalExceptionMiddleware</c> permanece como follow-up separado (#504);
+/// este helper cobre o caso específico do invariante singleton (CA-02) que esta
+/// Story introduz.
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string SingletonConstraint = "ix_instituicao_singleton_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o
+    /// caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é a do índice único
+    /// parcial que garante o singleton da Instituição.
+    /// </summary>
+    public static bool IsSingletonConflict(string? constraint) =>
+        string.Equals(constraint, SingletonConstraint, StringComparison.Ordinal);
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/RemoverUnidadeCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/RemoverUnidadeCommandHandler.cs
@@ -10,24 +10,26 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
 /// <summary>
 /// Handler do <see cref="RemoverUnidadeCommand"/>. Executa soft-delete via
 /// <c>SoftDeleteInterceptor</c> — bloqueia se a unidade for superior de outra
-/// unidade viva.
+/// unidade viva, ou se for a raiz (reitoria) de uma Instituição viva.
 /// </summary>
 /// <remarks>
-/// O bloqueio por <c>instituicao.unidade_raiz_id</c> (CA-06 §"raiz da
-/// Instituição") será adicionado quando o agregado Instituicao for implementado
-/// (issue #585), que depende desta Story.
+/// O bloqueio por <c>instituicao.unidade_raiz_id</c> preserva a integridade do
+/// vínculo da Instituição com a reitoria (issue #585): uma Unidade referenciada
+/// como raiz não pode ser removida enquanto a Instituição viva apontar para ela.
 /// </remarks>
 public static class RemoverUnidadeCommandHandler
 {
     public static async Task<Result> Handle(
         RemoverUnidadeCommand command,
         IUnidadeRepository repository,
+        IInstituicaoRepository instituicaoRepository,
         IUnitOfWork unitOfWork,
         IUnidadeCacheInvalidator cacheInvalidator,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(instituicaoRepository);
         ArgumentNullException.ThrowIfNull(unitOfWork);
         ArgumentNullException.ThrowIfNull(cacheInvalidator);
 
@@ -44,6 +46,20 @@ public static class RemoverUnidadeCommandHandler
             return Result.Failure(new DomainError(
                 UnidadeErrorCodes.RemocaoBloqueadaPorSubordinadas,
                 "Não é possível remover uma Unidade que possui unidades subordinadas ativas."));
+        }
+
+        // NOTA: checagem check-then-act, simétrica à de PossuiSubordinadasVivasAsync
+        // acima. Sob concorrência (remoção desta Unidade × criação/edição de uma
+        // Instituição que a escolhe como raiz) a checagem pode ver `false` antes do
+        // commit da Instituição, e como a remoção é soft-delete a FK Restrict não
+        // barra o estado final (Instituição viva → Unidade removida). A serialização
+        // estrita (lock/isolamento serializável) é controle de concorrência
+        // cross-cutting comum a todos os cadastros — front separado, não desta Story.
+        if (await instituicaoRepository.ExisteComUnidadeRaizAsync(command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                UnidadeErrorCodes.RemocaoBloqueadaPorInstituicao,
+                "Não é possível remover uma Unidade que é raiz de uma Instituição."));
         }
 
         // SoftDeleteInterceptor converte EntityState.Deleted em soft-delete

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/DTOs/InstituicaoDto.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/DTOs/InstituicaoDto.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para a <c>Instituicao</c> singleton. Exposto pelos
+/// endpoints do controller; suporta HATEOAS Level 1 via <c>_links</c>.
+/// </summary>
+public sealed record InstituicaoDto(
+    Guid Id,
+    string CodigoEmec,
+    string Nome,
+    string Sigla,
+    string OrganizacaoAcademica,
+    string CategoriaAdministrativa,
+    string? Cnpj,
+    string? Mantenedora,
+    string? CodigoMantenedoraEmec,
+    string? Situacao,
+    string? AtoCredenciamento,
+    string? AtoRecredenciamento,
+    string? ConceitoInstitucional,
+    string? Igc,
+    string? Website,
+    string? EnderecoSede,
+    string? MunicipioSede,
+    Guid? UnidadeRaizId,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Mappings/InstituicaoMapping.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Mappings/InstituicaoMapping.cs
@@ -1,0 +1,48 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Mappings;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+
+public static class InstituicaoMapping
+{
+    public static InstituicaoDto ToDto(this Instituicao instituicao)
+    {
+        ArgumentNullException.ThrowIfNull(instituicao);
+        return new InstituicaoDto(
+            instituicao.Id,
+            instituicao.CodigoEmec,
+            instituicao.Nome,
+            instituicao.Sigla,
+            instituicao.OrganizacaoAcademica,
+            instituicao.CategoriaAdministrativa,
+            instituicao.Cnpj,
+            instituicao.Mantenedora,
+            instituicao.CodigoMantenedoraEmec,
+            instituicao.Situacao,
+            instituicao.AtoCredenciamento,
+            instituicao.AtoRecredenciamento,
+            instituicao.ConceitoInstitucional,
+            instituicao.Igc,
+            instituicao.Website,
+            instituicao.EnderecoSede,
+            instituicao.MunicipioSede,
+            instituicao.UnidadeRaizId,
+            instituicao.CreatedAt);
+    }
+
+    public static InstituicaoView ToView(this Instituicao instituicao)
+    {
+        ArgumentNullException.ThrowIfNull(instituicao);
+        return new InstituicaoView(
+            instituicao.Id,
+            instituicao.CodigoEmec,
+            instituicao.Nome,
+            instituicao.Sigla,
+            instituicao.Cnpj,
+            instituicao.OrganizacaoAcademica,
+            instituicao.CategoriaAdministrativa,
+            instituicao.MunicipioSede,
+            instituicao.UnidadeRaizId);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Instituicoes/ObterInstituicaoQuery.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Instituicoes/ObterInstituicaoQuery.cs
@@ -1,0 +1,10 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Instituicoes;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+
+/// <summary>
+/// Obtém a Instituição singleton viva, ou <see langword="null"/> se nenhuma foi
+/// cadastrada. Não há parâmetro de seleção — há no máximo uma (ADR-0055).
+/// </summary>
+public sealed record ObterInstituicaoQuery : IQuery<InstituicaoDto?>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Instituicoes/ObterInstituicaoQueryHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Instituicoes/ObterInstituicaoQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Instituicoes;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Mappings;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+public static class ObterInstituicaoQueryHandler
+{
+    public static async Task<InstituicaoDto?> Handle(
+        ObterInstituicaoQuery query,
+        IInstituicaoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        Instituicao? instituicao = await repository
+            .ObterParaLeituraAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return instituicao?.ToDto();
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Instituicao.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Instituicao.cs
@@ -1,0 +1,354 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+
+/// <summary>
+/// Instituição de ensino superior dona da plataforma — a Unifesspa no
+/// deployment da Unifesspa (ADR-0055). Carrega a identificação regulatória
+/// e-MEC (código, classificação, mantenedora, atos de credenciamento,
+/// indicadores de qualidade) que serve de cabeçalho institucional exibido em
+/// editais, comprovantes e telas administrativas.
+/// </summary>
+/// <remarks>
+/// <para><strong>Singleton</strong> (UNI-REQ-0007 · ADR-0055): cada deployment
+/// atende uma única instituição, logo há no máximo uma <c>Instituicao</c> viva
+/// (não soft-deleted) por instância. O cardinal de um é garantido em duas
+/// camadas — guard de domínio na criação (o handler consulta o repositório
+/// antes de criar) e índice único parcial de banco sobre uma coluna sentinela
+/// constante <c>WHERE is_deleted = false</c>. A remoção é lógica; uma
+/// Instituição removida não conta para o limite, liberando o recadastramento.</para>
+/// <para>Não há unicidade própria sobre <c>codigo_emec</c>: sob o singleton, o
+/// cardinal de um já garante a identidade (o dicionário marca a coluna como
+/// <c>text NOT NULL</c>, sem <c>UNIQUE</c>).</para>
+/// <para>A vinculação com a <c>Unidade</c> raiz (reitoria) é por
+/// <c>UnidadeRaizId</c> — FK intra-banco (ADR-0054). A conferência de que a
+/// Unidade referenciada é viva e do tipo reitoria é responsabilidade do handler
+/// (via repositório); esta entidade recebe o Id já validado.</para>
+/// </remarks>
+public sealed class Instituicao : EntityBase, IAuditableEntity
+{
+    private const int CodigoEmecMaxLength = 20;
+    private const int NomeMaxLength = 250;
+    private const int SiglaMaxLength = 50;
+    private const int OrganizacaoAcademicaMaxLength = 100;
+    private const int CategoriaAdministrativaMaxLength = 100;
+    private const int CampoOpcionalCurtoMaxLength = 100;
+    private const int CampoOpcionalMedioMaxLength = 255;
+    private const int CampoOpcionalLongoMaxLength = 500;
+
+    public string CodigoEmec { get; private set; } = string.Empty;
+    public string Nome { get; private set; } = string.Empty;
+    public string Sigla { get; private set; } = string.Empty;
+    public string OrganizacaoAcademica { get; private set; } = string.Empty;
+    public string CategoriaAdministrativa { get; private set; } = string.Empty;
+    public string? Cnpj { get; private set; }
+    public string? Mantenedora { get; private set; }
+    public string? CodigoMantenedoraEmec { get; private set; }
+    public string? Situacao { get; private set; }
+    public string? AtoCredenciamento { get; private set; }
+    public string? AtoRecredenciamento { get; private set; }
+    public string? ConceitoInstitucional { get; private set; }
+    public string? Igc { get; private set; }
+    public string? Website { get; private set; }
+    public string? EnderecoSede { get; private set; }
+    public string? MunicipioSede { get; private set; }
+    public Guid? UnidadeRaizId { get; private set; }
+
+    /// <summary>
+    /// Sentinela constante (sempre <see langword="true"/>) — concern de
+    /// persistência que materializa a salvaguarda física do singleton: o índice
+    /// único parcial <c>WHERE is_deleted = false</c> sobre esta coluna admite no
+    /// máximo um registro vivo (ADR-0055), e o CHECK de banco impede qualquer
+    /// outro valor. Não é dado de negócio; não é exposto em DTO/View.
+    /// </summary>
+    public bool RegistroVivoSentinela { get; private set; } = true;
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private Instituicao()
+    {
+    }
+
+    /// <summary>
+    /// Cria a Instituição. Valida apenas formato e domínio local — o invariante
+    /// singleton (no máximo uma viva) e a conferência do tipo da Unidade raiz são
+    /// responsabilidade do handler chamador (dependem do repositório).
+    /// </summary>
+    public static Result<Instituicao> Criar(
+        string codigoEmec,
+        string nome,
+        string sigla,
+        string organizacaoAcademica,
+        string categoriaAdministrativa,
+        string? cnpj,
+        string? mantenedora,
+        string? codigoMantenedoraEmec,
+        string? situacao,
+        string? atoCredenciamento,
+        string? atoRecredenciamento,
+        string? conceitoInstitucional,
+        string? igc,
+        string? website,
+        string? enderecoSede,
+        string? municipioSede,
+        Guid? unidadeRaizId)
+    {
+        ArgumentNullException.ThrowIfNull(codigoEmec);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(sigla);
+        ArgumentNullException.ThrowIfNull(organizacaoAcademica);
+        ArgumentNullException.ThrowIfNull(categoriaAdministrativa);
+
+        Result validacao = ValidarCampos(
+            codigoEmec, nome, sigla, organizacaoAcademica, categoriaAdministrativa,
+            cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
+            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede, municipioSede);
+        if (validacao.IsFailure)
+        {
+            return Result<Instituicao>.Failure(validacao.Error!);
+        }
+
+        var instituicao = new Instituicao();
+        instituicao.AplicarCampos(
+            codigoEmec, nome, sigla, organizacaoAcademica, categoriaAdministrativa,
+            cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
+            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede,
+            municipioSede, unidadeRaizId);
+
+        return Result<Instituicao>.Success(instituicao);
+    }
+
+    /// <summary>
+    /// Atualiza os dados regulatórios e o vínculo com a reitoria. A conferência
+    /// do tipo da Unidade raiz informada é responsabilidade do handler.
+    /// </summary>
+    public Result Atualizar(
+        string codigoEmec,
+        string nome,
+        string sigla,
+        string organizacaoAcademica,
+        string categoriaAdministrativa,
+        string? cnpj,
+        string? mantenedora,
+        string? codigoMantenedoraEmec,
+        string? situacao,
+        string? atoCredenciamento,
+        string? atoRecredenciamento,
+        string? conceitoInstitucional,
+        string? igc,
+        string? website,
+        string? enderecoSede,
+        string? municipioSede,
+        Guid? unidadeRaizId)
+    {
+        ArgumentNullException.ThrowIfNull(codigoEmec);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(sigla);
+        ArgumentNullException.ThrowIfNull(organizacaoAcademica);
+        ArgumentNullException.ThrowIfNull(categoriaAdministrativa);
+
+        Result validacao = ValidarCampos(
+            codigoEmec, nome, sigla, organizacaoAcademica, categoriaAdministrativa,
+            cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
+            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede, municipioSede);
+        if (validacao.IsFailure)
+        {
+            return validacao;
+        }
+
+        AplicarCampos(
+            codigoEmec, nome, sigla, organizacaoAcademica, categoriaAdministrativa,
+            cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
+            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede,
+            municipioSede, unidadeRaizId);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(
+        string codigoEmec,
+        string nome,
+        string sigla,
+        string organizacaoAcademica,
+        string categoriaAdministrativa,
+        string? cnpj,
+        string? mantenedora,
+        string? codigoMantenedoraEmec,
+        string? situacao,
+        string? atoCredenciamento,
+        string? atoRecredenciamento,
+        string? conceitoInstitucional,
+        string? igc,
+        string? website,
+        string? enderecoSede,
+        string? municipioSede,
+        Guid? unidadeRaizId)
+    {
+        CodigoEmec = codigoEmec.Trim();
+        Nome = nome.Trim();
+        Sigla = sigla.Trim();
+        OrganizacaoAcademica = organizacaoAcademica.Trim();
+        CategoriaAdministrativa = categoriaAdministrativa.Trim();
+        Cnpj = NormalizarOpcional(cnpj);
+        Mantenedora = NormalizarOpcional(mantenedora);
+        CodigoMantenedoraEmec = NormalizarOpcional(codigoMantenedoraEmec);
+        Situacao = NormalizarOpcional(situacao);
+        AtoCredenciamento = NormalizarOpcional(atoCredenciamento);
+        AtoRecredenciamento = NormalizarOpcional(atoRecredenciamento);
+        ConceitoInstitucional = NormalizarOpcional(conceitoInstitucional);
+        Igc = NormalizarOpcional(igc);
+        Website = NormalizarOpcional(website);
+        EnderecoSede = NormalizarOpcional(enderecoSede);
+        MunicipioSede = NormalizarOpcional(municipioSede);
+        UnidadeRaizId = unidadeRaizId;
+    }
+
+    private static string? NormalizarOpcional(string? valor)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return null;
+        }
+
+        return valor.Trim();
+    }
+
+    private static Result ValidarCampos(
+        string codigoEmec,
+        string nome,
+        string sigla,
+        string organizacaoAcademica,
+        string categoriaAdministrativa,
+        string? cnpj,
+        string? mantenedora,
+        string? codigoMantenedoraEmec,
+        string? situacao,
+        string? atoCredenciamento,
+        string? atoRecredenciamento,
+        string? conceitoInstitucional,
+        string? igc,
+        string? website,
+        string? enderecoSede,
+        string? municipioSede)
+    {
+        if (string.IsNullOrWhiteSpace(codigoEmec))
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.CodigoEmecObrigatorio,
+                "Código e-MEC da Instituição é obrigatório."));
+        }
+
+        if (codigoEmec.Trim().Length > CodigoEmecMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.CodigoEmecTamanho,
+                $"Código e-MEC deve ter no máximo {CodigoEmecMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.NomeObrigatorio,
+                "Nome da Instituição é obrigatório."));
+        }
+
+        if (nome.Trim().Length > NomeMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.NomeTamanho,
+                $"Nome da Instituição deve ter no máximo {NomeMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(sigla))
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.SiglaObrigatoria,
+                "Sigla da Instituição é obrigatória."));
+        }
+
+        if (sigla.Trim().Length > SiglaMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.SiglaTamanho,
+                $"Sigla da Instituição deve ter no máximo {SiglaMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(organizacaoAcademica))
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.OrganizacaoAcademicaObrigatoria,
+                "Organização acadêmica da Instituição é obrigatória."));
+        }
+
+        if (organizacaoAcademica.Trim().Length > OrganizacaoAcademicaMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.OrganizacaoAcademicaTamanho,
+                $"Organização acadêmica deve ter no máximo {OrganizacaoAcademicaMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(categoriaAdministrativa))
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.CategoriaAdministrativaObrigatoria,
+                "Categoria administrativa da Instituição é obrigatória."));
+        }
+
+        if (categoriaAdministrativa.Trim().Length > CategoriaAdministrativaMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                InstituicaoErrorCodes.CategoriaAdministrativaTamanho,
+                $"Categoria administrativa deve ter no máximo {CategoriaAdministrativaMaxLength} caracteres."));
+        }
+
+        return ValidarOpcionais(
+            cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
+            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede, municipioSede);
+    }
+
+    private static Result ValidarOpcionais(
+        string? cnpj,
+        string? mantenedora,
+        string? codigoMantenedoraEmec,
+        string? situacao,
+        string? atoCredenciamento,
+        string? atoRecredenciamento,
+        string? conceitoInstitucional,
+        string? igc,
+        string? website,
+        string? enderecoSede,
+        string? municipioSede)
+    {
+        (string? valor, int max)[] opcionais =
+        [
+            (cnpj, CampoOpcionalCurtoMaxLength),
+            (mantenedora, NomeMaxLength),
+            (codigoMantenedoraEmec, CodigoEmecMaxLength),
+            (situacao, CampoOpcionalCurtoMaxLength),
+            (atoCredenciamento, CampoOpcionalLongoMaxLength),
+            (atoRecredenciamento, CampoOpcionalLongoMaxLength),
+            (conceitoInstitucional, CampoOpcionalCurtoMaxLength),
+            (igc, CampoOpcionalCurtoMaxLength),
+            (website, CampoOpcionalMedioMaxLength),
+            (enderecoSede, CampoOpcionalLongoMaxLength),
+            (municipioSede, CampoOpcionalCurtoMaxLength),
+        ];
+
+        foreach ((string? valor, int max) in opcionais)
+        {
+            if (valor is not null && valor.Trim().Length > max)
+            {
+                return Result.Failure(new DomainError(
+                    InstituicaoErrorCodes.CampoOpcionalTamanho,
+                    $"Um dos campos opcionais excede o tamanho máximo de {max} caracteres."));
+            }
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Errors/InstituicaoErrorCodes.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Errors/InstituicaoErrorCodes.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+
+public static class InstituicaoErrorCodes
+{
+    public const string CodigoEmecObrigatorio = "Instituicao.CodigoEmecObrigatorio";
+    public const string CodigoEmecTamanho = "Instituicao.CodigoEmecTamanho";
+    public const string NomeObrigatorio = "Instituicao.NomeObrigatorio";
+    public const string NomeTamanho = "Instituicao.NomeTamanho";
+    public const string SiglaObrigatoria = "Instituicao.SiglaObrigatoria";
+    public const string SiglaTamanho = "Instituicao.SiglaTamanho";
+    public const string OrganizacaoAcademicaObrigatoria = "Instituicao.OrganizacaoAcademicaObrigatoria";
+    public const string OrganizacaoAcademicaTamanho = "Instituicao.OrganizacaoAcademicaTamanho";
+    public const string CategoriaAdministrativaObrigatoria = "Instituicao.CategoriaAdministrativaObrigatoria";
+    public const string CategoriaAdministrativaTamanho = "Instituicao.CategoriaAdministrativaTamanho";
+    public const string CampoOpcionalTamanho = "Instituicao.CampoOpcionalTamanho";
+
+    /// <summary>
+    /// Invariante singleton: já existe uma Instituição viva e a topologia de
+    /// instância única (ADR-0055) admite no máximo uma.
+    /// </summary>
+    public const string JaExisteInstituicaoViva = "Instituicao.JaExisteInstituicaoViva";
+
+    public const string NaoEncontrada = "Instituicao.NaoEncontrada";
+
+    public const string UnidadeRaizNaoEncontrada = "Instituicao.UnidadeRaizNaoEncontrada";
+    public const string UnidadeRaizNaoEhReitoria = "Instituicao.UnidadeRaizNaoEhReitoria";
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IInstituicaoRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IInstituicaoRepository.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+
+/// <summary>
+/// Repositório da entidade singleton <see cref="Instituicao"/> (ADR-0054: banco
+/// isolado de Organização). Todas as leituras excluem registros soft-deleted via
+/// query filter do EF Core, de modo que "viva" e "presente nas leituras padrão"
+/// são equivalentes.
+/// </summary>
+public interface IInstituicaoRepository
+{
+    /// <summary>
+    /// Carrega a Instituição pelo Id, rastreada pelo contexto — para mutação
+    /// (atualização/remoção).
+    /// </summary>
+    Task<Instituicao?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Carrega a Instituição viva (singleton) para leitura (<c>AsNoTracking</c>),
+    /// ou <see langword="null"/> se nenhuma existe — para projeção em DTO/View.
+    /// </summary>
+    Task<Instituicao?> ObterParaLeituraAsync(CancellationToken cancellationToken);
+
+    Task AdicionarAsync(Instituicao instituicao, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca a Instituição para remoção no contexto EF. O
+    /// <c>SoftDeleteInterceptor</c> converte automaticamente para soft-delete
+    /// preenchendo <c>DeletedBy</c>/<c>DeletedAt</c> a partir do
+    /// <c>IUserContext</c> e do <c>TimeProvider</c>.
+    /// </summary>
+    void Remover(Instituicao instituicao);
+
+    /// <summary>
+    /// Indica se já existe alguma Instituição viva — guard de domínio do
+    /// invariante singleton, consultado na criação (ADR-0055).
+    /// </summary>
+    Task<bool> ExisteAlgumaVivaAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Indica se alguma Instituição viva referencia <paramref name="unidadeId"/>
+    /// como unidade raiz — usado para bloquear a remoção de uma Unidade que é a
+    /// reitoria vinculada à Instituição.
+    /// </summary>
+    Task<bool> ExisteComUnidadeRaizAsync(Guid unidadeId, CancellationToken cancellationToken);
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Caching/InstituicaoCacheInvalidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Caching/InstituicaoCacheInvalidator.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Caching;
+
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em OrganizacaoInstitucionalInfrastructureRegistration.")]
+internal sealed partial class InstituicaoCacheInvalidator : IInstituicaoCacheInvalidator
+{
+    private readonly ICacheService _cache;
+    private readonly ILogger<InstituicaoCacheInvalidator> _logger;
+
+    public InstituicaoCacheInvalidator(ICacheService cache, ILogger<InstituicaoCacheInvalidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(logger);
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task InvalidarAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _cache.RemoverAsync(InstituicaoCacheKeys.InstituicaoAtual, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogFalhaInvalidacao(_logger, ex);
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Falha ao invalidar cache da Instituição após mutação — cache stale até TTL natural.")]
+    private static partial void LogFalhaInvalidacao(ILogger logger, Exception exception);
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Caching/InstituicaoCacheKeys.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Caching/InstituicaoCacheKeys.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Caching;
+
+internal static class InstituicaoCacheKeys
+{
+    public const string InstituicaoAtual = "organizacao:instituicao:atual";
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/DependencyInjection.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/DependencyInjection.cs
@@ -37,6 +37,7 @@ public static class OrganizacaoInstitucionalInfrastructureRegistration
 
         services.AddScoped<IAreaOrganizacionalRepository, AreaOrganizacionalRepository>();
         services.AddScoped<IUnidadeRepository, UnidadeRepository>();
+        services.AddScoped<IInstituicaoRepository, InstituicaoRepository>();
 
         // Readers cross-módulo (ADR-0056) + cache invalidators. Scoped porque
         // dependem de ICacheService (Scoped) e DbContext (Scoped).
@@ -44,6 +45,8 @@ public static class OrganizacaoInstitucionalInfrastructureRegistration
         services.AddScoped<IAreaOrganizacionalCacheInvalidator, AreaOrganizacionalCacheInvalidator>();
         services.AddScoped<IUnidadeReader, UnidadeReader>();
         services.AddScoped<IUnidadeCacheInvalidator, UnidadeCacheInvalidator>();
+        services.AddScoped<IInstituicaoReader, InstituicaoReader>();
+        services.AddScoped<IInstituicaoCacheInvalidator, InstituicaoCacheInvalidator>();
 
         return services;
     }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/InstituicaoConfiguration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/InstituicaoConfiguration.cs
@@ -1,0 +1,77 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class InstituicaoConfiguration : IEntityTypeConfiguration<Instituicao>
+{
+    public void Configure(EntityTypeBuilder<Instituicao> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // CHECK fixa a sentinela como verdadeiramente constante no banco: sem ela,
+        // qualquer caminho de escrita (SQL de carga, correção manual) poderia gravar
+        // registro_vivo_sentinela = false e burlar o índice único parcial — duas
+        // Instituições vivas (uma true, uma false) passariam. Com o CHECK, a coluna
+        // só admite true, então o índice único parcial garante de fato o singleton.
+        builder.ToTable("instituicao", t =>
+            t.HasCheckConstraint("ck_instituicao_singleton_sentinela", "registro_vivo_sentinela = true"));
+        builder.HasKey(i => i.Id);
+
+        builder.Property(i => i.CodigoEmec).HasMaxLength(20).IsRequired();
+        builder.Property(i => i.Nome).HasMaxLength(250).IsRequired();
+        builder.Property(i => i.Sigla).HasMaxLength(50).IsRequired();
+        builder.Property(i => i.OrganizacaoAcademica).HasMaxLength(100).IsRequired();
+        builder.Property(i => i.CategoriaAdministrativa).HasMaxLength(100).IsRequired();
+        builder.Property(i => i.Cnpj).HasMaxLength(100);
+        builder.Property(i => i.Mantenedora).HasMaxLength(250);
+        builder.Property(i => i.CodigoMantenedoraEmec).HasMaxLength(20);
+        builder.Property(i => i.Situacao).HasMaxLength(100);
+        builder.Property(i => i.AtoCredenciamento).HasMaxLength(500);
+        builder.Property(i => i.AtoRecredenciamento).HasMaxLength(500);
+        builder.Property(i => i.ConceitoInstitucional).HasMaxLength(100);
+        builder.Property(i => i.Igc).HasMaxLength(100);
+        builder.Property(i => i.Website).HasMaxLength(255);
+        builder.Property(i => i.EnderecoSede).HasMaxLength(500);
+        builder.Property(i => i.MunicipioSede).HasMaxLength(100);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(i => i.CreatedBy).HasMaxLength(255);
+        builder.Property(i => i.UpdatedBy).HasMaxLength(255);
+
+        // Vínculo com a Unidade raiz (reitoria): FK intra-banco (ADR-0054).
+        // Restrict no banco — a remoção lógica da Unidade é barrada pelo handler
+        // (UnidadeErrorCodes.RemocaoBloqueadaPorInstituicao); o RESTRICT cobre o
+        // DELETE físico residual.
+        builder.HasOne<Unidade>()
+            .WithMany()
+            .HasForeignKey(i => i.UnidadeRaizId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(i => i.UnidadeRaizId)
+            .HasDatabaseName("ix_instituicao_unidade_raiz_id");
+
+        // Salvaguarda física do singleton: a sentinela é uma propriedade real
+        // sempre true (a entidade a inicializa), então o EF grava true de forma
+        // confiável — diferente de uma shadow bool, que o EF gravaria como o
+        // default CLR (false) e violaria o CHECK. HasDefaultValue cobre inserts
+        // crus que omitam a coluna.
+        builder.Property(i => i.RegistroVivoSentinela)
+            .HasColumnName("registro_vivo_sentinela")
+            .HasDefaultValue(true);
+
+        builder.HasIndex(i => i.RegistroVivoSentinela)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_instituicao_singleton_vivo");
+
+        builder.HasQueryFilter(i => !i.IsDeleted);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260609230450_AddInstituicao.Designer.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260609230450_AddInstituicao.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(OrganizacaoInstitucionalDbContext))]
-    partial class OrganizacaoInstitucionalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260609230450_AddInstituicao")]
+    partial class AddInstituicao
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260609230450_AddInstituicao.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260609230450_AddInstituicao.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstituicao : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "instituicao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo_emec = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    nome = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    sigla = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    organizacao_academica = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    categoria_administrativa = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    cnpj = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    mantenedora = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: true),
+                    codigo_mantenedora_emec = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    situacao = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ato_credenciamento = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    ato_recredenciamento = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    conceito_institucional = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    igc = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    website = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    endereco_sede = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    municipio_sede = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    unidade_raiz_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    registro_vivo_sentinela = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_instituicao", x => x.id);
+                    table.CheckConstraint("ck_instituicao_singleton_sentinela", "registro_vivo_sentinela = true");
+                    table.ForeignKey(
+                        name: "fk_instituicao_unidades_unidade_raiz_id",
+                        column: x => x.unidade_raiz_id,
+                        principalTable: "unidade",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_instituicao_singleton_vivo",
+                table: "instituicao",
+                column: "registro_vivo_sentinela",
+                unique: true,
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_instituicao_unidade_raiz_id",
+                table: "instituicao",
+                column: "unidade_raiz_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Forward-only per ADR-0054 §J: nova migration "Reverte..." é o
+            // mecanismo canônico de revert. Dropar a tabela aqui induziria um
+            // `database update <baseline>` a destruir instituicao em staging/prod
+            // sem audit trail — caminho proibido.
+            throw new NotSupportedException("Forward-only migration per ADR-0054 §J.");
+        }
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/OrganizacaoInstitucionalDbContext.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/OrganizacaoInstitucionalDbContext.cs
@@ -26,6 +26,8 @@ public sealed class OrganizacaoInstitucionalDbContext : DbContext, IUnitOfWork
     public DbSet<UnidadeIdentificadorHistorico> UnidadesIdentificadoresHistorico =>
         Set<UnidadeIdentificadorHistorico>();
 
+    public DbSet<Instituicao> Instituicoes => Set<Instituicao>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do agregado
     /// para permitir gravação adjacente no outbox; entries cifradas at-rest

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/InstituicaoRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/InstituicaoRepository.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em OrganizacaoInstitucionalInfrastructureRegistration.")]
+internal sealed class InstituicaoRepository : IInstituicaoRepository
+{
+    private readonly OrganizacaoInstitucionalDbContext _dbContext;
+
+    public InstituicaoRepository(OrganizacaoInstitucionalDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<Instituicao?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Instituicoes
+            .FirstOrDefaultAsync(i => i.Id == id, cancellationToken);
+    }
+
+    public Task<Instituicao?> ObterParaLeituraAsync(CancellationToken cancellationToken)
+    {
+        // Query filter exclui soft-deleted; sob o singleton há no máximo uma viva.
+        return _dbContext.Instituicoes
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task AdicionarAsync(Instituicao instituicao, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(instituicao);
+        await _dbContext.Instituicoes.AddAsync(instituicao, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(Instituicao instituicao)
+    {
+        ArgumentNullException.ThrowIfNull(instituicao);
+        _dbContext.Instituicoes.Remove(instituicao);
+    }
+
+    public Task<bool> ExisteAlgumaVivaAsync(CancellationToken cancellationToken)
+    {
+        // Query filter exclui soft-deleted ⇒ AnyAsync reflete apenas registros vivos.
+        return _dbContext.Instituicoes
+            .AsNoTracking()
+            .AnyAsync(cancellationToken);
+    }
+
+    public Task<bool> ExisteComUnidadeRaizAsync(Guid unidadeId, CancellationToken cancellationToken)
+    {
+        return _dbContext.Instituicoes
+            .AsNoTracking()
+            .AnyAsync(i => i.UnidadeRaizId == unidadeId, cancellationToken);
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Readers/InstituicaoReader.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Readers/InstituicaoReader.cs
@@ -1,0 +1,109 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Mappings;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Caching;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação canônica de <see cref="IInstituicaoReader"/>: cache Redis
+/// (TTL 5 min) fail-open sobre a <c>Instituicao</c> singleton.
+/// </summary>
+/// <remarks>
+/// Sem stampede protection por lease (ao contrário do <c>UnidadeReader</c>): a
+/// carga da fonte é uma consulta de uma única linha (singleton — ADR-0055),
+/// barata o bastante para que uma corrida de cache miss não justifique a
+/// coordenação. Nunca cacheia ausência — quando ainda não há Instituição
+/// cadastrada, a fonte é consultada a cada chamada até a primeira criação.
+/// </remarks>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em OrganizacaoInstitucionalInfrastructureRegistration.")]
+internal sealed partial class InstituicaoReader : IInstituicaoReader
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    private readonly ICacheService _cache;
+    private readonly OrganizacaoInstitucionalDbContext _dbContext;
+    private readonly ILogger<InstituicaoReader> _logger;
+
+    public InstituicaoReader(
+        ICacheService cache,
+        OrganizacaoInstitucionalDbContext dbContext,
+        ILogger<InstituicaoReader> logger)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(logger);
+        _cache = cache;
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    public async Task<InstituicaoView?> ObterAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        InstituicaoView? cacheado = await ObterDoCacheAsync(cancellationToken).ConfigureAwait(false);
+        if (cacheado is not null)
+        {
+            return cacheado;
+        }
+
+        Instituicao? instituicao = await _dbContext.Instituicoes
+            .AsNoTracking()
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (instituicao is null)
+        {
+            return null;
+        }
+
+        InstituicaoView view = instituicao.ToView();
+
+        try
+        {
+            await _cache.DefinirAsync(InstituicaoCacheKeys.InstituicaoAtual, view, CacheTtl, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogFalhaPopularCache(_logger, ex);
+        }
+
+        return view;
+    }
+
+    private async Task<InstituicaoView?> ObterDoCacheAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _cache.ObterAsync<InstituicaoView>(
+                InstituicaoCacheKeys.InstituicaoAtual,
+                cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            LogFalhaLerCache(_logger, ex);
+            return null;
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Falha ao popular cache da Instituição após carregar da fonte.")]
+    private static partial void LogFalhaPopularCache(ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Falha ao ler cache da Instituição; usando fonte direta.")]
+    private static partial void LogFalhaLerCache(ILogger logger, Exception exception);
+}

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/IInstituicaoReader.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/IInstituicaoReader.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo da <c>Instituicao</c> singleton (ADR-0056). Expõe o
+/// estado vivo do cabeçalho institucional para consumo por outros bounded
+/// contexts (ex.: Seleção, Configuração) sem acesso direto ao banco de
+/// Organização (ADR-0054).
+/// </summary>
+/// <remarks>
+/// A <c>Instituicao</c> é singleton (ADR-0055): há no máximo uma viva por
+/// instância. A implementação canônica resolve o registro corrente respaldada
+/// por cache Redis, sem congelamento — o consumo é sempre do dado vivo. Cada API
+/// que precisa do cabeçalho institucional hospeda sua própria instância via
+/// <c>AddOrganizacaoInstitucionalInfrastructure()</c>.
+/// </remarks>
+public interface IInstituicaoReader
+{
+    /// <summary>
+    /// Obtém a Instituição viva (singleton), ou <see langword="null"/> se nenhuma
+    /// foi cadastrada ainda.
+    /// </summary>
+    Task<InstituicaoView?> ObterAsync(CancellationToken cancellationToken = default);
+}

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/InstituicaoView.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/InstituicaoView.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Governance.Contracts;
+
+/// <summary>
+/// DTO read-only da <c>Instituicao</c> singleton para consumo cross-módulo via
+/// <see cref="IInstituicaoReader"/> (ADR-0056). Expõe o cabeçalho institucional
+/// (identificação regulatória e-MEC) que outros bounded contexts — Seleção,
+/// Configuração — exibem em editais e comprovantes, sem dados de auditoria
+/// interna nem acesso direto à tabela do banco de Organização (ADR-0054).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="CodigoEmec">Código e-MEC da instituição (chave natural regulatória).</param>
+/// <param name="Nome">Nome formal da instituição.</param>
+/// <param name="Sigla">Sigla da instituição.</param>
+/// <param name="Cnpj">CNPJ da pessoa jurídica, ou <see langword="null"/> se não informado.</param>
+/// <param name="OrganizacaoAcademica">Classificação e-MEC de organização acadêmica.</param>
+/// <param name="CategoriaAdministrativa">Classificação e-MEC de categoria administrativa.</param>
+/// <param name="MunicipioSede">Município da sede, ou <see langword="null"/> se não informado.</param>
+/// <param name="UnidadeRaizId">Id da Unidade raiz (reitoria), ou <see langword="null"/> se ainda não vinculada.</param>
+public sealed record InstituicaoView(
+    Guid Id,
+    string CodigoEmec,
+    string Nome,
+    string Sigla,
+    string? Cnpj,
+    string OrganizacaoAcademica,
+    string CategoriaAdministrativa,
+    string? MunicipioSede,
+    Guid? UnidadeRaizId);

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarInstituicaoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarInstituicaoCommandHandlerTests.cs
@@ -1,0 +1,108 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+public sealed class AtualizarInstituicaoCommandHandlerTests
+{
+    private static Instituicao InstituicaoExistente() =>
+        Instituicao.Criar(
+            "3990", "Universidade Federal do Sul e Sudeste do Pará", "Unifesspa", "Universidade", "Pública Federal",
+            null, null, null, null, null, null, null, null, null, null, null, null).Value!;
+
+    private static AtualizarInstituicaoCommand CommandValido(Guid id, Guid? unidadeRaizId = null) => new(
+        id, "3990", "Universidade Federal do Sul e Sudeste do Pará", "Unifesspa", "Universidade", "Pública Federal",
+        Cnpj: null, Mantenedora: null, CodigoMantenedoraEmec: null, Situacao: null, AtoCredenciamento: null,
+        AtoRecredenciamento: null, ConceitoInstitucional: null, Igc: null, Website: null, EnderecoSede: null,
+        MunicipioSede: null, unidadeRaizId);
+
+    private static Unidade NovaUnidade(TipoUnidade tipo) =>
+        Unidade.Criar(
+            "Reitoria", null, Slug.From("reitoria").Value!, "REIT", "REIT001",
+            null, tipo, false, new DateOnly(2026, 1, 1), null, OrigemUnidade.CriadoNoUniPlus).Value!;
+
+    [Fact(DisplayName = "Handle com Instituição inexistente retorna NaoEncontrada e NÃO persiste")]
+    public async Task Handle_ComInstituicaoInexistente_RetornaNaoEncontrada()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        repo.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Instituicao?)null);
+
+        Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
+            CommandValido(Guid.CreateVersion7()), repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.NaoEncontrada);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com campos válidos atualiza e invalida cache")]
+    public async Task Handle_ComCamposValidos_AtualizaEInvalidaCache()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        Instituicao existente = InstituicaoExistente();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
+            CommandValido(existente.Id), repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await uow.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.Received(1).InvalidarAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com unidade raiz reitoria aceita o vínculo (CA-04)")]
+    public async Task Handle_ComUnidadeRaizReitoria_Aceita()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        Instituicao existente = InstituicaoExistente();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        Unidade reitoria = NovaUnidade(TipoUnidade.Reitoria);
+        unidadeRepo.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(reitoria);
+
+        Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
+            CommandValido(existente.Id, reitoria.Id), repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.UnidadeRaizId.Should().Be(reitoria.Id);
+    }
+
+    [Fact(DisplayName = "Handle com unidade raiz de outro tipo retorna UnidadeRaizNaoEhReitoria (CA-04)")]
+    public async Task Handle_ComUnidadeRaizNaoReitoria_RetornaErro()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        Instituicao existente = InstituicaoExistente();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        Unidade centro = NovaUnidade(TipoUnidade.Centro);
+        unidadeRepo.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(centro);
+
+        Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
+            CommandValido(existente.Id, Guid.CreateVersion7()), repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.UnidadeRaizNaoEhReitoria);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/CriarInstituicaoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/CriarInstituicaoCommandHandlerTests.cs
@@ -1,0 +1,153 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+
+public sealed class CriarInstituicaoCommandHandlerTests
+{
+    private static CriarInstituicaoCommand CommandValido(Guid? unidadeRaizId = null) => new(
+        "3990",
+        "Universidade Federal do Sul e Sudeste do Pará",
+        "Unifesspa",
+        "Universidade",
+        "Pública Federal",
+        Cnpj: null,
+        Mantenedora: null,
+        CodigoMantenedoraEmec: null,
+        Situacao: null,
+        AtoCredenciamento: null,
+        AtoRecredenciamento: null,
+        ConceitoInstitucional: null,
+        Igc: null,
+        Website: null,
+        EnderecoSede: null,
+        MunicipioSede: null,
+        unidadeRaizId);
+
+    private static Unidade NovaUnidade(TipoUnidade tipo) =>
+        Unidade.Criar(
+            "Reitoria", null, Slug.From("reitoria").Value!, "REIT", "REIT001",
+            null, tipo, false, new DateOnly(2026, 1, 1), null, OrigemUnidade.CriadoNoUniPlus).Value!;
+
+    [Fact(DisplayName = "Handle sem Instituição existente cria, persiste e invalida cache (CA-01)")]
+    public async Task Handle_SemInstituicaoExistente_CriaInstituicaoAtiva()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        repo.ExisteAlgumaVivaAsync(Arg.Any<CancellationToken>()).Returns(false);
+
+        Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
+            CommandValido(), repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBeEmpty();
+        await repo.Received(1).AdicionarAsync(Arg.Any<Instituicao>(), Arg.Any<CancellationToken>());
+        await uow.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.Received(1).InvalidarAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com Instituição viva existente retorna JaExiste e NÃO persiste (CA-02)")]
+    public async Task Handle_ComInstituicaoVivaExistente_RetornaJaExiste()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        repo.ExisteAlgumaVivaAsync(Arg.Any<CancellationToken>()).Returns(true);
+
+        Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
+            CommandValido(), repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.JaExisteInstituicaoViva);
+        await repo.DidNotReceive().AdicionarAsync(Arg.Any<Instituicao>(), Arg.Any<CancellationToken>());
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com unidade raiz inexistente retorna UnidadeRaizNaoEncontrada (CA-04)")]
+    public async Task Handle_ComUnidadeRaizInexistente_RetornaErro()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        repo.ExisteAlgumaVivaAsync(Arg.Any<CancellationToken>()).Returns(false);
+        Guid raizId = Guid.CreateVersion7();
+        unidadeRepo.ObterPorIdParaLeituraAsync(raizId, Arg.Any<CancellationToken>()).Returns((Unidade?)null);
+
+        Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
+            CommandValido(raizId), repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.UnidadeRaizNaoEncontrada);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com unidade raiz de outro tipo retorna UnidadeRaizNaoEhReitoria (CA-04)")]
+    public async Task Handle_ComUnidadeRaizNaoReitoria_RetornaErro()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        repo.ExisteAlgumaVivaAsync(Arg.Any<CancellationToken>()).Returns(false);
+        Unidade centro = NovaUnidade(TipoUnidade.Centro);
+        unidadeRepo.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(centro);
+
+        Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
+            CommandValido(Guid.CreateVersion7()), repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.UnidadeRaizNaoEhReitoria);
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com unidade raiz do tipo reitoria cria com sucesso (CA-04 contraprova)")]
+    public async Task Handle_ComUnidadeRaizReitoria_Cria()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        repo.ExisteAlgumaVivaAsync(Arg.Any<CancellationToken>()).Returns(false);
+        Unidade reitoria = NovaUnidade(TipoUnidade.Reitoria);
+        unidadeRepo.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(reitoria);
+
+        Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
+            CommandValido(reitoria.Id), repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await repo.Received(1).AdicionarAsync(Arg.Any<Instituicao>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com campo obrigatório vazio retorna erro de domínio e NÃO persiste")]
+    public async Task Handle_ComCampoObrigatorioVazio_RetornaErro()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        repo.ExisteAlgumaVivaAsync(Arg.Any<CancellationToken>()).Returns(false);
+        CriarInstituicaoCommand command = CommandValido() with { CodigoEmec = "" };
+
+        Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
+            command, repo, unidadeRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.CodigoEmecObrigatorio);
+        await repo.DidNotReceive().AdicionarAsync(Arg.Any<Instituicao>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/RemoverInstituicaoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/RemoverInstituicaoCommandHandlerTests.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
+
+public sealed class RemoverInstituicaoCommandHandlerTests
+{
+    private static Instituicao InstituicaoExistente() =>
+        Instituicao.Criar(
+            "3990", "Universidade Federal do Sul e Sudeste do Pará", "Unifesspa", "Universidade", "Pública Federal",
+            null, null, null, null, null, null, null, null, null, null, null, null).Value!;
+
+    [Fact(DisplayName = "Handle com Instituição existente faz soft-delete e invalida cache (CA-05)")]
+    public async Task Handle_ComInstituicaoExistente_RemoveEInvalidaCache()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        Instituicao existente = InstituicaoExistente();
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await RemoverInstituicaoCommandHandler.Handle(
+            new RemoverInstituicaoCommand(existente.Id), repo, uow, cache, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        repo.Received(1).Remover(existente);
+        await uow.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.Received(1).InvalidarAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com Instituição inexistente retorna NaoEncontrada e NÃO persiste")]
+    public async Task Handle_ComInstituicaoInexistente_RetornaNaoEncontrada()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        repo.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Instituicao?)null);
+
+        Result resultado = await RemoverInstituicaoCommandHandler.Handle(
+            new RemoverInstituicaoCommand(Guid.CreateVersion7()), repo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.NaoEncontrada);
+        repo.DidNotReceive().Remover(Arg.Any<Instituicao>());
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/RemoverUnidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/RemoverUnidadeCommandHandlerTests.cs
@@ -34,15 +34,17 @@ public sealed class RemoverUnidadeCommandHandlerTests
     public async Task Handle_ComUnidadeValida_RemoveEInvalidaCache()
     {
         IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IInstituicaoRepository instituicaoRepo = Substitute.For<IInstituicaoRepository>();
         IUnitOfWork uow = Substitute.For<IUnitOfWork>();
         IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
 
         Unidade unidade = CriarUnidade();
         repo.ObterPorIdAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(unidade);
         repo.PossuiSubordinadasVivasAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(false);
+        instituicaoRepo.ExisteComUnidadeRaizAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(false);
 
         Result resultado = await RemoverUnidadeCommandHandler.Handle(
-            new RemoverUnidadeCommand(unidade.Id), repo, uow, cache, CancellationToken.None);
+            new RemoverUnidadeCommand(unidade.Id), repo, instituicaoRepo, uow, cache, CancellationToken.None);
 
         resultado.IsSuccess.Should().BeTrue();
         repo.Received(1).Remover(unidade);
@@ -54,12 +56,13 @@ public sealed class RemoverUnidadeCommandHandlerTests
     public async Task Handle_ComUnidadeInexistente_RetornaNaoEncontrada()
     {
         IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IInstituicaoRepository instituicaoRepo = Substitute.For<IInstituicaoRepository>();
         IUnitOfWork uow = Substitute.For<IUnitOfWork>();
         IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
         repo.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Unidade?)null);
 
         Result resultado = await RemoverUnidadeCommandHandler.Handle(
-            new RemoverUnidadeCommand(Guid.NewGuid()), repo, uow, cache, CancellationToken.None);
+            new RemoverUnidadeCommand(Guid.NewGuid()), repo, instituicaoRepo, uow, cache, CancellationToken.None);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(UnidadeErrorCodes.NaoEncontrada);
@@ -71,6 +74,7 @@ public sealed class RemoverUnidadeCommandHandlerTests
     public async Task Handle_ComSubordinadasVivas_RetornaBloqueio()
     {
         IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IInstituicaoRepository instituicaoRepo = Substitute.For<IInstituicaoRepository>();
         IUnitOfWork uow = Substitute.For<IUnitOfWork>();
         IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
 
@@ -79,11 +83,34 @@ public sealed class RemoverUnidadeCommandHandlerTests
         repo.PossuiSubordinadasVivasAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(true);
 
         Result resultado = await RemoverUnidadeCommandHandler.Handle(
-            new RemoverUnidadeCommand(unidade.Id), repo, uow, cache, CancellationToken.None);
+            new RemoverUnidadeCommand(unidade.Id), repo, instituicaoRepo, uow, cache, CancellationToken.None);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(UnidadeErrorCodes.RemocaoBloqueadaPorSubordinadas);
         repo.DidNotReceive().Remover(Arg.Any<Unidade>());
         await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com unidade que é raiz de Instituição viva retorna RemocaoBloqueadaPorInstituicao e NÃO persiste")]
+    public async Task Handle_ComUnidadeRaizDeInstituicao_RetornaBloqueio()
+    {
+        IUnidadeRepository repo = Substitute.For<IUnidadeRepository>();
+        IInstituicaoRepository instituicaoRepo = Substitute.For<IInstituicaoRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IUnidadeCacheInvalidator cache = Substitute.For<IUnidadeCacheInvalidator>();
+
+        Unidade unidade = CriarUnidade();
+        repo.ObterPorIdAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(unidade);
+        repo.PossuiSubordinadasVivasAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(false);
+        instituicaoRepo.ExisteComUnidadeRaizAsync(unidade.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result resultado = await RemoverUnidadeCommandHandler.Handle(
+            new RemoverUnidadeCommand(unidade.Id), repo, instituicaoRepo, uow, cache, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(UnidadeErrorCodes.RemocaoBloqueadaPorInstituicao);
+        repo.DidNotReceive().Remover(Arg.Any<Unidade>());
+        await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        await cache.DidNotReceive().InvalidarAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/InstituicaoTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/InstituicaoTests.cs
@@ -1,0 +1,130 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
+
+/// <summary>
+/// Testes de unidade do agregado <see cref="Instituicao"/> (Story #585):
+/// validação de formato na factory e na atualização. O invariante singleton e a
+/// conferência do tipo da Unidade raiz são responsabilidade do handler e estão
+/// cobertos nos testes de Application/Integration.
+/// </summary>
+public sealed class InstituicaoTests
+{
+    private static Result<Instituicao> CriarValida(
+        string codigoEmec = "3990",
+        string nome = "Universidade Federal do Sul e Sudeste do Pará",
+        string sigla = "Unifesspa",
+        string organizacaoAcademica = "Universidade",
+        string categoriaAdministrativa = "Pública Federal",
+        Guid? unidadeRaizId = null) =>
+        Instituicao.Criar(
+            codigoEmec,
+            nome,
+            sigla,
+            organizacaoAcademica,
+            categoriaAdministrativa,
+            cnpj: null,
+            mantenedora: null,
+            codigoMantenedoraEmec: null,
+            situacao: null,
+            atoCredenciamento: null,
+            atoRecredenciamento: null,
+            conceitoInstitucional: null,
+            igc: null,
+            website: null,
+            enderecoSede: null,
+            municipioSede: null,
+            unidadeRaizId);
+
+    [Fact(DisplayName = "Criar com campos válidos retorna sucesso com Id Guid v7 não vazio (CA-01)")]
+    public void Criar_ComCamposValidos_RetornaSucessoComGuidV7()
+    {
+        Result<Instituicao> resultado = CriarValida();
+
+        resultado.IsSuccess.Should().BeTrue();
+        Instituicao instituicao = resultado.Value!;
+        instituicao.Id.Should().NotBe(Guid.Empty);
+        instituicao.Id.Version.Should().Be(7);
+        instituicao.CodigoEmec.Should().Be("3990");
+        instituicao.Sigla.Should().Be("Unifesspa");
+        instituicao.IsDeleted.Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "Criar sem um campo obrigatório retorna o erro correspondente (CA-03)")]
+    [InlineData("", "Nome", "SIGLA", "Org", "Cat", InstituicaoErrorCodes.CodigoEmecObrigatorio)]
+    [InlineData("3990", "", "SIGLA", "Org", "Cat", InstituicaoErrorCodes.NomeObrigatorio)]
+    [InlineData("3990", "Nome", "", "Org", "Cat", InstituicaoErrorCodes.SiglaObrigatoria)]
+    [InlineData("3990", "Nome", "SIGLA", "", "Cat", InstituicaoErrorCodes.OrganizacaoAcademicaObrigatoria)]
+    [InlineData("3990", "Nome", "SIGLA", "Org", "", InstituicaoErrorCodes.CategoriaAdministrativaObrigatoria)]
+    public void Criar_SemCampoObrigatorio_RetornaErro(
+        string codigoEmec,
+        string nome,
+        string sigla,
+        string organizacaoAcademica,
+        string categoriaAdministrativa,
+        string codigoEsperado)
+    {
+        Result<Instituicao> resultado = CriarValida(
+            codigoEmec, nome, sigla, organizacaoAcademica, categoriaAdministrativa);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(codigoEsperado);
+    }
+
+    [Fact(DisplayName = "Criar normaliza Trim dos campos e converte opcionais em branco para null")]
+    public void Criar_NormalizaTrimEOpcionaisVazios()
+    {
+        Result<Instituicao> resultado = Instituicao.Criar(
+            "  3990  ", "  Universidade  ", "  Unifesspa  ", "  Universidade  ", "  Pública Federal  ",
+            cnpj: "   ", mantenedora: "  Fundação  ", codigoMantenedoraEmec: null, situacao: null,
+            atoCredenciamento: null, atoRecredenciamento: null, conceitoInstitucional: null, igc: null,
+            website: null, enderecoSede: null, municipioSede: "  Marabá  ", unidadeRaizId: null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        Instituicao instituicao = resultado.Value!;
+        instituicao.CodigoEmec.Should().Be("3990");
+        instituicao.Nome.Should().Be("Universidade");
+        instituicao.Cnpj.Should().BeNull("string só com espaços vira null");
+        instituicao.Mantenedora.Should().Be("Fundação");
+        instituicao.MunicipioSede.Should().Be("Marabá");
+    }
+
+    [Fact(DisplayName = "Atualizar com campos válidos altera o estado regulatório e o vínculo")]
+    public void Atualizar_ComCamposValidos_AlteraEstado()
+    {
+        Instituicao instituicao = CriarValida().Value!;
+        Guid novaRaiz = Guid.CreateVersion7();
+
+        Result resultado = instituicao.Atualizar(
+            "4000", "Universidade Federal Renomeada", "UFR", "Universidade", "Pública Federal",
+            cnpj: "12.345.678/0001-99", mantenedora: null, codigoMantenedoraEmec: null, situacao: "Credenciada",
+            atoCredenciamento: "Portaria 123", atoRecredenciamento: null, conceitoInstitucional: "4", igc: "4",
+            website: "https://unifesspa.edu.br", enderecoSede: null, municipioSede: "Marabá", unidadeRaizId: novaRaiz);
+
+        resultado.IsSuccess.Should().BeTrue();
+        instituicao.CodigoEmec.Should().Be("4000");
+        instituicao.Sigla.Should().Be("UFR");
+        instituicao.Situacao.Should().Be("Credenciada");
+        instituicao.UnidadeRaizId.Should().Be(novaRaiz);
+    }
+
+    [Fact(DisplayName = "Atualizar sem nome retorna NomeObrigatorio e preserva o estado anterior")]
+    public void Atualizar_SemNome_RetornaErro()
+    {
+        Instituicao instituicao = CriarValida().Value!;
+
+        Result resultado = instituicao.Atualizar(
+            "3990", "", "Unifesspa", "Universidade", "Pública Federal",
+            cnpj: null, mantenedora: null, codigoMantenedoraEmec: null, situacao: null,
+            atoCredenciamento: null, atoRecredenciamento: null, conceitoInstitucional: null, igc: null,
+            website: null, enderecoSede: null, municipioSede: null, unidadeRaizId: null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.NomeObrigatorio);
+        instituicao.Nome.Should().Be("Universidade Federal do Sul e Sudeste do Pará");
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoDbFixture.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoDbFixture.cs
@@ -1,0 +1,77 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Instituicoes;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Testcontainers.PostgreSql;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Unidades;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+
+/// <summary>
+/// Fixture xUnit que provisiona um Postgres efêmero (Testcontainers) com o
+/// schema do <see cref="OrganizacaoInstitucionalDbContext"/> aplicado via
+/// <c>MigrateAsync</c>, e expõe uma factory de DbContext com os MESMOS
+/// interceptors da produção (SoftDelete + Auditable).
+/// </summary>
+/// <remarks>
+/// Story #585 — valida ponta-a-ponta o invariante singleton da
+/// <c>Instituicao</c>: índice único parcial sobre a coluna sentinela
+/// (<c>WHERE is_deleted = false</c>), soft-delete liberando o slot, FK intra-banco
+/// <c>unidade_raiz_id → unidade(id)</c> e audit trail.
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IAsyncLifetime + IClassFixture<T> exigem tipo público.")]
+[SuppressMessage(
+    "Reliability",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Disposable resources released by IAsyncLifetime.DisposeAsync — xUnit invoca deterministicamente.")]
+public sealed class InstituicaoDbFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_instituicao_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    public string ConnectionString => _postgres.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync().ConfigureAwait(false);
+
+        await using OrganizacaoInstitucionalDbContext context = CreateDbContext(userId: null);
+        await context.Database.MigrateAsync().ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _postgres.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Constrói um <see cref="OrganizacaoInstitucionalDbContext"/> com os
+    /// interceptors de produção. Quando <paramref name="userId"/> é informado,
+    /// simula um <c>IUserContext</c> autenticado; caso contrário, os interceptors
+    /// usam o fallback <c>"system"</c>.
+    /// </summary>
+    public OrganizacaoInstitucionalDbContext CreateDbContext(string? userId)
+    {
+        StubUserContext? userContext = userId is null ? null : new StubUserContext(userId);
+
+        DbContextOptions<OrganizacaoInstitucionalDbContext> options =
+            new DbContextOptionsBuilder<OrganizacaoInstitucionalDbContext>()
+                .UseNpgsql(ConnectionString)
+                .UseSnakeCaseNamingConvention()
+                .AddInterceptors(
+                    new SoftDeleteInterceptor(TimeProvider.System, userContext),
+                    new AuditableInterceptor(TimeProvider.System, userContext))
+                .Options;
+
+        return new OrganizacaoInstitucionalDbContext(options);
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoEndpointTests.cs
@@ -1,0 +1,100 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Instituicoes;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Text;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Smoke tests dos endpoints da <c>Instituicao</c> singleton (Story #585).
+/// Verificam routing, autenticação/autorização e o 404 do GET quando nenhuma
+/// Instituição foi cadastrada, com Wolverine rodando contra Postgres efêmero
+/// (<see cref="OrganizacaoEndpointFixture"/>).
+/// </summary>
+[Collection(OrganizacaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class InstituicaoEndpointTests
+{
+    private readonly OrganizacaoEndpointFixture _fixture;
+
+    public InstituicaoEndpointTests(OrganizacaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/instituicao retorna 404 quando nenhuma Instituição cadastrada")]
+    public async Task Obter_SemInstituicao_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/instituicao", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/admin/instituicao sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Post,
+            new Uri("/api/admin/instituicao", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "Idempotency-Key é obrigatório — sem ela o filtro retorna 400 antes do action");
+    }
+
+    [Fact(DisplayName = "POST /api/admin/instituicao sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Post,
+            new Uri("/api/admin/instituicao", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "PUT /api/admin/instituicao/{id} sem autenticação retorna 401")]
+    public async Task Atualizar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Put,
+            new Uri($"/api/admin/instituicao/{Guid.NewGuid()}", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "DELETE /api/admin/instituicao/{id} sem autenticação retorna 401")]
+    public async Task Remover_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+
+        HttpResponseMessage response = await client.DeleteAsync(
+            new Uri($"/api/admin/instituicao/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoPersistenceTests.cs
@@ -1,0 +1,266 @@
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.Instituicoes;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Integração ponta-a-ponta da Story #585 contra Postgres real. Cobre os
+/// cenários de persistência da <see cref="Instituicao"/> singleton: índice único
+/// parcial sentinela (no máximo uma viva), soft-delete liberando o slot, audit
+/// trail e FK intra-banco <c>unidade_raiz_id → unidade(id)</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IClassFixture<T> exige tipo de teste público.")]
+public sealed class InstituicaoPersistenceTests : IClassFixture<InstituicaoDbFixture>
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private static readonly DateOnly DataInicio = new(2026, 1, 1);
+
+    private readonly InstituicaoDbFixture _fixture;
+
+    public InstituicaoPersistenceTests(InstituicaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Insert persiste a Instituição e preenche created_by via AuditableInterceptor")]
+    public async Task Insert_PersisteEPreencheAuditTrail()
+    {
+        // Estado compartilhado pela IClassFixture + singleton: limpa antes de
+        // inserir para que a suíte não dependa da ordem de execução dos testes.
+        await using OrganizacaoInstitucionalDbContext fresh = _fixture.CreateDbContext(AdminA);
+        await LimparInstituicoesAsync(fresh);
+
+        Instituicao instituicao = NovaInstituicao("9001", "INS-A");
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Instituicoes.Add(instituicao);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        Instituicao persistida = await readCtx.Instituicoes.SingleAsync(i => i.Id == instituicao.Id);
+
+        persistida.CodigoEmec.Should().Be("9001");
+        persistida.IsDeleted.Should().BeFalse();
+        persistida.CreatedBy.Should().Be(AdminA);
+        persistida.UpdatedBy.Should().BeNull("apenas criação — sem update ainda");
+    }
+
+    [Fact(DisplayName = "Índice único parcial rejeita uma segunda Instituição viva (singleton — CA-02)")]
+    public async Task Singleton_SegundaInstituicaoVivaRejeitada()
+    {
+        await using OrganizacaoInstitucionalDbContext fresh = _fixture.CreateDbContext(AdminA);
+        await LimparInstituicoesAsync(fresh);
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Instituicoes.Add(NovaInstituicao("9100", "INS-1"));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.Instituicoes.Add(NovaInstituicao("9101", "INS-2"));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        // Trava as constantes que o handler usa para traduzir a corrida concorrente
+        // (UniqueConstraintViolation.GetViolatedConstraint/IsSingletonConflict) em
+        // JaExisteInstituicaoViva/409: SqlState 23505 + nome do índice sentinela.
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        var pg = ex.InnerException as Npgsql.PostgresException;
+        pg.Should().NotBeNull();
+        pg!.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_instituicao_singleton_vivo");
+    }
+
+    [Fact(DisplayName = "CHECK constraint impede gravar a sentinela como false (singleton constante no banco)")]
+    public async Task CheckConstraint_ImpedeSentinelaFalse()
+    {
+        await using OrganizacaoInstitucionalDbContext fresh = _fixture.CreateDbContext(AdminA);
+        await LimparInstituicoesAsync(fresh);
+
+        Instituicao instituicao = NovaInstituicao("9500", "INS-CK");
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Instituicoes.Add(instituicao);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext rawCtx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await rawCtx.Database.ExecuteSqlAsync(
+            $"UPDATE instituicao SET registro_vivo_sentinela = false WHERE id = {instituicao.Id}");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "a CHECK constraint ck_instituicao_singleton_sentinela só admite a sentinela true");
+    }
+
+    [Fact(DisplayName = "Soft-delete liberta o slot singleton — nova Instituição é aceita após exclusão (CA-05)")]
+    public async Task Singleton_AposSoftDeleteNovaAceita()
+    {
+        await using OrganizacaoInstitucionalDbContext fresh = _fixture.CreateDbContext(AdminA);
+        await LimparInstituicoesAsync(fresh);
+
+        Instituicao primeira = NovaInstituicao("9200", "INS-DEL");
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Instituicoes.Add(primeira);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            Instituicao tracked = await ctx.Instituicoes.SingleAsync(i => i.Id == primeira.Id);
+            ctx.Instituicoes.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        // O registro removido permanece na trilha (IgnoreQueryFilters) com a auditoria preenchida.
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            Instituicao removida = await ctx.Instituicoes
+                .IgnoreQueryFilters()
+                .SingleAsync(i => i.Id == primeira.Id);
+            removida.IsDeleted.Should().BeTrue();
+            removida.DeletedAt.Should().NotBeNull();
+            removida.DeletedBy.Should().Be(AdminB);
+        }
+
+        // Nova Instituição viva é aceita — o índice único parcial só vê registros vivos.
+        await using OrganizacaoInstitucionalDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.Instituicoes.Add(NovaInstituicao("9201", "INS-NOVA"));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync("slot liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "ExisteAlgumaVivaAsync reflete registros vivos e ignora os soft-deleted (CA-05)")]
+    public async Task ExisteAlgumaVivaAsync_RefleteRegistrosVivos()
+    {
+        await using OrganizacaoInstitucionalDbContext fresh = _fixture.CreateDbContext(AdminA);
+        await LimparInstituicoesAsync(fresh);
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            var repoVazio = new InstituicaoRepository(ctx);
+            (await repoVazio.ExisteAlgumaVivaAsync(CancellationToken.None)).Should().BeFalse();
+        }
+
+        Instituicao instituicao = NovaInstituicao("9300", "INS-EX");
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Instituicoes.Add(instituicao);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            var repoComUma = new InstituicaoRepository(ctx);
+            (await repoComUma.ExisteAlgumaVivaAsync(CancellationToken.None)).Should().BeTrue();
+        }
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            Instituicao tracked = await ctx.Instituicoes.SingleAsync(i => i.Id == instituicao.Id);
+            ctx.Instituicoes.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            var repoPosRemocao = new InstituicaoRepository(ctx);
+            (await repoPosRemocao.ExisteAlgumaVivaAsync(CancellationToken.None))
+                .Should().BeFalse("registro removido não conta para o limite singleton");
+        }
+    }
+
+    [Fact(DisplayName = "FK unidade_raiz_id aceita vínculo com Unidade do tipo reitoria (CA-04)")]
+    public async Task Fk_UnidadeRaizReitoria_Aceita()
+    {
+        await using OrganizacaoInstitucionalDbContext fresh = _fixture.CreateDbContext(AdminA);
+        await LimparInstituicoesAsync(fresh);
+
+        Unidade reitoria = NovaReitoria("reitoria-fk", "RFK", "RFK001");
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(reitoria);
+            await ctx.SaveChangesAsync();
+        }
+
+        Instituicao instituicao = NovaInstituicao("9400", "INS-FK", reitoria.Id);
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Instituicoes.Add(instituicao);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        Instituicao persistida = await readCtx.Instituicoes.SingleAsync(i => i.Id == instituicao.Id);
+        persistida.UnidadeRaizId.Should().Be(reitoria.Id);
+
+        var repository = new InstituicaoRepository(readCtx);
+        (await repository.ExisteComUnidadeRaizAsync(reitoria.Id, CancellationToken.None))
+            .Should().BeTrue("a Instituição referencia esta Unidade como raiz");
+        (await repository.ExisteComUnidadeRaizAsync(Guid.CreateVersion7(), CancellationToken.None))
+            .Should().BeFalse("nenhuma Instituição referencia uma Unidade aleatória");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    private static async Task LimparInstituicoesAsync(OrganizacaoInstitucionalDbContext ctx)
+    {
+        // Cada teste precisa de um ponto de partida sem Instituição viva — o
+        // singleton compartilha o slot único entre todos os testes da fixture.
+        await ctx.Database.ExecuteSqlRawAsync("DELETE FROM instituicao");
+    }
+
+    private static Instituicao NovaInstituicao(string codigoEmec, string sigla, Guid? unidadeRaizId = null) =>
+        Instituicao.Criar(
+            codigoEmec,
+            $"Instituição {sigla}",
+            sigla,
+            "Universidade",
+            "Pública Federal",
+            cnpj: null,
+            mantenedora: null,
+            codigoMantenedoraEmec: null,
+            situacao: null,
+            atoCredenciamento: null,
+            atoRecredenciamento: null,
+            conceitoInstitucional: null,
+            igc: null,
+            website: null,
+            enderecoSede: null,
+            municipioSede: null,
+            unidadeRaizId).Value!;
+
+    private static Unidade NovaReitoria(string slug, string sigla, string codigo) =>
+        Unidade.Criar(
+            nome: "Reitoria",
+            alias: null,
+            slug: Slug.From(slug).Value!,
+            sigla: sigla,
+            codigo: codigo,
+            unidadeSuperiorId: null,
+            tipo: TipoUnidade.Reitoria,
+            unidadeAcademica: false,
+            vigenciaInicio: DataInicio,
+            vigenciaFim: null,
+            origem: OrigemUnidade.CriadoNoUniPlus).Value!;
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoPersistenceTests.cs
@@ -82,9 +82,8 @@ public sealed class InstituicaoPersistenceTests : IClassFixture<InstituicaoDbFix
         // (UniqueConstraintViolation.GetViolatedConstraint/IsSingletonConflict) em
         // JaExisteInstituicaoViva/409: SqlState 23505 + nome do índice sentinela.
         DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
-        var pg = ex.InnerException as Npgsql.PostgresException;
-        pg.Should().NotBeNull();
-        pg!.SqlState.Should().Be("23505");
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
         pg.ConstraintName.Should().Be("ix_instituicao_singleton_vivo");
     }
 


### PR DESCRIPTION
## Resumo

- Implementa a Story #585 — a entidade **Instituicao** (singleton) e seu CRUD administrativo no módulo OrganizacaoInstitucional. A Instituição descreve a própria instituição dona da plataforma (identificação regulatória e-MEC) e serve de cabeçalho institucional para editais e comprovantes.
- Cada deployment atende **uma única instituição** (ADR-0055): há no máximo uma Instituição viva por instância, garantido em duas camadas.
- Acompanha a fiação de desenvolvimento local (organizacao-api no compose, dependência explícita de Keycloak) e a coleção Postman da API.

## Mudanças

### Domínio e Aplicação
- Entidade `Instituicao` (sealed, factory `Criar` + `Atualizar`), `InstituicaoErrorCodes`, `IInstituicaoRepository`.
- Commands Criar/Atualizar/Remover + handlers (Wolverine, static) + validators (FluentValidation); query singleton `ObterInstituicao`; DTO/mapping; guard do vínculo com a reitoria.

### Contratos de governança (read-side, ADR-0056)
- `IInstituicaoReader` + `InstituicaoView` em `Governance.Contracts` — consumo vivo cross-módulo, sem congelamento por FK/snapshot.

### Infraestrutura
- Config EF: índice único parcial (`WHERE is_deleted = false`) sobre coluna sentinela constante (propriedade real sempre `true`, fixada por `CHECK`) + FK intra-banco `unidade_raiz_id -> unidade(id)`.
- Repositório, reader com cache fail-open, invalidador de cache, migration **forward-only** `AddInstituicao` (ADR-0054).

### API
- `InstituicaoController` (GET público singleton + POST/PUT/DELETE admin), HATEOAS Level 1, mapeamentos de erro para HTTP (ProblemDetails RFC 9457).

### Integridade com a reitoria (forward-reference da #586)
- `RemoverUnidadeCommandHandler` passa a bloquear a remoção de uma Unidade que é raiz de uma Instituição viva.

### Desenvolvimento / infra local
- `organizacao-api` no compose de exemplo (porta 5263, usuário `_app` dedicado); `depends_on` de **Keycloak** declarado em todas as APIs dev; coleção Postman por API em `.../API/postman/` (excluída do publish).

## Invariante singleton

Defesa em duas camadas: guard de domínio na criação (`ExisteAlgumaVivaAsync`) + índice único parcial de banco. Uma corrida concorrente que passe pelo guard e colida no índice é traduzida para o mesmo erro de domínio (**409**), sem acoplar a camada Application ao EF. A remoção é soft-delete e libera o slot para recadastramento.

## Testes

- **Domínio:** 70 · **Aplicação:** 36 · **Integração (Postgres real):** 27 · **Arquitetura:** 22 — todos verdes, build sem avisos.
- Cobertura dos critérios de aceite CA-01 a CA-07 (incluindo o índice singleton, o CHECK da sentinela, soft-delete liberando o slot, FK e auditoria).
- Coleção Postman validada com Newman contra a API ao vivo: 14 requests, 23 asserções, 0 falhas.

## Checklist

- [x] Build sem erros/avisos (`-warnaserror`)
- [x] Testes passando (155 + Postman 23/23)
- [x] Migration forward-only (ADR-0054)
- [x] Soft-delete + auditoria
- [x] Strings user-facing em pt-BR

Closes #585