### PR TITLE
feat(authorization): cria módulo com enums e value objects de apoio

### DIFF
--- a/UniPlus.slnx
+++ b/UniPlus.slnx
@@ -31,6 +31,7 @@
   </Folder>
   <Folder Name="/src/shared/">
     <Project Path="src/shared/Unifesspa.UniPlus.Application.Abstractions/Unifesspa.UniPlus.Application.Abstractions.csproj" />
+    <Project Path="src/shared/Unifesspa.UniPlus.Authorization/Unifesspa.UniPlus.Authorization.csproj" />
     <Project Path="src/shared/Unifesspa.UniPlus.Governance.Contracts/Unifesspa.UniPlus.Governance.Contracts.csproj" />
     <Project Path="src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj" />
     <Project Path="src/shared/Unifesspa.UniPlus.Kernel/Unifesspa.UniPlus.Kernel.csproj" />
@@ -38,6 +39,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/Unifesspa.UniPlus.Application.Abstractions.UnitTests/Unifesspa.UniPlus.Application.Abstractions.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.Authorization.UnitTests/Unifesspa.UniPlus.Authorization.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Ingresso.ArchTests/Unifesspa.UniPlus.Ingresso.ArchTests.csproj" />

--- a/src/shared/Unifesspa.UniPlus.Authorization/Enums/FonteGrant.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Enums/FonteGrant.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Authorization.Enums;
+
+/// <summary>
+/// Origem rastreável de uma concessão efetiva (<c>EffectiveGrant</c>) avaliada
+/// pela decisão de autorização (ADR-0078). Distingue o que veio no token do que
+/// foi resolvido no servidor — concessões server-side são sempre temporárias e
+/// exigem validade explícita.
+/// </summary>
+public enum FonteGrant
+{
+    /// <summary>Permissão presente no token de acesso (claim). Pode não ter validade própria — herda a validade do token.</summary>
+    Token = 0,
+
+    /// <summary>Vínculo derivado de grupo OIDC resolvido no servidor. Concessão temporária — exige validade explícita.</summary>
+    OidcGroupBinding = 1,
+
+    /// <summary>Concessão excepcional fora do grupo padrão, resolvida no servidor. Concessão temporária — exige validade explícita.</summary>
+    PermissaoExcecional = 2,
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Enums/MotivoNegativa.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Enums/MotivoNegativa.cs
@@ -1,0 +1,50 @@
+namespace Unifesspa.UniPlus.Authorization.Enums;
+
+/// <summary>
+/// Conjunto fechado de motivos pelos quais a decisão de autorização nega o
+/// acesso (ADR-0078). O motivo é estável e <b>sem dados pessoais</b> — serve a
+/// diagnóstico e auditoria. São exatamente 13 motivos; o identificador C# está
+/// em PascalCase e o valor canônico de serialização externa em <c>snake_case</c>
+/// está indicado em cada membro.
+/// </summary>
+public enum MotivoNegativa
+{
+    /// <summary>Valor canônico: <c>multifator_nao_satisfeito</c>.</summary>
+    MultifatorNaoSatisfeito = 0,
+
+    /// <summary>Valor canônico: <c>dupla_aprovacao_invalida</c>.</summary>
+    DuplaAprovacaoInvalida = 1,
+
+    /// <summary>Valor canônico: <c>sem_concessao_aplicavel</c>.</summary>
+    SemConcessaoAplicavel = 2,
+
+    /// <summary>Valor canônico: <c>concessao_expirada</c>.</summary>
+    ConcessaoExpirada = 3,
+
+    /// <summary>Valor canônico: <c>fase_fechada</c>.</summary>
+    FaseFechada = 4,
+
+    /// <summary>Valor canônico: <c>estado_do_recurso_incompativel</c>.</summary>
+    EstadoDoRecursoIncompativel = 5,
+
+    /// <summary>Valor canônico: <c>escopo_de_auditoria_inativo</c>.</summary>
+    EscopoDeAuditoriaInativo = 6,
+
+    /// <summary>Valor canônico: <c>equipe_inativa_no_processo</c>.</summary>
+    EquipeInativaNoProcesso = 7,
+
+    /// <summary>Valor canônico: <c>atribuicao_documental_inativa</c>.</summary>
+    AtribuicaoDocumentalInativa = 8,
+
+    /// <summary>Valor canônico: <c>base_legal_ausente</c>.</summary>
+    BaseLegalAusente = 9,
+
+    /// <summary>Valor canônico: <c>conformidade_legal_nao_validada</c>.</summary>
+    ConformidadeLegalNaoValidada = 10,
+
+    /// <summary>Valor canônico: <c>contexto_obrigatorio_ausente</c>.</summary>
+    ContextoObrigatorioAusente = 11,
+
+    /// <summary>Valor canônico: <c>mecanismo_revogacao_degradado</c>.</summary>
+    MecanismoRevogacaoDegradado = 12,
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Enums/OrigemRequisicao.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Enums/OrigemRequisicao.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Authorization.Enums;
+
+/// <summary>
+/// Canal pelo qual a requisição autorizada chegou ao sistema, usado como
+/// atributo de contexto na decisão de autorização (ADR-0078).
+/// </summary>
+/// <remarks>
+/// Os identificadores C# estão em PascalCase; a serialização externa usa o
+/// valor canônico em <c>kebab-case</c>/<c>snake_case</c> conforme indicado em
+/// cada membro. A serialização canônica é responsabilidade da camada de borda
+/// (outra story), não deste tipo de contrato em memória.
+/// </remarks>
+public enum OrigemRequisicao
+{
+    /// <summary>API HTTP pública. Valor canônico: <c>api</c>.</summary>
+    Api = 0,
+
+    /// <summary>Processamento assíncrono (jobs/outbox). Valor canônico: <c>jobs</c>.</summary>
+    Jobs = 1,
+
+    /// <summary>Ferramenta administrativa de linha de comando. Valor canônico: <c>admin-cli</c>/<c>admin_cli</c>.</summary>
+    AdminCli = 2,
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Enums/Sensibilidade.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Enums/Sensibilidade.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Authorization.Enums;
+
+/// <summary>
+/// Classificação de sensibilidade do dado retornado por uma operação, usada
+/// pela decisão de autorização para aplicar proteção por permissão e base legal
+/// (LGPD-by-design, ADR-0078). A escala é crescente: <see cref="Publica"/> é o
+/// dado de menor proteção e <see cref="Sensivel"/> o de maior.
+/// </summary>
+public enum Sensibilidade
+{
+    /// <summary>Dado público — sem restrição de divulgação.</summary>
+    Publica = 0,
+
+    /// <summary>Dado interno — restrito ao âmbito institucional.</summary>
+    Interna = 1,
+
+    /// <summary>Dado pessoal — protegido pela LGPD (art. 5º, I).</summary>
+    Pessoal = 2,
+
+    /// <summary>Dado pessoal sensível — protegido pela LGPD (art. 5º, II).</summary>
+    Sensivel = 3,
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Authorization.Errors;
+
+/// <summary>
+/// Códigos estáveis de erro de validação das fábricas dos tipos formais do
+/// contrato de autorização (ADR-0078). Distintos do <c>MotivoNegativa</c>: estes
+/// sinalizam construção inválida de um value object; aquele explica uma negativa
+/// de acesso já decidida.
+/// </summary>
+public static class AuthorizationErrorCodes
+{
+    public const string UsuarioRefEmissorObrigatorio = "Authorization.UsuarioRef.EmissorObrigatorio";
+    public const string UsuarioRefSubjectObrigatorio = "Authorization.UsuarioRef.SubjectObrigatorio";
+
+    public const string EffectiveGrantPermissaoObrigatoria = "Authorization.EffectiveGrant.PermissaoObrigatoria";
+    public const string EffectiveGrantValidadeObrigatoria = "Authorization.EffectiveGrant.ValidadeObrigatoria";
+
+    public const string EscopoAuditoriaEscopoObrigatorio = "Authorization.EscopoAuditoriaVigente.EscopoObrigatorio";
+
+    public const string AtuacaoUnidadeObrigatoria = "Authorization.AtuacaoVigente.UnidadeObrigatoria";
+
+    public const string DualApprovalPermissaoObrigatoria = "Authorization.DualApprovalGrant.PermissaoObrigatoria";
+    public const string DualApprovalRecursoHashObrigatorio = "Authorization.DualApprovalGrant.RecursoHashObrigatorio";
+    public const string DualApprovalAprovadoresIguais = "Authorization.DualApprovalGrant.AprovadoresIguais";
+    public const string DualApprovalValidadeNaoPosterior = "Authorization.DualApprovalGrant.ValidadeNaoPosterior";
+    public const string DualApprovalValidadeAcimaDoLimite = "Authorization.DualApprovalGrant.ValidadeAcimaDoLimite";
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
@@ -12,6 +12,7 @@ public static class AuthorizationErrorCodes
     public const string UsuarioRefSubjectObrigatorio = "Authorization.UsuarioRef.SubjectObrigatorio";
 
     public const string EffectiveGrantPermissaoObrigatoria = "Authorization.EffectiveGrant.PermissaoObrigatoria";
+    public const string EffectiveGrantEscopoInvalido = "Authorization.EffectiveGrant.EscopoInvalido";
     public const string EffectiveGrantValidadeObrigatoria = "Authorization.EffectiveGrant.ValidadeObrigatoria";
     public const string EffectiveGrantEscopoExcecionalObrigatorio = "Authorization.EffectiveGrant.EscopoExcecionalObrigatorio";
 

--- a/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
@@ -13,6 +13,7 @@ public static class AuthorizationErrorCodes
 
     public const string EffectiveGrantPermissaoObrigatoria = "Authorization.EffectiveGrant.PermissaoObrigatoria";
     public const string EffectiveGrantValidadeObrigatoria = "Authorization.EffectiveGrant.ValidadeObrigatoria";
+    public const string EffectiveGrantEscopoExcecionalObrigatorio = "Authorization.EffectiveGrant.EscopoExcecionalObrigatorio";
 
     public const string EscopoAuditoriaEscopoObrigatorio = "Authorization.EscopoAuditoriaVigente.EscopoObrigatorio";
 

--- a/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
@@ -10,13 +10,16 @@ public static class AuthorizationErrorCodes
 {
     public const string UsuarioRefEmissorObrigatorio = "Authorization.UsuarioRef.EmissorObrigatorio";
     public const string UsuarioRefSubjectObrigatorio = "Authorization.UsuarioRef.SubjectObrigatorio";
+    public const string UsuarioRefUsuarioIdInvalido = "Authorization.UsuarioRef.UsuarioIdInvalido";
 
     public const string EffectiveGrantPermissaoObrigatoria = "Authorization.EffectiveGrant.PermissaoObrigatoria";
+    public const string EffectiveGrantGrantIdInvalido = "Authorization.EffectiveGrant.GrantIdInvalido";
     public const string EffectiveGrantEscopoInvalido = "Authorization.EffectiveGrant.EscopoInvalido";
     public const string EffectiveGrantValidadeObrigatoria = "Authorization.EffectiveGrant.ValidadeObrigatoria";
     public const string EffectiveGrantEscopoExcecionalObrigatorio = "Authorization.EffectiveGrant.EscopoExcecionalObrigatorio";
 
     public const string EscopoAuditoriaEscopoObrigatorio = "Authorization.EscopoAuditoriaVigente.EscopoObrigatorio";
+    public const string EscopoAuditoriaUnidadeInvalida = "Authorization.EscopoAuditoriaVigente.UnidadeInvalida";
 
     public const string AtuacaoUnidadeObrigatoria = "Authorization.AtuacaoVigente.UnidadeObrigatoria";
 

--- a/src/shared/Unifesspa.UniPlus.Authorization/Unifesspa.UniPlus.Authorization.csproj
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Unifesspa.UniPlus.Authorization.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Unifesspa.UniPlus.Kernel\Unifesspa.UniPlus.Kernel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/AtuacaoVigente.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/AtuacaoVigente.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Authorization.ValueObjects;
+
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Snapshot de contrato de uma atuação institucional vigente (sessão delegada),
+/// consumido pela decisão de autorização (ADR-0078) — <b>não</b> é a entidade
+/// persistida. Representa o usuário operando em nome de uma unidade, com
+/// validade própria.
+/// </summary>
+public sealed record AtuacaoVigente
+{
+    /// <summary>Unidade representada na atuação delegada.</summary>
+    public Guid UnidadeRepresentadaId { get; }
+
+    /// <summary>Validade da atuação.</summary>
+    public DateTimeOffset ValidoAte { get; }
+
+    private AtuacaoVigente(Guid unidadeRepresentadaId, DateTimeOffset validoAte)
+    {
+        UnidadeRepresentadaId = unidadeRepresentadaId;
+        ValidoAte = validoAte;
+    }
+
+    /// <summary>
+    /// Constrói uma <see cref="AtuacaoVigente"/> validada. Rejeita unidade
+    /// representada vazia (<see cref="Guid.Empty"/>).
+    /// </summary>
+    public static Result<AtuacaoVigente> From(Guid unidadeRepresentadaId, DateTimeOffset validoAte)
+    {
+        if (unidadeRepresentadaId == Guid.Empty)
+        {
+            return Result<AtuacaoVigente>.Failure(new DomainError(
+                AuthorizationErrorCodes.AtuacaoUnidadeObrigatoria,
+                "Unidade representada é obrigatória."));
+        }
+
+        return Result<AtuacaoVigente>.Success(new AtuacaoVigente(unidadeRepresentadaId, validoAte));
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/DualApprovalGrant.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/DualApprovalGrant.cs
@@ -1,0 +1,152 @@
+namespace Unifesspa.UniPlus.Authorization.ValueObjects;
+
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Concessão de dupla aprovação (four-eyes) para uma operação sensível,
+/// consumida pela decisão de autorização (ADR-0078). Dois aprovadores
+/// <b>distintos</b> autorizam uma operação sobre um recurso específico
+/// (<see cref="RecursoHash"/>), com uma janela de validade curta — no máximo
+/// <b>1 hora</b> após a concessão. O identificador é um GUID v7
+/// (<see cref="Guid.CreateVersion7()"/>, ADR-0032), ordenável temporalmente.
+/// </summary>
+/// <remarks>
+/// A persistência, o algoritmo do <see cref="RecursoHash"/> e o consumo atômico
+/// de uso único são responsabilidade de stories irmãs (#609, #612). Este tipo é
+/// apenas o contrato em memória, com as invariantes de construção.
+/// </remarks>
+public sealed record DualApprovalGrant
+{
+    /// <summary>Janela máxima de validade após a concessão.</summary>
+    public static readonly TimeSpan JanelaMaxima = TimeSpan.FromHours(1);
+
+    /// <summary>Identificador GUID v7 da concessão.</summary>
+    public Guid Id { get; }
+
+    /// <summary>Primeiro aprovador.</summary>
+    public UsuarioRef AprovadorPrimario { get; }
+
+    /// <summary>Segundo aprovador — distinto do primário.</summary>
+    public UsuarioRef AprovadorSecundario { get; }
+
+    /// <summary>Hash opaco do recurso alvo (algoritmo definido em story irmã).</summary>
+    public string RecursoHash { get; }
+
+    /// <summary>Código da permissão concedida.</summary>
+    public string PermissaoCodigo { get; }
+
+    /// <summary>Instante da concessão.</summary>
+    public DateTimeOffset ConcedidoEm { get; }
+
+    /// <summary>Validade da concessão — no máximo 1h após <see cref="ConcedidoEm"/>.</summary>
+    public DateTimeOffset ValidoAte { get; }
+
+    /// <summary>Marcador de uso único (o consumo atômico fica em story irmã).</summary>
+    public bool Usado { get; }
+
+    /// <summary>Instante do uso, quando consumida. Opcional.</summary>
+    public DateTimeOffset? UsadoEm { get; }
+
+    /// <summary>Quem consumiu a concessão. Opcional.</summary>
+    public UsuarioRef? UsadoPor { get; }
+
+    private DualApprovalGrant(
+        Guid id,
+        UsuarioRef aprovadorPrimario,
+        UsuarioRef aprovadorSecundario,
+        string recursoHash,
+        string permissaoCodigo,
+        DateTimeOffset concedidoEm,
+        DateTimeOffset validoAte,
+        bool usado,
+        DateTimeOffset? usadoEm,
+        UsuarioRef? usadoPor)
+    {
+        Id = id;
+        AprovadorPrimario = aprovadorPrimario;
+        AprovadorSecundario = aprovadorSecundario;
+        RecursoHash = recursoHash;
+        PermissaoCodigo = permissaoCodigo;
+        ConcedidoEm = concedidoEm;
+        ValidoAte = validoAte;
+        Usado = usado;
+        UsadoEm = usadoEm;
+        UsadoPor = usadoPor;
+    }
+
+    /// <summary>
+    /// Constrói um <see cref="DualApprovalGrant"/> validado, com identificador
+    /// GUID v7. Rejeita aprovador secundário igual ao primário (mesma
+    /// identidade OIDC), validade não posterior à concessão e validade acima do
+    /// limite de 1 hora.
+    /// </summary>
+    public static Result<DualApprovalGrant> From(
+        UsuarioRef aprovadorPrimario,
+        UsuarioRef aprovadorSecundario,
+        string? recursoHash,
+        string? permissaoCodigo,
+        DateTimeOffset concedidoEm,
+        DateTimeOffset validoAte,
+        bool usado = false,
+        DateTimeOffset? usadoEm = null,
+        UsuarioRef? usadoPor = null)
+    {
+        ArgumentNullException.ThrowIfNull(aprovadorPrimario);
+        ArgumentNullException.ThrowIfNull(aprovadorSecundario);
+
+        if (string.IsNullOrWhiteSpace(permissaoCodigo))
+        {
+            return Result<DualApprovalGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.DualApprovalPermissaoObrigatoria,
+                "Código da permissão é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(recursoHash))
+        {
+            return Result<DualApprovalGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.DualApprovalRecursoHashObrigatorio,
+                "Hash do recurso é obrigatório."));
+        }
+
+        if (MesmaIdentidade(aprovadorPrimario, aprovadorSecundario))
+        {
+            return Result<DualApprovalGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.DualApprovalAprovadoresIguais,
+                "Aprovador secundário deve ser distinto do primário."));
+        }
+
+        if (validoAte <= concedidoEm)
+        {
+            return Result<DualApprovalGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.DualApprovalValidadeNaoPosterior,
+                "Validade deve ser posterior à concessão."));
+        }
+
+        if (validoAte - concedidoEm > JanelaMaxima)
+        {
+            return Result<DualApprovalGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.DualApprovalValidadeAcimaDoLimite,
+                "Validade não pode exceder 1 hora após a concessão."));
+        }
+
+        return Result<DualApprovalGrant>.Success(new DualApprovalGrant(
+            Guid.CreateVersion7(),
+            aprovadorPrimario,
+            aprovadorSecundario,
+            recursoHash.Trim(),
+            permissaoCodigo.Trim(),
+            concedidoEm,
+            validoAte,
+            usado,
+            usadoEm,
+            usadoPor));
+    }
+
+    // Dois aprovadores são a mesma pessoa quando compartilham emissor + subject
+    // do token (par único de identidade OIDC) — não o UsuarioId interno, que
+    // pode estar ausente em um dos lados.
+    private static bool MesmaIdentidade(UsuarioRef a, UsuarioRef b) =>
+        string.Equals(a.Emissor, b.Emissor, StringComparison.Ordinal)
+        && string.Equals(a.Subject, b.Subject, StringComparison.Ordinal);
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EffectiveGrant.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EffectiveGrant.cs
@@ -96,6 +96,15 @@ public sealed record EffectiveGrant
                 "Código da permissão é obrigatório."));
         }
 
+        if (EscopoVazioInformado(escopoUnidadeId)
+            || EscopoVazioInformado(escopoProcessoId)
+            || EscopoVazioInformado(escopoChamadaId))
+        {
+            return Result<EffectiveGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.EffectiveGrantEscopoInvalido,
+                "Escopo informado não pode ser Guid.Empty — use um identificador real ou nulo."));
+        }
+
         if (fonte is FonteGrant.OidcGroupBinding or FonteGrant.PermissaoExcecional && validoAte is null)
         {
             return Result<EffectiveGrant>.Failure(new DomainError(
@@ -125,4 +134,8 @@ public sealed record EffectiveGrant
             validoAte,
             concedidoPor));
     }
+
+    // Um escopo Guid é "informado mas vazio" quando vem preenchido com
+    // Guid.Empty — nunca um identificador real (o projeto usa Guid v7).
+    private static bool EscopoVazioInformado(Guid? escopo) => escopo is { } valor && valor == Guid.Empty;
 }

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EffectiveGrant.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EffectiveGrant.cs
@@ -96,9 +96,16 @@ public sealed record EffectiveGrant
                 "Código da permissão é obrigatório."));
         }
 
-        if (EscopoVazioInformado(escopoUnidadeId)
-            || EscopoVazioInformado(escopoProcessoId)
-            || EscopoVazioInformado(escopoChamadaId))
+        if (GuidVazioInformado(grantId))
+        {
+            return Result<EffectiveGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.EffectiveGrantGrantIdInvalido,
+                "GrantId informado não pode ser Guid.Empty — use um identificador real ou nulo."));
+        }
+
+        if (GuidVazioInformado(escopoUnidadeId)
+            || GuidVazioInformado(escopoProcessoId)
+            || GuidVazioInformado(escopoChamadaId))
         {
             return Result<EffectiveGrant>.Failure(new DomainError(
                 AuthorizationErrorCodes.EffectiveGrantEscopoInvalido,
@@ -135,7 +142,7 @@ public sealed record EffectiveGrant
             concedidoPor));
     }
 
-    // Um escopo Guid é "informado mas vazio" quando vem preenchido com
+    // Um Guid opcional é "informado mas vazio" quando vem preenchido com
     // Guid.Empty — nunca um identificador real (o projeto usa Guid v7).
-    private static bool EscopoVazioInformado(Guid? escopo) => escopo is { } valor && valor == Guid.Empty;
+    private static bool GuidVazioInformado(Guid? valor) => valor is { } g && g == Guid.Empty;
 }

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EffectiveGrant.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EffectiveGrant.cs
@@ -1,0 +1,112 @@
+namespace Unifesspa.UniPlus.Authorization.ValueObjects;
+
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Concessão efetiva avaliada pela decisão de autorização (ADR-0078): uma
+/// permissão que o sujeito de fato possui, com sua origem rastreável
+/// (<see cref="Fonte"/>), escopo opcional (unidade, processo, chamada),
+/// eventual restrição por tipo de recurso e validade. Concessões resolvidas no
+/// servidor (<see cref="FonteGrant.OidcGroupBinding"/>,
+/// <see cref="FonteGrant.PermissaoExcecional"/>) são sempre temporárias e
+/// exigem <see cref="ValidoAte"/>; concessões vindas do token
+/// (<see cref="FonteGrant.Token"/>) herdam a validade do token e podem não ter
+/// validade própria.
+/// </summary>
+public sealed record EffectiveGrant
+{
+    /// <summary>Código da permissão concedida.</summary>
+    public string PermissaoCodigo { get; }
+
+    /// <summary>Origem rastreável da concessão.</summary>
+    public FonteGrant Fonte { get; }
+
+    /// <summary>Identificador da concessão de origem, quando aplicável. Opcional.</summary>
+    public Guid? GrantId { get; }
+
+    /// <summary>Escopo por unidade organizacional. Opcional.</summary>
+    public Guid? EscopoUnidadeId { get; }
+
+    /// <summary>Escopo por processo seletivo. Opcional.</summary>
+    public Guid? EscopoProcessoId { get; }
+
+    /// <summary>Escopo por chamada. Opcional.</summary>
+    public Guid? EscopoChamadaId { get; }
+
+    /// <summary>Restrição da concessão a um tipo de recurso específico. Opcional.</summary>
+    public string? RecursoTipoRestricao { get; }
+
+    /// <summary>Validade da concessão. Obrigatória para concessões server-side; opcional para token.</summary>
+    public DateTimeOffset? ValidoAte { get; }
+
+    /// <summary>Quem concedeu, para concessões excepcionais. Opcional.</summary>
+    public UsuarioRef? ConcedidoPor { get; }
+
+    private EffectiveGrant(
+        string permissaoCodigo,
+        FonteGrant fonte,
+        Guid? grantId,
+        Guid? escopoUnidadeId,
+        Guid? escopoProcessoId,
+        Guid? escopoChamadaId,
+        string? recursoTipoRestricao,
+        DateTimeOffset? validoAte,
+        UsuarioRef? concedidoPor)
+    {
+        PermissaoCodigo = permissaoCodigo;
+        Fonte = fonte;
+        GrantId = grantId;
+        EscopoUnidadeId = escopoUnidadeId;
+        EscopoProcessoId = escopoProcessoId;
+        EscopoChamadaId = escopoChamadaId;
+        RecursoTipoRestricao = recursoTipoRestricao;
+        ValidoAte = validoAte;
+        ConcedidoPor = concedidoPor;
+    }
+
+    /// <summary>
+    /// Constrói uma <see cref="EffectiveGrant"/> validada. Rejeita código de
+    /// permissão vazio e concessão server-side
+    /// (<see cref="FonteGrant.OidcGroupBinding"/> /
+    /// <see cref="FonteGrant.PermissaoExcecional"/>) sem
+    /// <paramref name="validoAte"/>.
+    /// </summary>
+    public static Result<EffectiveGrant> From(
+        string? permissaoCodigo,
+        FonteGrant fonte,
+        Guid? grantId = null,
+        Guid? escopoUnidadeId = null,
+        Guid? escopoProcessoId = null,
+        Guid? escopoChamadaId = null,
+        string? recursoTipoRestricao = null,
+        DateTimeOffset? validoAte = null,
+        UsuarioRef? concedidoPor = null)
+    {
+        if (string.IsNullOrWhiteSpace(permissaoCodigo))
+        {
+            return Result<EffectiveGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.EffectiveGrantPermissaoObrigatoria,
+                "Código da permissão é obrigatório."));
+        }
+
+        if (fonte is FonteGrant.OidcGroupBinding or FonteGrant.PermissaoExcecional && validoAte is null)
+        {
+            return Result<EffectiveGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.EffectiveGrantValidadeObrigatoria,
+                "Concessão resolvida no servidor exige validade explícita (ValidoAte)."));
+        }
+
+        return Result<EffectiveGrant>.Success(new EffectiveGrant(
+            permissaoCodigo.Trim(),
+            fonte,
+            grantId,
+            escopoUnidadeId,
+            escopoProcessoId,
+            escopoChamadaId,
+            recursoTipoRestricao,
+            validoAte,
+            concedidoPor));
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EffectiveGrant.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EffectiveGrant.cs
@@ -71,7 +71,12 @@ public sealed record EffectiveGrant
     /// permissão vazio e concessão server-side
     /// (<see cref="FonteGrant.OidcGroupBinding"/> /
     /// <see cref="FonteGrant.PermissaoExcecional"/>) sem
-    /// <paramref name="validoAte"/>.
+    /// <paramref name="validoAte"/>. Adicionalmente, a concessão excepcional
+    /// (<see cref="FonteGrant.PermissaoExcecional"/>) exige <b>ao menos um
+    /// escopo</b> — unidade, processo, chamada ou tipo de recurso (ADR-0084):
+    /// uma concessão fora do perfil padrão nunca é global irrestrita.
+    /// <see cref="FonteGrant.Token"/> e <see cref="FonteGrant.OidcGroupBinding"/>
+    /// podem ser permissões globais, sem escopo.
     /// </summary>
     public static Result<EffectiveGrant> From(
         string? permissaoCodigo,
@@ -96,6 +101,17 @@ public sealed record EffectiveGrant
             return Result<EffectiveGrant>.Failure(new DomainError(
                 AuthorizationErrorCodes.EffectiveGrantValidadeObrigatoria,
                 "Concessão resolvida no servidor exige validade explícita (ValidoAte)."));
+        }
+
+        if (fonte is FonteGrant.PermissaoExcecional
+            && escopoUnidadeId is null
+            && escopoProcessoId is null
+            && escopoChamadaId is null
+            && string.IsNullOrWhiteSpace(recursoTipoRestricao))
+        {
+            return Result<EffectiveGrant>.Failure(new DomainError(
+                AuthorizationErrorCodes.EffectiveGrantEscopoExcecionalObrigatorio,
+                "Concessão excepcional exige ao menos um escopo (unidade, processo, chamada ou tipo de recurso)."));
         }
 
         return Result<EffectiveGrant>.Success(new EffectiveGrant(

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EscopoAuditoriaVigente.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EscopoAuditoriaVigente.cs
@@ -29,7 +29,9 @@ public sealed record EscopoAuditoriaVigente
 
     /// <summary>
     /// Constrói um <see cref="EscopoAuditoriaVigente"/> validado. Rejeita
-    /// escopo vazio (<see cref="Guid.Empty"/>).
+    /// escopo vazio (<see cref="Guid.Empty"/>) e <paramref name="unidadeId"/>
+    /// informado como <see cref="Guid.Empty"/> — nulo é o escopo global; um
+    /// valor informado precisa ser um identificador real.
     /// </summary>
     public static Result<EscopoAuditoriaVigente> From(Guid escopoId, DateTimeOffset validoAte, Guid? unidadeId = null)
     {
@@ -38,6 +40,13 @@ public sealed record EscopoAuditoriaVigente
             return Result<EscopoAuditoriaVigente>.Failure(new DomainError(
                 AuthorizationErrorCodes.EscopoAuditoriaEscopoObrigatorio,
                 "Identificador do escopo de auditoria é obrigatório."));
+        }
+
+        if (unidadeId is { } unidade && unidade == Guid.Empty)
+        {
+            return Result<EscopoAuditoriaVigente>.Failure(new DomainError(
+                AuthorizationErrorCodes.EscopoAuditoriaUnidadeInvalida,
+                "Unidade informada não pode ser Guid.Empty — use um identificador real ou nulo (escopo global)."));
         }
 
         return Result<EscopoAuditoriaVigente>.Success(new EscopoAuditoriaVigente(escopoId, unidadeId, validoAte));

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EscopoAuditoriaVigente.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/EscopoAuditoriaVigente.cs
@@ -1,0 +1,45 @@
+namespace Unifesspa.UniPlus.Authorization.ValueObjects;
+
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Snapshot de contrato de um escopo de auditoria vigente, consumido pela
+/// decisão de autorização (ADR-0078) — <b>não</b> é a entidade persistida. A
+/// hierarquia institucional não herda permissão; o acesso de auditoria é
+/// explícito e vinculado a uma unidade opcional, com validade própria.
+/// </summary>
+public sealed record EscopoAuditoriaVigente
+{
+    /// <summary>Identificador do escopo de auditoria.</summary>
+    public Guid EscopoId { get; }
+
+    /// <summary>Unidade à qual o escopo se aplica. Opcional (escopo global quando nulo).</summary>
+    public Guid? UnidadeId { get; }
+
+    /// <summary>Validade do escopo.</summary>
+    public DateTimeOffset ValidoAte { get; }
+
+    private EscopoAuditoriaVigente(Guid escopoId, Guid? unidadeId, DateTimeOffset validoAte)
+    {
+        EscopoId = escopoId;
+        UnidadeId = unidadeId;
+        ValidoAte = validoAte;
+    }
+
+    /// <summary>
+    /// Constrói um <see cref="EscopoAuditoriaVigente"/> validado. Rejeita
+    /// escopo vazio (<see cref="Guid.Empty"/>).
+    /// </summary>
+    public static Result<EscopoAuditoriaVigente> From(Guid escopoId, DateTimeOffset validoAte, Guid? unidadeId = null)
+    {
+        if (escopoId == Guid.Empty)
+        {
+            return Result<EscopoAuditoriaVigente>.Failure(new DomainError(
+                AuthorizationErrorCodes.EscopoAuditoriaEscopoObrigatorio,
+                "Identificador do escopo de auditoria é obrigatório."));
+        }
+
+        return Result<EscopoAuditoriaVigente>.Success(new EscopoAuditoriaVigente(escopoId, unidadeId, validoAte));
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/UsuarioRef.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/UsuarioRef.cs
@@ -32,7 +32,12 @@ public sealed record UsuarioRef
 
     /// <summary>
     /// Constrói uma <see cref="UsuarioRef"/> validada. Rejeita emissor ou
-    /// sujeito vazios.
+    /// sujeito em branco e, fora isso, armazena ambos os claims
+    /// <b>verbatim</b>: emissor e subject são tokens opacos do OIDC e a
+    /// identidade (incluindo a dupla aprovação e a auditoria) é comparada por
+    /// emissor + subject. Normalizar com <c>Trim</c> aliasaria sujeitos
+    /// distintos (<c>" abc"</c> vs <c>"abc"</c>) e quebraria a correspondência
+    /// com o token original.
     /// </summary>
     public static Result<UsuarioRef> From(string? emissor, string? subject, Guid? usuarioId = null)
     {
@@ -50,6 +55,6 @@ public sealed record UsuarioRef
                 "Subject do usuário é obrigatório."));
         }
 
-        return Result<UsuarioRef>.Success(new UsuarioRef(emissor.Trim(), subject.Trim(), usuarioId));
+        return Result<UsuarioRef>.Success(new UsuarioRef(emissor, subject, usuarioId));
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/UsuarioRef.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/UsuarioRef.cs
@@ -55,6 +55,13 @@ public sealed record UsuarioRef
                 "Subject do usuário é obrigatório."));
         }
 
+        if (usuarioId is { } id && id == Guid.Empty)
+        {
+            return Result<UsuarioRef>.Failure(new DomainError(
+                AuthorizationErrorCodes.UsuarioRefUsuarioIdInvalido,
+                "UsuarioId informado não pode ser Guid.Empty — use um identificador real ou nulo."));
+        }
+
         return Result<UsuarioRef>.Success(new UsuarioRef(emissor, subject, usuarioId));
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/UsuarioRef.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/ValueObjects/UsuarioRef.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Authorization.ValueObjects;
+
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Referência ao usuário (sujeito) de uma decisão de autorização (ADR-0078,
+/// ADR-0033). O sujeito é identificado pelo par <see cref="Emissor"/> +
+/// <see cref="Subject"/> do token OIDC — o <see cref="Subject"/> é uma string
+/// <b>opaca</b> e <b>nunca</b> um <see cref="Guid"/>: identificadores de
+/// provedores externos (Gov.br, Keycloak) não têm forma de GUID, e tipar como
+/// GUID rejeitaria silenciosamente sujeitos válidos. O <see cref="UsuarioId"/>
+/// é o identificador interno opcional, quando o usuário já está conhecido.
+/// </summary>
+public sealed record UsuarioRef
+{
+    /// <summary>Emissor do token (issuer OIDC).</summary>
+    public string Emissor { get; }
+
+    /// <summary>Sujeito (claim <c>sub</c>) — string opaca, nunca um GUID.</summary>
+    public string Subject { get; }
+
+    /// <summary>Identificador interno do usuário, quando já resolvido. Opcional.</summary>
+    public Guid? UsuarioId { get; }
+
+    private UsuarioRef(string emissor, string subject, Guid? usuarioId)
+    {
+        Emissor = emissor;
+        Subject = subject;
+        UsuarioId = usuarioId;
+    }
+
+    /// <summary>
+    /// Constrói uma <see cref="UsuarioRef"/> validada. Rejeita emissor ou
+    /// sujeito vazios.
+    /// </summary>
+    public static Result<UsuarioRef> From(string? emissor, string? subject, Guid? usuarioId = null)
+    {
+        if (string.IsNullOrWhiteSpace(emissor))
+        {
+            return Result<UsuarioRef>.Failure(new DomainError(
+                AuthorizationErrorCodes.UsuarioRefEmissorObrigatorio,
+                "Emissor do usuário é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            return Result<UsuarioRef>.Failure(new DomainError(
+                AuthorizationErrorCodes.UsuarioRefSubjectObrigatorio,
+                "Subject do usuário é obrigatório."));
+        }
+
+        return Result<UsuarioRef>.Success(new UsuarioRef(emissor.Trim(), subject.Trim(), usuarioId));
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/packages.lock.json
+++ b/src/shared/Unifesspa.UniPlus.Authorization/packages.lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Enums/MotivoNegativaTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Enums/MotivoNegativaTests.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.Enums;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Enums;
+
+public sealed class MotivoNegativaTests
+{
+    [Fact]
+    public void MotivoNegativa_EhConjuntoFechadoDe13Valores()
+    {
+        Enum.GetValues<MotivoNegativa>().Should().HaveCount(13,
+            "ADR-0078 define um conjunto fechado de 13 motivos de negativa");
+    }
+
+    [Fact]
+    public void MotivoNegativa_ValoresSaoDistintos()
+    {
+        int[] valores = Enum.GetValues<MotivoNegativa>().Cast<int>().ToArray();
+
+        valores.Should().OnlyHaveUniqueItems();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Unifesspa.UniPlus.Authorization.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Unifesspa.UniPlus.Authorization.UnitTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="AwesomeAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\shared\Unifesspa.UniPlus.Authorization\Unifesspa.UniPlus.Authorization.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/AtuacaoVigenteTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/AtuacaoVigenteTests.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtuacaoVigenteTests
+{
+    [Fact]
+    public void AtuacaoVigente_DadosValidos_Constroi()
+    {
+        Guid unidade = Guid.CreateVersion7();
+        DateTimeOffset validoAte = DateTimeOffset.UtcNow.AddHours(8);
+
+        Result<AtuacaoVigente> resultado = AtuacaoVigente.From(unidade, validoAte);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.UnidadeRepresentadaId.Should().Be(unidade);
+        resultado.Value.ValidoAte.Should().Be(validoAte);
+    }
+
+    [Fact]
+    public void AtuacaoVigente_UnidadeVazia_Rejeita()
+    {
+        Result<AtuacaoVigente> resultado = AtuacaoVigente.From(Guid.Empty, DateTimeOffset.UtcNow.AddHours(8));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.AtuacaoUnidadeObrigatoria);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/DualApprovalGrantTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/DualApprovalGrantTests.cs
@@ -1,0 +1,148 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class DualApprovalGrantTests
+{
+    private const string Emissor = "https://sso.gov.br";
+    private const string RecursoHash = "sha256:abc123";
+    private const string Permissao = "selecao.resultado.homologar";
+
+    private static UsuarioRef Aprovador(string subject) => UsuarioRef.From(Emissor, subject).Value!;
+
+    // ─── CA-05: aprovador secundário igual ao primário é rejeitado ─────────
+
+    [Fact]
+    public void DualApprovalGrant_SecundarioIgualPrimario_Rejeita()
+    {
+        UsuarioRef primario = Aprovador("sub-1");
+
+        // Mesma identidade OIDC (emissor + subject), ainda que outra instância
+        // e com UsuarioId distinto — deve ser tratado como o mesmo aprovador.
+        UsuarioRef secundario = UsuarioRef.From(Emissor, "sub-1", Guid.CreateVersion7()).Value!;
+
+        DateTimeOffset concedidoEm = DateTimeOffset.UtcNow;
+
+        Result<DualApprovalGrant> resultado = DualApprovalGrant.From(
+            primario, secundario, RecursoHash, Permissao, concedidoEm, concedidoEm.AddMinutes(30));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.DualApprovalAprovadoresIguais);
+    }
+
+    // ─── CA-05: validade acima do limite de 1h é rejeitada ─────────────────
+
+    [Fact]
+    public void DualApprovalGrant_ValidadeAcimaDoLimite_Rejeita()
+    {
+        DateTimeOffset concedidoEm = DateTimeOffset.UtcNow;
+
+        Result<DualApprovalGrant> resultado = DualApprovalGrant.From(
+            Aprovador("sub-1"),
+            Aprovador("sub-2"),
+            RecursoHash,
+            Permissao,
+            concedidoEm,
+            concedidoEm.AddHours(1).AddSeconds(1));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.DualApprovalValidadeAcimaDoLimite);
+    }
+
+    // ─── CA-05: contraprova — distintos, validade no limite, marcador de uso ──
+
+    [Fact]
+    public void DualApprovalGrant_AprovadoresDistintos_Constroi()
+    {
+        UsuarioRef primario = Aprovador("sub-1");
+        UsuarioRef secundario = Aprovador("sub-2");
+        DateTimeOffset concedidoEm = DateTimeOffset.UtcNow;
+        DateTimeOffset validoAte = concedidoEm.Add(DualApprovalGrant.JanelaMaxima); // exatamente no limite (1h)
+        DateTimeOffset usadoEm = concedidoEm.AddMinutes(10);
+
+        Result<DualApprovalGrant> resultado = DualApprovalGrant.From(
+            primario, secundario, RecursoHash, Permissao, concedidoEm, validoAte,
+            usado: true, usadoEm: usadoEm, usadoPor: secundario);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.AprovadorPrimario.Should().Be(primario);
+        resultado.Value.AprovadorSecundario.Should().Be(secundario);
+        resultado.Value.ValidoAte.Should().Be(validoAte);
+        resultado.Value.Usado.Should().BeTrue();
+        resultado.Value.UsadoEm.Should().Be(usadoEm);
+        resultado.Value.UsadoPor.Should().Be(secundario);
+    }
+
+    [Fact]
+    public void DualApprovalGrant_IdentificadorEhGuidV7()
+    {
+        DateTimeOffset concedidoEm = DateTimeOffset.UtcNow;
+
+        Result<DualApprovalGrant> resultado = DualApprovalGrant.From(
+            Aprovador("sub-1"), Aprovador("sub-2"), RecursoHash, Permissao, concedidoEm, concedidoEm.AddMinutes(30));
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Id.Should().NotBe(Guid.Empty);
+        resultado.Value.Id.Version.Should().Be(7, "o identificador segue a ADR-0032 (GUID v7)");
+    }
+
+    [Fact]
+    public void DualApprovalGrant_NaoUsado_PorPadrao()
+    {
+        DateTimeOffset concedidoEm = DateTimeOffset.UtcNow;
+
+        Result<DualApprovalGrant> resultado = DualApprovalGrant.From(
+            Aprovador("sub-1"), Aprovador("sub-2"), RecursoHash, Permissao, concedidoEm, concedidoEm.AddMinutes(30));
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Usado.Should().BeFalse();
+        resultado.Value.UsadoEm.Should().BeNull();
+        resultado.Value.UsadoPor.Should().BeNull();
+    }
+
+    [Fact]
+    public void DualApprovalGrant_ValidadeNaoPosteriorAConcessao_Rejeita()
+    {
+        DateTimeOffset concedidoEm = DateTimeOffset.UtcNow;
+
+        Result<DualApprovalGrant> resultado = DualApprovalGrant.From(
+            Aprovador("sub-1"), Aprovador("sub-2"), RecursoHash, Permissao, concedidoEm, concedidoEm);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.DualApprovalValidadeNaoPosterior);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DualApprovalGrant_PermissaoVazia_Rejeita(string? permissao)
+    {
+        DateTimeOffset concedidoEm = DateTimeOffset.UtcNow;
+
+        Result<DualApprovalGrant> resultado = DualApprovalGrant.From(
+            Aprovador("sub-1"), Aprovador("sub-2"), RecursoHash, permissao, concedidoEm, concedidoEm.AddMinutes(30));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.DualApprovalPermissaoObrigatoria);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DualApprovalGrant_RecursoHashVazio_Rejeita(string? recursoHash)
+    {
+        DateTimeOffset concedidoEm = DateTimeOffset.UtcNow;
+
+        Result<DualApprovalGrant> resultado = DualApprovalGrant.From(
+            Aprovador("sub-1"), Aprovador("sub-2"), recursoHash, Permissao, concedidoEm, concedidoEm.AddMinutes(30));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.DualApprovalRecursoHashObrigatorio);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EffectiveGrantTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EffectiveGrantTests.cs
@@ -139,6 +139,38 @@ public sealed class EffectiveGrantTests
         resultado.Value!.Fonte.Should().Be(FonteGrant.PermissaoExcecional);
     }
 
+    [Fact]
+    public void EffectiveGrant_ExcepcionalComEscopoGuidVazio_Rejeita()
+    {
+        // Guid.Empty não é um identificador real: a concessão excepcional não
+        // pode atravessar o boundary com escopo "informado mas vazio".
+        DateTimeOffset validade = DateTimeOffset.UtcNow.AddHours(1);
+
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(
+            Permissao, FonteGrant.PermissaoExcecional, escopoUnidadeId: Guid.Empty, validoAte: validade);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EffectiveGrantEscopoInvalido);
+    }
+
+    [Theory]
+    [InlineData("unidade")]
+    [InlineData("processo")]
+    [InlineData("chamada")]
+    public void EffectiveGrant_EscopoGuidVazio_Rejeita(string escopo)
+    {
+        // Vale para qualquer fonte — um escopo Guid.Empty é sempre inválido.
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(
+            Permissao,
+            FonteGrant.Token,
+            escopoUnidadeId: escopo == "unidade" ? Guid.Empty : null,
+            escopoProcessoId: escopo == "processo" ? Guid.Empty : null,
+            escopoChamadaId: escopo == "chamada" ? Guid.Empty : null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EffectiveGrantEscopoInvalido);
+    }
+
     // ─── Permissão obrigatória ─────────────────────────────────────────────
 
     [Theory]

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EffectiveGrantTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EffectiveGrantTests.cs
@@ -153,6 +153,15 @@ public sealed class EffectiveGrantTests
         resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EffectiveGrantEscopoInvalido);
     }
 
+    [Fact]
+    public void EffectiveGrant_GrantIdGuidVazio_Rejeita()
+    {
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(Permissao, FonteGrant.Token, grantId: Guid.Empty);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EffectiveGrantGrantIdInvalido);
+    }
+
     [Theory]
     [InlineData("unidade")]
     [InlineData("processo")]

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EffectiveGrantTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EffectiveGrantTests.cs
@@ -1,0 +1,105 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class EffectiveGrantTests
+{
+    private const string Permissao = "selecao.editais.publicar";
+
+    // ─── Fonte rastreável é preservada ─────────────────────────────────────
+
+    [Fact]
+    public void EffectiveGrant_PreservaFonteRastreavel()
+    {
+        DateTimeOffset validade = DateTimeOffset.UtcNow.AddHours(1);
+
+        Result<EffectiveGrant> token = EffectiveGrant.From(Permissao, FonteGrant.Token);
+        Result<EffectiveGrant> oidc = EffectiveGrant.From(Permissao, FonteGrant.OidcGroupBinding, validoAte: validade);
+        Result<EffectiveGrant> excepcional = EffectiveGrant.From(Permissao, FonteGrant.PermissaoExcecional, validoAte: validade);
+
+        token.Value!.Fonte.Should().Be(FonteGrant.Token);
+        oidc.Value!.Fonte.Should().Be(FonteGrant.OidcGroupBinding);
+        excepcional.Value!.Fonte.Should().Be(FonteGrant.PermissaoExcecional);
+    }
+
+    [Fact]
+    public void EffectiveGrant_PreservaEscoposERestricaoDeRecurso()
+    {
+        Guid unidade = Guid.CreateVersion7();
+        Guid processo = Guid.CreateVersion7();
+        Guid chamada = Guid.CreateVersion7();
+        Guid grantId = Guid.CreateVersion7();
+
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(
+            Permissao,
+            FonteGrant.Token,
+            grantId: grantId,
+            escopoUnidadeId: unidade,
+            escopoProcessoId: processo,
+            escopoChamadaId: chamada,
+            recursoTipoRestricao: "Edital");
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.GrantId.Should().Be(grantId);
+        resultado.Value.EscopoUnidadeId.Should().Be(unidade);
+        resultado.Value.EscopoProcessoId.Should().Be(processo);
+        resultado.Value.EscopoChamadaId.Should().Be(chamada);
+        resultado.Value.RecursoTipoRestricao.Should().Be("Edital");
+    }
+
+    // ─── CA-03b: concessão server-side sem validade é rejeitada ────────────
+
+    [Theory]
+    [InlineData(FonteGrant.OidcGroupBinding)]
+    [InlineData(FonteGrant.PermissaoExcecional)]
+    public void EffectiveGrant_ServerSideSemValidade_Rejeita(FonteGrant fonte)
+    {
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(Permissao, fonte);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EffectiveGrantValidadeObrigatoria);
+    }
+
+    [Theory]
+    [InlineData(FonteGrant.OidcGroupBinding)]
+    [InlineData(FonteGrant.PermissaoExcecional)]
+    public void EffectiveGrant_ServerSideComValidade_Aceita(FonteGrant fonte)
+    {
+        DateTimeOffset validade = DateTimeOffset.UtcNow.AddHours(2);
+
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(Permissao, fonte, validoAte: validade);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.ValidoAte.Should().Be(validade);
+    }
+
+    // ─── CA-03b: contraprova — token sem validade é aceito ─────────────────
+
+    [Fact]
+    public void EffectiveGrant_TokenSemValidade_Aceita()
+    {
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(Permissao, FonteGrant.Token);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.ValidoAte.Should().BeNull();
+    }
+
+    // ─── Permissão obrigatória ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EffectiveGrant_PermissaoVazia_Rejeita(string? permissao)
+    {
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(permissao, FonteGrant.Token);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EffectiveGrantPermissaoObrigatoria);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EffectiveGrantTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EffectiveGrantTests.cs
@@ -20,7 +20,8 @@ public sealed class EffectiveGrantTests
 
         Result<EffectiveGrant> token = EffectiveGrant.From(Permissao, FonteGrant.Token);
         Result<EffectiveGrant> oidc = EffectiveGrant.From(Permissao, FonteGrant.OidcGroupBinding, validoAte: validade);
-        Result<EffectiveGrant> excepcional = EffectiveGrant.From(Permissao, FonteGrant.PermissaoExcecional, validoAte: validade);
+        Result<EffectiveGrant> excepcional = EffectiveGrant.From(
+            Permissao, FonteGrant.PermissaoExcecional, escopoUnidadeId: Guid.CreateVersion7(), validoAte: validade);
 
         token.Value!.Fonte.Should().Be(FonteGrant.Token);
         oidc.Value!.Fonte.Should().Be(FonteGrant.OidcGroupBinding);
@@ -65,14 +66,13 @@ public sealed class EffectiveGrantTests
         resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EffectiveGrantValidadeObrigatoria);
     }
 
-    [Theory]
-    [InlineData(FonteGrant.OidcGroupBinding)]
-    [InlineData(FonteGrant.PermissaoExcecional)]
-    public void EffectiveGrant_ServerSideComValidade_Aceita(FonteGrant fonte)
+    [Fact]
+    public void EffectiveGrant_OidcGroupBindingComValidadeSemEscopo_Aceita()
     {
+        // OidcGroupBinding pode representar permissão global — não exige escopo.
         DateTimeOffset validade = DateTimeOffset.UtcNow.AddHours(2);
 
-        Result<EffectiveGrant> resultado = EffectiveGrant.From(Permissao, fonte, validoAte: validade);
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(Permissao, FonteGrant.OidcGroupBinding, validoAte: validade);
 
         resultado.IsSuccess.Should().BeTrue();
         resultado.Value!.ValidoAte.Should().Be(validade);
@@ -87,6 +87,56 @@ public sealed class EffectiveGrantTests
 
         resultado.IsSuccess.Should().BeTrue();
         resultado.Value!.ValidoAte.Should().BeNull();
+    }
+
+    // ─── ADR-0084: concessão excepcional exige ao menos um escopo ──────────
+
+    [Fact]
+    public void EffectiveGrant_ExcepcionalSemEscopo_Rejeita()
+    {
+        DateTimeOffset validade = DateTimeOffset.UtcNow.AddHours(1);
+
+        Result<EffectiveGrant> resultado =
+            EffectiveGrant.From(Permissao, FonteGrant.PermissaoExcecional, validoAte: validade);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EffectiveGrantEscopoExcecionalObrigatorio,
+            "uma concessão fora do perfil padrão nunca é global irrestrita (ADR-0084)");
+    }
+
+    [Fact]
+    public void EffectiveGrant_ExcepcionalComRecursoTipoEmBranco_Rejeita()
+    {
+        // Restrição de recurso só com espaços não conta como escopo.
+        DateTimeOffset validade = DateTimeOffset.UtcNow.AddHours(1);
+
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(
+            Permissao, FonteGrant.PermissaoExcecional, recursoTipoRestricao: "   ", validoAte: validade);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EffectiveGrantEscopoExcecionalObrigatorio);
+    }
+
+    [Theory]
+    [InlineData("unidade")]
+    [InlineData("processo")]
+    [InlineData("chamada")]
+    [InlineData("recurso")]
+    public void EffectiveGrant_ExcepcionalComUmEscopo_Aceita(string escopo)
+    {
+        DateTimeOffset validade = DateTimeOffset.UtcNow.AddHours(1);
+
+        Result<EffectiveGrant> resultado = EffectiveGrant.From(
+            Permissao,
+            FonteGrant.PermissaoExcecional,
+            escopoUnidadeId: escopo == "unidade" ? Guid.CreateVersion7() : null,
+            escopoProcessoId: escopo == "processo" ? Guid.CreateVersion7() : null,
+            escopoChamadaId: escopo == "chamada" ? Guid.CreateVersion7() : null,
+            recursoTipoRestricao: escopo == "recurso" ? "Edital" : null,
+            validoAte: validade);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Fonte.Should().Be(FonteGrant.PermissaoExcecional);
     }
 
     // ─── Permissão obrigatória ─────────────────────────────────────────────

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EscopoAuditoriaVigenteTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EscopoAuditoriaVigenteTests.cs
@@ -42,4 +42,15 @@ public sealed class EscopoAuditoriaVigenteTests
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EscopoAuditoriaEscopoObrigatorio);
     }
+
+    [Fact]
+    public void EscopoAuditoriaVigente_UnidadeGuidVazio_Rejeita()
+    {
+        // null é o escopo global; um Guid.Empty informado é malformado.
+        Result<EscopoAuditoriaVigente> resultado =
+            EscopoAuditoriaVigente.From(Guid.CreateVersion7(), DateTimeOffset.UtcNow.AddDays(30), Guid.Empty);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EscopoAuditoriaUnidadeInvalida);
+    }
 }

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EscopoAuditoriaVigenteTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/EscopoAuditoriaVigenteTests.cs
@@ -1,0 +1,45 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class EscopoAuditoriaVigenteTests
+{
+    [Fact]
+    public void EscopoAuditoriaVigente_DadosValidos_Constroi()
+    {
+        Guid escopoId = Guid.CreateVersion7();
+        Guid unidadeId = Guid.CreateVersion7();
+        DateTimeOffset validoAte = DateTimeOffset.UtcNow.AddDays(30);
+
+        Result<EscopoAuditoriaVigente> resultado = EscopoAuditoriaVigente.From(escopoId, validoAte, unidadeId);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.EscopoId.Should().Be(escopoId);
+        resultado.Value.UnidadeId.Should().Be(unidadeId);
+        resultado.Value.ValidoAte.Should().Be(validoAte);
+    }
+
+    [Fact]
+    public void EscopoAuditoriaVigente_UnidadeOpcional_AceitaNulo()
+    {
+        Result<EscopoAuditoriaVigente> resultado =
+            EscopoAuditoriaVigente.From(Guid.CreateVersion7(), DateTimeOffset.UtcNow.AddDays(30));
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.UnidadeId.Should().BeNull();
+    }
+
+    [Fact]
+    public void EscopoAuditoriaVigente_EscopoVazio_Rejeita()
+    {
+        Result<EscopoAuditoriaVigente> resultado =
+            EscopoAuditoriaVigente.From(Guid.Empty, DateTimeOffset.UtcNow.AddDays(30));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.EscopoAuditoriaEscopoObrigatorio);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/UsuarioRefTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/UsuarioRefTests.cs
@@ -99,6 +99,16 @@ public sealed class UsuarioRefTests
         resultado.Value!.UsuarioId.Should().BeNull();
     }
 
+    [Fact]
+    public void UsuarioRef_UsuarioIdGuidVazio_Rejeita()
+    {
+        // UsuarioId opcional aceita nulo, mas um Guid.Empty informado é malformado.
+        Result<UsuarioRef> resultado = UsuarioRef.From("https://sso.gov.br", "sub-123", Guid.Empty);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.UsuarioRefUsuarioIdInvalido);
+    }
+
     // ─── Igualdade por valor ───────────────────────────────────────────────
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/UsuarioRefTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/UsuarioRefTests.cs
@@ -1,0 +1,104 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class UsuarioRefTests
+{
+    // ─── CA-02: Subject é texto opaco, nunca GUID ──────────────────────────
+
+    [Fact]
+    public void UsuarioRef_SubjectEhTextoOpaco_NaoGuid()
+    {
+        // Subjects reais de Gov.br/Keycloak não têm forma de GUID.
+        const string subjectOpaco = "f:7c2b9e10-keycloak:01234567890";
+
+        Guid.TryParse(subjectOpaco, out _).Should().BeFalse("o subject não deve ser um GUID");
+
+        Result<UsuarioRef> resultado = UsuarioRef.From("https://sso.gov.br", subjectOpaco);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Subject.Should().Be(subjectOpaco);
+
+        typeof(UsuarioRef).GetProperty(nameof(UsuarioRef.Subject))!.PropertyType
+            .Should().Be<string>("o subject é estruturalmente uma string opaca, nunca um Guid");
+    }
+
+    // ─── CA-02: emissor/subject vazios são rejeitados ──────────────────────
+
+    [Theory]
+    [InlineData(null, "sub-123")]
+    [InlineData("", "sub-123")]
+    [InlineData("   ", "sub-123")]
+    public void UsuarioRef_EmissorVazio_Rejeita(string? emissor, string subject)
+    {
+        Result<UsuarioRef> resultado = UsuarioRef.From(emissor, subject);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.UsuarioRefEmissorObrigatorio);
+    }
+
+    [Theory]
+    [InlineData("https://sso.gov.br", null)]
+    [InlineData("https://sso.gov.br", "")]
+    [InlineData("https://sso.gov.br", "   ")]
+    public void UsuarioRef_SubjectVazio_Rejeita(string emissor, string? subject)
+    {
+        Result<UsuarioRef> resultado = UsuarioRef.From(emissor, subject);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.UsuarioRefSubjectObrigatorio);
+    }
+
+    // ─── CA-02: contraprova positiva ───────────────────────────────────────
+
+    [Fact]
+    public void UsuarioRef_EmissorESubjectValidos_Constroi()
+    {
+        Guid usuarioId = Guid.CreateVersion7();
+
+        Result<UsuarioRef> resultado = UsuarioRef.From("https://sso.gov.br", "sub-123", usuarioId);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Emissor.Should().Be("https://sso.gov.br");
+        resultado.Value.Subject.Should().Be("sub-123");
+        resultado.Value.UsuarioId.Should().Be(usuarioId);
+    }
+
+    [Fact]
+    public void UsuarioRef_NormalizaEspacosNasPontas()
+    {
+        Result<UsuarioRef> resultado = UsuarioRef.From("  https://sso.gov.br  ", "  sub-123  ");
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Emissor.Should().Be("https://sso.gov.br");
+        resultado.Value.Subject.Should().Be("sub-123");
+    }
+
+    [Fact]
+    public void UsuarioRef_UsuarioIdOpcional_AceitaNulo()
+    {
+        Result<UsuarioRef> resultado = UsuarioRef.From("https://sso.gov.br", "sub-123");
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.UsuarioId.Should().BeNull();
+    }
+
+    // ─── Igualdade por valor ───────────────────────────────────────────────
+
+    [Fact]
+    public void UsuarioRef_MesmoEmissorSubjectEUsuarioId_SaoIguais()
+    {
+        Guid usuarioId = Guid.CreateVersion7();
+
+        UsuarioRef a = UsuarioRef.From("https://sso.gov.br", "sub-123", usuarioId).Value!;
+        UsuarioRef b = UsuarioRef.From("https://sso.gov.br", "sub-123", usuarioId).Value!;
+
+        a.Should().Be(b);
+        (a == b).Should().BeTrue();
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/UsuarioRefTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/ValueObjects/UsuarioRefTests.cs
@@ -69,13 +69,25 @@ public sealed class UsuarioRefTests
     }
 
     [Fact]
-    public void UsuarioRef_NormalizaEspacosNasPontas()
+    public void UsuarioRef_PreservaEmissorESubjectVerbatim()
     {
-        Result<UsuarioRef> resultado = UsuarioRef.From("  https://sso.gov.br  ", "  sub-123  ");
+        // Claims opacos do OIDC: espaços de fronteira fazem parte do token e
+        // não podem ser normalizados — Trim aliasaria sujeitos distintos e
+        // quebraria a fidelidade da auditoria por emissor + subject.
+        Result<UsuarioRef> resultado = UsuarioRef.From(" https://sso.gov.br ", " sub-123 ");
 
         resultado.IsSuccess.Should().BeTrue();
-        resultado.Value!.Emissor.Should().Be("https://sso.gov.br");
-        resultado.Value.Subject.Should().Be("sub-123");
+        resultado.Value!.Emissor.Should().Be(" https://sso.gov.br ");
+        resultado.Value.Subject.Should().Be(" sub-123 ");
+    }
+
+    [Fact]
+    public void UsuarioRef_SubjectsDiferindoPorEspaco_NaoSaoIguais()
+    {
+        UsuarioRef compacto = UsuarioRef.From("https://sso.gov.br", "sub-123").Value!;
+        UsuarioRef comEspaco = UsuarioRef.From("https://sso.gov.br", " sub-123").Value!;
+
+        comEspaco.Should().NotBe(compacto, "subjects opacos distintos não podem ser aliasados por normalização");
     }
 
     [Fact]

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/packages.lock.json
@@ -1,0 +1,119 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.4.0, )",
+        "resolved": "9.4.0",
+        "contentHash": "dJxkWiQ8D+xT6Gr2sSL83+Mar+Vpy2JTcUPxFcckpPJ8VYBfSgnk+zqpS6t7kcGnjz8NLyF14qfuoL4bKzzoew=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "unifesspa.uniplus.authorization": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Contexto

Primeira entrega de código da frente de Autorização (Epic #600 → Story #608, task #651). Cria o módulo cross-cutting **`Unifesspa.UniPlus.Authorization`** (`src/shared/`, novo) que abriga os tipos formais do contrato de decisão de autorização ([ADR-0078](docs/adrs/0078-modelo-de-autorizacao-pbac-abac.md)): os **enums de apoio** e os **value objects de apoio** com suas validações de fábrica.

Sem EF Core, persistência ou soft-delete — são tipos de contrato em memória, referenciando apenas o `Kernel` (`Result<T>`/`DomainError`).

## O que muda

**Scaffold**
- Projeto `src/shared/Unifesspa.UniPlus.Authorization` (ref. apenas ao `Kernel`) e projeto de testes `tests/Unifesspa.UniPlus.Authorization.UnitTests`.
- Ambos registrados no `UniPlus.slnx`; `TreatWarningsAsErrors` herdado do `Directory.Build.props`.

**Enums**
- `Sensibilidade`, `FonteGrant`, `OrigemRequisicao` e `MotivoNegativa` (conjunto fechado de 13 motivos, sem dado pessoal). Identificadores C# em PascalCase; os valores canônicos `snake_case`/`kebab-case` da serialização externa ficam documentados em XML doc — a serialização em si fica na camada de borda (outra story).

**Value objects** (`sealed record` imutáveis, fábrica `From` → `Result<T>`, padrão `Slug.From`)
- `UsuarioRef` — `Subject` é `string` opaca, estruturalmente nunca um `Guid`; rejeita emissor/subject vazios.
- `EffectiveGrant` — preserva a `Fonte` rastreável; rejeita concessão server-side (`OidcGroupBinding`/`PermissaoExcecional`) sem `ValidoAte`; aceita `Token` sem validade.
- `EscopoAuditoriaVigente` / `AtuacaoVigente` — snapshots de contrato (não entidades persistidas).
- `DualApprovalGrant` — `Id` GUID v7 ([ADR-0032](docs/adrs/0032-guid-v7-como-identidade-padrao.md)); rejeita aprovador secundário igual ao primário (mesma identidade OIDC emissor+subject) e validade acima de 1h.

## Critérios de aceite (Story #608)

- **CA-02** — `UsuarioRef.Subject` é `string`; fábrica rejeita emissor/subject vazios e aceita válidos. ✅
- **CA-03b** — fábrica de `EffectiveGrant` rejeita server-side sem `ValidoAte` e aceita `Token` sem validade. ✅
- **CA-05** — `DualApprovalGrant` rejeita secundário igual ao primário e validade acima de 1h; aceita distintos, validade no limite e marcador de uso. ✅
- Build e testes verdes, sem warnings; igualdade por valor. ✅

## Fora de escopo (tasks irmãs)

- Tipos da assinatura da decisão (`AuthorizationDecision`, `DenyReason` etc.) → #652
- Fitness de contrato por reflection → #653
- Persistência do `DualApprovalGrant`, algoritmo do `RecursoHash`, consumo atômico de uso único → Stories #609/#612

## Validação local

- `dotnet build UniPlus.slnx` — 42 projetos, 0 erros, 0 warnings
- `dotnet test` do módulo — **40 testes verdes**
- `dotnet test` ArchTests gerais — **22 testes verdes** (nenhuma regra de fitness rejeita o novo assembly shared)

Closes #651
