### PR TITLE
docs(banco): atualiza topologia e btree_gist pós-KILL do eixo de Área

### DIFF
--- a/docker/init-db.sql
+++ b/docker/init-db.sql
@@ -34,10 +34,11 @@ CREATE DATABASE uniplus_organizacao OWNER uniplus_organizacao_app;
 -- Extensões dos databases de aplicação:
 --   uuid-ossp  — geração de UUIDs
 --   pg_trgm    — busca por similaridade (trigram matching)
---   btree_gist — exclusion constraints GIST das junction tables de
---                AreasDeInteresse (ADR-0060). Habilitada nos bancos que
---                hospedam entidades com governança por área na Sprint 3:
---                selecao, configuracao e organizacao.
+--   btree_gist — pré-requisito de exclusion constraints GIST em junction
+--                tables temporais (ADR-0060). A junction de áreas de interesse
+--                (primeira aplicação) saiu no KILL do eixo de Área (Epic #600);
+--                a extensão segue provisionada em selecao, configuracao e
+--                organizacao para junctions temporais futuras.
 
 \c uniplus_selecao
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/docs/guia-banco-de-dados.md
+++ b/docs/guia-banco-de-dados.md
@@ -35,14 +35,14 @@ Uni+ usa **5 bancos PostgreSQL 18 isolados** (um por módulo), no mesmo host PG 
 | `uniplus_ingresso` | `uniplus` | `IngressoDbContext` | Chamadas, Convocações, Matrículas, DocumentosMatricula |
 | `uniplus_portal` | `uniplus` | `PortalDbContext` | Vazio até primeira Story tocar entity Portal |
 | `uniplus_configuracao` | `uniplus_configuracao_app` | `ConfiguracaoDbContext` | Catálogos cross-cutting: Modalidade, NecessidadeEspecial, TipoDocumento, Endereco |
-| `uniplus_organizacao` | `uniplus_organizacao_app` | `OrganizacaoInstitucionalDbContext` (a criar — F1.S2) | AreaOrganizacional |
+| `uniplus_organizacao` | `uniplus_organizacao_app` | `OrganizacaoInstitucionalDbContext` | Unidade, Instituição |
 
 Os bancos legados (Selecao/Ingresso/Portal) compartilham o superusuário `uniplus`. Os bancos da Sprint 3 (Configuracao/Organizacao) usam **usuários `_app` dedicados, cada um dono (`OWNER`) do seu próprio banco** — o owner tem DDL completo no schema `public` (necessário a partir do PG 15, que removeu o `CREATE` implícito) e instala extensões trusted sem superusuário. Provisionamento em `docker/init-db.sql`.
 
 Extensões habilitadas:
 
 - `uuid-ossp`, `pg_trgm` — em todos os bancos de aplicação.
-- `btree_gist` — em `uniplus_selecao`, `uniplus_configuracao` e `uniplus_organizacao`: requerida pelos exclusion constraints GIST das junction tables de `AreasDeInteresse` ([ADR-0060](adrs/0060-junction-tables-por-entidade-com-view-unificada.md)). Em dev é habilitada via `init-db.sql`; em standalone/HML/PROD, via a primeira migration de cada DbContext (idempotente, `CREATE EXTENSION IF NOT EXISTS`).
+- `btree_gist` — em `uniplus_selecao`, `uniplus_configuracao` e `uniplus_organizacao`: pré-requisito de exclusion constraints GIST em junction tables temporais ([ADR-0060](adrs/0060-junction-tables-por-entidade-com-view-unificada.md)). A primeira aplicação (junction de áreas de interesse) foi removida no KILL do eixo de Área (Epic #600); a extensão segue provisionada — em dev via `init-db.sql`, em standalone/HML/PROD via a primeira migration de cada DbContext (idempotente, `CREATE EXTENSION IF NOT EXISTS`) — para junctions temporais futuras.
 
 Schemas usados em cada banco:
 


### PR DESCRIPTION
## O quê

Limpeza de documentação após o KILL do eixo de Área (PRs #635 e #637, mergeados). Duas referências obsoletas no guia de banco + o comentário equivalente no `docker/init-db.sql`:

- **Topologia** (`guia-banco-de-dados.md`): o banco `organizacao` listava `AreaOrganizacional` (removido no #635) e marcava o DbContext como "(a criar — F1.S2)". Agora lista `Unidade, Instituição`.
- **`btree_gist`**: era justificado pelas junction tables de `AreasDeInteresse` (removidas no #637). Reescrito como pré-requisito genérico de exclusion constraints GIST em junction tables temporais, com a nota de que a primeira aplicação (áreas de interesse) saiu no KILL e que a extensão segue provisionada para junctions temporais futuras.
- Mesmo ajuste no comentário do `docker/init-db.sql`.

## Por quê

Após o KILL não há mais nenhum `EXCLUDE USING GIST` vivo no schema (a junction do `selecao` foi dropada; `configuracao`/`organizacao` não têm). A extensão continua provisionada (init-db + migrations) para uso futuro — apenas a justificativa específica ficou desatualizada.
