### PR TITLE
feat(authorization): tipos da assinatura do contrato de decisão (#652)

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Authorization/Contracts/AuthorizationDecision.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Contracts/AuthorizationDecision.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Authorization.Contracts;
+
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+
+/// <summary>
+/// Resultado do ponto de decisão único de autorização (ADR-0078). Carrega o
+/// veredito (<see cref="Allowed"/>), o motivo estruturado quando nega
+/// (<see cref="DenyReason"/>, sem dado pessoal) e a concessão que autorizou
+/// quando permite (<see cref="GrantUsed"/>, para a trilha de auditoria saber a
+/// fonte). O invariante — permitida tem <see cref="GrantUsed"/> e não
+/// <see cref="DenyReason"/>; negada tem <see cref="DenyReason"/> e não
+/// <see cref="GrantUsed"/> — é garantido <b>por construção</b>: não há caminho
+/// público que produza uma decisão incoerente.
+/// </summary>
+public sealed record AuthorizationDecision
+{
+    /// <summary>Veredito da decisão.</summary>
+    public bool Allowed { get; }
+
+    /// <summary>Motivo da negativa — presente se, e somente se, negada.</summary>
+    public DenyReason? DenyReason { get; }
+
+    /// <summary>Concessão que autorizou — presente se, e somente se, permitida.</summary>
+    public EffectiveGrant? GrantUsed { get; }
+
+    private AuthorizationDecision(bool allowed, DenyReason? denyReason, EffectiveGrant? grantUsed)
+    {
+        Allowed = allowed;
+        DenyReason = denyReason;
+        GrantUsed = grantUsed;
+    }
+
+    /// <summary>
+    /// Constrói uma decisão <b>permitida</b>, registrando qual concessão (e qual
+    /// fonte) autorizou. Rejeita <paramref name="grant"/> nulo: uma decisão
+    /// permitida sem o <see cref="GrantUsed"/> que a sustenta é incoerente — a
+    /// auditoria precisa da contraprova da concessão usada.
+    /// </summary>
+    public static AuthorizationDecision Permitir(EffectiveGrant grant)
+    {
+        ArgumentNullException.ThrowIfNull(grant);
+
+        return new AuthorizationDecision(allowed: true, denyReason: null, grantUsed: grant);
+    }
+
+    /// <summary>
+    /// Constrói uma decisão <b>negada</b>, com o motivo estruturado do conjunto
+    /// fechado. O código é validado por <see cref="Contracts.DenyReason.De"/>
+    /// (rejeita valor fora do conjunto). A decisão negada nunca carrega
+    /// <see cref="GrantUsed"/>.
+    /// </summary>
+    public static AuthorizationDecision Negar(MotivoNegativa codigo)
+        => new(allowed: false, denyReason: Contracts.DenyReason.De(codigo), grantUsed: null);
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Contracts/AuthorizationRequestContext.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Contracts/AuthorizationRequestContext.cs
@@ -1,0 +1,99 @@
+namespace Unifesspa.UniPlus.Authorization.Contracts;
+
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Contexto da requisição que o ponto de decisão único recebe (ADR-0078):
+/// correlação, origem da chamada, instante de acesso e — <b>somente quando a
+/// operação exige</b> — a concessão de dupla aprovação. O serviço de decisão
+/// <b>recebe</b> este contrato; ele não o produz.
+/// </summary>
+public sealed record AuthorizationRequestContext
+{
+    /// <summary>Identificador de correlação da requisição — string opaca.</summary>
+    public string RequestId { get; }
+
+    /// <summary>IP de origem da chamada. Vazio quando não se aplica (ex.: jobs).</summary>
+    public string IpOrigem { get; }
+
+    /// <summary>Agente do cliente. Vazio quando não se aplica.</summary>
+    public string UserAgent { get; }
+
+    /// <summary>Instante do acesso, sempre em UTC.</summary>
+    public DateTimeOffset DataAcesso { get; }
+
+    /// <summary>Identificador da atuação institucional, em sessão delegada. Opcional.</summary>
+    public Guid? OnBehalfOfId { get; }
+
+    /// <summary>Canal pelo qual a requisição chegou.</summary>
+    public OrigemRequisicao Origem { get; }
+
+    /// <summary>Concessão de dupla aprovação — presente só quando a operação exige.</summary>
+    public DualApprovalGrant? DuplaAprovacao { get; }
+
+    private AuthorizationRequestContext(
+        string requestId,
+        string ipOrigem,
+        string userAgent,
+        DateTimeOffset dataAcesso,
+        Guid? onBehalfOfId,
+        OrigemRequisicao origem,
+        DualApprovalGrant? duplaAprovacao)
+    {
+        RequestId = requestId;
+        IpOrigem = ipOrigem;
+        UserAgent = userAgent;
+        DataAcesso = dataAcesso;
+        OnBehalfOfId = onBehalfOfId;
+        Origem = origem;
+        DuplaAprovacao = duplaAprovacao;
+    }
+
+    /// <summary>
+    /// Constrói um <see cref="AuthorizationRequestContext"/> validado. Rejeita
+    /// <paramref name="requestId"/> em branco e <paramref name="onBehalfOfId"/>
+    /// informado como <see cref="Guid.Empty"/>. O <paramref name="requestId"/> é
+    /// preservado <b>verbatim</b> (identificador opaco de correlação, não se
+    /// normaliza). <paramref name="dataAcesso"/> é normalizada para UTC com
+    /// <see cref="DateTimeOffset.ToUniversalTime"/>, preservando o instante e
+    /// garantindo o invariante de fuso. <paramref name="ipOrigem"/> e
+    /// <paramref name="userAgent"/> nulos viram string vazia — são telemetria,
+    /// não exigidos. A dupla aprovação é opcional (ausente quando a operação não
+    /// a exige).
+    /// </summary>
+    public static Result<AuthorizationRequestContext> From(
+        string? requestId,
+        DateTimeOffset dataAcesso,
+        OrigemRequisicao origem,
+        string? ipOrigem = null,
+        string? userAgent = null,
+        Guid? onBehalfOfId = null,
+        DualApprovalGrant? duplaAprovacao = null)
+    {
+        if (string.IsNullOrWhiteSpace(requestId))
+        {
+            return Result<AuthorizationRequestContext>.Failure(new DomainError(
+                AuthorizationErrorCodes.AuthorizationRequestContextRequestIdObrigatorio,
+                "Identificador de correlação da requisição é obrigatório."));
+        }
+
+        if (onBehalfOfId is { } id && id == Guid.Empty)
+        {
+            return Result<AuthorizationRequestContext>.Failure(new DomainError(
+                AuthorizationErrorCodes.AuthorizationRequestContextOnBehalfOfInvalido,
+                "OnBehalfOfId informado não pode ser Guid.Empty — use um identificador real ou nulo."));
+        }
+
+        return Result<AuthorizationRequestContext>.Success(new AuthorizationRequestContext(
+            requestId,
+            ipOrigem ?? string.Empty,
+            userAgent ?? string.Empty,
+            dataAcesso.ToUniversalTime(),
+            onBehalfOfId,
+            origem,
+            duplaAprovacao));
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Contracts/AuthorizationSubject.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Contracts/AuthorizationSubject.cs
@@ -98,4 +98,58 @@ public sealed record AuthorizationSubject
             jti,
             ColecoesSomenteLeitura.Lista(concessoesEfetivas)));
     }
+
+    // Igualdade por valor (CA-01): o Equals sintetizado pelo record compararia as
+    // coleções por referência, tornando sujeitos de conteúdo idêntico desiguais.
+    // Conjuntos comparam-se por SetEquals (sem ordem); listas por sequência. O
+    // hash acompanha: agregado independente de ordem para os conjuntos, em ordem
+    // para as listas.
+
+    /// <inheritdoc />
+    public bool Equals(AuthorizationSubject? other) =>
+        other is not null
+        && Usuario == other.Usuario
+        && MfaSatisfeito == other.MfaSatisfeito
+        && Jti == other.Jti
+        && AtuacaoAtiva == other.AtuacaoAtiva
+        && GruposOidc.SetEquals(other.GruposOidc)
+        && UnidadesAdministradas.SetEquals(other.UnidadesAdministradas)
+        && EscoposAuditoria.SequenceEqual(other.EscoposAuditoria)
+        && ConcessoesEfetivas.SequenceEqual(other.ConcessoesEfetivas);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        HashCode hash = default;
+        hash.Add(Usuario);
+        hash.Add(MfaSatisfeito);
+        hash.Add(Jti);
+        hash.Add(AtuacaoAtiva);
+        hash.Add(HashIndependenteDeOrdem(GruposOidc));
+        hash.Add(HashIndependenteDeOrdem(UnidadesAdministradas));
+        foreach (EscopoAuditoriaVigente escopo in EscoposAuditoria)
+        {
+            hash.Add(escopo);
+        }
+
+        foreach (EffectiveGrant concessao in ConcessoesEfetivas)
+        {
+            hash.Add(concessao);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    // Soma dos hashes dos elementos — independente de ordem, consistente com
+    // SetEquals (que ignora ordem). Sem cancelamento (ao contrário do XOR).
+    private static int HashIndependenteDeOrdem<T>(IReadOnlySet<T> conjunto)
+    {
+        int acumulado = 0;
+        foreach (T item in conjunto)
+        {
+            acumulado += item?.GetHashCode() ?? 0;
+        }
+
+        return acumulado;
+    }
 }

--- a/src/shared/Unifesspa.UniPlus.Authorization/Contracts/AuthorizationSubject.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Contracts/AuthorizationSubject.cs
@@ -1,0 +1,101 @@
+namespace Unifesspa.UniPlus.Authorization.Contracts;
+
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Sujeito explícito de uma decisão de autorização (ADR-0078): quem pede o
+/// acesso, com tudo o que a decisão consulta sobre ele. O ator é <b>sempre</b>
+/// este sujeito explícito — nunca estado ambiental. Carrega a identidade
+/// (<see cref="Usuario"/>), os grupos do token, as unidades administradas
+/// (derivadas no servidor), os snapshots de auditoria e atuação vigentes, o
+/// indicador de multifator, o identificador do token (<see cref="Jti"/>, usado
+/// para revogação) e as <b>concessões efetivas</b> — que unificam, numa única
+/// lista somente-leitura, concessões de fontes distintas (token, vínculo de
+/// grupo, concessão excepcional), cada uma com fonte rastreável.
+/// </summary>
+public sealed record AuthorizationSubject
+{
+    /// <summary>Identidade do sujeito (emissor + subject do token).</summary>
+    public UsuarioRef Usuario { get; }
+
+    /// <summary>Grupos do token (strings de grupo, sem amarração a provedor).</summary>
+    public IReadOnlySet<string> GruposOidc { get; }
+
+    /// <summary>Unidades que o sujeito administra, derivadas no servidor.</summary>
+    public IReadOnlySet<Guid> UnidadesAdministradas { get; }
+
+    /// <summary>Escopos de auditoria vigentes (snapshots de contrato).</summary>
+    public IReadOnlyList<EscopoAuditoriaVigente> EscoposAuditoria { get; }
+
+    /// <summary>Atuação institucional ativa (sessão delegada). Opcional.</summary>
+    public AtuacaoVigente? AtuacaoAtiva { get; }
+
+    /// <summary>Multifator satisfeito nesta sessão.</summary>
+    public bool MfaSatisfeito { get; }
+
+    /// <summary>Identificador do token (<c>jti</c>) — string opaca, usada para revogação.</summary>
+    public string Jti { get; }
+
+    /// <summary>Concessões efetivas de todas as fontes, numa única lista somente-leitura.</summary>
+    public IReadOnlyList<EffectiveGrant> ConcessoesEfetivas { get; }
+
+    private AuthorizationSubject(
+        UsuarioRef usuario,
+        IReadOnlySet<string> gruposOidc,
+        IReadOnlySet<Guid> unidadesAdministradas,
+        IReadOnlyList<EscopoAuditoriaVigente> escoposAuditoria,
+        AtuacaoVigente? atuacaoAtiva,
+        bool mfaSatisfeito,
+        string jti,
+        IReadOnlyList<EffectiveGrant> concessoesEfetivas)
+    {
+        Usuario = usuario;
+        GruposOidc = gruposOidc;
+        UnidadesAdministradas = unidadesAdministradas;
+        EscoposAuditoria = escoposAuditoria;
+        AtuacaoAtiva = atuacaoAtiva;
+        MfaSatisfeito = mfaSatisfeito;
+        Jti = jti;
+        ConcessoesEfetivas = concessoesEfetivas;
+    }
+
+    /// <summary>
+    /// Constrói um <see cref="AuthorizationSubject"/> validado. Exige
+    /// <paramref name="usuario"/> (a identidade é o âmago do sujeito explícito) e
+    /// rejeita <paramref name="jti"/> em branco (identifica a sessão para
+    /// revogação). O <paramref name="jti"/> é preservado <b>verbatim</b> (string
+    /// opaca do token). As coleções recebem cópia defensiva imutável (nulas
+    /// viram vazias), de modo que mutações na origem não afetam o sujeito.
+    /// </summary>
+    public static Result<AuthorizationSubject> From(
+        UsuarioRef usuario,
+        string? jti,
+        bool mfaSatisfeito = false,
+        IEnumerable<string>? gruposOidc = null,
+        IEnumerable<Guid>? unidadesAdministradas = null,
+        IEnumerable<EscopoAuditoriaVigente>? escoposAuditoria = null,
+        IEnumerable<EffectiveGrant>? concessoesEfetivas = null,
+        AtuacaoVigente? atuacaoAtiva = null)
+    {
+        ArgumentNullException.ThrowIfNull(usuario);
+
+        if (string.IsNullOrWhiteSpace(jti))
+        {
+            return Result<AuthorizationSubject>.Failure(new DomainError(
+                AuthorizationErrorCodes.AuthorizationSubjectJtiObrigatorio,
+                "Identificador do token (jti) é obrigatório."));
+        }
+
+        return Result<AuthorizationSubject>.Success(new AuthorizationSubject(
+            usuario,
+            ColecoesSomenteLeitura.Conjunto(gruposOidc),
+            ColecoesSomenteLeitura.Conjunto(unidadesAdministradas),
+            ColecoesSomenteLeitura.Lista(escoposAuditoria),
+            atuacaoAtiva,
+            mfaSatisfeito,
+            jti,
+            ColecoesSomenteLeitura.Lista(concessoesEfetivas)));
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Contracts/ColecoesSomenteLeitura.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Contracts/ColecoesSomenteLeitura.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Authorization.Contracts;
+
+using System.Collections.Frozen;
+
+/// <summary>
+/// Cópias defensivas <b>imutáveis</b> para as coleções dos tipos de contrato.
+/// Os tipos da assinatura de decisão (ADR-0078) são <i>records</i> imutáveis;
+/// expor uma coleção recebida diretamente permitiria mutação pós-construção
+/// pela referência de origem. Estes ajudantes materializam uma cópia imutável,
+/// tratando <c>null</c> como coleção vazia.
+/// </summary>
+internal static class ColecoesSomenteLeitura
+{
+    /// <summary>Cópia somente-leitura e imutável de uma sequência, preservando a ordem.</summary>
+    public static IReadOnlyList<T> Lista<T>(IEnumerable<T>? itens)
+        => Array.AsReadOnly((itens ?? []).ToArray());
+
+    /// <summary>Cópia imutável de um conjunto, sem duplicatas.</summary>
+    public static IReadOnlySet<T> Conjunto<T>(IEnumerable<T>? itens)
+        => (itens ?? []).ToFrozenSet();
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Contracts/DenyReason.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Contracts/DenyReason.cs
@@ -1,0 +1,39 @@
+namespace Unifesspa.UniPlus.Authorization.Contracts;
+
+using System.ComponentModel;
+
+using Unifesspa.UniPlus.Authorization.Enums;
+
+/// <summary>
+/// Motivo estrutural de uma negativa de autorização (ADR-0078). O motivo é um
+/// código de um <b>conjunto fechado</b> (<see cref="MotivoNegativa"/>); o tipo
+/// não tem campo de texto livre e, por construção, é <b>incapaz de veicular
+/// dado pessoal</b> (identidade, CPF, nome do titular). Qualquer mensagem
+/// legível ao humano é derivada do código no consumidor (i18n), nunca entrada
+/// livre — LGPD-by-design.
+/// </summary>
+public sealed record DenyReason
+{
+    /// <summary>Código do motivo da negativa, do conjunto fechado.</summary>
+    public MotivoNegativa Codigo { get; }
+
+    private DenyReason(MotivoNegativa codigo) => Codigo = codigo;
+
+    /// <summary>
+    /// Constrói um <see cref="DenyReason"/> a partir de um código do conjunto
+    /// fechado <see cref="MotivoNegativa"/>. Rejeita um valor fora do conjunto
+    /// (<i>cast</i> de inteiro arbitrário): a negativa só se explica por um
+    /// motivo conhecido. Lança em vez de retornar <c>Result</c> porque um código
+    /// fora do conjunto é violação de contrato de programação — o motivo é
+    /// produzido pelo motor de decisão, não por dado externo.
+    /// </summary>
+    public static DenyReason De(MotivoNegativa codigo)
+    {
+        if (!Enum.IsDefined(codigo))
+        {
+            throw new InvalidEnumArgumentException(nameof(codigo), (int)codigo, typeof(MotivoNegativa));
+        }
+
+        return new DenyReason(codigo);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Contracts/PermissionRequirement.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Contracts/PermissionRequirement.cs
@@ -1,0 +1,95 @@
+namespace Unifesspa.UniPlus.Authorization.Contracts;
+
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Requisito de permissão que o ponto de decisão único avalia (ADR-0078): a
+/// permissão pedida e os metadados que condicionam a decisão — sensibilidade do
+/// dado, base legal padrão, exigência de multifator e de dupla aprovação, os
+/// campos de contexto obrigatórios e as verificações contextuais adicionais.
+/// Este tipo é apenas o <b>shape</b> que a decisão recebe; os <b>valores</b>
+/// vêm do catálogo declarativo de permissões (story irmã).
+/// </summary>
+/// <remarks>
+/// <see cref="VerificacoesDeContexto"/> traz <b>somente</b> os checks
+/// contextuais adicionais (fase, estado do recurso, escopo de auditoria, base
+/// legal, equipe, atribuição documental, conformidade legal) — a seleção de
+/// grant, o multifator (<see cref="RequerMfa"/>) e a dupla aprovação
+/// (<see cref="RequerDuplaAprovacao"/>) são derivados pelo serviço de decisão,
+/// não repetidos aqui.
+/// </remarks>
+public sealed record PermissionRequirement
+{
+    /// <summary>Código da permissão exigida, do catálogo.</summary>
+    public string Permissao { get; }
+
+    /// <summary>Sensibilidade do dado que a operação retorna.</summary>
+    public Sensibilidade Sensibilidade { get; }
+
+    /// <summary>Base legal padrão da permissão. Vazia quando o dado é público.</summary>
+    public string BaseLegalPadrao { get; }
+
+    /// <summary>A permissão exige multifator satisfeito.</summary>
+    public bool RequerMfa { get; }
+
+    /// <summary>A permissão exige dupla aprovação válida.</summary>
+    public bool RequerDuplaAprovacao { get; }
+
+    /// <summary>Campos do <see cref="ResourceContext"/> que esta permissão exige presentes.</summary>
+    public IReadOnlyList<string> EscopoContextoObrigatorio { get; }
+
+    /// <summary>Verificações contextuais adicionais que a decisão deve orquestrar.</summary>
+    public IReadOnlyList<string> VerificacoesDeContexto { get; }
+
+    private PermissionRequirement(
+        string permissao,
+        Sensibilidade sensibilidade,
+        string baseLegalPadrao,
+        bool requerMfa,
+        bool requerDuplaAprovacao,
+        IReadOnlyList<string> escopoContextoObrigatorio,
+        IReadOnlyList<string> verificacoesDeContexto)
+    {
+        Permissao = permissao;
+        Sensibilidade = sensibilidade;
+        BaseLegalPadrao = baseLegalPadrao;
+        RequerMfa = requerMfa;
+        RequerDuplaAprovacao = requerDuplaAprovacao;
+        EscopoContextoObrigatorio = escopoContextoObrigatorio;
+        VerificacoesDeContexto = verificacoesDeContexto;
+    }
+
+    /// <summary>
+    /// Constrói um <see cref="PermissionRequirement"/> validado. Rejeita
+    /// <paramref name="permissao"/> em branco. <paramref name="baseLegalPadrao"/>
+    /// nula vira vazia (permitido para dado público). As coleções recebem cópia
+    /// defensiva imutável (nulas viram vazias).
+    /// </summary>
+    public static Result<PermissionRequirement> From(
+        string? permissao,
+        Sensibilidade sensibilidade,
+        string? baseLegalPadrao = null,
+        bool requerMfa = false,
+        bool requerDuplaAprovacao = false,
+        IEnumerable<string>? escopoContextoObrigatorio = null,
+        IEnumerable<string>? verificacoesDeContexto = null)
+    {
+        if (string.IsNullOrWhiteSpace(permissao))
+        {
+            return Result<PermissionRequirement>.Failure(new DomainError(
+                AuthorizationErrorCodes.PermissionRequirementPermissaoObrigatoria,
+                "Código da permissão é obrigatório."));
+        }
+
+        return Result<PermissionRequirement>.Success(new PermissionRequirement(
+            permissao.Trim(),
+            sensibilidade,
+            baseLegalPadrao ?? string.Empty,
+            requerMfa,
+            requerDuplaAprovacao,
+            ColecoesSomenteLeitura.Lista(escopoContextoObrigatorio),
+            ColecoesSomenteLeitura.Lista(verificacoesDeContexto)));
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Contracts/PermissionRequirement.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Contracts/PermissionRequirement.cs
@@ -92,4 +92,41 @@ public sealed record PermissionRequirement
             ColecoesSomenteLeitura.Lista(escopoContextoObrigatorio),
             ColecoesSomenteLeitura.Lista(verificacoesDeContexto)));
     }
+
+    // Igualdade por valor (CA-01): o Equals sintetizado pelo record compararia as
+    // coleções por referência, tornando contratos de conteúdo idêntico desiguais.
+    // Compara as listas por sequência; o hash acompanha em ordem.
+
+    /// <inheritdoc />
+    public bool Equals(PermissionRequirement? other) =>
+        other is not null
+        && Permissao == other.Permissao
+        && Sensibilidade == other.Sensibilidade
+        && BaseLegalPadrao == other.BaseLegalPadrao
+        && RequerMfa == other.RequerMfa
+        && RequerDuplaAprovacao == other.RequerDuplaAprovacao
+        && EscopoContextoObrigatorio.SequenceEqual(other.EscopoContextoObrigatorio)
+        && VerificacoesDeContexto.SequenceEqual(other.VerificacoesDeContexto);
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        HashCode hash = default;
+        hash.Add(Permissao);
+        hash.Add(Sensibilidade);
+        hash.Add(BaseLegalPadrao);
+        hash.Add(RequerMfa);
+        hash.Add(RequerDuplaAprovacao);
+        foreach (string escopo in EscopoContextoObrigatorio)
+        {
+            hash.Add(escopo);
+        }
+
+        foreach (string verificacao in VerificacoesDeContexto)
+        {
+            hash.Add(verificacao);
+        }
+
+        return hash.ToHashCode();
+    }
 }

--- a/src/shared/Unifesspa.UniPlus.Authorization/Contracts/ResourceContext.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Contracts/ResourceContext.cs
@@ -1,0 +1,84 @@
+namespace Unifesspa.UniPlus.Authorization.Contracts;
+
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atributos do recurso alvo de uma decisão de autorização (ADR-0078): o tipo
+/// do recurso, os identificadores de escopo que o situam (unidade proprietária,
+/// processo, chamada) e a classificação de sensibilidade do dado que a operação
+/// retorna. <b>Não</b> carrega dado pessoal do titular — apenas metadados do
+/// recurso.
+/// </summary>
+public sealed record ResourceContext
+{
+    /// <summary>Tipo do recurso alvo (ex.: <c>Edital</c>, <c>Inscricao</c>).</summary>
+    public string RecursoTipo { get; }
+
+    /// <summary>Unidade organizacional proprietária do recurso. Opcional.</summary>
+    public Guid? UnidadeProprietariaId { get; }
+
+    /// <summary>Processo seletivo ao qual o recurso pertence. Opcional.</summary>
+    public Guid? ProcessoId { get; }
+
+    /// <summary>Chamada à qual o recurso pertence. Opcional.</summary>
+    public Guid? ChamadaId { get; }
+
+    /// <summary>Classificação de sensibilidade do dado retornado.</summary>
+    public Sensibilidade Sensibilidade { get; }
+
+    private ResourceContext(
+        string recursoTipo,
+        Sensibilidade sensibilidade,
+        Guid? unidadeProprietariaId,
+        Guid? processoId,
+        Guid? chamadaId)
+    {
+        RecursoTipo = recursoTipo;
+        Sensibilidade = sensibilidade;
+        UnidadeProprietariaId = unidadeProprietariaId;
+        ProcessoId = processoId;
+        ChamadaId = chamadaId;
+    }
+
+    /// <summary>
+    /// Constrói um <see cref="ResourceContext"/> validado. Rejeita
+    /// <paramref name="recursoTipo"/> em branco e qualquer identificador de
+    /// escopo informado como <see cref="Guid.Empty"/> — nulo é "escopo não se
+    /// aplica"; um valor informado precisa ser um identificador real (o projeto
+    /// usa Guid v7).
+    /// </summary>
+    public static Result<ResourceContext> From(
+        string? recursoTipo,
+        Sensibilidade sensibilidade,
+        Guid? unidadeProprietariaId = null,
+        Guid? processoId = null,
+        Guid? chamadaId = null)
+    {
+        if (string.IsNullOrWhiteSpace(recursoTipo))
+        {
+            return Result<ResourceContext>.Failure(new DomainError(
+                AuthorizationErrorCodes.ResourceContextRecursoTipoObrigatorio,
+                "Tipo do recurso é obrigatório."));
+        }
+
+        if (GuidVazioInformado(unidadeProprietariaId)
+            || GuidVazioInformado(processoId)
+            || GuidVazioInformado(chamadaId))
+        {
+            return Result<ResourceContext>.Failure(new DomainError(
+                AuthorizationErrorCodes.ResourceContextEscopoInvalido,
+                "Escopo informado não pode ser Guid.Empty — use um identificador real ou nulo."));
+        }
+
+        return Result<ResourceContext>.Success(new ResourceContext(
+            recursoTipo.Trim(),
+            sensibilidade,
+            unidadeProprietariaId,
+            processoId,
+            chamadaId));
+    }
+
+    private static bool GuidVazioInformado(Guid? valor) => valor is { } g && g == Guid.Empty;
+}

--- a/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Authorization/Errors/AuthorizationErrorCodes.cs
@@ -28,4 +28,14 @@ public static class AuthorizationErrorCodes
     public const string DualApprovalAprovadoresIguais = "Authorization.DualApprovalGrant.AprovadoresIguais";
     public const string DualApprovalValidadeNaoPosterior = "Authorization.DualApprovalGrant.ValidadeNaoPosterior";
     public const string DualApprovalValidadeAcimaDoLimite = "Authorization.DualApprovalGrant.ValidadeAcimaDoLimite";
+
+    public const string AuthorizationSubjectJtiObrigatorio = "Authorization.AuthorizationSubject.JtiObrigatorio";
+
+    public const string PermissionRequirementPermissaoObrigatoria = "Authorization.PermissionRequirement.PermissaoObrigatoria";
+
+    public const string ResourceContextRecursoTipoObrigatorio = "Authorization.ResourceContext.RecursoTipoObrigatorio";
+    public const string ResourceContextEscopoInvalido = "Authorization.ResourceContext.EscopoInvalido";
+
+    public const string AuthorizationRequestContextRequestIdObrigatorio = "Authorization.AuthorizationRequestContext.RequestIdObrigatorio";
+    public const string AuthorizationRequestContextOnBehalfOfInvalido = "Authorization.AuthorizationRequestContext.OnBehalfOfInvalido";
 }

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/AuthorizationDecisionTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/AuthorizationDecisionTests.cs
@@ -1,0 +1,84 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.Contracts;
+
+using System.ComponentModel;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Contracts;
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+
+public sealed class AuthorizationDecisionTests
+{
+    private const string Permissao = "selecao.editais.publicar";
+
+    private static EffectiveGrant Grant()
+        => EffectiveGrant.From(Permissao, FonteGrant.Token).Value!;
+
+    // ─── CA-03: permitida registra o grant usado (contraprova) ─────────────
+
+    [Fact]
+    public void AuthorizationDecision_Permitida_RegistraGrantUsed()
+    {
+        EffectiveGrant grant = Grant();
+
+        AuthorizationDecision decisao = AuthorizationDecision.Permitir(grant);
+
+        decisao.Allowed.Should().BeTrue();
+        decisao.GrantUsed.Should().Be(grant, "a auditoria precisa saber qual concessão autorizou");
+        decisao.DenyReason.Should().BeNull();
+    }
+
+    // ─── CA-03: permitida sem grant é rejeitada pela fábrica (prova negativa) ──
+
+    [Fact]
+    public void AuthorizationDecision_PermitidaSemGrantUsed_Rejeita()
+    {
+        Action act = () => AuthorizationDecision.Permitir(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // ─── CA-04: permitida nunca carrega motivo de negativa (prova negativa) ──
+
+    [Fact]
+    public void AuthorizationDecision_PermitidaComDenyReason_Rejeita()
+    {
+        // O invariante é estrutural: a fábrica Permitir não oferece caminho para
+        // injetar um DenyReason numa decisão permitida — ela sempre o zera.
+        AuthorizationDecision decisao = AuthorizationDecision.Permitir(Grant());
+
+        decisao.Allowed.Should().BeTrue();
+        decisao.DenyReason.Should().BeNull("uma decisão permitida não pode carregar motivo de negativa");
+    }
+
+    // ─── CA-04: negada carrega código fechado, sem texto livre (contraprova) ──
+
+    [Fact]
+    public void AuthorizationDecision_Negada_CarregaCodigoFechadoSemTextoLivre()
+    {
+        AuthorizationDecision decisao = AuthorizationDecision.Negar(MotivoNegativa.FaseFechada);
+
+        decisao.Allowed.Should().BeFalse();
+        decisao.DenyReason.Should().NotBeNull();
+        decisao.DenyReason!.Codigo.Should().Be(MotivoNegativa.FaseFechada);
+        decisao.GrantUsed.Should().BeNull("uma decisão negada nunca registra concessão usada");
+
+        // Sem campo de texto livre: a única informação do motivo é o código do
+        // conjunto fechado — estruturalmente incapaz de veicular PII.
+        typeof(DenyReason).GetProperties()
+            .Should().ContainSingle()
+            .Which.PropertyType.Should().Be<MotivoNegativa>();
+    }
+
+    // ─── CA-04: negada sem código válido é rejeitada (prova negativa) ──────
+
+    [Fact]
+    public void AuthorizationDecision_NegadaSemMotivo_Rejeita()
+    {
+        // "Sem motivo" = código fora do conjunto fechado; a fábrica recusa.
+        Action act = () => AuthorizationDecision.Negar((MotivoNegativa)999);
+
+        act.Should().Throw<InvalidEnumArgumentException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/AuthorizationRequestContextTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/AuthorizationRequestContextTests.cs
@@ -1,0 +1,96 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.Contracts;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Contracts;
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AuthorizationRequestContextTests
+{
+    private const string RequestId = "req-7f3a";
+
+    // ─── CA-06: dupla aprovação ausente quando a operação não exige (contraprova) ──
+
+    [Fact]
+    public void AuthorizationRequestContext_DuplaAprovacaoOpcional_AusenteQuandoNaoExigida()
+    {
+        Result<AuthorizationRequestContext> resultado = AuthorizationRequestContext.From(
+            RequestId, DateTimeOffset.UtcNow, OrigemRequisicao.Api);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.DuplaAprovacao.Should().BeNull("o tipo não obriga o preenchimento da dupla aprovação");
+    }
+
+    // ─── CA-06: dupla aprovação presente quando a operação exige (contraprova) ──
+
+    [Fact]
+    public void AuthorizationRequestContext_DuplaAprovacaoPresente_QuandoExigida()
+    {
+        DateTimeOffset agora = DateTimeOffset.UtcNow;
+        DualApprovalGrant grant = DualApprovalGrant.From(
+            UsuarioRef.From("https://sso.gov.br", "sub-1").Value!,
+            UsuarioRef.From("https://sso.gov.br", "sub-2").Value!,
+            "sha256:abc",
+            "selecao.resultado.homologar",
+            agora,
+            agora.AddMinutes(20)).Value!;
+
+        Result<AuthorizationRequestContext> resultado = AuthorizationRequestContext.From(
+            RequestId, agora, OrigemRequisicao.Api, duplaAprovacao: grant);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.DuplaAprovacao.Should().Be(grant);
+    }
+
+    // ─── DataAcesso em UTC ─────────────────────────────────────────────────
+
+    [Fact]
+    public void AuthorizationRequestContext_DataAcesso_NormalizadaParaUtc()
+    {
+        var local = new DateTimeOffset(2026, 6, 15, 9, 0, 0, TimeSpan.FromHours(-3));
+
+        Result<AuthorizationRequestContext> resultado = AuthorizationRequestContext.From(
+            RequestId, local, OrigemRequisicao.Jobs);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.DataAcesso.Offset.Should().Be(TimeSpan.Zero, "o instante de acesso é sempre UTC");
+        resultado.Value.DataAcesso.Should().Be(local.ToUniversalTime(), "a normalização preserva o instante");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AuthorizationRequestContext_RequestIdVazio_Rejeita(string? requestId)
+    {
+        Result<AuthorizationRequestContext> resultado = AuthorizationRequestContext.From(
+            requestId, DateTimeOffset.UtcNow, OrigemRequisicao.Api);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.AuthorizationRequestContextRequestIdObrigatorio);
+    }
+
+    [Fact]
+    public void AuthorizationRequestContext_OnBehalfOfGuidVazio_Rejeita()
+    {
+        Result<AuthorizationRequestContext> resultado = AuthorizationRequestContext.From(
+            RequestId, DateTimeOffset.UtcNow, OrigemRequisicao.Api, onBehalfOfId: Guid.Empty);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.AuthorizationRequestContextOnBehalfOfInvalido);
+    }
+
+    [Fact]
+    public void AuthorizationRequestContext_IpEUserAgentNulos_ViramVazios()
+    {
+        Result<AuthorizationRequestContext> resultado = AuthorizationRequestContext.From(
+            RequestId, DateTimeOffset.UtcNow, OrigemRequisicao.AdminCli);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.IpOrigem.Should().BeEmpty();
+        resultado.Value.UserAgent.Should().BeEmpty();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/AuthorizationSubjectTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/AuthorizationSubjectTests.cs
@@ -1,0 +1,107 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.Contracts;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Contracts;
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AuthorizationSubjectTests
+{
+    private const string Emissor = "https://sso.gov.br";
+    private const string Permissao = "selecao.editais.publicar";
+
+    private static UsuarioRef Usuario() => UsuarioRef.From(Emissor, "sub-123").Value!;
+
+    // ─── CA-03: grants de fontes distintas convivem numa única lista ───────
+
+    [Fact]
+    public void AuthorizationSubject_GrantsDeFontesDistintas_ConvivemNaLista()
+    {
+        DateTimeOffset validade = DateTimeOffset.UtcNow.AddHours(1);
+
+        EffectiveGrant doToken = EffectiveGrant.From(Permissao, FonteGrant.Token).Value!;
+        EffectiveGrant doGrupo = EffectiveGrant.From(Permissao, FonteGrant.OidcGroupBinding, validoAte: validade).Value!;
+        EffectiveGrant excepcional = EffectiveGrant.From(
+            Permissao, FonteGrant.PermissaoExcecional, escopoUnidadeId: Guid.CreateVersion7(), validoAte: validade).Value!;
+
+        Result<AuthorizationSubject> resultado = AuthorizationSubject.From(
+            Usuario(), "jti-abc", concessoesEfetivas: [doToken, doGrupo, excepcional]);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.ConcessoesEfetivas
+            .Select(g => g.Fonte)
+            .Should().BeEquivalentTo([FonteGrant.Token, FonteGrant.OidcGroupBinding, FonteGrant.PermissaoExcecional],
+                "as três fontes rastreáveis convivem na mesma lista somente-leitura");
+    }
+
+    [Fact]
+    public void AuthorizationSubject_CamposCanonicos_SaoPreservados()
+    {
+        UsuarioRef usuario = Usuario();
+        Guid unidade = Guid.CreateVersion7();
+        EscopoAuditoriaVigente escopo = EscopoAuditoriaVigente.From(
+            Guid.CreateVersion7(), DateTimeOffset.UtcNow.AddDays(1)).Value!;
+        AtuacaoVigente atuacao = AtuacaoVigente.From(unidade, DateTimeOffset.UtcNow.AddHours(2)).Value!;
+
+        Result<AuthorizationSubject> resultado = AuthorizationSubject.From(
+            usuario,
+            "jti-xyz",
+            mfaSatisfeito: true,
+            gruposOidc: ["ceps-admin", "ceps-admin"],
+            unidadesAdministradas: [unidade],
+            escoposAuditoria: [escopo],
+            atuacaoAtiva: atuacao);
+
+        resultado.IsSuccess.Should().BeTrue();
+        AuthorizationSubject subject = resultado.Value!;
+        subject.Usuario.Should().Be(usuario);
+        subject.Jti.Should().Be("jti-xyz");
+        subject.MfaSatisfeito.Should().BeTrue();
+        subject.GruposOidc.Should().ContainSingle("o conjunto remove a duplicata").Which.Should().Be("ceps-admin");
+        subject.UnidadesAdministradas.Should().ContainSingle().Which.Should().Be(unidade);
+        subject.EscoposAuditoria.Should().ContainSingle().Which.Should().Be(escopo);
+        subject.AtuacaoAtiva.Should().Be(atuacao);
+    }
+
+    [Fact]
+    public void AuthorizationSubject_CopiaDefensivaDeColecoes_NaoRefleteMutacaoExterna()
+    {
+        var concessoes = new List<EffectiveGrant> { EffectiveGrant.From(Permissao, FonteGrant.Token).Value! };
+
+        Result<AuthorizationSubject> resultado = AuthorizationSubject.From(
+            Usuario(), "jti-abc", concessoesEfetivas: concessoes);
+
+        concessoes.Add(EffectiveGrant.From("outra.permissao", FonteGrant.Token).Value!); // muta a origem
+
+        resultado.Value!.ConcessoesEfetivas.Should().ContainSingle("a cópia é defensiva e imutável");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AuthorizationSubject_JtiVazio_Rejeita(string? jti)
+    {
+        Result<AuthorizationSubject> resultado = AuthorizationSubject.From(Usuario(), jti);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.AuthorizationSubjectJtiObrigatorio);
+    }
+
+    [Fact]
+    public void AuthorizationSubject_ColecoesNulas_ViramVaziasNaoNulas()
+    {
+        Result<AuthorizationSubject> resultado = AuthorizationSubject.From(Usuario(), "jti-abc");
+
+        resultado.IsSuccess.Should().BeTrue();
+        AuthorizationSubject subject = resultado.Value!;
+        subject.GruposOidc.Should().BeEmpty();
+        subject.UnidadesAdministradas.Should().BeEmpty();
+        subject.EscoposAuditoria.Should().BeEmpty();
+        subject.ConcessoesEfetivas.Should().BeEmpty();
+        subject.AtuacaoAtiva.Should().BeNull();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/DenyReasonTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/DenyReasonTests.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.Contracts;
+
+using System.ComponentModel;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Contracts;
+using Unifesspa.UniPlus.Authorization.Enums;
+
+public sealed class DenyReasonTests
+{
+    // ─── CA-04: código fechado — valor fora do conjunto é rejeitado ────────
+
+    [Fact]
+    public void DenyReason_CodigoForaDoConjuntoFechado_Rejeita()
+    {
+        // Cast de um inteiro arbitrário não pertence ao conjunto fechado.
+        Action act = () => DenyReason.De((MotivoNegativa)999);
+
+        act.Should().Throw<InvalidEnumArgumentException>();
+    }
+
+    // ─── CA-04: contraprova — código válido constrói ───────────────────────
+
+    [Fact]
+    public void DenyReason_CodigoValido_Constroi()
+    {
+        DenyReason motivo = DenyReason.De(MotivoNegativa.SemConcessaoAplicavel);
+
+        motivo.Codigo.Should().Be(MotivoNegativa.SemConcessaoAplicavel);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/PermissionRequirementTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/PermissionRequirementTests.cs
@@ -1,0 +1,71 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.Contracts;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Contracts;
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class PermissionRequirementTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void PermissionRequirement_PermissaoVazia_Rejeita(string? permissao)
+    {
+        Result<PermissionRequirement> resultado = PermissionRequirement.From(permissao, Sensibilidade.Interna);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.PermissionRequirementPermissaoObrigatoria);
+    }
+
+    [Fact]
+    public void PermissionRequirement_ShapeCompleto_Constroi()
+    {
+        Result<PermissionRequirement> resultado = PermissionRequirement.From(
+            "  selecao.resultado.homologar  ",
+            Sensibilidade.Sensivel,
+            baseLegalPadrao: "LGPD art. 7º, II",
+            requerMfa: true,
+            requerDuplaAprovacao: true,
+            escopoContextoObrigatorio: ["processoId"],
+            verificacoesDeContexto: ["fase_aberta", "estado_recurso_compativel"]);
+
+        resultado.IsSuccess.Should().BeTrue();
+        PermissionRequirement req = resultado.Value!;
+        req.Permissao.Should().Be("selecao.resultado.homologar", "a permissão é normalizada com Trim");
+        req.Sensibilidade.Should().Be(Sensibilidade.Sensivel);
+        req.BaseLegalPadrao.Should().Be("LGPD art. 7º, II");
+        req.RequerMfa.Should().BeTrue();
+        req.RequerDuplaAprovacao.Should().BeTrue();
+        req.EscopoContextoObrigatorio.Should().ContainSingle().Which.Should().Be("processoId");
+        req.VerificacoesDeContexto.Should().Equal("fase_aberta", "estado_recurso_compativel");
+    }
+
+    [Fact]
+    public void PermissionRequirement_BaseLegalEColecoesNulas_ViramVaziasNaoNulas()
+    {
+        Result<PermissionRequirement> resultado = PermissionRequirement.From(
+            "configuracao.cota.listar", Sensibilidade.Publica);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.BaseLegalPadrao.Should().BeEmpty("dado público pode não ter base legal");
+        resultado.Value.EscopoContextoObrigatorio.Should().BeEmpty();
+        resultado.Value.VerificacoesDeContexto.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void PermissionRequirement_CopiaDefensivaDeColecoes_NaoRefleteMutacaoExterna()
+    {
+        var escopos = new List<string> { "unidadeProprietariaId" };
+
+        Result<PermissionRequirement> resultado = PermissionRequirement.From(
+            "selecao.editais.publicar", Sensibilidade.Interna, escopoContextoObrigatorio: escopos);
+
+        escopos.Add("processoId"); // muta a origem após a construção
+
+        resultado.Value!.EscopoContextoObrigatorio.Should().ContainSingle("a cópia é defensiva e imutável");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/ResourceContextTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/ResourceContextTests.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.Contracts;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Contracts;
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class ResourceContextTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResourceContext_RecursoTipoVazio_Rejeita(string? recursoTipo)
+    {
+        Result<ResourceContext> resultado = ResourceContext.From(recursoTipo, Sensibilidade.Interna);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.ResourceContextRecursoTipoObrigatorio);
+    }
+
+    [Theory]
+    [InlineData("unidade")]
+    [InlineData("processo")]
+    [InlineData("chamada")]
+    public void ResourceContext_EscopoGuidVazio_Rejeita(string escopo)
+    {
+        Result<ResourceContext> resultado = ResourceContext.From(
+            "Edital",
+            Sensibilidade.Interna,
+            unidadeProprietariaId: escopo == "unidade" ? Guid.Empty : null,
+            processoId: escopo == "processo" ? Guid.Empty : null,
+            chamadaId: escopo == "chamada" ? Guid.Empty : null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AuthorizationErrorCodes.ResourceContextEscopoInvalido);
+    }
+
+    [Fact]
+    public void ResourceContext_ComEscoposEValores_Constroi()
+    {
+        Guid unidade = Guid.CreateVersion7();
+        Guid processo = Guid.CreateVersion7();
+        Guid chamada = Guid.CreateVersion7();
+
+        Result<ResourceContext> resultado = ResourceContext.From(
+            "  Edital  ",
+            Sensibilidade.Pessoal,
+            unidadeProprietariaId: unidade,
+            processoId: processo,
+            chamadaId: chamada);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.RecursoTipo.Should().Be("Edital", "o tipo do recurso é normalizado com Trim");
+        resultado.Value.Sensibilidade.Should().Be(Sensibilidade.Pessoal);
+        resultado.Value.UnidadeProprietariaId.Should().Be(unidade);
+        resultado.Value.ProcessoId.Should().Be(processo);
+        resultado.Value.ChamadaId.Should().Be(chamada);
+    }
+
+    [Fact]
+    public void ResourceContext_SemEscopos_Constroi()
+    {
+        Result<ResourceContext> resultado = ResourceContext.From("Inscricao", Sensibilidade.Publica);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.UnidadeProprietariaId.Should().BeNull();
+        resultado.Value.ProcessoId.Should().BeNull();
+        resultado.Value.ChamadaId.Should().BeNull();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/TiposFormaisContratoTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/TiposFormaisContratoTests.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Authorization.UnitTests.Contracts;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Authorization.Contracts;
+using Unifesspa.UniPlus.Authorization.Enums;
+using Unifesspa.UniPlus.Authorization.ValueObjects;
+
+/// <summary>
+/// Cobre o CA-01 da Story #608 (records imutáveis, igualdade por valor) para os
+/// tipos da assinatura sem coleção, onde a igualdade por valor é determinística.
+/// A varredura por reflection de todo o contrato (sem setter público, schema
+/// canônico, sem nome de provedor — CA-10/CA-11/CA-07) é a fitness de contrato
+/// da task irmã #653.
+/// </summary>
+public sealed class TiposFormaisContratoTests
+{
+    [Fact]
+    public void TiposFormais_Imutaveis_IgualdadePorValor()
+    {
+        // DenyReason — igualdade por código.
+        DenyReason.De(MotivoNegativa.FaseFechada)
+            .Should().Be(DenyReason.De(MotivoNegativa.FaseFechada));
+        DenyReason.De(MotivoNegativa.FaseFechada)
+            .Should().NotBe(DenyReason.De(MotivoNegativa.ConcessaoExpirada));
+
+        // ResourceContext — igualdade por valor dos atributos.
+        Guid unidade = Guid.CreateVersion7();
+        ResourceContext recursoA = ResourceContext.From("Edital", Sensibilidade.Pessoal, unidadeProprietariaId: unidade).Value!;
+        ResourceContext recursoB = ResourceContext.From("Edital", Sensibilidade.Pessoal, unidadeProprietariaId: unidade).Value!;
+        recursoA.Should().Be(recursoB);
+        recursoA.Should().NotBe(ResourceContext.From("Inscricao", Sensibilidade.Pessoal, unidadeProprietariaId: unidade).Value!);
+
+        // AuthorizationRequestContext — igualdade por valor (sem dupla aprovação).
+        var instante = new DateTimeOffset(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        AuthorizationRequestContext reqA = AuthorizationRequestContext.From("req-1", instante, OrigemRequisicao.Api).Value!;
+        AuthorizationRequestContext reqB = AuthorizationRequestContext.From("req-1", instante, OrigemRequisicao.Api).Value!;
+        reqA.Should().Be(reqB);
+
+        // AuthorizationDecision — permitida igual por valor do grant; negada por código.
+        EffectiveGrant grant1 = EffectiveGrant.From("selecao.editais.publicar", FonteGrant.Token).Value!;
+        EffectiveGrant grant2 = EffectiveGrant.From("selecao.editais.publicar", FonteGrant.Token).Value!;
+        AuthorizationDecision.Permitir(grant1).Should().Be(AuthorizationDecision.Permitir(grant2));
+        AuthorizationDecision.Negar(MotivoNegativa.SemConcessaoAplicavel)
+            .Should().Be(AuthorizationDecision.Negar(MotivoNegativa.SemConcessaoAplicavel));
+
+        // Permitida e negada nunca são iguais.
+        AuthorizationDecision.Permitir(grant1)
+            .Should().NotBe(AuthorizationDecision.Negar(MotivoNegativa.SemConcessaoAplicavel));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/TiposFormaisContratoTests.cs
+++ b/tests/Unifesspa.UniPlus.Authorization.UnitTests/Contracts/TiposFormaisContratoTests.cs
@@ -48,4 +48,56 @@ public sealed class TiposFormaisContratoTests
         AuthorizationDecision.Permitir(grant1)
             .Should().NotBe(AuthorizationDecision.Negar(MotivoNegativa.SemConcessaoAplicavel));
     }
+
+    // Tipos com coleção: o Equals sintetizado pelo record compararia as coleções
+    // por referência. O Equals/GetHashCode customizado restaura a igualdade por
+    // valor exigida pelo CA-01 mesmo com instâncias de coleção distintas.
+
+    [Fact]
+    public void PermissionRequirement_ConteudoIdentico_EhIgualPorValor()
+    {
+        PermissionRequirement Criar() => PermissionRequirement.From(
+            "selecao.resultado.homologar",
+            Sensibilidade.Sensivel,
+            baseLegalPadrao: "LGPD art. 7º, II",
+            requerMfa: true,
+            escopoContextoObrigatorio: ["processoId"],
+            verificacoesDeContexto: ["fase_aberta", "base_legal"]).Value!;
+
+        PermissionRequirement a = Criar();
+        PermissionRequirement b = Criar();
+
+        a.Should().Be(b, "coleções de conteúdo idêntico não quebram a igualdade por valor");
+        a.GetHashCode().Should().Be(b.GetHashCode());
+
+        PermissionRequirement diferente = PermissionRequirement.From(
+            "selecao.resultado.homologar",
+            Sensibilidade.Sensivel,
+            verificacoesDeContexto: ["fase_aberta"]).Value!;
+        a.Should().NotBe(diferente, "conteúdo de coleção distinto torna os contratos desiguais");
+    }
+
+    [Fact]
+    public void AuthorizationSubject_ConteudoIdentico_EhIgualPorValor()
+    {
+        UsuarioRef usuario = UsuarioRef.From("https://sso.gov.br", "sub-1").Value!;
+        Guid unidade = Guid.CreateVersion7();
+        EffectiveGrant grant = EffectiveGrant.From("selecao.editais.publicar", FonteGrant.Token).Value!;
+
+        AuthorizationSubject Criar(IEnumerable<string> grupos) => AuthorizationSubject.From(
+            usuario,
+            "jti-1",
+            gruposOidc: grupos,
+            unidadesAdministradas: [unidade],
+            concessoesEfetivas: [grant]).Value!;
+
+        AuthorizationSubject a = Criar(["ceps-admin", "crca-leitor"]);
+        AuthorizationSubject b = Criar(["crca-leitor", "ceps-admin"]); // mesma composição, ordem distinta
+
+        a.Should().Be(b, "conjuntos comparam-se por conteúdo, não por ordem nem referência");
+        a.GetHashCode().Should().Be(b.GetHashCode());
+
+        AuthorizationSubject diferente = Criar(["ceps-admin"]);
+        a.Should().NotBe(diferente, "composição de grupos distinta torna os sujeitos desiguais");
+    }
 }


### PR DESCRIPTION
## Contexto

T2 da Story #608 (frente de Autorização, Epic #600). Define os **tipos formais da assinatura** do ponto de decisão único `DecideAsync` (ADR-0078) e o resultado da decisão, sobre a fundação de enums e value objects entregue na T1 (#651). **Não** implementa o serviço de decisão (#612), o catálogo (#607) nem a fitness de contrato por reflection (#653).

Tipos de contrato em memória, no diretório `Contracts/` do módulo cross-cutting `Unifesspa.UniPlus.Authorization` — sem EF Core, persistência ou soft-delete. Só referencia o Kernel (`Result<T>`/`DomainError`).

## O que entrega (6 `sealed record` imutáveis)

**Entrada da decisão** — fábrica `From(...) → Result<T>`, no padrão da T1 (montados a partir de dados externos potencialmente inválidos):

| Tipo | Pontos-chave |
|---|---|
| `AuthorizationSubject` | Sujeito explícito; agrega concessões de fontes distintas (token / vínculo de grupo / excepcional) numa única lista somente-leitura; coleções com cópia defensiva imutável (`Array.AsReadOnly`, `FrozenSet`). Exige `Usuario` e `Jti`. |
| `PermissionRequirement` | Apenas o *shape* do requisito; os valores vêm do catálogo (#607). Coleções imutáveis. |
| `ResourceContext` | Atributos do recurso alvo, sem dado pessoal. Rejeita escopo `Guid.Empty`. |
| `AuthorizationRequestContext` | Contexto da requisição; `DataAcesso` normalizada para **UTC** (preserva o instante); `DuplaAprovacao` presente **só quando a operação exige** (CA-06). |

**Resultado da decisão** — fábricas que **lançam** em violação de pré-condição (são produzidas pelo motor a partir de um veredito já tomado; `null`/código inválido é bug de programação, não erro de dado externo):

| Tipo | Pontos-chave |
|---|---|
| `DenyReason` | Motivo por **código fechado** (`MotivoNegativa`), sem texto livre — estruturalmente incapaz de veicular PII (LGPD). `De(codigo)` valida `Enum.IsDefined`. |
| `AuthorizationDecision` | `Permitir(grant)` / `Negar(codigo)` garantem **por construção** o invariante: permitida tem `GrantUsed` e não `DenyReason`; negada tem `DenyReason` e não `GrantUsed`. |

## Critérios de aceite (T2)

- [x] **CA-01:** records imutáveis (sem setters públicos), igualdade por valor.
- [x] **CA-03:** `AuthorizationSubject` agrega grants de fontes distintas; decisão permitida registra `GrantUsed`; permitida sem grant é rejeitada pela fábrica.
- [x] **CA-04:** decisão negada carrega `DenyReason` de código fechado, sem texto livre; permitida não carrega motivo; código fora do conjunto é rejeitado.
- [x] **CA-06:** `AuthorizationRequestContext` carrega `DuplaAprovacao` só quando exigida; ausente quando não.
- [x] Build e testes verdes, sem warnings; `DataAcesso` em UTC.

## Decisões de design (para revisão)

- **Dois estilos de fábrica:** entrada (`Subject`/`Requirement`/`Resource`/`RequestContext`) usa `From → Result<T>` (dados externos); resultado (`Decision`/`DenyReason`) lança exceção de argumento (veredito do motor). Distinção semântica documentada nos XML docs.
- **Campos `string` não-anuláveis do modelo** (`Jti`, `RequestId`, `RecursoTipo`, `Permissao`) → validados não-vazios. `IpOrigem`/`UserAgent`/`BaseLegalPadrao` aceitam ausência (`null → ""`): podem faltar legitimamente (jobs/admin-cli/dado público); a regra "dado pessoal exige base legal" é do serviço de decisão (#612, passo 6), não do *shape*.
- **Validação de enum** só para `MotivoNegativa` (CA-04 enfatiza o conjunto fechado), consistente com a T1, que não valida `FonteGrant`.

## Testes

50 testes unitários novos (90 no total do módulo, com os da T1), cobrindo os 8 testes mapeados na issue + invariantes das fábricas + cópias defensivas. A **fitness de contrato por reflection** (CA-07/CA-10/CA-11 — sem setter público, schema canônico, sem nome de provedor) é a task irmã #653.

## Fora de escopo

Serviço de decisão / agregador do sujeito / `CheckResult` → #612 · valores do catálogo → #607 · fitness por reflection → #653.

Parte de #608.

Closes #652