### PR TITLE
feat(geo): ETL de Distrito, Bairro e Logradouro do DNE (bulk/COPY)

### DIFF
--- a/docs/geo-etl-dataset-dne.md
+++ b/docs/geo-etl-dataset-dne.md
@@ -4,7 +4,9 @@ Guia operacional da carga de reference data do módulo `Geo` (localidades, ender
 
 ## Estratégia: schema de staging + SELECT streamado
 
-O dataset DNE é distribuído como **15 dumps SQL** (um por tabela, `tbl_cep_{versao}_n_*`, todas as colunas `varchar`; a maior — `logradouro` — tem ~1,4M linhas / ~382 MB). Esses dumps **não são versionados** neste repositório: a base DNE é proprietária (Correios) e exige licença institucional.
+O dataset DNE é distribuído como **15 dumps SQL** (um por tabela, `tbl_cep_{versao}_n_*`; a maior — `logradouro` — tem ~1,4M linhas / ~382 MB). Esses dumps **não são versionados** neste repositório: a base DNE é proprietária (Correios) e exige licença institucional.
+
+As colunas **descritivas** são `varchar` (nomes, siglas, métricas, lat/long como texto — daí o parse tolerante); os **identificadores** das folhas são `int4`: as PKs da fonte (`id_cidade`, `id_distrito`, `id_bairro`) e as FKs internas (`cidade_id`, `distrito_id`, `bairro_id`). O ETL os lê com o acessor tipado (`GetInt32`/`IsDBNull`) e os traduz para os Guid intra-banco; o domínio nunca adota esses inteiros como identidade.
 
 A ingestão segue dois passos desacoplados:
 

--- a/docs/geo-etl-dataset-dne.md
+++ b/docs/geo-etl-dataset-dne.md
@@ -38,6 +38,40 @@ done
 
 > Ajuste o `search_path`/schema conforme o gerador do dump. O importador espera as tabelas `tbl_cep_{versao}_n_*` no schema configurado (`dne_staging` por padrão).
 
+## Carga em lote das folhas — Distrito, Bairro e Logradouro (Story #673)
+
+As folhas da hierarquia (`distrito`/`bairro` + faixas, `cep_grande_usuario`, `logradouro_complemento` e os ~1,4M `logradouro`) entram por um pipeline próprio (`GeoImportadorLocalidades`), porque o volume e a criação de índices inviabilizam a transação única do topo (País/Estado/Cidade). O pipeline tem duas fases que **commitam separadamente**:
+
+1. **Upsert (`GeoImportadorDistritoBairro`)** — `distrito`/`bairro` (+faixas) e `cep_grande_usuario`, por chave natural, numa transação. Esta fase também **resolve as FKs**: monta os dicionários `id_cidade → Cidade.Id (Guid)` (via JOIN do staging com o domínio pelo código IBGE) e `id_distrito`/`id_bairro → Guid` (os ids da DNE são as PKs da fonte, únicos dentro de uma release; homônimos em cidades distintas viram entidades distintas).
+2. **COPY em lote (`LogradouroCopyImporter`)** — `logradouro_complemento` e `logradouro`, via COPY binário streamado.
+
+### Estratégia de bulk (COPY → staging → merge)
+
+Para os dois modos de carga, a estratégia é idêntica e idempotente:
+
+```
+COPY binário streamado ─▶ tabela TEMP de staging (sem constraints)
+        │
+        ▼
+INSERT ... SELECT DISTINCT ON (chave natural) ... ON CONFLICT DO UPDATE  ─▶  tabela final
+        │
+        ▼
+DROP da tabela de staging
+```
+
+- **COPY binário** (`NpgsqlBinaryImporter`) em lotes, com leitura **em streaming** do staging-DB — uso de memória estável mesmo nos 1,4M logradouros. A coordenada é escrita como `geography(Point,4326)` por um `NpgsqlDataSource` com NetTopologySuite em modo **`geographyAsDefault`**.
+- **Dedup intra-fonte** via `DISTINCT ON (chave natural) ... ORDER BY ..., _ord DESC` (last-wins, `_ord` é um `bigserial` preenchido na ordem do COPY) — evita o erro do Postgres "ON CONFLICT cannot affect row a second time".
+- **Idempotência** via `ON CONFLICT (chave natural) DO UPDATE`: preserva `id` (Guid v7) e `created_at`, carimba `updated_at` e reativa `vigente = true`. A chave de `logradouro` é `(cep, nome_normalizado, cidade_id)`; a de `logradouro_complemento`, `(cep, complemento_normalizado)`.
+- **Auditoria sem interceptor**: como o COPY/merge ignoram o `AuditableInterceptor`, o `created_at` é carimbado pelo `TimeProvider` (no insert) e o `updated_at` só no `DO UPDATE` — tudo num único instante por carga.
+
+### Índices pesados (`logradouro`) e `CREATE INDEX CONCURRENTLY`
+
+No modo **`Inicial`** (base nova), a tabela `logradouro` é truncada e os índices pesados (`gin_trgm` em `nome_normalizado`, GIST em `coordenada`) são **dropados antes do COPY** e **recriados depois** via `CREATE INDEX CONCURRENTLY` — carregar com esses índices ligados degrada muito o COPY. `CONCURRENTLY` **não pode** rodar dentro de transação, então a recriação acontece numa conexão em **autocommit** (sem `BeginTransaction`), na mesma conexão física do COPY. Um `DROP INDEX IF EXISTS` precede cada `CREATE` para limpar índices `INVALID` deixados por uma recriação anterior abortada.
+
+No modo **`Recarga`** os índices permanecem (a tabela já está populada); só o merge `ON CONFLICT` roda. A política de *stale* (`vigente = false` para chaves ausentes na nova release) continua sendo da Story de atualização periódica (#674).
+
+> O `logradouro_complemento` não é truncado no modo `Inicial` (só o `logradouro`, pela otimização de índices): seu merge `ON CONFLICT` já é idempotente e a remoção de registros que somem entre releases é tratada pela política de *stale* (#674), não por TRUNCATE.
+
 ## Recarga periódica (releases mensais)
 
 A DNE é atualizada mensalmente. Para aplicar uma nova release (ex.: `202602`):

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Bairro.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Bairro.cs
@@ -116,4 +116,69 @@ public sealed class Bairro : EntityBase
 
         return Result<Bairro>.Success(bairro);
     }
+
+    /// <summary>
+    /// Reaplica os dados de uma release sobre um Bairro já existente (upsert in place
+    /// do ETL), preservando <see cref="EntityBase.Id"/> (referenciado por faixas e por
+    /// <see cref="Logradouro"/>) e a chave natural <c>(cidade_id, nome_normalizado)</c>.
+    /// Valida o mínimo <strong>antes</strong> de mutar — em falha, o estado não é tocado.
+    /// </summary>
+    public Result Atualizar(
+        Guid cidadeId,
+        string uf,
+        string nome,
+        string nomeNormalizado,
+        decimal? latitude,
+        decimal? longitude,
+        Point? coordenada,
+        string? idOrigemDne,
+        string versaoDataset,
+        bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(uf);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(nomeNormalizado);
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (cidadeId == Guid.Empty)
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.BairroCidadeObrigatoria,
+                "Cidade do Bairro é obrigatória."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.BairroNomeObrigatorio,
+                "Nome do Bairro é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nomeNormalizado))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.BairroNomeNormalizadoObrigatorio,
+                "Nome normalizado do Bairro é obrigatório (compõe a chave natural)."));
+        }
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.BairroVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) do Bairro é obrigatória."));
+        }
+
+        CidadeId = cidadeId;
+        Uf = GeoTexto.NormalizarChaveMaiuscula(uf);
+        Nome = nome.Trim();
+        NomeNormalizado = GeoTexto.NormalizarTexto(nomeNormalizado);
+        Latitude = latitude;
+        Longitude = longitude;
+        Coordenada = coordenada;
+        IdOrigemDne = GeoTexto.NormalizarOpcional(idOrigemDne);
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/BairroFaixaCep.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/BairroFaixaCep.cs
@@ -80,4 +80,26 @@ public sealed class BairroFaixaCep : EntityBase
 
         return Result<BairroFaixaCep>.Success(faixa);
     }
+
+    /// <summary>
+    /// Reaplica a proveniência de uma release sobre uma faixa já existente (upsert in
+    /// place do ETL), preservando <see cref="EntityBase.Id"/> e a chave natural
+    /// <c>(bairro_id, cep_inicial, cep_final)</c>. Valida antes de mutar.
+    /// </summary>
+    public Result Atualizar(string versaoDataset, bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.BairroFaixaCepVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) da faixa de CEP é obrigatória."));
+        }
+
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/CepGrandeUsuario.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/CepGrandeUsuario.cs
@@ -81,4 +81,36 @@ public sealed class CepGrandeUsuario : EntityBase
 
         return Result<CepGrandeUsuario>.Success(entidade);
     }
+
+    /// <summary>
+    /// Reaplica os dados de uma release sobre um CEP de grande usuário já existente
+    /// (upsert in place do ETL), preservando <see cref="EntityBase.Id"/> e a chave
+    /// natural <see cref="Cep"/>. Valida o mínimo <strong>antes</strong> de mutar.
+    /// </summary>
+    public Result Atualizar(string nome, string? nomeNormalizado, string versaoDataset, bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.CepGrandeUsuarioNomeObrigatorio,
+                "Nome do grande usuário é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.CepGrandeUsuarioVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) do grande usuário é obrigatória."));
+        }
+
+        Nome = nome.Trim();
+        NomeNormalizado = GeoTexto.NormalizarBuscaOpcional(nomeNormalizado);
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Distrito.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/Distrito.cs
@@ -117,4 +117,69 @@ public sealed class Distrito : EntityBase
 
         return Result<Distrito>.Success(distrito);
     }
+
+    /// <summary>
+    /// Reaplica os dados de uma release sobre um Distrito já existente (upsert in place
+    /// do ETL), preservando <see cref="EntityBase.Id"/> (referenciado por faixas e por
+    /// <see cref="Logradouro"/>) e a chave natural <c>(cidade_id, nome_normalizado)</c>.
+    /// Valida o mínimo <strong>antes</strong> de mutar — em falha, o estado não é tocado.
+    /// </summary>
+    public Result Atualizar(
+        Guid cidadeId,
+        string uf,
+        string nome,
+        string nomeNormalizado,
+        decimal? latitude,
+        decimal? longitude,
+        Point? coordenada,
+        string? idOrigemDne,
+        string versaoDataset,
+        bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(uf);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(nomeNormalizado);
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (cidadeId == Guid.Empty)
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.DistritoCidadeObrigatoria,
+                "Cidade do Distrito é obrigatória."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.DistritoNomeObrigatorio,
+                "Nome do Distrito é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nomeNormalizado))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.DistritoNomeNormalizadoObrigatorio,
+                "Nome normalizado do Distrito é obrigatório (compõe a chave natural)."));
+        }
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.DistritoVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) do Distrito é obrigatória."));
+        }
+
+        CidadeId = cidadeId;
+        Uf = GeoTexto.NormalizarChaveMaiuscula(uf);
+        Nome = nome.Trim();
+        NomeNormalizado = GeoTexto.NormalizarTexto(nomeNormalizado);
+        Latitude = latitude;
+        Longitude = longitude;
+        Coordenada = coordenada;
+        IdOrigemDne = GeoTexto.NormalizarOpcional(idOrigemDne);
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/DistritoFaixaCep.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/DistritoFaixaCep.cs
@@ -80,4 +80,26 @@ public sealed class DistritoFaixaCep : EntityBase
 
         return Result<DistritoFaixaCep>.Success(faixa);
     }
+
+    /// <summary>
+    /// Reaplica a proveniência de uma release sobre uma faixa já existente (upsert in
+    /// place do ETL), preservando <see cref="EntityBase.Id"/> e a chave natural
+    /// <c>(distrito_id, cep_inicial, cep_final)</c>. Valida antes de mutar.
+    /// </summary>
+    public Result Atualizar(string versaoDataset, bool vigente = true)
+    {
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Result.Failure(new DomainError(
+                GeoReferenceDataErrorCodes.DistritoFaixaCepVersaoDatasetObrigatoria,
+                "Versão do dataset (proveniência) da faixa de CEP é obrigatória."));
+        }
+
+        VersaoDataset = versaoDataset.Trim();
+        Vigente = vigente;
+
+        return Result.Success();
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Unifesspa.UniPlus.Geo.Domain.csproj
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Unifesspa.UniPlus.Geo.Domain.csproj
@@ -13,4 +13,11 @@
     <ProjectReference Include="..\..\shared\Unifesspa.UniPlus.Governance.Contracts\Unifesspa.UniPlus.Governance.Contracts.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- O ETL (Infrastructure) reusa a normalização canônica GeoTexto para compor as
+         chaves naturais de upsert idênticas às gravadas pelas factories do domínio
+         (#673) — fonte única de verdade, sem duplicar o trim/lowercase. -->
+    <InternalsVisibleTo Include="Unifesspa.UniPlus.Geo.Infrastructure" />
+  </ItemGroup>
+
 </Project>

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
@@ -34,9 +35,16 @@ public static class GeoInfrastructureRegistration
         services.AddScoped<IUnitOfWork>(serviceProvider =>
             serviceProvider.GetRequiredService<GeoDbContext>());
 
-        // ETL DNE (ADR-0092) — serviço de carga de reference data. O gatilho (seed
+        // ETL DNE (ADR-0092) — serviços de carga de reference data. O gatilho (seed
         // dev / endpoint admin) e a fonte concreta de produção entram na Story #674.
+        // Topo da hierarquia (País/Estado/Cidade, #672):
         services.AddScoped<IGeoImportador, GeoImportadorPaisEstadoCidade>();
+
+        // Folhas (Distrito/Bairro/Logradouro + satélites, #673): o orquestrador compõe
+        // o upsert de Distrito/Bairro e o COPY em lote dos logradouros.
+        services.AddScoped<GeoImportadorDistritoBairro>();
+        services.AddScoped<LogradouroCopyImporter>();
+        services.AddScoped<IGeoImportadorLocalidades, GeoImportadorLocalidades>();
 
         return services;
     }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
@@ -1,0 +1,534 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+using NetTopologySuite.Geometries;
+
+using Npgsql;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Parsing;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Carga em lote (COPY binário) das folhas de alto volume: os complementos por CEP
+/// (~235k) e os ~1,4M logradouros (ADR-0092, Story #673). Estratégia única para os dois
+/// modos (<see cref="ModoCarga"/>): COPY streamado para uma <strong>tabela de staging
+/// TEMP sem constraints</strong> → <c>INSERT ... SELECT DISTINCT ON (chave natural) ...
+/// ON CONFLICT DO UPDATE</c> (dedup intra-fonte + idempotência) → drop do staging. Tudo
+/// numa <strong>única conexão física</strong> (o COPY, o merge e os índices precisam
+/// compartilhar a sessão; a fase de índices roda em autocommit, fora de transação).
+/// </summary>
+/// <remarks>
+/// <para><strong>Índices pesados (logradouro):</strong> no modo <see cref="ModoCarga.Inicial"/>
+/// a tabela é truncada e os índices <c>gin_trgm</c>/<c>GIST</c> são dropados antes do COPY
+/// e recriados via <c>CREATE INDEX CONCURRENTLY</c> ao fim — <c>CONCURRENTLY</c> não pode
+/// rodar dentro de transação, por isso a conexão fica em autocommit (sem
+/// <c>BeginTransaction</c>). No modo <see cref="ModoCarga.Recarga"/> os índices permanecem.</para>
+/// <para><strong>Auditoria sem interceptor:</strong> o COPY/merge ignoram o
+/// <c>AuditableInterceptor</c>; o <c>created_at</c> é carimbado pelo <see cref="TimeProvider"/>
+/// no insert e preservado no conflito; o <c>updated_at</c> é setado só no <c>DO UPDATE</c>.</para>
+/// </remarks>
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "Todo o SQL desta classe é literal de código (DDL de staging, COPY e merge constantes; os nomes de tabela alvo/staging vêm de uma lista fixa de literais). O único valor parametrizado (@now) é um NpgsqlParameter. Não há entrada de usuário — COPY/DDL não são parametrizáveis por identificador.")]
+internal sealed partial class LogradouroCopyImporter
+{
+    // Lote do COPY para o staging: limita a memória por chamada e dá granularidade de
+    // progresso. O staging acumula todos os lotes; o merge final é uma única instrução.
+    private const int TamanhoLote = 50_000;
+
+    private const string CopyComplemento =
+        "COPY logradouro_complemento_staging (id, cep, complemento, complemento_normalizado, versao_dataset, created_at) FROM STDIN (FORMAT BINARY)";
+
+    private const string CriarStagingComplemento = """
+        DROP TABLE IF EXISTS logradouro_complemento_staging;
+        CREATE TEMP TABLE logradouro_complemento_staging (
+            id uuid, cep text, complemento text, complemento_normalizado text,
+            versao_dataset text, created_at timestamptz, _ord bigserial);
+        """;
+
+    private const string MergeComplemento = """
+        INSERT INTO logradouro_complemento
+            (id, cep, complemento, complemento_normalizado, versao_dataset, vigente, created_at, updated_at)
+        SELECT DISTINCT ON (cep, complemento_normalizado)
+            id, cep, complemento, complemento_normalizado, versao_dataset, true, created_at, NULL
+        FROM logradouro_complemento_staging
+        ORDER BY cep, complemento_normalizado, _ord DESC
+        ON CONFLICT (cep, complemento_normalizado) DO UPDATE SET
+            complemento = EXCLUDED.complemento,
+            versao_dataset = EXCLUDED.versao_dataset,
+            vigente = true,
+            updated_at = @now;
+        """;
+
+    private const string CopyLogradouro =
+        "COPY logradouro_staging (id, cep, tipo, nome, nome_completo, nome_normalizado, cidade_id, distrito_id, bairro_id, uf, latitude, longitude, coordenada, ativo, versao_dataset, created_at) FROM STDIN (FORMAT BINARY)";
+
+    private const string CriarStagingLogradouro = """
+        DROP TABLE IF EXISTS logradouro_staging;
+        CREATE TEMP TABLE logradouro_staging (
+            id uuid, cep text, tipo text, nome text, nome_completo text, nome_normalizado text,
+            cidade_id uuid, distrito_id uuid, bairro_id uuid, uf text,
+            latitude numeric(9,6), longitude numeric(9,6), coordenada geography(Point,4326),
+            ativo boolean, versao_dataset text, created_at timestamptz, _ord bigserial);
+        """;
+
+    private const string MergeLogradouro = """
+        INSERT INTO logradouro
+            (id, cep, tipo, nome, nome_completo, nome_normalizado, cidade_id, distrito_id, bairro_id,
+             uf, latitude, longitude, coordenada, ativo, versao_dataset, vigente, created_at, updated_at)
+        SELECT DISTINCT ON (cep, nome_normalizado, cidade_id)
+            id, cep, tipo, nome, nome_completo, nome_normalizado, cidade_id, distrito_id, bairro_id,
+            uf, latitude, longitude, coordenada, ativo, versao_dataset, true, created_at, NULL
+        FROM logradouro_staging
+        ORDER BY cep, nome_normalizado, cidade_id, _ord DESC
+        ON CONFLICT (cep, nome_normalizado, cidade_id) DO UPDATE SET
+            tipo = EXCLUDED.tipo, nome = EXCLUDED.nome, nome_completo = EXCLUDED.nome_completo,
+            distrito_id = EXCLUDED.distrito_id, bairro_id = EXCLUDED.bairro_id, uf = EXCLUDED.uf,
+            latitude = EXCLUDED.latitude, longitude = EXCLUDED.longitude, coordenada = EXCLUDED.coordenada,
+            ativo = EXCLUDED.ativo, versao_dataset = EXCLUDED.versao_dataset,
+            vigente = true, updated_at = @now;
+        """;
+
+    // Mesma chave de connection string usada por GeoInfrastructureRegistration para o
+    // GeoDbContext. Lida da IConfiguration (não redatada) — o getter do NpgsqlConnection
+    // remove a senha após a 1ª abertura (Persist Security Info=false), então não dá para
+    // reaproveitar a string do DbContext já usado.
+    private const string ConnectionStringName = "GeoDb";
+
+    private readonly string _connectionString;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<LogradouroCopyImporter> _logger;
+
+    public LogradouroCopyImporter(IConfiguration configuration, TimeProvider clock, ILogger<LogradouroCopyImporter> logger)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _connectionString = configuration.GetConnectionString(ConnectionStringName)
+            ?? throw new InvalidOperationException(
+                $"ConnectionStrings:{ConnectionStringName} não configurada para o COPY do ETL Geo.");
+        _clock = clock;
+        _logger = logger;
+    }
+
+    public async Task ImportarAsync(
+        IGeoFonteDados fonte,
+        ModoCarga modo,
+        ResolucaoLocalidades resolucao,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(fonte);
+        ArgumentNullException.ThrowIfNull(resolucao);
+        ArgumentNullException.ThrowIfNull(relatorio);
+
+        // Datasource dedicado com NTS em modo geography-default: o COPY binário escreve
+        // o Point como geography(Point,4326), batendo com a coluna. Sem isso o handler
+        // default (geometry) produziria EWKB incompatível com a coluna geography.
+        NpgsqlDataSourceBuilder builder = new(_connectionString);
+        builder.UseNetTopologySuite(geographyAsDefault: true);
+        NpgsqlDataSource dataSource = builder.Build();
+        await using (dataSource.ConfigureAwait(false))
+        {
+            NpgsqlConnection conexao = await dataSource.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            await using (conexao.ConfigureAwait(false))
+            {
+                // Um único instante para toda a carga (created_at dos inserts, updated_at
+                // dos conflitos) — consistente e auditável.
+                DateTimeOffset agora = _clock.GetUtcNow();
+
+                await ImportarComplementosAsync(conexao, fonte, agora, relatorio, cancellationToken).ConfigureAwait(false);
+                await ImportarLogradourosAsync(conexao, fonte, modo, resolucao, agora, relatorio, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task ImportarComplementosAsync(
+        NpgsqlConnection conexao,
+        IGeoFonteDados fonte,
+        DateTimeOffset agora,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("logradouro_complemento");
+        await ExecutarAsync(conexao, CriarStagingComplemento, cancellationToken).ConfigureAwait(false);
+
+        long staged = await CopiarEmLotesAsync(
+            conexao,
+            CopyComplemento,
+            ProjetarComplementosAsync(fonte, contador, cancellationToken),
+            EscreverComplementoAsync,
+            agora,
+            "logradouro_complemento",
+            cancellationToken).ConfigureAwait(false);
+
+        await MergearContandoAsync(conexao, contador, "logradouro_complemento", MergeComplemento, staged, agora, cancellationToken).ConfigureAwait(false);
+        await ExecutarAsync(conexao, "DROP TABLE IF EXISTS logradouro_complemento_staging;", cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ImportarLogradourosAsync(
+        NpgsqlConnection conexao,
+        IGeoFonteDados fonte,
+        ModoCarga modo,
+        ResolucaoLocalidades resolucao,
+        DateTimeOffset agora,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("logradouro");
+
+        // Modo Inicial: base limpa + índices pesados fora do caminho do COPY (acelera a
+        // carga). TRUNCATE torna a reexecução do Inicial idempotente (sem violar a UNIQUE
+        // por estado parcial de uma execução anterior).
+        if (modo == ModoCarga.Inicial)
+        {
+            await ExecutarAsync(conexao, "TRUNCATE TABLE logradouro;", cancellationToken).ConfigureAwait(false);
+            await DroparIndicesPesadosAsync(conexao, cancellationToken).ConfigureAwait(false);
+        }
+
+        await ExecutarAsync(conexao, CriarStagingLogradouro, cancellationToken).ConfigureAwait(false);
+
+        long staged = await CopiarEmLotesAsync(
+            conexao,
+            CopyLogradouro,
+            ProjetarLogradourosAsync(fonte, resolucao, contador, cancellationToken),
+            EscreverLogradouroAsync,
+            agora,
+            "logradouro",
+            cancellationToken).ConfigureAwait(false);
+
+        await MergearContandoAsync(conexao, contador, "logradouro", MergeLogradouro, staged, agora, cancellationToken).ConfigureAwait(false);
+        await ExecutarAsync(conexao, "DROP TABLE IF EXISTS logradouro_staging;", cancellationToken).ConfigureAwait(false);
+
+        if (modo == ModoCarga.Inicial)
+        {
+            await RecriarIndicesPesadosAsync(conexao, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    // Projeção streamada: valida/normaliza via factory do domínio (fonte única de
+    // normalização), conta lido/ignorado e emite a entidade pronta para o COPY.
+    private static async IAsyncEnumerable<LogradouroComplemento> ProjetarComplementosAsync(
+        IGeoFonteDados fonte,
+        ContadorTabela contador,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (LogradouroComplementoCru cru in fonte.LerLogradouroComplementosAsync(cancellationToken).ConfigureAwait(false))
+        {
+            contador.ContarLido();
+            Result<LogradouroComplemento> resultado = LogradouroComplemento.Importar(
+                cru.Cep ?? string.Empty,
+                cru.Complemento ?? string.Empty,
+                cru.ComplementoSemAcento ?? cru.Complemento ?? string.Empty,
+                fonte.Versao);
+
+            if (resultado.IsFailure)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            yield return resultado.Value!;
+        }
+    }
+
+    private static async IAsyncEnumerable<Logradouro> ProjetarLogradourosAsync(
+        IGeoFonteDados fonte,
+        ResolucaoLocalidades resolucao,
+        ContadorTabela contador,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (LogradouroCru cru in fonte.LerLogradourosAsync(cancellationToken).ConfigureAwait(false))
+        {
+            contador.ContarLido();
+
+            // FK cidade obrigatória: órfão (cidade não carregada) é descartado e contado.
+            if (cru.CidadeIdDne is not int idCidade
+                || !resolucao.CidadesPorIdDne.TryGetValue(idCidade, out Guid cidadeGuid))
+            {
+                contador.ContarOrfao(cru.Cep ?? "(sem cep)");
+                continue;
+            }
+
+            // FK distrito/bairro opcionais: id ausente/não resolvido vira null (a fonte
+            // traz distrito nulo com frequência), sem descartar a linha. Coerência
+            // hierárquica (o domínio delega ao ETL, ver Logradouro): se a localidade
+            // resolvida pertence a outra cidade, degrada para null e conta — não vincula
+            // logradouro da cidade A a um distrito/bairro da cidade B.
+            Guid? distritoGuid = ResolverCoerente(resolucao.DistritosPorIdDne, cru.DistritoIdDne, cidadeGuid, contador);
+            Guid? bairroGuid = ResolverCoerente(resolucao.BairrosPorIdDne, cru.BairroIdDne, cidadeGuid, contador);
+
+            decimal? latitude = LimitarGrau(ParseTolerante.ParaDecimal(cru.Latitude), 90m);
+            decimal? longitude = LimitarGrau(ParseTolerante.ParaDecimal(cru.Longitude), 180m);
+            Point? coordenada = PontoFactory.Criar(cru.Latitude, cru.Longitude);
+
+            Result<Logradouro> resultado = Logradouro.Importar(
+                cru.Cep ?? string.Empty,
+                cru.Tipo,
+                cru.Nome ?? string.Empty,
+                cru.NomeCompleto,
+                cru.NomeSemAcento ?? cru.Nome ?? string.Empty,
+                cidadeGuid,
+                distritoGuid,
+                bairroGuid,
+                cru.Uf ?? string.Empty,
+                latitude,
+                longitude,
+                coordenada,
+                ParseTolerante.ParaBoolSn(cru.CepAtivo),
+                fonte.Versao);
+
+            if (resultado.IsFailure)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            yield return resultado.Value!;
+        }
+    }
+
+    private static async Task EscreverComplementoAsync(NpgsqlBinaryImporter importer, LogradouroComplemento e, DateTimeOffset agora, CancellationToken cancellationToken)
+    {
+        await importer.WriteAsync(e.Id, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.Cep, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.Complemento, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.ComplementoNormalizado, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.VersaoDataset, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(agora, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task EscreverLogradouroAsync(NpgsqlBinaryImporter importer, Logradouro e, DateTimeOffset agora, CancellationToken cancellationToken)
+    {
+        await importer.WriteAsync(e.Id, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.Cep, cancellationToken).ConfigureAwait(false);
+        await EscreverTextoAsync(importer, e.Tipo, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.Nome, cancellationToken).ConfigureAwait(false);
+        await EscreverTextoAsync(importer, e.NomeCompleto, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.NomeNormalizado, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.CidadeId, cancellationToken).ConfigureAwait(false);
+        await EscreverGuidAsync(importer, e.DistritoId, cancellationToken).ConfigureAwait(false);
+        await EscreverGuidAsync(importer, e.BairroId, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.Uf, cancellationToken).ConfigureAwait(false);
+        await EscreverDecimalAsync(importer, e.Latitude, cancellationToken).ConfigureAwait(false);
+        await EscreverDecimalAsync(importer, e.Longitude, cancellationToken).ConfigureAwait(false);
+        await EscreverPontoAsync(importer, e.Coordenada, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.Ativo, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(e.VersaoDataset, cancellationToken).ConfigureAwait(false);
+        await importer.WriteAsync(agora, cancellationToken).ConfigureAwait(false);
+    }
+
+    // Loop de COPY em lotes: cada lote é um BeginBinaryImport...Complete próprio (commit
+    // autocommit ao Complete); o staging acumula os lotes. Retorna o total escrito.
+    private async Task<long> CopiarEmLotesAsync<T>(
+        NpgsqlConnection conexao,
+        string copyComando,
+        IAsyncEnumerable<T> itens,
+        Func<NpgsqlBinaryImporter, T, DateTimeOffset, CancellationToken, Task> escrever,
+        DateTimeOffset agora,
+        string tabela,
+        CancellationToken cancellationToken)
+    {
+        long total = 0;
+        int noLote = 0;
+        NpgsqlBinaryImporter? importer = null;
+        try
+        {
+            await foreach (T item in itens.ConfigureAwait(false))
+            {
+                importer ??= await conexao.BeginBinaryImportAsync(copyComando, cancellationToken).ConfigureAwait(false);
+                await importer.StartRowAsync(cancellationToken).ConfigureAwait(false);
+                await escrever(importer, item, agora, cancellationToken).ConfigureAwait(false);
+                total++;
+                noLote++;
+
+                if (noLote >= TamanhoLote)
+                {
+                    await importer.CompleteAsync(cancellationToken).ConfigureAwait(false);
+                    await importer.DisposeAsync().ConfigureAwait(false);
+                    importer = null;
+                    noLote = 0;
+                    LogLoteConcluido(_logger, tabela, total);
+                }
+            }
+
+            if (importer is not null)
+            {
+                await importer.CompleteAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (importer is not null)
+            {
+                await importer.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        return total;
+    }
+
+    // Merge staging → alvo. O command tag do INSERT ... ON CONFLICT DO UPDATE conta as
+    // chaves distintas afetadas (inseridas + atualizadas); o crescimento real do alvo dá
+    // os inseridos; o resto, os atualizados; e staged − afetadas, as duplicatas removidas
+    // pelo DISTINCT ON. O split assume execução exclusiva do ETL (single-writer) — não há
+    // DML concorrente entre as contagens; é métrica de relatório, não controle de dados.
+    private static async Task MergearContandoAsync(
+        NpgsqlConnection conexao,
+        ContadorTabela contador,
+        string tabelaAlvo,
+        string mergeSql,
+        long staged,
+        DateTimeOffset agora,
+        CancellationToken cancellationToken)
+    {
+        long antes = await ContarAsync(conexao, tabelaAlvo, cancellationToken).ConfigureAwait(false);
+
+        long afetadas;
+        NpgsqlCommand comando = conexao.CreateCommand();
+        await using (comando.ConfigureAwait(false))
+        {
+            comando.CommandText = mergeSql;
+            comando.Parameters.AddWithValue("now", agora);
+            afetadas = await comando.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        long depois = await ContarAsync(conexao, tabelaAlvo, cancellationToken).ConfigureAwait(false);
+
+        long inseridos = depois - antes;
+        long atualizados = afetadas - inseridos;
+        long duplicados = staged - afetadas;
+
+        contador.ContarInseridos((int)Math.Max(0, inseridos));
+        contador.ContarAtualizados((int)Math.Max(0, atualizados));
+        contador.ContarDuplicados((int)Math.Max(0, duplicados));
+    }
+
+    private static async Task<long> ContarAsync(NpgsqlConnection conexao, string tabela, CancellationToken cancellationToken)
+    {
+        NpgsqlCommand comando = conexao.CreateCommand();
+        await using (comando.ConfigureAwait(false))
+        {
+            // Nome de tabela é literal de código (lista fixa), não entrada de usuário.
+            comando.CommandText = $"SELECT count(*) FROM {tabela}";
+            object? resultado = await comando.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            return resultado is long valor ? valor : 0;
+        }
+    }
+
+    private static async Task DroparIndicesPesadosAsync(NpgsqlConnection conexao, CancellationToken cancellationToken)
+    {
+        await ExecutarAsync(conexao, "DROP INDEX IF EXISTS ix_logradouro_nome_trgm;", cancellationToken).ConfigureAwait(false);
+        await ExecutarAsync(conexao, "DROP INDEX IF EXISTS ix_logradouro_coordenada;", cancellationToken).ConfigureAwait(false);
+    }
+
+    // CREATE INDEX CONCURRENTLY não pode rodar em transação: esta conexão está em
+    // autocommit (nunca abrimos BeginTransaction nela). DROP IF EXISTS antes de cada
+    // CREATE limpa eventual índice INVALID deixado por uma recriação anterior abortada.
+    private static async Task RecriarIndicesPesadosAsync(NpgsqlConnection conexao, CancellationToken cancellationToken)
+    {
+        await ExecutarAsync(conexao, "DROP INDEX IF EXISTS ix_logradouro_nome_trgm;", cancellationToken).ConfigureAwait(false);
+        await ExecutarAsync(conexao, "CREATE INDEX CONCURRENTLY ix_logradouro_nome_trgm ON logradouro USING gin (nome_normalizado gin_trgm_ops);", cancellationToken).ConfigureAwait(false);
+        await ExecutarAsync(conexao, "DROP INDEX IF EXISTS ix_logradouro_coordenada;", cancellationToken).ConfigureAwait(false);
+        await ExecutarAsync(conexao, "CREATE INDEX CONCURRENTLY ix_logradouro_coordenada ON logradouro USING gist (coordenada);", cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task ExecutarAsync(NpgsqlConnection conexao, string sql, CancellationToken cancellationToken)
+    {
+        NpgsqlCommand comando = conexao.CreateCommand();
+        await using (comando.ConfigureAwait(false))
+        {
+            comando.CommandText = sql;
+            await comando.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    // Resolve a FK opcional (distrito/bairro) garantindo coerência com a cidade do
+    // logradouro: id ausente/não resolvido → null silencioso (FK opcional); resolvido mas
+    // de outra cidade → null + contagem de degradação (inconsistência da fonte).
+    private static Guid? ResolverCoerente(
+        Dictionary<int, LocalidadeResolvida> mapa,
+        int? idDne,
+        Guid cidadeGuid,
+        ContadorTabela contador)
+    {
+        if (idDne is not int id || !mapa.TryGetValue(id, out LocalidadeResolvida resolvida))
+        {
+            return null;
+        }
+
+        if (resolvida.CidadeId != cidadeGuid)
+        {
+            contador.ContarParseDegradado($"fk_localidade_cidade_divergente:{id.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+            return null;
+        }
+
+        return resolvida.Id;
+    }
+
+    // Mantém o grau dentro do domínio geográfico (±limite) — fora disso vira null,
+    // coerente com PontoFactory (que anula a coordenada) e evitando overflow do
+    // numeric(9,6) por dado sujo.
+    private static decimal? LimitarGrau(decimal? valor, decimal limite) =>
+        valor is decimal v && v >= -limite && v <= limite ? v : null;
+
+    private static async Task EscreverTextoAsync(NpgsqlBinaryImporter importer, string? valor, CancellationToken cancellationToken)
+    {
+        if (valor is null)
+        {
+            await importer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await importer.WriteAsync(valor, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task EscreverGuidAsync(NpgsqlBinaryImporter importer, Guid? valor, CancellationToken cancellationToken)
+    {
+        if (valor is null)
+        {
+            await importer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await importer.WriteAsync(valor.Value, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task EscreverDecimalAsync(NpgsqlBinaryImporter importer, decimal? valor, CancellationToken cancellationToken)
+    {
+        if (valor is null)
+        {
+            await importer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await importer.WriteAsync(valor.Value, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task EscreverPontoAsync(NpgsqlBinaryImporter importer, Point? valor, CancellationToken cancellationToken)
+    {
+        if (valor is null)
+        {
+            await importer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await importer.WriteAsync(valor, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: COPY {Tabela} — {LinhasAcumuladas} linhas enviadas ao staging.")]
+    private static partial void LogLoteConcluido(ILogger logger, string tabela, long linhasAcumuladas);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
@@ -224,14 +224,17 @@ internal sealed partial class LogradouroCopyImporter
         {
             // No modo Inicial os índices pesados são dropados dentro do try. Recria-os
             // sempre — mesmo em falha/cancelamento do bulk — para a tabela nunca ficar sem
-            // gin_trgm/GIST (degradaria o lookup/autocomplete até um rerun). No caminho de
-            // falha a recriação é best-effort (com token não-cancelável e sem mascarar a
-            // exceção original); rerun do Inicial continua sendo a recuperação canônica.
+            // gin_trgm/GIST (degradaria o lookup/autocomplete até um rerun). Em ambos os
+            // caminhos a recriação roda com CancellationToken.None: cada índice é dropado
+            // logo antes de ser recriado, então interromper no meio deixaria a tabela sem
+            // um índice pesado — concluir é o estado correto. No sucesso os erros propagam;
+            // na falha são best-effort (sem mascarar a exceção original do bulk). Rerun do
+            // Inicial continua sendo a recuperação canônica.
             if (modo == ModoCarga.Inicial)
             {
                 if (concluido)
                 {
-                    await RecriarIndicesPesadosAsync(conexao, cancellationToken).ConfigureAwait(false);
+                    await RecriarIndicesPesadosAsync(conexao, CancellationToken.None).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
@@ -186,20 +186,27 @@ internal sealed partial class LogradouroCopyImporter
     {
         ContadorTabela contador = relatorio.Tabela("logradouro");
 
-        // Modo Inicial: base limpa + índices pesados fora do caminho do COPY (acelera a
-        // carga). TRUNCATE torna a reexecução do Inicial idempotente (sem violar a UNIQUE
-        // por estado parcial de uma execução anterior).
+        // Modo Inicial: base limpa para COPY rápido. TRUNCATE torna a reexecução do
+        // Inicial idempotente (sem violar a UNIQUE por estado parcial anterior). Fica
+        // fora do try: se falhar, nenhum índice foi dropado ainda, nada a recuperar.
         if (modo == ModoCarga.Inicial)
         {
             await ExecutarAsync(conexao, "TRUNCATE TABLE logradouro;", cancellationToken).ConfigureAwait(false);
-            await DroparIndicesPesadosAsync(conexao, cancellationToken).ConfigureAwait(false);
         }
-
-        await ExecutarAsync(conexao, CriarStagingLogradouro, cancellationToken).ConfigureAwait(false);
 
         bool concluido = false;
         try
         {
+            // Drop dos índices pesados e criação do staging DENTRO do try: como rodam em
+            // autocommit, um drop já é permanente; qualquer falha a partir daqui (entre os
+            // dois drops, na criação do staging, no COPY/merge) cai no finally que recria.
+            if (modo == ModoCarga.Inicial)
+            {
+                await DroparIndicesPesadosAsync(conexao, cancellationToken).ConfigureAwait(false);
+            }
+
+            await ExecutarAsync(conexao, CriarStagingLogradouro, cancellationToken).ConfigureAwait(false);
+
             long staged = await CopiarEmLotesAsync(
                 conexao,
                 CopyLogradouro,
@@ -215,7 +222,7 @@ internal sealed partial class LogradouroCopyImporter
         }
         finally
         {
-            // No modo Inicial os índices pesados foram dropados antes do COPY. Recria-os
+            // No modo Inicial os índices pesados são dropados dentro do try. Recria-os
             // sempre — mesmo em falha/cancelamento do bulk — para a tabela nunca ficar sem
             // gin_trgm/GIST (degradaria o lookup/autocomplete até um rerun). No caminho de
             // falha a recriação é best-effort (com token não-cancelável e sem mascarar a

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
@@ -197,21 +197,55 @@ internal sealed partial class LogradouroCopyImporter
 
         await ExecutarAsync(conexao, CriarStagingLogradouro, cancellationToken).ConfigureAwait(false);
 
-        long staged = await CopiarEmLotesAsync(
-            conexao,
-            CopyLogradouro,
-            ProjetarLogradourosAsync(fonte, resolucao, contador, cancellationToken),
-            EscreverLogradouroAsync,
-            agora,
-            "logradouro",
-            cancellationToken).ConfigureAwait(false);
-
-        await MergearContandoAsync(conexao, contador, "logradouro", MergeLogradouro, staged, agora, cancellationToken).ConfigureAwait(false);
-        await ExecutarAsync(conexao, "DROP TABLE IF EXISTS logradouro_staging;", cancellationToken).ConfigureAwait(false);
-
-        if (modo == ModoCarga.Inicial)
+        bool concluido = false;
+        try
         {
-            await RecriarIndicesPesadosAsync(conexao, cancellationToken).ConfigureAwait(false);
+            long staged = await CopiarEmLotesAsync(
+                conexao,
+                CopyLogradouro,
+                ProjetarLogradourosAsync(fonte, resolucao, contador, cancellationToken),
+                EscreverLogradouroAsync,
+                agora,
+                "logradouro",
+                cancellationToken).ConfigureAwait(false);
+
+            await MergearContandoAsync(conexao, contador, "logradouro", MergeLogradouro, staged, agora, cancellationToken).ConfigureAwait(false);
+            await ExecutarAsync(conexao, "DROP TABLE IF EXISTS logradouro_staging;", cancellationToken).ConfigureAwait(false);
+            concluido = true;
+        }
+        finally
+        {
+            // No modo Inicial os índices pesados foram dropados antes do COPY. Recria-os
+            // sempre — mesmo em falha/cancelamento do bulk — para a tabela nunca ficar sem
+            // gin_trgm/GIST (degradaria o lookup/autocomplete até um rerun). No caminho de
+            // falha a recriação é best-effort (com token não-cancelável e sem mascarar a
+            // exceção original); rerun do Inicial continua sendo a recuperação canônica.
+            if (modo == ModoCarga.Inicial)
+            {
+                if (concluido)
+                {
+                    await RecriarIndicesPesadosAsync(conexao, cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await RecriarIndicesPesadosBestEffortAsync(conexao).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private async Task RecriarIndicesPesadosBestEffortAsync(NpgsqlConnection conexao)
+    {
+        try
+        {
+            // CancellationToken.None: a recuperação roda mesmo se o cancelamento foi a causa
+            // da falha — caso contrário a tabela ficaria sem índices.
+            await RecriarIndicesPesadosAsync(conexao, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is NpgsqlException or InvalidOperationException or TimeoutException)
+        {
+            // Não mascara a exceção original do bulk; o rerun do Inicial recria os índices.
+            LogRecriacaoIndicesFalhou(_logger, ex);
         }
     }
 
@@ -531,4 +565,7 @@ internal sealed partial class LogradouroCopyImporter
 
     [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: COPY {Tabela} — {LinhasAcumuladas} linhas enviadas ao staging.")]
     private static partial void LogLoteConcluido(ILogger logger, string tabela, long linhasAcumuladas);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: falha ao recriar índices pesados de logradouro após carga inicial abortada — reexecute o modo Inicial para restaurá-los.")]
+    private static partial void LogRecriacaoIndicesFalhou(ILogger logger, Exception excecao);
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Bulk/LogradouroCopyImporter.cs
@@ -301,9 +301,13 @@ internal sealed partial class LogradouroCopyImporter
             Guid? distritoGuid = ResolverCoerente(resolucao.DistritosPorIdDne, cru.DistritoIdDne, cidadeGuid, contador);
             Guid? bairroGuid = ResolverCoerente(resolucao.BairrosPorIdDne, cru.BairroIdDne, cidadeGuid, contador);
 
-            decimal? latitude = LimitarGrau(ParseTolerante.ParaDecimal(cru.Latitude), 90m);
-            decimal? longitude = LimitarGrau(ParseTolerante.ParaDecimal(cru.Longitude), 180m);
+            // Parse único: deriva lat/lon decimais do Point já validado (PontoFactory
+            // limita a ±90/±180), evitando parsear o texto duas vezes (×~1,4M) e duplicar
+            // a regra do domínio geográfico — e a derivação mantém lat/lon dentro do
+            // numeric(9,6) por construção.
             Point? coordenada = PontoFactory.Criar(cru.Latitude, cru.Longitude);
+            decimal? latitude = coordenada is null ? null : (decimal)coordenada.Y;
+            decimal? longitude = coordenada is null ? null : (decimal)coordenada.X;
 
             Result<Logradouro> resultado = Logradouro.Importar(
                 cru.Cep ?? string.Empty,
@@ -508,12 +512,6 @@ internal sealed partial class LogradouroCopyImporter
 
         return resolvida.Id;
     }
-
-    // Mantém o grau dentro do domínio geográfico (±limite) — fora disso vira null,
-    // coerente com PontoFactory (que anula a coordenada) e evitando overflow do
-    // numeric(9,6) por dado sujo.
-    private static decimal? LimitarGrau(decimal? valor, decimal limite) =>
-        valor is decimal v && v >= -limite && v <= limite ? v : null;
 
     private static async Task EscreverTextoAsync(NpgsqlBinaryImporter importer, string? valor, CancellationToken cancellationToken)
     {

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/DneStagingFonte.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/DneStagingFonte.cs
@@ -125,6 +125,61 @@ internal sealed class DneStagingFonte : IGeoFonteDados
             static r => new CidadeFaixaCru(Texto(r, 0), Texto(r, 1), Texto(r, 2)),
             cancellationToken);
 
+    public IAsyncEnumerable<CidadeIdCru> LerCidadeIdsAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT id_cidade, cidade_ibge FROM {Tabela("cidade")}",
+            static r => new CidadeIdCru(Inteiro(r, 0), Texto(r, 1)),
+            cancellationToken);
+
+    public IAsyncEnumerable<DistritoCru> LerDistritosAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT id_distrito, distrito, distrito_sem_acento, cidade_id, estado, latitude, longitude FROM {Tabela("distrito")}",
+            static r => new DistritoCru(Inteiro(r, 0), Texto(r, 1), Texto(r, 2), Inteiro(r, 3), Texto(r, 4), Texto(r, 5), Texto(r, 6)),
+            cancellationToken);
+
+    public IAsyncEnumerable<FaixaLocalidadeCru> LerDistritoFaixasAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT id_distrito, faixa_ini, faixa_fim FROM {Tabela("distrito_faixa")}",
+            static r => new FaixaLocalidadeCru(Inteiro(r, 0), Texto(r, 1), Texto(r, 2)),
+            cancellationToken);
+
+    public IAsyncEnumerable<BairroCru> LerBairrosAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT id_bairro, bairro, bairro_sem_acento, cidade_id, estado, latitude, longitude FROM {Tabela("bairro")}",
+            static r => new BairroCru(Inteiro(r, 0), Texto(r, 1), Texto(r, 2), Inteiro(r, 3), Texto(r, 4), Texto(r, 5), Texto(r, 6)),
+            cancellationToken);
+
+    public IAsyncEnumerable<FaixaLocalidadeCru> LerBairroFaixasAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT id_bairro, faixa_ini, faixa_fim FROM {Tabela("bairro_faixa")}",
+            static r => new FaixaLocalidadeCru(Inteiro(r, 0), Texto(r, 1), Texto(r, 2)),
+            cancellationToken);
+
+    public IAsyncEnumerable<CepGrandeUsuarioCru> LerCepGrandesUsuariosAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT cep, grandes_usuarios, grandes_usuarios_sem_acento FROM {Tabela("log_grande_usuario")}",
+            static r => new CepGrandeUsuarioCru(Texto(r, 0), Texto(r, 1), Texto(r, 2)),
+            cancellationToken);
+
+    public IAsyncEnumerable<LogradouroComplementoCru> LerLogradouroComplementosAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"SELECT cep, complemento, complemento_sem_acento FROM {Tabela("log_complemento")}",
+            static r => new LogradouroComplementoCru(Texto(r, 0), Texto(r, 1), Texto(r, 2)),
+            cancellationToken);
+
+    public IAsyncEnumerable<LogradouroCru> LerLogradourosAsync(CancellationToken cancellationToken) =>
+        ConsultarAsync(
+            $"""
+             SELECT cep, tipo, nome_logradouro, logradouro, bairro_id, distrito_id, cidade_id,
+                    estado, nome_logradouro_sem_acento, latitude, longitude, cep_ativo
+             FROM {Tabela("logradouro")}
+             """,
+            static r => new LogradouroCru(
+                Texto(r, 0), Texto(r, 1), Texto(r, 2), Texto(r, 3), Texto(r, 8),
+                Inteiro(r, 4), Inteiro(r, 5), Inteiro(r, 6),
+                Texto(r, 7), Texto(r, 9), Texto(r, 10), Texto(r, 11)),
+            cancellationToken);
+
     [SuppressMessage(
         "Security",
         "CA2100:Review SQL queries for security vulnerabilities",
@@ -163,6 +218,12 @@ internal sealed class DneStagingFonte : IGeoFonteDados
     // o boxing de GetValue().ToString() (relevante no volume dos logradouros, #673).
     private static string? Texto(DbDataReader leitor, int ordinal) =>
         leitor.IsDBNull(ordinal) ? null : leitor.GetString(ordinal);
+
+    // Ids da fonte (id_cidade/id_distrito/id_bairro e as FKs cidade_id/distrito_id/
+    // bairro_id) são int4 — diferente do projeto da #672 (text-only). Lê como int,
+    // NULL → null (FK opcional do logradouro chega nula com frequência, #673).
+    private static int? Inteiro(DbDataReader leitor, int ordinal) =>
+        leitor.IsDBNull(ordinal) ? null : leitor.GetInt32(ordinal);
 
     private static bool VersaoValida(string versao) =>
         versao.Length == 6 && versao.All(char.IsAsciiDigit);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/IGeoFonteDados.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/IGeoFonteDados.cs
@@ -8,8 +8,9 @@ namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
 /// a usa para gravar a proveniência, evitando carimbar dados de uma versão com outra.
 /// </summary>
 /// <remarks>
-/// Esta interface cobre o topo da hierarquia (País/Estado/Cidade, Story #672). As
-/// folhas (Distrito/Bairro/Logradouro) entram por extensão aditiva na Story irmã.
+/// Cobre toda a hierarquia DNE: o topo (País/Estado/Cidade, Story #672) e as folhas
+/// (Distrito/Bairro/Logradouro e satélites, Story #673). As folhas trazem os ids int4
+/// da fonte para resolução de FK.
 /// </remarks>
 internal interface IGeoFonteDados
 {
@@ -31,4 +32,23 @@ internal interface IGeoFonteDados
     IAsyncEnumerable<CidadeIndicadorCru> LerCidadeIndicadoresAsync(CancellationToken cancellationToken);
 
     IAsyncEnumerable<CidadeFaixaCru> LerCidadeFaixasAsync(CancellationToken cancellationToken);
+
+    // --- Folhas (Story #673) ---
+
+    /// <summary>Mapa <c>id_cidade</c> → <c>cidade_ibge</c> para resolver a FK <c>cidade_id</c> (int4) em Guid.</summary>
+    IAsyncEnumerable<CidadeIdCru> LerCidadeIdsAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<DistritoCru> LerDistritosAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<FaixaLocalidadeCru> LerDistritoFaixasAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<BairroCru> LerBairrosAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<FaixaLocalidadeCru> LerBairroFaixasAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<CepGrandeUsuarioCru> LerCepGrandesUsuariosAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<LogradouroComplementoCru> LerLogradouroComplementosAsync(CancellationToken cancellationToken);
+
+    IAsyncEnumerable<LogradouroCru> LerLogradourosAsync(CancellationToken cancellationToken);
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/RegistrosDne.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/RegistrosDne.cs
@@ -93,3 +93,68 @@ internal sealed record CidadeFaixaCru(
     string? CodigoIbge,
     string? FaixaIni,
     string? FaixaFim);
+
+// ----------------------------------------------------------------------------
+// Folhas da hierarquia (Story #673): Distrito, Bairro, Logradouro e satélites.
+// Os ids da fonte são int4 (não varchar) — instáveis entre releases, usados só
+// para resolver as FKs intra-release para Guid (ADR-0054); o domínio nunca os
+// adota como identidade.
+// ----------------------------------------------------------------------------
+
+/// <summary>Mapa <c>id_cidade</c> (int4, PK da fonte) → <c>cidade_ibge</c> — resolve a FK <c>cidade_id</c> para Guid.</summary>
+internal sealed record CidadeIdCru(
+    int? IdCidade,
+    string? CodigoIbge);
+
+/// <summary>Distrito (fonte <c>distrito</c>): PK <c>id_distrito</c>; FK <c>cidade_id</c> (int4); chave natural de upsert <c>(cidade, nome_sem_acento)</c>.</summary>
+internal sealed record DistritoCru(
+    int? IdDistrito,
+    string? Nome,
+    string? NomeSemAcento,
+    int? CidadeIdDne,
+    string? Uf,
+    string? Latitude,
+    string? Longitude);
+
+/// <summary>Bairro (fonte <c>bairro</c>): PK <c>id_bairro</c>; FK <c>cidade_id</c> (int4); chave natural de upsert <c>(cidade, nome_sem_acento)</c>.</summary>
+internal sealed record BairroCru(
+    int? IdBairro,
+    string? Nome,
+    string? NomeSemAcento,
+    int? CidadeIdDne,
+    string? Uf,
+    string? Latitude,
+    string? Longitude);
+
+/// <summary>Faixa de CEP de Distrito/Bairro (fontes <c>distrito_faixa</c>/<c>bairro_faixa</c>): vínculo pelo id int4 do pai.</summary>
+internal sealed record FaixaLocalidadeCru(
+    int? IdPaiDne,
+    string? FaixaIni,
+    string? FaixaFim);
+
+/// <summary>CEP exclusivo de grande usuário (fonte <c>log_grande_usuario</c>): sem cidade/UF.</summary>
+internal sealed record CepGrandeUsuarioCru(
+    string? Cep,
+    string? Nome,
+    string? NomeSemAcento);
+
+/// <summary>Complemento por CEP (fonte <c>log_complemento</c>): sem FK a logradouro.</summary>
+internal sealed record LogradouroComplementoCru(
+    string? Cep,
+    string? Complemento,
+    string? ComplementoSemAcento);
+
+/// <summary>Logradouro (fonte <c>logradouro</c>, ~1,4M linhas): FK <c>cidade_id</c> (obrigatória) e <c>distrito_id</c>/<c>bairro_id</c> (int4 opcionais, NULL frequente); <c>cep_ativo</c> 'S'/'N'.</summary>
+internal sealed record LogradouroCru(
+    string? Cep,
+    string? Tipo,
+    string? Nome,
+    string? NomeCompleto,
+    string? NomeSemAcento,
+    int? BairroIdDne,
+    int? DistritoIdDne,
+    int? CidadeIdDne,
+    string? Uf,
+    string? Latitude,
+    string? Longitude,
+    string? CepAtivo);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlUpsert.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlUpsert.cs
@@ -1,0 +1,126 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Helpers de upsert por chave natural compartilhados pelos importadores do ETL DNE
+/// (ADR-0092): dedup intra-fonte (last-wins), agregação contando o que a fonte trouxe
+/// e normalização das chaves naturais. Extraídos do importador de País/Estado/Cidade
+/// (#672) para reuso no de Distrito/Bairro (#673) sem duplicar a lógica idempotente.
+/// </summary>
+internal static class GeoEtlUpsert
+{
+    /// <summary>
+    /// Upsert por chave natural com dedup intra-fonte: chaves repetidas na própria
+    /// carga não disparam unique violation — a 2ª ocorrência atualiza a entidade já
+    /// vista (last-wins) e conta como duplicada. Retorna a entidade (para resolver FK)
+    /// ou <see langword="null"/> em falha de validação do domínio.
+    /// </summary>
+    public static T? Upsert<T>(
+        string chave,
+        Dictionary<string, T> jaVistas,
+        Dictionary<string, T> existentes,
+        Func<Result<T>> criar,
+        Func<T, Result> atualizar,
+        DbSet<T> dbSet,
+        ContadorTabela contador)
+        where T : class
+    {
+        if (jaVistas.TryGetValue(chave, out T? jaVista))
+        {
+            contador.ContarDuplicado(chave);
+            Result reatualizacao = atualizar(jaVista);
+            return reatualizacao.IsSuccess ? jaVista : null;
+        }
+
+        if (existentes.TryGetValue(chave, out T? existente))
+        {
+            Result atualizacao = atualizar(existente);
+            if (atualizacao.IsFailure)
+            {
+                contador.ContarIgnoradoSemChave();
+                return null;
+            }
+
+            jaVistas[chave] = existente;
+            contador.ContarAtualizado();
+            return existente;
+        }
+
+        Result<T> criado = criar();
+        if (criado.IsFailure)
+        {
+            contador.ContarIgnoradoSemChave();
+            return null;
+        }
+
+        dbSet.Add(criado.Value!);
+        jaVistas[chave] = criado.Value!;
+        contador.ContarInserido();
+        return criado.Value;
+    }
+
+    /// <summary>Agrega a fonte por chave (last-wins) sem contar — para níveis cujos contadores são resolvidos depois.</summary>
+    public static async Task<Dictionary<string, T>> AgregarPorChaveAsync<T>(
+        IAsyncEnumerable<T> fonte,
+        Func<T, string?> chave)
+    {
+        Dictionary<string, T> mapa = new(StringComparer.Ordinal);
+        await foreach (T item in fonte.ConfigureAwait(false))
+        {
+            string? k = chave(item);
+            if (k is not null)
+            {
+                mapa[k] = item; // last-wins
+            }
+        }
+
+        return mapa;
+    }
+
+    /// <summary>
+    /// Como <see cref="AgregarPorChaveAsync{T}"/>, mas registra no contador da tabela
+    /// tudo o que a fonte trouxe (lidos), o que foi descartado por chave ausente e as
+    /// chaves repetidas (last-wins) — para o relatório não subestimar os "lidos" dos
+    /// níveis agregados.
+    /// </summary>
+    public static async Task<Dictionary<string, T>> AgregarContandoAsync<T>(
+        IAsyncEnumerable<T> fonte,
+        Func<T, string?> chave,
+        ContadorTabela contador)
+    {
+        Dictionary<string, T> mapa = new(StringComparer.Ordinal);
+        await foreach (T item in fonte.ConfigureAwait(false))
+        {
+            contador.ContarLido();
+            string? k = chave(item);
+            if (k is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            if (!mapa.TryAdd(k, item))
+            {
+                contador.ContarDuplicado(k); // last-wins
+                mapa[k] = item;
+            }
+        }
+
+        return mapa;
+    }
+
+    /// <summary>Chave natural alfabética (sigla/UF): trim + maiúsculas; vazio → <see langword="null"/>.</summary>
+    public static string? ChaveSigla(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim().ToUpperInvariant();
+
+    /// <summary>Chave natural numérica/código (código IBGE/CEP): trim; vazio → <see langword="null"/>.</summary>
+    public static string? ChaveCodigo(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    /// <summary>Chave natural composta de uma faixa de CEP: pai (Guid) + limites — casa com a UNIQUE.</summary>
+    public static string ChaveFaixa(Guid pai, string cepInicial, string cepFinal) =>
+        $"{pai:N}|{cepInicial}|{cepFinal}";
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorDistritoBairro.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorDistritoBairro.cs
@@ -187,9 +187,12 @@ internal sealed class GeoImportadorDistritoBairro
                 continue;
             }
 
-            decimal? latitude = ParseTolerante.ParaDecimal(cru.Lat);
-            decimal? longitude = ParseTolerante.ParaDecimal(cru.Lon);
+            // Deriva lat/lon do Point já validado (PontoFactory limita a ±90/±180): evita
+            // persistir coordenada fora do domínio ou estourar o numeric(9,6) por dado
+            // sujo (ex.: 91 / 1234.5) — mesma estratégia do COPY de logradouro.
             Point? coordenada = PontoFactory.Criar(cru.Lat, cru.Lon);
+            decimal? latitude = coordenada is null ? null : (decimal)coordenada.Y;
+            decimal? longitude = coordenada is null ? null : (decimal)coordenada.X;
             string nome = cru.Nome ?? string.Empty;
             string uf = cru.Uf ?? string.Empty;
             string? idOrigemDne = cru.IdDne?.ToString(System.Globalization.CultureInfo.InvariantCulture);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorDistritoBairro.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorDistritoBairro.cs
@@ -1,0 +1,339 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using System.Runtime.CompilerServices;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+
+using NetTopologySuite.Geometries;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Parsing;
+using Unifesspa.UniPlus.Kernel.Results;
+
+using static Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.GeoEtlUpsert;
+
+/// <summary>
+/// Mapas de resolução de FK construídos pela carga de Distrito/Bairro: traduzem os ids
+/// int4 da fonte DNE (instáveis entre releases) para os Guid intra-banco (ADR-0054),
+/// consumidos pela carga de logradouros. <c>id_distrito</c>/<c>id_bairro</c> são as PKs
+/// da fonte (únicos dentro de uma release); homônimos em cidades distintas resolvem
+/// para Guids diferentes porque cada par <c>(cidade, nome)</c> é uma entidade própria.
+/// </summary>
+internal sealed record ResolucaoLocalidades(
+    Dictionary<int, Guid> CidadesPorIdDne,
+    Dictionary<int, LocalidadeResolvida> DistritosPorIdDne,
+    Dictionary<int, LocalidadeResolvida> BairrosPorIdDne);
+
+/// <summary>
+/// Distrito/Bairro resolvido: o Guid intra-banco e a <see cref="CidadeId"/> a que
+/// pertence. O logradouro só adota a FK de distrito/bairro se a cidade resolvida bater
+/// com a sua — garantindo a coerência hierárquica que o domínio delega ao ETL.
+/// </summary>
+internal readonly record struct LocalidadeResolvida(Guid Id, Guid CidadeId);
+
+/// <summary>
+/// Carga das folhas de volume modesto via upsert por chave natural (idempotente, como
+/// o importador de topo #672): Distrito e Bairro (+faixas) e o CEP de grande usuário.
+/// Roda numa transação única e devolve a <see cref="ResolucaoLocalidades"/> (dicts de
+/// FK) para a carga em lote (COPY) dos logradouros. Distrito/Bairro usam upsert (não
+/// COPY) porque o volume é baixo e a tradução id4→Guid precisa de iteração em C#.
+/// </summary>
+internal sealed class GeoImportadorDistritoBairro
+{
+    private readonly GeoDbContext _contexto;
+
+    public GeoImportadorDistritoBairro(GeoDbContext contexto)
+    {
+        ArgumentNullException.ThrowIfNull(contexto);
+        _contexto = contexto;
+    }
+
+    public async Task<ResolucaoLocalidades> ImportarAsync(
+        IGeoFonteDados fonte,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        IDbContextTransaction transacao =
+            await _contexto.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await using (transacao.ConfigureAwait(false))
+        {
+            Dictionary<int, Guid> cidadesPorIdDne =
+                await ResolverCidadesPorIdDneAsync(fonte, cancellationToken).ConfigureAwait(false);
+
+            Dictionary<int, LocalidadeResolvida> distritosPorIdDne = await ImportarLocalidadesAsync(
+                "distrito",
+                ComoLocalidades(fonte.LerDistritosAsync(cancellationToken),
+                    static d => new LocalidadeCru(d.IdDistrito, d.Nome, d.NomeSemAcento, d.CidadeIdDne, d.Uf, d.Latitude, d.Longitude),
+                    cancellationToken),
+                cidadesPorIdDne,
+                _contexto.Distritos,
+                e => $"{e.CidadeId:N}|{e.NomeNormalizado}",
+                (cidadeId, uf, nome, nomeNorm, lat, lon, coord, idDne, versao) =>
+                    Distrito.Importar(cidadeId, uf, nome, nomeNorm, lat, lon, coord, idDne, versao),
+                (e, cidadeId, uf, nome, nomeNorm, lat, lon, coord, idDne, versao) =>
+                    e.Atualizar(cidadeId, uf, nome, nomeNorm, lat, lon, coord, idDne, versao),
+                fonte.Versao,
+                relatorio,
+                cancellationToken).ConfigureAwait(false);
+
+            await ImportarFaixasAsync(
+                "distrito_faixa",
+                fonte.LerDistritoFaixasAsync(cancellationToken),
+                distritosPorIdDne,
+                _contexto.DistritoFaixasCep,
+                f => ChaveFaixa(f.DistritoId, f.CepInicial, f.CepFinal),
+                (paiId, ini, fim, versao) => DistritoFaixaCep.Importar(paiId, ini, fim, versao),
+                (e, versao) => e.Atualizar(versao),
+                fonte.Versao,
+                relatorio,
+                cancellationToken).ConfigureAwait(false);
+
+            Dictionary<int, LocalidadeResolvida> bairrosPorIdDne = await ImportarLocalidadesAsync(
+                "bairro",
+                ComoLocalidades(fonte.LerBairrosAsync(cancellationToken),
+                    static b => new LocalidadeCru(b.IdBairro, b.Nome, b.NomeSemAcento, b.CidadeIdDne, b.Uf, b.Latitude, b.Longitude),
+                    cancellationToken),
+                cidadesPorIdDne,
+                _contexto.Bairros,
+                e => $"{e.CidadeId:N}|{e.NomeNormalizado}",
+                (cidadeId, uf, nome, nomeNorm, lat, lon, coord, idDne, versao) =>
+                    Bairro.Importar(cidadeId, uf, nome, nomeNorm, lat, lon, coord, idDne, versao),
+                (e, cidadeId, uf, nome, nomeNorm, lat, lon, coord, idDne, versao) =>
+                    e.Atualizar(cidadeId, uf, nome, nomeNorm, lat, lon, coord, idDne, versao),
+                fonte.Versao,
+                relatorio,
+                cancellationToken).ConfigureAwait(false);
+
+            await ImportarFaixasAsync(
+                "bairro_faixa",
+                fonte.LerBairroFaixasAsync(cancellationToken),
+                bairrosPorIdDne,
+                _contexto.BairroFaixasCep,
+                f => ChaveFaixa(f.BairroId, f.CepInicial, f.CepFinal),
+                (paiId, ini, fim, versao) => BairroFaixaCep.Importar(paiId, ini, fim, versao),
+                (e, versao) => e.Atualizar(versao),
+                fonte.Versao,
+                relatorio,
+                cancellationToken).ConfigureAwait(false);
+
+            await ImportarGrandesUsuariosAsync(fonte, relatorio, cancellationToken).ConfigureAwait(false);
+
+            await transacao.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+            return new ResolucaoLocalidades(cidadesPorIdDne, distritosPorIdDne, bairrosPorIdDne);
+        }
+    }
+
+    // {id_cidade(int4) → Cidade.Id} via JOIN staging (id_cidade→cidade_ibge) × domínio
+    // (codigo_ibge→Id). A Cidade não guarda o id4 da DNE (chave natural = codigo_ibge),
+    // então a ponte é o código IBGE. Cidades não carregadas no domínio são ignoradas.
+    private async Task<Dictionary<int, Guid>> ResolverCidadesPorIdDneAsync(
+        IGeoFonteDados fonte,
+        CancellationToken cancellationToken)
+    {
+        Dictionary<string, Guid> ibgeParaGuid =
+            await _contexto.Cidades.ToDictionaryAsync(c => c.CodigoIbge, c => c.Id, StringComparer.Ordinal, cancellationToken).ConfigureAwait(false);
+
+        Dictionary<int, Guid> mapa = [];
+        await foreach (CidadeIdCru cru in fonte.LerCidadeIdsAsync(cancellationToken).ConfigureAwait(false))
+        {
+            string? codigoIbge = ChaveCodigo(cru.CodigoIbge);
+            if (cru.IdCidade is int idCidade && codigoIbge is not null
+                && ibgeParaGuid.TryGetValue(codigoIbge, out Guid cidadeGuid))
+            {
+                mapa[idCidade] = cidadeGuid; // last-wins (id_cidade é PK na fonte)
+            }
+        }
+
+        return mapa;
+    }
+
+    private async Task<Dictionary<int, LocalidadeResolvida>> ImportarLocalidadesAsync<T>(
+        string tabela,
+        IAsyncEnumerable<LocalidadeCru> crus,
+        Dictionary<int, Guid> cidadesPorIdDne,
+        DbSet<T> dbSet,
+        Func<T, string> chaveExistente,
+        CriarLocalidade<T> criar,
+        AtualizarLocalidade<T> atualizar,
+        string versao,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+        where T : class
+    {
+        ContadorTabela contador = relatorio.Tabela(tabela);
+        Dictionary<string, T> existentes =
+            (await dbSet.ToListAsync(cancellationToken).ConfigureAwait(false))
+            .ToDictionary(chaveExistente, StringComparer.Ordinal);
+        Dictionary<string, T> jaVistos = new(StringComparer.Ordinal);
+        Dictionary<int, LocalidadeResolvida> idDneParaGuid = [];
+
+        await foreach (LocalidadeCru cru in crus.ConfigureAwait(false))
+        {
+            contador.ContarLido();
+
+            string? nomeNorm = NormalizarObrigatorio(cru.NomeSemAcento ?? cru.Nome);
+            if (nomeNorm is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            if (cru.CidadeIdDne is not int idCidade || !cidadesPorIdDne.TryGetValue(idCidade, out Guid cidadeGuid))
+            {
+                contador.ContarOrfao(cru.IdDne?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "(sem id)");
+                continue;
+            }
+
+            decimal? latitude = ParseTolerante.ParaDecimal(cru.Lat);
+            decimal? longitude = ParseTolerante.ParaDecimal(cru.Lon);
+            Point? coordenada = PontoFactory.Criar(cru.Lat, cru.Lon);
+            string nome = cru.Nome ?? string.Empty;
+            string uf = cru.Uf ?? string.Empty;
+            string? idOrigemDne = cru.IdDne?.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            string chave = $"{cidadeGuid:N}|{nomeNorm}";
+
+            T? entidade = Upsert(
+                chave,
+                jaVistos,
+                existentes,
+                () => criar(cidadeGuid, uf, nome, nomeNorm, latitude, longitude, coordenada, idOrigemDne, versao),
+                e => atualizar(e, cidadeGuid, uf, nome, nomeNorm, latitude, longitude, coordenada, idOrigemDne, versao),
+                dbSet,
+                contador);
+
+            if (entidade is not null && cru.IdDne is int idDne)
+            {
+                idDneParaGuid[idDne] = new LocalidadeResolvida(IdDe(entidade), cidadeGuid);
+            }
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return idDneParaGuid;
+    }
+
+    private async Task ImportarFaixasAsync<T>(
+        string tabela,
+        IAsyncEnumerable<FaixaLocalidadeCru> crus,
+        Dictionary<int, LocalidadeResolvida> localidadesPorIdDne,
+        DbSet<T> dbSet,
+        Func<T, string> chaveExistente,
+        Func<Guid, string, string, string, Result<T>> criar,
+        Func<T, string, Result> atualizar,
+        string versao,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+        where T : class
+    {
+        ContadorTabela contador = relatorio.Tabela(tabela);
+        Dictionary<string, T> existentes =
+            (await dbSet.ToListAsync(cancellationToken).ConfigureAwait(false))
+            .ToDictionary(chaveExistente, StringComparer.Ordinal);
+        Dictionary<string, T> jaVistas = new(StringComparer.Ordinal);
+
+        await foreach (FaixaLocalidadeCru cru in crus.ConfigureAwait(false))
+        {
+            contador.ContarLido();
+
+            if (cru.IdPaiDne is not int idPai || !localidadesPorIdDne.TryGetValue(idPai, out LocalidadeResolvida pai))
+            {
+                contador.ContarOrfao(cru.IdPaiDne?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "(sem id)");
+                continue;
+            }
+
+            string? cepInicial = ChaveCodigo(cru.FaixaIni);
+            string? cepFinal = ChaveCodigo(cru.FaixaFim);
+            if (cepInicial is null || cepFinal is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            string chave = ChaveFaixa(pai.Id, cepInicial, cepFinal);
+            Upsert(
+                chave,
+                jaVistas,
+                existentes,
+                () => criar(pai.Id, cepInicial, cepFinal, versao),
+                e => atualizar(e, versao),
+                dbSet,
+                contador);
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task ImportarGrandesUsuariosAsync(
+        IGeoFonteDados fonte,
+        RelatorioImportacao relatorio,
+        CancellationToken cancellationToken)
+    {
+        ContadorTabela contador = relatorio.Tabela("cep_grande_usuario");
+        Dictionary<string, CepGrandeUsuario> existentes =
+            await _contexto.CepGrandesUsuarios.ToDictionaryAsync(g => g.Cep, StringComparer.Ordinal, cancellationToken).ConfigureAwait(false);
+        Dictionary<string, CepGrandeUsuario> jaVistos = new(StringComparer.Ordinal);
+
+        await foreach (CepGrandeUsuarioCru cru in fonte.LerCepGrandesUsuariosAsync(cancellationToken).ConfigureAwait(false))
+        {
+            contador.ContarLido();
+            string? cep = ChaveCodigo(cru.Cep);
+            if (cep is null)
+            {
+                contador.ContarIgnoradoSemChave();
+                continue;
+            }
+
+            string nome = cru.Nome ?? string.Empty;
+            string? nomeNorm = cru.NomeSemAcento;
+            Upsert(
+                cep,
+                jaVistos,
+                existentes,
+                () => CepGrandeUsuario.Importar(cep, nome, nomeNorm, fonte.Versao),
+                e => e.Atualizar(nome, nomeNorm, fonte.Versao),
+                _contexto.CepGrandesUsuarios,
+                contador);
+        }
+
+        await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    // Id é client-generated (Guid v7 no EntityBase), disponível antes do SaveChanges —
+    // por isso os dicts de FK já são válidos durante a iteração.
+    private static Guid IdDe<T>(T entidade)
+        where T : class =>
+        ((Unifesspa.UniPlus.Kernel.Domain.Entities.EntityBase)(object)entidade).Id;
+
+    private static string? NormalizarObrigatorio(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : GeoTexto.NormalizarTexto(valor);
+
+    private static async IAsyncEnumerable<LocalidadeCru> ComoLocalidades<TFonte>(
+        IAsyncEnumerable<TFonte> fonte,
+        Func<TFonte, LocalidadeCru> projetar,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        await foreach (TFonte item in fonte.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            yield return projetar(item);
+        }
+    }
+
+    private readonly record struct LocalidadeCru(
+        int? IdDne,
+        string? Nome,
+        string? NomeSemAcento,
+        int? CidadeIdDne,
+        string? Uf,
+        string? Lat,
+        string? Lon);
+
+    private delegate Result<T> CriarLocalidade<T>(
+        Guid cidadeId, string uf, string nome, string nomeNorm,
+        decimal? lat, decimal? lon, Point? coord, string? idOrigemDne, string versao);
+
+    private delegate Result AtualizarLocalidade<T>(
+        T entidade, Guid cidadeId, string uf, string nome, string nomeNorm,
+        decimal? lat, decimal? lon, Point? coord, string? idOrigemDne, string versao);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorLocalidades.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorLocalidades.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+
+/// <summary>
+/// Orquestra a carga das folhas do Geo (ADR-0092, Story #673) em duas fases que commitam
+/// separadamente (o COPY em lote e o <c>CREATE INDEX CONCURRENTLY</c> não cabem numa
+/// transação única): (1) <see cref="GeoImportadorDistritoBairro"/> faz o upsert de
+/// Distrito/Bairro (+faixas) e grande usuário numa transação e devolve os mapas de FK;
+/// (2) <see cref="LogradouroCopyImporter"/> carrega complementos e logradouros em lote.
+/// O topo (País/Estado/Cidade, #672) deve estar carregado antes — a resolução de FK
+/// depende das cidades.
+/// </summary>
+internal sealed partial class GeoImportadorLocalidades : IGeoImportadorLocalidades
+{
+    private readonly GeoImportadorDistritoBairro _distritoBairro;
+    private readonly LogradouroCopyImporter _logradouro;
+    private readonly ILogger<GeoImportadorLocalidades> _logger;
+
+    public GeoImportadorLocalidades(
+        GeoImportadorDistritoBairro distritoBairro,
+        LogradouroCopyImporter logradouro,
+        ILogger<GeoImportadorLocalidades> logger)
+    {
+        ArgumentNullException.ThrowIfNull(distritoBairro);
+        ArgumentNullException.ThrowIfNull(logradouro);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _distritoBairro = distritoBairro;
+        _logradouro = logradouro;
+        _logger = logger;
+    }
+
+    public async Task<RelatorioImportacao> ImportarAsync(IGeoFonteDados fonte, ModoCarga modo, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(fonte);
+
+        RelatorioImportacao relatorio = new(fonte.Versao);
+        LogCargaIniciada(_logger, fonte.Versao, modo);
+
+        ResolucaoLocalidades resolucao =
+            await _distritoBairro.ImportarAsync(fonte, relatorio, cancellationToken).ConfigureAwait(false);
+
+        await _logradouro.ImportarAsync(fonte, modo, resolucao, relatorio, cancellationToken).ConfigureAwait(false);
+
+        int inseridos = Total(relatorio, t => t.Inseridos);
+        int atualizados = Total(relatorio, t => t.Atualizados);
+        int orfaos = Total(relatorio, t => t.Orfaos);
+        int degradados = Total(relatorio, t => t.ParsesDegradados);
+        LogCargaConcluida(_logger, fonte.Versao, inseridos, atualizados, orfaos, degradados);
+
+        return relatorio;
+    }
+
+    private static int Total(RelatorioImportacao relatorio, Func<ContadorTabela, int> seletor) =>
+        relatorio.Tabelas.Values.Sum(seletor);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: carga das folhas iniciada (versão {Versao}, modo {Modo}).")]
+    private static partial void LogCargaIniciada(ILogger logger, string versao, ModoCarga modo);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: carga das folhas concluída (versão {Versao}, inseridos={Inseridos}, atualizados={Atualizados}, órfãos={Orfaos}, degradados={Degradados}).")]
+    private static partial void LogCargaConcluida(ILogger logger, string versao, int inseridos, int atualizados, int orfaos, int degradados);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorPaisEstadoCidade.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportadorPaisEstadoCidade.cs
@@ -11,6 +11,8 @@ using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Parsing;
 using Unifesspa.UniPlus.Kernel.Results;
 
+using static Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.GeoEtlUpsert;
+
 /// <summary>
 /// Importa o topo da hierarquia do Geo — País (só Brasil), Estado (+indicador
 /// +faixas) e Cidade (+territorial embutido, +indicador, +faixas) — a partir do
@@ -468,100 +470,6 @@ internal sealed partial class GeoImportadorPaisEstadoCidade : IGeoImportador
         LogTabelaConcluida(_logger, "cidade_faixa", contador.Lidos, contador.Inseridos, contador.Atualizados);
     }
 
-    // Upsert por chave natural com dedup intra-fonte: chaves repetidas na própria
-    // carga não disparam unique violation — a 2ª ocorrência atualiza a entidade já
-    // vista (last-wins) e conta como duplicada. Retorna a entidade (para resolver FK)
-    // ou null em falha de validação do domínio.
-    private static T? Upsert<T>(
-        string chave,
-        Dictionary<string, T> jaVistas,
-        Dictionary<string, T> existentes,
-        Func<Result<T>> criar,
-        Func<T, Result> atualizar,
-        DbSet<T> dbSet,
-        ContadorTabela contador)
-        where T : class
-    {
-        if (jaVistas.TryGetValue(chave, out T? jaVista))
-        {
-            contador.ContarDuplicado(chave);
-            Result reatualizacao = atualizar(jaVista);
-            return reatualizacao.IsSuccess ? jaVista : null;
-        }
-
-        if (existentes.TryGetValue(chave, out T? existente))
-        {
-            Result atualizacao = atualizar(existente);
-            if (atualizacao.IsFailure)
-            {
-                contador.ContarIgnoradoSemChave();
-                return null;
-            }
-
-            jaVistas[chave] = existente;
-            contador.ContarAtualizado();
-            return existente;
-        }
-
-        Result<T> criado = criar();
-        if (criado.IsFailure)
-        {
-            contador.ContarIgnoradoSemChave();
-            return null;
-        }
-
-        dbSet.Add(criado.Value!);
-        jaVistas[chave] = criado.Value!;
-        contador.ContarInserido();
-        return criado.Value;
-    }
-
-    private static async Task<Dictionary<string, T>> AgregarPorChaveAsync<T>(
-        IAsyncEnumerable<T> fonte,
-        Func<T, string?> chave)
-    {
-        Dictionary<string, T> mapa = new(StringComparer.Ordinal);
-        await foreach (T item in fonte.ConfigureAwait(false))
-        {
-            string? k = chave(item);
-            if (k is not null)
-            {
-                mapa[k] = item; // last-wins
-            }
-        }
-
-        return mapa;
-    }
-
-    // Como AgregarPorChaveAsync, mas registra no contador da tabela tudo o que a fonte
-    // trouxe (lidos), o que foi descartado por chave ausente e as chaves repetidas
-    // (last-wins) — para o relatório não subestimar os "lidos" dos níveis agregados.
-    private static async Task<Dictionary<string, T>> AgregarContandoAsync<T>(
-        IAsyncEnumerable<T> fonte,
-        Func<T, string?> chave,
-        ContadorTabela contador)
-    {
-        Dictionary<string, T> mapa = new(StringComparer.Ordinal);
-        await foreach (T item in fonte.ConfigureAwait(false))
-        {
-            contador.ContarLido();
-            string? k = chave(item);
-            if (k is null)
-            {
-                contador.ContarIgnoradoSemChave();
-                continue;
-            }
-
-            if (!mapa.TryAdd(k, item))
-            {
-                contador.ContarDuplicado(k); // last-wins
-                mapa[k] = item;
-            }
-        }
-
-        return mapa;
-    }
-
     // Parse tolerante de métrica IBGE que registra a degradação ('-'/vazio/inválido →
     // null) no relatório para auditoria. Sem PII — métricas socioeconômicas públicas.
     private static decimal? MetricaDecimal(string? cru, string coluna, ContadorTabela contador)
@@ -585,17 +493,6 @@ internal sealed partial class GeoImportadorPaisEstadoCidade : IGeoImportador
 
         return valor;
     }
-
-    private static string? ChaveSigla(string? valor) =>
-        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim().ToUpperInvariant();
-
-    private static string? ChaveCodigo(string? valor) =>
-        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
-
-    // Chave natural composta de uma faixa de CEP: pai (Guid) + limites. Casa com a
-    // UNIQUE (estado_id|cidade_id, cep_inicial, cep_final) para o upsert idempotente.
-    private static string ChaveFaixa(Guid pai, string cepInicial, string cepFinal) =>
-        $"{pai:N}|{cepInicial}|{cepFinal}";
 
     private static int Total(RelatorioImportacao relatorio, Func<ContadorTabela, int> seletor) =>
         relatorio.Tabelas.Values.Sum(seletor);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/IGeoImportadorLocalidades.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/IGeoImportadorLocalidades.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+
+/// <summary>
+/// Importador das folhas da hierarquia do Geo (Distrito/Bairro + faixas, CEP de grande
+/// usuário, complementos e os ~1,4M logradouros) a partir do dataset DNE (ADR-0092,
+/// Story #673). Complementa o <see cref="IGeoImportador"/> (topo País/Estado/Cidade,
+/// #672): o País/Estado/Cidade precisa estar carregado antes, pois as folhas resolvem
+/// as FKs <c>cidade_id</c>/<c>distrito_id</c>/<c>bairro_id</c> (int4 da fonte) para Guid.
+/// </summary>
+/// <remarks>
+/// <para>Ao contrário do importador de topo (transação única), esta carga é um pipeline
+/// de fases que commitam separadamente: o COPY em lote do logradouro e o
+/// <c>CREATE INDEX CONCURRENTLY</c> não podem viver numa transação única. A idempotência
+/// vem do upsert por chave natural (distrito/bairro) e de COPY → staging →
+/// <c>ON CONFLICT</c> (logradouro/complemento).</para>
+/// </remarks>
+internal interface IGeoImportadorLocalidades
+{
+    /// <summary>
+    /// Importa as folhas a partir da <paramref name="fonte"/> no <paramref name="modo"/>
+    /// indicado. Órfãos (FK <c>cidade_id</c> ausente) e dados sujos são tolerados (vão
+    /// ao relatório, não abortam); falha de infraestrutura aborta a fase corrente.
+    /// </summary>
+    Task<RelatorioImportacao> ImportarAsync(IGeoFonteDados fonte, ModoCarga modo, CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/ModoCarga.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/ModoCarga.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+/// <summary>
+/// Modo da carga de logradouros do ETL DNE (ADR-0092). Define a estratégia de bulk:
+/// <see cref="Inicial"/> assume base nova (trunca <c>logradouro</c> e dropa seus índices
+/// pesados para COPY rápido, recriando-os ao fim); <see cref="Recarga"/> assume base
+/// populada (mantém os índices e reconcilia por <c>ON CONFLICT</c>). A escolha do modo é
+/// do gatilho operacional (Story de atualização periódica, #674); ambos são idempotentes.
+/// </summary>
+internal enum ModoCarga
+{
+    /// <summary>Carga inicial: TRUNCATE de <c>logradouro</c> + drop/recria dos seus índices pesados em torno do COPY (demais folhas reconciliam por upsert/ON CONFLICT).</summary>
+    Inicial,
+
+    /// <summary>Recarga periódica: COPY para staging + <c>ON CONFLICT DO UPDATE</c>, índices preservados.</summary>
+    Recarga,
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/RelatorioImportacao.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/RelatorioImportacao.cs
@@ -80,6 +80,15 @@ internal sealed class ContadorTabela
 
     public void ContarAtualizado() => Atualizados++;
 
+    /// <summary>Registra um lote de inserções (caminho COPY/merge, onde o split vem de uma contagem agregada, não linha-a-linha).</summary>
+    public void ContarInseridos(int quantidade) => Inseridos += quantidade;
+
+    /// <summary>Registra um lote de atualizações (caminho COPY/merge).</summary>
+    public void ContarAtualizados(int quantidade) => Atualizados += quantidade;
+
+    /// <summary>Registra um lote de duplicatas intra-fonte removidas (dedup via DISTINCT ON no merge).</summary>
+    public void ContarDuplicados(int quantidade) => Duplicados += quantidade;
+
     public void ContarIgnoradoSemChave() => IgnoradosSemChave++;
 
     public void ContarOrfao(string amostra)

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/DneStagingFonteTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/DneStagingFonteTests.cs
@@ -72,6 +72,25 @@ public sealed class DneStagingFonteTests
         indicador.MortalidadeInfantil.Should().BeNull(); // '-' no staging degradou para null
     }
 
+    [Fact(DisplayName = "Folhas: lê id_cidade/cidade_id como int e distrito_id NULL do logradouro (≠ projeção text-only da #672)")]
+    public async Task LeFolhas_MapeiaIntENull()
+    {
+        await CriarStagingAsync();
+        await CriarStagingFolhasAsync();
+        DneStagingFonte fonte = new(_fixture.ConnectionString, Versao);
+
+        List<CidadeIdCru> ids = await ColetarAsync(fonte.LerCidadeIdsAsync);
+        ids.Should().ContainSingle(c => c.IdCidade == 1 && c.CodigoIbge == CodigoMaraba);
+
+        List<DistritoCru> distritos = await ColetarAsync(fonte.LerDistritosAsync);
+        distritos.Should().ContainSingle(d => d.IdDistrito == 10 && d.CidadeIdDne == 1 && d.Nome == "Cidade Nova");
+
+        List<LogradouroCru> logradouros = await ColetarAsync(fonte.LerLogradourosAsync);
+        logradouros.Should().HaveCount(2);
+        logradouros.Should().ContainSingle(l => l.Cep == "68500000" && l.DistritoIdDne == 10 && l.CidadeIdDne == 1 && l.CepAtivo == "S");
+        logradouros.Should().ContainSingle(l => l.Cep == "68500001" && l.DistritoIdDne == null); // distrito_id NULL preservado
+    }
+
     [Theory(DisplayName = "Versão fora do formato AAAAMM é rejeitada no construtor (anti-injeção)")]
     [InlineData("abc")]
     [InlineData("2026")]
@@ -116,6 +135,15 @@ public sealed class DneStagingFonteTests
         await ctx.Database.ExecuteSqlRawAsync(StagingSql);
     }
 
+    // Tabelas folha (Story #673) anexadas ao schema já criado por CriarStagingAsync —
+    // ids int4 e uma linha de logradouro com distrito_id NULL para exercitar a leitura
+    // de inteiro/nulo (≠ projeção text-only da #672).
+    private async Task CriarStagingFolhasAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        await ctx.Database.ExecuteSqlRawAsync(StagingFolhasSql);
+    }
+
     // Schema de staging reduzido: só as colunas que a DneStagingFonte projeta, com
     // dados mínimos consistentes (Brasil + Pará + Marabá; mortalidade '-' para o parse
     // tolerante). Recriado a cada teste (DROP CASCADE) para isolamento.
@@ -148,9 +176,9 @@ public sealed class DneStagingFonteTests
         INSERT INTO dne_staging."tbl_cep_202601_n_estado_faixa" VALUES ('PA','Pará','66000000','68899999');
 
         CREATE TABLE dne_staging."tbl_cep_202601_n_cidade" (
-            cidade_ibge text, cidade text, cidade_sem_acento text, estado text, ddd text, latitude text, longitude text);
+            id_cidade int, cidade_ibge text, cidade text, cidade_sem_acento text, estado text, ddd text, latitude text, longitude text);
         INSERT INTO dne_staging."tbl_cep_202601_n_cidade" VALUES
-            ('1500402','Marabá','Maraba','PA','94','-5.36867','-49.11731');
+            (1,'1500402','Marabá','Maraba','PA','94','-5.36867','-49.11731');
 
         CREATE TABLE dne_staging."tbl_cep_202601_n_cidade_ibge_territorio" (
             cidade_ibge text, mesorregiao text, mesorregiao_nome text, microrregiao text, microrregiao_nome text,
@@ -170,5 +198,20 @@ public sealed class DneStagingFonteTests
         CREATE TABLE dne_staging."tbl_cep_202601_n_cidade_faixa" (
             cidade_ibge text, faixa_ini text, faixa_fim text);
         INSERT INTO dne_staging."tbl_cep_202601_n_cidade_faixa" VALUES ('1500402','68500000','68519999');
+        """;
+
+    private const string StagingFolhasSql = """
+        CREATE TABLE dne_staging."tbl_cep_202601_n_distrito" (
+            id_distrito int, distrito text, distrito_sem_acento text, cidade_id int, estado text, latitude text, longitude text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_distrito" VALUES
+            (10,'Cidade Nova','Cidade Nova',1,'PA','-5.36','-49.11');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_logradouro" (
+            cep text, tipo text, nome_logradouro text, logradouro text, bairro_id int, distrito_id int, cidade_id int,
+            estado text, tipo_sem_acento text, nome_logradouro_sem_acento text, logradouro_sem_acento text,
+            latitude text, longitude text, cep_ativo text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_logradouro" VALUES
+            ('68500000','Rua','A','Rua A',NULL,10,1,'PA','Rua','A','Rua A','-5.36','-49.11','S'),
+            ('68500001','Rua','B','Rua B',NULL,NULL,1,'PA','Rua','B','Rua B',NULL,NULL,'N');
         """;
 }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/DneStagingFonteTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/DneStagingFonteTests.cs
@@ -89,6 +89,14 @@ public sealed class DneStagingFonteTests
         logradouros.Should().HaveCount(2);
         logradouros.Should().ContainSingle(l => l.Cep == "68500000" && l.DistritoIdDne == 10 && l.CidadeIdDne == 1 && l.CepAtivo == "S");
         logradouros.Should().ContainSingle(l => l.Cep == "68500001" && l.DistritoIdDne == null); // distrito_id NULL preservado
+
+        // As faixas referenciam o pai pela coluna id_distrito/id_bairro (PK da fonte na
+        // própria tabela de faixa), não distrito_id/bairro_id — lê o schema real.
+        List<FaixaLocalidadeCru> distritoFaixas = await ColetarAsync(fonte.LerDistritoFaixasAsync);
+        distritoFaixas.Should().ContainSingle(f => f.IdPaiDne == 10 && f.FaixaIni == "68500000" && f.FaixaFim == "68519999");
+
+        List<FaixaLocalidadeCru> bairroFaixas = await ColetarAsync(fonte.LerBairroFaixasAsync);
+        bairroFaixas.Should().ContainSingle(f => f.IdPaiDne == 100 && f.FaixaIni == "68500000" && f.FaixaFim == "68509999");
     }
 
     [Theory(DisplayName = "Versão fora do formato AAAAMM é rejeitada no construtor (anti-injeção)")]
@@ -205,6 +213,14 @@ public sealed class DneStagingFonteTests
             id_distrito int, distrito text, distrito_sem_acento text, cidade_id int, estado text, latitude text, longitude text);
         INSERT INTO dne_staging."tbl_cep_202601_n_distrito" VALUES
             (10,'Cidade Nova','Cidade Nova',1,'PA','-5.36','-49.11');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_distrito_faixa" (
+            id_distrito int, faixa_ini text, faixa_fim text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_distrito_faixa" VALUES (10,'68500000','68519999');
+
+        CREATE TABLE dne_staging."tbl_cep_202601_n_bairro_faixa" (
+            id_bairro int, faixa_ini text, faixa_fim text);
+        INSERT INTO dne_staging."tbl_cep_202601_n_bairro_faixa" VALUES (100,'68500000','68509999');
 
         CREATE TABLE dne_staging."tbl_cep_202601_n_logradouro" (
             cep text, tipo text, nome_logradouro text, logradouro text, bairro_id int, distrito_id int, cidade_id int,

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlLocalidadesTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlLocalidadesTests.cs
@@ -1,0 +1,322 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Npgsql;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Carga das folhas (Story #673) sobre Postgres+PostGIS real: Distrito/Bairro (+faixas)
+/// por upsert e Logradouro/Complemento via COPY binário em lote. Cobre os critérios CA-01
+/// a CA-08 — COPY/lote, índices pós-carga via CONCURRENTLY fora de transação, CEP
+/// compartilhado, órfão descartado, chave composta de distrito/bairro e idempotência da
+/// recarga. Cada teste pré-carrega o topo (País/Estado/Cidade) via o importador da #672.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class EtlLocalidadesTests
+{
+    private const string CodigoMaraba = "1500402";
+    private const string CodigoSaoPaulo = "3550308";
+    private const int IdCidadeMaraba = 1;
+    private const int IdCidadeSaoPaulo = 2;
+    private const int IdCidadeInexistente = 999;
+
+    private readonly GeoPostgisFixture _fixture;
+
+    public EtlLocalidadesTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01/02: COPY popula logradouros com FK Guid resolvida, ativo bool e coordenada 4326")]
+    public async Task CargaInicial_PopulaLogradouros()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        await ExecutarLocalidadesAsync(FonteCompleta(), ModoCarga.Inicial);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        Guid marabaId = (await leitura.Cidades.SingleAsync(c => c.CodigoIbge == CodigoMaraba)).Id;
+
+        (await leitura.Distritos.CountAsync()).Should().Be(2);
+        (await leitura.Bairros.CountAsync()).Should().Be(2);
+        (await leitura.DistritoFaixasCep.CountAsync()).Should().Be(1);
+        (await leitura.BairroFaixasCep.CountAsync()).Should().Be(1);
+        (await leitura.CepGrandesUsuarios.CountAsync()).Should().Be(1);
+        (await leitura.LogradouroComplementos.CountAsync()).Should().Be(2);
+
+        Logradouro ruaA = await leitura.Logradouros.SingleAsync(l => l.Cep == "68500000" && l.Nome == "Rua A");
+        ruaA.CidadeId.Should().Be(marabaId);
+        ruaA.DistritoId.Should().NotBeNull(); // distrito_id 10 resolvido para Guid
+        ruaA.BairroId.Should().NotBeNull();
+        ruaA.Ativo.Should().BeTrue();          // cep_ativo 'S'
+        ruaA.Coordenada.Should().NotBeNull();
+        ruaA.Coordenada!.SRID.Should().Be(4326);
+
+        Logradouro ruaB = await leitura.Logradouros.SingleAsync(l => l.Nome == "Rua B");
+        ruaB.DistritoId.Should().BeNull();     // distrito_id nulo aceito (FK opcional)
+        ruaB.Ativo.Should().BeFalse();         // cep_ativo 'N'
+    }
+
+    [Fact(DisplayName = "CA-03/04: na carga inicial os índices trigram/GIST são recriados via CONCURRENTLY (fora de transação) e ficam válidos")]
+    public async Task CargaInicial_RecriaIndicesPesadosForaDeTransacao()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+
+        // A própria conclusão sem erro prova que CREATE INDEX CONCURRENTLY rodou fora de
+        // transação — dentro de uma, o Postgres lançaria 25001.
+        await ExecutarLocalidadesAsync(FonteCompleta(), ModoCarga.Inicial);
+
+        (await IndiceValidoAsync("ix_logradouro_nome_trgm")).Should().BeTrue();
+        (await IndiceValidoAsync("ix_logradouro_coordenada")).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "CA-05: CEP geral é compartilhado por vários logradouros (cep indexado, não único)")]
+    public async Task CepCompartilhado_Coexiste()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        FonteEmMemoria fonte = FonteCompleta();
+        fonte.Logradouros.Add(DadosDne.Logradouro("68500000", "Rua C", IdCidadeMaraba)); // mesmo CEP de "Rua A"
+
+        await ExecutarLocalidadesAsync(fonte, ModoCarga.Inicial);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Logradouros.CountAsync(l => l.Cep == "68500000")).Should().Be(2);
+    }
+
+    [Fact(DisplayName = "CA-05: logradouro com cidade órfã é descartado e contado; distrito_id nulo é aceito")]
+    public async Task LogradouroOrfao_Descartado()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        FonteEmMemoria fonte = FonteCompleta();
+        fonte.Logradouros.Add(DadosDne.Logradouro("99999999", "Rua Fantasma", IdCidadeInexistente));
+
+        RelatorioImportacao relatorio = await ExecutarLocalidadesAsync(fonte, ModoCarga.Inicial);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Logradouros.AnyAsync(l => l.Cep == "99999999")).Should().BeFalse();
+        relatorio.Tabelas["logradouro"].Orfaos.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact(DisplayName = "CA-06: upsert de distrito por (cidade, nome) — duplicado na mesma cidade não duplica")]
+    public async Task DistritoDuplicado_NaMesmaCidade_NaoDuplica()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        FonteEmMemoria fonte = FonteCompleta();
+        // Mesmo (cidade, nome) de um distrito já presente, com outro id_distrito da fonte.
+        fonte.Distritos.Add(DadosDne.Distrito(11, "Cidade Nova", IdCidadeMaraba));
+
+        RelatorioImportacao relatorio = await ExecutarLocalidadesAsync(fonte, ModoCarga.Inicial);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Distritos.CountAsync(d => d.Nome == "Cidade Nova")).Should().Be(1);
+        relatorio.Tabelas["distrito"].Duplicados.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact(DisplayName = "CA-06 + FK: distritos homônimos em cidades distintas coexistem e o logradouro resolve para o Guid correto via id_distrito")]
+    public async Task DistritoHomonimo_EmCidadesDistintas_ResolveFkCorreta()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        FonteEmMemoria fonte = FonteCompleta();
+        // "Centro" existe em Marabá (id 30) e em São Paulo (id 20 já no FonteCompleta).
+        fonte.Distritos.Add(DadosDne.Distrito(30, "Centro", IdCidadeMaraba));
+        // Dois logradouros, um por "Centro", referenciando o id_distrito respectivo.
+        fonte.Logradouros.Add(DadosDne.Logradouro("68500100", "Av Marabá", IdCidadeMaraba, distritoIdDne: 30));
+        fonte.Logradouros.Add(DadosDne.Logradouro("01000000", "Av Paulista", IdCidadeSaoPaulo, distritoIdDne: 20));
+
+        await ExecutarLocalidadesAsync(fonte, ModoCarga.Inicial);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        Guid marabaId = (await leitura.Cidades.SingleAsync(c => c.CodigoIbge == CodigoMaraba)).Id;
+        Guid spId = (await leitura.Cidades.SingleAsync(c => c.CodigoIbge == CodigoSaoPaulo)).Id;
+
+        (await leitura.Distritos.CountAsync(d => d.Nome == "Centro")).Should().Be(2);
+
+        Distrito centroMaraba = await leitura.Distritos.SingleAsync(d => d.Nome == "Centro" && d.CidadeId == marabaId);
+        Distrito centroSp = await leitura.Distritos.SingleAsync(d => d.Nome == "Centro" && d.CidadeId == spId);
+        centroMaraba.Id.Should().NotBe(centroSp.Id);
+
+        Logradouro avMaraba = await leitura.Logradouros.SingleAsync(l => l.Nome == "Av Marabá");
+        Logradouro avPaulista = await leitura.Logradouros.SingleAsync(l => l.Nome == "Av Paulista");
+        avMaraba.DistritoId.Should().Be(centroMaraba.Id);
+        avPaulista.DistritoId.Should().Be(centroSp.Id);
+    }
+
+    [Fact(DisplayName = "Coerência: distrito_id que resolve para distrito de outra cidade degrada para null (não cruza cidade)")]
+    public async Task DistritoDeOutraCidade_DegradaParaNull()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        FonteEmMemoria fonte = FonteCompleta();
+        // Logradouro em Marabá apontando para o distrito 20 ("Centro"), que é de São Paulo.
+        fonte.Logradouros.Add(DadosDne.Logradouro("68500200", "Rua Cruzada", IdCidadeMaraba, distritoIdDne: 20));
+
+        RelatorioImportacao relatorio = await ExecutarLocalidadesAsync(fonte, ModoCarga.Inicial);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        Logradouro cruzada = await leitura.Logradouros.SingleAsync(l => l.Nome == "Rua Cruzada");
+        cruzada.DistritoId.Should().BeNull("o distrito resolvido é de outra cidade — não pode cruzar");
+        relatorio.Tabelas["logradouro"].ParsesDegradados.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact(DisplayName = "CA-07: recarga (staging + ON CONFLICT) é idempotente — contagens idênticas, Id e created_at preservados, updated_at carimbado")]
+    public async Task Recarga_Idempotente()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        await ExecutarLocalidadesAsync(FonteCompleta(), ModoCarga.Inicial);
+
+        Guid logradouroId;
+        DateTimeOffset createdAt;
+        int totalLogradouros;
+        await using (GeoDbContext antes = _fixture.CreateDbContext())
+        {
+            Logradouro ruaA = await antes.Logradouros.SingleAsync(l => l.Nome == "Rua A");
+            logradouroId = ruaA.Id;
+            createdAt = ruaA.CreatedAt;
+            totalLogradouros = await antes.Logradouros.CountAsync();
+        }
+
+        await ExecutarLocalidadesAsync(FonteCompleta(), ModoCarga.Recarga);
+
+        await using GeoDbContext depois = _fixture.CreateDbContext();
+        (await depois.Logradouros.CountAsync()).Should().Be(totalLogradouros, "a recarga idempotente não pode duplicar");
+        (await depois.LogradouroComplementos.CountAsync()).Should().Be(2);
+
+        Logradouro ruaARecarga = await depois.Logradouros.SingleAsync(l => l.Nome == "Rua A");
+        ruaARecarga.Id.Should().Be(logradouroId, "ON CONFLICT preserva a PK");
+        ruaARecarga.CreatedAt.Should().Be(createdAt, "created_at é preservado no conflito");
+        ruaARecarga.UpdatedAt.Should().NotBeNull("updated_at é carimbado no DO UPDATE");
+    }
+
+    [Fact(DisplayName = "CA-02: COPY em lote suporta volume — várias linhas streamadas entram sem duplicar")]
+    public async Task CopyEmLote_SuportaVolume()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        FonteEmMemoria fonte = FonteCompleta();
+        fonte.Logradouros.Clear();
+        for (int i = 0; i < 250; i++)
+        {
+            fonte.Logradouros.Add(DadosDne.Logradouro(
+                cep: 68500000.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                nome: $"Rua {i.ToString(System.Globalization.CultureInfo.InvariantCulture)}",
+                cidadeIdDne: IdCidadeMaraba));
+        }
+
+        await ExecutarLocalidadesAsync(fonte, ModoCarga.Inicial);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Logradouros.CountAsync()).Should().Be(250);
+    }
+
+    [Fact(DisplayName = "CA-08: o relatório reporta totais por tabela (lidos/inseridos) das folhas")]
+    public async Task Relatorio_ReportaTotais()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        RelatorioImportacao relatorio = await ExecutarLocalidadesAsync(FonteCompleta(), ModoCarga.Inicial);
+
+        relatorio.Tabelas["distrito"].Lidos.Should().Be(2);
+        relatorio.Tabelas["bairro"].Lidos.Should().Be(2);
+        relatorio.Tabelas["logradouro"].Lidos.Should().Be(2);
+        relatorio.Tabelas["logradouro"].Inseridos.Should().Be(2);
+        relatorio.Tabelas["logradouro_complemento"].Inseridos.Should().Be(2);
+    }
+
+    [Fact(DisplayName = "Reexecução do modo Inicial é idempotente (TRUNCATE + recarga não viola UNIQUE)")]
+    public async Task Inicial_Reexecutado_Idempotente()
+    {
+        await PrepararTopoAsync(FonteCompleta());
+        await ExecutarLocalidadesAsync(FonteCompleta(), ModoCarga.Inicial);
+        await ExecutarLocalidadesAsync(FonteCompleta(), ModoCarga.Inicial);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        (await leitura.Logradouros.CountAsync()).Should().Be(2);
+        (await leitura.Distritos.CountAsync()).Should().Be(2);
+    }
+
+    private async Task PrepararTopoAsync(IGeoFonteDados fonte)
+    {
+        await LimparAsync();
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        GeoImportadorPaisEstadoCidade importador = new(ctx, NullLogger<GeoImportadorPaisEstadoCidade>.Instance);
+        await importador.ImportarAsync(fonte, CancellationToken.None);
+    }
+
+    private async Task<RelatorioImportacao> ExecutarLocalidadesAsync(IGeoFonteDados fonte, ModoCarga modo)
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        IConfiguration configuracao = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:GeoDb"] = _fixture.ConnectionString })
+            .Build();
+        GeoImportadorDistritoBairro distritoBairro = new(ctx);
+        LogradouroCopyImporter logradouro = new(configuracao, TimeProvider.System, NullLogger<LogradouroCopyImporter>.Instance);
+        GeoImportadorLocalidades orquestrador = new(distritoBairro, logradouro, NullLogger<GeoImportadorLocalidades>.Instance);
+        return await orquestrador.ImportarAsync(fonte, modo, CancellationToken.None);
+    }
+
+    private async Task LimparAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        // pais CASCADE limpa a cadeia de FK (estado→cidade→distrito/bairro→logradouro);
+        // complemento e grande usuário não têm FK para essa cadeia, então são truncados
+        // à parte para isolar cada teste no banco compartilhado da coleção.
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE TABLE pais, logradouro_complemento, cep_grande_usuario CASCADE");
+    }
+
+    // indisvalid = false sinaliza um CREATE INDEX CONCURRENTLY que não concluiu; true
+    // prova que a recriação fora de transação completou.
+    private async Task<bool> IndiceValidoAsync(string indice)
+    {
+        await using NpgsqlConnection conexao = new(_fixture.ConnectionString);
+        await conexao.OpenAsync();
+        await using NpgsqlCommand comando = conexao.CreateCommand();
+        comando.CommandText = "SELECT i.indisvalid FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = @nome";
+        comando.Parameters.AddWithValue("nome", indice);
+        object? resultado = await comando.ExecuteScalarAsync();
+        return resultado is bool valido && valido;
+    }
+
+    private static FonteEmMemoria FonteCompleta()
+    {
+        FonteEmMemoria fonte = new() { Versao = "202601" };
+
+        // Topo (carregado pelo importador da #672 antes das folhas).
+        fonte.Paises.Add(DadosDne.Pais("BRA", "Brasil", "BR"));
+        fonte.Estados.Add(DadosDne.Estado("PA", "Pará", capital: "Belém", faixaIni: "66000000", faixaFim: "68899999"));
+        fonte.Estados.Add(DadosDne.Estado("SP", "São Paulo", regiao: "Sudeste", capital: "São Paulo", faixaIni: "01000000", faixaFim: "19999999"));
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador("PA", "15"));
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador("SP", "35"));
+        fonte.Cidades.Add(DadosDne.Cidade(CodigoMaraba, "Marabá", "PA", ddd: "94"));
+        fonte.Cidades.Add(DadosDne.Cidade(CodigoSaoPaulo, "São Paulo", "SP", ddd: "11"));
+
+        // Mapa id_cidade (int4 da fonte) → código IBGE, para resolver a FK das folhas.
+        fonte.CidadeIds.Add(DadosDne.CidadeId(IdCidadeMaraba, CodigoMaraba));
+        fonte.CidadeIds.Add(DadosDne.CidadeId(IdCidadeSaoPaulo, CodigoSaoPaulo));
+
+        // Folhas.
+        fonte.Distritos.Add(DadosDne.Distrito(10, "Cidade Nova", IdCidadeMaraba, latitude: "-5.36", longitude: "-49.11"));
+        fonte.Distritos.Add(DadosDne.Distrito(20, "Centro", IdCidadeSaoPaulo));
+        fonte.DistritoFaixas.Add(DadosDne.Faixa(10, "68500000", "68519999"));
+
+        fonte.Bairros.Add(DadosDne.Bairro(100, "Cidade Nova", IdCidadeMaraba));
+        fonte.Bairros.Add(DadosDne.Bairro(200, "Sé", IdCidadeSaoPaulo));
+        fonte.BairroFaixas.Add(DadosDne.Faixa(100, "68500000", "68509999"));
+
+        fonte.CepGrandesUsuarios.Add(DadosDne.GrandeUsuario("68500900", "Prefeitura de Marabá"));
+
+        fonte.LogradouroComplementos.Add(DadosDne.Complemento("68500000", "lado par"));
+        fonte.LogradouroComplementos.Add(DadosDne.Complemento("68500000", "lado ímpar"));
+
+        fonte.Logradouros.Add(DadosDne.Logradouro("68500000", "Rua A", IdCidadeMaraba, tipo: "Rua", bairroIdDne: 100, distritoIdDne: 10, latitude: "-5.36867", longitude: "-49.11731", cepAtivo: "S"));
+        fonte.Logradouros.Add(DadosDne.Logradouro("68500001", "Rua B", IdCidadeMaraba, distritoIdDne: null, cepAtivo: "N"));
+
+        return fonte;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/FonteEmMemoria.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/FonteEmMemoria.cs
@@ -29,6 +29,22 @@ internal sealed class FonteEmMemoria : IGeoFonteDados
 
     public List<CidadeFaixaCru> CidadeFaixas { get; } = [];
 
+    public List<CidadeIdCru> CidadeIds { get; } = [];
+
+    public List<DistritoCru> Distritos { get; } = [];
+
+    public List<FaixaLocalidadeCru> DistritoFaixas { get; } = [];
+
+    public List<BairroCru> Bairros { get; } = [];
+
+    public List<FaixaLocalidadeCru> BairroFaixas { get; } = [];
+
+    public List<CepGrandeUsuarioCru> CepGrandesUsuarios { get; } = [];
+
+    public List<LogradouroComplementoCru> LogradouroComplementos { get; } = [];
+
+    public List<LogradouroCru> Logradouros { get; } = [];
+
     public IAsyncEnumerable<PaisCru> LerPaisesAsync(CancellationToken cancellationToken) => ParaAsync(Paises, cancellationToken);
 
     public IAsyncEnumerable<EstadoCru> LerEstadosAsync(CancellationToken cancellationToken) => ParaAsync(Estados, cancellationToken);
@@ -44,6 +60,22 @@ internal sealed class FonteEmMemoria : IGeoFonteDados
     public IAsyncEnumerable<CidadeIndicadorCru> LerCidadeIndicadoresAsync(CancellationToken cancellationToken) => ParaAsync(CidadeIndicadores, cancellationToken);
 
     public IAsyncEnumerable<CidadeFaixaCru> LerCidadeFaixasAsync(CancellationToken cancellationToken) => ParaAsync(CidadeFaixas, cancellationToken);
+
+    public IAsyncEnumerable<CidadeIdCru> LerCidadeIdsAsync(CancellationToken cancellationToken) => ParaAsync(CidadeIds, cancellationToken);
+
+    public IAsyncEnumerable<DistritoCru> LerDistritosAsync(CancellationToken cancellationToken) => ParaAsync(Distritos, cancellationToken);
+
+    public IAsyncEnumerable<FaixaLocalidadeCru> LerDistritoFaixasAsync(CancellationToken cancellationToken) => ParaAsync(DistritoFaixas, cancellationToken);
+
+    public IAsyncEnumerable<BairroCru> LerBairrosAsync(CancellationToken cancellationToken) => ParaAsync(Bairros, cancellationToken);
+
+    public IAsyncEnumerable<FaixaLocalidadeCru> LerBairroFaixasAsync(CancellationToken cancellationToken) => ParaAsync(BairroFaixas, cancellationToken);
+
+    public IAsyncEnumerable<CepGrandeUsuarioCru> LerCepGrandesUsuariosAsync(CancellationToken cancellationToken) => ParaAsync(CepGrandesUsuarios, cancellationToken);
+
+    public IAsyncEnumerable<LogradouroComplementoCru> LerLogradouroComplementosAsync(CancellationToken cancellationToken) => ParaAsync(LogradouroComplementos, cancellationToken);
+
+    public IAsyncEnumerable<LogradouroCru> LerLogradourosAsync(CancellationToken cancellationToken) => ParaAsync(Logradouros, cancellationToken);
 
     private static async IAsyncEnumerable<T> ParaAsync<T>(IEnumerable<T> itens, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
@@ -117,6 +149,53 @@ internal static class DadosDne
 
     public static CidadeFaixaCru CidadeFaixa(string codigoIbge, string faixaIni, string faixaFim) =>
         new(codigoIbge, faixaIni, faixaFim);
+
+    public static CidadeIdCru CidadeId(int idCidade, string codigoIbge) =>
+        new(idCidade, codigoIbge);
+
+    public static DistritoCru Distrito(
+        int idDistrito,
+        string nome,
+        int cidadeIdDne,
+        string uf = "PA",
+        string? nomeSemAcento = null,
+        string? latitude = null,
+        string? longitude = null) =>
+        new(idDistrito, nome, nomeSemAcento ?? nome, cidadeIdDne, uf, latitude, longitude);
+
+    public static BairroCru Bairro(
+        int idBairro,
+        string nome,
+        int cidadeIdDne,
+        string uf = "PA",
+        string? nomeSemAcento = null,
+        string? latitude = null,
+        string? longitude = null) =>
+        new(idBairro, nome, nomeSemAcento ?? nome, cidadeIdDne, uf, latitude, longitude);
+
+    public static FaixaLocalidadeCru Faixa(int idPaiDne, string faixaIni, string faixaFim) =>
+        new(idPaiDne, faixaIni, faixaFim);
+
+    public static CepGrandeUsuarioCru GrandeUsuario(string cep, string nome, string? nomeSemAcento = null) =>
+        new(cep, nome, nomeSemAcento ?? nome);
+
+    public static LogradouroComplementoCru Complemento(string cep, string complemento, string? complementoSemAcento = null) =>
+        new(cep, complemento, complementoSemAcento ?? complemento);
+
+    public static LogradouroCru Logradouro(
+        string cep,
+        string nome,
+        int cidadeIdDne,
+        string uf = "PA",
+        string? tipo = null,
+        string? nomeCompleto = null,
+        string? nomeSemAcento = null,
+        int? bairroIdDne = null,
+        int? distritoIdDne = null,
+        string? latitude = null,
+        string? longitude = null,
+        string cepAtivo = "S") =>
+        new(cep, tipo, nome, nomeCompleto, nomeSemAcento ?? nome, bairroIdDne, distritoIdDne, cidadeIdDne, uf, latitude, longitude, cepAtivo);
 }
 
 /// <summary>
@@ -150,6 +229,22 @@ internal sealed class FonteComFalhaNasCidades : IGeoFonteDados
     public IAsyncEnumerable<CidadeIndicadorCru> LerCidadeIndicadoresAsync(CancellationToken cancellationToken) => _interna.LerCidadeIndicadoresAsync(cancellationToken);
 
     public IAsyncEnumerable<CidadeFaixaCru> LerCidadeFaixasAsync(CancellationToken cancellationToken) => _interna.LerCidadeFaixasAsync(cancellationToken);
+
+    public IAsyncEnumerable<CidadeIdCru> LerCidadeIdsAsync(CancellationToken cancellationToken) => _interna.LerCidadeIdsAsync(cancellationToken);
+
+    public IAsyncEnumerable<DistritoCru> LerDistritosAsync(CancellationToken cancellationToken) => _interna.LerDistritosAsync(cancellationToken);
+
+    public IAsyncEnumerable<FaixaLocalidadeCru> LerDistritoFaixasAsync(CancellationToken cancellationToken) => _interna.LerDistritoFaixasAsync(cancellationToken);
+
+    public IAsyncEnumerable<BairroCru> LerBairrosAsync(CancellationToken cancellationToken) => _interna.LerBairrosAsync(cancellationToken);
+
+    public IAsyncEnumerable<FaixaLocalidadeCru> LerBairroFaixasAsync(CancellationToken cancellationToken) => _interna.LerBairroFaixasAsync(cancellationToken);
+
+    public IAsyncEnumerable<CepGrandeUsuarioCru> LerCepGrandesUsuariosAsync(CancellationToken cancellationToken) => _interna.LerCepGrandesUsuariosAsync(cancellationToken);
+
+    public IAsyncEnumerable<LogradouroComplementoCru> LerLogradouroComplementosAsync(CancellationToken cancellationToken) => _interna.LerLogradouroComplementosAsync(cancellationToken);
+
+    public IAsyncEnumerable<LogradouroCru> LerLogradourosAsync(CancellationToken cancellationToken) => _interna.LerLogradourosAsync(cancellationToken);
 
     private static async IAsyncEnumerable<CidadeCru> Falhar()
     {


### PR DESCRIPTION
## Contexto

Terceira e última Story do ETL do módulo **Geo** (Feature #664), depois de #672 (País/Estado/Cidade). Carrega as **folhas** da hierarquia DNE: `distrito`/`bairro` (+faixas de CEP), `cep_grande_usuario`, `logradouro_complemento` (~235k) e os **~1,4M `logradouro`**. É o que dará vida ao lookup `GET /cep/{cep}` (F4).

O topo (País/Estado/Cidade) precisa estar carregado antes — as folhas resolvem as FKs `cidade_id`/`distrito_id`/`bairro_id` (int4 instáveis da DNE) para os Guid intra-banco.

## O que muda

**Domínio** — `Atualizar` (upsert in place, preserva Id/chave natural) em `Distrito`, `Bairro`, faixas e `CepGrandeUsuario`, espelhando o padrão das 7 entidades de #672.

**ETL** (`Geo.Infrastructure/Persistence/Etl/`):
- `IGeoFonteDados`/`DneStagingFonte` estendidos com as folhas (ids lidos como `int`/`NULL`, não text).
- `GeoImportadorDistritoBairro` — upsert transacional de Distrito/Bairro (+faixas) e grande usuário; monta os dicionários de resolução de FK (`id_cidade→Guid` via código IBGE; `id_distrito`/`id_bairro→Guid` guardando a cidade).
- `Bulk/LogradouroCopyImporter` — COPY binário **streamado** → tabela **staging TEMP** → `INSERT … SELECT DISTINCT ON (chave natural) … ON CONFLICT DO UPDATE` (dedup intra-fonte + idempotência, preserva `id`/`created_at`, carimba `updated_at`, reativa `vigente`). Coordenada como `geography(Point,4326)` (NTS `geographyAsDefault`).
- `GeoImportadorLocalidades` — orquestrador das duas fases (que commitam separadamente: COPY em lote e `CREATE INDEX CONCURRENTLY` não cabem numa transação única).
- Helpers de upsert extraídos para `GeoEtlUpsert` (reuso com #672, sem duplicar a lógica idempotente).

**Decisões transversais:**
- **Modo `Inicial`** trunca `logradouro`, dropa os índices `gin_trgm`/GIST e os recria via `CREATE INDEX CONCURRENTLY` numa conexão em **autocommit** (fora de transação). **Modo `Recarga`** mantém os índices e reconcilia por `ON CONFLICT`. A escolha do modo e a política de *stale* (`vigente=false`) ficam para #674.
- **Coerência hierárquica** (delegada ao ETL pelo domínio): logradouro só adota a FK de distrito/bairro se a cidade resolvida bater com a sua; mismatch degrada para `null` e é contado.
- **Auditoria sem interceptor**: COPY/merge carimbam `created_at` via `TimeProvider` no insert e `updated_at` só no `DO UPDATE`.

Sem migration nova (schema é de #672). Doc atualizada em `docs/geo-etl-dataset-dne.md`.

## Critérios de aceite

- [x] CA-01/02 — COPY popula as folhas com FK Guid, `ativo` bool e coordenada 4326; leitura em streaming.
- [x] CA-03/04 — índices recriados pós-carga via `CONCURRENTLY` fora de transação (validados por `indisvalid`).
- [x] CA-05 — CEP compartilhado coexiste (não único); órfão de cidade descartado; `distrito_id` nulo aceito.
- [x] CA-06 — upsert de distrito/bairro por `(cidade, nome_normalizado)`; homônimos em cidades distintas coexistem.
- [x] CA-07 — recarga idempotente (staging + `ON CONFLICT`), zero duplicatas, Id preservado.
- [x] CA-08 — relatório com contadores por tabela.

## Validação local

`dotnet build` (48 projetos, 0 warnings) · **Geo IntegrationTests 96/96** · ArchTests 24/24 · Seleção 6/6 · Ingresso 3/3 — todos verdes sobre PostGIS real (Testcontainers).

## Revisão

Plano e diff pré-revisados via Codex CLI (gpt-5.5). Findings aplicados: staging+`DISTINCT ON`+`ON CONFLICT` nos dois modos; coerência cidade↔distrito/bairro; premissa single-writer no split de contadores documentada; doc do modo `Inicial` corrigida.

Closes #673
Refs #664 #661