### PR TITLE
feat(geo): ETL de carga DNE de País, Estado e Cidade

### DIFF
--- a/docs/geo-etl-dataset-dne.md
+++ b/docs/geo-etl-dataset-dne.md
@@ -1,0 +1,53 @@
+# ETL do Geo — ingestão do dataset DNE
+
+Guia operacional da carga de reference data do módulo `Geo` (localidades, endereçamento e georreferência nacional) a partir do dataset **DNE Correios + IBGE**. Decisões em [ADR-0090](adrs/0090-modulo-geo-localidades.md), [ADR-0091](adrs/0091-postgis-georreferencia-nts.md) e [ADR-0092](adrs/0092-etl-carga-dne-reference-data.md).
+
+## Estratégia: schema de staging + SELECT streamado
+
+O dataset DNE é distribuído como **15 dumps SQL** (um por tabela, `tbl_cep_{versao}_n_*`, todas as colunas `varchar`; a maior — `logradouro` — tem ~1,4M linhas / ~382 MB). Esses dumps **não são versionados** neste repositório: a base DNE é proprietária (Correios) e exige licença institucional.
+
+A ingestão segue dois passos desacoplados:
+
+1. **Provisionamento (fora do ciclo da API):** os dumps são restaurados num **schema de staging** (`dne_staging`) do banco `uniplus_geo`, via `psql`. Os dumps são auto-suficientes (`DROP TABLE IF EXISTS` + `CREATE TABLE` + `INSERT`), então re-restaurar é limpo e idempotente.
+2. **Carga (serviço de `Geo.Infrastructure`):** o ETL lê o staging por `SELECT` **streamado** (`DbDataReader` — leitura linha-a-linha, uso de memória estável mesmo nas tabelas grandes), aplica **parse tolerante** (`'-'`/vazio → `null`, `'S'`/`'N'` → `bool`, lat/long → `geography(Point,4326)`), resolve as FKs e faz **upsert por chave natural** no schema do domínio (`public`).
+
+```
+dumps .sql  ──psql -f──▶  dne_staging (15 tabelas varchar)
+                              │  SELECT streamado (DneStagingFonte)
+                              ▼
+        parse tolerante ─▶ upsert por chave natural ─▶ public.* (domínio Uni+)
+```
+
+### Por que staging-DB (e não parsear os .sql em C#)
+
+- **Streaming nativo:** o `DbDataReader` do Npgsql resolve os ~382 MB de logradouro sem carregar o arquivo em memória — sem reimplementar um parser de `INSERT` textual (frágil com escaping/acentos/`NULL`).
+- **Resolução de FK:** as FKs internas da DNE (`id_cidade`, `distrito_id`, `bairro_id`, inteiros **instáveis entre releases**) ficam disponíveis para JOIN no staging. O domínio nunca usa esses inteiros como identidade — usa Guid v7 ([ADR-0032](adrs/0032-guid-v7-como-identidade.md)) + chave natural.
+- **Recarga idempotente:** ver abaixo.
+
+## Restauração do staging (dev)
+
+```bash
+# 1. Descompactar os dumps (ex.: tbl_cep_202601_postgresql.zip) num diretório.
+# 2. Criar o schema de staging e restaurar cada dump:
+psql "$GEO_CONN" -c 'DROP SCHEMA IF EXISTS dne_staging CASCADE; CREATE SCHEMA dne_staging;'
+for f in tbl_cep_202601_n_*.sql; do
+  # os dumps criam tabelas em "public"; restaure-os sob o schema dne_staging
+  psql "$GEO_CONN" -c "SET search_path TO dne_staging;" -f "$f"
+done
+```
+
+> Ajuste o `search_path`/schema conforme o gerador do dump. O importador espera as tabelas `tbl_cep_{versao}_n_*` no schema configurado (`dne_staging` por padrão).
+
+## Recarga periódica (releases mensais)
+
+A DNE é atualizada mensalmente. Para aplicar uma nova release (ex.: `202602`):
+
+1. Restaurar o novo dump no `dne_staging` (substitui o anterior).
+2. Disparar a importação informando a versão `202602`.
+3. O ETL faz **upsert por chave natural** — `sigla_iso`/`uf`/`codigo_ibge` são estáveis entre releases: insere o novo, atualiza o que mudou, grava `versao_dataset=202602` em cada linha tocada. Reaplicar a **mesma** versão é no-op (idempotente).
+
+A política de *stale* (marcar `vigente=false` as chaves ausentes na nova release) e o gatilho operacional (seed em dev + endpoint admin `POST /api/admin/geo/importacoes`) são entregues na Story de atualização periódica do Epic.
+
+## Parse tolerante (anti-frágil)
+
+A fonte é toda `varchar` e traz `'-'`/vazio para dado ausente (≈27% dos municípios em `mortalidade_infantil`). Toda métrica externa é `nullable` e degrada para `null` sem abortar a carga — só chave natural e `nome` são obrigatórios. Cada degradação é registrada (sem PII — métricas IBGE públicas) num **relatório de validação** com contadores por tabela (lidos/inseridos/atualizados/órfãos/duplicados/degradados) e amostras para auditoria. A carga só aborta por falha de infraestrutura (conexão/transação), com **rollback total** (transação única).

--- a/docs/geo-etl-dataset-dne.md
+++ b/docs/geo-etl-dataset-dne.md
@@ -50,4 +50,11 @@ A política de *stale* (marcar `vigente=false` as chaves ausentes na nova releas
 
 ## Parse tolerante (anti-frágil)
 
-A fonte é toda `varchar` e traz `'-'`/vazio para dado ausente (≈27% dos municípios em `mortalidade_infantil`). Toda métrica externa é `nullable` e degrada para `null` sem abortar a carga — só chave natural e `nome` são obrigatórios. Cada degradação é registrada (sem PII — métricas IBGE públicas) num **relatório de validação** com contadores por tabela (lidos/inseridos/atualizados/órfãos/duplicados/degradados) e amostras para auditoria. A carga só aborta por falha de infraestrutura (conexão/transação), com **rollback total** (transação única).
+A fonte é toda `varchar` e traz `'-'`/vazio para dado ausente (≈27% dos municípios em `mortalidade_infantil`). Toda métrica externa é `nullable` e degrada para `null` sem abortar a carga — só chave natural e `nome` são obrigatórios.
+
+Tipos do domínio por natureza da coluna (a fonte não os distingue):
+
+- **Identificadores → `string`** (preservam zeros à esquerda, sem aritmética): `codigo_ibge`, `cep`/`cep_inicial`/`cep_final`, `ddd`, `uf`/siglas.
+- **Métricas inteiras → `int?`**: `populacao_residente(_2022)`, `matriculas_ensino_fundamental_2023`, `rendimento_mensal_per_capita`, `total_veiculos_2023` (chegam inteiros na fonte real, ex.: `'1095'`, `'350273'`).
+- **Métricas fracionárias / monetárias → `decimal?`**: `area_territorial_km2`, `densidade_demografica`, `idh`, `escolarizacao_6_a_14_anos`, `mortalidade_infantil`, `receitas`/`despesas` (≈bilhões), `pib_per_capita`. Sempre `InvariantCulture` (ponto decimal); vírgula é **rejeitada** (não vira separador de milhar).
+- **`'S'`/`'N'` → `bool`**; **`aniversario` (`DD/MM`) → `string`** (não é data); **lat/long → `geography(Point,4326)`** com validação de domínio (`[-90,90]`/`[-180,180]`). Cada degradação é registrada (sem PII — métricas IBGE públicas) num **relatório de validação** com contadores por tabela (lidos/inseridos/atualizados/órfãos/duplicados/degradados) e amostras para auditoria. A carga só aborta por falha de infraestrutura (conexão/transação), com **rollback total** (transação única).

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Cidade.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Cidade.cs
@@ -156,4 +156,79 @@ public sealed class Cidade : EntityBase
 
         return Result<Cidade>.Success(cidade);
     }
+
+    /// <summary>
+    /// Reaplica os dados de uma release sobre um Município já existente (upsert in
+    /// place do ETL), preservando <see cref="EntityBase.Id"/> (referenciado por
+    /// Indicador/faixas e por outros módulos via código IBGE) e a chave natural
+    /// <see cref="CodigoIbge"/>. Os campos territoriais são reaplicados juntos
+    /// (a fonte os agrega por código IBGE antes da chamada). Valida o mínimo
+    /// <strong>antes</strong> de mutar — em falha, o estado não é tocado.
+    /// </summary>
+    public Result Atualizar(
+        Guid estadoId,
+        string uf,
+        string nome,
+        string? nomeNormalizado,
+        string? ddd,
+        decimal? latitude,
+        decimal? longitude,
+        Point? coordenada,
+        string? mesorregiaoCodigo,
+        string? mesorregiaoNome,
+        string? microrregiaoCodigo,
+        string? microrregiaoNome,
+        string? regiaoIntermediariaCodigo,
+        string? regiaoIntermediariaNome,
+        string? regiaoImediataCodigo,
+        string? regiaoImediataNome,
+        string versaoDataset,
+        bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(uf);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (estadoId == Guid.Empty)
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.CidadeEstadoObrigatorio,
+                "Estado da Cidade é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.CidadeNomeObrigatorio,
+                "Nome da Cidade é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.CidadeVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) da Cidade é obrigatória."));
+        }
+
+        EstadoId = estadoId;
+        Uf = GeoTexto.NormalizarChaveMaiuscula(uf);
+        Nome = nome.Trim();
+        NomeNormalizado = GeoTexto.NormalizarBuscaOpcional(nomeNormalizado);
+        Ddd = GeoTexto.NormalizarOpcional(ddd);
+        Latitude = latitude;
+        Longitude = longitude;
+        Coordenada = coordenada;
+        MesorregiaoCodigo = GeoTexto.NormalizarOpcional(mesorregiaoCodigo);
+        MesorregiaoNome = GeoTexto.NormalizarOpcional(mesorregiaoNome);
+        MicrorregiaoCodigo = GeoTexto.NormalizarOpcional(microrregiaoCodigo);
+        MicrorregiaoNome = GeoTexto.NormalizarOpcional(microrregiaoNome);
+        RegiaoIntermediariaCodigo = GeoTexto.NormalizarOpcional(regiaoIntermediariaCodigo);
+        RegiaoIntermediariaNome = GeoTexto.NormalizarOpcional(regiaoIntermediariaNome);
+        RegiaoImediataCodigo = GeoTexto.NormalizarOpcional(regiaoImediataCodigo);
+        RegiaoImediataNome = GeoTexto.NormalizarOpcional(regiaoImediataNome);
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/CidadeFaixaCep.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/CidadeFaixaCep.cs
@@ -83,4 +83,26 @@ public sealed class CidadeFaixaCep : EntityBase
 
         return Result<CidadeFaixaCep>.Success(faixa);
     }
+
+    /// <summary>
+    /// Reaplica os dados de uma release sobre a faixa já existente (upsert in place do
+    /// ETL por chave natural <c>(cidade_id, cep_inicial, cep_final)</c>), preservando
+    /// <see cref="EntityBase.Id"/>. A chave natural não muda — só a proveniência.
+    /// </summary>
+    public Result Atualizar(string versaoDataset, bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.CidadeFaixaCepVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) da faixa de CEP é obrigatória."));
+        }
+
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/CidadeIndicador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/CidadeIndicador.cs
@@ -113,4 +113,52 @@ public sealed class CidadeIndicador : EntityBase
 
         return Result<CidadeIndicador>.Success(indicador);
     }
+
+    /// <summary>
+    /// Reaplica os indicadores de uma release sobre o satélite já existente (upsert
+    /// in place do ETL), preservando <see cref="EntityBase.Id"/> e o vínculo
+    /// <see cref="CidadeId"/>. Valida o mínimo <strong>antes</strong> de mutar.
+    /// </summary>
+    public Result Atualizar(
+        string? gentilico,
+        string? prefeito,
+        decimal? areaKm2,
+        int? populacaoResidente,
+        decimal? densidadeDemografica,
+        decimal? escolarizacao6a14,
+        decimal? idh,
+        decimal? mortalidadeInfantil,
+        decimal? receitas,
+        decimal? despesas,
+        decimal? pibPerCapita,
+        string? aniversario,
+        string versaoDataset,
+        bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.CidadeIndicadorVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) do indicador de Cidade é obrigatória."));
+        }
+
+        Gentilico = GeoTexto.NormalizarOpcional(gentilico);
+        Prefeito = GeoTexto.NormalizarOpcional(prefeito);
+        AreaKm2 = areaKm2;
+        PopulacaoResidente = populacaoResidente;
+        DensidadeDemografica = densidadeDemografica;
+        Escolarizacao6a14 = escolarizacao6a14;
+        Idh = idh;
+        MortalidadeInfantil = mortalidadeInfantil;
+        Receitas = receitas;
+        Despesas = despesas;
+        PibPerCapita = pibPerCapita;
+        Aniversario = GeoTexto.NormalizarOpcional(aniversario);
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Estado.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Estado.cs
@@ -136,4 +136,66 @@ public sealed class Estado : EntityBase
 
         return Result<Estado>.Success(estado);
     }
+
+    /// <summary>
+    /// Reaplica os dados de uma release sobre um Estado já existente (upsert in place
+    /// do ETL), preservando <see cref="EntityBase.Id"/> (referenciado por
+    /// Cidade/Indicador/faixas) e a chave natural <see cref="Uf"/>. Valida o mínimo
+    /// <strong>antes</strong> de mutar — em falha, o estado não é tocado.
+    /// </summary>
+    public Result Atualizar(
+        Guid paisId,
+        string nome,
+        string? nomeNormalizado,
+        string? regiao,
+        string? capital,
+        string? codigoIbge,
+        decimal? latitude,
+        decimal? longitude,
+        Point? coordenada,
+        string? cepInicial,
+        string? cepFinal,
+        string versaoDataset,
+        bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (paisId == Guid.Empty)
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.EstadoPaisObrigatorio,
+                "País do Estado é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.EstadoNomeObrigatorio,
+                "Nome do Estado é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.EstadoVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) do Estado é obrigatória."));
+        }
+
+        PaisId = paisId;
+        Nome = nome.Trim();
+        NomeNormalizado = GeoTexto.NormalizarBuscaOpcional(nomeNormalizado);
+        Regiao = GeoTexto.NormalizarOpcional(regiao);
+        Capital = GeoTexto.NormalizarOpcional(capital);
+        CodigoIbge = GeoTexto.NormalizarOpcional(codigoIbge);
+        Latitude = latitude;
+        Longitude = longitude;
+        Coordenada = coordenada;
+        CepInicial = GeoTexto.NormalizarOpcional(cepInicial);
+        CepFinal = GeoTexto.NormalizarOpcional(cepFinal);
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/EstadoFaixaCep.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/EstadoFaixaCep.cs
@@ -90,4 +90,27 @@ public sealed class EstadoFaixaCep : EntityBase
 
         return Result<EstadoFaixaCep>.Success(faixa);
     }
+
+    /// <summary>
+    /// Reaplica os dados de uma release sobre a faixa já existente (upsert in place do
+    /// ETL por chave natural <c>(estado_id, cep_inicial, cep_final)</c>), preservando
+    /// <see cref="EntityBase.Id"/>. A chave natural não muda — só metadados/proveniência.
+    /// </summary>
+    public Result Atualizar(string? descricao, string versaoDataset, bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.EstadoFaixaCepVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) da faixa de CEP é obrigatória."));
+        }
+
+        Descricao = GeoTexto.NormalizarOpcional(descricao);
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/EstadoIndicador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/EstadoIndicador.cs
@@ -108,4 +108,50 @@ public sealed class EstadoIndicador : EntityBase
 
         return Result<EstadoIndicador>.Success(indicador);
     }
+
+    /// <summary>
+    /// Reaplica os indicadores de uma release sobre o satélite já existente (upsert
+    /// in place do ETL), preservando <see cref="EntityBase.Id"/> e o vínculo
+    /// <see cref="EstadoId"/>. Valida o mínimo <strong>antes</strong> de mutar.
+    /// </summary>
+    public Result Atualizar(
+        string? gentilico,
+        string? governador,
+        decimal? areaKm2,
+        int? populacaoResidente2022,
+        decimal? densidadeDemografica,
+        int? matriculasEnsinoFundamental2023,
+        decimal? idh,
+        decimal? receitasBrutas,
+        decimal? despesasBrutas,
+        int? rendimentoMensalPerCapita,
+        int? totalVeiculos2023,
+        string versaoDataset,
+        bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.EstadoIndicadorVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) do indicador de Estado é obrigatória."));
+        }
+
+        Gentilico = GeoTexto.NormalizarOpcional(gentilico);
+        Governador = GeoTexto.NormalizarOpcional(governador);
+        AreaKm2 = areaKm2;
+        PopulacaoResidente2022 = populacaoResidente2022;
+        DensidadeDemografica = densidadeDemografica;
+        MatriculasEnsinoFundamental2023 = matriculasEnsinoFundamental2023;
+        Idh = idh;
+        ReceitasBrutas = receitasBrutas;
+        DespesasBrutas = despesasBrutas;
+        RendimentoMensalPerCapita = rendimentoMensalPerCapita;
+        TotalVeiculos2023 = totalVeiculos2023;
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Pais.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Pais.cs
@@ -111,4 +111,50 @@ public sealed class Pais : EntityBase
 
         return Result<Pais>.Success(pais);
     }
+
+    /// <summary>
+    /// Reaplica os dados de uma release sobre um País já existente (upsert in place
+    /// do ETL), preservando <see cref="EntityBase.Id"/> e a chave natural
+    /// <see cref="SiglaIso"/>. Valida o mínimo <strong>antes</strong> de mutar — em
+    /// falha, o estado da entidade não é tocado (atomicidade da mutação).
+    /// </summary>
+    public Result Atualizar(
+        string sigla,
+        string nome,
+        string? codigoBcb,
+        string? codigoRfb,
+        string? codigoSped,
+        string? codigoSiscomex,
+        string versaoDataset,
+        bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(sigla);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.PaisNomeObrigatorio,
+                "Nome do País é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.PaisVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) do País é obrigatória."));
+        }
+
+        Sigla = GeoTexto.NormalizarChaveMaiuscula(sigla);
+        Nome = nome.Trim();
+        CodigoBcb = GeoTexto.NormalizarOpcional(codigoBcb);
+        CodigoRfb = GeoTexto.NormalizarOpcional(codigoRfb);
+        CodigoSped = GeoTexto.NormalizarOpcional(codigoSped);
+        CodigoSiscomex = GeoTexto.NormalizarOpcional(codigoSiscomex);
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
@@ -32,6 +33,10 @@ public static class GeoInfrastructureRegistration
 
         services.AddScoped<IUnitOfWork>(serviceProvider =>
             serviceProvider.GetRequiredService<GeoDbContext>());
+
+        // ETL DNE (ADR-0092) — serviço de carga de reference data. O gatilho (seed
+        // dev / endpoint admin) e a fonte concreta de produção entram na Story #674.
+        services.AddScoped<IGeoImportador, GeoImportadorPaisEstadoCidade>();
 
         return services;
     }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/DneStagingFonte.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/DneStagingFonte.cs
@@ -1,0 +1,171 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+using Npgsql;
+
+/// <summary>
+/// <see cref="IGeoFonteDados"/> que lê o dataset DNE de um <strong>schema de
+/// staging</strong> (os 15 dumps Navicat restaurados via <c>psql</c>), por
+/// <c>SELECT</c> streamado (<see cref="DbDataReader"/> — leitura linha-a-linha, uso
+/// de memória estável mesmo nas tabelas grandes). O nome de cada tabela é derivado
+/// da <see cref="Versao"/> (<c>tbl_cep_{versao}_n_{sufixo}</c>), garantindo que a
+/// release lida é exatamente a que o importador carimba como proveniência.
+/// </summary>
+/// <remarks>
+/// <see cref="Versao"/> e o nome do schema são validados no construtor (não há como
+/// parametrizar identificadores de tabela em SQL): só dígitos (AAAAMM) e identificador
+/// Postgres seguro são aceitos — defesa contra injeção via configuração administrativa.
+/// </remarks>
+internal sealed class DneStagingFonte : IGeoFonteDados
+{
+    public const string SchemaPadrao = "dne_staging";
+
+    private readonly string _connectionString;
+    private readonly string _schema;
+
+    public DneStagingFonte(string connectionString, string versao, string schema = SchemaPadrao)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        ArgumentException.ThrowIfNullOrWhiteSpace(versao);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schema);
+
+        if (!VersaoValida(versao))
+        {
+            throw new ArgumentException(
+                $"Versão do dataset inválida: '{versao}'. Esperado AAAAMM (6 dígitos).",
+                nameof(versao));
+        }
+
+        if (!IdentificadorValido(schema))
+        {
+            throw new ArgumentException(
+                $"Nome de schema inválido: '{schema}'.",
+                nameof(schema));
+        }
+
+        _connectionString = connectionString;
+        _schema = schema;
+        Versao = versao;
+    }
+
+    public string Versao { get; }
+
+    public IAsyncEnumerable<PaisCru> LerPaisesAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT sigla_iso, sigla, nome_pt, pais_bcb, pais_rbf, pais_sped, pais_siscomex FROM {Tabela("paises_ibge")}",
+            static r => new PaisCru(Texto(r, 0), Texto(r, 1), Texto(r, 2), Texto(r, 3), Texto(r, 4), Texto(r, 5), Texto(r, 6)),
+            cancellationToken);
+
+    public IAsyncEnumerable<EstadoCru> LerEstadosAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT sigla, estado, estado_sem_acento, regiao, capital, faixa_ini, faixa_fim, latitude, longitude FROM {Tabela("estado")}",
+            static r => new EstadoCru(Texto(r, 0), Texto(r, 1), Texto(r, 2), Texto(r, 3), Texto(r, 4), Texto(r, 5), Texto(r, 6), Texto(r, 7), Texto(r, 8)),
+            cancellationToken);
+
+    public IAsyncEnumerable<EstadoIndicadorCru> LerEstadoIndicadoresAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"""
+             SELECT uf, codigo_ibge, gentilico, governador, area_territorial_km2,
+                    populacao_residente_2022, densidade_demografica_hab_km2,
+                    matriculas_ensino_fundamental_2023, idh_indice_desenv_humano,
+                    total_receitas_brutas_realizadas, total_despesas_brutas_empenhadas,
+                    rendimento_mensal_per_capita, total_veiculos_2023
+             FROM {Tabela("estado_ibge")}
+             """,
+            static r => new EstadoIndicadorCru(
+                Texto(r, 0), Texto(r, 1), Texto(r, 2), Texto(r, 3), Texto(r, 4), Texto(r, 5), Texto(r, 6),
+                Texto(r, 7), Texto(r, 8), Texto(r, 9), Texto(r, 10), Texto(r, 11), Texto(r, 12)),
+            cancellationToken);
+
+    public IAsyncEnumerable<EstadoFaixaCru> LerEstadoFaixasAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT sigla, regiao, faixa_ini, faixa_fim FROM {Tabela("estado_faixa")}",
+            static r => new EstadoFaixaCru(Texto(r, 0), Texto(r, 1), Texto(r, 2), Texto(r, 3)),
+            cancellationToken);
+
+    public IAsyncEnumerable<CidadeCru> LerCidadesAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT cidade_ibge, cidade, cidade_sem_acento, estado, ddd, latitude, longitude FROM {Tabela("cidade")}",
+            static r => new CidadeCru(Texto(r, 0), Texto(r, 1), Texto(r, 2), Texto(r, 3), Texto(r, 4), Texto(r, 5), Texto(r, 6)),
+            cancellationToken);
+
+    public IAsyncEnumerable<CidadeTerritorioCru> LerCidadeTerritoriosAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"""
+             SELECT cidade_ibge, mesorregiao, mesorregiao_nome, microrregiao, microrregiao_nome,
+                    regiao_intermediaria, regiao_intermediaria_nome,
+                    regiao_geografica_imediata, regiao_geografica_imediata_nome
+             FROM {Tabela("cidade_ibge_territorio")}
+             """,
+            static r => new CidadeTerritorioCru(
+                Texto(r, 0), Texto(r, 1), Texto(r, 2), Texto(r, 3), Texto(r, 4),
+                Texto(r, 5), Texto(r, 6), Texto(r, 7), Texto(r, 8)),
+            cancellationToken);
+
+    public IAsyncEnumerable<CidadeIndicadorCru> LerCidadeIndicadoresAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"""
+             SELECT cidade_ibge, gentilico, prefeito, area_territorial_km2, populacao_residente,
+                    densidade_demografica, escolarizacao_6_a_14_anos, idice_de_desenv_humano,
+                    mortalidade_infantil, receitas_realizadas, despesas_empenhadas,
+                    pib_per_capita, aniversario_municipio
+             FROM {Tabela("cidade_ibge")}
+             """,
+            static r => new CidadeIndicadorCru(
+                Texto(r, 0), Texto(r, 1), Texto(r, 2), Texto(r, 3), Texto(r, 4), Texto(r, 5), Texto(r, 6),
+                Texto(r, 7), Texto(r, 8), Texto(r, 9), Texto(r, 10), Texto(r, 11), Texto(r, 12)),
+            cancellationToken);
+
+    public IAsyncEnumerable<CidadeFaixaCru> LerCidadeFaixasAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT cidade_ibge, faixa_ini, faixa_fim FROM {Tabela("cidade_faixa")}",
+            static r => new CidadeFaixaCru(Texto(r, 0), Texto(r, 1), Texto(r, 2)),
+            cancellationToken);
+
+    [SuppressMessage(
+        "Security",
+        "CA2100:Review SQL queries for security vulnerabilities",
+        Justification = "O SQL é literal de código (lista de colunas fixa) somada ao nome de tabela cujo schema e versão são validados no construtor (dígitos/identificador Postgres seguro). Não há entrada de usuário na query — não é parametrizável por se tratar de identificador de tabela.")]
+    private async IAsyncEnumerable<T> ConsultarAsync<T>(
+        string sql,
+        Func<DbDataReader, T> mapear,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        NpgsqlConnection conexao = new(_connectionString);
+        await using (conexao.ConfigureAwait(false))
+        {
+            await conexao.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            NpgsqlCommand comando = conexao.CreateCommand();
+            await using (comando.ConfigureAwait(false))
+            {
+                comando.CommandText = sql;
+                DbDataReader leitor = await comando.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                await using (leitor.ConfigureAwait(false))
+                {
+                    while (await leitor.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    {
+                        yield return mapear(leitor);
+                    }
+                }
+            }
+        }
+    }
+
+    // Identificador de tabela qualificado e citado. Schema e versão já validados —
+    // o sufixo é literal de código; não há entrada de usuário no nome da tabela.
+    private string Tabela(string sufixo) => $"\"{_schema}\".\"tbl_cep_{Versao}_n_{sufixo}\"";
+
+    private static string? Texto(DbDataReader leitor, int ordinal) =>
+        leitor.IsDBNull(ordinal) ? null : leitor.GetValue(ordinal)?.ToString();
+
+    private static bool VersaoValida(string versao) =>
+        versao.Length == 6 && versao.All(char.IsAsciiDigit);
+
+    private static bool IdentificadorValido(string identificador) =>
+        (char.IsAsciiLetter(identificador[0]) || identificador[0] == '_')
+        && identificador.All(c => char.IsAsciiLetterOrDigit(c) || c == '_');
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/DneStagingFonte.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/DneStagingFonte.cs
@@ -159,13 +159,17 @@ internal sealed class DneStagingFonte : IGeoFonteDados
     // o sufixo é literal de código; não há entrada de usuário no nome da tabela.
     private string Tabela(string sufixo) => $"\"{_schema}\".\"tbl_cep_{Versao}_n_{sufixo}\"";
 
+    // As colunas projetadas pela fonte são todas text/varchar na DNE — GetString evita
+    // o boxing de GetValue().ToString() (relevante no volume dos logradouros, #673).
     private static string? Texto(DbDataReader leitor, int ordinal) =>
-        leitor.IsDBNull(ordinal) ? null : leitor.GetValue(ordinal)?.ToString();
+        leitor.IsDBNull(ordinal) ? null : leitor.GetString(ordinal);
 
     private static bool VersaoValida(string versao) =>
         versao.Length == 6 && versao.All(char.IsAsciiDigit);
 
     private static bool IdentificadorValido(string identificador) =>
-        (char.IsAsciiLetter(identificador[0]) || identificador[0] == '_')
+        // PostgreSQL trunca identificadores em 63 bytes — defesa em profundidade.
+        identificador.Length is >= 1 and <= 63
+        && (char.IsAsciiLetter(identificador[0]) || identificador[0] == '_')
         && identificador.All(c => char.IsAsciiLetterOrDigit(c) || c == '_');
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/IGeoFonteDados.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/IGeoFonteDados.cs
@@ -1,0 +1,34 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+
+/// <summary>
+/// Fonte do dataset DNE para o ETL (ADR-0092). Abstrai a origem dos registros crus
+/// por tabela — em produção/dev a implementação <see cref="DneStagingFonte"/> lê via
+/// <c>SELECT</c> streamado de um schema de staging; em teste, uma fonte em memória.
+/// A <see cref="Versao"/> (AAAAMM) é a fonte única de verdade da release: o importador
+/// a usa para gravar a proveniência, evitando carimbar dados de uma versão com outra.
+/// </summary>
+/// <remarks>
+/// Esta interface cobre o topo da hierarquia (País/Estado/Cidade, Story #672). As
+/// folhas (Distrito/Bairro/Logradouro) entram por extensão aditiva na Story irmã.
+/// </remarks>
+internal interface IGeoFonteDados
+{
+    /// <summary>Release DNE (AAAAMM) que esta fonte representa.</summary>
+    string Versao { get; }
+
+    IAsyncEnumerable<PaisCru> LerPaisesAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<EstadoCru> LerEstadosAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<EstadoIndicadorCru> LerEstadoIndicadoresAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<EstadoFaixaCru> LerEstadoFaixasAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<CidadeCru> LerCidadesAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<CidadeTerritorioCru> LerCidadeTerritoriosAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<CidadeIndicadorCru> LerCidadeIndicadoresAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<CidadeFaixaCru> LerCidadeFaixasAsync(CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/RegistrosDne.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/RegistrosDne.cs
@@ -1,0 +1,95 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+
+// Registros "crus" (varchar da fonte DNE) lidos pela IGeoFonteDados antes do parse
+// tolerante. Espelham apenas as colunas que o importador de País/Estado/Cidade usa
+// (Epic §9). Identificadores ficam string crua; métricas são parseadas no importador.
+// Nomes são semânticos do domínio Uni+ (a fonte usa rótulos como "estado" para a UF).
+
+/// <summary>País (fonte <c>paises_ibge</c>) — só o registro <c>BRA</c> é carregado.</summary>
+internal sealed record PaisCru(
+    string? SiglaIso,
+    string? Sigla,
+    string? Nome,
+    string? CodigoBcb,
+    string? CodigoRfb,
+    string? CodigoSped,
+    string? CodigoSiscomex);
+
+/// <summary>Estado/UF (fonte <c>estado</c>): chave natural <c>sigla</c>; faixa geral em <c>faixa_ini/fim</c>.</summary>
+internal sealed record EstadoCru(
+    string? Uf,
+    string? Nome,
+    string? NomeSemAcento,
+    string? Regiao,
+    string? Capital,
+    string? FaixaIni,
+    string? FaixaFim,
+    string? Latitude,
+    string? Longitude);
+
+/// <summary>Indicadores socioeconômicos do Estado (fonte <c>estado_ibge</c>, 1:1 por <c>uf</c>).</summary>
+internal sealed record EstadoIndicadorCru(
+    string? Uf,
+    string? CodigoIbge,
+    string? Gentilico,
+    string? Governador,
+    string? AreaTerritorialKm2,
+    string? PopulacaoResidente2022,
+    string? DensidadeDemografica,
+    string? MatriculasEnsinoFundamental2023,
+    string? Idh,
+    string? ReceitasBrutas,
+    string? DespesasBrutas,
+    string? RendimentoMensalPerCapita,
+    string? TotalVeiculos2023);
+
+/// <summary>Faixa de CEP do Estado (fonte <c>estado_faixa</c>): <c>descricao</c> = <c>regiao</c>.</summary>
+internal sealed record EstadoFaixaCru(
+    string? Uf,
+    string? Descricao,
+    string? FaixaIni,
+    string? FaixaFim);
+
+/// <summary>Município (fonte <c>cidade</c>): chave natural <c>cidade_ibge</c>; vínculo por <c>estado</c> (UF).</summary>
+internal sealed record CidadeCru(
+    string? CodigoIbge,
+    string? Nome,
+    string? NomeSemAcento,
+    string? Uf,
+    string? Ddd,
+    string? Latitude,
+    string? Longitude);
+
+/// <summary>Recorte territorial IBGE do município (fonte <c>cidade_ibge_territorio</c>, casa por <c>cidade_ibge</c>).</summary>
+internal sealed record CidadeTerritorioCru(
+    string? CodigoIbge,
+    string? MesorregiaoCodigo,
+    string? MesorregiaoNome,
+    string? MicrorregiaoCodigo,
+    string? MicrorregiaoNome,
+    string? RegiaoIntermediariaCodigo,
+    string? RegiaoIntermediariaNome,
+    string? RegiaoImediataCodigo,
+    string? RegiaoImediataNome);
+
+/// <summary>Indicadores socioeconômicos do município (fonte <c>cidade_ibge</c>, casa por <c>cidade_ibge</c>).</summary>
+internal sealed record CidadeIndicadorCru(
+    string? CodigoIbge,
+    string? Gentilico,
+    string? Prefeito,
+    string? AreaTerritorialKm2,
+    string? PopulacaoResidente,
+    string? DensidadeDemografica,
+    string? Escolarizacao6a14,
+    string? Idh,
+    string? MortalidadeInfantil,
+    string? Receitas,
+    string? Despesas,
+    string? PibPerCapita,
+    string? Aniversario);
+
+/// <summary>Faixa de CEP do município (fonte <c>cidade_faixa</c>, casa por <c>cidade_ibge</c>).</summary>
+internal sealed record CidadeFaixaCru(
+    string? CodigoIbge,
+    string? FaixaIni,
+    string? FaixaFim);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorPaisEstadoCidade.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorPaisEstadoCidade.cs
@@ -51,9 +51,19 @@ internal sealed partial class GeoImportadorPaisEstadoCidade : IGeoImportador
         await using (transacao.ConfigureAwait(false))
         {
             Guid brasilId = await ImportarPaisAsync(fonte, relatorio, cancellationToken).ConfigureAwait(false);
+            if (brasilId == Guid.Empty)
+            {
+                // País-âncora (Brasil) ausente no dataset: sem ele estados/cidades
+                // ficariam órfãos e a carga retornaria verde-vazia, indistinguível de
+                // uma base legitimamente vazia. Sinaliza explicitamente o caso.
+                LogBrasilAusente(_logger, fonte.Versao);
+            }
 
+            // Agrega os indicadores contando lidos/sem-chave/duplicados no próprio
+            // contador da tabela — o relatório reflete o total da fonte, não só os
+            // registros com chave (a agregação não pode descartar em silêncio).
             Dictionary<string, EstadoIndicadorCru> indicadoresEstado =
-                await AgregarPorChaveAsync(fonte.LerEstadoIndicadoresAsync(cancellationToken), i => ChaveSigla(i.Uf)).ConfigureAwait(false);
+                await AgregarContandoAsync(fonte.LerEstadoIndicadoresAsync(cancellationToken), i => ChaveSigla(i.Uf), relatorio.Tabela("estado_indicador")).ConfigureAwait(false);
 
             Dictionary<string, Guid> estadosPorUf =
                 await ImportarEstadosAsync(fonte, brasilId, indicadoresEstado, relatorio, cancellationToken).ConfigureAwait(false);
@@ -65,7 +75,10 @@ internal sealed partial class GeoImportadorPaisEstadoCidade : IGeoImportador
 
             Dictionary<string, Guid> cidadesPorCodigo =
                 await ImportarCidadesAsync(fonte, estadosPorUf, territorios, relatorio, cancellationToken).ConfigureAwait(false);
-            await ImportarCidadeIndicadoresAsync(fonte, cidadesPorCodigo, fonte.Versao, relatorio, cancellationToken).ConfigureAwait(false);
+
+            Dictionary<string, CidadeIndicadorCru> indicadoresCidade =
+                await AgregarContandoAsync(fonte.LerCidadeIndicadoresAsync(cancellationToken), i => ChaveCodigo(i.CodigoIbge), relatorio.Tabela("cidade_indicador")).ConfigureAwait(false);
+            await ImportarCidadeIndicadoresAsync(cidadesPorCodigo, indicadoresCidade, fonte.Versao, relatorio, cancellationToken).ConfigureAwait(false);
             await ImportarCidadeFaixasAsync(fonte, cidadesPorCodigo, fonte.Versao, relatorio, cancellationToken).ConfigureAwait(false);
 
             await transacao.CommitAsync(cancellationToken).ConfigureAwait(false);
@@ -192,9 +205,10 @@ internal sealed partial class GeoImportadorPaisEstadoCidade : IGeoImportador
         Dictionary<Guid, EstadoIndicador> existentes =
             await _contexto.EstadoIndicadores.ToDictionaryAsync(i => i.EstadoId, cancellationToken).ConfigureAwait(false);
 
+        // Lidos/sem-chave/duplicados já foram contados na agregação (AgregarContandoAsync);
+        // aqui só resta resolver órfão (UF sem estado carregado) e o upsert.
         foreach ((string uf, EstadoIndicadorCru cru) in indicadores)
         {
-            contador.ContarLido();
             if (!estadosPorUf.TryGetValue(uf, out Guid estadoId))
             {
                 contador.ContarOrfao(uf);
@@ -352,21 +366,19 @@ internal sealed partial class GeoImportadorPaisEstadoCidade : IGeoImportador
     }
 
     private async Task ImportarCidadeIndicadoresAsync(
-        IGeoFonteDados fonte,
         Dictionary<string, Guid> cidadesPorCodigo,
+        Dictionary<string, CidadeIndicadorCru> indicadores,
         string versao,
         RelatorioImportacao relatorio,
         CancellationToken cancellationToken)
     {
         ContadorTabela contador = relatorio.Tabela("cidade_indicador");
-        Dictionary<string, CidadeIndicadorCru> porCodigo =
-            await AgregarPorChaveAsync(fonte.LerCidadeIndicadoresAsync(cancellationToken), i => ChaveCodigo(i.CodigoIbge)).ConfigureAwait(false);
         Dictionary<Guid, CidadeIndicador> existentes =
             await _contexto.CidadeIndicadores.ToDictionaryAsync(i => i.CidadeId, cancellationToken).ConfigureAwait(false);
 
-        foreach ((string codigo, CidadeIndicadorCru cru) in porCodigo)
+        // Lidos/sem-chave/duplicados contados na agregação; aqui só órfão + upsert.
+        foreach ((string codigo, CidadeIndicadorCru cru) in indicadores)
         {
-            contador.ContarLido();
             if (!cidadesPorCodigo.TryGetValue(codigo, out Guid cidadeId))
             {
                 contador.ContarOrfao(codigo);
@@ -521,6 +533,35 @@ internal sealed partial class GeoImportadorPaisEstadoCidade : IGeoImportador
         return mapa;
     }
 
+    // Como AgregarPorChaveAsync, mas registra no contador da tabela tudo o que a fonte
+    // trouxe (lidos), o que foi descartado por chave ausente e as chaves repetidas
+    // (last-wins) — para o relatório não subestimar os "lidos" dos níveis agregados.
+    private static async Task<Dictionary<string, T>> AgregarContandoAsync<T>(
+        IAsyncEnumerable<T> fonte,
+        Func<T, string?> chave,
+        ContadorTabela contador)
+    {
+        Dictionary<string, T> mapa = new(StringComparer.Ordinal);
+        await foreach (T item in fonte.ConfigureAwait(false))
+        {
+            contador.ContarLido();
+            string? k = chave(item);
+            if (k is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            if (!mapa.TryAdd(k, item))
+            {
+                contador.ContarDuplicado(k); // last-wins
+                mapa[k] = item;
+            }
+        }
+
+        return mapa;
+    }
+
     // Parse tolerante de métrica IBGE que registra a degradação ('-'/vazio/inválido →
     // null) no relatório para auditoria. Sem PII — métricas socioeconômicas públicas.
     private static decimal? MetricaDecimal(string? cru, string coluna, ContadorTabela contador)
@@ -561,6 +602,9 @@ internal sealed partial class GeoImportadorPaisEstadoCidade : IGeoImportador
 
     [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: carga iniciada (versão {Versao}).")]
     private static partial void LogCargaIniciada(ILogger logger, string versao);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: país-âncora 'BRA' ausente no dataset da versão {Versao} — nenhum estado/cidade será carregado.")]
+    private static partial void LogBrasilAusente(ILogger logger, string versao);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: tabela {Tabela} concluída (lidos={Lidos}, inseridos={Inseridos}, atualizados={Atualizados}).")]
     private static partial void LogTabelaConcluida(ILogger logger, string tabela, int lidos, int inseridos, int atualizados);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorPaisEstadoCidade.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorPaisEstadoCidade.cs
@@ -1,0 +1,570 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+
+using NetTopologySuite.Geometries;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Parsing;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Importa o topo da hierarquia do Geo — País (só Brasil), Estado (+indicador
+/// +faixas) e Cidade (+territorial embutido, +indicador, +faixas) — a partir do
+/// dataset DNE (ADR-0092). Toda a carga roda numa <strong>única transação</strong>:
+/// <c>SaveChanges</c> por nível, mas commit só no fim — uma falha no meio faz
+/// rollback total, evitando publicar uma release mista. O upsert por chave natural
+/// (<c>Importar</c>/<c>Atualizar</c> do domínio) torna a recarga idempotente.
+/// </summary>
+/// <remarks>
+/// Esta Story (#672) faz <strong>carga inicial + upsert</strong>. A política de
+/// <em>stale</em> (marcar <c>vigente=false</c> para chaves ausentes numa nova
+/// release) é da Story de atualização periódica (#674) — aqui todo registro tocado
+/// nasce/permanece vigente.
+/// </remarks>
+internal sealed partial class GeoImportadorPaisEstadoCidade : IGeoImportador
+{
+    private readonly GeoDbContext _contexto;
+    private readonly ILogger<GeoImportadorPaisEstadoCidade> _logger;
+
+    public GeoImportadorPaisEstadoCidade(GeoDbContext contexto, ILogger<GeoImportadorPaisEstadoCidade> logger)
+    {
+        ArgumentNullException.ThrowIfNull(contexto);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _contexto = contexto;
+        _logger = logger;
+    }
+
+    public async Task<RelatorioImportacao> ImportarAsync(IGeoFonteDados fonte, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(fonte);
+
+        RelatorioImportacao relatorio = new(fonte.Versao);
+        LogCargaIniciada(_logger, fonte.Versao);
+
+        IDbContextTransaction transacao =
+            await _contexto.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await using (transacao.ConfigureAwait(false))
+        {
+            Guid brasilId = await ImportarPaisAsync(fonte, relatorio, cancellationToken).ConfigureAwait(false);
+
+            Dictionary<string, EstadoIndicadorCru> indicadoresEstado =
+                await AgregarPorChaveAsync(fonte.LerEstadoIndicadoresAsync(cancellationToken), i => ChaveSigla(i.Uf)).ConfigureAwait(false);
+
+            Dictionary<string, Guid> estadosPorUf =
+                await ImportarEstadosAsync(fonte, brasilId, indicadoresEstado, relatorio, cancellationToken).ConfigureAwait(false);
+            await ImportarEstadoIndicadoresAsync(estadosPorUf, indicadoresEstado, fonte.Versao, relatorio, cancellationToken).ConfigureAwait(false);
+            await ImportarEstadoFaixasAsync(fonte, estadosPorUf, fonte.Versao, relatorio, cancellationToken).ConfigureAwait(false);
+
+            Dictionary<string, CidadeTerritorioCru> territorios =
+                await AgregarPorChaveAsync(fonte.LerCidadeTerritoriosAsync(cancellationToken), t => ChaveCodigo(t.CodigoIbge)).ConfigureAwait(false);
+
+            Dictionary<string, Guid> cidadesPorCodigo =
+                await ImportarCidadesAsync(fonte, estadosPorUf, territorios, relatorio, cancellationToken).ConfigureAwait(false);
+            await ImportarCidadeIndicadoresAsync(fonte, cidadesPorCodigo, fonte.Versao, relatorio, cancellationToken).ConfigureAwait(false);
+            await ImportarCidadeFaixasAsync(fonte, cidadesPorCodigo, fonte.Versao, relatorio, cancellationToken).ConfigureAwait(false);
+
+            await transacao.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        int inseridos = Total(relatorio, t => t.Inseridos);
+        int atualizados = Total(relatorio, t => t.Atualizados);
+        int orfaos = Total(relatorio, t => t.Orfaos);
+        int degradados = Total(relatorio, t => t.ParsesDegradados);
+        LogCargaConcluida(_logger, fonte.Versao, inseridos, atualizados, orfaos, degradados);
+
+        return relatorio;
+    }
+
+    private async Task<Guid> ImportarPaisAsync(IGeoFonteDados fonte, RelatorioImportacao relatorio, CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("pais");
+        Dictionary<string, Pais> existentes =
+            await _contexto.Paises.ToDictionaryAsync(p => p.SiglaIso, StringComparer.Ordinal, cancellationToken).ConfigureAwait(false);
+        Dictionary<string, Pais> jaVistos = new(StringComparer.Ordinal);
+        Guid brasilId = Guid.Empty;
+
+        await foreach (PaisCru cru in fonte.LerPaisesAsync(cancellationToken).ConfigureAwait(false))
+        {
+            contador.ContarLido();
+            string? siglaIso = ChaveSigla(cru.SiglaIso);
+            if (siglaIso is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            // Carga restrita ao Brasil (decisão TL do Epic) — os demais países não
+            // são erro, apenas fora de escopo; não contam como ignorados.
+            if (!string.Equals(siglaIso, "BRA", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            Pais? pais = Upsert(
+                siglaIso,
+                jaVistos,
+                existentes,
+                () => Pais.Importar(siglaIso, cru.Sigla ?? string.Empty, cru.Nome ?? string.Empty, cru.CodigoBcb, cru.CodigoRfb, cru.CodigoSped, cru.CodigoSiscomex, fonte.Versao),
+                existente => existente.Atualizar(cru.Sigla ?? string.Empty, cru.Nome ?? string.Empty, cru.CodigoBcb, cru.CodigoRfb, cru.CodigoSped, cru.CodigoSiscomex, fonte.Versao),
+                _contexto.Paises,
+                contador);
+
+            if (pais is not null)
+            {
+                brasilId = pais.Id;
+            }
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        LogTabelaConcluida(_logger, "pais", contador.Lidos, contador.Inseridos, contador.Atualizados);
+        return brasilId;
+    }
+
+    private async Task<Dictionary<string, Guid>> ImportarEstadosAsync(
+        IGeoFonteDados fonte,
+        Guid brasilId,
+        Dictionary<string, EstadoIndicadorCru> indicadores,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("estado");
+        Dictionary<string, Guid> estadosPorUf = new(StringComparer.Ordinal);
+
+        // Sem o País (Brasil) carregado, os estados ficariam órfãos de FK — aborta o nível.
+        if (brasilId == Guid.Empty)
+        {
+            return estadosPorUf;
+        }
+
+        Dictionary<string, Estado> existentes =
+            await _contexto.Estados.ToDictionaryAsync(e => e.Uf, StringComparer.Ordinal, cancellationToken).ConfigureAwait(false);
+        Dictionary<string, Estado> jaVistos = new(StringComparer.Ordinal);
+
+        await foreach (EstadoCru cru in fonte.LerEstadosAsync(cancellationToken).ConfigureAwait(false))
+        {
+            contador.ContarLido();
+            string? uf = ChaveSigla(cru.Uf);
+            if (uf is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            indicadores.TryGetValue(uf, out EstadoIndicadorCru? indicador);
+            string? codigoIbge = indicador?.CodigoIbge;
+            decimal? latitude = ParseTolerante.ParaDecimal(cru.Latitude);
+            decimal? longitude = ParseTolerante.ParaDecimal(cru.Longitude);
+            Point? coordenada = PontoFactory.Criar(cru.Latitude, cru.Longitude);
+
+            Estado? estado = Upsert(
+                uf,
+                jaVistos,
+                existentes,
+                () => Estado.Importar(brasilId, uf, cru.Nome ?? string.Empty, cru.NomeSemAcento, cru.Regiao, cru.Capital, codigoIbge, latitude, longitude, coordenada, cru.FaixaIni, cru.FaixaFim, fonte.Versao),
+                existente => existente.Atualizar(brasilId, cru.Nome ?? string.Empty, cru.NomeSemAcento, cru.Regiao, cru.Capital, codigoIbge, latitude, longitude, coordenada, cru.FaixaIni, cru.FaixaFim, fonte.Versao),
+                _contexto.Estados,
+                contador);
+
+            if (estado is not null)
+            {
+                estadosPorUf[uf] = estado.Id;
+            }
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        LogTabelaConcluida(_logger, "estado", contador.Lidos, contador.Inseridos, contador.Atualizados);
+        return estadosPorUf;
+    }
+
+    private async Task ImportarEstadoIndicadoresAsync(
+        Dictionary<string, Guid> estadosPorUf,
+        Dictionary<string, EstadoIndicadorCru> indicadores,
+        string versao,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("estado_indicador");
+        Dictionary<Guid, EstadoIndicador> existentes =
+            await _contexto.EstadoIndicadores.ToDictionaryAsync(i => i.EstadoId, cancellationToken).ConfigureAwait(false);
+
+        foreach ((string uf, EstadoIndicadorCru cru) in indicadores)
+        {
+            contador.ContarLido();
+            if (!estadosPorUf.TryGetValue(uf, out Guid estadoId))
+            {
+                contador.ContarOrfao(uf);
+                continue;
+            }
+
+            decimal? area = MetricaDecimal(cru.AreaTerritorialKm2, "area_territorial_km2", contador);
+            int? populacao = MetricaInteira(cru.PopulacaoResidente2022, "populacao_residente_2022", contador);
+            decimal? densidade = MetricaDecimal(cru.DensidadeDemografica, "densidade_demografica_hab_km2", contador);
+            int? matriculas = MetricaInteira(cru.MatriculasEnsinoFundamental2023, "matriculas_ensino_fundamental_2023", contador);
+            decimal? idh = MetricaDecimal(cru.Idh, "idh_indice_desenv_humano", contador);
+            decimal? receitas = MetricaDecimal(cru.ReceitasBrutas, "total_receitas_brutas_realizadas", contador);
+            decimal? despesas = MetricaDecimal(cru.DespesasBrutas, "total_despesas_brutas_empenhadas", contador);
+            int? rendimento = MetricaInteira(cru.RendimentoMensalPerCapita, "rendimento_mensal_per_capita", contador);
+            int? veiculos = MetricaInteira(cru.TotalVeiculos2023, "total_veiculos_2023", contador);
+
+            if (existentes.TryGetValue(estadoId, out EstadoIndicador? existente))
+            {
+                existente.Atualizar(cru.Gentilico, cru.Governador, area, populacao, densidade, matriculas, idh, receitas, despesas, rendimento, veiculos, versao);
+                contador.ContarAtualizado();
+            }
+            else
+            {
+                Result<EstadoIndicador> criado = EstadoIndicador.Importar(estadoId, cru.Gentilico, cru.Governador, area, populacao, densidade, matriculas, idh, receitas, despesas, rendimento, veiculos, versao);
+                if (criado.IsFailure)
+                {
+                    contador.ContarIgnoradoSemChave();
+                    continue;
+                }
+
+                _contexto.EstadoIndicadores.Add(criado.Value!);
+                contador.ContarInserido();
+            }
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        LogTabelaConcluida(_logger, "estado_indicador", contador.Lidos, contador.Inseridos, contador.Atualizados);
+    }
+
+    private async Task ImportarEstadoFaixasAsync(
+        IGeoFonteDados fonte,
+        Dictionary<string, Guid> estadosPorUf,
+        string versao,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("estado_faixa");
+
+        // Upsert por chave natural (estado_id, cep_inicial, cep_final) — UNIQUE — em
+        // vez de delete+insert: preserva o Id da faixa entre cargas (idempotência real)
+        // e o dedup intra-fonte do Upsert evita que faixas repetidas na fonte estourem
+        // a UNIQUE e provoquem rollback total. A remoção de faixas que somem entre
+        // releases (stale) é da Story de atualização periódica (#674).
+        Guid[] estadoIds = [.. estadosPorUf.Values];
+        Dictionary<string, EstadoFaixaCep> existentes =
+            (await _contexto.EstadoFaixasCep.Where(f => estadoIds.Contains(f.EstadoId)).ToListAsync(cancellationToken).ConfigureAwait(false))
+            .ToDictionary(f => ChaveFaixa(f.EstadoId, f.CepInicial, f.CepFinal), StringComparer.Ordinal);
+        Dictionary<string, EstadoFaixaCep> jaVistas = new(StringComparer.Ordinal);
+
+        await foreach (EstadoFaixaCru cru in fonte.LerEstadoFaixasAsync(cancellationToken).ConfigureAwait(false))
+        {
+            contador.ContarLido();
+            string? uf = ChaveSigla(cru.Uf);
+            if (uf is null || !estadosPorUf.TryGetValue(uf, out Guid estadoId))
+            {
+                contador.ContarOrfao(uf ?? "(sem uf)");
+                continue;
+            }
+
+            string? cepInicial = ChaveCodigo(cru.FaixaIni);
+            string? cepFinal = ChaveCodigo(cru.FaixaFim);
+            if (cepInicial is null || cepFinal is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            string chave = ChaveFaixa(estadoId, cepInicial, cepFinal);
+            Upsert(
+                chave,
+                jaVistas,
+                existentes,
+                () => EstadoFaixaCep.Importar(estadoId, cepInicial, cepFinal, cru.Descricao, versao),
+                existente => existente.Atualizar(cru.Descricao, versao),
+                _contexto.EstadoFaixasCep,
+                contador);
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        LogTabelaConcluida(_logger, "estado_faixa", contador.Lidos, contador.Inseridos, contador.Atualizados);
+    }
+
+    private async Task<Dictionary<string, Guid>> ImportarCidadesAsync(
+        IGeoFonteDados fonte,
+        Dictionary<string, Guid> estadosPorUf,
+        Dictionary<string, CidadeTerritorioCru> territorios,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("cidade");
+        Dictionary<string, Guid> cidadesPorCodigo = new(StringComparer.Ordinal);
+
+        Dictionary<string, Cidade> existentes =
+            await _contexto.Cidades.ToDictionaryAsync(c => c.CodigoIbge, StringComparer.Ordinal, cancellationToken).ConfigureAwait(false);
+        Dictionary<string, Cidade> jaVistas = new(StringComparer.Ordinal);
+
+        await foreach (CidadeCru cru in fonte.LerCidadesAsync(cancellationToken).ConfigureAwait(false))
+        {
+            contador.ContarLido();
+            string? codigoIbge = ChaveCodigo(cru.CodigoIbge);
+            if (codigoIbge is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            string? uf = ChaveSigla(cru.Uf);
+            if (uf is null || !estadosPorUf.TryGetValue(uf, out Guid estadoId))
+            {
+                contador.ContarOrfao(codigoIbge);
+                continue;
+            }
+
+            territorios.TryGetValue(codigoIbge, out CidadeTerritorioCru? territorio);
+            decimal? latitude = ParseTolerante.ParaDecimal(cru.Latitude);
+            decimal? longitude = ParseTolerante.ParaDecimal(cru.Longitude);
+            Point? coordenada = PontoFactory.Criar(cru.Latitude, cru.Longitude);
+
+            Cidade? cidade = Upsert(
+                codigoIbge,
+                jaVistas,
+                existentes,
+                () => Cidade.Importar(
+                    estadoId, uf, codigoIbge, cru.Nome ?? string.Empty, cru.NomeSemAcento, cru.Ddd, latitude, longitude, coordenada,
+                    territorio?.MesorregiaoCodigo, territorio?.MesorregiaoNome, territorio?.MicrorregiaoCodigo, territorio?.MicrorregiaoNome,
+                    territorio?.RegiaoIntermediariaCodigo, territorio?.RegiaoIntermediariaNome, territorio?.RegiaoImediataCodigo, territorio?.RegiaoImediataNome,
+                    fonte.Versao),
+                existente => existente.Atualizar(
+                    estadoId, uf, cru.Nome ?? string.Empty, cru.NomeSemAcento, cru.Ddd, latitude, longitude, coordenada,
+                    territorio?.MesorregiaoCodigo, territorio?.MesorregiaoNome, territorio?.MicrorregiaoCodigo, territorio?.MicrorregiaoNome,
+                    territorio?.RegiaoIntermediariaCodigo, territorio?.RegiaoIntermediariaNome, territorio?.RegiaoImediataCodigo, territorio?.RegiaoImediataNome,
+                    fonte.Versao),
+                _contexto.Cidades,
+                contador);
+
+            if (cidade is not null)
+            {
+                cidadesPorCodigo[codigoIbge] = cidade.Id;
+            }
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        LogTabelaConcluida(_logger, "cidade", contador.Lidos, contador.Inseridos, contador.Atualizados);
+        return cidadesPorCodigo;
+    }
+
+    private async Task ImportarCidadeIndicadoresAsync(
+        IGeoFonteDados fonte,
+        Dictionary<string, Guid> cidadesPorCodigo,
+        string versao,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("cidade_indicador");
+        Dictionary<string, CidadeIndicadorCru> porCodigo =
+            await AgregarPorChaveAsync(fonte.LerCidadeIndicadoresAsync(cancellationToken), i => ChaveCodigo(i.CodigoIbge)).ConfigureAwait(false);
+        Dictionary<Guid, CidadeIndicador> existentes =
+            await _contexto.CidadeIndicadores.ToDictionaryAsync(i => i.CidadeId, cancellationToken).ConfigureAwait(false);
+
+        foreach ((string codigo, CidadeIndicadorCru cru) in porCodigo)
+        {
+            contador.ContarLido();
+            if (!cidadesPorCodigo.TryGetValue(codigo, out Guid cidadeId))
+            {
+                contador.ContarOrfao(codigo);
+                continue;
+            }
+
+            decimal? area = MetricaDecimal(cru.AreaTerritorialKm2, "area_territorial_km2", contador);
+            int? populacao = MetricaInteira(cru.PopulacaoResidente, "populacao_residente", contador);
+            decimal? densidade = MetricaDecimal(cru.DensidadeDemografica, "densidade_demografica", contador);
+            decimal? escolarizacao = MetricaDecimal(cru.Escolarizacao6a14, "escolarizacao_6_a_14_anos", contador);
+            decimal? idh = MetricaDecimal(cru.Idh, "idice_de_desenv_humano", contador);
+            decimal? mortalidade = MetricaDecimal(cru.MortalidadeInfantil, "mortalidade_infantil", contador);
+            decimal? receitas = MetricaDecimal(cru.Receitas, "receitas_realizadas", contador);
+            decimal? despesas = MetricaDecimal(cru.Despesas, "despesas_empenhadas", contador);
+            decimal? pib = MetricaDecimal(cru.PibPerCapita, "pib_per_capita", contador);
+
+            if (existentes.TryGetValue(cidadeId, out CidadeIndicador? existente))
+            {
+                existente.Atualizar(cru.Gentilico, cru.Prefeito, area, populacao, densidade, escolarizacao, idh, mortalidade, receitas, despesas, pib, cru.Aniversario, versao);
+                contador.ContarAtualizado();
+            }
+            else
+            {
+                Result<CidadeIndicador> criado = CidadeIndicador.Importar(cidadeId, cru.Gentilico, cru.Prefeito, area, populacao, densidade, escolarizacao, idh, mortalidade, receitas, despesas, pib, cru.Aniversario, versao);
+                if (criado.IsFailure)
+                {
+                    contador.ContarIgnoradoSemChave();
+                    continue;
+                }
+
+                _contexto.CidadeIndicadores.Add(criado.Value!);
+                contador.ContarInserido();
+            }
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        LogTabelaConcluida(_logger, "cidade_indicador", contador.Lidos, contador.Inseridos, contador.Atualizados);
+    }
+
+    private async Task ImportarCidadeFaixasAsync(
+        IGeoFonteDados fonte,
+        Dictionary<string, Guid> cidadesPorCodigo,
+        string versao,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("cidade_faixa");
+
+        // Upsert por chave natural (cidade_id, cep_inicial, cep_final) — UNIQUE — com
+        // dedup intra-fonte (ver estado_faixa): preserva Id e não estoura a UNIQUE.
+        Guid[] cidadeIds = [.. cidadesPorCodigo.Values];
+        Dictionary<string, CidadeFaixaCep> existentes =
+            (await _contexto.CidadeFaixasCep.Where(f => cidadeIds.Contains(f.CidadeId)).ToListAsync(cancellationToken).ConfigureAwait(false))
+            .ToDictionary(f => ChaveFaixa(f.CidadeId, f.CepInicial, f.CepFinal), StringComparer.Ordinal);
+        Dictionary<string, CidadeFaixaCep> jaVistas = new(StringComparer.Ordinal);
+
+        await foreach (CidadeFaixaCru cru in fonte.LerCidadeFaixasAsync(cancellationToken).ConfigureAwait(false))
+        {
+            contador.ContarLido();
+            string? codigo = ChaveCodigo(cru.CodigoIbge);
+            if (codigo is null || !cidadesPorCodigo.TryGetValue(codigo, out Guid cidadeId))
+            {
+                contador.ContarOrfao(codigo ?? "(sem codigo)");
+                continue;
+            }
+
+            string? cepInicial = ChaveCodigo(cru.FaixaIni);
+            string? cepFinal = ChaveCodigo(cru.FaixaFim);
+            if (cepInicial is null || cepFinal is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            string chave = ChaveFaixa(cidadeId, cepInicial, cepFinal);
+            Upsert(
+                chave,
+                jaVistas,
+                existentes,
+                () => CidadeFaixaCep.Importar(cidadeId, cepInicial, cepFinal, versao),
+                existente => existente.Atualizar(versao),
+                _contexto.CidadeFaixasCep,
+                contador);
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        LogTabelaConcluida(_logger, "cidade_faixa", contador.Lidos, contador.Inseridos, contador.Atualizados);
+    }
+
+    // Upsert por chave natural com dedup intra-fonte: chaves repetidas na própria
+    // carga não disparam unique violation — a 2ª ocorrência atualiza a entidade já
+    // vista (last-wins) e conta como duplicada. Retorna a entidade (para resolver FK)
+    // ou null em falha de validação do domínio.
+    private static T? Upsert<T>(
+        string chave,
+        Dictionary<string, T> jaVistas,
+        Dictionary<string, T> existentes,
+        Func<Result<T>> criar,
+        Func<T, Result> atualizar,
+        DbSet<T> dbSet,
+        ContadorTabela contador)
+        where T : class
+    {
+        if (jaVistas.TryGetValue(chave, out T? jaVista))
+        {
+            contador.ContarDuplicado(chave);
+            Result reatualizacao = atualizar(jaVista);
+            return reatualizacao.IsSuccess ? jaVista : null;
+        }
+
+        if (existentes.TryGetValue(chave, out T? existente))
+        {
+            Result atualizacao = atualizar(existente);
+            if (atualizacao.IsFailure)
+            {
+                contador.ContarIgnoradoSemChave();
+                return null;
+            }
+
+            jaVistas[chave] = existente;
+            contador.ContarAtualizado();
+            return existente;
+        }
+
+        Result<T> criado = criar();
+        if (criado.IsFailure)
+        {
+            contador.ContarIgnoradoSemChave();
+            return null;
+        }
+
+        dbSet.Add(criado.Value!);
+        jaVistas[chave] = criado.Value!;
+        contador.ContarInserido();
+        return criado.Value;
+    }
+
+    private static async Task<Dictionary<string, T>> AgregarPorChaveAsync<T>(
+        IAsyncEnumerable<T> fonte,
+        Func<T, string?> chave)
+    {
+        Dictionary<string, T> mapa = new(StringComparer.Ordinal);
+        await foreach (T item in fonte.ConfigureAwait(false))
+        {
+            string? k = chave(item);
+            if (k is not null)
+            {
+                mapa[k] = item; // last-wins
+            }
+        }
+
+        return mapa;
+    }
+
+    // Parse tolerante de métrica IBGE que registra a degradação ('-'/vazio/inválido →
+    // null) no relatório para auditoria. Sem PII — métricas socioeconômicas públicas.
+    private static decimal? MetricaDecimal(string? cru, string coluna, ContadorTabela contador)
+    {
+        decimal? valor = ParseTolerante.ParaDecimal(cru);
+        if (valor is null && !string.IsNullOrWhiteSpace(cru))
+        {
+            contador.ContarParseDegradado($"{coluna}={cru.Trim()}");
+        }
+
+        return valor;
+    }
+
+    private static int? MetricaInteira(string? cru, string coluna, ContadorTabela contador)
+    {
+        int? valor = ParseTolerante.ParaInteiro(cru);
+        if (valor is null && !string.IsNullOrWhiteSpace(cru))
+        {
+            contador.ContarParseDegradado($"{coluna}={cru.Trim()}");
+        }
+
+        return valor;
+    }
+
+    private static string? ChaveSigla(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim().ToUpperInvariant();
+
+    private static string? ChaveCodigo(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    // Chave natural composta de uma faixa de CEP: pai (Guid) + limites. Casa com a
+    // UNIQUE (estado_id|cidade_id, cep_inicial, cep_final) para o upsert idempotente.
+    private static string ChaveFaixa(Guid pai, string cepInicial, string cepFinal) =>
+        $"{pai:N}|{cepInicial}|{cepFinal}";
+
+    private static int Total(RelatorioImportacao relatorio, Func<ContadorTabela, int> seletor) =>
+        relatorio.Tabelas.Values.Sum(seletor);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: carga iniciada (versão {Versao}).")]
+    private static partial void LogCargaIniciada(ILogger logger, string versao);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: tabela {Tabela} concluída (lidos={Lidos}, inseridos={Inseridos}, atualizados={Atualizados}).")]
+    private static partial void LogTabelaConcluida(ILogger logger, string tabela, int lidos, int inseridos, int atualizados);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: carga concluída (versão {Versao}, inseridos={Inseridos}, atualizados={Atualizados}, órfãos={Orfaos}, degradados={Degradados}).")]
+    private static partial void LogCargaConcluida(ILogger logger, string versao, int inseridos, int atualizados, int orfaos, int degradados);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/IGeoImportador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/IGeoImportador.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+
+/// <summary>
+/// Importador idempotente de reference data do Geo a partir do dataset DNE
+/// (ADR-0092). A carga é um serviço transacional de <c>Geo.Infrastructure</c>
+/// (não um command Wolverine — não há regra de negócio nem evento de domínio,
+/// é carga de reference data autoritativo). A proveniência (<c>versao_dataset</c>)
+/// vem da própria <see cref="IGeoFonteDados.Versao"/>.
+/// </summary>
+internal interface IGeoImportador
+{
+    /// <summary>
+    /// Importa o topo da hierarquia (País → Estado → Cidade, com indicadores e faixas)
+    /// numa única transação: upsert por chave natural (idempotente — reaplicar a mesma
+    /// versão deixa o banco idêntico), órfãos e degradações tolerados (vão ao relatório,
+    /// não abortam a carga). Falha de infraestrutura faz rollback total.
+    /// </summary>
+    Task<RelatorioImportacao> ImportarAsync(IGeoFonteDados fonte, CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Parsing/ParseTolerante.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Parsing/ParseTolerante.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Parsing;
+
+using System.Globalization;
+
+/// <summary>
+/// Conversores tolerantes do ETL DNE (ADR-0092). A fonte é toda <c>varchar</c> e
+/// traz <c>'-'</c>/vazio para dado ausente (≈27% dos municípios em
+/// <c>mortalidade_infantil</c>): toda métrica externa é <c>nullable</c> e
+/// <c>'-'</c>/vazio/não-numérico <strong>degrada para <see langword="null"/> sem
+/// lançar</strong>, para a carga nunca abortar por dado sujo. <see cref="CultureInfo.InvariantCulture"/>
+/// sempre — a fonte usa ponto como separador decimal.
+/// </summary>
+internal static class ParseTolerante
+{
+    // Sinal + ponto decimal apenas. SEM AllowThousands: a fonte usa ponto como
+    // separador decimal e não tem milhar; aceitar vírgula faria "6,52" virar 652
+    // (corrompendo o dado) em vez de degradar — queremos rejeitar e cair para null.
+    private const NumberStyles EstiloDecimal = NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint;
+
+    /// <summary>Converte para <see cref="decimal"/> tolerante; ausência/inválido → <see langword="null"/>.</summary>
+    public static decimal? ParaDecimal(string? valor) =>
+        decimal.TryParse(Limpar(valor), EstiloDecimal, CultureInfo.InvariantCulture, out decimal numero)
+            ? numero
+            : null;
+
+    /// <summary>Converte para <see cref="int"/> tolerante; ausência/inválido → <see langword="null"/>.</summary>
+    public static int? ParaInteiro(string? valor) =>
+        int.TryParse(Limpar(valor), NumberStyles.Integer, CultureInfo.InvariantCulture, out int numero)
+            ? numero
+            : null;
+
+    /// <summary>Mapeia o indicador <c>'S'</c>/<c>'N'</c> da DNE para <see cref="bool"/> (só <c>'S'</c> é verdadeiro).</summary>
+    public static bool ParaBoolSn(string? valor) =>
+        string.Equals(Limpar(valor), "S", StringComparison.OrdinalIgnoreCase);
+
+    // Trim; '-' (sentinela de ausência da DNE) e vazio/branco viram null antes do TryParse.
+    private static string? Limpar(string? valor)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return null;
+        }
+
+        string limpo = valor.Trim();
+        return limpo == "-" ? null : limpo;
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Parsing/PontoFactory.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Parsing/PontoFactory.cs
@@ -1,0 +1,36 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Parsing;
+
+using NetTopologySuite.Geometries;
+
+/// <summary>
+/// Materializa a coordenada textual da DNE (latitude/longitude) num
+/// <see cref="Point"/> SRID 4326 — <c>geography(Point,4326)</c> (ADR-0091).
+/// Parse tolerante: se qualquer componente faltar ou não parsear, retorna
+/// <see langword="null"/> (a coordenada é opcional). Ordem PostGIS/NTS:
+/// <strong>X = longitude, Y = latitude</strong>.
+/// </summary>
+internal static class PontoFactory
+{
+    private const int Srid4326 = 4326;
+
+    public static Point? Criar(string? latitude, string? longitude)
+    {
+        decimal? lat = ParseTolerante.ParaDecimal(latitude);
+        decimal? lon = ParseTolerante.ParaDecimal(longitude);
+
+        if (lat is null || lon is null)
+        {
+            return null;
+        }
+
+        // Coordenada fora do domínio geográfico (lat ∈ [-90,90], lon ∈ [-180,180])
+        // degrada para null: um dado opcional sujo não pode estourar no
+        // geography(Point,4326) e derrubar a carga inteira (parse tolerante, ADR-0092).
+        if (lat.Value is < -90m or > 90m || lon.Value is < -180m or > 180m)
+        {
+            return null;
+        }
+
+        return new Point((double)lon.Value, (double)lat.Value) { SRID = Srid4326 };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/RelatorioImportacao.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/RelatorioImportacao.cs
@@ -1,0 +1,110 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+/// <summary>
+/// Acumula o resultado de uma carga do ETL DNE por tabela (ADR-0092): contadores
+/// (lidos/inseridos/atualizados/órfãos/duplicados/ignorados/degradados) e amostras
+/// de divergência (valor cru não-parseável que degradou para <see langword="null"/>,
+/// órfão, duplicata) para auditoria. <strong>Reference data público — NUNCA carrega
+/// PII</strong>; é emitido ao fim via <c>[LoggerMessage]</c>. A carga não aborta por
+/// dado sujo (vai para o relatório); aborta só por falha de infraestrutura.
+/// </summary>
+internal sealed class RelatorioImportacao
+{
+    private const int MaxAmostrasPorTabela = 25;
+
+    private readonly Dictionary<string, ContadorTabela> _tabelas = new(StringComparer.Ordinal);
+
+    public RelatorioImportacao(string versaoDataset)
+    {
+        VersaoDataset = versaoDataset;
+    }
+
+    /// <summary>Release DNE (AAAAMM) desta carga.</summary>
+    public string VersaoDataset { get; }
+
+    public IReadOnlyDictionary<string, ContadorTabela> Tabelas => _tabelas;
+
+    /// <summary>Obtém (criando se necessário) o contador da tabela informada.</summary>
+    public ContadorTabela Tabela(string nome)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(nome);
+
+        if (!_tabelas.TryGetValue(nome, out ContadorTabela? contador))
+        {
+            contador = new ContadorTabela(nome, MaxAmostrasPorTabela);
+            _tabelas[nome] = contador;
+        }
+
+        return contador;
+    }
+}
+
+/// <summary>Contadores e amostras de divergência de uma tabela na carga do ETL.</summary>
+internal sealed class ContadorTabela
+{
+    private readonly int _maxAmostras;
+    private readonly List<string> _amostras = [];
+
+    internal ContadorTabela(string tabela, int maxAmostras)
+    {
+        Tabela = tabela;
+        _maxAmostras = maxAmostras;
+    }
+
+    public string Tabela { get; }
+
+    public int Lidos { get; private set; }
+
+    public int Inseridos { get; private set; }
+
+    public int Atualizados { get; private set; }
+
+    /// <summary>Registros sem chave natural utilizável (descartados).</summary>
+    public int IgnoradosSemChave { get; private set; }
+
+    /// <summary>Registros cuja FK obrigatória não resolveu (descartados).</summary>
+    public int Orfaos { get; private set; }
+
+    /// <summary>Chaves naturais repetidas dentro da própria fonte (last-wins).</summary>
+    public int Duplicados { get; private set; }
+
+    /// <summary>Valores externos que não parsearam e degradaram para <see langword="null"/>.</summary>
+    public int ParsesDegradados { get; private set; }
+
+    /// <summary>Amostras (sem PII) de divergências, limitadas para não inflar o log.</summary>
+    public IReadOnlyList<string> Amostras => _amostras;
+
+    public void ContarLido() => Lidos++;
+
+    public void ContarInserido() => Inseridos++;
+
+    public void ContarAtualizado() => Atualizados++;
+
+    public void ContarIgnoradoSemChave() => IgnoradosSemChave++;
+
+    public void ContarOrfao(string amostra)
+    {
+        Orfaos++;
+        Amostrar(amostra);
+    }
+
+    public void ContarDuplicado(string amostra)
+    {
+        Duplicados++;
+        Amostrar(amostra);
+    }
+
+    public void ContarParseDegradado(string amostra)
+    {
+        ParsesDegradados++;
+        Amostrar(amostra);
+    }
+
+    private void Amostrar(string amostra)
+    {
+        if (_amostras.Count < _maxAmostras)
+        {
+            _amostras.Add(amostra);
+        }
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Unifesspa.UniPlus.Geo.Infrastructure.csproj
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Unifesspa.UniPlus.Geo.Infrastructure.csproj
@@ -14,4 +14,10 @@
     <ProjectReference Include="..\Unifesspa.UniPlus.Geo.Application\Unifesspa.UniPlus.Geo.Application.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expõe internals (ETL: importador, fonte, parse) aos testes de integração —
+         mesmo padrão dos demais módulos. -->
+    <InternalsVisibleTo Include="Unifesspa.UniPlus.Geo.IntegrationTests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/DneStagingFonteTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/DneStagingFonteTests.cs
@@ -1,0 +1,174 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// <see cref="DneStagingFonte"/>: lê o dataset DNE de um schema de staging real
+/// (dumps restaurados) por <c>SELECT</c> streamado, e o importador roda fim-a-fim
+/// sobre ele. Cobre também a validação anti-injeção de versão/schema.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class DneStagingFonteTests
+{
+    private const string Versao = "202601";
+    private const string CodigoMaraba = "1500402";
+
+    private readonly GeoPostgisFixture _fixture;
+
+    public DneStagingFonteTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Lê os registros do staging mapeando colunas para os records crus")]
+    public async Task LeRegistros_MapeiaColunas()
+    {
+        await CriarStagingAsync();
+        DneStagingFonte fonte = new(_fixture.ConnectionString, Versao);
+
+        List<PaisCru> paises = await ColetarAsync(fonte.LerPaisesAsync);
+        paises.Should().HaveCount(2);
+        paises.Should().Contain(p => p.SiglaIso == "BRA" && p.Nome == "Brasil");
+
+        List<EstadoCru> estados = await ColetarAsync(fonte.LerEstadosAsync);
+        estados.Should().ContainSingle(e => e.Uf == "PA" && e.Latitude == "-1.9981271");
+
+        List<CidadeCru> cidades = await ColetarAsync(fonte.LerCidadesAsync);
+        cidades.Should().ContainSingle(c => c.CodigoIbge == CodigoMaraba && c.Uf == "PA");
+    }
+
+    [Fact(DisplayName = "Importador roda fim-a-fim sobre o staging (SELECT streamado → upsert), com parse tolerante")]
+    public async Task EndToEnd_PopulaBancoViaStaging()
+    {
+        await LimparDominioAsync();
+        await CriarStagingAsync();
+
+        DneStagingFonte fonte = new(_fixture.ConnectionString, Versao);
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            GeoImportadorPaisEstadoCidade importador = new(ctx, NullLogger<GeoImportadorPaisEstadoCidade>.Instance);
+            await importador.ImportarAsync(fonte, CancellationToken.None);
+        }
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Paises.CountAsync()).Should().Be(1);
+        Estado para = await leitura.Estados.SingleAsync(e => e.Uf == "PA");
+        para.CodigoIbge.Should().Be("15");
+
+        Cidade maraba = await leitura.Cidades.SingleAsync(c => c.CodigoIbge == CodigoMaraba);
+        maraba.MesorregiaoNome.Should().Be("Sudeste Paraense");
+        maraba.Coordenada.Should().NotBeNull();
+
+        CidadeIndicador indicador = await leitura.CidadeIndicadores.SingleAsync(i => i.CidadeId == maraba.Id);
+        indicador.MortalidadeInfantil.Should().BeNull(); // '-' no staging degradou para null
+    }
+
+    [Theory(DisplayName = "Versão fora do formato AAAAMM é rejeitada no construtor (anti-injeção)")]
+    [InlineData("abc")]
+    [InlineData("2026")]
+    [InlineData("20260")]
+    [InlineData("2026-01")]
+    public void VersaoInvalida_Lanca(string versao)
+    {
+        Action criar = () => _ = new DneStagingFonte(_fixture.ConnectionString, versao);
+        criar.Should().Throw<ArgumentException>();
+    }
+
+    [Theory(DisplayName = "Nome de schema não-identificador é rejeitado no construtor (anti-injeção)")]
+    [InlineData("dne staging")]
+    [InlineData("dne;drop")]
+    [InlineData("1schema")]
+    public void SchemaInvalido_Lanca(string schema)
+    {
+        Action criar = () => _ = new DneStagingFonte(_fixture.ConnectionString, Versao, schema);
+        criar.Should().Throw<ArgumentException>();
+    }
+
+    private static async Task<List<T>> ColetarAsync<T>(Func<CancellationToken, IAsyncEnumerable<T>> ler)
+    {
+        List<T> itens = [];
+        await foreach (T item in ler(CancellationToken.None).ConfigureAwait(false))
+        {
+            itens.Add(item);
+        }
+
+        return itens;
+    }
+
+    private async Task LimparDominioAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE TABLE pais CASCADE");
+    }
+
+    private async Task CriarStagingAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        await ctx.Database.ExecuteSqlRawAsync(StagingSql);
+    }
+
+    // Schema de staging reduzido: só as colunas que a DneStagingFonte projeta, com
+    // dados mínimos consistentes (Brasil + Pará + Marabá; mortalidade '-' para o parse
+    // tolerante). Recriado a cada teste (DROP CASCADE) para isolamento.
+    private const string StagingSql = """
+        DROP SCHEMA IF EXISTS dne_staging CASCADE;
+        CREATE SCHEMA dne_staging;
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_paises_ibge" (
+            sigla_iso text, sigla text, nome_pt text, pais_bcb text, pais_rbf text, pais_sped text, pais_siscomex text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_paises_ibge" VALUES
+            ('BRA','BR','Brasil','1058','106','1058','105'),
+            ('ARG','AR','Argentina','639','63','639','63');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_estado" (
+            sigla text, estado text, estado_sem_acento text, regiao text, capital text,
+            faixa_ini text, faixa_fim text, latitude text, longitude text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_estado" VALUES
+            ('PA','Pará','Para','Norte','Belém','66000000','68899999','-1.9981271','-54.9306152');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_estado_ibge" (
+            uf text, codigo_ibge text, gentilico text, governador text, area_territorial_km2 text,
+            populacao_residente_2022 text, densidade_demografica_hab_km2 text, matriculas_ensino_fundamental_2023 text,
+            idh_indice_desenv_humano text, total_receitas_brutas_realizadas text, total_despesas_brutas_empenhadas text,
+            rendimento_mensal_per_capita text, total_veiculos_2023 text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_estado_ibge" VALUES
+            ('PA','15','paraense','HELDER','1245870.242','8120131','6.52','1331723','0.69','52747856526.44','43981234831.53','1282','2627090');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_estado_faixa" (
+            sigla text, regiao text, faixa_ini text, faixa_fim text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_estado_faixa" VALUES ('PA','Pará','66000000','68899999');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_cidade" (
+            cidade_ibge text, cidade text, cidade_sem_acento text, estado text, ddd text, latitude text, longitude text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_cidade" VALUES
+            ('1500402','Marabá','Maraba','PA','94','-5.36867','-49.11731');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_cidade_ibge_territorio" (
+            cidade_ibge text, mesorregiao text, mesorregiao_nome text, microrregiao text, microrregiao_nome text,
+            regiao_intermediaria text, regiao_intermediaria_nome text,
+            regiao_geografica_imediata text, regiao_geografica_imediata_nome text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_cidade_ibge_territorio" VALUES
+            ('1500402','1503','Sudeste Paraense','15009','Marabá','1503','Marabá','150009','Marabá');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_cidade_ibge" (
+            cidade_ibge text, gentilico text, prefeito text, area_territorial_km2 text, populacao_residente text,
+            densidade_demografica text, escolarizacao_6_a_14_anos text, idice_de_desenv_humano text,
+            mortalidade_infantil text, receitas_realizadas text, despesas_empenhadas text, pib_per_capita text,
+            aniversario_municipio text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_cidade_ibge" VALUES
+            ('1500402','marabaense','PREFEITO','15128.27','283542','18.7','96.5','0.668','-','1234567.89','1000000.00','25000.00','05/04');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_cidade_faixa" (
+            cidade_ibge text, faixa_ini text, faixa_fim text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_cidade_faixa" VALUES ('1500402','68500000','68519999');
+        """;
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlPaisEstadoCidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlPaisEstadoCidadeTests.cs
@@ -60,6 +60,27 @@ public sealed class EtlPaisEstadoCidadeTests
         (await leitura.EstadoFaixasCep.CountAsync()).Should().Be(2);
         (await leitura.CidadeIndicadores.CountAsync()).Should().Be(2);
         (await leitura.CidadeFaixasCep.CountAsync()).Should().Be(1);
+
+        // Métrica IBGE decimal/inteira não-nula carregada com InvariantCulture (ponto
+        // decimal) — pega um eventual erro de tipo/cultura que a degradação não cobre.
+        EstadoIndicador indicadorPara = await leitura.EstadoIndicadores.SingleAsync(i => i.EstadoId == para.Id);
+        indicadorPara.Idh.Should().Be(0.69m);
+        indicadorPara.ReceitasBrutas.Should().Be(52747856526.44m);
+        indicadorPara.PopulacaoResidente2022.Should().Be(8120131);
+    }
+
+    [Fact(DisplayName = "Relatório: indicador sem chave natural na fonte é contado em Lidos e IgnoradosSemChave (não some na agregação)")]
+    public async Task RelatorioIndicador_ContaDescartePorChaveAusente()
+    {
+        await LimparAsync();
+        FonteEmMemoria fonte = FonteCompleta();
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador(uf: null, codigoIbge: "99")); // chave nula
+
+        RelatorioImportacao relatorio = await ExecutarAsync(fonte);
+
+        // 2 com UF (PA, SP) + 1 sem UF = 3 lidos; o sem-UF é contado como ignorado.
+        relatorio.Tabelas["estado_indicador"].Lidos.Should().Be(3);
+        relatorio.Tabelas["estado_indicador"].IgnoradosSemChave.Should().BeGreaterThanOrEqualTo(1);
     }
 
     [Fact(DisplayName = "CA-05: apenas o registro BRA é carregado, mesmo com países estrangeiros na fonte")]

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlPaisEstadoCidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlPaisEstadoCidadeTests.cs
@@ -1,0 +1,226 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Carga do ETL País/Estado/Cidade (Story #672) sobre Postgres+PostGIS real
+/// (<see cref="GeoPostgisFixture"/>): carga inicial, idempotência com Guid preservado,
+/// parse tolerante, órfãos, filtro Brasil, dedup intra-fonte e rollback transacional.
+/// Cada teste limpa as tabelas antes (a coleção roda sem paralelismo).
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class EtlPaisEstadoCidadeTests
+{
+    private const string CodigoMaraba = "1500402";
+    private const string CodigoSaoPaulo = "3550308";
+    private const string CodigoCidadeOrfa = "9999999";
+
+    private readonly GeoPostgisFixture _fixture;
+
+    public EtlPaisEstadoCidadeTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01: carga inicial popula País (Brasil), Estados e Cidades com coordenada 4326 e territorial embutido")]
+    public async Task CargaInicial_PopulaHierarquia()
+    {
+        await LimparAsync();
+        await ExecutarAsync(FonteCompleta());
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+
+        (await leitura.Paises.CountAsync()).Should().Be(1);
+        Pais brasil = await leitura.Paises.SingleAsync();
+        brasil.SiglaIso.Should().Be("BRA");
+
+        (await leitura.Estados.CountAsync()).Should().Be(2);
+        Estado para = await leitura.Estados.SingleAsync(e => e.Uf == "PA");
+        para.PaisId.Should().Be(brasil.Id);
+        para.CodigoIbge.Should().Be("15");
+
+        // A cidade órfã (UF inexistente) não entra; restam as 2 válidas.
+        (await leitura.Cidades.CountAsync()).Should().Be(2);
+        Cidade maraba = await leitura.Cidades.SingleAsync(c => c.CodigoIbge == CodigoMaraba);
+        maraba.EstadoId.Should().Be(para.Id);
+        maraba.MesorregiaoNome.Should().Be("Sudeste Paraense"); // territorial embutido (join por código IBGE)
+        maraba.Coordenada.Should().NotBeNull();
+        maraba.Coordenada!.SRID.Should().Be(4326);
+
+        (await leitura.EstadoIndicadores.CountAsync()).Should().Be(2);
+        (await leitura.EstadoFaixasCep.CountAsync()).Should().Be(2);
+        (await leitura.CidadeIndicadores.CountAsync()).Should().Be(2);
+        (await leitura.CidadeFaixasCep.CountAsync()).Should().Be(1);
+    }
+
+    [Fact(DisplayName = "CA-05: apenas o registro BRA é carregado, mesmo com países estrangeiros na fonte")]
+    public async Task SomenteBrasil_IgnoraEstrangeiros()
+    {
+        await LimparAsync();
+        RelatorioImportacao relatorio = await ExecutarAsync(FonteCompleta());
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Paises.CountAsync()).Should().Be(1);
+        (await leitura.Paises.SingleAsync()).SiglaIso.Should().Be("BRA");
+
+        relatorio.Tabelas["pais"].Lidos.Should().Be(3);     // BRA + ARG + USA lidos da fonte
+        relatorio.Tabelas["pais"].Inseridos.Should().Be(1); // só BRA persistido
+    }
+
+    [Fact(DisplayName = "CA-04: cidade cujo Estado não foi carregado é contada como órfã e não persistida")]
+    public async Task CidadeOrfa_NaoInsereERegistra()
+    {
+        await LimparAsync();
+        RelatorioImportacao relatorio = await ExecutarAsync(FonteCompleta());
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Cidades.AnyAsync(c => c.CodigoIbge == CodigoCidadeOrfa)).Should().BeFalse();
+        relatorio.Tabelas["cidade"].Orfaos.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact(DisplayName = "CA-03: indicador com mortalidade '-' persiste null e conta como parse degradado, sem abortar")]
+    public async Task ParseTolerante_HifenDegradaParaNull()
+    {
+        await LimparAsync();
+        RelatorioImportacao relatorio = await ExecutarAsync(FonteCompleta());
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        Cidade maraba = await leitura.Cidades.SingleAsync(c => c.CodigoIbge == CodigoMaraba);
+        CidadeIndicador indicador = await leitura.CidadeIndicadores.SingleAsync(i => i.CidadeId == maraba.Id);
+
+        indicador.MortalidadeInfantil.Should().BeNull();
+        relatorio.Tabelas["cidade_indicador"].ParsesDegradados.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact(DisplayName = "CA-02: reexecução preserva os Guids (não troca PK) e não duplica; o 2º passe reporta Atualizados")]
+    public async Task Idempotencia_PreservaGuidsESemDuplicar()
+    {
+        await LimparAsync();
+        FonteEmMemoria fonte = FonteCompleta();
+        await ExecutarAsync(fonte);
+
+        IdsCapturados primeiros = await CapturarIdsAsync();
+
+        RelatorioImportacao segunda = await ExecutarAsync(fonte);
+        IdsCapturados segundos = await CapturarIdsAsync();
+
+        // Inclui o Id de uma faixa: o upsert por chave natural não pode trocar a PK de
+        // ninguém (país/estado/cidade têm filhos; faixas preservam Id por idempotência).
+        segundos.Should().Be(primeiros, "o upsert in place não pode trocar a PK entre cargas");
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Paises.CountAsync()).Should().Be(1);
+        (await leitura.Estados.CountAsync()).Should().Be(2);
+        (await leitura.Cidades.CountAsync()).Should().Be(2);
+        (await leitura.EstadoIndicadores.CountAsync()).Should().Be(2);
+        (await leitura.EstadoFaixasCep.CountAsync()).Should().Be(2);
+        (await leitura.CidadeFaixasCep.CountAsync()).Should().Be(1);
+
+        segunda.Tabelas["pais"].Atualizados.Should().Be(1);
+        segunda.Tabelas["pais"].Inseridos.Should().Be(0);
+        segunda.Tabelas["estado"].Atualizados.Should().Be(2);
+        segunda.Tabelas["cidade"].Atualizados.Should().Be(2);
+        segunda.Tabelas["estado_faixa"].Atualizados.Should().Be(2);
+        segunda.Tabelas["estado_faixa"].Inseridos.Should().Be(0);
+    }
+
+    [Fact(DisplayName = "Dedup intra-fonte: duas linhas com a mesma UF não disparam unique violation; a 2ª conta como duplicata")]
+    public async Task DuplicataIntraFonte_NaoQuebraEContabiliza()
+    {
+        await LimparAsync();
+        FonteEmMemoria fonte = FonteCompleta();
+        fonte.Estados.Add(DadosDne.Estado("PA", "Pará (duplicado)", latitude: "-3.0", longitude: "-52.0"));
+
+        RelatorioImportacao relatorio = await ExecutarAsync(fonte);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Estados.CountAsync(e => e.Uf == "PA")).Should().Be(1);
+        relatorio.Tabelas["estado"].Duplicados.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact(DisplayName = "Rollback: falha no meio da carga reverte tudo — nem País nem Estado ficam persistidos")]
+    public async Task FalhaNoMeio_FazRollbackTotal()
+    {
+        await LimparAsync();
+        FonteComFalhaNasCidades fonte = new(FonteCompleta());
+
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            GeoImportadorPaisEstadoCidade importador = new(ctx, NullLogger<GeoImportadorPaisEstadoCidade>.Instance);
+            Func<Task> carga = () => importador.ImportarAsync(fonte, CancellationToken.None);
+            await carga.Should().ThrowAsync<InvalidOperationException>();
+        }
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Paises.CountAsync()).Should().Be(0);
+        (await leitura.Estados.CountAsync()).Should().Be(0);
+    }
+
+    private async Task<IdsCapturados> CapturarIdsAsync()
+    {
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        Guid brasil = (await leitura.Paises.SingleAsync(p => p.SiglaIso == "BRA")).Id;
+        Estado para = await leitura.Estados.SingleAsync(e => e.Uf == "PA");
+        Guid maraba = (await leitura.Cidades.SingleAsync(c => c.CodigoIbge == CodigoMaraba)).Id;
+        Guid indicadorPara = (await leitura.EstadoIndicadores.SingleAsync(i => i.EstadoId == para.Id)).Id;
+        Guid faixaPara = (await leitura.EstadoFaixasCep.SingleAsync(f => f.EstadoId == para.Id)).Id;
+        return new IdsCapturados(brasil, para.Id, maraba, indicadorPara, faixaPara);
+    }
+
+    private readonly record struct IdsCapturados(Guid Brasil, Guid Para, Guid Maraba, Guid IndicadorPara, Guid FaixaPara);
+
+    private async Task<RelatorioImportacao> ExecutarAsync(IGeoFonteDados fonte)
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        GeoImportadorPaisEstadoCidade importador = new(ctx, NullLogger<GeoImportadorPaisEstadoCidade>.Instance);
+        return await importador.ImportarAsync(fonte, CancellationToken.None);
+    }
+
+    private async Task LimparAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        // TRUNCATE ... CASCADE limpa toda a hierarquia (estado → cidade → satélites)
+        // por dependência de FK, isolando cada teste no banco compartilhado da coleção.
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE TABLE pais CASCADE");
+    }
+
+    private static FonteEmMemoria FonteCompleta()
+    {
+        FonteEmMemoria fonte = new() { Versao = "202601" };
+
+        fonte.Paises.Add(DadosDne.Pais("BRA", "Brasil", "BR"));
+        fonte.Paises.Add(DadosDne.Pais("ARG", "Argentina", "AR"));
+        fonte.Paises.Add(DadosDne.Pais("USA", "Estados Unidos", "US"));
+
+        fonte.Estados.Add(DadosDne.Estado("PA", "Pará", capital: "Belém", latitude: "-1.9981271", longitude: "-54.9306152", faixaIni: "66000000", faixaFim: "68899999"));
+        fonte.Estados.Add(DadosDne.Estado("SP", "São Paulo", regiao: "Sudeste", capital: "São Paulo", latitude: "-23.5", longitude: "-46.6", faixaIni: "01000000", faixaFim: "19999999"));
+
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador("PA", "15", idh: "0.69", populacao: "8120131", receitas: "52747856526.44"));
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador("SP", "35", idh: "0.806", populacao: "44411238"));
+
+        fonte.EstadoFaixas.Add(DadosDne.EstadoFaixa("PA", "66000000", "68899999", "Pará"));
+        fonte.EstadoFaixas.Add(DadosDne.EstadoFaixa("SP", "01000000", "19999999", "São Paulo"));
+
+        fonte.Cidades.Add(DadosDne.Cidade(CodigoMaraba, "Marabá", "PA", ddd: "94", latitude: "-5.36867", longitude: "-49.11731"));
+        fonte.Cidades.Add(DadosDne.Cidade(CodigoSaoPaulo, "São Paulo", "SP", ddd: "11", latitude: "-23.56287", longitude: "-46.65468"));
+        fonte.Cidades.Add(DadosDne.Cidade(CodigoCidadeOrfa, "Cidade Órfã", "ZZ")); // UF sem estado carregado
+
+        fonte.CidadeTerritorios.Add(DadosDne.CidadeTerritorio(CodigoMaraba, mesorregiaoNome: "Sudeste Paraense", microrregiaoNome: "Marabá"));
+
+        fonte.CidadeIndicadores.Add(DadosDne.CidadeIndicador(CodigoMaraba, mortalidadeInfantil: "-", populacao: "283542", aniversario: "05/04"));
+        fonte.CidadeIndicadores.Add(DadosDne.CidadeIndicador(CodigoSaoPaulo, mortalidadeInfantil: "11.5", populacao: "11451245"));
+
+        fonte.CidadeFaixas.Add(DadosDne.CidadeFaixa(CodigoMaraba, "68500000", "68519999"));
+
+        return fonte;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/FonteEmMemoria.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/FonteEmMemoria.cs
@@ -1,0 +1,162 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using System.Runtime.CompilerServices;
+
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+
+/// <summary>
+/// <see cref="IGeoFonteDados"/> em memória para exercitar o importador sem um schema
+/// de staging real — determinístico e legível. A <see cref="Versao"/> é a proveniência
+/// da carga.
+/// </summary>
+internal sealed class FonteEmMemoria : IGeoFonteDados
+{
+    public string Versao { get; init; } = "202601";
+
+    public List<PaisCru> Paises { get; } = [];
+
+    public List<EstadoCru> Estados { get; } = [];
+
+    public List<EstadoIndicadorCru> EstadoIndicadores { get; } = [];
+
+    public List<EstadoFaixaCru> EstadoFaixas { get; } = [];
+
+    public List<CidadeCru> Cidades { get; } = [];
+
+    public List<CidadeTerritorioCru> CidadeTerritorios { get; } = [];
+
+    public List<CidadeIndicadorCru> CidadeIndicadores { get; } = [];
+
+    public List<CidadeFaixaCru> CidadeFaixas { get; } = [];
+
+    public IAsyncEnumerable<PaisCru> LerPaisesAsync(CancellationToken cancellationToken) => ParaAsync(Paises, cancellationToken);
+
+    public IAsyncEnumerable<EstadoCru> LerEstadosAsync(CancellationToken cancellationToken) => ParaAsync(Estados, cancellationToken);
+
+    public IAsyncEnumerable<EstadoIndicadorCru> LerEstadoIndicadoresAsync(CancellationToken cancellationToken) => ParaAsync(EstadoIndicadores, cancellationToken);
+
+    public IAsyncEnumerable<EstadoFaixaCru> LerEstadoFaixasAsync(CancellationToken cancellationToken) => ParaAsync(EstadoFaixas, cancellationToken);
+
+    public IAsyncEnumerable<CidadeCru> LerCidadesAsync(CancellationToken cancellationToken) => ParaAsync(Cidades, cancellationToken);
+
+    public IAsyncEnumerable<CidadeTerritorioCru> LerCidadeTerritoriosAsync(CancellationToken cancellationToken) => ParaAsync(CidadeTerritorios, cancellationToken);
+
+    public IAsyncEnumerable<CidadeIndicadorCru> LerCidadeIndicadoresAsync(CancellationToken cancellationToken) => ParaAsync(CidadeIndicadores, cancellationToken);
+
+    public IAsyncEnumerable<CidadeFaixaCru> LerCidadeFaixasAsync(CancellationToken cancellationToken) => ParaAsync(CidadeFaixas, cancellationToken);
+
+    private static async IAsyncEnumerable<T> ParaAsync<T>(IEnumerable<T> itens, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        foreach (T item in itens)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return item;
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// Builders de registros crus DNE com defaults sensatos — montam dados de teste
+/// legíveis sem repetir os muitos campos posicionais dos records.
+/// </summary>
+internal static class DadosDne
+{
+    public static PaisCru Pais(string siglaIso, string nome, string sigla = "XX") =>
+        new(siglaIso, sigla, nome, CodigoBcb: null, CodigoRfb: null, CodigoSped: null, CodigoSiscomex: null);
+
+    public static EstadoCru Estado(
+        string uf,
+        string nome,
+        string? regiao = "Norte",
+        string? capital = null,
+        string? latitude = null,
+        string? longitude = null,
+        string? faixaIni = null,
+        string? faixaFim = null) =>
+        new(uf, nome, NomeSemAcento: nome, regiao, capital, faixaIni, faixaFim, latitude, longitude);
+
+    public static EstadoIndicadorCru EstadoIndicador(
+        string uf,
+        string? codigoIbge,
+        string? idh = null,
+        string? populacao = null,
+        string? receitas = null) =>
+        new(uf, codigoIbge, Gentilico: null, Governador: null, AreaTerritorialKm2: null, populacao,
+            DensidadeDemografica: null, MatriculasEnsinoFundamental2023: null, idh, receitas,
+            DespesasBrutas: null, RendimentoMensalPerCapita: null, TotalVeiculos2023: null);
+
+    public static EstadoFaixaCru EstadoFaixa(string uf, string faixaIni, string faixaFim, string? descricao = null) =>
+        new(uf, descricao, faixaIni, faixaFim);
+
+    public static CidadeCru Cidade(
+        string codigoIbge,
+        string nome,
+        string uf,
+        string? ddd = null,
+        string? latitude = null,
+        string? longitude = null) =>
+        new(codigoIbge, nome, NomeSemAcento: nome, uf, ddd, latitude, longitude);
+
+    public static CidadeTerritorioCru CidadeTerritorio(
+        string codigoIbge,
+        string? mesorregiaoNome = null,
+        string? microrregiaoNome = null) =>
+        new(codigoIbge, MesorregiaoCodigo: null, mesorregiaoNome, MicrorregiaoCodigo: null, microrregiaoNome,
+            RegiaoIntermediariaCodigo: null, RegiaoIntermediariaNome: null, RegiaoImediataCodigo: null, RegiaoImediataNome: null);
+
+    public static CidadeIndicadorCru CidadeIndicador(
+        string codigoIbge,
+        string? mortalidadeInfantil = null,
+        string? populacao = null,
+        string? aniversario = null) =>
+        new(codigoIbge, Gentilico: null, Prefeito: null, AreaTerritorialKm2: null, populacao,
+            DensidadeDemografica: null, Escolarizacao6a14: null, Idh: null, mortalidadeInfantil,
+            Receitas: null, Despesas: null, PibPerCapita: null, aniversario);
+
+    public static CidadeFaixaCru CidadeFaixa(string codigoIbge, string faixaIni, string faixaFim) =>
+        new(codigoIbge, faixaIni, faixaFim);
+}
+
+/// <summary>
+/// Decora uma <see cref="FonteEmMemoria"/> fazendo a leitura de cidades lançar — o
+/// País/Estado já foram persistidos (dentro da transação) quando a falha ocorre, o
+/// que prova o rollback total da carga (nenhum dado publicado em release parcial).
+/// </summary>
+internal sealed class FonteComFalhaNasCidades : IGeoFonteDados
+{
+    private readonly FonteEmMemoria _interna;
+
+    public FonteComFalhaNasCidades(FonteEmMemoria interna)
+    {
+        _interna = interna;
+    }
+
+    public string Versao => _interna.Versao;
+
+    public IAsyncEnumerable<PaisCru> LerPaisesAsync(CancellationToken cancellationToken) => _interna.LerPaisesAsync(cancellationToken);
+
+    public IAsyncEnumerable<EstadoCru> LerEstadosAsync(CancellationToken cancellationToken) => _interna.LerEstadosAsync(cancellationToken);
+
+    public IAsyncEnumerable<EstadoIndicadorCru> LerEstadoIndicadoresAsync(CancellationToken cancellationToken) => _interna.LerEstadoIndicadoresAsync(cancellationToken);
+
+    public IAsyncEnumerable<EstadoFaixaCru> LerEstadoFaixasAsync(CancellationToken cancellationToken) => _interna.LerEstadoFaixasAsync(cancellationToken);
+
+    public IAsyncEnumerable<CidadeCru> LerCidadesAsync(CancellationToken cancellationToken) => Falhar();
+
+    public IAsyncEnumerable<CidadeTerritorioCru> LerCidadeTerritoriosAsync(CancellationToken cancellationToken) => _interna.LerCidadeTerritoriosAsync(cancellationToken);
+
+    public IAsyncEnumerable<CidadeIndicadorCru> LerCidadeIndicadoresAsync(CancellationToken cancellationToken) => _interna.LerCidadeIndicadoresAsync(cancellationToken);
+
+    public IAsyncEnumerable<CidadeFaixaCru> LerCidadeFaixasAsync(CancellationToken cancellationToken) => _interna.LerCidadeFaixasAsync(cancellationToken);
+
+    private static async IAsyncEnumerable<CidadeCru> Falhar()
+    {
+        await Task.CompletedTask.ConfigureAwait(false);
+        throw new InvalidOperationException("Falha simulada ao ler cidades do dataset.");
+#pragma warning disable CS0162 // Unreachable: necessário para o método ser um iterador async.
+        yield break;
+#pragma warning restore CS0162
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/FonteEmMemoria.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/FonteEmMemoria.cs
@@ -78,7 +78,7 @@ internal static class DadosDne
         new(uf, nome, NomeSemAcento: nome, regiao, capital, faixaIni, faixaFim, latitude, longitude);
 
     public static EstadoIndicadorCru EstadoIndicador(
-        string uf,
+        string? uf,
         string? codigoIbge,
         string? idh = null,
         string? populacao = null,

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/ParseToleranteTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/ParseToleranteTests.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Parsing;
+
+/// <summary>
+/// Conversores tolerantes do ETL (ADR-0092): <c>'-'</c>/vazio/não-numérico degradam
+/// para <see langword="null"/> sem lançar; decimais usam <c>InvariantCulture</c>.
+/// </summary>
+public sealed class ParseToleranteTests
+{
+    [Theory]
+    [InlineData("184.413", 184.413)]
+    [InlineData("0.69", 0.69)]
+    [InlineData("52747856526.44", 52747856526.44)]
+    [InlineData("  6.52  ", 6.52)]
+    public void ParaDecimal_ValorNumerico_UsaInvariantCulture(string entrada, double esperado)
+    {
+        ParseTolerante.ParaDecimal(entrada).Should().Be((decimal)esperado);
+    }
+
+    [Theory]
+    [InlineData("-")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("indisponível")]
+    [InlineData("6,52")]          // vírgula NÃO é separador (a fonte usa ponto) → degrada, não vira 652
+    [InlineData("1.234.567,89")]  // formato pt-BR é rejeitado pela mesma razão
+    public void ParaDecimal_AusenteOuInvalido_DegradaParaNull(string? entrada)
+    {
+        ParseTolerante.ParaDecimal(entrada).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("8120131", 8120131)]
+    [InlineData("1282", 1282)]
+    public void ParaInteiro_ValorInteiro_Converte(string entrada, int esperado)
+    {
+        ParseTolerante.ParaInteiro(entrada).Should().Be(esperado);
+    }
+
+    [Theory]
+    [InlineData("-")]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("6.52")]
+    public void ParaInteiro_AusenteOuNaoInteiro_DegradaParaNull(string? entrada)
+    {
+        ParseTolerante.ParaInteiro(entrada).Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("S", true)]
+    [InlineData("s", true)]
+    [InlineData("N", false)]
+    [InlineData("-", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void ParaBoolSn_MapeiaSomenteS(string? entrada, bool esperado)
+    {
+        ParseTolerante.ParaBoolSn(entrada).Should().Be(esperado);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/PontoFactoryTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/PontoFactoryTests.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using AwesomeAssertions;
+
+using NetTopologySuite.Geometries;
+
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Parsing;
+
+/// <summary>
+/// <see cref="PontoFactory"/>: materializa lat/long em <see cref="Point"/> SRID 4326,
+/// ordem PostGIS X=longitude / Y=latitude; ausência de qualquer componente → null.
+/// </summary>
+public sealed class PontoFactoryTests
+{
+    [Fact(DisplayName = "lat/long válidos viram Point 4326 com X=longitude e Y=latitude")]
+    public void Criar_LatLongValidos_PontoComOrdemXLonYLat()
+    {
+        Point? ponto = PontoFactory.Criar("-23.55068", "-46.63413");
+
+        ponto.Should().NotBeNull();
+        ponto!.SRID.Should().Be(4326);
+        ponto.X.Should().Be(-46.63413);
+        ponto.Y.Should().Be(-23.55068);
+    }
+
+    [Theory]
+    [InlineData(null, "-46.63413")]
+    [InlineData("-23.55068", null)]
+    [InlineData("-", "-")]
+    [InlineData("abc", "-46.63413")]
+    [InlineData("", "")]
+    public void Criar_ComponenteAusenteOuInvalido_RetornaNull(string? latitude, string? longitude)
+    {
+        PontoFactory.Criar(latitude, longitude).Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Coordenada fora do domínio geográfico degrada para null (não estoura no geography)")]
+    [InlineData("999", "999")]
+    [InlineData("91", "-46.6")]
+    [InlineData("-90.5", "0")]
+    [InlineData("-23.5", "181")]
+    [InlineData("0", "-180.5")]
+    public void Criar_ForaDoDominioGeografico_RetornaNull(string latitude, string longitude)
+    {
+        PontoFactory.Criar(latitude, longitude).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Contexto

Story #672 (Feature #664 — Geo F3 ETL de carga DNE). A F2 entregou o schema e as factories `Importar(...)`; ninguém havia **populado** o banco. Esta Story entrega o importador do **topo da hierarquia** — `pais` (só Brasil), `estado` (+indicador +faixas) e `cidade` (+territorial embutido, +indicador, +faixas) — a partir do dataset DNE 202601.

## Estratégia de ingestão (decisão TL)

Os 15 dumps SQL (Navicat, todas-`varchar`) são restaurados num **schema de staging** (`dne_staging`); o ETL lê via **`SELECT` streamado** (`DbDataReader` — memória estável mesmo nas tabelas grandes), aplica parse tolerante e faz **upsert por chave natural**. Detalhes em [`docs/geo-etl-dataset-dne.md`](../blob/feature/672-geo-etl-pais-estado-cidade/docs/geo-etl-dataset-dne.md). É o que habilita a recarga mensal idempotente (Story de atualização periódica, #674).

## O que entra

- **Domínio:** método `Atualizar(...)` em País/Estado/Cidade/indicadores/faixas — upsert in place que **preserva o `Id` (Guid v7)** e a chave natural; valida antes de mutar (atomicidade).
- **`Geo.Infrastructure/Persistence/Etl/`:**
  - `IGeoFonteDados` + records crus + `DneStagingFonte` (`SELECT` streamado; nome de tabela derivado da versão; validação anti-injeção de `versao`/`schema`).
  - `ParseTolerante` (`'-'`/vazio/não-numérico → `null`, `InvariantCulture`, **sem** separador de milhar) e `PontoFactory` (`Point` 4326, ordem X=lon/Y=lat, **com validação de domínio geográfico**).
  - `GeoImportadorPaisEstadoCidade` — ordem topológica, agregação cidade+território / estado+IBGE, **upsert por chave natural com dedup intra-fonte**, **transação única** (rollback total em falha), `[LoggerMessage]`.
  - `RelatorioImportacao` — contadores por tabela + amostras (sem PII).

## Critérios de aceite

- [x] **CA-01** carga inicial popula País(BRA)/Estados/Cidades com `Coordenada` 4326 e territorial embutido
- [x] **CA-02** idempotência: reexecutar deixa o banco idêntico, **Guid preservado** (inclusive faixas), 2º passe reporta Atualizados
- [x] **CA-03** parse tolerante: `mortalidade '-'` → `null`, sem abortar; conta degradado
- [x] **CA-04** cidade órfã (UF sem estado) registrada e não inserida
- [x] **CA-05** só Brasil carregado, apesar dos estrangeiros na fonte
- [x] **CA-06** relatório por tabela emitido via `[LoggerMessage]`, sem PII

## Testes

`dotnet test` Geo: **83/83**. Cobre parse (incl. rejeição de vírgula decimal e coordenada fora de faixa), idempotência com Guid, órfãos, filtro Brasil, dedup intra-fonte, rollback transacional — com fonte em memória e com `DneStagingFonte` sobre staging reduzido real. Suíte completa da solution e ArchTests verdes localmente.

## Revisão prévia

Plano e diff revisados via Codex CLI antes do PR; achados aplicados — destaque: parse decimal sem milhar (anti-corrupção de `"6,52"`), validação de faixa geográfica da coordenada, e faixas de CEP por **upsert** (não delete+insert) para preservar `Id` e deduplicar intra-fonte.

## Fora de escopo (Story #674)

Gatilho operacional (seed em dev + endpoint admin `POST /api/admin/geo/importacoes`) e política de *stale* (`vigente=false` para chaves ausentes numa nova release). O ETL de Distrito/Bairro/Logradouro (bulk/COPY) é a Story #673.

Closes #672
Refs #664