### PR TITLE
refactor(kernel): torna soft-delete opt-in via ISoftDeletable

### DIFF
--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
 /// <see cref="DbContext"/> do módulo Configuracao — banco
@@ -31,6 +32,9 @@ public sealed class ConfiguracaoDbContext : DbContext, IUnitOfWork
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(ConfiguracaoDbContext).Assembly);
         // Configurações cross-cutting de Infrastructure.Core (idempotency_cache).
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdempotencyEntry).Assembly);
+        // Convenção global de soft-delete (issue #629): aplica `!IsDeleted` a todo
+        // tipo ISoftDeletable, após os ApplyConfigurations registrarem os tipos.
+        modelBuilder.AplicarFiltroGlobalSoftDelete();
         base.OnModelCreating(modelBuilder);
     }
 

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Chamada.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Chamada.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Ingresso.Domain.Entities;
 using Enums;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
-public sealed class Chamada : EntityBase
+public sealed class Chamada : SoftDeletableEntity
 {
     public Guid EditalId { get; private set; }
     public int Numero { get; private set; }

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Convocacao.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Convocacao.cs
@@ -5,7 +5,7 @@ using Events;
 using ValueObjects;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
-public sealed class Convocacao : EntityBase
+public sealed class Convocacao : SoftDeletableEntity
 {
     public Guid ChamadaId { get; private set; }
     public Guid InscricaoId { get; private set; }

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/DocumentoMatricula.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/DocumentoMatricula.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Ingresso.Domain.Entities;
 
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
-public sealed class DocumentoMatricula : EntityBase
+public sealed class DocumentoMatricula : SoftDeletableEntity
 {
     public Guid MatriculaId { get; private set; }
     public string TipoDocumento { get; private set; } = string.Empty;

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Matricula.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Entities/Matricula.cs
@@ -4,7 +4,7 @@ using Enums;
 using Events;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
-public sealed class Matricula : EntityBase
+public sealed class Matricula : SoftDeletableEntity
 {
     public Guid ConvocacaoId { get; private set; }
     public Guid CandidatoId { get; private set; }

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Configurations/ChamadaConfiguration.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Configurations/ChamadaConfiguration.cs
@@ -22,7 +22,5 @@ public sealed class ChamadaConfiguration : IEntityTypeConfiguration<Chamada>
         builder.HasMany(c => c.Convocacoes).WithOne().HasForeignKey(cv => cv.ChamadaId);
 
         builder.HasIndex(c => new { c.EditalId, c.Numero }).IsUnique();
-
-        builder.HasQueryFilter(c => !c.IsDeleted);
     }
 }

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Configurations/ConvocacaoConfiguration.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Configurations/ConvocacaoConfiguration.cs
@@ -23,7 +23,5 @@ public sealed class ConvocacaoConfiguration : IEntityTypeConfiguration<Convocaca
         builder.Property(c => c.Status).HasConversion<int>().IsRequired();
         builder.Property(c => c.Posicao).IsRequired();
         builder.Property(c => c.CodigoCurso).HasMaxLength(50).IsRequired();
-
-        builder.HasQueryFilter(c => !c.IsDeleted);
     }
 }

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Configurations/DocumentoMatriculaConfiguration.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Configurations/DocumentoMatriculaConfiguration.cs
@@ -18,7 +18,5 @@ public sealed class DocumentoMatriculaConfiguration : IEntityTypeConfiguration<D
         builder.Property(d => d.NomeArquivo).HasMaxLength(500).IsRequired();
         builder.Property(d => d.CaminhoStorage).HasMaxLength(1000).IsRequired();
         builder.Property(d => d.MotivoRejeicao).HasMaxLength(1000);
-
-        builder.HasQueryFilter(d => !d.IsDeleted);
     }
 }

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Configurations/MatriculaConfiguration.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/Configurations/MatriculaConfiguration.cs
@@ -19,7 +19,5 @@ public sealed class MatriculaConfiguration : IEntityTypeConfiguration<Matricula>
         builder.Property(m => m.Observacoes).HasMaxLength(2000);
 
         builder.HasMany(m => m.Documentos).WithOne().HasForeignKey(d => d.MatriculaId);
-
-        builder.HasQueryFilter(m => !m.IsDeleted);
     }
 }

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/IngressoDbContext.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Persistence/IngressoDbContext.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using Domain.Entities;
 using Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 public sealed class IngressoDbContext : DbContext, IUnitOfWork
 {
@@ -20,6 +21,9 @@ public sealed class IngressoDbContext : DbContext, IUnitOfWork
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(IngressoDbContext).Assembly);
+        // Convenção global de soft-delete (issue #629): aplica `!IsDeleted` a todo
+        // tipo ISoftDeletable, após os ApplyConfigurations registrarem os tipos.
+        modelBuilder.AplicarFiltroGlobalSoftDelete();
         base.OnModelCreating(modelBuilder);
     }
 

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/RemoverUnidadeCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Unidades/RemoverUnidadeCommandHandler.cs
@@ -63,7 +63,10 @@ public static class RemoverUnidadeCommandHandler
         }
 
         // SoftDeleteInterceptor converte EntityState.Deleted em soft-delete
-        // preenchendo DeletedBy/DeletedAt a partir de IUserContext + TimeProvider.
+        // (Unidade é ISoftDeletable), preenchendo DeletedBy/DeletedAt a partir de
+        // IUserContext + TimeProvider. O Historico carregado por ObterPorIdAsync
+        // NÃO é cascateado (FK Restrict, issue #629): a trilha append-only de
+        // identificadores é preservada mesmo no soft-delete da Unidade.
         repository.Remover(unidade);
 
         await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/AreaOrganizacional.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/AreaOrganizacional.cs
@@ -25,7 +25,7 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
 /// <c>AreaOrganizacional</c> NÃO é "área-scoped"; ela é a própria dimensão de
 /// governança. Não tem <c>Proprietario</c> nem <c>AreasDeInteresse</c>.</para>
 /// </remarks>
-public sealed partial class AreaOrganizacional : EntityBase, IAuditableEntity
+public sealed partial class AreaOrganizacional : SoftDeletableEntity, IAuditableEntity
 {
     private const int NomeMaxLength = 120;
     private const int NomeMinLength = 2;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Instituicao.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Instituicao.cs
@@ -28,7 +28,7 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
 /// Unidade referenciada é viva e do tipo reitoria é responsabilidade do handler
 /// (via repositório); esta entidade recebe o Id já validado.</para>
 /// </remarks>
-public sealed class Instituicao : EntityBase, IAuditableEntity
+public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
 {
     private const int CodigoEmecMaxLength = 20;
     private const int NomeMaxLength = 250;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Unidade.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Unidade.cs
@@ -25,7 +25,7 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
 /// <para>Detecção de ciclo na hierarquia é responsabilidade do handler (via
 /// repositório); este agregado recebe o ID do superior já validado.</para>
 /// </remarks>
-public sealed class Unidade : EntityBase, IAuditableEntity
+public sealed class Unidade : SoftDeletableEntity, IAuditableEntity
 {
     private const int NomeMaxLength = 250;
     private const int NomeMinLength = 2;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/UnidadeIdentificadorHistorico.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/UnidadeIdentificadorHistorico.cs
@@ -12,9 +12,11 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
 /// <remarks>
 /// Entidade interna ao agregado <see cref="Unidade"/>; criada apenas por
 /// métodos do agregado. Construtor privado mantém o invariante.
-/// Soft-delete herdado de <see cref="EntityBase"/> não se aplica: o histórico
-/// é imutável (append-only). Entradas fechadas não são deletadas — mantidas
-/// para auditoria.
+/// Não implementa soft-delete: deriva de <see cref="EntityBase"/> (não de
+/// <c>SoftDeletableEntity</c>), portanto não carrega as colunas
+/// is_deleted/deleted_at/deleted_by. O histórico é imutável (append-only):
+/// entradas fechadas não são deletadas — a vigência é encerrada por
+/// <see cref="VigenciaFim"/> e mantida para auditoria.
 /// </remarks>
 public sealed class UnidadeIdentificadorHistorico : EntityBase
 {

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/AreaOrganizacionalConfiguration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/AreaOrganizacionalConfiguration.cs
@@ -36,10 +36,5 @@ internal sealed class AreaOrganizacionalConfiguration : IEntityTypeConfiguration
         // do IUserContext. EntityBase.CreatedAt/UpdatedAt mantidos pela EntityBase.
         builder.Property(a => a.CreatedBy).HasMaxLength(255);
         builder.Property(a => a.UpdatedBy).HasMaxLength(255);
-
-        // Soft delete query filter (ADR — pattern Uni+). Reader e listagens
-        // públicas operam apenas sobre não-deletadas; auditoria histórica
-        // bypassa o filter via IgnoreQueryFilters.
-        builder.HasQueryFilter(a => !a.IsDeleted);
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/InstituicaoConfiguration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/InstituicaoConfiguration.cs
@@ -71,7 +71,5 @@ internal sealed class InstituicaoConfiguration : IEntityTypeConfiguration<Instit
             .IsUnique()
             .HasFilter("is_deleted = false")
             .HasDatabaseName("ix_instituicao_singleton_vivo");
-
-        builder.HasQueryFilter(i => !i.IsDeleted);
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/UnidadeConfiguration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/UnidadeConfiguration.cs
@@ -44,11 +44,23 @@ internal sealed class UnidadeConfiguration : IEntityTypeConfiguration<Unidade>
             .IsRequired(false)
             .OnDelete(DeleteBehavior.Restrict);
 
-        // Histórico de identificadores — coleção owned dentro do agregado
+        // Histórico de identificadores (append-only): NÃO cascatear (issue #629).
+        // O histórico não implementa ISoftDeletable; com Cascade, remover a Unidade
+        // marcaria os históricos carregados (ObterPorIdAsync faz Include) como Deleted
+        // e — como o SoftDeleteInterceptor só converte ISoftDeletable — eles sofreriam
+        // hard-delete físico, destruindo a trilha de auditoria.
+        //
+        // ClientNoAction (e não Restrict/NoAction): com o histórico required já
+        // rastreado, Restrict/NoAction lançam "required relationship severed" ao
+        // marcar a Unidade como Deleted — ANTES de o interceptor convertê-la em
+        // soft-delete. ClientNoAction instrui o EF a não tocar nem validar os
+        // dependentes; o interceptor então converte a Unidade em UPDATE (soft-delete)
+        // e o histórico permanece intacto. A Unidade nunca é hard-deletada, logo a
+        // integridade referencial é preservada na prática (FK NO ACTION no banco).
         builder.HasMany(u => u.Historico)
             .WithOne()
             .HasForeignKey(h => h.UnidadeId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.ClientNoAction);
 
         // Índices únicos parciais (WHERE is_deleted = false) — unicidade entre vivos
         builder.HasIndex(u => u.Slug)

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/UnidadeConfiguration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/UnidadeConfiguration.cs
@@ -73,7 +73,5 @@ internal sealed class UnidadeConfiguration : IEntityTypeConfiguration<Unidade>
         // Hierarquia: índice para busca de subordinadas
         builder.HasIndex(u => u.UnidadeSuperiorId)
             .HasDatabaseName("ix_unidade_superior_id");
-
-        builder.HasQueryFilter(u => !u.IsDeleted);
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260610010229_RemoveColunasSoftDeleteHistoricoIdentificador.Designer.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260610010229_RemoveColunasSoftDeleteHistoricoIdentificador.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(OrganizacaoInstitucionalDbContext))]
-    partial class OrganizacaoInstitucionalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610010229_RemoveColunasSoftDeleteHistoricoIdentificador")]
+    partial class RemoveColunasSoftDeleteHistoricoIdentificador
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260610010229_RemoveColunasSoftDeleteHistoricoIdentificador.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260610010229_RemoveColunasSoftDeleteHistoricoIdentificador.cs
@@ -1,0 +1,43 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveColunasSoftDeleteHistoricoIdentificador : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Issue #629: soft-delete passa a ser opt-in via ISoftDeletable.
+            // UnidadeIdentificadorHistorico é append-only (não implementa a
+            // interface) e perde as colunas antes herdadas de EntityBase.
+            // Destrutivo, mas seguro: o histórico nunca era soft-deletado em
+            // fluxo normal (is_deleted sempre false) e a vigência continua
+            // encerrada por vigencia_fim — comportamento preservado.
+            migrationBuilder.DropColumn(
+                name: "deleted_at",
+                table: "unidade_identificador_historico");
+
+            migrationBuilder.DropColumn(
+                name: "deleted_by",
+                table: "unidade_identificador_historico");
+
+            migrationBuilder.DropColumn(
+                name: "is_deleted",
+                table: "unidade_identificador_historico");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Forward-only per ADR-0054 §J: nova migration "Reverte..." é o
+            // mecanismo canônico de revert. Re-adicionar as colunas aqui
+            // reintroduziria soft-delete numa entidade append-only — caminho
+            // proibido.
+            throw new NotSupportedException("Forward-only migration per ADR-0054 §J.");
+        }
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260610025241_RestringeFkHistoricoIdentificador.Designer.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260610025241_RestringeFkHistoricoIdentificador.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(OrganizacaoInstitucionalDbContext))]
-    partial class OrganizacaoInstitucionalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260610025241_RestringeFkHistoricoIdentificador")]
+    partial class RestringeFkHistoricoIdentificador
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260610025241_RestringeFkHistoricoIdentificador.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260610025241_RestringeFkHistoricoIdentificador.cs
@@ -1,0 +1,42 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class RestringeFkHistoricoIdentificador : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Issue #629: troca a FK do histórico de identificadores de ON DELETE
+            // CASCADE para NO ACTION (DeleteBehavior.ClientNoAction). O histórico é
+            // append-only e não implementa ISoftDeletable; com CASCADE, soft-deletar
+            // a Unidade (com o histórico carregado por ObterPorIdAsync) hard-deletava
+            // as linhas via cascade em memória do EF. Com NO ACTION o cascade não
+            // ocorre e a Unidade é soft-deletada (UPDATE, nunca DELETE físico),
+            // preservando a trilha de auditoria.
+            migrationBuilder.DropForeignKey(
+                name: "fk_unidade_identificador_historico_unidade_unidade_id",
+                table: "unidade_identificador_historico");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_unidade_identificador_historico_unidade_unidade_id",
+                table: "unidade_identificador_historico",
+                column: "unidade_id",
+                principalTable: "unidade",
+                principalColumn: "id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Forward-only per ADR-0054 §J: nova migration "Reverte..." é o
+            // mecanismo canônico de revert. Voltar a FK para CASCADE reintroduziria
+            // o hard-delete do histórico append-only — caminho proibido.
+            throw new NotSupportedException("Forward-only migration per ADR-0054 §J.");
+        }
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/OrganizacaoInstitucionalDbContext.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/OrganizacaoInstitucionalDbContext.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
 
 /// <summary>
@@ -41,6 +42,10 @@ public sealed class OrganizacaoInstitucionalDbContext : DbContext, IUnitOfWork
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(OrganizacaoInstitucionalDbContext).Assembly);
         // Configurações cross-cutting de Infrastructure.Core (idempotency_cache).
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdempotencyEntry).Assembly);
+        // Convenção global de soft-delete (issue #629): aplica `!IsDeleted` a todo
+        // tipo ISoftDeletable, após os ApplyConfigurations registrarem os tipos.
+        // UnidadeIdentificadorHistorico não implementa ISoftDeletable → não filtra.
+        modelBuilder.AplicarFiltroGlobalSoftDelete();
         base.OnModelCreating(modelBuilder);
     }
 

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/Persistence/PortalDbContext.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/Persistence/PortalDbContext.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Portal.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 using Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 public sealed class PortalDbContext : DbContext, IUnitOfWork
 {
@@ -14,6 +15,9 @@ public sealed class PortalDbContext : DbContext, IUnitOfWork
     {
         ArgumentNullException.ThrowIfNull(modelBuilder);
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(PortalDbContext).Assembly);
+        // Convenção global de soft-delete (issue #629): aplica `!IsDeleted` a todo
+        // tipo ISoftDeletable, após os ApplyConfigurations registrarem os tipos.
+        modelBuilder.AplicarFiltroGlobalSoftDelete();
         base.OnModelCreating(modelBuilder);
     }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Candidato.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Candidato.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
 
-public sealed class Candidato : EntityBase
+public sealed class Candidato : SoftDeletableEntity
 {
     public Cpf Cpf { get; private set; } = null!;
     public NomeSocial NomeSocial { get; private set; } = null!;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Cota.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Cota.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
 using Enums;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
-public sealed class Cota : EntityBase
+public sealed class Cota : SoftDeletableEntity
 {
     public Guid EditalId { get; private set; }
     public ModalidadeConcorrencia Modalidade { get; private set; }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
@@ -5,7 +5,7 @@ using Events;
 using ValueObjects;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
-public sealed class Edital : EntityBase
+public sealed class Edital : SoftDeletableEntity
 {
     public NumeroEdital NumeroEdital { get; private set; } = null!;
     public string Titulo { get; private set; } = string.Empty;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Etapa.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Etapa.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
 
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
-public sealed class Etapa : EntityBase
+public sealed class Etapa : SoftDeletableEntity
 {
     public Guid EditalId { get; private set; }
     public string Nome { get; private set; } = string.Empty;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Inscricao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Inscricao.cs
@@ -7,7 +7,7 @@ using Events;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Kernel.Results;
 
-public sealed class Inscricao : EntityBase
+public sealed class Inscricao : SoftDeletableEntity
 {
     public Guid CandidatoId { get; private set; }
     public Guid EditalId { get; private set; }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ObrigatoriedadeLegal.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ObrigatoriedadeLegal.cs
@@ -46,7 +46,7 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
     "CA1054:URI-like parameters should not be strings",
     Justification = "Pareado com a justificativa de CA1056 acima — factory aceita string para "
         + "preservar fidelidade do payload textual da citação normativa.")]
-public sealed class ObrigatoriedadeLegal : EntityBase, IAuditableEntity, IAreaScopedEntity
+public sealed class ObrigatoriedadeLegal : SoftDeletableEntity, IAuditableEntity, IAreaScopedEntity
 {
     /// <summary>
     /// Valor sentinela aceito em <see cref="TipoEditalCodigo"/> para regras

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
 
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
-public sealed class ProcessoSeletivo : EntityBase
+public sealed class ProcessoSeletivo : SoftDeletableEntity
 {
     public Guid EditalId { get; private set; }
     public string CodigoCurso { get; private set; } = string.Empty;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CandidatoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CandidatoConfiguration.cs
@@ -35,7 +35,5 @@ public sealed class CandidatoConfiguration : IEntityTypeConfiguration<Candidato>
         builder.Property(c => c.Telefone).HasMaxLength(20);
 
         builder.Ignore(c => c.NomeExibicao);
-
-        builder.HasQueryFilter(c => !c.IsDeleted);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CotaConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CotaConfiguration.cs
@@ -17,7 +17,5 @@ public sealed class CotaConfiguration : IEntityTypeConfiguration<Cota>
         builder.Property(c => c.Modalidade).HasConversion<int>().IsRequired();
         builder.Property(c => c.PercentualVagas).HasPrecision(5, 2).IsRequired();
         builder.Property(c => c.Descricao).HasMaxLength(500);
-
-        builder.HasQueryFilter(c => !c.IsDeleted);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EditalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EditalConfiguration.cs
@@ -46,7 +46,5 @@ public sealed class EditalConfiguration : IEntityTypeConfiguration<Edital>
 
         builder.HasMany(e => e.Etapas).WithOne().HasForeignKey(et => et.EditalId);
         builder.HasMany(e => e.Cotas).WithOne().HasForeignKey(c => c.EditalId);
-
-        builder.HasQueryFilter(e => !e.IsDeleted);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EtapaConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EtapaConfiguration.cs
@@ -24,7 +24,5 @@ public sealed class EtapaConfiguration : IEntityTypeConfiguration<Etapa>
         builder.Property(e => e.Peso).HasPrecision(5, 2).IsRequired();
         builder.Property(e => e.Ordem).IsRequired();
         builder.Property(e => e.NotaMinima).HasPrecision(5, 2);
-
-        builder.HasQueryFilter(e => !e.IsDeleted);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/InscricaoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/InscricaoConfiguration.cs
@@ -22,7 +22,5 @@ public sealed class InscricaoConfiguration : IEntityTypeConfiguration<Inscricao>
 
         builder.HasIndex(i => new { i.CandidatoId, i.EditalId });
         builder.HasIndex(i => i.NumeroInscricao).IsUnique();
-
-        builder.HasQueryFilter(i => !i.IsDeleted);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ObrigatoriedadeLegalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ObrigatoriedadeLegalConfiguration.cs
@@ -122,8 +122,6 @@ internal sealed class ObrigatoriedadeLegalConfiguration()
         // é responsabilidade do domínio na hora da escrita.
         builder.Ignore(o => o.AreasDeInteresse);
 
-        builder.HasQueryFilter(o => !o.IsDeleted);
-
         // CA-02 — UNIQUE parcial sobre Hash. Soft-deletes não disputam o slot,
         // permitindo recriar uma regra com hash idêntico após a desativação
         // da anterior (cenário de versionamento canônico do ADR-0058).

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
@@ -18,7 +18,5 @@ public sealed class ProcessoSeletivoConfiguration : IEntityTypeConfiguration<Pro
         builder.Property(p => p.NomeCurso).HasMaxLength(300).IsRequired();
         builder.Property(p => p.Campus).HasMaxLength(200).IsRequired();
         builder.Property(p => p.Turno).HasMaxLength(50);
-
-        builder.HasQueryFilter(p => !p.IsDeleted);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
@@ -6,6 +6,7 @@ using Domain.Entities;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 public sealed class SelecaoDbContext : DbContext, IUnitOfWork
 {
@@ -56,6 +57,9 @@ public sealed class SelecaoDbContext : DbContext, IUnitOfWork
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(SelecaoDbContext).Assembly);
         // Configurações cross-cutting de Infrastructure.Core (ex.: idempotency_cache).
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdempotencyEntry).Assembly);
+        // Convenção global de soft-delete (issue #629): aplica `!IsDeleted` a todo
+        // tipo ISoftDeletable, após os ApplyConfigurations registrarem os tipos.
+        modelBuilder.AplicarFiltroGlobalSoftDelete();
         base.OnModelCreating(modelBuilder);
     }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 using Unifesspa.UniPlus.Application.Abstractions.Authentication;
-using Kernel.Domain.Entities;
+using Kernel.Domain.Interfaces;
 
 // LGPD audit trail (issue #127): converte DELETE em UPDATE preservando o
 // identificador do usuário responsável em DeletedBy. Em requests autenticados,
@@ -64,8 +64,12 @@ public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
         string deletedBy = ResolveDeletedBy();
         DateTimeOffset deletedAt = _timeProvider.GetUtcNow();
 
-        foreach (Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<EntityBase> entry
-            in context.ChangeTracker.Entries<EntityBase>())
+        // Opt-in por interface (issue #629): só entidades ISoftDeletable são
+        // convertidas em soft-delete. Entidades que não implementam a interface
+        // (ex.: históricos append-only como UnidadeIdentificadorHistorico) sofrem
+        // hard-delete físico — coerente com sua semântica imutável.
+        foreach (Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry<ISoftDeletable> entry
+            in context.ChangeTracker.Entries<ISoftDeletable>())
         {
             if (entry.State == EntityState.Deleted)
             {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/ModelBuilderSoftDeleteExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/ModelBuilderSoftDeleteExtensions.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+
+using System.Linq.Expressions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+/// <summary>
+/// Convenção global de soft-delete (issue #629): aplica o filtro
+/// <c>e =&gt; !e.IsDeleted</c> a todo tipo de entidade não-owned que implemente
+/// <see cref="ISoftDeletable"/>. Substitui as chamadas <c>HasQueryFilter</c>
+/// manuais espalhadas pelas configurações — o opt-in via interface é o único
+/// critério: quem não implementa não filtra nem carrega colunas de soft-delete.
+/// </summary>
+public static class ModelBuilderSoftDeleteExtensions
+{
+    /// <summary>
+    /// Chave do query filter nomeado de soft-delete. Usa filtro <b>nomeado</b>
+    /// (EF Core 10) em vez de anônimo para coexistir com futuros filtros por
+    /// entidade (ex.: visibilidade área-scoped, ADR-0060): o EF Core proíbe
+    /// combinar um filtro anônimo e um nomeado no mesmo tipo
+    /// (<c>AnonymousAndNamedFiltersCombined</c>). <c>IgnoreQueryFilters()</c>
+    /// sem argumentos continua removendo todos os filtros, inclusive este.
+    /// </summary>
+    public const string FiltroSoftDeleteKey = "SoftDelete";
+
+    /// <summary>
+    /// Invocada no fim de cada <c>OnModelCreating</c>, após as configurações
+    /// terem registrado os tipos no modelo. Owned types são ignorados (não
+    /// suportam query filter); entidades sem <see cref="ISoftDeletable"/> não
+    /// são tocadas.
+    /// </summary>
+    /// <param name="modelBuilder">O <see cref="ModelBuilder"/> em construção.</param>
+    public static void AplicarFiltroGlobalSoftDelete(this ModelBuilder modelBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(modelBuilder);
+
+        foreach (IMutableEntityType entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            // Owned types compartilham a tabela do dono e não admitem query
+            // filter próprio — a issue #629 exige pulá-los explicitamente.
+            if (entityType.IsOwned())
+            {
+                continue;
+            }
+
+            if (!typeof(ISoftDeletable).IsAssignableFrom(entityType.ClrType))
+            {
+                continue;
+            }
+
+            LambdaExpression filtro = ConstruirFiltroNaoExcluido(entityType.ClrType);
+            modelBuilder.Entity(entityType.ClrType).HasQueryFilter(FiltroSoftDeleteKey, filtro);
+        }
+    }
+
+    // e => !e.IsDeleted — construído dinamicamente porque o tipo concreto só é
+    // conhecido em runtime ao varrer o modelo. IsDeleted é membro de
+    // ISoftDeletable, sempre presente nos tipos selecionados pelo filtro acima.
+    private static LambdaExpression ConstruirFiltroNaoExcluido(Type clrType)
+    {
+        ParameterExpression parametro = Expression.Parameter(clrType, "e");
+        MemberExpression isDeleted = Expression.Property(parametro, nameof(ISoftDeletable.IsDeleted));
+        UnaryExpression naoExcluido = Expression.Not(isDeleted);
+        return Expression.Lambda(naoExcluido, parametro);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
@@ -16,28 +16,18 @@ public abstract class EntityBase
     // CreatedAt como audit trail obrigatório, expondo o mesmo dado.
     public Guid Id { get; protected init; } = Guid.CreateVersion7();
 
-    // CreatedAt/UpdatedAt/DeletedAt são audit trail de persistência: a fonte
-    // única do instante é o relógio injetado (TimeProvider) nos interceptors
-    // de Infrastructure (AuditableInterceptor/SoftDeleteInterceptor), nunca
-    // DateTimeOffset.UtcNow lido no domínio. Por isso CreatedAt NÃO tem
-    // inicializador — uma entidade transiente (pré-SaveChanges) tem CreatedAt
-    // default; o AuditableInterceptor o carimba em Added. O fitness test
-    // RelogioViaTimeProviderTests bane leituras diretas de relógio em src/.
+    // CreatedAt/UpdatedAt são audit trail de persistência: a fonte única do
+    // instante é o relógio injetado (TimeProvider) no AuditableInterceptor
+    // de Infrastructure, nunca DateTimeOffset.UtcNow lido no domínio. Por isso
+    // CreatedAt NÃO tem inicializador — uma entidade transiente (pré-SaveChanges)
+    // tem CreatedAt default; o AuditableInterceptor o carimba em Added. O fitness
+    // test RelogioViaTimeProviderTests bane leituras diretas de relógio em src/.
+    //
+    // Soft-delete NÃO vive aqui (issue #629): é capability opt-in via
+    // SoftDeletableEntity : EntityBase, ISoftDeletable — só entidades que
+    // derivam dela carregam IsDeleted/DeletedAt/DeletedBy e as colunas no banco.
     public DateTimeOffset CreatedAt { get; protected set; }
     public DateTimeOffset? UpdatedAt { get; protected set; }
-    public bool IsDeleted { get; private set; }
-    public DateTimeOffset? DeletedAt { get; private set; }
-    public string? DeletedBy { get; private set; }
-
-    // O instante é parâmetro, não relógio lido aqui: o caller (SoftDeleteInterceptor
-    // ou repositório) provê deletedAt a partir do TimeProvider injetado, mantendo
-    // o domínio determinístico e a leitura de relógio concentrada em Infrastructure.
-    public void MarkAsDeleted(string deletedBy, DateTimeOffset deletedAt)
-    {
-        IsDeleted = true;
-        DeletedAt = deletedAt;
-        DeletedBy = deletedBy;
-    }
 
     private readonly List<IDomainEvent> _domainEvents = [];
     public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/SoftDeletableEntity.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/SoftDeletableEntity.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Kernel.Domain.Entities;
+
+using Interfaces;
+
+// Base opt-in de soft-delete (issue #629): só entidades que precisam de
+// exclusão lógica derivam daqui. EntityBase carrega apenas identidade,
+// timestamps e domain events — sem colunas de soft-delete. O critério de
+// opt-in é a interface ISoftDeletable: o SoftDeleteInterceptor itera
+// Entries<ISoftDeletable>() e a convenção AplicarFiltroGlobalSoftDelete
+// aplica `e => !e.IsDeleted` a todo tipo que a implementa. Esta classe
+// existe só para carregar a implementação dos membros uma única vez,
+// evitando duplicá-la nas entidades soft-deletable.
+public abstract class SoftDeletableEntity : EntityBase, ISoftDeletable
+{
+    public bool IsDeleted { get; private set; }
+    public DateTimeOffset? DeletedAt { get; private set; }
+    public string? DeletedBy { get; private set; }
+
+    // O instante é parâmetro, não relógio lido aqui: o caller (SoftDeleteInterceptor
+    // ou repositório) provê deletedAt a partir do TimeProvider injetado, mantendo
+    // o domínio determinístico e a leitura de relógio concentrada em Infrastructure.
+    public void MarkAsDeleted(string deletedBy, DateTimeOffset deletedAt)
+    {
+        IsDeleted = true;
+        DeletedAt = deletedAt;
+        DeletedBy = deletedBy;
+    }
+}

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/SoftDeleteOptInConventionTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/SoftDeleteOptInConventionTests.cs
@@ -1,0 +1,137 @@
+namespace Unifesspa.UniPlus.ArchTests.SolutionRules;
+
+using System.Linq;
+using System.Reflection;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Ingresso.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Portal.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// Fitness function da issue #629: soft-delete é capability opt-in via
+/// <see cref="ISoftDeletable"/>. Garante as invariantes:
+/// <list type="bullet">
+/// <item>CA-01: <see cref="EntityBase"/> não declara membros de soft-delete;</item>
+/// <item>CA-07: a convenção <c>AplicarFiltroGlobalSoftDelete</c> aplica o filtro
+/// <c>!IsDeleted</c> a toda entidade <see cref="ISoftDeletable"/> dos cinco
+/// DbContexts e a nenhuma outra; nenhuma entidade não-soft mapeia a coluna
+/// <c>is_deleted</c>.</item>
+/// </list>
+/// </summary>
+public sealed class SoftDeleteOptInConventionTests
+{
+    [Fact(DisplayName = "CA-01: EntityBase não declara soft-delete; SoftDeletableEntity carrega o contrato")]
+    public void EntityBase_NaoDeclaraSoftDelete()
+    {
+        string[] membrosSoftDelete = ["IsDeleted", "DeletedAt", "DeletedBy", "MarkAsDeleted"];
+
+        foreach (string membro in membrosSoftDelete)
+        {
+            typeof(EntityBase)
+                .GetMember(membro, BindingFlags.Public | BindingFlags.Instance)
+                .Should().BeEmpty($"EntityBase não deve declarar '{membro}' (issue #629: soft-delete é opt-in)");
+        }
+
+        typeof(ISoftDeletable).IsAssignableFrom(typeof(EntityBase)).Should().BeFalse(
+            "EntityBase não implementa ISoftDeletable — só SoftDeletableEntity o faz");
+        typeof(ISoftDeletable).IsAssignableFrom(typeof(SoftDeletableEntity)).Should().BeTrue(
+            "SoftDeletableEntity é a base que carrega a implementação de ISoftDeletable");
+        typeof(EntityBase).IsAssignableFrom(typeof(SoftDeletableEntity)).Should().BeTrue(
+            "SoftDeletableEntity estende EntityBase (soft-delete é opt-in sobre a identidade)");
+    }
+
+    [Fact(DisplayName = "CA-07: convenção aplica soft-delete a toda ISoftDeletable e a nenhuma outra (5 DbContexts)")]
+    public void Convencao_SoftDelete_OptIn_Invariante()
+    {
+        List<string> violacoes = [];
+
+        foreach (DbContext contexto in CriarContextos())
+        {
+            using (contexto)
+            {
+                string ctxNome = contexto.GetType().Name;
+
+                foreach (IEntityType entityType in contexto.Model.GetEntityTypes())
+                {
+                    if (entityType.IsOwned())
+                    {
+                        continue;
+                    }
+
+                    Type clr = entityType.ClrType;
+                    bool isSoftDeletable = typeof(ISoftDeletable).IsAssignableFrom(clr);
+                    bool temFiltroSoftDelete = entityType.GetDeclaredQueryFilters()
+                        .Any(f => f.Key == ModelBuilderSoftDeleteExtensions.FiltroSoftDeleteKey);
+                    bool mapeiaColunaIsDeleted =
+                        entityType.FindProperty(nameof(ISoftDeletable.IsDeleted)) is not null;
+
+                    if (isSoftDeletable)
+                    {
+                        if (!typeof(SoftDeletableEntity).IsAssignableFrom(clr))
+                        {
+                            violacoes.Add($"{clr.FullName}: implementa ISoftDeletable mas não deriva de SoftDeletableEntity.");
+                        }
+
+                        if (!temFiltroSoftDelete)
+                        {
+                            violacoes.Add($"{clr.FullName} ({ctxNome}): ISoftDeletable sem o filtro de soft-delete da convenção.");
+                        }
+
+                        if (!mapeiaColunaIsDeleted)
+                        {
+                            violacoes.Add($"{clr.FullName} ({ctxNome}): ISoftDeletable sem coluna is_deleted mapeada.");
+                        }
+                    }
+                    else
+                    {
+                        if (mapeiaColunaIsDeleted)
+                        {
+                            violacoes.Add($"{clr.FullName} ({ctxNome}): NÃO implementa ISoftDeletable mas mapeia coluna is_deleted.");
+                        }
+
+                        if (temFiltroSoftDelete)
+                        {
+                            violacoes.Add($"{clr.FullName} ({ctxNome}): NÃO implementa ISoftDeletable mas tem filtro de soft-delete.");
+                        }
+                    }
+                }
+            }
+        }
+
+        violacoes.Should().BeEmpty(
+            "issue #629: soft-delete é opt-in — toda ISoftDeletable filtra por convenção e carrega is_deleted; "
+            + "quem não implementa não filtra nem mapeia a coluna. Violações:\n" + string.Join("\n", violacoes));
+    }
+
+    // Constrói o modelo de cada DbContext com o provider InMemory: a convenção
+    // de query filter e o mapeamento de colunas são provider-agnostic, então o
+    // modelo materializado reflete fielmente o que vai a produção (Npgsql).
+    private static IEnumerable<DbContext> CriarContextos()
+    {
+        yield return Criar<SelecaoDbContext>();
+        yield return Criar<IngressoDbContext>();
+        yield return Criar<PortalDbContext>();
+        yield return Criar<OrganizacaoInstitucionalDbContext>();
+        yield return Criar<ConfiguracaoDbContext>();
+    }
+
+    private static TContext Criar<TContext>()
+        where TContext : DbContext
+    {
+        DbContextOptions<TContext> options = new DbContextOptionsBuilder<TContext>()
+            .UseInMemoryDatabase(typeof(TContext).Name)
+            .Options;
+
+        return (TContext)Activator.CreateInstance(typeof(TContext), options)!;
+    }
+}

--- a/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
@@ -11,6 +11,11 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <!-- InMemory: o fitness test SoftDeleteOptInConventionTests (issue #629)
+         materializa o modelo EF dos 5 DbContexts — model building é
+         provider-agnostic — para verificar que a convenção de soft-delete
+         aplicou o query filter a cada ISoftDeletable. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="TngTech.ArchUnitNET" />
     <PackageReference Include="TngTech.ArchUnitNET.xUnit" />
   </ItemGroup>

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -25,6 +25,17 @@
           "Microsoft.Extensions.Hosting": "10.0.7"
         }
       },
+      "Microsoft.EntityFrameworkCore.InMemory": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "RAns8RTPymM9GsIdY5Y8wWdpdMEXputTl24+95WhYzqF4HhT0i+jFmNgDxBTy386vU9ruoUC5gcPAiuJr8SZxg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.5.1, )",

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/Interceptors/SoftDeleteInterceptorTests.cs
@@ -23,7 +23,14 @@ public sealed class SoftDeleteInterceptorTests
         public override DateTimeOffset GetUtcNow() => now;
     }
 
-    private sealed class EntidadeTeste : EntityBase
+    private sealed class EntidadeTeste : SoftDeletableEntity
+    {
+        public string Nome { get; set; } = string.Empty;
+    }
+
+    // Entidade que NÃO implementa ISoftDeletable — o interceptor não deve
+    // convertê-la em soft-delete; sofre hard-delete físico (CA-06, issue #629).
+    private sealed class EntidadeNaoSoft : EntityBase
     {
         public string Nome { get; set; } = string.Empty;
     }
@@ -31,6 +38,7 @@ public sealed class SoftDeleteInterceptorTests
     private sealed class ContextoTeste(DbContextOptions<ContextoTeste> options) : DbContext(options)
     {
         public DbSet<EntidadeTeste> Entidades { get; set; } = null!;
+        public DbSet<EntidadeNaoSoft> EntidadesNaoSoft { get; set; } = null!;
     }
 
     private static ContextoTeste CriarContexto(IUserContext? userContext = null) =>
@@ -174,5 +182,38 @@ public sealed class SoftDeleteInterceptorTests
         contexto.SaveChanges();
 
         entidade.DeletedBy.Should().Be(SystemUser);
+    }
+
+    // CA-06 (issue #629): só ISoftDeletable é convertida em soft-delete.
+    // Uma entidade que deriva de EntityBase mas não implementa a interface
+    // é fisicamente removida — o interceptor não a intercepta.
+    [Fact]
+    public void SavingChanges_DadoEntidadeNaoSoftDeletableRemovida_EntaoDeveSerHardDeleteFisico()
+    {
+        using ContextoTeste contexto = CriarContexto();
+        EntidadeNaoSoft entidade = new() { Nome = "hard delete" };
+        contexto.EntidadesNaoSoft.Add(entidade);
+        contexto.SaveChanges();
+
+        contexto.EntidadesNaoSoft.Remove(entidade);
+        contexto.SaveChanges();
+
+        contexto.EntidadesNaoSoft.Find(entidade.Id).Should().BeNull(
+            "entidade sem ISoftDeletable sofre hard-delete físico (CA-06)");
+    }
+
+    [Fact]
+    public async Task SavingChangesAsync_DadoEntidadeNaoSoftDeletableRemovida_EntaoDeveSerHardDeleteFisico()
+    {
+        await using ContextoTeste contexto = CriarContexto();
+        EntidadeNaoSoft entidade = new() { Nome = "hard delete" };
+        contexto.EntidadesNaoSoft.Add(entidade);
+        await contexto.SaveChangesAsync();
+
+        contexto.EntidadesNaoSoft.Remove(entidade);
+        await contexto.SaveChangesAsync();
+
+        (await contexto.EntidadesNaoSoft.FindAsync(entidade.Id)).Should().BeNull(
+            "entidade sem ISoftDeletable sofre hard-delete físico (CA-06)");
     }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/ModelBuilderSoftDeleteExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Persistence/ModelBuilderSoftDeleteExtensionsTests.cs
@@ -1,0 +1,79 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Persistence;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+// Comportamento da convenção AplicarFiltroGlobalSoftDelete (issue #629):
+// aplica `!IsDeleted` a tipos ISoftDeletable e ignora os demais. Cobre CA-05
+// (consulta padrão exclui deletados; IgnoreQueryFilters expõe).
+public sealed class ModelBuilderSoftDeleteExtensionsTests
+{
+    private static readonly DateTimeOffset Instante = new(2026, 6, 9, 12, 0, 0, TimeSpan.Zero);
+
+    private sealed class EntidadeSoft : SoftDeletableEntity
+    {
+        public string Nome { get; set; } = string.Empty;
+    }
+
+    private sealed class EntidadeNaoSoft : EntityBase
+    {
+        public string Nome { get; set; } = string.Empty;
+    }
+
+    private sealed class ContextoConvencao(DbContextOptions<ContextoConvencao> options) : DbContext(options)
+    {
+        public DbSet<EntidadeSoft> Softs => Set<EntidadeSoft>();
+        public DbSet<EntidadeNaoSoft> NaoSofts => Set<EntidadeNaoSoft>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.AplicarFiltroGlobalSoftDelete();
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+
+    private static ContextoConvencao CriarContexto() =>
+        new(new DbContextOptionsBuilder<ContextoConvencao>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    [Fact(DisplayName = "CA-05: consulta padrão exclui ISoftDeletable marcada como excluída; IgnoreQueryFilters expõe")]
+    public void Convencao_FiltraExcluidos_IgnoreQueryFiltersExpoe()
+    {
+        using ContextoConvencao contexto = CriarContexto();
+        EntidadeSoft viva = new() { Nome = "viva" };
+        EntidadeSoft excluida = new() { Nome = "excluída" };
+        excluida.MarkAsDeleted("auditor", Instante);
+        contexto.Softs.AddRange(viva, excluida);
+        contexto.SaveChanges();
+
+        List<EntidadeSoft> visiveis = [.. contexto.Softs];
+        visiveis.Should().ContainSingle("o filtro de convenção exclui registros is_deleted = true")
+            .Which.Id.Should().Be(viva.Id);
+
+        List<EntidadeSoft> todas = [.. contexto.Softs.IgnoreQueryFilters()];
+        todas.Should().HaveCount(2, "IgnoreQueryFilters() remove o filtro e expõe a linha excluída");
+    }
+
+    [Fact(DisplayName = "Convenção não filtra nem mapeia coluna em entidade que não implementa ISoftDeletable")]
+    public void Convencao_NaoFiltra_EntidadeNaoSoft()
+    {
+        using ContextoConvencao contexto = CriarContexto();
+        contexto.NaoSofts.AddRange(
+            new EntidadeNaoSoft { Nome = "a" },
+            new EntidadeNaoSoft { Nome = "b" });
+        contexto.SaveChanges();
+
+        List<EntidadeNaoSoft> todas = [.. contexto.NaoSofts];
+        todas.Should().HaveCount(2);
+
+        contexto.Model.FindEntityType(typeof(EntidadeNaoSoft))!
+            .FindProperty(nameof(ISoftDeletable.IsDeleted))
+            .Should().BeNull("entidade sem ISoftDeletable não mapeia a coluna is_deleted");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/EntityBaseTests.cs
@@ -5,8 +5,9 @@ using AwesomeAssertions;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 
 // Cobre o ciclo de vida básico do EntityBase. A drenagem de domain events
-// fica em EntityBaseDomainEventsTests — esta classe foca em Id, audit e
-// soft delete (ADR-0032 + invariantes da issue #127).
+// fica em EntityBaseDomainEventsTests; soft-delete (opt-in via
+// SoftDeletableEntity, issue #629) fica em SoftDeletableEntityTests — esta
+// classe foca em Id e audit timestamps (ADR-0032).
 public sealed class EntityBaseTests
 {
     [Fact(DisplayName = "Nova entidade nasce com Id UUID v7 (preserva ordering temporal)")]
@@ -41,44 +42,12 @@ public sealed class EntityBaseTests
         entidade.CreatedAt.Should().Be(default);
     }
 
-    [Fact(DisplayName = "Entidade recém-criada não tem UpdatedAt, IsDeleted, DeletedAt, DeletedBy")]
-    public void NovaEntidade_FlagsDeAuditNaoIniciam()
+    [Fact(DisplayName = "Entidade recém-criada não tem UpdatedAt")]
+    public void NovaEntidade_NaoTemUpdatedAt()
     {
         EntidadeDeTeste entidade = new();
 
         entidade.UpdatedAt.Should().BeNull();
-        entidade.IsDeleted.Should().BeFalse();
-        entidade.DeletedAt.Should().BeNull();
-        entidade.DeletedBy.Should().BeNull();
-    }
-
-    [Fact(DisplayName = "MarkAsDeleted altera IsDeleted, DeletedAt (instante recebido) e DeletedBy")]
-    public void MarkAsDeleted_AlteraFlagsDeSoftDelete()
-    {
-        EntidadeDeTeste entidade = new();
-        // Instante determinístico: o caller (SoftDeleteInterceptor/repositório)
-        // provê deletedAt a partir do TimeProvider; o domínio só o registra.
-        DateTimeOffset instante = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
-
-        entidade.MarkAsDeleted("usuario@exemplo.com", instante);
-
-        entidade.IsDeleted.Should().BeTrue();
-        entidade.DeletedBy.Should().Be("usuario@exemplo.com");
-        entidade.DeletedAt.Should().Be(instante);
-        entidade.DeletedAt!.Value.Offset.Should().Be(TimeSpan.Zero);
-    }
-
-    [Fact(DisplayName = "MarkAsDeleted pode ser chamado mais de uma vez — sobrescreve DeletedBy")]
-    public void MarkAsDeleted_PodeSerChamadoMaisDeUmaVez()
-    {
-        EntidadeDeTeste entidade = new();
-        DateTimeOffset instante = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
-        entidade.MarkAsDeleted("primeiro", instante);
-
-        entidade.MarkAsDeleted("segundo", instante);
-
-        entidade.IsDeleted.Should().BeTrue();
-        entidade.DeletedBy.Should().Be("segundo");
     }
 
     [Fact(DisplayName = "DomainEvents inicia como coleção vazia e imutável (não array)")]

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/SoftDeletableEntityTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Entities/SoftDeletableEntityTests.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+// Cobre a capability opt-in de soft-delete (issue #629): SoftDeletableEntity
+// carrega a implementação de ISoftDeletable que antes vivia em EntityBase.
+// O carimbo automático em SaveChanges é coberto por SoftDeleteInterceptorTests.
+public sealed class SoftDeletableEntityTests
+{
+    [Fact(DisplayName = "SoftDeletableEntity é um EntityBase e implementa ISoftDeletable")]
+    public void SoftDeletableEntity_HerdaEntityBase_EImplementaContrato()
+    {
+        EntidadeDeTeste entidade = new();
+
+        entidade.Should().BeAssignableTo<EntityBase>("soft-delete é opt-in sobre a base de identidade");
+        entidade.Should().BeAssignableTo<ISoftDeletable>("o opt-in é detectado pelo interceptor e pela convenção via interface");
+        entidade.Id.Should().NotBeEmpty("Id continua vindo de EntityBase");
+    }
+
+    [Fact(DisplayName = "Entidade recém-criada não está deletada (IsDeleted/DeletedAt/DeletedBy)")]
+    public void NovaEntidade_NaoIniciaDeletada()
+    {
+        EntidadeDeTeste entidade = new();
+
+        entidade.IsDeleted.Should().BeFalse();
+        entidade.DeletedAt.Should().BeNull();
+        entidade.DeletedBy.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "MarkAsDeleted altera IsDeleted, DeletedAt (instante recebido) e DeletedBy")]
+    public void MarkAsDeleted_AlteraFlagsDeSoftDelete()
+    {
+        EntidadeDeTeste entidade = new();
+        // Instante determinístico: o caller (SoftDeleteInterceptor/repositório)
+        // provê deletedAt a partir do TimeProvider; o domínio só o registra.
+        DateTimeOffset instante = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
+
+        entidade.MarkAsDeleted("usuario@exemplo.com", instante);
+
+        entidade.IsDeleted.Should().BeTrue();
+        entidade.DeletedBy.Should().Be("usuario@exemplo.com");
+        entidade.DeletedAt.Should().Be(instante);
+        entidade.DeletedAt!.Value.Offset.Should().Be(TimeSpan.Zero);
+    }
+
+    [Fact(DisplayName = "MarkAsDeleted pode ser chamado mais de uma vez — sobrescreve DeletedBy")]
+    public void MarkAsDeleted_PodeSerChamadoMaisDeUmaVez()
+    {
+        EntidadeDeTeste entidade = new();
+        DateTimeOffset instante = new(2026, 5, 24, 12, 0, 0, TimeSpan.Zero);
+        entidade.MarkAsDeleted("primeiro", instante);
+
+        entidade.MarkAsDeleted("segundo", instante);
+
+        entidade.IsDeleted.Should().BeTrue();
+        entidade.DeletedBy.Should().Be("segundo");
+    }
+
+    private sealed class EntidadeDeTeste : SoftDeletableEntity
+    {
+    }
+}

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadePersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadePersistenceTests.cs
@@ -306,6 +306,50 @@ public sealed class UnidadePersistenceTests : IClassFixture<UnidadeDbFixture>
         (await repository.CodigoExisteEntreLivosAsync(" TRIMCOD ", null, CancellationToken.None)).Should().BeTrue();
     }
 
+    [Fact(DisplayName = "Soft-delete de Unidade preserva o histórico de identificadores (FK não cascateia) — regressão #629")]
+    public async Task SoftDelete_PreservaHistoricoDeIdentificadores()
+    {
+        // Regressão (issue #629 / PR #631): ObterPorIdAsync faz Include(Historico);
+        // com a FK em Cascade, Remover(unidade) marcava os históricos carregados como
+        // Deleted e — como o SoftDeleteInterceptor só converte ISoftDeletable — eles
+        // sofriam hard-delete físico, destruindo a trilha append-only. A FK Restrict
+        // impede o cascade em memória: a Unidade vira soft-delete e o histórico sobrevive.
+        Unidade unidade = NovaUnidade("hist-preserva", "HPRES", "HPR001");
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Unidades.Add(unidade);
+            await ctx.SaveChangesAsync();
+        }
+
+        // Caminho EXATO do RemoverUnidadeCommandHandler: ObterPorIdAsync (Include
+        // Historico, rastreado) seguido de Remover, no mesmo contexto.
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            var repository = new UnidadeRepository(ctx);
+            Unidade tracked = (await repository.ObterPorIdAsync(unidade.Id, CancellationToken.None))!;
+            tracked.Historico.Should().HaveCount(3,
+                "a criação abriu 3 entradas (Slug, Sigla, Codigo), carregadas e rastreadas");
+
+            repository.Remover(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext readCtx = _fixture.CreateDbContext(userId: null);
+
+        // Unidade soft-deletada (UPDATE is_deleted=true), não removida fisicamente.
+        Unidade excluida = await readCtx.Unidades
+            .IgnoreQueryFilters()
+            .SingleAsync(u => u.Id == unidade.Id);
+        excluida.IsDeleted.Should().BeTrue();
+
+        // Histórico append-only PRESERVADO — as 3 linhas seguem no banco.
+        int historicoCount = await readCtx.UnidadesIdentificadoresHistorico
+            .CountAsync(h => h.UnidadeId == unidade.Id);
+        historicoCount.Should().Be(3,
+            "o histórico de identificadores não pode ser hard-deletado no soft-delete da Unidade (issue #629)");
+    }
+
     // ── Factory helper ───────────────────────────────────────────────────
 
     private static Unidade NovaUnidade(


### PR DESCRIPTION
## Resumo

- Inverte o modelo de soft-delete: deixa de ser **herança forçada** em `EntityBase` (toda entidade ganhava `is_deleted`/`deleted_at`/`deleted_by` no banco) para ser **capability opt-in** de quem implementa `ISoftDeletable`.
- `EntityBase` reduz-se a identidade + timestamps + domain events; nova base `SoftDeletableEntity : EntityBase, ISoftDeletable` carrega a implementação dos membros.
- O filtro `!IsDeleted` passa a ser aplicado por **convenção** (filtro nomeado EF Core 10) nos 5 DbContexts, eliminando as 14 chamadas `HasQueryFilter` manuais.

Closes #629

## Mudanças

### Kernel
- `EntityBase`: removidos `IsDeleted`/`DeletedAt`/`DeletedBy`/`MarkAsDeleted`.
- **Novo** `SoftDeletableEntity : EntityBase, ISoftDeletable` — implementação única dos membros de soft-delete.

### Domain (14 entidades re-baseadas → `SoftDeletableEntity`)
- Seleção: `Edital`, `Etapa`, `Cota`, `Inscricao`, `Candidato`, `ProcessoSeletivo`, `ObrigatoriedadeLegal`.
- Ingresso: `Chamada`, `Convocacao`, `Matricula`, `DocumentoMatricula`.
- Organização: `Unidade`, `Instituicao`, `AreaOrganizacional`.
- `UnidadeIdentificadorHistorico` (append-only) **permanece** em `EntityBase` e perde as colunas soft.

### Infrastructure.Core
- **Novo** `ModelBuilderSoftDeleteExtensions.AplicarFiltroGlobalSoftDelete` — aplica `e => !e.IsDeleted` via filtro **nomeado** (`"SoftDelete"`) a todo tipo não-owned `ISoftDeletable`. Filtro nomeado (não anônimo) para coexistir com futuros filtros de visibilidade área-scoped (ADR-0060) — o EF Core 10 proíbe combinar anônimo + nomeado.
- `SoftDeleteInterceptor`: passa a chavear em `ISoftDeletable`; entidades não-soft sofrem **hard-delete** físico.

### Persistência
- 5 DbContexts (Selecao, Ingresso, Portal, OrganizacaoInstitucional, Configuracao) invocam a convenção no fim de `OnModelCreating`.
- 14 `HasQueryFilter(e => !e.IsDeleted)` removidos das configurações (índices parciais `HasFilter("is_deleted = false")` preservados).
- **Migração forward-only** (ADR-0054) `RemoveColunasSoftDeleteHistoricoIdentificador`: dropa `is_deleted`/`deleted_at`/`deleted_by` de `unidade_identificador_historico`; vigência segue encerrada por `vigencia_fim`.

### Testes
- **Novo** `SoftDeletableEntityTests` (Kernel) — soft-delete movido de `EntityBaseTests`.
- **Novo** `ModelBuilderSoftDeleteExtensionsTests` (Infra.Core) — CA-05: consulta exclui excluídos; `IgnoreQueryFilters()` expõe.
- **Novo** `SoftDeleteOptInConventionTests` (ArchTests) — fitness function: constrói os 5 modelos EF e trava a invariante opt-in (CA-01/CA-07).
- `SoftDeleteInterceptorTests`: re-base + casos de hard-delete para não-`ISoftDeletable` (CA-06).

## Critérios de aceite

Todos os 8 (CA-01 a CA-08) atendidos — ver issue #629.

## Testes

- **1156 testes** (unit + integração + arch) — todos passando.
- Build com `-warnaserror`: 0 erros, 0 warnings.
- Validação end-to-end: migração aplicada em Postgres real + Newman 23/23 na API de Organização (ciclo soft-delete → 404 + singleton).

## Checklist

- [x] Build sem errors (0 warnings)
- [x] Testes passando (1156)
- [x] Migração forward-only (ADR-0054) revisada
- [x] Validação runtime (Newman) na API afetada