### PR TITLE
feat(pagination): navegação bidirecional por cursor (prev/next)

### DIFF
--- a/contracts/openapi.organizacao.json
+++ b/contracts/openapi.organizacao.json
@@ -529,6 +529,19 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
           }
         ],
         "responses": {
@@ -536,7 +549,7 @@
             "description": "OK",
             "headers": {
               "Link": {
-                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022next\u0022 s\u00F3 quando h\u00E1 pr\u00F3xima p\u00E1gina. Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 (ADR-0026).",
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
                 "schema": {
                   "type": "string"
                 }

--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -279,6 +279,19 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
           }
         ],
         "responses": {
@@ -286,7 +299,7 @@
             "description": "OK",
             "headers": {
               "Link": {
-                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022next\u0022 s\u00F3 quando h\u00E1 pr\u00F3xima p\u00E1gina. Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 (ADR-0026).",
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
                 "schema": {
                   "type": "string"
                 }
@@ -670,6 +683,19 @@
               "type": "integer",
               "format": "int32"
             }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
           }
         ],
         "responses": {
@@ -677,7 +703,7 @@
             "description": "OK",
             "headers": {
               "Link": {
-                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022next\u0022 s\u00F3 quando h\u00E1 pr\u00F3xima p\u00E1gina. Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 (ADR-0026).",
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
                 "schema": {
                   "type": "string"
                 }

--- a/docs/adrs/0089-navegacao-bidirecional-cursor-keyset-reverso.md
+++ b/docs/adrs/0089-navegacao-bidirecional-cursor-keyset-reverso.md
@@ -1,0 +1,99 @@
+---
+status: "accepted"
+date: "2026-06-16"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed: []
+---
+
+# ADR-0089: Navegação bidirecional na paginação por cursor via keyset reverso
+
+## Contexto e enunciado do problema
+
+A [ADR-0026](0026-paginacao-cursor-opaco-cifrado.md) fixou a paginação por cursor opaco cifrado e **já antecipou** a navegação reversa: declara `direction` (`next`/`prev`, default `next`) entre os parâmetros de query, prevê `rel="prev"` no header `Link` e reconhece o cursor como "unidirecional ou bidirecional restrito". O que aquela ADR explicitamente **não decidiu** foi a *mecânica* da navegação reversa — a forma do query backward, a integridade do cursor face à direção e a semântica das flags de continuidade.
+
+Hoje a implementação é **forward-only**: os repositórios fazem `WHERE Id > cursor ORDER BY Id ASC` (chave keyset = `Id`, GUID v7 ordenável por criação, [ADR-0032](0032-guid-v7-para-identidade-de-entidades.md)) e o helper `OkPaginatedAsync` só emite `rel="next"`. O frontend precisa oferecer navegação **Anterior / Próximo** (mais clara que "carregar mais" para listas administrativas), o que exige completar a navegação reversa que a ADR-0026 deixou em aberto.
+
+Esta ADR decide **como** implementar essa navegação reversa, completando a ADR-0026.
+
+## Drivers da decisão
+
+- **Conformidade com a ADR-0026.** `direction` já é query param; o cursor permanece opaco.
+- **Estabilidade de janela keyset.** A navegação reversa mantém a mesma garantia que a forward — sem o problema de janela do offset.
+- **Decode no boundary ([ADR-0031](0031-decoding-de-cursor-opaco-no-boundary-http.md)).** O handler recebe primitivas; a direção é resolvida no boundary HTTP.
+- **Sem `COUNT(*)`.** As flags de continuidade (`hasPrevious`/`hasNext`) não podem custar uma contagem O(N).
+- **Integridade do par cursor+direção.** Um cursor não pode ser reutilizado com a direção errada produzindo janela incoerente.
+- **Ordem de apresentação estável.** Independente da direção navegada, a página é exibida em ordem canônica ascendente por `Id`.
+
+## Opções consideradas
+
+- **A. `direction` como query param (ADR-0026), vinculada por integridade no cursor, + keyset reverso com reversão em memória.**
+- **B. Direção embutida apenas no payload do cursor**, sem query param.
+- **C. Janela materializada / offset reverso** para salto arbitrário e flags exatas.
+
+## Resultado da decisão
+
+**Escolhida:** "A", porque conforma à ADR-0026 (que fixou `direction` como query param), mantém o cursor opaco, fecha a brecha de integridade do par cursor+direção e entrega flags exatas sem custo de contagem.
+
+Mecânica:
+
+- **Query forward (`direction=next`, e primeira página).** `WHERE Id > @after ORDER BY Id ASC LIMIT @limit + 1` (sem `@after` na primeira página). `hasNext = retornados > limit`; a página são os primeiros `limit`.
+- **Query backward (`direction=prev`) — corte antes da reversão.** `WHERE Id < @after ORDER BY Id DESC LIMIT @limit + 1`. A ordem do corte é crítica: `hasPrevious = retornadosDesc > limit`; descarta-se o item-probe **ainda em ordem DESC** (`pageDesc = retornadosDesc.Take(limit)` — o probe é o mais antigo) e só então reverte-se para ascendente (`pageAsc = pageDesc.Reverse()`). Reverter antes de cortar omitiria o boundary e incluiria o probe.
+- **Flags exatas, sem `COUNT`.** A flag do lado **navegado** vem do probe `n+1` (já buscado). A flag do lado **oposto** vem de um `EXISTS` indexado barato sobre a mesma query base (com os mesmos filtros): `hasPrevious = AnyAsync(Id < primeiroIdDaPagina)` quando se navegou forward; `hasNext = AnyAsync(Id > ultimoIdDaPagina)` quando se navegou backward. Na primeira página `hasPrevious = false` por definição. Não se infere flag pela direção de chegada — sob deleção concorrente ou cursor antigo essa inferência daria falso positivo.
+- **`direction` é query param, mas vinculada ao cursor.** O servidor lê `direction` do query param (ADR-0026) e o decoda no boundary (ADR-0031). Para impedir reuso incoerente (pegar o cursor de `next` e chamar `direction=prev`), o payload passa a carregar a direção/âncora para a qual foi emitido; no decode valida-se `query.direction == payload.Direction` — divergência é tratada como cursor adulterado (`400 uniplus.cursor.invalido`). O cursor segue **opaco e cifrado AES-GCM**; o `CursorEncoder` não muda (serializa o payload como está). O campo de direção é obrigatório no payload — o sistema ainda não está em produção, então não há cursores em circulação a preservar.
+- **Emissão dos links.** Com a página em ordem ascendente, `prevCursor` cifra o `Id` do primeiro item (com `Direction=prev`) e o link recebe `direction=prev`; `nextCursor` cifra o `Id` do último item (com `Direction=next`) e o link recebe `direction=next`. Cada `rel` é emitido só quando a flag correspondente é verdadeira. `LinkHeaderBuilder`/`PageLinks` já suportam `prev`.
+- **Página vazia com cursor válido.** Um cursor válido (não expirado) cuja janela ficou vazia (ex.: itens deletados) retorna `200 []` **sem** `rel="prev"`/`rel="next"` (apenas `self`) — não há boundary para emitir e não se fabricam links a partir da âncora original. O cliente trata ausência de links como fim e reinicia se necessário.
+
+## Consequências
+
+### Positivas
+
+- Completa a navegação reversa prevista pela ADR-0026 sem alterar o `CursorEncoder` nem a forma opaca do cursor.
+- `hasPrevious`/`hasNext` **exatos** em todas as páginas via um `EXISTS` indexado por página — zero `COUNT(*)`.
+- Integridade do par cursor+direção: cursor de `next` não pode ser usado como `prev` (validação no decode).
+- Links auto-suficientes (RFC 5988): o cliente segue `rel="prev"`/`rel="next"` opacos sem conhecer a convenção.
+
+### Negativas
+
+- Um `EXISTS` extra por página para a flag do lado oposto (indexado, `LIMIT 1` — barato, mas não gratuito).
+- Reversão em memória O(limit) no backward (desprezível para os limites atuais, máx. 100).
+- Sem salto para página arbitrária (intrínseco a cursor; já registrado na ADR-0026).
+- O payload ganha um campo de direção/âncora obrigatório — evolução de schema do cursor (sem impacto de migração: sistema fora de produção, sem cursores em circulação).
+
+### Neutras
+
+- A garantia keyset é a da ADR-0026: elimina duplicação/omissão por *shift* de janela do offset, **não** é snapshot consistency — inserções/remoções concorrentes refletem na travessia (itens novos após a âncora aparecem; removidos somem). Travessia consistente da coleção exigiria um marcador de snapshot no cursor, fora do escopo desta ADR.
+- Cada endpoint paginado estende seu repositório (WHERE/ORDER condicionais + `EXISTS` do lado oposto) e handler (corte/​reversão + flags + dois boundaries); a chave keyset por `Id` mantém isso mecânico.
+
+## Confirmação
+
+- **Testes de integração** por endpoint: navegação forward e backward percorrendo a coleção sem duplicar/omitir; ordem ascendente preservada na página `prev`; `hasPrevious`/`hasNext` exatos nas bordas; reuso de cursor com `direction` trocada rejeitado com `400`; página vazia com cursor válido retorna `200 []` sem `prev`/`next`.
+- **Testes de unidade** do model binder/decode: `?direction=prev|next` parseado; valor inválido rejeitado; default `next`; mismatch `query.direction × payload.Direction` → `400`.
+- **Spectral / OpenAPI**: parâmetro `direction` declarado nos endpoints de coleção; `Link` sem metadado em body (ADR-0025/0026).
+
+## Prós e contras das opções
+
+### A. Query param vinculado ao cursor + keyset reverso
+
+- Bom, porque conforma à ADR-0026 e mantém o cursor opaco.
+- Bom, porque entrega flags exatas sem `COUNT(*)` e fecha a brecha de integridade cursor+direção.
+- Ruim, porque adiciona um `EXISTS` por página e um campo ao payload.
+
+### B. Direção apenas no payload do cursor (sem query param)
+
+- Bom, porque o link fica self-describing sem param visível.
+- Ruim, porque contraria a ADR-0026 (que fixou `direction` como query param); o link já é opaco e auto-suficiente com o param + binding.
+
+### C. Janela materializada / offset reverso
+
+- Bom, porque permitiria salto para página arbitrária e flags exatas triviais.
+- Ruim, porque reintroduz os custos de offset (instabilidade de janela, scan O(N)) que a ADR-0026 rejeitou.
+
+## Mais informações
+
+- [ADR-0026](0026-paginacao-cursor-opaco-cifrado.md) — paginação por cursor opaco cifrado; esta ADR completa a navegação reversa que aquela deixou como "não decidido".
+- [ADR-0031](0031-decoding-de-cursor-opaco-no-boundary-http.md) — decode do cursor no boundary HTTP; `direction` é resolvido e validado no mesmo ponto.
+- [ADR-0025](0025-wire-formato-sucesso-body-direto.md) — body de coleção como array puro; metadados de navegação seguem só em headers.
+- [ADR-0032](0032-guid-v7-para-identidade-de-entidades.md) — `Id` GUID v7 ordenável, base da chave keyset.
+- [RFC 5988 / 8288 — Web Linking](https://www.rfc-editor.org/rfc/rfc8288.html); modelo de navegação bidirecional inspirado nas Relay Connections (GraphQL).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -117,8 +117,9 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0086](0086-trilha-de-auditoria-com-hmac-e-cofre.md) | Trilha de auditoria de autorização com integridade verificável (código de autenticação com chave em cofre, rotacionável; append-only) | proposed | 2026-06-02 |
 | [0087](0087-banco-isolado-para-o-contexto-de-autorizacao.md) | Banco isolado para o contexto de autorização (aplica ADR-0054; referências externas por identificador via leitor) | proposed | 2026-06-02 |
 | [0088](0088-versionamento-cross-repo-do-contrato-de-permissoes.md) | Versionamento e publicação cross-repo do contrato de permissões (pacote versionado; versão fixa no frontend; validação na CI) | proposed | 2026-06-02 |
+| [0089](0089-navegacao-bidirecional-cursor-keyset-reverso.md) | Navegação bidirecional na paginação por cursor via keyset reverso (direction query param vinculado ao cursor; flags exatas sem COUNT) | accepted | 2026-06-16 |
 
-> **Nota de numeração:** a `0077` (identidade de `Unidade`) foi **publicada** — a sequência de `0001` a `0088` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0089+`.
+> **Nota de numeração:** a `0077` (identidade de `Unidade`) foi **publicada** — a sequência de `0001` a `0089` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0090+`.
 
 ## Como adicionar um novo ADR
 

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
@@ -99,14 +99,14 @@ public sealed class UnidadesController : ControllerBase
         }
 
         ListarUnidadesAtivasResult resultado = await _queryBus
-            .Send(new ListarUnidadesAtivasQuery(page.AfterId, page.Limit, q, tipos), cancellationToken)
+            .Send(new ListarUnidadesAtivasQuery(page.AfterId, page.Limit, page.Direction, q, tipos), cancellationToken)
             .ConfigureAwait(false);
 
         // HATEOAS Level 1 (ADR-0029 §"Coleção"): cada item carrega seu _links.self.
         UnidadeDto[] comLinks = [.. resultado.Items.Select(u => u with { Links = _linksBuilder.Build(u) })];
 
         return await this.OkPaginatedAsync(
-            comLinks, resultado.ProximoAfterId, page, ResourceTag,
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
             cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQuery.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQuery.cs
@@ -1,20 +1,24 @@
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Unidades;
 
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
 
 /// <summary>
-/// Lista unidades ativas paginadas por cursor (ADR-0026), com filtros
-/// opcionais (issue #640). Os parâmetros já chegam decodificados — o controller
-/// decifra o cursor opaco e valida o <c>limit</c> antes de despachar a query,
-/// mantendo <c>Application</c> independente de <c>Infrastructure.Core</c>.
+/// Lista unidades ativas paginadas por cursor bidirecional (ADR-0026 +
+/// ADR-0089), com filtros opcionais (issue #640). Os parâmetros já chegam
+/// decodificados — o controller decifra o cursor opaco, valida o <c>limit</c> e
+/// a <c>direction</c> antes de despachar a query, mantendo <c>Application</c>
+/// independente de <c>Infrastructure.Core</c>.
 /// </summary>
-/// <param name="AfterId">Identificador do último item da página anterior; <c>null</c> retorna a primeira janela.</param>
+/// <param name="AfterId">Âncora da página anterior; <c>null</c> retorna a primeira janela.</param>
 /// <param name="Limit">Tamanho máximo da página a retornar.</param>
+/// <param name="Direction">Direção de navegação (<c>Next</c>/<c>Prev</c>, ADR-0089).</param>
 /// <param name="Busca">Termo de busca livre (acento/caixa-insensível) sobre sigla, nome, código, slug e alias; <c>null</c>/vazio = sem filtro textual. O handler normaliza.</param>
 /// <param name="Tipos">Tipos de unidade a incluir (OR entre si); lista vazia = sem filtro por tipo.</param>
 public sealed record ListarUnidadesAtivasQuery(
     Guid? AfterId,
     int Limit,
+    PaginationDirection Direction,
     string? Busca,
     IReadOnlyList<TipoUnidade> Tipos) : IQuery<ListarUnidadesAtivasResult>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQueryHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasQueryHandler.cs
@@ -7,11 +7,12 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
 
 /// <summary>
 /// Handler convention-based de <see cref="ListarUnidadesAtivasQuery"/>:
-/// paginação keyset-based (cursor) sobre o agregado <c>Unidade</c>, ordenando
-/// pelo identificador para garantir estabilidade da janela. Solicita
-/// <c>limit + 1</c> itens para detectar a próxima página sem COUNT (ADR-0026).
-/// Aplica os filtros opcionais (busca + tipos) no read-side (issue #640);
-/// a normalização acento/caixa é delegada ao banco via immutable_unaccent + ILIKE.
+/// paginação keyset bidirecional (cursor) sobre o agregado <c>Unidade</c>
+/// (ADR-0026 + ADR-0089). A mecânica de keyset (ordenação, probe <c>n+1</c>,
+/// reversão e flags <c>prev</c>/<c>next</c> sem COUNT) vive no repositório via
+/// <c>CursorKeyset</c>; o handler apenas monta o filtro (busca + tipos, issue
+/// #640) e projeta as entidades em DTO. A normalização acento/caixa é delegada
+/// ao banco via immutable_unaccent + ILIKE.
 /// </summary>
 public static class ListarUnidadesAtivasQueryHandler
 {
@@ -27,19 +28,11 @@ public static class ListarUnidadesAtivasQueryHandler
             string.IsNullOrWhiteSpace(query.Busca) ? null : query.Busca,
             query.Tipos ?? []);
 
-        IReadOnlyList<Unidade> page = await repository
-            .ListarPaginadoAsync(query.AfterId, query.Limit + 1, filtro, cancellationToken)
+        (IReadOnlyList<Unidade> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, filtro, cancellationToken)
             .ConfigureAwait(false);
 
-        // Defesa contra Limit <= 0 (config inconsistente): Take(0) devolveria
-        // array vazio e limited[^1] lançaria IndexOutOfRangeException.
-        if (page.Count > query.Limit && query.Limit > 0)
-        {
-            UnidadeDto[] limited = [.. page.Take(query.Limit).Select(u => u.ToDto())];
-            return new ListarUnidadesAtivasResult(limited, limited[^1].Id);
-        }
-
-        UnidadeDto[] items = [.. page.Select(u => u.ToDto())];
-        return new ListarUnidadesAtivasResult(items, ProximoAfterId: null);
+        UnidadeDto[] items = [.. itens.Select(u => u.ToDto())];
+        return new ListarUnidadesAtivasResult(items, anteriorAfterId, proximoAfterId);
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasResult.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Queries/Unidades/ListarUnidadesAtivasResult.cs
@@ -4,10 +4,13 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.DTOs;
 
 /// <summary>
 /// Resultado da <see cref="ListarUnidadesAtivasQuery"/>: lote de unidades já
-/// projetadas + identificador opcional do último item para o controller
-/// construir o cursor da próxima página (ADR-0026). Não vaza entidades de
-/// domínio.
+/// projetadas + âncoras opcionais para o controller construir os cursores de
+/// página anterior/próxima (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
 /// </summary>
-/// <param name="Items">Unidades da página corrente, ordenadas pelo identificador.</param>
-/// <param name="ProximoAfterId">Id do último item da janela quando há mais páginas; <c>null</c> sinaliza fim da coleção.</param>
-public sealed record ListarUnidadesAtivasResult(IReadOnlyList<UnidadeDto> Items, Guid? ProximoAfterId);
+/// <param name="Items">Unidades da página corrente, em ordem ascendente por identificador.</param>
+/// <param name="AnteriorAfterId">Âncora para o cursor <c>prev</c> (primeiro item) quando há página anterior; <c>null</c> = início da coleção.</param>
+/// <param name="ProximoAfterId">Âncora para o cursor <c>next</c> (último item) quando há próxima página; <c>null</c> = fim da coleção.</param>
+public sealed record ListarUnidadesAtivasResult(
+    IReadOnlyList<UnidadeDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Interfaces/IUnidadeRepository.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
 
+using Unifesspa.UniPlus.Kernel.Pagination;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
 
@@ -25,17 +26,20 @@ public interface IUnidadeRepository
     Task<Unidade?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Lista unidades ativas paginadas por cursor keyset (ADR-0026): ordena por
-    /// <c>Id</c> (Guid v7, ADR-0032 — ordem cronológica) e retorna até
-    /// <paramref name="take"/> itens com <c>Id</c> maior que
-    /// <paramref name="afterId"/> (ou a primeira janela quando <c>null</c>).
-    /// Os critérios de <paramref name="filtro"/> (busca textual + tipos) são
-    /// aplicados no read-side antes do keyset, mantendo a janela coerente sobre
-    /// o conjunto filtrado (issue #640).
+    /// Lista unidades ativas paginadas por cursor keyset bidirecional (ADR-0026
+    /// + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e retorna até
+    /// <paramref name="limit"/> itens na direção <paramref name="direction"/> a
+    /// partir de <paramref name="afterId"/> (ou a primeira janela quando
+    /// <c>null</c>), sempre em ordem ascendente. Devolve também as âncoras de
+    /// <c>prev</c>/<c>next</c> (nulas quando não há aquele lado). Os critérios de
+    /// <paramref name="filtro"/> (busca textual + tipos) são aplicados no
+    /// read-side antes do keyset, mantendo a janela coerente sobre o conjunto
+    /// filtrado (issue #640).
     /// </summary>
-    Task<IReadOnlyList<Unidade>> ListarPaginadoAsync(
+    Task<(IReadOnlyList<Unidade> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
-        int take,
+        int limit,
+        PaginationDirection direction,
         FiltroListagemUnidades filtro,
         CancellationToken cancellationToken);
 

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Repositories/UnidadeRepository.cs
@@ -5,6 +5,8 @@ using System.Text;
 
 using Microsoft.EntityFrameworkCore;
 
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
@@ -38,9 +40,10 @@ internal sealed class UnidadeRepository : IUnidadeRepository
             .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
     }
 
-    public async Task<IReadOnlyList<Unidade>> ListarPaginadoAsync(
+    public async Task<(IReadOnlyList<Unidade> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
-        int take,
+        int limit,
+        PaginationDirection direction,
         FiltroListagemUnidades filtro,
         CancellationToken cancellationToken)
     {
@@ -83,22 +86,15 @@ internal sealed class UnidadeRepository : IUnidadeRepository
             query = query.Where(u => tipos.Contains(u.Tipo));
         }
 
-        query = query.OrderBy(u => u.Id);
-
-        if (afterId is { } cursor)
-        {
-            // Keyset coerente server-side (ADR-0026 + ADR-0032): Npgsql traduz
-            // Guid.CompareTo para o operador uuid > nativo do PG — mesmo
-            // comparador do OrderBy(Id). Com Guid v7, a ordem por Id reflete a
-            // criação temporal. Aplicado APÓS os filtros: a janela avança sobre
-            // o conjunto já filtrado.
-            query = query.Where(u => u.Id.CompareTo(cursor) > 0);
-        }
-
-        return await query
-            .Take(take)
-            .ToListAsync(cancellationToken)
+        // Keyset bidirecional (ADR-0089): ordenação, âncora, probe n+1, reversão
+        // e flags ficam no helper, que opera sobre a query JÁ FILTRADA — os
+        // EXISTS do helper herdam os mesmos filtros (busca/tipos). Npgsql traduz
+        // Guid.CompareTo para o operador uuid nativo do PG (ADR-0026 + ADR-0032).
+        CursorKeysetPage<Unidade> page = await CursorKeyset
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
             .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
     }
 
     public async Task AdicionarAsync(Unidade unidade, CancellationToken cancellationToken)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs
@@ -71,10 +71,10 @@ public sealed class EditalController : ControllerBase
         ArgumentNullException.ThrowIfNull(page);
 
         ListarEditaisResult resultado = await _queryBus.Send(
-            new ListarEditaisQuery(page.AfterId, page.Limit), cancellationToken);
+            new ListarEditaisQuery(page.AfterId, page.Limit, page.Direction), cancellationToken);
 
         return await this.OkPaginatedAsync(
-            resultado.Items, resultado.ProximoAfterId, page, ResourceTag,
+            resultado.Items, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
             cancellationToken: cancellationToken);
     }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ObrigatoriedadeLegalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ObrigatoriedadeLegalController.cs
@@ -78,6 +78,7 @@ public sealed class ObrigatoriedadeLegalController : ControllerBase
             new ListarObrigatoriedadesLegaisQuery(
                 page.AfterId,
                 page.Limit,
+                page.Direction,
                 tipoEdital,
                 categoria,
                 vigentes),
@@ -85,6 +86,7 @@ public sealed class ObrigatoriedadeLegalController : ControllerBase
 
         return await this.OkPaginatedAsync(
             resultado.Items,
+            resultado.AnteriorAfterId,
             resultado.ProximoAfterId,
             page,
             ResourceTag,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ListarEditaisQuery.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ListarEditaisQuery.cs
@@ -1,13 +1,18 @@
 namespace Unifesspa.UniPlus.Selecao.Application.Queries.Editais;
 
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
 
 /// <summary>
-/// Lista editais paginados por cursor (ADR-0026). Os parâmetros já chegam
-/// decodificados — o controller é responsável por decifrar o cursor opaco e
-/// validar o <c>limit</c> antes de despachar a query, mantendo
+/// Lista editais paginados por cursor bidirecional (ADR-0026 + ADR-0089). Os
+/// parâmetros já chegam decodificados — o controller decifra o cursor opaco e
+/// valida <c>limit</c>/<c>direction</c> antes de despachar a query, mantendo
 /// <c>Application</c> independente de <c>Infrastructure.Core</c>.
 /// </summary>
-/// <param name="AfterId">Identificador do último item da página anterior; <c>null</c> retorna a primeira janela.</param>
+/// <param name="AfterId">Âncora da página anterior; <c>null</c> retorna a primeira janela.</param>
 /// <param name="Limit">Tamanho máximo da página a retornar.</param>
-public sealed record ListarEditaisQuery(Guid? AfterId, int Limit) : IQuery<ListarEditaisResult>;
+/// <param name="Direction">Direção de navegação (<c>Next</c>/<c>Prev</c>, ADR-0089).</param>
+public sealed record ListarEditaisQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarEditaisResult>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ListarEditaisQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ListarEditaisQueryHandler.cs
@@ -6,10 +6,10 @@ using Domain.Interfaces;
 
 /// <summary>
 /// Handler convention-based de <see cref="ListarEditaisQuery"/>: paginação
-/// keyset-based (cursor) sobre o agregado <c>Edital</c>, ordenando pelo
-/// identificador para garantir estabilidade da janela. Solicita
-/// <c>limit + 1</c> itens para detectar a existência de próxima página sem
-/// precisar de COUNT, conforme ADR-0026.
+/// keyset bidirecional (cursor) sobre o agregado <c>Edital</c> (ADR-0026 +
+/// ADR-0089). A mecânica de keyset (ordenação, probe <c>n+1</c>, reversão e
+/// flags <c>prev</c>/<c>next</c> sem COUNT) vive no repositório via
+/// <c>CursorKeyset</c>; o handler apenas projeta as entidades em DTO.
 /// </summary>
 public static class ListarEditaisQueryHandler
 {
@@ -21,22 +21,12 @@ public static class ListarEditaisQueryHandler
         ArgumentNullException.ThrowIfNull(query);
         ArgumentNullException.ThrowIfNull(editalRepository);
 
-        IReadOnlyList<Edital> page = await editalRepository
-            .ListarPaginadoAsync(query.AfterId, query.Limit + 1, cancellationToken)
+        (IReadOnlyList<Edital> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await editalRepository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
             .ConfigureAwait(false);
 
-        // Defesa contra Limit <= 0 (config inconsistente que escapou aos
-        // validators): Take(0) devolveria array vazio e limited[^1] lançaria
-        // IndexOutOfRangeException, virando 500 numa listagem normal.
-        if (page.Count > query.Limit && query.Limit > 0)
-        {
-            EditalDto[] limited = [.. page.Take(query.Limit).Select(Project)];
-            Guid proximo = limited[^1].Id;
-            return new ListarEditaisResult(limited, proximo);
-        }
-
-        EditalDto[] items = [.. page.Select(Project)];
-        return new ListarEditaisResult(items, ProximoAfterId: null);
+        EditalDto[] items = [.. itens.Select(Project)];
+        return new ListarEditaisResult(items, anteriorAfterId, proximoAfterId);
     }
 
     private static EditalDto Project(Edital edital) => new(

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ListarEditaisResult.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ListarEditaisResult.cs
@@ -7,6 +7,10 @@ using DTOs;
 /// + identificador opcional do último item para o controller construir o
 /// cursor da próxima página. Não vaza entidades de domínio nem PII.
 /// </summary>
-/// <param name="Items">Editais da página corrente, ordenados pelo identificador.</param>
-/// <param name="ProximoAfterId">Id do último item da janela quando há mais páginas; <c>null</c> sinaliza fim da coleção.</param>
-public sealed record ListarEditaisResult(IReadOnlyList<EditalDto> Items, Guid? ProximoAfterId);
+/// <param name="Items">Editais da página corrente, em ordem ascendente por identificador.</param>
+/// <param name="AnteriorAfterId">Âncora para o cursor <c>prev</c> quando há página anterior; <c>null</c> = início da coleção.</param>
+/// <param name="ProximoAfterId">Âncora para o cursor <c>next</c> quando há próxima página; <c>null</c> = fim da coleção.</param>
+public sealed record ListarEditaisResult(
+    IReadOnlyList<EditalDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisQuery.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisQuery.cs
@@ -1,17 +1,19 @@
 namespace Unifesspa.UniPlus.Selecao.Application.Queries.ObrigatoriedadesLegais;
 
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
 using Unifesspa.UniPlus.Selecao.Domain.Enums;
 
 /// <summary>
-/// Query paginada por cursor (ADR-0026) com filtros admin. <c>Vigentes</c>
-/// default <see langword="true"/> — leitura pública padrão; admin pode
-/// passar <see langword="false"/> para incluir regras com
+/// Query paginada por cursor bidirecional (ADR-0026 + ADR-0089) com filtros
+/// admin. <c>Vigentes</c> default <see langword="true"/> — leitura pública
+/// padrão; admin pode passar <see langword="false"/> para incluir regras com
 /// <c>VigenciaFim</c> passada.
 /// </summary>
 public sealed record ListarObrigatoriedadesLegaisQuery(
     Guid? AfterId,
-    int Take,
+    int Limit,
+    PaginationDirection Direction,
     string? TipoEditalCodigo,
     CategoriaObrigatoriedade? Categoria,
     bool Vigentes) : IQuery<ListarObrigatoriedadesLegaisResult>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisQueryHandler.cs
@@ -10,9 +10,9 @@ using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
 
 /// <summary>
 /// Handler convention-based de <see cref="ListarObrigatoriedadesLegaisQuery"/>.
-/// Paginação keyset por <c>Id</c> (ADR-0026 + Guid v7). Solicita
-/// <c>take + 1</c> para detectar próxima página sem COUNT — mesma estratégia
-/// do <c>ListarEditaisQueryHandler</c>.
+/// Paginação keyset bidirecional por <c>Id</c> (ADR-0026 + ADR-0089 + Guid v7).
+/// A mecânica de keyset (probe <c>n+1</c>, reversão, flags sem COUNT) vive no
+/// repositório via <c>CursorKeyset</c>; o handler apenas projeta em DTO.
 /// </summary>
 public static class ListarObrigatoriedadesLegaisQueryHandler
 {
@@ -24,28 +24,19 @@ public static class ListarObrigatoriedadesLegaisQueryHandler
         ArgumentNullException.ThrowIfNull(query);
         ArgumentNullException.ThrowIfNull(repository);
 
-        IReadOnlyList<ObrigatoriedadeLegal> page = await repository.ListarPaginadoAsync(
-            query.AfterId,
-            query.Take + 1,
-            query.TipoEditalCodigo,
-            query.Categoria,
-            query.Vigentes,
-            cancellationToken).ConfigureAwait(false);
-
-        if (page.Count == 0)
-        {
-            return new ListarObrigatoriedadesLegaisResult([], ProximoAfterId: null);
-        }
-
-        bool temProxima = page.Count > query.Take && query.Take > 0;
-        IReadOnlyList<ObrigatoriedadeLegal> visiveis = temProxima
-            ? [.. page.Take(query.Take)]
-            : page;
+        (IReadOnlyList<ObrigatoriedadeLegal> itens, Guid? anteriorAfterId, Guid? proximoAfterId) =
+            await repository.ListarPaginadoAsync(
+                query.AfterId,
+                query.Limit,
+                query.Direction,
+                query.TipoEditalCodigo,
+                query.Categoria,
+                query.Vigentes,
+                cancellationToken).ConfigureAwait(false);
 
         ObrigatoriedadeLegalDto[] items =
-            [.. visiveis.Select(ObrigatoriedadeLegalMapping.ToDto)];
+            [.. itens.Select(ObrigatoriedadeLegalMapping.ToDto)];
 
-        Guid? proximo = temProxima ? items[^1].Id : null;
-        return new ListarObrigatoriedadesLegaisResult(items, proximo);
+        return new ListarObrigatoriedadesLegaisResult(items, anteriorAfterId, proximoAfterId);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisResult.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ObrigatoriedadesLegais/ListarObrigatoriedadesLegaisResult.cs
@@ -5,11 +5,11 @@ using System.Collections.Generic;
 using Unifesspa.UniPlus.Selecao.Application.DTOs;
 
 /// <summary>
-/// Resultado paginado do <see cref="ListarObrigatoriedadesLegaisQuery"/>.
-/// <see cref="ProximoAfterId"/> é o último <c>Id</c> da janela retornada
-/// quando houve <c>take</c> itens — controller emite o cursor encriptado
-/// + header <c>Link</c> de next.
+/// Resultado paginado do <see cref="ListarObrigatoriedadesLegaisQuery"/>
+/// (ADR-0089). As âncoras <c>prev</c>/<c>next</c> são os <c>Id</c> de fronteira
+/// da janela; o controller emite os cursores cifrados + header <c>Link</c>.
 /// </summary>
 public sealed record ListarObrigatoriedadesLegaisResult(
     IReadOnlyList<ObrigatoriedadeLegalDto> Items,
+    Guid? AnteriorAfterId,
     Guid? ProximoAfterId);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IEditalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IEditalRepository.cs
@@ -2,17 +2,23 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Interfaces;
 
 using Entities;
 using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Pagination;
 
 public interface IEditalRepository : IRepository<Edital>
 {
     Task<Edital?> ObterComEtapasECotasAsync(Guid id, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Lista editais paginados por chave (ADR-0026): ordena por <c>Id</c>, retorna
-    /// até <paramref name="take"/> itens cujo <c>Id</c> é maior que
-    /// <paramref name="afterId"/>. <c>null</c> em <paramref name="afterId"/> retorna
-    /// a primeira janela. Implementações devem aplicar <c>AsNoTracking</c> e
-    /// honrar a ordenação de forma idempotente.
+    /// Lista editais paginados por cursor keyset bidirecional (ADR-0026 +
+    /// ADR-0089): ordena por <c>Id</c> e retorna até <paramref name="limit"/>
+    /// itens na direção <paramref name="direction"/> a partir de
+    /// <paramref name="afterId"/> (ou a primeira janela quando <c>null</c>),
+    /// sempre em ordem ascendente, junto das âncoras de <c>prev</c>/<c>next</c>
+    /// (nulas quando não há aquele lado). Implementações aplicam <c>AsNoTracking</c>.
     /// </summary>
-    Task<IReadOnlyList<Edital>> ListarPaginadoAsync(Guid? afterId, int take, CancellationToken cancellationToken = default);
+    Task<(IReadOnlyList<Edital> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken = default);
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IObrigatoriedadeLegalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IObrigatoriedadeLegalRepository.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Interfaces;
 using System.Collections.Generic;
 
 using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Pagination;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
 using Unifesspa.UniPlus.Selecao.Domain.Enums;
 
@@ -18,13 +19,16 @@ using Unifesspa.UniPlus.Selecao.Domain.Enums;
 public interface IObrigatoriedadeLegalRepository : IRepository<ObrigatoriedadeLegal>
 {
     /// <summary>
-    /// Lista regras paginadas com filtros admin. Ordenação estável por
-    /// <c>Id</c> (Guid v7 cronológico). <paramref name="afterId"/> aplica
-    /// keyset; <paramref name="take"/> limita a janela.
+    /// Lista regras paginadas por cursor keyset bidirecional (ADR-0026 +
+    /// ADR-0089) com filtros admin. Ordenação estável por <c>Id</c> (Guid v7
+    /// cronológico); retorna até <paramref name="limit"/> itens na direção
+    /// <paramref name="direction"/> a partir de <paramref name="afterId"/>,
+    /// sempre em ordem ascendente, com as âncoras de <c>prev</c>/<c>next</c>.
     /// </summary>
-    Task<IReadOnlyList<ObrigatoriedadeLegal>> ListarPaginadoAsync(
+    Task<(IReadOnlyList<ObrigatoriedadeLegal> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
-        int take,
+        int limit,
+        PaginationDirection direction,
         string? tipoEditalCodigo,
         CategoriaObrigatoriedade? categoria,
         bool vigentes,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/EditalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/EditalRepository.cs
@@ -4,6 +4,8 @@ using Microsoft.EntityFrameworkCore;
 
 using Domain.Entities;
 using Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
 
 public sealed class EditalRepository : IEditalRepository
 {
@@ -57,28 +59,21 @@ public sealed class EditalRepository : IEditalRepository
             .ConfigureAwait(false);
     }
 
-    public async Task<IReadOnlyList<Edital>> ListarPaginadoAsync(
+    public async Task<(IReadOnlyList<Edital> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
-        int take,
+        int limit,
+        PaginationDirection direction,
         CancellationToken cancellationToken = default)
     {
-        IQueryable<Edital> query = _context.Editais
-            .AsNoTracking()
-            .OrderBy(e => e.Id);
+        // Keyset bidirecional (ADR-0089): ordenação, âncora, probe n+1, reversão
+        // e flags ficam no helper. Npgsql traduz Guid.CompareTo para o operador
+        // uuid nativo do PG; com Guid v7 (ADR-0032) a ordem por Id é cronológica.
+        IQueryable<Edital> query = _context.Editais.AsNoTracking();
 
-        if (afterId is { } cursor)
-        {
-            // Keyset coerente server-side (ADR-0026 + ADR-0032): Npgsql traduz
-            // Guid.CompareTo para o operador uuid > nativo do PG — mesmo
-            // comparador que o OrderBy(Id) acima. Com Guid v7 (ADR-0032), a
-            // ordenação por Id reflete criação temporal — clientes recebem
-            // editais em ordem cronológica natural ao paginar.
-            query = query.Where(e => e.Id.CompareTo(cursor) > 0);
-        }
-
-        return await query
-            .Take(take)
-            .ToListAsync(cancellationToken)
+        CursorKeysetPage<Edital> page = await CursorKeyset
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
             .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ObrigatoriedadeLegalRepository.cs
@@ -5,7 +5,9 @@ using System.Linq;
 
 using Microsoft.EntityFrameworkCore;
 
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Kernel.Pagination;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
 using Unifesspa.UniPlus.Selecao.Domain.Enums;
 using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
@@ -73,17 +75,19 @@ public sealed class ObrigatoriedadeLegalRepository : IObrigatoriedadeLegalReposi
         _context.ObrigatoriedadesLegais.Remove(entity);
     }
 
-    public async Task<IReadOnlyList<ObrigatoriedadeLegal>> ListarPaginadoAsync(
+    public async Task<(IReadOnlyList<ObrigatoriedadeLegal> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
-        int take,
+        int limit,
+        PaginationDirection direction,
         string? tipoEditalCodigo,
         CategoriaObrigatoriedade? categoria,
         bool vigentes,
         CancellationToken cancellationToken = default)
     {
+        // Sem OrderBy aqui: o helper keyset (ADR-0089) ordena e fatia. Aplicamos
+        // só os filtros; os EXISTS de flag do helper herdam a mesma query base.
         IQueryable<ObrigatoriedadeLegal> query = _context.ObrigatoriedadesLegais
-            .AsNoTracking()
-            .OrderBy(o => o.Id);
+            .AsNoTracking();
 
         if (!string.IsNullOrWhiteSpace(tipoEditalCodigo))
         {
@@ -104,12 +108,11 @@ public sealed class ObrigatoriedadeLegalRepository : IObrigatoriedadeLegalReposi
                 && (o.VigenciaFim == null || o.VigenciaFim > hoje));
         }
 
-        if (afterId is { } cursor)
-        {
-            query = query.Where(o => o.Id.CompareTo(cursor) > 0);
-        }
+        CursorKeysetPage<ObrigatoriedadeLegal> page = await CursorKeyset
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
 
-        return await query.Take(take).ToListAsync(cancellationToken).ConfigureAwait(false);
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
     }
 
     public async Task<IReadOnlyList<ObrigatoriedadeLegal>> ObterVigentesParaTipoEditalAsync(

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/UniPlusOpenApiServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/UniPlusOpenApiServiceCollectionExtensions.cs
@@ -37,6 +37,7 @@ public static class UniPlusOpenApiServiceCollectionExtensions
         services.TryAddSingleton<UniPlusInfoTransformer>();
         services.TryAddSingleton<UniPlusOperationTransformer>();
         services.TryAddSingleton<CursorPaginationOperationTransformer>();
+        services.TryAddSingleton<PaginationOrphanSchemaDocumentTransformer>();
         services.TryAddSingleton<UniPlusSchemaTransformer>();
 
         services.AddOpenApi(documentName, options =>
@@ -44,6 +45,7 @@ public static class UniPlusOpenApiServiceCollectionExtensions
             options.AddDocumentTransformer<UniPlusInfoTransformer>();
             options.AddOperationTransformer<UniPlusOperationTransformer>();
             options.AddOperationTransformer<CursorPaginationOperationTransformer>();
+            options.AddDocumentTransformer<PaginationOrphanSchemaDocumentTransformer>();
             options.AddSchemaTransformer<UniPlusSchemaTransformer>();
         });
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/CursorPaginationOperationTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/CursorPaginationOperationTransformer.cs
@@ -31,12 +31,13 @@ public sealed class CursorPaginationOperationTransformer : IOpenApiOperationTran
 {
     private const string CursorParam = "cursor";
     private const string LimitParam = "limit";
+    private const string DirectionParam = "direction";
     private const string LinkHeader = "Link";
     private const string PageSizeHeader = "X-Page-Size";
     private const string PaginatedExtension = "x-uniplus-paginated";
     private const string OkStatus = "200";
 
-    private static readonly string[] LeakedPageRequestProperties = ["AfterId", "Limit"];
+    private static readonly string[] LeakedPageRequestProperties = ["AfterId", "Limit", "Direction"];
 
     public Task TransformAsync(
         OpenApiOperation operation,
@@ -129,6 +130,21 @@ public sealed class CursorPaginationOperationTransformer : IOpenApiOperationTran
                 Format = "int32",
             },
         });
+        operation.Parameters.Add(new OpenApiParameter
+        {
+            Name = DirectionParam,
+            In = ParameterLocation.Query,
+            Required = false,
+            Description = "Direção de navegação keyset (ADR-0089): 'next' (default) avança, "
+                + "'prev' retrocede. Normalmente o cliente apenas segue o cursor opaco do "
+                + "rel=\"prev\"/rel=\"next\" do header Link — que já inclui o direction correto.",
+            Schema = new OpenApiSchema
+            {
+                Type = JsonSchemaType.String,
+                Enum = [JsonValue.Create("next")!, JsonValue.Create("prev")!],
+                Default = JsonValue.Create("next"),
+            },
+        });
     }
 
     private static void DeclareResponseHeaders(OpenApiOperation operation)
@@ -144,8 +160,9 @@ public sealed class CursorPaginationOperationTransformer : IOpenApiOperationTran
         okResponse.Headers[LinkHeader] = new OpenApiHeader
         {
             Description = "Links de navegação da paginação (RFC 5988/8288). "
-                + "rel=\"self\" sempre presente; rel=\"next\" só quando há próxima página. "
-                + "Cada link carrega o cursor opaco no parâmetro `cursor` (ADR-0026).",
+                + "rel=\"self\" sempre presente; rel=\"prev\"/rel=\"next\" quando há página "
+                + "anterior/próxima (ADR-0089). Cada link carrega o cursor opaco no parâmetro "
+                + "`cursor` e o `direction` correspondente (ADR-0026).",
             Schema = new OpenApiSchema
             {
                 Type = JsonSchemaType.String,

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/PaginationOrphanSchemaDocumentTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/PaginationOrphanSchemaDocumentTransformer.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.OpenApi;
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+/// <summary>
+/// Document transformer que remove o schema órfão <c>PaginationDirection</c>
+/// das <c>components.schemas</c>. O enum <see cref="Pagination.PaginationDirection"/>
+/// é propriedade interna de <c>PageRequest</c>/<c>CursorPayload</c> (pós-decode),
+/// nunca serializada em corpo de request/response — o ApiExplorer ainda registra
+/// um schema para ela ao descrever o <c>PageRequest</c> como query bag.
+/// <para>
+/// O <see cref="CursorPaginationOperationTransformer"/> já remove o parâmetro
+/// vazado <c>Direction</c> e declara o wire param <c>direction</c> com schema
+/// inline (string enum <c>next</c>/<c>prev</c>) — logo o schema de componente
+/// fica sem nenhuma referência (<c>$ref</c>). Schema órfão não só é ruído no
+/// contrato como diverge entre módulos (cada API serializa enums de forma
+/// distinta: string vs integer), quebrando a fitness function da ADR-0035.
+/// </para>
+/// <para>
+/// Remoção cirúrgica por nome, espelhando a filosofia do operation transformer
+/// (que poda <c>AfterId</c>/<c>Limit</c>/<c>Direction</c> por nome exato).
+/// </para>
+/// </summary>
+public sealed class PaginationOrphanSchemaDocumentTransformer : IOpenApiDocumentTransformer
+{
+    private const string OrphanSchemaName = "PaginationDirection";
+
+    public Task TransformAsync(
+        OpenApiDocument document,
+        OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(context);
+
+        document.Components?.Schemas?.Remove(OrphanSchemaName);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorBindingErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorBindingErrorCodes.cs
@@ -11,6 +11,7 @@ public static class CursorBindingErrorCodes
     public const string Invalido = "Cursor.Invalido";
     public const string Expirado = "Cursor.Expirado";
     public const string LimitInvalido = "Cursor.LimitInvalido";
+    public const string DirecaoInvalida = "Cursor.DirecaoInvalida";
 
     /// <summary>Chave em <c>HttpContext.Items</c> onde o binder publica o código do erro.</summary>
     public const string HttpContextItemKey = "__UniPlusCursorBindingError";

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorKeyset.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorKeyset.cs
@@ -1,0 +1,138 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Página keyset bidirecional (ADR-0089): <see cref="Items"/> já em ordem
+/// ascendente canônica por <c>Id</c> e as âncoras para emissão de
+/// <c>rel="prev"</c>/<c>rel="next"</c>. Âncora nula = não há aquele lado.
+/// </summary>
+public sealed record CursorKeysetPage<T>(
+    IReadOnlyList<T> Items,
+    Guid? PrevAfterId,
+    Guid? NextAfterId)
+{
+    /// <summary>Há página anterior (emite <c>rel="prev"</c>).</summary>
+    public bool HasPrevious => PrevAfterId is not null;
+
+    /// <summary>Há próxima página (emite <c>rel="next"</c>).</summary>
+    public bool HasNext => NextAfterId is not null;
+}
+
+/// <summary>
+/// Aplica paginação keyset bidirecional (ADR-0089) sobre uma query <b>já
+/// filtrada</b> (os filtros de negócio, ex.: <c>q</c>/<c>tipo</c>, devem estar
+/// aplicados em <paramref name="filtered"/> antes da chamada). Chave de
+/// ordenação = <c>Id</c> (GUID v7 ordenável, ADR-0032).
+/// </summary>
+/// <remarks>
+/// <para><b>Forward</b> (<see cref="PaginationDirection.Next"/>): <c>Id &gt;
+/// âncora</c>, <c>ORDER BY Id ASC</c>.</para>
+/// <para><b>Backward</b> (<see cref="PaginationDirection.Prev"/>): <c>Id &lt;
+/// âncora</c>, <c>ORDER BY Id DESC</c>; o item-probe é cortado <b>ainda em
+/// DESC</b> (é o mais antigo) e só então a lista é revertida para ascendente —
+/// reverter antes de cortar omitiria o boundary.</para>
+/// <para><b>Flags exatas sem <c>COUNT</c></b>: o lado navegado vem do probe
+/// <c>n+1</c>; o lado oposto vem de um <c>EXISTS</c> indexado sobre a mesma
+/// query base (mesmos filtros).</para>
+/// </remarks>
+public static class CursorKeyset
+{
+    public static async Task<CursorKeysetPage<T>> ApplyAsync<T>(
+        IQueryable<T> filtered,
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken = default)
+        where T : EntityBase
+    {
+        ArgumentNullException.ThrowIfNull(filtered);
+
+        return direction == PaginationDirection.Prev
+            ? await ApplyBackwardAsync(filtered, afterId, limit, cancellationToken).ConfigureAwait(false)
+            : await ApplyForwardAsync(filtered, afterId, limit, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<CursorKeysetPage<T>> ApplyForwardAsync<T>(
+        IQueryable<T> filtered,
+        Guid? afterId,
+        int limit,
+        CancellationToken cancellationToken)
+        where T : EntityBase
+    {
+        IQueryable<T> forward = afterId is { } anchor
+            ? filtered.Where(e => e.Id.CompareTo(anchor) > 0)
+            : filtered;
+
+        List<T> fetched = await forward
+            .OrderBy(e => e.Id)
+            .Take(limit + 1)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        bool hasNext = fetched.Count > limit;
+        if (hasNext)
+            fetched.RemoveAt(fetched.Count - 1);
+
+        if (fetched.Count == 0)
+            return new CursorKeysetPage<T>(fetched, PrevAfterId: null, NextAfterId: null);
+
+        // hasPrevious só faz sentido quando há âncora (não é a primeira página);
+        // confirmado por EXISTS indexado (sem COUNT) sobre a query filtrada.
+        // Boundaries extraídos para locais — expression tree não aceita índice.
+        Guid firstId = fetched[0].Id;
+        Guid lastId = fetched[^1].Id;
+        bool hasPrevious = afterId is not null
+            && await filtered
+                .AnyAsync(e => e.Id.CompareTo(firstId) < 0, cancellationToken)
+                .ConfigureAwait(false);
+
+        return new CursorKeysetPage<T>(
+            fetched,
+            PrevAfterId: hasPrevious ? firstId : null,
+            NextAfterId: hasNext ? lastId : null);
+    }
+
+    private static async Task<CursorKeysetPage<T>> ApplyBackwardAsync<T>(
+        IQueryable<T> filtered,
+        Guid? afterId,
+        int limit,
+        CancellationToken cancellationToken)
+        where T : EntityBase
+    {
+        IQueryable<T> backward = afterId is { } anchor
+            ? filtered.Where(e => e.Id.CompareTo(anchor) < 0)
+            : filtered;
+
+        List<T> fetchedDesc = await backward
+            .OrderByDescending(e => e.Id)
+            .Take(limit + 1)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        bool hasPrevious = fetchedDesc.Count > limit;
+        // Corta o item-probe AINDA em DESC (é o mais antigo) e só depois reverte.
+        if (hasPrevious)
+            fetchedDesc.RemoveAt(fetchedDesc.Count - 1);
+        fetchedDesc.Reverse();
+        List<T> page = fetchedDesc;
+
+        if (page.Count == 0)
+            return new CursorKeysetPage<T>(page, PrevAfterId: null, NextAfterId: null);
+
+        // Boundaries em locais — expression tree não aceita índice from-end.
+        Guid firstId = page[0].Id;
+        Guid lastId = page[^1].Id;
+        bool hasNext = await filtered
+            .AnyAsync(e => e.Id.CompareTo(lastId) > 0, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new CursorKeysetPage<T>(
+            page,
+            PrevAfterId: hasPrevious ? firstId : null,
+            NextAfterId: hasNext ? lastId : null);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorPayload.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorPayload.cs
@@ -1,15 +1,24 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 
+using Unifesspa.UniPlus.Kernel.Pagination;
+
 /// <summary>
 /// Payload claro do cursor opaco AES-GCM (ADR-0026). Carregamos apenas os
 /// campos estritamente necessários para retomar a paginação e o escopo do
 /// recurso — nunca PII (CPF, nome, e-mail, número de inscrição), conforme
 /// ADR-0019.
 /// </summary>
-/// <param name="After">Chave de continuação (id ou sort key serializada do último item da página anterior).</param>
+/// <param name="After">Chave de continuação (id ou sort key serializada do item de fronteira da página anterior).</param>
 /// <param name="Limit">Tamanho de página efetivamente solicitado.</param>
 /// <param name="ResourceTag">Identificador do recurso paginado (ex.: <c>editais</c>); previne reuso cross-resource.</param>
 /// <param name="ExpiresAt">Instante UTC após o qual o cursor é rejeitado com 410.</param>
+/// <param name="Direction">
+/// Direção para a qual o cursor foi emitido (ADR-0089). Vincula o cursor à sua
+/// direção: o boundary valida <c>query.direction == payload.Direction</c> e
+/// rejeita reuso incoerente (cursor de <c>next</c> chamado como <c>prev</c>)
+/// como adulteração (400). O sistema não está em produção — não há cursores
+/// legados sem o campo a preservar.
+/// </param>
 /// <param name="UserId">
 /// Sub claim do JWT de quem emitiu o cursor. <c>null</c> em recursos públicos
 /// (ex.: <c>/api/editais</c>); obrigatório em recursos user-scoped
@@ -23,4 +32,5 @@ public sealed record CursorPayload(
     int Limit,
     string ResourceTag,
     DateTimeOffset ExpiresAt,
+    PaginationDirection Direction,
     string? UserId = null);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PageRequest.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PageRequest.cs
@@ -1,11 +1,14 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 
+using Unifesspa.UniPlus.Kernel.Pagination;
+
 /// <summary>
 /// Parâmetros decodificados de um request paginado: chave de continuação
-/// (<see cref="AfterId"/>, ausente na primeira página) e tamanho efetivo da
-/// janela (<see cref="Limit"/>). Como esses valores chegam via wire é
+/// (<see cref="AfterId"/>, ausente na primeira página), tamanho efetivo da
+/// janela (<see cref="Limit"/>) e direção de navegação
+/// (<see cref="Direction"/>, ADR-0089). Como esses valores chegam via wire é
 /// responsabilidade do binder configurado por atributo (ex.:
 /// <c>[FromCursor]</c> para cursor opaco AES-GCM, ADR-0026); outros
 /// mecanismos podem ser adicionados sem afetar o consumo.
 /// </summary>
-public sealed record PageRequest(Guid? AfterId, int Limit);
+public sealed record PageRequest(Guid? AfterId, int Limit, PaginationDirection Direction);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PageRequestModelBinder.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PageRequestModelBinder.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Kernel.Pagination;
 
 /// <summary>
 /// Binder de <see cref="PageRequest"/>: lê <c>cursor</c> e <c>limit</c> do
@@ -28,6 +29,7 @@ public sealed class PageRequestModelBinder : IModelBinder
 {
     private const string CursorParam = "cursor";
     private const string LimitParam = "limit";
+    private const string DirectionParam = "direction";
 
     public async Task BindModelAsync(ModelBindingContext bindingContext)
     {
@@ -49,6 +51,14 @@ public sealed class PageRequestModelBinder : IModelBinder
         {
             FailWith(bindingContext, CursorBindingErrorCodes.LimitInvalido,
                 $"O parâmetro 'limit' deve estar entre {options.LimitMin} e {options.LimitMax}.");
+            return;
+        }
+
+        // Direção (ADR-0089): 'next' (default) ou 'prev'. Valor desconhecido → 422.
+        if (!TryParseDirection(query[DirectionParam], out PaginationDirection direction))
+        {
+            FailWith(bindingContext, CursorBindingErrorCodes.DirecaoInvalida,
+                "O parâmetro 'direction' deve ser 'next' ou 'prev'.");
             return;
         }
 
@@ -75,6 +85,15 @@ public sealed class PageRequestModelBinder : IModelBinder
                 case CursorDecodeStatus.Success:
                     if (!Guid.TryParse(decoded.Payload!.After, out Guid parsedAfter)
                         || !string.Equals(decoded.Payload.ResourceTag, attribute.Resource, StringComparison.Ordinal))
+                    {
+                        FailWith(bindingContext, CursorBindingErrorCodes.Invalido, "O cursor informado é inválido.");
+                        return;
+                    }
+
+                    // Integridade do par cursor+direção (ADR-0089): um cursor
+                    // emitido para 'next' não pode ser navegado como 'prev' (e
+                    // vice-versa) — divergência é tratada como adulteração.
+                    if (decoded.Payload.Direction != direction)
                     {
                         FailWith(bindingContext, CursorBindingErrorCodes.Invalido, "O cursor informado é inválido.");
                         return;
@@ -133,7 +152,34 @@ public sealed class PageRequestModelBinder : IModelBinder
         // O keyset (afterId) é o que mantém estabilidade da janela, não o limit.
         int effectiveLimit = requestedLimit ?? cursorLimit ?? options.LimitDefault;
 
-        bindingContext.Result = ModelBindingResult.Success(new PageRequest(afterId, effectiveLimit));
+        // Primeira página (sem cursor) é sempre forward — 'prev' sem âncora não
+        // tem sentido; coage para 'next' em vez de erro.
+        PaginationDirection effectiveDirection = afterId is null ? PaginationDirection.Next : direction;
+
+        bindingContext.Result = ModelBindingResult.Success(
+            new PageRequest(afterId, effectiveLimit, effectiveDirection));
+    }
+
+    private static bool TryParseDirection(
+        Microsoft.Extensions.Primitives.StringValues raw,
+        out PaginationDirection direction)
+    {
+        direction = PaginationDirection.Next;
+
+        string? first = raw.Count == 0 ? null : raw[0];
+        if (string.IsNullOrWhiteSpace(first))
+            return true; // ausente → default Next
+
+        if (string.Equals(first, "next", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (string.Equals(first, "prev", StringComparison.OrdinalIgnoreCase))
+        {
+            direction = PaginationDirection.Prev;
+            return true;
+        }
+
+        return false; // valor informado mas inválido
     }
 
     private static int? TryParseLimit(Microsoft.Extensions.Primitives.StringValues raw)

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PaginationControllerExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PaginationControllerExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Kernel.Pagination;
 
 /// <summary>
 /// Extensões de <see cref="ControllerBase"/> para responder coleções
@@ -26,6 +27,7 @@ public static class PaginationControllerExtensions
     public static async Task<IActionResult> OkPaginatedAsync<T>(
         this ControllerBase controller,
         IReadOnlyList<T> items,
+        Guid? prevAfterId,
         Guid? nextAfterId,
         PageRequest page,
         string resource,
@@ -43,53 +45,57 @@ public static class PaginationControllerExtensions
         TimeProvider timeProvider = services.GetRequiredService<TimeProvider>();
 
         // User-binding (ADR-0026 §"User-binding em cursores user-scoped"):
-        // recurso user-scoped popula UserId no payload com o sub do principal
-        // corrente — emissão e decode validam o mesmo binding. Resolução de
-        // IUserContext só acontece quando há próxima página A SER EMITIDA;
-        // last-page (sem cursor) não toca o DI evitando friction em testes
-        // slice-level que registram só CursorEncoder/TimeProvider.
-        string? nextCursor = null;
-        if (nextAfterId is { } proximo)
+        // recurso user-scoped vincula o sub do principal corrente ao cursor —
+        // emissão e decode validam o mesmo binding. Resolução de IUserContext só
+        // acontece quando há ALGUM cursor a emitir (prev ou next); página única
+        // sem navegação não toca o DI, evitando friction em testes slice-level
+        // que registram só CursorEncoder/TimeProvider.
+        string? userId = null;
+        if ((prevAfterId is not null || nextAfterId is not null) && requireUserBinding)
         {
-            string? userId = null;
-            if (requireUserBinding)
+            IUserContext userContext = services.GetRequiredService<IUserContext>();
+            if (!userContext.IsAuthenticated || string.IsNullOrEmpty(userContext.UserId))
             {
-                IUserContext userContext = services.GetRequiredService<IUserContext>();
-                if (!userContext.IsAuthenticated || string.IsNullOrEmpty(userContext.UserId))
-                {
-                    throw new InvalidOperationException(
-                        "OkPaginatedAsync com requireUserBinding=true exige principal autenticado. " +
-                        "Verifique se o endpoint tem [Authorize] e se o middleware de auth está antes do MVC.");
-                }
-                userId = userContext.UserId;
+                throw new InvalidOperationException(
+                    "OkPaginatedAsync com requireUserBinding=true exige principal autenticado. " +
+                    "Verifique se o endpoint tem [Authorize] e se o middleware de auth está antes do MVC.");
             }
-
-            CursorPayload payload = new(
-                After: proximo.ToString(),
-                Limit: page.Limit,
-                ResourceTag: resource,
-                ExpiresAt: timeProvider.GetUtcNow().Add(options.CursorTtl),
-                UserId: userId);
-            nextCursor = await encoder.EncodeAsync(payload, cancellationToken).ConfigureAwait(false);
+            userId = userContext.UserId;
         }
+
+        DateTimeOffset expiresAt = timeProvider.GetUtcNow().Add(options.CursorTtl);
+
+        // O cursor vincula sua direção (ADR-0089): o link prev cifra a âncora
+        // com Direction=Prev; o next, com Direction=Next. O boundary rejeita
+        // reuso com a direção trocada.
+        string? prevCursor = prevAfterId is { } anterior
+            ? await encoder.EncodeAsync(
+                new CursorPayload(anterior.ToString(), page.Limit, resource, expiresAt, PaginationDirection.Prev, userId),
+                cancellationToken).ConfigureAwait(false)
+            : null;
+
+        string? nextCursor = nextAfterId is { } proximo
+            ? await encoder.EncodeAsync(
+                new CursorPayload(proximo.ToString(), page.Limit, resource, expiresAt, PaginationDirection.Next, userId),
+                cancellationToken).ConfigureAwait(false)
+            : null;
 
         HttpRequest request = controller.Request;
         string? originalCursor = request.Query["cursor"];
+        string? originalDirection = request.Query["direction"];
         string? originalLimit = request.Query["limit"];
         int? originalLimitParsed = int.TryParse(originalLimit, NumberStyles.Integer, CultureInfo.InvariantCulture, out int parsed)
             ? parsed
             : null;
 
-        // Self espelha o request original (cursor + limit como vieram).
-        // Next NÃO inclui limit: o cursor já carrega o tamanho de janela
-        // (clampado server-side no decode). Incluir ?limit=N na URL faria
-        // o validator do binder rodar primeiro e rejeitar com 422 caso a
-        // config tenha apertado LimitMax após a emissão do cursor —
-        // quebrando navegação de cursores stale que ainda estariam OK.
+        // Self espelha o request original (cursor + limit + direction como vieram).
+        // Prev/Next NÃO incluem limit (o cursor já carrega a janela, clampada no
+        // decode) e carregam a direção explícita — a navegação fica auto-suficiente
+        // (RFC 5988): o cliente segue o link opaco sem conhecer a convenção.
         PageLinks links = new(
-            Self: BuildLink(request, originalCursor, originalLimitParsed),
-            Next: nextCursor is null ? null : BuildLink(request, nextCursor, limit: null),
-            Prev: null);
+            Self: BuildLink(request, originalCursor, originalLimitParsed, originalDirection),
+            Next: nextCursor is null ? null : BuildLink(request, nextCursor, limit: null, "next"),
+            Prev: prevCursor is null ? null : BuildLink(request, prevCursor, limit: null, "prev"));
 
         controller.Response.Headers["Link"] = LinkHeaderBuilder.Build(links);
         controller.Response.Headers["X-Page-Size"] = items.Count.ToString(CultureInfo.InvariantCulture);
@@ -97,9 +103,9 @@ public static class PaginationControllerExtensions
         return controller.Ok(items);
     }
 
-    private static readonly string[] ReservedPaginationParams = ["cursor", "limit"];
+    private static readonly string[] ReservedPaginationParams = ["cursor", "limit", "direction"];
 
-    private static string BuildLink(HttpRequest request, string? cursor, int? limit)
+    private static string BuildLink(HttpRequest request, string? cursor, int? limit, string? direction)
     {
         // Inclui PathBase para honrar deploys atrás de reverse proxy
         // (Traefik, nginx, ingress) ou hosts com app.UsePathBase("/foo").
@@ -111,6 +117,8 @@ public static class PaginationControllerExtensions
             parts.Add($"cursor={Uri.EscapeDataString(cursor)}");
         if (limit is { } l)
             parts.Add($"limit={l.ToString(CultureInfo.InvariantCulture)}");
+        if (!string.IsNullOrEmpty(direction))
+            parts.Add($"direction={Uri.EscapeDataString(direction)}");
 
         // Preserva os demais query params do request (filtros como q/tipo) nos
         // links self/next. Sem isso, seguir rel="next" numa listagem filtrada

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PaginationDomainErrorRegistration.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PaginationDomainErrorRegistration.cs
@@ -25,5 +25,7 @@ internal sealed class PaginationDomainErrorRegistration : IDomainErrorRegistrati
             new DomainErrorMapping(StatusCodes.Status410Gone, "uniplus.cursor.expirado", "Cursor de paginação expirado")),
         new(CursorBindingErrorCodes.LimitInvalido,
             new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.cursor.limit_invalido", "Tamanho de página inválido")),
+        new(CursorBindingErrorCodes.DirecaoInvalida,
+            new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.cursor.direcao_invalida", "Direção de paginação inválida")),
     ];
 }

--- a/src/shared/Unifesspa.UniPlus.Kernel/Pagination/PaginationDirection.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Pagination/PaginationDirection.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Direção de navegação numa coleção paginada por cursor keyset (ADR-0089).
+/// <c>Next</c> avança (itens após a âncora); <c>Prev</c> retrocede (itens antes
+/// da âncora). Em ambos os casos a página é apresentada em ordem ascendente
+/// canônica por <c>Id</c>.
+/// <para>
+/// Vive no Kernel porque é parte do contrato de portas de repositório (Domain),
+/// além de ser consumida por Application (query) e Infrastructure (cursor/binder).
+/// </para>
+/// </summary>
+public enum PaginationDirection
+{
+    /// <summary>Próxima página: itens com <c>Id</c> maior que a âncora.</summary>
+    Next = 0,
+
+    /// <summary>Página anterior: itens com <c>Id</c> menor que a âncora.</summary>
+    Prev = 1,
+}

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Pagination/CursorEncoderTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Pagination/CursorEncoderTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
 using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
 
 public sealed class CursorEncoderTests
 {
@@ -37,7 +38,8 @@ public sealed class CursorEncoderTests
     public async Task Encode_Decode_FazRoundtrip()
     {
         (CursorEncoder encoder, _) = CriarEncoder();
-        CursorPayload payload = new("01HQ...id", 20, "editais", DateTimeOffset.UtcNow.AddMinutes(10));
+        CursorPayload payload = new(
+            "01HQ...id", 20, "editais", DateTimeOffset.UtcNow.AddMinutes(10), PaginationDirection.Prev);
 
         string token = await encoder.EncodeAsync(payload);
         CursorDecodeResult resultado = await encoder.TryDecodeAsync(token);
@@ -47,13 +49,15 @@ public sealed class CursorEncoderTests
         resultado.Payload.Limit.Should().Be(payload.Limit);
         resultado.Payload.ResourceTag.Should().Be(payload.ResourceTag);
         resultado.Payload.ExpiresAt.Should().BeCloseTo(payload.ExpiresAt, TimeSpan.FromMilliseconds(1));
+        resultado.Payload.Direction.Should().Be(PaginationDirection.Prev);
     }
 
     [Fact]
     public async Task TryDecode_TokenAdulterado_RetornaInvalid()
     {
         (CursorEncoder encoder, _) = CriarEncoder();
-        CursorPayload payload = new("id", 10, "editais", DateTimeOffset.UtcNow.AddMinutes(5));
+        CursorPayload payload = new(
+            "id", 10, "editais", DateTimeOffset.UtcNow.AddMinutes(5), PaginationDirection.Next);
         string token = await encoder.EncodeAsync(payload);
 
         // Inverte um caractere central, preservando comprimento e alfabeto base64url.
@@ -72,7 +76,8 @@ public sealed class CursorEncoderTests
     {
         DateTimeOffset baseTime = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
         (CursorEncoder encoder, MutableTimeProvider time) = CriarEncoder(baseTime);
-        CursorPayload payload = new("id", 10, "editais", baseTime.AddMinutes(5));
+        CursorPayload payload = new(
+            "id", 10, "editais", baseTime.AddMinutes(5), PaginationDirection.Next);
         string token = await encoder.EncodeAsync(payload);
 
         time.Advance(TimeSpan.FromMinutes(10));

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Pagination/PageRequestModelBinderTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Pagination/PageRequestModelBinderTests.cs
@@ -100,6 +100,93 @@ public sealed class PageRequestModelBinderTests
     }
 
     [Fact]
+    public async Task BindModelAsync_SemDirection_DefaultEhNext()
+    {
+        ModelBindingContext context = CreateContext("editais", queryString: "");
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        PageRequest page = context.Result.Model.Should().BeOfType<PageRequest>().Subject;
+        page.Direction.Should().Be(PaginationDirection.Next);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_DirectionInvalida_RetornaDirecaoInvalida()
+    {
+        ModelBindingContext context = CreateContext("editais", queryString: "?direction=foo");
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeFalse();
+        context.HttpContext.Items[CursorBindingErrorCodes.HttpContextItemKey]
+            .Should().Be(CursorBindingErrorCodes.DirecaoInvalida);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_CursorPrevComDirectionPrev_RetornaPageRequestPrev()
+    {
+        Guid expectedAfter = Guid.NewGuid();
+        ServiceProvider services = BuildServices();
+        CursorEncoder encoder = services.GetRequiredService<CursorEncoder>();
+        string cursor = await encoder.EncodeAsync(new CursorPayload(
+            After: expectedAfter.ToString(),
+            Limit: 20,
+            ResourceTag: "editais",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            Direction: PaginationDirection.Prev));
+
+        ModelBindingContext context = CreateContext(
+            "editais",
+            queryString: $"?cursor={Uri.EscapeDataString(cursor)}&direction=prev",
+            servicesOverride: services);
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        PageRequest page = context.Result.Model.Should().BeOfType<PageRequest>().Subject;
+        page.AfterId.Should().Be(expectedAfter);
+        page.Direction.Should().Be(PaginationDirection.Prev);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_CursorNextNavegadoComoPrev_RetornaCursorInvalido()
+    {
+        // Integridade do par cursor+direção (ADR-0089): cursor emitido para next
+        // não pode ser reutilizado com direction=prev.
+        ServiceProvider services = BuildServices();
+        CursorEncoder encoder = services.GetRequiredService<CursorEncoder>();
+        string cursorNext = await encoder.EncodeAsync(new CursorPayload(
+            After: Guid.NewGuid().ToString(),
+            Limit: 20,
+            ResourceTag: "editais",
+            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            Direction: PaginationDirection.Next));
+
+        ModelBindingContext context = CreateContext(
+            "editais",
+            queryString: $"?cursor={Uri.EscapeDataString(cursorNext)}&direction=prev",
+            servicesOverride: services);
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        context.Result.IsModelSet.Should().BeFalse();
+        context.HttpContext.Items[CursorBindingErrorCodes.HttpContextItemKey]
+            .Should().Be(CursorBindingErrorCodes.Invalido);
+    }
+
+    [Fact]
+    public async Task BindModelAsync_PrevSemCursor_CoageParaNext()
+    {
+        // 'prev' sem âncora não tem sentido: a primeira página é sempre forward.
+        ModelBindingContext context = CreateContext("editais", queryString: "?direction=prev");
+
+        await new PageRequestModelBinder().BindModelAsync(context);
+
+        PageRequest page = context.Result.Model.Should().BeOfType<PageRequest>().Subject;
+        page.AfterId.Should().BeNull();
+        page.Direction.Should().Be(PaginationDirection.Next);
+    }
+
+    [Fact]
     public async Task BindModelAsync_CursorBase64UrlInvalido_RetornaCursorInvalido()
     {
         ModelBindingContext context = CreateContext("editais", queryString: "?cursor=@@@@");

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Pagination/PageRequestModelBinderTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Pagination/PageRequestModelBinderTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.Options;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
 using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
 
 public sealed class PageRequestModelBinderTests
 {
@@ -121,7 +122,7 @@ public sealed class PageRequestModelBinderTests
             After: Guid.NewGuid().ToString(),
             Limit: 10,
             ResourceTag: "inscricoes",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
 
         ModelBindingContext context = CreateContext(
             "editais",
@@ -144,7 +145,7 @@ public sealed class PageRequestModelBinderTests
             After: "not-a-guid",
             Limit: 10,
             ResourceTag: "editais",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
 
         ModelBindingContext context = CreateContext(
             "editais",
@@ -168,7 +169,7 @@ public sealed class PageRequestModelBinderTests
             After: expectedAfter.ToString(),
             Limit: 50,
             ResourceTag: "editais",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
 
         ModelBindingContext context = CreateContext(
             "editais",
@@ -193,7 +194,7 @@ public sealed class PageRequestModelBinderTests
             After: expectedAfter.ToString(),
             Limit: 10, // do cursor
             ResourceTag: "editais",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10)));
 
         ModelBindingContext context = CreateContext(
             "editais",
@@ -218,7 +219,7 @@ public sealed class PageRequestModelBinderTests
             After: afterId.ToString(),
             Limit: 10,
             ResourceTag: "inscricoes",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
             UserId: "user-alice"));
 
         DefaultModelBindingContext context = CreateContext(
@@ -242,7 +243,7 @@ public sealed class PageRequestModelBinderTests
             After: afterId.ToString(),
             Limit: 10,
             ResourceTag: "inscricoes",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
             UserId: "user-alice"));
 
         DefaultModelBindingContext context = CreateContext(
@@ -270,7 +271,7 @@ public sealed class PageRequestModelBinderTests
             After: afterId.ToString(),
             Limit: 10,
             ResourceTag: "inscricoes",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
             UserId: null));
 
         DefaultModelBindingContext context = CreateContext(
@@ -294,7 +295,7 @@ public sealed class PageRequestModelBinderTests
             After: afterId.ToString(),
             Limit: 10,
             ResourceTag: "inscricoes",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
             UserId: "user-alice"));
 
         DefaultModelBindingContext context = CreateContext(
@@ -320,7 +321,7 @@ public sealed class PageRequestModelBinderTests
             After: afterId.ToString(),
             Limit: 10,
             ResourceTag: "editais",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
             UserId: "user-someoneelse"));
 
         DefaultModelBindingContext context = CreateContext(
@@ -342,7 +343,7 @@ public sealed class PageRequestModelBinderTests
             After: afterId.ToString(),
             Limit: 10,
             ResourceTag: "editais",
-            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(-1))); // já expirado
+            Direction: PaginationDirection.Next,            ExpiresAt: DateTimeOffset.UtcNow.AddMinutes(-1))); // já expirado
 
         ModelBindingContext context = CreateContext(
             "editais",

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeFiltroListagemTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeFiltroListagemTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 using AwesomeAssertions;
 
+using Unifesspa.UniPlus.Kernel.Pagination;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Interfaces;
@@ -191,7 +192,9 @@ public sealed class UnidadeFiltroListagemTests : IClassFixture<UnidadeDbFixture>
     {
         await using OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(userId: null);
         var repository = new UnidadeRepository(ctx);
-        return await repository.ListarPaginadoAsync(afterId, take, filtro, CancellationToken.None);
+        (IReadOnlyList<Unidade> itens, _, _) = await repository
+            .ListarPaginadoAsync(afterId, take, PaginationDirection.Next, filtro, CancellationToken.None);
+        return itens;
     }
 
     private async Task<IReadOnlyList<Guid>> ListarIdsAsync(FiltroListagemUnidades filtro)

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeFiltroListagemTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unidades/UnidadeFiltroListagemTests.cs
@@ -185,6 +185,61 @@ public sealed class UnidadeFiltroListagemTests : IClassFixture<UnidadeDbFixture>
         return unidade.Id;
     }
 
+    [Fact(DisplayName = "Navegação bidirecional: prev volta à página anterior em ordem ascendente, com flags exatas")]
+    public async Task Navegacao_Bidirecional_PrevVoltaPaginaAnterior_ComFlagsExatas()
+    {
+        string iso = NovoToken();
+        // 5 unidades em ordem de criação (Guid v7 monotônico) → ASC por Id.
+        Guid[] ids =
+        [
+            await SeedAsync(nome: $"BiDir {iso} 0", sigla: NovoToken(), codigo: NovoToken(), slug: NovoSlug()),
+            await SeedAsync(nome: $"BiDir {iso} 1", sigla: NovoToken(), codigo: NovoToken(), slug: NovoSlug()),
+            await SeedAsync(nome: $"BiDir {iso} 2", sigla: NovoToken(), codigo: NovoToken(), slug: NovoSlug()),
+            await SeedAsync(nome: $"BiDir {iso} 3", sigla: NovoToken(), codigo: NovoToken(), slug: NovoSlug()),
+            await SeedAsync(nome: $"BiDir {iso} 4", sigla: NovoToken(), codigo: NovoToken(), slug: NovoSlug()),
+        ];
+        FiltroListagemUnidades filtro = FiltroDeBusca(iso);
+
+        // Página 1 (forward, limit 2): [0,1]; sem anterior; com próximo.
+        (IReadOnlyList<Unidade> p1, Guid? p1Ant, Guid? p1Prox) =
+            await PaginarAsync(filtro, limit: 2, afterId: null, PaginationDirection.Next);
+        p1.Select(u => u.Id).Should().Equal(ids[0], ids[1]);
+        p1Ant.Should().BeNull();
+        p1Prox.Should().Be(ids[1]);
+
+        // Página 2 (forward a partir do próximo da p1): [2,3]; com anterior e próximo.
+        (IReadOnlyList<Unidade> p2, Guid? p2Ant, Guid? p2Prox) =
+            await PaginarAsync(filtro, limit: 2, afterId: p1Prox, PaginationDirection.Next);
+        p2.Select(u => u.Id).Should().Equal(ids[2], ids[3]);
+        p2Ant.Should().Be(ids[2]);
+        p2Prox.Should().Be(ids[3]);
+
+        // Backward a partir do anterior da p2 (ids[2]): volta à página 1 [0,1] em ASC.
+        (IReadOnlyList<Unidade> volta, Guid? voltaAnt, Guid? voltaProx) =
+            await PaginarAsync(filtro, limit: 2, afterId: p2Ant, PaginationDirection.Prev);
+        volta.Select(u => u.Id).Should().Equal(ids[0], ids[1]);
+        voltaAnt.Should().BeNull();   // ids[0] é o início → sem anterior
+        voltaProx.Should().Be(ids[1]); // há próximo (ids[2..])
+
+        // Última página (forward a partir de ids[3]): [4]; sem próximo, com anterior.
+        (IReadOnlyList<Unidade> ultima, Guid? ultAnt, Guid? ultProx) =
+            await PaginarAsync(filtro, limit: 2, afterId: p2Prox, PaginationDirection.Next);
+        ultima.Select(u => u.Id).Should().Equal(ids[4]);
+        ultProx.Should().BeNull();
+        ultAnt.Should().Be(ids[4]);
+    }
+
+    private async Task<(IReadOnlyList<Unidade> Itens, Guid? Anterior, Guid? Proximo)> PaginarAsync(
+        FiltroListagemUnidades filtro,
+        int limit,
+        Guid? afterId,
+        PaginationDirection direction)
+    {
+        await using OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var repository = new UnidadeRepository(ctx);
+        return await repository.ListarPaginadoAsync(afterId, limit, direction, filtro, CancellationToken.None);
+    }
+
     private async Task<IReadOnlyList<Unidade>> ListarAsync(
         FiltroListagemUnidades filtro,
         int take = TakeAlto,


### PR DESCRIPTION
## Contexto

Closes #656. Completa a navegação reversa que a ADR-0026 (cursor opaco) já antecipava: a API passa a oferecer paginação keyset **bidirecional** (prev/next), não apenas forward-only. A decisão e o desenho estão registrados na **ADR-0089**.

A motivação veio do frontend (uniplus-web): "Anterior/Próximo" é mais claro para o usuário em listas administrativas do que acumulação "Carregar mais" — esta última só se justifica em infinite-scroll, cenário que o front ainda não tem. Para suportar prev/next de forma limpa, sem pilha de cursores no cliente (anti-padrão), a direção precisa ser resolvida no backend via keyset reverso.

Sistema fora de produção → **sem cursores legados a preservar**: o caminho forward-only antigo foi removido por completo (sem código legado), conforme alinhado na issue.

## O que muda

**Kernel**
- `PaginationDirection` (`{ Next, Prev }`) promovido ao Kernel — visível a Domain (porta de repositório), Application (query) e Infrastructure (cursor/binder).

**Infrastructure.Core — paginação**
- `CursorKeyset.ApplyAsync<T>` — keyset forward/backward num único helper. Backward roda `ORDER BY DESC`, corta o item-probe **antes** de reverter para ASC, devolvendo a página na ordem natural.
- Flags `hasPrevious`/`hasNext` **exatas** via probe n+1 no lado navegado + `EXISTS` indexado no lado oposto — sem `COUNT`.
- `CursorPayload` ganha `Direction` (obrigatório): vincula o cursor à direção. O binder valida `query.direction == payload.Direction` e rejeita reuso incoerente como adulteração (`400`); `direction` inválido → `422` (`uniplus.cursor.direcao_invalida`); `prev` sem cursor é coagido a `next` na primeira página.
- `OkPaginatedAsync` com assinatura única bidirecional: emite `rel="prev"` + `rel="next"` com o `direction` correspondente embutido no cursor de cada link (header `Link`, RFC 5988/8288).

**Endpoints migrados (todos os 3 paginados)**
- `unidades` (com filtros `q`/`tipo`), `editais`, `obrigatoriedades-legais` (com filtros) — todos usam o mesmo helper keyset bidirecional.

**OpenAPI**
- Param `direction` declarado inline (string enum `next`/`prev`, default `next`) e header `Link` descrito para prev/next.
- O enum interno `PaginationDirection` vazava nas `components.schemas` como **schema órfão** (não-referenciado) e divergia entre módulos (string em selecao por causa do `JsonStringEnumConverter` global × integer em organizacao), **quebrando a fitness function da ADR-0035**. O novo `PaginationOrphanSchemaDocumentTransformer` poda o órfão; baselines de `organizacao` e `selecao` regeneradas (`ingresso` não pagina).

## Testes

- **Unit (binder)**: primeira página coage `prev`→`next`; `direction` inválido → `422`; cursor `prev` navegado como `prev` aceito; cursor `next` reusado como `prev` rejeitado como adulteração; ausência de `direction` assume `next`.
- **Integração (PostgreSQL real)**: round-trip forward→backward reconstrói a página anterior em ordem ASC e expõe flags exatas nas bordas (primeira e última página).
- Suíte completa local verde: build 42 projetos 0 warning; Infra.Core unit 600; OrganizacaoInstitucional integração 41; Selecao integração 98; Ingresso integração 8; ArchTests 22 (fitness ADR-0035 verde).

## Critérios de aceite (#656)

- [x] Cursor bidirecional (prev/next) seguro, com direção vinculada ao cursor.
- [x] ADR registrando a decisão (ADR-0089).
- [x] Aplicado aos endpoints paginados existentes.
- [x] Contrato OpenAPI atualizado e baselines regeneradas.

## Notas de revisão

- Integridade: a direção viaja **dentro** do cursor AES-GCM e é cross-checada com o query param — reuso cross-direction é tratado como adulteração.
- Sem `COUNT` em nenhum caminho — flags derivam de probe n+1 + `EXISTS`.
