### PR TITLE
chore(infra): realinha Auth__Authority das APIs ao realm unifesspa em frontend-test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,12 @@ docker compose -f docker/docker-compose.yml up -d
 # APIs em modo desenvolvimento
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
 
+# Testar um FRONTEND (uniplus-web) contra estas APIs: adicionar o override frontend-test,
+# que realinha o Auth__Authority de TODAS as APIs ao realm `unifesspa` (o override base usa
+# `unifesspa-dev-local`, que faz toda mutação responder 401 + loop de re-login no front;
+# GET de lista é [AllowAnonymous] e mascara). Ver CONTRIBUTING.md §"Testar um frontend".
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml -f docker/docker-compose.frontend-test.yml up -d
+
 # Migrations EF Core — ver CONTRIBUTING.md §Entity Framework + docs/guia-banco-de-dados.md (ADR-0054).
 dotnet ef migrations add <Nome> --project src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure --context SelecaoDbContext --output-dir Persistence/Migrations
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,44 @@ docker compose up -d
 
 Isso inicia: PostgreSQL 18, Redis, Kafka (KRaft), MinIO e Keycloak (dev mode).
 
+### Testar um frontend contra as APIs conteinerizadas
+
+Para rodar um app do `uniplus-web` (ex.: `configuracao`, `selecao`) contra estas
+APIs, **suba a stack com o override `frontend-test`**:
+
+```bash
+docker compose -f docker-compose.yml \
+               -f docker-compose.override.yml \
+               -f docker-compose.frontend-test.yml up -d
+```
+
+Depois, em `uniplus-web`: `npx nx serve configuracao` (→ :4203) ou
+`npx nx serve selecao` (→ :4200, via gateway Traefik :5000).
+
+**Por que o override é obrigatório.** O `docker-compose.override.yml` configura
+as APIs com `Auth__Authority` apontando para o realm **`unifesspa-dev-local`**
+(usado por scripts de smoke), enquanto os frontends autenticam no realm
+**`unifesspa`** (clients `*-web`). Sem o `frontend-test.yml`, que realinha todas
+as APIs ao realm `unifesspa`, o sintoma é:
+
+- `GET` de listas funciona (são `[AllowAnonymous]` — retornam 200 e **mascaram**
+  o problema), mas
+- **toda mutação** (POST/PUT/DELETE) responde **401** e o frontend entra em
+  **loop de re-login** (o `authErrorInterceptor` redireciona ao Keycloak).
+
+> **Sessões manuais longas (opcional):** o `accessTokenLifespan` do realm é 300s
+> por padrão; refreshes frequentes podem atrapalhar testes interativos. Para
+> ampliar para 30 min durante o teste:
+> ```bash
+> TOKEN=$(curl -s http://localhost:8080/realms/master/protocol/openid-connect/token \
+>   -d grant_type=password -d client_id=admin-cli -d username=admin -d password=admin \
+>   | jq -r .access_token)
+> curl -s -X PUT http://localhost:8080/admin/realms/unifesspa \
+>   -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+>   -d '{"accessTokenLifespan":1800}'
+> ```
+> Usuário de teste com role `plataforma-admin`: `admin` / `E2eTest!123`.
+
 ---
 
 ## Estrutura do projeto

--- a/docker/docker-compose.frontend-test.yml
+++ b/docker/docker-compose.frontend-test.yml
@@ -1,21 +1,32 @@
-# Gateway de DESENVOLVIMENTO para testar o frontend `selecao` (npx nx serve selecao)
-# contra as APIs conteinerizadas — SEM editar código do frontend.
+# Override de DESENVOLVIMENTO para testar os frontends (selecao, configuracao,
+# ingresso, ...) contra as APIs conteinerizadas — SEM editar código do frontend.
 #
-# O runtime-config do selecao usa um único `apiUrl=http://localhost:5000` e chama
-# /api/editais... (path pré-ADR-0064). Este arquivo:
-#   1. Sobe um Traefik na :5000 que roteia por path-prefix (ADR-0064) e reescreve
-#      /api/editais -> /api/selecao/editais (ver traefik/dynamic.yml).
-#   2. Realinha o Auth__Authority da selecao-api ao realm `unifesspa` (o realm em
-#      que o frontend autentica), em vez do `unifesspa-dev-local` do override
-#      (esse é usado por scripts de smoke). CORS p/ localhost:4200 já vem do
-#      appsettings.Development.json da API.
+# Faz duas coisas:
+#   1. Realinha o `Auth__Authority` de TODAS as APIs de módulo ao realm
+#      `unifesspa` — o realm em que os frontends autenticam (clients `*-web`,
+#      que emitem aud=uniplus via o client scope default `uniplus-profile`) —
+#      em vez do `unifesspa-dev-local` do docker-compose.override.yml (usado por
+#      scripts de smoke). Sem isso, endpoints autenticados rejeitam o token com
+#      401 e o frontend entra em loop de re-login; o GET de lista é
+#      `[AllowAnonymous]`, então retorna 200 e MASCARA o problema. Issuer
+#      canonicalizado por KC_HOSTNAME. CORS p/ localhost:42xx já vem do
+#      appsettings.Development.json de cada API.
+#   2. Sobe um Traefik na :5000 que roteia por path-prefix (ADR-0064) e reescreve
+#      /api/editais -> /api/selecao/editais (ver traefik/dynamic.yml) — necessário
+#      apenas para o frontend `selecao`, cujo runtime-config usa um único
+#      `apiUrl=http://localhost:5000` (path pré-ADR-0064). Os demais apps falam
+#      direto com a porta da API (ex.: `configuracao` -> organizacao-api :5263) e
+#      NÃO dependem do Traefik.
 #
 # Uso:
 #   docker compose -f docker-compose.yml \
 #                  -f docker-compose.override.yml \
 #                  -f docker-compose.frontend-test.yml up -d
 #
-# Depois: cd ../../uniplus-web && npx nx serve selecao  ->  http://localhost:4200
+# Depois, em uniplus-web:
+#   npx nx serve selecao       -> http://localhost:4200  (via gateway :5000)
+#   npx nx serve configuracao  -> http://localhost:4203  (direto na organizacao-api :5263)
+#   npx nx serve ingresso      -> http://localhost:4201  (direto na ingresso-api)
 services:
   traefik:
     image: traefik:v3.3
@@ -36,9 +47,20 @@ services:
       selecao-api:
         condition: service_healthy
 
+  # Todas as APIs de módulo passam a validar o realm `unifesspa` (o que os
+  # frontends usam), substituindo o `unifesspa-dev-local` do override.
   selecao-api:
     environment:
-      # O frontend `selecao` autentica no realm `unifesspa` (client selecao-web),
-      # que emite aud=uniplus via o client scope default `uniplus-profile`. A API
-      # precisa validar ESSE realm. Issuer canonicalizado por KC_HOSTNAME.
+      Auth__Authority: "http://keycloak:8080/realms/unifesspa"
+
+  ingresso-api:
+    environment:
+      Auth__Authority: "http://keycloak:8080/realms/unifesspa"
+
+  organizacao-api:
+    environment:
+      Auth__Authority: "http://keycloak:8080/realms/unifesspa"
+
+  configuracao-api:
+    environment:
       Auth__Authority: "http://keycloak:8080/realms/unifesspa"


### PR DESCRIPTION
## Contexto

Testar um frontend do `uniplus-web` (ex.: app `configuracao` → :4203) contra as APIs conteinerizadas falhava em **toda mutação** com **401** e o frontend entrava em **loop de re-login**.

## Causa-raiz

O `docker-compose.override.yml` aponta as 4 APIs de módulo ao realm **`unifesspa-dev-local`** (smoke scripts), mas os frontends autenticam no realm **`unifesspa`** (clients `*-web`). Realms diferentes → 401 nos endpoints autenticados. O `GET` de lista é `[AllowAnonymous]`, então retorna 200 e **mascara** o problema. O `frontend-test.yml` já realinhava **apenas** a `selecao-api`.

## Mudança

- **`docker/docker-compose.frontend-test.yml`**: realinha o `Auth__Authority` de **todas** as APIs de módulo (selecao/ingresso/organizacao/configuracao) ao realm `unifesspa`. O gateway Traefik :5000 permanece (só o `selecao` depende dele; `configuracao`/`ingresso` falam direto com a porta da API).
- **`CONTRIBUTING.md`**: nova subseção "Testar um frontend contra as APIs conteinerizadas" — comando do override, o sintoma 401/redirect e o ajuste opcional de `accessTokenLifespan` para sessões manuais.
- **`CLAUDE.md`**: pointer para o override e o pitfall.

## Validação

`docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.frontend-test.yml config` válido — todas as APIs resolvem `Auth__Authority=http://keycloak:8080/realms/unifesspa`. Verificado ao vivo: com o realinhamento, o cadastro de Unidade + Instituição pela UI do app `configuracao` persiste no backend (antes: 401).

Closes #659