### PR TITLE
feat(configuracao): cadastros de Campus e Local de Oferta (#587)

### DIFF
--- a/UniPlus.slnx
+++ b/UniPlus.slnx
@@ -61,6 +61,9 @@
     <Project Path="tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Unifesspa.UniPlus.Configuracao.Application.UnitTests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Unifesspa.UniPlus.Configuracao.IntegrationTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Geo.IntegrationTests/Unifesspa.UniPlus.Geo.IntegrationTests.csproj" />
   </Folder>
 </Solution>

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -7,6 +7,7 @@ Specs OpenAPI 3.1 versionados como **fonte de verdade do contrato V1** da `unipl
 - `openapi.selecao.json` — spec do módulo Seleção (endpoints `/api/editais`, `/api/auth/me`, `/api/profile/me`).
 - `openapi.ingresso.json` — spec do módulo Ingresso (stub atual; endpoints próprios chegam em sprints posteriores).
 - `openapi.organizacao.json` — spec do módulo Organização Institucional (Instituição e Unidades, incluindo as variantes administrativas `/api/admin/*`). Áreas Organizacionais ficam fora do contrato — em aposentadoria (issue #625), o controller foi removido.
+- `openapi.configuracao.json` — spec do módulo Configuração (Campus e Local de Oferta, incluindo as variantes administrativas `/api/admin/*`). A Cidade é referenciada por código IBGE + display cache (ADR-0090) — não há endpoint de cidade aqui.
 
 ## Como o spec é gerado
 
@@ -28,6 +29,7 @@ A integração `OpenApiEndpointTests` nos módulos com baseline (`tests/Unifessp
 UPDATE_OPENAPI_BASELINE=1 dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests --filter "FullyQualifiedName~SpecRuntime"
 UPDATE_OPENAPI_BASELINE=1 dotnet test tests/Unifesspa.UniPlus.Ingresso.IntegrationTests --filter "FullyQualifiedName~SpecRuntime"
 UPDATE_OPENAPI_BASELINE=1 dotnet test tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests --filter "FullyQualifiedName~SpecRuntime"
+UPDATE_OPENAPI_BASELINE=1 dotnet test tests/Unifesspa.UniPlus.Configuracao.IntegrationTests --filter "FullyQualifiedName~SpecRuntime"
 ```
 
 Os arquivos `contracts/openapi.{selecao,ingresso,organizacao}.json` são reescritos. **Revise o diff** (`git diff contracts/`) e só commit se a mudança for intencional. PRs que mudam controllers sem regerar o baseline falham CI.

--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -1,0 +1,1694 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Uni\u002B \u2014 configuracao",
+    "description": "API REST do Sistema Unificado Unifesspa (Uni\u002B). Contrato can\u00F4nico V1 \u2014 ProblemDetails RFC 9457, pagina\u00E7\u00E3o cursor opaco, vendor MIME versioning. Toda string user-facing em pt-BR (ADR-0022).",
+    "contact": {
+      "name": "CTIC Unifesspa",
+      "url": "https://developers.uniplus.unifesspa.edu.br",
+      "email": "ctic@unifesspa.edu.br"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    },
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.uniplus.unifesspa.edu.br",
+      "description": "Produ\u00E7\u00E3o"
+    },
+    {
+      "url": "https://api.hml.uniplus.unifesspa.edu.br",
+      "description": "Homologa\u00E7\u00E3o"
+    }
+  ],
+  "paths": {
+    "/api/auth/me": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Retorna o usu\u00E1rio autenticado",
+        "description": "Retorna informa\u00E7\u00F5es do usu\u00E1rio extra\u00EDdas do access token. Requer autentica\u00E7\u00E3o.",
+        "operationId": "GetAuthenticatedUser",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticatedUserResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/profile/me": {
+      "get": {
+        "tags": [
+          "Profile"
+        ],
+        "summary": "Retorna o perfil do usu\u00E1rio autenticado",
+        "description": "Retorna atributos de identidade e institucionais (CPF, NomeSocial) extra\u00EDdos do access token. Requer autentica\u00E7\u00E3o.",
+        "operationId": "GetAuthenticatedUserProfile",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfileResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/_smoke/storage/upload": {
+      "post": {
+        "tags": [
+          "_smoke"
+        ],
+        "summary": "Smoke E2E \u2014 Storage upload",
+        "description": "Faz upload de um arquivo no bucket configurado para validar conectividade \u002B credentials do MinIO. Restrito a usu\u00E1rios com role admin.",
+        "operationId": "smokeStorageUpload",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "file"
+                ],
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "$ref": "#/components/schemas/IFormFile"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/_smoke/cache/{key}": {
+      "get": {
+        "tags": [
+          "_smoke"
+        ],
+        "summary": "Smoke E2E \u2014 Cache probe",
+        "description": "Faz SET/GET de uma chave tempor\u00E1ria no Redis com TTL 5min para validar conectividade. Restrito a usu\u00E1rios com role admin.",
+        "operationId": "smokeCacheProbe",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/_smoke/messaging/publish": {
+      "post": {
+        "tags": [
+          "_smoke"
+        ],
+        "summary": "Smoke E2E \u2014 Messaging publish",
+        "description": "Publica um SmokePingMessage via Wolverine outbox para validar persist\u00EAncia \u002B transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usu\u00E1rios com role admin.",
+        "operationId": "smokeMessagingPublish",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/campi": {
+      "get": {
+        "tags": [
+          "Campi"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CampusDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CampusDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CampusDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/campi/{id}": {
+      "get": {
+        "tags": [
+          "Campi"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampusDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampusDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CampusDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/campi": {
+      "post": {
+        "tags": [
+          "Campi"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCampusCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCampusCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCampusCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/admin/campi/{id}": {
+      "put": {
+        "tags": [
+          "Campi"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarCampusCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarCampusCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarCampusCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "Campi"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/locais-oferta": {
+      "get": {
+        "tags": [
+          "LocaisOferta"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LocalOfertaDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LocalOfertaDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LocalOfertaDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/locais-oferta/{id}": {
+      "get": {
+        "tags": [
+          "LocaisOferta"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalOfertaDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalOfertaDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalOfertaDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/locais-oferta": {
+      "post": {
+        "tags": [
+          "LocaisOferta"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarLocalOfertaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarLocalOfertaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarLocalOfertaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/admin/locais-oferta/{id}": {
+      "put": {
+        "tags": [
+          "LocaisOferta"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarLocalOfertaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarLocalOfertaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarLocalOfertaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "LocaisOferta"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AtualizarCampusCommand": {
+        "required": [
+          "id",
+          "sigla",
+          "nome",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf",
+          "endereco",
+          "cep",
+          "latitude",
+          "longitude",
+          "codigoEmec"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sigla": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "cidadeNome": {
+            "type": "string"
+          },
+          "cidadeUf": {
+            "type": "string"
+          },
+          "endereco": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cep": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "codigoEmec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "AtualizarLocalOfertaCommand": {
+        "required": [
+          "id",
+          "tipo",
+          "campusResponsavelId",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf",
+          "endereco",
+          "codigoEmec"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tipo": {
+            "$ref": "#/components/schemas/TipoLocalOferta"
+          },
+          "campusResponsavelId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "cidadeNome": {
+            "type": "string"
+          },
+          "cidadeUf": {
+            "type": "string"
+          },
+          "endereco": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "codigoEmec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "AuthenticatedUserResponse": {
+        "required": [
+          "userId",
+          "name",
+          "email",
+          "roles",
+          "timestamp"
+        ],
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "email": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CampusDto": {
+        "required": [
+          "id",
+          "sigla",
+          "nome",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf",
+          "cidadeOrigem",
+          "cidadeDisplayAtualizadoEm",
+          "endereco",
+          "cep",
+          "latitude",
+          "longitude",
+          "codigoEmec",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sigla": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "cidadeNome": {
+            "type": "string"
+          },
+          "cidadeUf": {
+            "type": "string"
+          },
+          "cidadeOrigem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeDisplayAtualizadoEm": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "endereco": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cep": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "codigoEmec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CriarCampusCommand": {
+        "required": [
+          "sigla",
+          "nome",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf",
+          "endereco",
+          "cep",
+          "latitude",
+          "longitude",
+          "codigoEmec"
+        ],
+        "type": "object",
+        "properties": {
+          "sigla": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "cidadeNome": {
+            "type": "string"
+          },
+          "cidadeUf": {
+            "type": "string"
+          },
+          "endereco": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cep": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "codigoEmec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "CriarLocalOfertaCommand": {
+        "required": [
+          "tipo",
+          "campusResponsavelId",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf",
+          "endereco",
+          "codigoEmec"
+        ],
+        "type": "object",
+        "properties": {
+          "tipo": {
+            "$ref": "#/components/schemas/TipoLocalOferta"
+          },
+          "campusResponsavelId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "cidadeNome": {
+            "type": "string"
+          },
+          "cidadeUf": {
+            "type": "string"
+          },
+          "endereco": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "codigoEmec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "IFormFile": {
+        "type": "string",
+        "format": "binary"
+      },
+      "LocalOfertaDto": {
+        "required": [
+          "id",
+          "tipo",
+          "campusResponsavelId",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf",
+          "cidadeOrigem",
+          "cidadeDisplayAtualizadoEm",
+          "endereco",
+          "codigoEmec",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tipo": {
+            "$ref": "#/components/schemas/TipoLocalOferta"
+          },
+          "campusResponsavelId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "cidadeNome": {
+            "type": "string"
+          },
+          "cidadeUf": {
+            "type": "string"
+          },
+          "cidadeOrigem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeDisplayAtualizadoEm": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "endereco": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "codigoEmec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "instance": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "TipoLocalOferta": {
+        "enum": [
+          "nenhum",
+          "campusSede",
+          "campusForaDeSede",
+          "cursoForaDeSede",
+          "poloEad",
+          "convenioInteriorizacao",
+          "outro"
+        ],
+        "type": "string"
+      },
+      "UserProfileResponse": {
+        "required": [
+          "userId",
+          "name",
+          "email",
+          "cpf",
+          "nomeSocial",
+          "roles",
+          "timestamp"
+        ],
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "email": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cpf": {
+            "pattern": "^\\d{11}$",
+            "type": [
+              "null",
+              "string"
+            ],
+            "description": "CPF (apenas d\u00EDgitos, sem formata\u00E7\u00E3o). PII \u2014 sempre mascarar em logs (\u0027***.999.999-**\u0027, ADR-0011)."
+          },
+          "nomeSocial": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Auth"
+    },
+    {
+      "name": "Profile"
+    },
+    {
+      "name": "_smoke"
+    },
+    {
+      "name": "Campi"
+    },
+    {
+      "name": "LocaisOferta"
+    }
+  ]
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CampiController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CampiController.cs
@@ -1,0 +1,186 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.Campi;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/campi</c>,
+/// <c>GET /api/campi/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/admin/campi</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ #587).
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class CampiController : ControllerBase
+{
+    private const string ResourceTag = "campi";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<CampusDto> _linksBuilder;
+
+    public CampiController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<CampusDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista os campi ativos, paginados por cursor opaco bidirecional (ADR-0026 +
+    /// ADR-0089). Navegação via header <c>Link</c> (RFC 5988/8288); cada item
+    /// carrega seu <c>_links.self</c> (ADR-0029 §"Coleção").
+    /// </summary>
+    [HttpGet("campi")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "campus", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<CampusDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarCampiResult resultado = await _queryBus
+            .Send(new ListarCampiQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        CampusDto[] comLinks = [.. resultado.Items.Select(c => c with { Links = _linksBuilder.Build(c) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém um campus pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("campi/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "campus", Versions = [1])]
+    [ProducesResponseType(typeof(CampusDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        CampusDto? campus = await _queryBus
+            .Send(new ObterCampusPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (campus is null)
+        {
+            return NotFound();
+        }
+
+        CampusDto comLinks = campus with { Links = _linksBuilder.Build(campus) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria um novo campus. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/campi")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarCampusCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza um campus existente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/campi/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarCampusCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) um campus. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/campi/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverCampusCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/LocaisOfertaController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/LocaisOfertaController.cs
@@ -1,0 +1,184 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.LocaisOferta;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/locais-oferta</c>,
+/// <c>GET /api/locais-oferta/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/admin/locais-oferta</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ #587).
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class LocaisOfertaController : ControllerBase
+{
+    private const string ResourceTag = "locais-oferta";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<LocalOfertaDto> _linksBuilder;
+
+    public LocaisOfertaController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<LocalOfertaDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista os locais de oferta ativos, paginados por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029 §"Coleção").
+    /// </summary>
+    [HttpGet("locais-oferta")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "local-oferta", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<LocalOfertaDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarLocaisOfertaResult resultado = await _queryBus
+            .Send(new ListarLocaisOfertaQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        LocalOfertaDto[] comLinks = [.. resultado.Items.Select(l => l with { Links = _linksBuilder.Build(l) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém um local de oferta pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("locais-oferta/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "local-oferta", Versions = [1])]
+    [ProducesResponseType(typeof(LocalOfertaDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        LocalOfertaDto? local = await _queryBus
+            .Send(new ObterLocalOfertaPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (local is null)
+        {
+            return NotFound();
+        }
+
+        LocalOfertaDto comLinks = local with { Links = _linksBuilder.Build(local) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria um novo local de oferta. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/locais-oferta")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarLocalOfertaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza um local de oferta existente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/locais-oferta/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarLocalOfertaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) um local de oferta. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/locais-oferta/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverLocalOfertaCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -2,13 +2,15 @@ namespace Unifesspa.UniPlus.Configuracao.API.Errors;
 
 using System.Diagnostics.CodeAnalysis;
 
+using Microsoft.AspNetCore.Http;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 
 /// <summary>
-/// Registry de mapeamentos de erros de domínio do Configuracao para wire
-/// codes / status HTTP. Vazio em V1 — as entidades (Modalidade,
-/// NecessidadeEspecial, TipoDocumento, Endereco) entram em F2 com seus
-/// próprios códigos <c>uniplus.configuracao.*</c>.
+/// Registry de mapeamentos de erros de domínio do Configuracao para wire codes
+/// / status HTTP. Cobre os cadastros <c>Campus</c> e <c>LocalOferta</c> e a
+/// validação da referência de cidade do Geo (UNI-REQ #587 · ADR-0090).
 /// </summary>
 [SuppressMessage(
     "Performance",
@@ -16,5 +18,147 @@ using Unifesspa.UniPlus.Infrastructure.Core.Errors;
     Justification = "Instanciada via IServiceProvider.AddSingleton<IDomainErrorRegistration, ConfiguracaoDomainErrorRegistration>().")]
 internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistration
 {
-    public IEnumerable<KeyValuePair<string, DomainErrorMapping>> GetMappings() => [];
+    public IEnumerable<KeyValuePair<string, DomainErrorMapping>> GetMappings() =>
+    [
+        // ── Referência de cidade do Geo (compartilhada por Campus e LocalOferta) ──
+        new(CidadeReferenciaErrorCodes.CodigoIbgeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.cidade_referencia.codigo_ibge_obrigatorio",
+                "Código IBGE da cidade é obrigatório")),
+
+        new(CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.cidade_referencia.codigo_ibge_formato_invalido",
+                "Código IBGE da cidade em formato inválido")),
+
+        new(CidadeReferenciaErrorCodes.UfObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.cidade_referencia.uf_obrigatoria",
+                "UF da cidade é obrigatória")),
+
+        new(CidadeReferenciaErrorCodes.UfIncoerente,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.cidade_referencia.uf_incoerente",
+                "UF informada incompatível com o prefixo do código IBGE")),
+
+        new(CidadeReferenciaErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.cidade_referencia.nome_obrigatorio",
+                "Nome da cidade é obrigatório")),
+
+        // ── Campus ────────────────────────────────────────────────────────
+        new(CampusErrorCodes.SiglaObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.campus.sigla_obrigatoria",
+                "Sigla do campus é obrigatória")),
+
+        new(CampusErrorCodes.SiglaTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.campus.sigla_tamanho",
+                "Tamanho da sigla do campus inválido")),
+
+        new(CampusErrorCodes.SiglaJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.campus.sigla_ja_existe",
+                "Já existe um campus ativo com esta sigla")),
+
+        new(CampusErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.campus.nome_obrigatorio",
+                "Nome do campus é obrigatório")),
+
+        new(CampusErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.campus.nome_tamanho",
+                "Tamanho do nome do campus inválido")),
+
+        new(CampusErrorCodes.EnderecoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.campus.endereco_tamanho",
+                "Tamanho do endereço do campus inválido")),
+
+        new(CampusErrorCodes.CepInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.campus.cep_invalido",
+                "CEP do campus em formato inválido")),
+
+        new(CampusErrorCodes.LatitudeForaDeFaixa,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.campus.latitude_fora_de_faixa",
+                "Latitude do campus fora da faixa válida")),
+
+        new(CampusErrorCodes.LongitudeForaDeFaixa,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.campus.longitude_fora_de_faixa",
+                "Longitude do campus fora da faixa válida")),
+
+        new(CampusErrorCodes.CodigoEmecTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.campus.codigo_emec_tamanho",
+                "Tamanho do código e-MEC do campus inválido")),
+
+        new(CampusErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.campus.nao_encontrado",
+                "Campus não encontrado")),
+
+        new(CampusErrorCodes.RemocaoBloqueadaPorLocalOferta,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.campus.remocao_bloqueada_por_local_oferta",
+                "Não é possível remover um campus responsável por locais de oferta ativos")),
+
+        // ── LocalOferta ───────────────────────────────────────────────────
+        new(LocalOfertaErrorCodes.TipoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.local_oferta.tipo_invalido",
+                "Tipo de local de oferta inválido")),
+
+        new(LocalOfertaErrorCodes.CampusResponsavelNaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.local_oferta.campus_responsavel_nao_encontrado",
+                "Campus responsável informado não encontrado")),
+
+        new(LocalOfertaErrorCodes.EnderecoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.local_oferta.endereco_tamanho",
+                "Tamanho do endereço do local de oferta inválido")),
+
+        new(LocalOfertaErrorCodes.CodigoEmecTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.local_oferta.codigo_emec_tamanho",
+                "Tamanho do código e-MEC do local de oferta inválido")),
+
+        new(LocalOfertaErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.local_oferta.nao_encontrado",
+                "Local de oferta não encontrado")),
+
+        new(LocalOfertaErrorCodes.RemocaoBloqueadaPorOfertaCurso,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.local_oferta.remocao_bloqueada_por_oferta_curso",
+                "Não é possível remover um local de oferta referenciado por oferta de curso ativa")),
+    ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CampusLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CampusLinksBuilder.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="CampusDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<CampusDto>, CampusLinksBuilder>().")]
+internal sealed class CampusLinksBuilder : IResourceLinksBuilder<CampusDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CampusLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(CampusDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "Campi";
+
+        string self = ResolverPath(httpContext, nameof(CampiController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(httpContext, nameof(CampiController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/LocalOfertaLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/LocalOfertaLinksBuilder.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="LocalOfertaDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<LocalOfertaDto>, LocalOfertaLinksBuilder>().")]
+internal sealed class LocalOfertaLinksBuilder : IResourceLinksBuilder<LocalOfertaDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public LocalOfertaLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(LocalOfertaDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "LocaisOferta";
+
+        string self = ResolverPath(httpContext, nameof(LocaisOfertaController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(httpContext, nameof(LocaisOfertaController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Program.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Program.cs
@@ -4,6 +4,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
 using Unifesspa.UniPlus.Infrastructure.Core.Cors;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 using Unifesspa.UniPlus.Infrastructure.Core.Logging;
 using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
@@ -11,7 +12,9 @@ using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Infrastructure.Core.Smoke;
 using Unifesspa.UniPlus.Configuracao.API.Errors;
+using Unifesspa.UniPlus.Configuracao.API.Hateoas;
 using Unifesspa.UniPlus.Configuracao.Application;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
 using Unifesspa.UniPlus.Configuracao.Infrastructure;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 
@@ -28,12 +31,19 @@ builder.Services.AddControllers()
     .AddJsonOptions(options =>
     {
         options.JsonSerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase;
+        // Enums em wire format como nome camelCase (ex.: "poloEad", não 4) — mesmo
+        // contrato do módulo Seleção. Sem isso, payload admin com enum como string
+        // vira 400 e o TipoLocalOferta sairia como inteiro mágico.
+        options.JsonSerializerOptions.Converters.Add(
+            new System.Text.Json.Serialization.JsonStringEnumConverter(System.Text.Json.JsonNamingPolicy.CamelCase));
     });
 
-// Minimal API endpoints use a separate JSON options pipeline.
+// Minimal API endpoints use a separate JSON options pipeline; manter em sincronia.
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
     options.SerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase;
+    options.SerializerOptions.Converters.Add(
+        new System.Text.Json.Serialization.JsonStringEnumConverter(System.Text.Json.JsonNamingPolicy.CamelCase));
 });
 
 builder.Services.AddEndpointsApiExplorer();
@@ -43,10 +53,17 @@ builder.Services.AddUniPlusOpenApi("configuracao", builder.Configuration);
 builder.Services.AddSingleton<IDomainErrorRegistration, ConfiguracaoDomainErrorRegistration>();
 builder.Services.AddDomainErrorMapper();
 
+// HATEOAS Level 1 (ADR-0029) — builders de _links dos cadastros (UNI-REQ #587).
+builder.Services.AddSingleton<IResourceLinksBuilder<CampusDto>, CampusLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<LocalOfertaDto>, LocalOfertaLinksBuilder>();
+
 // Idempotency-Key (ADR-0027) + criptografia para entries at-rest. Filter global
-// se ativa apenas em endpoints com [RequiresIdempotencyKey] — controllers admin
-// entram em F2.
+// se ativa apenas em endpoints com [RequiresIdempotencyKey] — os controllers
+// admin de Campus/LocalOferta o exigem.
 builder.Services.AddUniPlusEncryption(builder.Configuration);
+// Cursor pagination (ADR-0026) — CursorEncoder, PageRequestModelBinder e o hook
+// que traduz falhas do binder para 400/410/422; usado pelos GET de listagem.
+builder.Services.AddCursorPagination(builder.Configuration);
 builder.Services.AddIdempotency<ConfiguracaoDbContext>(builder.Configuration);
 
 builder.Services.AddOidcAuthentication(builder.Configuration, builder.Environment);
@@ -65,10 +82,15 @@ builder.Services.AddConfiguracaoInfrastructure();
 // cobre os 5 entry points com a regra.
 builder.Services.AddDbContextMigrationsOnStartup<ConfiguracaoDbContext>();
 
-// Wolverine como backbone CQRS/messaging (ADR-0003/0004/0005). Sem roteamento
-// específico em V1 — eventos de catálogo (Modalidade*Event, etc.) entram em F2
-// para invalidar cache cross-pod do reader (PG queue intra-módulo per ADR-0044).
-builder.Host.UseWolverineOutboxCascading(builder.Configuration, connectionStringName: "ConfiguracaoDb");
+// Wolverine como backbone CQRS/messaging (ADR-0003/0004/0005). Os command/query
+// handlers de Campus/LocalOferta vivem em Configuracao.Application — incluir o
+// assembly explicitamente para que o Wolverine os descubra (o scan default é só
+// o entry assembly da API). Sem roteamento Kafka em V1.
+builder.Host.UseWolverineOutboxCascading(
+    builder.Configuration,
+    connectionStringName: "ConfiguracaoDb",
+    configureRouting: opts =>
+        opts.Discovery.IncludeAssembly(typeof(ConfiguracaoApplicationServiceRegistration).Assembly));
 builder.Services.AddWolverineMessaging();
 
 builder.Services.AddCorsConfiguration(builder.Configuration, builder.Environment);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommand.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed record AtualizarCampusCommand(
+    Guid Id,
+    string Sigla,
+    string Nome,
+    string CidadeCodigoIbge,
+    string CidadeNome,
+    string CidadeUf,
+    string? Endereco,
+    string? Cep,
+    decimal? Latitude,
+    decimal? Longitude,
+    string? CodigoEmec) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandHandler.cs
@@ -39,14 +39,21 @@ public static class AtualizarCampusCommandHandler
                 $"Já existe um Campus vivo com a sigla '{command.Sigla}'."));
         }
 
+        // Só recarimba a proveniência/frescura do display cache quando o trio de
+        // cidade efetivamente muda — assim cidade_display_atualizado_em rastreia a
+        // última reconciliação da cidade, não qualquer edição de outro campo.
+        bool cidadeMudou = CidadeReferenciaMudou(command, campus);
+        string? cidadeOrigem = cidadeMudou ? ReferenciaCidadeGeo.OrigemGeoApi : campus.CidadeOrigem;
+        DateTimeOffset? cidadeAtualizadoEm = cidadeMudou ? timeProvider.GetUtcNow() : campus.CidadeDisplayAtualizadoEm;
+
         Result atualizarResult = campus.Atualizar(
             command.Sigla,
             command.Nome,
             command.CidadeCodigoIbge,
             command.CidadeNome,
             command.CidadeUf,
-            ReferenciaCidadeGeo.OrigemGeoApi,
-            timeProvider.GetUtcNow(),
+            cidadeOrigem,
+            cidadeAtualizadoEm,
             command.Endereco,
             command.Cep,
             command.Latitude,
@@ -62,4 +69,9 @@ public static class AtualizarCampusCommandHandler
 
         return Result.Success();
     }
+
+    private static bool CidadeReferenciaMudou(AtualizarCampusCommand command, Campus campus) =>
+        !string.Equals(command.CidadeCodigoIbge.Trim(), campus.CidadeCodigoIbge, StringComparison.Ordinal)
+        || !string.Equals(command.CidadeNome.Trim(), campus.CidadeNome, StringComparison.Ordinal)
+        || !string.Equals(command.CidadeUf.Trim(), campus.CidadeUf, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandHandler.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public static class AtualizarCampusCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarCampusCommand command,
+        ICampusRepository repository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        Campus? campus = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (campus is null)
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.NaoEncontrado,
+                "Campus não encontrado."));
+        }
+
+        // Sigla normaliza para uppercase no agregado e o índice único é case-insensitive
+        // (comparação OrdinalIgnoreCase) — só checa colisão quando a sigla muda.
+        if (!string.Equals(command.Sigla.Trim(), campus.Sigla, StringComparison.OrdinalIgnoreCase)
+            && await repository.SiglaExisteEntreLivosAsync(command.Sigla, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.SiglaJaExiste,
+                $"Já existe um Campus vivo com a sigla '{command.Sigla}'."));
+        }
+
+        Result atualizarResult = campus.Atualizar(
+            command.Sigla,
+            command.Nome,
+            command.CidadeCodigoIbge,
+            command.CidadeNome,
+            command.CidadeUf,
+            ReferenciaCidadeGeo.OrigemGeoApi,
+            timeProvider.GetUtcNow(),
+            command.Endereco,
+            command.Cep,
+            command.Latitude,
+            command.Longitude,
+            command.CodigoEmec);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandValidator.cs
@@ -40,6 +40,20 @@ public sealed class AtualizarCampusCommandValidator : AbstractValidator<Atualiza
             .MaximumLength(500).WithMessage("Endereço do Campus deve ter no máximo 500 caracteres.")
             .When(x => x.Endereco is not null);
 
+        RuleFor(x => x.Cep)
+            .Must(CampusCampoRegras.CepValidoOuAusente)
+            .WithMessage("CEP do Campus deve ter exatamente 8 dígitos numéricos.");
+
+        RuleFor(x => x.Latitude)
+            .InclusiveBetween(CampusCampoRegras.LatitudeMin, CampusCampoRegras.LatitudeMax)
+            .WithMessage("Latitude deve estar entre -90 e 90.")
+            .When(x => x.Latitude.HasValue);
+
+        RuleFor(x => x.Longitude)
+            .InclusiveBetween(CampusCampoRegras.LongitudeMin, CampusCampoRegras.LongitudeMax)
+            .WithMessage("Longitude deve estar entre -180 e 180.")
+            .When(x => x.Longitude.HasValue);
+
         RuleFor(x => x.CodigoEmec)
             .MaximumLength(20).WithMessage("Código e-MEC do Campus deve ter no máximo 20 caracteres.")
             .When(x => x.CodigoEmec is not null);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandValidator.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+
+public sealed class AtualizarCampusCommandValidator : AbstractValidator<AtualizarCampusCommand>
+{
+    public AtualizarCampusCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id do Campus é obrigatório.");
+
+        RuleFor(x => x.Sigla)
+            .NotEmpty().WithMessage("Sigla do Campus é obrigatória.")
+            .MaximumLength(20).WithMessage("Sigla do Campus deve ter no máximo 20 caracteres.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do Campus é obrigatório.")
+            .MinimumLength(2).WithMessage("Nome do Campus deve ter ao menos 2 caracteres.")
+            .MaximumLength(200).WithMessage("Nome do Campus deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.CidadeCodigoIbge)
+            .NotEmpty().WithMessage("Código IBGE da cidade é obrigatório.");
+
+        RuleFor(x => x.CidadeNome)
+            .NotEmpty().WithMessage("Nome da cidade é obrigatório.");
+
+        RuleFor(x => x.CidadeUf)
+            .NotEmpty().WithMessage("UF da cidade é obrigatória.");
+
+        RuleFor(x => x)
+            .Must(x => ReferenciaCidadeGeo.EhValida(x.CidadeCodigoIbge, x.CidadeNome, x.CidadeUf))
+            .WithMessage("Referência de cidade inválida: o código IBGE deve ter 7 dígitos e o prefixo de UF deve ser coerente com a UF informada.")
+            .When(x => !string.IsNullOrWhiteSpace(x.CidadeCodigoIbge)
+                && !string.IsNullOrWhiteSpace(x.CidadeNome)
+                && !string.IsNullOrWhiteSpace(x.CidadeUf));
+
+        RuleFor(x => x.Endereco)
+            .MaximumLength(500).WithMessage("Endereço do Campus deve ter no máximo 500 caracteres.")
+            .When(x => x.Endereco is not null);
+
+        RuleFor(x => x.CodigoEmec)
+            .MaximumLength(20).WithMessage("Código e-MEC do Campus deve ter no máximo 20 caracteres.")
+            .When(x => x.CodigoEmec is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CampusCampoRegras.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CampusCampoRegras.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+/// <summary>
+/// Regras de formato de campos opcionais do Campus compartilhadas entre os
+/// validators de criação e atualização — mantém a fronteira de validação
+/// simétrica (sigla/nome/cidade/cep/coordenadas todos antecipados no validator)
+/// sem duplicar predicados. Os limites espelham os do agregado <c>Campus</c>.
+/// </summary>
+internal static class CampusCampoRegras
+{
+    public const decimal LatitudeMin = -90m;
+    public const decimal LatitudeMax = 90m;
+    public const decimal LongitudeMin = -180m;
+    public const decimal LongitudeMax = 180m;
+
+    private const int CepLength = 8;
+
+    /// <summary>
+    /// Indica se o CEP é válido (8 dígitos numéricos) ou ausente. Espelha a
+    /// normalização do agregado (Trim) para não rejeitar um valor que o domínio
+    /// aceitaria.
+    /// </summary>
+    public static bool CepValidoOuAusente(string? cep)
+    {
+        if (string.IsNullOrWhiteSpace(cep))
+        {
+            return true;
+        }
+
+        string normalizado = cep.Trim();
+        return normalizado.Length == CepLength && normalizado.All(char.IsAsciiDigit);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommand.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria um Campus. A proveniência do display cache (<c>cidade_origem</c>) e o
+/// instante (<c>cidade_display_atualizado_em</c>) são carimbados pelo handler
+/// (server-side, ADR-0090) — não viajam no payload.
+/// </summary>
+public sealed record CriarCampusCommand(
+    string Sigla,
+    string Nome,
+    string CidadeCodigoIbge,
+    string CidadeNome,
+    string CidadeUf,
+    string? Endereco,
+    string? Cep,
+    decimal? Latitude,
+    decimal? Longitude,
+    string? CodigoEmec) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandHandler.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarCampusCommand"/> (convention-based Wolverine):
+/// confere a unicidade da sigla entre campi vivos, cria o agregado carimbando a
+/// proveniência do display cache (<c>cidade_origem = "geo-api"</c>) + instante a
+/// partir do <see cref="TimeProvider"/>, persiste e commita.
+/// </summary>
+public static class CriarCampusCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarCampusCommand command,
+        ICampusRepository repository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        if (await repository.SiglaExisteEntreLivosAsync(command.Sigla, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(new DomainError(
+                CampusErrorCodes.SiglaJaExiste,
+                $"Já existe um Campus vivo com a sigla '{command.Sigla}'."));
+        }
+
+        Result<Campus> campusResult = Campus.Criar(
+            command.Sigla,
+            command.Nome,
+            command.CidadeCodigoIbge,
+            command.CidadeNome,
+            command.CidadeUf,
+            ReferenciaCidadeGeo.OrigemGeoApi,
+            timeProvider.GetUtcNow(),
+            command.Endereco,
+            command.Cep,
+            command.Latitude,
+            command.Longitude,
+            command.CodigoEmec);
+
+        if (campusResult.IsFailure)
+        {
+            return Result<Guid>.Failure(campusResult.Error!);
+        }
+
+        Campus campus = campusResult.Value!;
+        await repository.AdicionarAsync(campus, cancellationToken).ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<Guid>.Success(campus.Id);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandValidator.cs
@@ -37,6 +37,20 @@ public sealed class CriarCampusCommandValidator : AbstractValidator<CriarCampusC
             .MaximumLength(500).WithMessage("Endereço do Campus deve ter no máximo 500 caracteres.")
             .When(x => x.Endereco is not null);
 
+        RuleFor(x => x.Cep)
+            .Must(CampusCampoRegras.CepValidoOuAusente)
+            .WithMessage("CEP do Campus deve ter exatamente 8 dígitos numéricos.");
+
+        RuleFor(x => x.Latitude)
+            .InclusiveBetween(CampusCampoRegras.LatitudeMin, CampusCampoRegras.LatitudeMax)
+            .WithMessage("Latitude deve estar entre -90 e 90.")
+            .When(x => x.Latitude.HasValue);
+
+        RuleFor(x => x.Longitude)
+            .InclusiveBetween(CampusCampoRegras.LongitudeMin, CampusCampoRegras.LongitudeMax)
+            .WithMessage("Longitude deve estar entre -180 e 180.")
+            .When(x => x.Longitude.HasValue);
+
         RuleFor(x => x.CodigoEmec)
             .MaximumLength(20).WithMessage("Código e-MEC do Campus deve ter no máximo 20 caracteres.")
             .When(x => x.CodigoEmec is not null);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandValidator.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+
+public sealed class CriarCampusCommandValidator : AbstractValidator<CriarCampusCommand>
+{
+    public CriarCampusCommandValidator()
+    {
+        RuleFor(x => x.Sigla)
+            .NotEmpty().WithMessage("Sigla do Campus é obrigatória.")
+            .MaximumLength(20).WithMessage("Sigla do Campus deve ter no máximo 20 caracteres.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do Campus é obrigatório.")
+            .MinimumLength(2).WithMessage("Nome do Campus deve ter ao menos 2 caracteres.")
+            .MaximumLength(200).WithMessage("Nome do Campus deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.CidadeCodigoIbge)
+            .NotEmpty().WithMessage("Código IBGE da cidade é obrigatório.");
+
+        RuleFor(x => x.CidadeNome)
+            .NotEmpty().WithMessage("Nome da cidade é obrigatório.");
+
+        RuleFor(x => x.CidadeUf)
+            .NotEmpty().WithMessage("UF da cidade é obrigatória.");
+
+        RuleFor(x => x)
+            .Must(x => ReferenciaCidadeGeo.EhValida(x.CidadeCodigoIbge, x.CidadeNome, x.CidadeUf))
+            .WithMessage("Referência de cidade inválida: o código IBGE deve ter 7 dígitos e o prefixo de UF deve ser coerente com a UF informada.")
+            .When(x => !string.IsNullOrWhiteSpace(x.CidadeCodigoIbge)
+                && !string.IsNullOrWhiteSpace(x.CidadeNome)
+                && !string.IsNullOrWhiteSpace(x.CidadeUf));
+
+        RuleFor(x => x.Endereco)
+            .MaximumLength(500).WithMessage("Endereço do Campus deve ter no máximo 500 caracteres.")
+            .When(x => x.Endereco is not null);
+
+        RuleFor(x => x.CodigoEmec)
+            .MaximumLength(20).WithMessage("Código e-MEC do Campus deve ter no máximo 20 caracteres.")
+            .When(x => x.CodigoEmec is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/RemoverCampusCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/RemoverCampusCommand.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed record RemoverCampusCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/RemoverCampusCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/RemoverCampusCommandHandler.cs
@@ -1,0 +1,52 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverCampusCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c> — bloqueia quando o campus é responsável por
+/// algum <c>LocalOferta</c> vivo (integridade do vínculo intra-banco, ADR-0065).
+/// </summary>
+public static class RemoverCampusCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverCampusCommand command,
+        ICampusRepository repository,
+        ILocalOfertaRepository localOfertaRepository,
+        IUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(localOfertaRepository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        Campus? campus = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (campus is null)
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.NaoEncontrado,
+                "Campus não encontrado."));
+        }
+
+        // Check-then-act, simétrico ao bloqueio de remoção da Unidade no pilot.
+        // Sob concorrência (remoção do campus × criação de LocalOferta que o aponta)
+        // a checagem pode ver `false` antes do commit; a serialização estrita é
+        // controle cross-cutting comum a todos os cadastros, fora desta Story.
+        if (await localOfertaRepository.ExisteVivoComCampusResponsavelAsync(command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.RemocaoBloqueadaPorLocalOferta,
+                "Não é possível remover um Campus que é responsável por Locais de Oferta ativos."));
+        }
+
+        repository.Remover(campus);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommand.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed record AtualizarLocalOfertaCommand(
+    Guid Id,
+    TipoLocalOferta Tipo,
+    Guid? CampusResponsavelId,
+    string CidadeCodigoIbge,
+    string CidadeNome,
+    string CidadeUf,
+    string? Endereco,
+    string? CodigoEmec) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandHandler.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public static class AtualizarLocalOfertaCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarLocalOfertaCommand command,
+        ILocalOfertaRepository repository,
+        ICampusRepository campusRepository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(campusRepository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        LocalOferta? local = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (local is null)
+        {
+            return Result.Failure(new DomainError(
+                LocalOfertaErrorCodes.NaoEncontrado,
+                "Local de Oferta não encontrado."));
+        }
+
+        if (command.CampusResponsavelId.HasValue
+            && command.CampusResponsavelId != local.CampusResponsavelId
+            && !await campusRepository.ExisteVivoAsync(command.CampusResponsavelId.Value, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                LocalOfertaErrorCodes.CampusResponsavelNaoEncontrado,
+                "O Campus responsável informado não foi encontrado."));
+        }
+
+        Result atualizarResult = local.Atualizar(
+            command.Tipo,
+            command.CampusResponsavelId,
+            command.CidadeCodigoIbge,
+            command.CidadeNome,
+            command.CidadeUf,
+            ReferenciaCidadeGeo.OrigemGeoApi,
+            timeProvider.GetUtcNow(),
+            command.Endereco,
+            command.CodigoEmec);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandHandler.cs
@@ -40,14 +40,20 @@ public static class AtualizarLocalOfertaCommandHandler
                 "O Campus responsável informado não foi encontrado."));
         }
 
+        // Só recarimba a proveniência/frescura do display cache quando o trio de
+        // cidade efetivamente muda (mesma semântica do Campus).
+        bool cidadeMudou = CidadeReferenciaMudou(command, local);
+        string? cidadeOrigem = cidadeMudou ? ReferenciaCidadeGeo.OrigemGeoApi : local.CidadeOrigem;
+        DateTimeOffset? cidadeAtualizadoEm = cidadeMudou ? timeProvider.GetUtcNow() : local.CidadeDisplayAtualizadoEm;
+
         Result atualizarResult = local.Atualizar(
             command.Tipo,
             command.CampusResponsavelId,
             command.CidadeCodigoIbge,
             command.CidadeNome,
             command.CidadeUf,
-            ReferenciaCidadeGeo.OrigemGeoApi,
-            timeProvider.GetUtcNow(),
+            cidadeOrigem,
+            cidadeAtualizadoEm,
             command.Endereco,
             command.CodigoEmec);
 
@@ -60,4 +66,9 @@ public static class AtualizarLocalOfertaCommandHandler
 
         return Result.Success();
     }
+
+    private static bool CidadeReferenciaMudou(AtualizarLocalOfertaCommand command, LocalOferta local) =>
+        !string.Equals(command.CidadeCodigoIbge.Trim(), local.CidadeCodigoIbge, StringComparison.Ordinal)
+        || !string.Equals(command.CidadeNome.Trim(), local.CidadeNome, StringComparison.Ordinal)
+        || !string.Equals(command.CidadeUf.Trim(), local.CidadeUf, StringComparison.OrdinalIgnoreCase);
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandValidator.cs
@@ -1,0 +1,43 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public sealed class AtualizarLocalOfertaCommandValidator : AbstractValidator<AtualizarLocalOfertaCommand>
+{
+    public AtualizarLocalOfertaCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id do Local de Oferta é obrigatório.");
+
+        RuleFor(x => x.Tipo)
+            .Must(t => Enum.IsDefined(t) && t != TipoLocalOferta.Nenhum)
+            .WithMessage("Tipo de Local de Oferta inválido.");
+
+        RuleFor(x => x.CidadeCodigoIbge)
+            .NotEmpty().WithMessage("Código IBGE da cidade é obrigatório.");
+
+        RuleFor(x => x.CidadeNome)
+            .NotEmpty().WithMessage("Nome da cidade é obrigatório.");
+
+        RuleFor(x => x.CidadeUf)
+            .NotEmpty().WithMessage("UF da cidade é obrigatória.");
+
+        RuleFor(x => x)
+            .Must(x => ReferenciaCidadeGeo.EhValida(x.CidadeCodigoIbge, x.CidadeNome, x.CidadeUf))
+            .WithMessage("Referência de cidade inválida: o código IBGE deve ter 7 dígitos e o prefixo de UF deve ser coerente com a UF informada.")
+            .When(x => !string.IsNullOrWhiteSpace(x.CidadeCodigoIbge)
+                && !string.IsNullOrWhiteSpace(x.CidadeNome)
+                && !string.IsNullOrWhiteSpace(x.CidadeUf));
+
+        RuleFor(x => x.Endereco)
+            .MaximumLength(500).WithMessage("Endereço do Local de Oferta deve ter no máximo 500 caracteres.")
+            .When(x => x.Endereco is not null);
+
+        RuleFor(x => x.CodigoEmec)
+            .MaximumLength(20).WithMessage("Código e-MEC do Local de Oferta deve ter no máximo 20 caracteres.")
+            .When(x => x.CodigoEmec is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommand.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria um Local de Oferta (modelo flat, ADR-0065). A proveniência do display
+/// cache (<c>cidade_origem</c>) e o instante são carimbados pelo handler.
+/// </summary>
+public sealed record CriarLocalOfertaCommand(
+    TipoLocalOferta Tipo,
+    Guid? CampusResponsavelId,
+    string CidadeCodigoIbge,
+    string CidadeNome,
+    string CidadeUf,
+    string? Endereco,
+    string? CodigoEmec) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommandHandler.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarLocalOfertaCommand"/>: confere a existência do
+/// campus responsável (quando informado, FK intra-banco opcional ADR-0065),
+/// cria o agregado carimbando a proveniência do display cache e persiste.
+/// </summary>
+public static class CriarLocalOfertaCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarLocalOfertaCommand command,
+        ILocalOfertaRepository repository,
+        ICampusRepository campusRepository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(campusRepository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        if (command.CampusResponsavelId.HasValue
+            && !await campusRepository.ExisteVivoAsync(command.CampusResponsavelId.Value, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(new DomainError(
+                LocalOfertaErrorCodes.CampusResponsavelNaoEncontrado,
+                "O Campus responsável informado não foi encontrado."));
+        }
+
+        Result<LocalOferta> localResult = LocalOferta.Criar(
+            command.Tipo,
+            command.CampusResponsavelId,
+            command.CidadeCodigoIbge,
+            command.CidadeNome,
+            command.CidadeUf,
+            ReferenciaCidadeGeo.OrigemGeoApi,
+            timeProvider.GetUtcNow(),
+            command.Endereco,
+            command.CodigoEmec);
+
+        if (localResult.IsFailure)
+        {
+            return Result<Guid>.Failure(localResult.Error!);
+        }
+
+        LocalOferta local = localResult.Value!;
+        await repository.AdicionarAsync(local, cancellationToken).ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<Guid>.Success(local.Id);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommandValidator.cs
@@ -1,0 +1,40 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public sealed class CriarLocalOfertaCommandValidator : AbstractValidator<CriarLocalOfertaCommand>
+{
+    public CriarLocalOfertaCommandValidator()
+    {
+        RuleFor(x => x.Tipo)
+            .Must(t => Enum.IsDefined(t) && t != TipoLocalOferta.Nenhum)
+            .WithMessage("Tipo de Local de Oferta inválido.");
+
+        RuleFor(x => x.CidadeCodigoIbge)
+            .NotEmpty().WithMessage("Código IBGE da cidade é obrigatório.");
+
+        RuleFor(x => x.CidadeNome)
+            .NotEmpty().WithMessage("Nome da cidade é obrigatório.");
+
+        RuleFor(x => x.CidadeUf)
+            .NotEmpty().WithMessage("UF da cidade é obrigatória.");
+
+        RuleFor(x => x)
+            .Must(x => ReferenciaCidadeGeo.EhValida(x.CidadeCodigoIbge, x.CidadeNome, x.CidadeUf))
+            .WithMessage("Referência de cidade inválida: o código IBGE deve ter 7 dígitos e o prefixo de UF deve ser coerente com a UF informada.")
+            .When(x => !string.IsNullOrWhiteSpace(x.CidadeCodigoIbge)
+                && !string.IsNullOrWhiteSpace(x.CidadeNome)
+                && !string.IsNullOrWhiteSpace(x.CidadeUf));
+
+        RuleFor(x => x.Endereco)
+            .MaximumLength(500).WithMessage("Endereço do Local de Oferta deve ter no máximo 500 caracteres.")
+            .When(x => x.Endereco is not null);
+
+        RuleFor(x => x.CodigoEmec)
+            .MaximumLength(20).WithMessage("Código e-MEC do Local de Oferta deve ter no máximo 20 caracteres.")
+            .When(x => x.CodigoEmec is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/RemoverLocalOfertaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/RemoverLocalOfertaCommand.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed record RemoverLocalOfertaCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/RemoverLocalOfertaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/RemoverLocalOfertaCommandHandler.cs
@@ -1,0 +1,50 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverLocalOfertaCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c> — bloqueia quando o local é referenciado por
+/// oferta de curso viva (UNI-REQ-0010). A entidade <c>oferta_curso</c> ainda não
+/// existe; a checagem é ponto de extensão (retorna <see langword="false"/>).
+/// </summary>
+public static class RemoverLocalOfertaCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverLocalOfertaCommand command,
+        ILocalOfertaRepository repository,
+        IUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        LocalOferta? local = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (local is null)
+        {
+            return Result.Failure(new DomainError(
+                LocalOfertaErrorCodes.NaoEncontrado,
+                "Local de Oferta não encontrado."));
+        }
+
+        // Ponto de extensão UNI-REQ-0010: oferta_curso ainda não existe no módulo,
+        // então a checagem retorna false hoje. Quando a oferta de curso chegar, o
+        // bloqueio passa a valer sem mudar este handler.
+        if (await repository.ReferenciadoPorOfertaCursoVivaAsync(command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                LocalOfertaErrorCodes.RemocaoBloqueadaPorOfertaCurso,
+                "Não é possível remover um Local de Oferta referenciado por oferta de curso ativa."));
+        }
+
+        repository.Remover(local);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CampusDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CampusDto.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>Campus</c>. Suporta HATEOAS Level 1 via
+/// <c>_links</c> (ADR-0029).
+/// </summary>
+public sealed record CampusDto(
+    Guid Id,
+    string Sigla,
+    string Nome,
+    string CidadeCodigoIbge,
+    string CidadeNome,
+    string CidadeUf,
+    string? CidadeOrigem,
+    DateTimeOffset? CidadeDisplayAtualizadoEm,
+    string? Endereco,
+    string? Cep,
+    decimal? Latitude,
+    decimal? Longitude,
+    string? CodigoEmec,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/LocalOfertaDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/LocalOfertaDto.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>LocalOferta</c>. Suporta HATEOAS Level 1 via
+/// <c>_links</c> (ADR-0029). O <see cref="Tipo"/> serializa como nome camelCase
+/// (JsonStringEnumConverter), mesmo contrato de entrada do command.
+/// </summary>
+public sealed record LocalOfertaDto(
+    Guid Id,
+    TipoLocalOferta Tipo,
+    Guid? CampusResponsavelId,
+    string CidadeCodigoIbge,
+    string CidadeNome,
+    string CidadeUf,
+    string? CidadeOrigem,
+    DateTimeOffset? CidadeDisplayAtualizadoEm,
+    string? Endereco,
+    string? CodigoEmec,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CampusMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CampusMapping.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+public static class CampusMapping
+{
+    public static CampusDto ToDto(this Campus campus)
+    {
+        ArgumentNullException.ThrowIfNull(campus);
+        return new CampusDto(
+            campus.Id,
+            campus.Sigla,
+            campus.Nome,
+            campus.CidadeCodigoIbge,
+            campus.CidadeNome,
+            campus.CidadeUf,
+            campus.CidadeOrigem,
+            campus.CidadeDisplayAtualizadoEm,
+            campus.Endereco,
+            campus.Cep,
+            campus.Latitude,
+            campus.Longitude,
+            campus.CodigoEmec,
+            campus.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/LocalOfertaMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/LocalOfertaMapping.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+public static class LocalOfertaMapping
+{
+    public static LocalOfertaDto ToDto(this LocalOferta local)
+    {
+        ArgumentNullException.ThrowIfNull(local);
+        return new LocalOfertaDto(
+            local.Id,
+            local.Tipo,
+            local.CampusResponsavelId,
+            local.CidadeCodigoIbge,
+            local.CidadeNome,
+            local.CidadeUf,
+            local.CidadeOrigem,
+            local.CidadeDisplayAtualizadoEm,
+            local.Endereco,
+            local.CodigoEmec,
+            local.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ListarCampiQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ListarCampiQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Campi;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista campi vivos paginados por cursor bidirecional (ADR-0026 + ADR-0089).
+/// O controller decifra o cursor opaco e valida limit/direction antes de
+/// despachar, mantendo a Application independente de Infrastructure.Core.
+/// </summary>
+public sealed record ListarCampiQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarCampiResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ListarCampiQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ListarCampiQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Campi;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarCampiQueryHandler
+{
+    public static async Task<ListarCampiResult> Handle(
+        ListarCampiQuery query,
+        ICampusRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<Campus> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        CampusDto[] items = [.. itens.Select(c => c.ToDto())];
+        return new ListarCampiResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ListarCampiResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ListarCampiResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Campi;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarCampiQuery"/>: lote de campi projetados +
+/// âncoras opcionais para o controller construir os cursores prev/next
+/// (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarCampiResult(
+    IReadOnlyList<CampusDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ObterCampusPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ObterCampusPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Campi;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterCampusPorIdQuery(Guid Id) : IQuery<CampusDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ObterCampusPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Campi/ObterCampusPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Campi;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterCampusPorIdQueryHandler
+{
+    public static async Task<CampusDto?> Handle(
+        ObterCampusPorIdQuery query,
+        ICampusRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        Campus? campus = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return campus?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ListarLocaisOfertaQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ListarLocaisOfertaQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.LocaisOferta;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista locais de oferta vivos paginados por cursor bidirecional (ADR-0026 +
+/// ADR-0089). O controller decifra o cursor opaco e valida limit/direction
+/// antes de despachar.
+/// </summary>
+public sealed record ListarLocaisOfertaQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarLocaisOfertaResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ListarLocaisOfertaQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ListarLocaisOfertaQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.LocaisOferta;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarLocaisOfertaQueryHandler
+{
+    public static async Task<ListarLocaisOfertaResult> Handle(
+        ListarLocaisOfertaQuery query,
+        ILocalOfertaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<LocalOferta> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        LocalOfertaDto[] items = [.. itens.Select(l => l.ToDto())];
+        return new ListarLocaisOfertaResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ListarLocaisOfertaResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ListarLocaisOfertaResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.LocaisOferta;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarLocaisOfertaQuery"/>: lote de locais de oferta
+/// projetados + âncoras opcionais para o controller construir os cursores
+/// prev/next (ADR-0026 + ADR-0089).
+/// </summary>
+public sealed record ListarLocaisOfertaResult(
+    IReadOnlyList<LocalOfertaDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ObterLocalOfertaPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ObterLocalOfertaPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.LocaisOferta;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterLocalOfertaPorIdQuery(Guid Id) : IQuery<LocalOfertaDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ObterLocalOfertaPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/LocaisOferta/ObterLocalOfertaPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.LocaisOferta;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterLocalOfertaPorIdQueryHandler
+{
+    public static async Task<LocalOfertaDto?> Handle(
+        ObterLocalOfertaPorIdQuery query,
+        ILocalOfertaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        LocalOferta? local = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return local?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Cidades/ReferenciaCidadeGeo.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Cidades/ReferenciaCidadeGeo.cs
@@ -135,9 +135,10 @@ public static class ReferenciaCidadeGeo
     }
 
     /// <summary>
-    /// Predicado conveniente (sem alocar <see cref="DomainError"/>) para uso em
+    /// Predicado conveniente (sem propagar <see cref="DomainError"/>) para uso em
     /// validators FluentValidation: indica se a referência tem formato e UF
-    /// coerentes.
+    /// coerentes. No caminho de falha o <see cref="Validar"/> subjacente ainda
+    /// instancia o erro, que é descartado aqui.
     /// </summary>
     public static bool EhValida(string? cidadeCodigoIbge, string? cidadeNome, string? cidadeUf) =>
         Validar(cidadeCodigoIbge, cidadeNome, cidadeUf).IsSuccess;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Cidades/ReferenciaCidadeGeo.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Cidades/ReferenciaCidadeGeo.cs
@@ -1,0 +1,144 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+
+using System.Collections.Frozen;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Validação server-side da referência de cidade do módulo <c>Geo</c>
+/// (ADR-0090). <c>Campus</c> e <c>LocalOferta</c> guardam
+/// <c>cidade_codigo_ibge</c> (código IBGE de 7 dígitos) + display cache
+/// (<c>cidade_nome</c>, <c>cidade_uf</c>) preenchido pelo frontend a partir da
+/// API do Geo — composição no cliente, sem FK cross-banco nem chamada ao Geo.
+/// </summary>
+/// <remarks>
+/// <para>A validação é apenas de <strong>formato</strong>: 7 dígitos numéricos,
+/// prefixo de UF (2 primeiros dígitos) coerente com a <c>cidade_uf</c> informada,
+/// e <c>cidade_nome</c> não-vazio. <strong>Não</strong> há verificação de dígito
+/// verificador (evita depender de algoritmo de DV não-padronizado, risco de
+/// falso-negativo) nem consulta ao Geo. A existência real da cidade fica a cargo
+/// do front (que só oferece cidades reais) + reconciliação eventual.</para>
+/// <para>Este padrão de referência fraca vale só para dado público estável
+/// (município IBGE) — nunca para invariante de autorização/elegibilidade/
+/// financeiro/legal.</para>
+/// </remarks>
+public static class ReferenciaCidadeGeo
+{
+    /// <summary>Comprimento exato do código IBGE de município (7 dígitos).</summary>
+    public const int CodigoIbgeLength = 7;
+
+    /// <summary>Comprimento da sigla de UF (2 letras).</summary>
+    public const int UfLength = 2;
+
+    /// <summary>Comprimento máximo do nome de cidade no display cache.</summary>
+    public const int NomeMaxLength = 150;
+
+    /// <summary>Comprimento máximo da proveniência do display cache.</summary>
+    public const int OrigemMaxLength = 50;
+
+    /// <summary>Proveniência padrão do display cache: composição no cliente sobre a API do Geo.</summary>
+    public const string OrigemGeoApi = "geo-api";
+
+    /// <summary>
+    /// Mapa prefixo (2 primeiros dígitos do código IBGE) → sigla da UF. É a fonte
+    /// de verdade do intervalo válido de prefixos (11–53, com lacunas) e da
+    /// coerência prefixo↔UF. Sem consultar o Geo.
+    /// </summary>
+    private static readonly FrozenDictionary<string, string> UfPorPrefixo = new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["11"] = "RO",
+        ["12"] = "AC",
+        ["13"] = "AM",
+        ["14"] = "RR",
+        ["15"] = "PA",
+        ["16"] = "AP",
+        ["17"] = "TO",
+        ["21"] = "MA",
+        ["22"] = "PI",
+        ["23"] = "CE",
+        ["24"] = "RN",
+        ["25"] = "PB",
+        ["26"] = "PE",
+        ["27"] = "AL",
+        ["28"] = "SE",
+        ["29"] = "BA",
+        ["31"] = "MG",
+        ["32"] = "ES",
+        ["33"] = "RJ",
+        ["35"] = "SP",
+        ["41"] = "PR",
+        ["42"] = "SC",
+        ["43"] = "RS",
+        ["50"] = "MS",
+        ["51"] = "MT",
+        ["52"] = "GO",
+        ["53"] = "DF",
+    }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Valida a referência de cidade (formato + coerência de UF). Retorna
+    /// <see cref="Result.Success"/> quando o código tem 7 dígitos numéricos com
+    /// prefixo de UF coerente com <paramref name="cidadeUf"/> e
+    /// <paramref name="cidadeNome"/> não-vazio; caso contrário, um
+    /// <see cref="DomainError"/> com o código apropriado de
+    /// <see cref="CidadeReferenciaErrorCodes"/>.
+    /// </summary>
+    public static Result Validar(string? cidadeCodigoIbge, string? cidadeNome, string? cidadeUf)
+    {
+        if (string.IsNullOrWhiteSpace(cidadeCodigoIbge))
+        {
+            return Result.Failure(new DomainError(
+                CidadeReferenciaErrorCodes.CodigoIbgeObrigatorio,
+                "Código IBGE da cidade é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(cidadeNome))
+        {
+            return Result.Failure(new DomainError(
+                CidadeReferenciaErrorCodes.NomeObrigatorio,
+                "Nome da cidade é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(cidadeUf))
+        {
+            return Result.Failure(new DomainError(
+                CidadeReferenciaErrorCodes.UfObrigatoria,
+                "UF da cidade é obrigatória."));
+        }
+
+        string codigo = cidadeCodigoIbge.Trim();
+        if (codigo.Length != CodigoIbgeLength || !codigo.All(char.IsAsciiDigit))
+        {
+            return Result.Failure(new DomainError(
+                CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido,
+                $"Código IBGE da cidade deve ter exatamente {CodigoIbgeLength} dígitos numéricos."));
+        }
+
+        string prefixo = codigo[..2];
+        if (!UfPorPrefixo.TryGetValue(prefixo, out string? ufDoPrefixo))
+        {
+            return Result.Failure(new DomainError(
+                CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido,
+                $"Os dois primeiros dígitos do código IBGE ('{prefixo}') não correspondem a uma UF válida."));
+        }
+
+        if (!string.Equals(ufDoPrefixo, cidadeUf.Trim(), StringComparison.OrdinalIgnoreCase))
+        {
+            return Result.Failure(new DomainError(
+                CidadeReferenciaErrorCodes.UfIncoerente,
+                $"O prefixo do código IBGE ('{prefixo}') corresponde à UF '{ufDoPrefixo}', "
+                + $"incompatível com a UF informada ('{cidadeUf.Trim()}')."));
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Predicado conveniente (sem alocar <see cref="DomainError"/>) para uso em
+    /// validators FluentValidation: indica se a referência tem formato e UF
+    /// coerentes.
+    /// </summary>
+    public static bool EhValida(string? cidadeCodigoIbge, string? cidadeNome, string? cidadeUf) =>
+        Validar(cidadeCodigoIbge, cidadeNome, cidadeUf).IsSuccess;
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Campus.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Campus.cs
@@ -1,0 +1,257 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Campus institucional — unidade física onde a instituição oferta cursos
+/// (UNI-REQ #587, módulo Configuração). Referencia a cidade do módulo
+/// <c>Geo</c> por <c>CidadeCodigoIbge</c> (código IBGE de 7 dígitos) + display
+/// cache (<c>CidadeNome</c>, <c>CidadeUf</c>), preenchido pelo frontend via
+/// composição no cliente (ADR-0090) — sem FK cross-banco nem chamada ao Geo.
+/// </summary>
+/// <remarks>
+/// <para>A <c>Sigla</c> é única entre campi vivos (não soft-deleted); a
+/// unicidade é validada pelo handler antes da factory e reforçada por índice
+/// único parcial de banco (<c>WHERE is_deleted = false</c>).</para>
+/// <para>O congelamento (snapshot RN08) é responsabilidade do Processo Seletivo
+/// (módulo Selecao, ADR-0061) — não há colunas de snapshot aqui.</para>
+/// </remarks>
+public sealed class Campus : SoftDeletableEntity, IAuditableEntity
+{
+    private const int SiglaMinLength = 1;
+    private const int SiglaMaxLength = 20;
+    private const int NomeMinLength = 2;
+    private const int NomeMaxLength = 200;
+    private const int EnderecoMaxLength = 500;
+    private const int CepLength = 8;
+    private const int CodigoEmecMaxLength = 20;
+    private const decimal LatitudeMin = -90m;
+    private const decimal LatitudeMax = 90m;
+    private const decimal LongitudeMin = -180m;
+    private const decimal LongitudeMax = 180m;
+
+    public string Sigla { get; private set; } = string.Empty;
+    public string Nome { get; private set; } = string.Empty;
+
+    // Referência de cidade do Geo (ADR-0090) — código + display cache.
+    public string CidadeCodigoIbge { get; private set; } = string.Empty;
+    public string CidadeNome { get; private set; } = string.Empty;
+    public string CidadeUf { get; private set; } = string.Empty;
+    public string? CidadeOrigem { get; private set; }
+    public DateTimeOffset? CidadeDisplayAtualizadoEm { get; private set; }
+
+    public string? Endereco { get; private set; }
+    public string? Cep { get; private set; }
+    public decimal? Latitude { get; private set; }
+    public decimal? Longitude { get; private set; }
+    public string? CodigoEmec { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private Campus()
+    {
+    }
+
+    /// <summary>
+    /// Cria um novo Campus. Valida formato e domínio local (incluindo a
+    /// referência de cidade via <see cref="ReferenciaCidadeGeo"/>). A unicidade
+    /// de <paramref name="sigla"/> entre campi vivos é responsabilidade do handler.
+    /// </summary>
+    public static Result<Campus> Criar(
+        string sigla,
+        string nome,
+        string cidadeCodigoIbge,
+        string cidadeNome,
+        string cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm,
+        string? endereco,
+        string? cep,
+        decimal? latitude,
+        decimal? longitude,
+        string? codigoEmec)
+    {
+        ArgumentNullException.ThrowIfNull(sigla);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(cidadeCodigoIbge);
+        ArgumentNullException.ThrowIfNull(cidadeNome);
+        ArgumentNullException.ThrowIfNull(cidadeUf);
+
+        Result validacao = ValidarCampos(
+            sigla, nome, cidadeCodigoIbge, cidadeNome, cidadeUf, endereco, cep, latitude, longitude, codigoEmec);
+        if (validacao.IsFailure)
+        {
+            return Result<Campus>.Failure(validacao.Error!);
+        }
+
+        var campus = new Campus();
+        campus.AplicarCampos(
+            sigla, nome, cidadeCodigoIbge, cidadeNome, cidadeUf, cidadeOrigem, cidadeDisplayAtualizadoEm,
+            endereco, cep, latitude, longitude, codigoEmec);
+
+        return Result<Campus>.Success(campus);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos do Campus. A unicidade de <paramref name="sigla"/>
+    /// (quando alterada) é responsabilidade do handler.
+    /// </summary>
+    public Result Atualizar(
+        string sigla,
+        string nome,
+        string cidadeCodigoIbge,
+        string cidadeNome,
+        string cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm,
+        string? endereco,
+        string? cep,
+        decimal? latitude,
+        decimal? longitude,
+        string? codigoEmec)
+    {
+        ArgumentNullException.ThrowIfNull(sigla);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(cidadeCodigoIbge);
+        ArgumentNullException.ThrowIfNull(cidadeNome);
+        ArgumentNullException.ThrowIfNull(cidadeUf);
+
+        Result validacao = ValidarCampos(
+            sigla, nome, cidadeCodigoIbge, cidadeNome, cidadeUf, endereco, cep, latitude, longitude, codigoEmec);
+        if (validacao.IsFailure)
+        {
+            return validacao;
+        }
+
+        AplicarCampos(
+            sigla, nome, cidadeCodigoIbge, cidadeNome, cidadeUf, cidadeOrigem, cidadeDisplayAtualizadoEm,
+            endereco, cep, latitude, longitude, codigoEmec);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(
+        string sigla,
+        string nome,
+        string cidadeCodigoIbge,
+        string cidadeNome,
+        string cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm,
+        string? endereco,
+        string? cep,
+        decimal? latitude,
+        decimal? longitude,
+        string? codigoEmec)
+    {
+        Sigla = sigla.Trim().ToUpperInvariant();
+        Nome = nome.Trim();
+        CidadeCodigoIbge = cidadeCodigoIbge.Trim();
+        CidadeNome = cidadeNome.Trim();
+        CidadeUf = cidadeUf.Trim().ToUpperInvariant();
+        CidadeOrigem = NormalizarOpcional(cidadeOrigem);
+        CidadeDisplayAtualizadoEm = cidadeDisplayAtualizadoEm;
+        Endereco = NormalizarOpcional(endereco);
+        Cep = NormalizarOpcional(cep);
+        Latitude = latitude;
+        Longitude = longitude;
+        CodigoEmec = NormalizarOpcional(codigoEmec);
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result ValidarCampos(
+        string sigla,
+        string nome,
+        string cidadeCodigoIbge,
+        string cidadeNome,
+        string cidadeUf,
+        string? endereco,
+        string? cep,
+        decimal? latitude,
+        decimal? longitude,
+        string? codigoEmec)
+    {
+        if (string.IsNullOrWhiteSpace(sigla))
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.SiglaObrigatoria,
+                "Sigla do Campus é obrigatória."));
+        }
+
+        if (sigla.Trim().Length is < SiglaMinLength or > SiglaMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.SiglaTamanho,
+                $"Sigla do Campus deve ter entre {SiglaMinLength} e {SiglaMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.NomeObrigatorio,
+                "Nome do Campus é obrigatório."));
+        }
+
+        if (nome.Trim().Length is < NomeMinLength or > NomeMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.NomeTamanho,
+                $"Nome do Campus deve ter entre {NomeMinLength} e {NomeMaxLength} caracteres."));
+        }
+
+        Result cidade = ReferenciaCidadeGeo.Validar(cidadeCodigoIbge, cidadeNome, cidadeUf);
+        if (cidade.IsFailure)
+        {
+            return cidade;
+        }
+
+        if (endereco is not null && endereco.Trim().Length > EnderecoMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.EnderecoTamanho,
+                $"Endereço do Campus deve ter no máximo {EnderecoMaxLength} caracteres."));
+        }
+
+        if (!string.IsNullOrWhiteSpace(cep))
+        {
+            string cepNormalizado = cep.Trim();
+            if (cepNormalizado.Length != CepLength || !cepNormalizado.All(char.IsAsciiDigit))
+            {
+                return Result.Failure(new DomainError(
+                    CampusErrorCodes.CepInvalido,
+                    $"CEP do Campus deve ter exatamente {CepLength} dígitos numéricos."));
+            }
+        }
+
+        if (latitude is { } lat && lat is < LatitudeMin or > LatitudeMax)
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.LatitudeForaDeFaixa,
+                $"Latitude deve estar entre {LatitudeMin} e {LatitudeMax}."));
+        }
+
+        if (longitude is { } lon && lon is < LongitudeMin or > LongitudeMax)
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.LongitudeForaDeFaixa,
+                $"Longitude deve estar entre {LongitudeMin} e {LongitudeMax}."));
+        }
+
+        if (codigoEmec is not null && codigoEmec.Trim().Length > CodigoEmecMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                CampusErrorCodes.CodigoEmecTamanho,
+                $"Código e-MEC do Campus deve ter no máximo {CodigoEmecMaxLength} caracteres."));
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/LocalOferta.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/LocalOferta.cs
@@ -1,0 +1,177 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Local de oferta de vagas (UNI-REQ #587, módulo Configuração). Modelo
+/// <strong>flat</strong> (ADR-0065): em vez de uma hierarquia de tipos, o
+/// <see cref="Tipo"/> classifica a modalidade e <see cref="CampusResponsavelId"/>
+/// (FK intra-banco opcional → <c>campus</c>) liga o local ao campus responsável
+/// quando aplicável. Referencia a cidade do <c>Geo</c> por código + display
+/// cache (ADR-0090), sem FK cross-banco.
+/// </summary>
+/// <remarks>
+/// O congelamento (snapshot RN08) é responsabilidade do Processo Seletivo
+/// (módulo Selecao, via oferta de curso congelada — ADR-0061); não há colunas
+/// de snapshot aqui.
+/// </remarks>
+public sealed class LocalOferta : SoftDeletableEntity, IAuditableEntity
+{
+    private const int EnderecoMaxLength = 500;
+    private const int CodigoEmecMaxLength = 20;
+
+    public TipoLocalOferta Tipo { get; private set; }
+    public Guid? CampusResponsavelId { get; private set; }
+
+    // Referência de cidade do Geo (ADR-0090) — código + display cache.
+    public string CidadeCodigoIbge { get; private set; } = string.Empty;
+    public string CidadeNome { get; private set; } = string.Empty;
+    public string CidadeUf { get; private set; } = string.Empty;
+    public string? CidadeOrigem { get; private set; }
+    public DateTimeOffset? CidadeDisplayAtualizadoEm { get; private set; }
+
+    public string? Endereco { get; private set; }
+    public string? CodigoEmec { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private LocalOferta()
+    {
+    }
+
+    /// <summary>
+    /// Cria um novo Local de Oferta. Valida formato e domínio local (tipo +
+    /// referência de cidade). A existência do campus responsável (quando
+    /// informado) é responsabilidade do handler.
+    /// </summary>
+    public static Result<LocalOferta> Criar(
+        TipoLocalOferta tipo,
+        Guid? campusResponsavelId,
+        string cidadeCodigoIbge,
+        string cidadeNome,
+        string cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm,
+        string? endereco,
+        string? codigoEmec)
+    {
+        ArgumentNullException.ThrowIfNull(cidadeCodigoIbge);
+        ArgumentNullException.ThrowIfNull(cidadeNome);
+        ArgumentNullException.ThrowIfNull(cidadeUf);
+
+        Result validacao = ValidarCampos(tipo, cidadeCodigoIbge, cidadeNome, cidadeUf, endereco, codigoEmec);
+        if (validacao.IsFailure)
+        {
+            return Result<LocalOferta>.Failure(validacao.Error!);
+        }
+
+        var local = new LocalOferta();
+        local.AplicarCampos(
+            tipo, campusResponsavelId, cidadeCodigoIbge, cidadeNome, cidadeUf, cidadeOrigem,
+            cidadeDisplayAtualizadoEm, endereco, codigoEmec);
+
+        return Result<LocalOferta>.Success(local);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos do Local de Oferta. A existência do campus
+    /// responsável (quando informado) é responsabilidade do handler.
+    /// </summary>
+    public Result Atualizar(
+        TipoLocalOferta tipo,
+        Guid? campusResponsavelId,
+        string cidadeCodigoIbge,
+        string cidadeNome,
+        string cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm,
+        string? endereco,
+        string? codigoEmec)
+    {
+        ArgumentNullException.ThrowIfNull(cidadeCodigoIbge);
+        ArgumentNullException.ThrowIfNull(cidadeNome);
+        ArgumentNullException.ThrowIfNull(cidadeUf);
+
+        Result validacao = ValidarCampos(tipo, cidadeCodigoIbge, cidadeNome, cidadeUf, endereco, codigoEmec);
+        if (validacao.IsFailure)
+        {
+            return validacao;
+        }
+
+        AplicarCampos(
+            tipo, campusResponsavelId, cidadeCodigoIbge, cidadeNome, cidadeUf, cidadeOrigem,
+            cidadeDisplayAtualizadoEm, endereco, codigoEmec);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(
+        TipoLocalOferta tipo,
+        Guid? campusResponsavelId,
+        string cidadeCodigoIbge,
+        string cidadeNome,
+        string cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm,
+        string? endereco,
+        string? codigoEmec)
+    {
+        Tipo = tipo;
+        CampusResponsavelId = campusResponsavelId;
+        CidadeCodigoIbge = cidadeCodigoIbge.Trim();
+        CidadeNome = cidadeNome.Trim();
+        CidadeUf = cidadeUf.Trim().ToUpperInvariant();
+        CidadeOrigem = NormalizarOpcional(cidadeOrigem);
+        CidadeDisplayAtualizadoEm = cidadeDisplayAtualizadoEm;
+        Endereco = NormalizarOpcional(endereco);
+        CodigoEmec = NormalizarOpcional(codigoEmec);
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result ValidarCampos(
+        TipoLocalOferta tipo,
+        string cidadeCodigoIbge,
+        string cidadeNome,
+        string cidadeUf,
+        string? endereco,
+        string? codigoEmec)
+    {
+        if (!Enum.IsDefined(tipo) || tipo == TipoLocalOferta.Nenhum)
+        {
+            return Result.Failure(new DomainError(
+                LocalOfertaErrorCodes.TipoInvalido,
+                "Tipo de Local de Oferta inválido — use um valor definido em TipoLocalOferta, diferente de Nenhum."));
+        }
+
+        Result cidade = ReferenciaCidadeGeo.Validar(cidadeCodigoIbge, cidadeNome, cidadeUf);
+        if (cidade.IsFailure)
+        {
+            return cidade;
+        }
+
+        if (endereco is not null && endereco.Trim().Length > EnderecoMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                LocalOfertaErrorCodes.EnderecoTamanho,
+                $"Endereço do Local de Oferta deve ter no máximo {EnderecoMaxLength} caracteres."));
+        }
+
+        if (codigoEmec is not null && codigoEmec.Trim().Length > CodigoEmecMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                LocalOfertaErrorCodes.CodigoEmecTamanho,
+                $"Código e-MEC do Local de Oferta deve ter no máximo {CodigoEmecMaxLength} caracteres."));
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/TipoLocalOferta.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/TipoLocalOferta.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Classificação de um <c>LocalOferta</c> quanto à modalidade de oferta de vagas
+/// (UNI-REQ #587). Roster fechado — novos tipos exigem deliberação do Tech Lead.
+/// O valor numérico faz parte do contrato: nunca renumerar existentes.
+/// </summary>
+public enum TipoLocalOferta
+{
+    /// <summary>Sentinela — indica corrupção se encontrado em runtime.</summary>
+    Nenhum = 0,
+
+    /// <summary>Campus sede da instituição.</summary>
+    CampusSede = 1,
+
+    /// <summary>Campus fora de sede (interiorização).</summary>
+    CampusForaDeSede = 2,
+
+    /// <summary>Oferta de curso fora de sede vinculada a um campus.</summary>
+    CursoForaDeSede = 3,
+
+    /// <summary>Polo de educação a distância (EaD).</summary>
+    PoloEad = 4,
+
+    /// <summary>Local de oferta resultante de convênio de interiorização.</summary>
+    ConvenioInteriorizacao = 5,
+
+    /// <summary>Outro tipo de local de oferta não enquadrado nos demais.</summary>
+    Outro = 6,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CampusErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CampusErrorCodes.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+public static class CampusErrorCodes
+{
+    public const string SiglaObrigatoria = "Campus.SiglaObrigatoria";
+    public const string SiglaTamanho = "Campus.SiglaTamanho";
+    public const string SiglaJaExiste = "Campus.SiglaJaExiste";
+    public const string NomeObrigatorio = "Campus.NomeObrigatorio";
+    public const string NomeTamanho = "Campus.NomeTamanho";
+    public const string EnderecoTamanho = "Campus.EnderecoTamanho";
+    public const string CepInvalido = "Campus.CepInvalido";
+    public const string LatitudeForaDeFaixa = "Campus.LatitudeForaDeFaixa";
+    public const string LongitudeForaDeFaixa = "Campus.LongitudeForaDeFaixa";
+    public const string CodigoEmecTamanho = "Campus.CodigoEmecTamanho";
+    public const string NaoEncontrado = "Campus.NaoEncontrado";
+    public const string RemocaoBloqueadaPorLocalOferta = "Campus.RemocaoBloqueadaPorLocalOferta";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CidadeReferenciaErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CidadeReferenciaErrorCodes.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+/// <summary>
+/// Códigos de erro da validação da referência de cidade do Geo (ADR-0090):
+/// compartilhados por <c>Campus</c> e <c>LocalOferta</c>, que guardam
+/// <c>cidade_codigo_ibge</c> + display cache em vez de uma FK cross-banco.
+/// A validação é apenas de formato + coerência de UF (sem dígito verificador,
+/// sem consultar o Geo).
+/// </summary>
+public static class CidadeReferenciaErrorCodes
+{
+    public const string CodigoIbgeObrigatorio = "CidadeReferencia.CodigoIbgeObrigatorio";
+    public const string CodigoIbgeFormatoInvalido = "CidadeReferencia.CodigoIbgeFormatoInvalido";
+    public const string UfObrigatoria = "CidadeReferencia.UfObrigatoria";
+    public const string UfIncoerente = "CidadeReferencia.UfIncoerente";
+    public const string NomeObrigatorio = "CidadeReferencia.NomeObrigatorio";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/LocalOfertaErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/LocalOfertaErrorCodes.cs
@@ -1,0 +1,11 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+public static class LocalOfertaErrorCodes
+{
+    public const string TipoInvalido = "LocalOferta.TipoInvalido";
+    public const string CampusResponsavelNaoEncontrado = "LocalOferta.CampusResponsavelNaoEncontrado";
+    public const string EnderecoTamanho = "LocalOferta.EnderecoTamanho";
+    public const string CodigoEmecTamanho = "LocalOferta.CodigoEmecTamanho";
+    public const string NaoEncontrado = "LocalOferta.NaoEncontrado";
+    public const string RemocaoBloqueadaPorOfertaCurso = "LocalOferta.RemocaoBloqueadaPorOfertaCurso";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICampusRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICampusRepository.cs
@@ -1,0 +1,43 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="Campus"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros
+/// soft-deleted via query filter por convenção.
+/// </summary>
+public interface ICampusRepository
+{
+    /// <summary>Carrega o campus rastreado pelo contexto, para mutação.</summary>
+    Task<Campus?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega o campus para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<Campus?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista campi vivos paginados por cursor keyset bidirecional (ADR-0026 +
+    /// ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras
+    /// de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<Campus> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(Campus campus, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca o campus para remoção; o <c>SoftDeleteInterceptor</c> converte em
+    /// soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(Campus campus);
+
+    /// <summary>Verifica se existe campus vivo com a sigla informada (case-insensitive), excluindo opcionalmente um Id.</summary>
+    Task<bool> SiglaExisteEntreLivosAsync(string sigla, Guid? excluirId, CancellationToken cancellationToken);
+
+    /// <summary>Verifica se existe campus vivo com o Id informado — usado por LocalOferta para conferir o campus responsável.</summary>
+    Task<bool> ExisteVivoAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ILocalOfertaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ILocalOfertaRepository.cs
@@ -1,0 +1,52 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="LocalOferta"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros
+/// soft-deleted via query filter por convenção.
+/// </summary>
+public interface ILocalOfertaRepository
+{
+    /// <summary>Carrega o local rastreado pelo contexto, para mutação.</summary>
+    Task<LocalOferta?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega o local para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<LocalOferta?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista locais de oferta vivos paginados por cursor keyset bidirecional
+    /// (ADR-0026 + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve
+    /// as âncoras de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<LocalOferta> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(LocalOferta localOferta, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca o local para remoção; o <c>SoftDeleteInterceptor</c> converte em
+    /// soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(LocalOferta localOferta);
+
+    /// <summary>
+    /// Indica se há algum local de oferta vivo que tem o campus informado como
+    /// responsável — bloqueia a remoção do campus (handler de remoção de Campus).
+    /// </summary>
+    Task<bool> ExisteVivoComCampusResponsavelAsync(Guid campusResponsavelId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Ponto de extensão (UNI-REQ-0010): indica se o local de oferta é
+    /// referenciado por alguma oferta de curso viva — caso em que a remoção é
+    /// bloqueada. A entidade <c>oferta_curso</c> ainda não existe no módulo, logo
+    /// a implementação retorna <see langword="false"/>. Quando a oferta de curso
+    /// chegar, esta checagem passa a consultá-la.
+    /// </summary>
+    Task<bool> ReferenciadoPorOfertaCursoVivaAsync(Guid localOfertaId, CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -3,13 +3,16 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
-using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
 /// Registra a infraestrutura do módulo Configuracao (DbContext + interceptors
-/// transversais soft delete + audit). Repositórios e readers entram em F2 com
-/// as entidades de catálogo.
+/// transversais soft delete + audit + repositórios dos cadastros Campus e
+/// LocalOferta, UNI-REQ #587). Wire-up centralizado em
+/// <see cref="UniPlusDbContextOptionsExtensions"/> (ADR-0054).
 /// </summary>
 public static class ConfiguracaoInfrastructureRegistration
 {
@@ -26,6 +29,9 @@ public static class ConfiguracaoInfrastructureRegistration
 
         services.AddScoped<IUnitOfWork>(serviceProvider =>
             serviceProvider.GetRequiredService<ConfiguracaoDbContext>());
+
+        services.AddScoped<ICampusRepository, CampusRepository>();
+        services.AddScoped<ILocalOfertaRepository, LocalOfertaRepository>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -3,15 +3,17 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
 /// <see cref="DbContext"/> do módulo Configuracao — banco
-/// <c>uniplus_configuracao</c>, naming snake_case (ADR-0054). Em V1 hospeda
-/// apenas <c>idempotency_cache</c> (entries cifradas at-rest via
-/// <c>IUniPlusEncryptionService</c>); entidades de catálogo (Modalidade,
-/// NecessidadeEspecial, TipoDocumento, Endereco) entram em F2.
+/// <c>uniplus_configuracao</c>, naming snake_case (ADR-0054). Hospeda os
+/// cadastros <see cref="Campus"/> e <see cref="LocalOferta"/> (UNI-REQ #587) e o
+/// cache de Idempotency-Key (ADR-0027) adjacente. A <c>Cidade</c> é dado do
+/// módulo <c>Geo</c> (ADR-0090) — referenciada por código + display cache, sem
+/// entidade/tabela própria aqui.
 /// </summary>
 public sealed class ConfiguracaoDbContext : DbContext, IUnitOfWork
 {
@@ -19,6 +21,10 @@ public sealed class ConfiguracaoDbContext : DbContext, IUnitOfWork
         : base(options)
     {
     }
+
+    public DbSet<Campus> Campi => Set<Campus>();
+
+    public DbSet<LocalOferta> LocaisOferta => Set<LocalOferta>();
 
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CampusConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CampusConfiguration.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class CampusConfiguration : IEntityTypeConfiguration<Campus>
+{
+    public void Configure(EntityTypeBuilder<Campus> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("campus");
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Sigla).HasMaxLength(20).IsRequired();
+        builder.Property(c => c.Nome).HasMaxLength(200).IsRequired();
+
+        // Referência de cidade do Geo (ADR-0090): código + display cache, sem FK
+        // cross-banco para uniplus_geo.
+        builder.Property(c => c.CidadeCodigoIbge)
+            .HasMaxLength(ReferenciaCidadeGeo.CodigoIbgeLength)
+            .IsFixedLength()
+            .IsRequired();
+        builder.Property(c => c.CidadeNome).HasMaxLength(ReferenciaCidadeGeo.NomeMaxLength).IsRequired();
+        builder.Property(c => c.CidadeUf)
+            .HasMaxLength(ReferenciaCidadeGeo.UfLength)
+            .IsFixedLength()
+            .IsRequired();
+        builder.Property(c => c.CidadeOrigem).HasMaxLength(ReferenciaCidadeGeo.OrigemMaxLength);
+        builder.Property(c => c.CidadeDisplayAtualizadoEm);
+
+        builder.Property(c => c.Endereco).HasMaxLength(500);
+        builder.Property(c => c.Cep).HasMaxLength(8).IsFixedLength();
+        builder.Property(c => c.Latitude).HasPrecision(9, 6);
+        builder.Property(c => c.Longitude).HasPrecision(9, 6);
+        builder.Property(c => c.CodigoEmec).HasMaxLength(20);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(c => c.CreatedBy).HasMaxLength(255);
+        builder.Property(c => c.UpdatedBy).HasMaxLength(255);
+
+        // Unicidade da sigla entre campi vivos (índice parcial).
+        builder.HasIndex(c => c.Sigla)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_campus_sigla_vivo");
+
+        // Índice de relatório/filtro pela cidade (ADR-0090).
+        builder.HasIndex(c => c.CidadeCodigoIbge)
+            .HasDatabaseName("ix_campus_cidade_codigo_ibge");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/LocalOfertaConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/LocalOfertaConfiguration.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class LocalOfertaConfiguration : IEntityTypeConfiguration<LocalOferta>
+{
+    public void Configure(EntityTypeBuilder<LocalOferta> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("local_oferta");
+        builder.HasKey(l => l.Id);
+
+        builder.Property(l => l.Tipo).HasConversion<string>().HasMaxLength(30).IsRequired();
+
+        // Referência de cidade do Geo (ADR-0090): código + display cache, sem FK
+        // cross-banco para uniplus_geo.
+        builder.Property(l => l.CidadeCodigoIbge)
+            .HasMaxLength(ReferenciaCidadeGeo.CodigoIbgeLength)
+            .IsFixedLength()
+            .IsRequired();
+        builder.Property(l => l.CidadeNome).HasMaxLength(ReferenciaCidadeGeo.NomeMaxLength).IsRequired();
+        builder.Property(l => l.CidadeUf)
+            .HasMaxLength(ReferenciaCidadeGeo.UfLength)
+            .IsFixedLength()
+            .IsRequired();
+        builder.Property(l => l.CidadeOrigem).HasMaxLength(ReferenciaCidadeGeo.OrigemMaxLength);
+        builder.Property(l => l.CidadeDisplayAtualizadoEm);
+
+        builder.Property(l => l.Endereco).HasMaxLength(500);
+        builder.Property(l => l.CodigoEmec).HasMaxLength(20);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(l => l.CreatedBy).HasMaxLength(255);
+        builder.Property(l => l.UpdatedBy).HasMaxLength(255);
+
+        // Campus responsável: FK intra-banco opcional (ADR-0065). Restrict no banco
+        // — a remoção lógica do Campus é barrada pelo handler
+        // (CampusErrorCodes.RemocaoBloqueadaPorLocalOferta); o RESTRICT cobre o
+        // DELETE físico residual.
+        builder.HasOne<Campus>()
+            .WithMany()
+            .HasForeignKey(l => l.CampusResponsavelId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(l => l.CampusResponsavelId)
+            .HasDatabaseName("ix_local_oferta_campus_responsavel_id");
+
+        // Índice de relatório/filtro pela cidade (ADR-0090).
+        builder.HasIndex(l => l.CidadeCodigoIbge)
+            .HasDatabaseName("ix_local_oferta_cidade_codigo_ibge");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260617210624_AddCampusELocalOferta.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260617210624_AddCampusELocalOferta.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617210624_AddCampusELocalOferta")]
+    partial class AddCampusELocalOferta
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260617210624_AddCampusELocalOferta.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260617210624_AddCampusELocalOferta.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCampusELocalOferta : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "campus",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    sigla = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    cidade_codigo_ibge = table.Column<string>(type: "character(7)", fixedLength: true, maxLength: 7, nullable: false),
+                    cidade_nome = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: false),
+                    cidade_uf = table.Column<string>(type: "character(2)", fixedLength: true, maxLength: 2, nullable: false),
+                    cidade_origem = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    cidade_display_atualizado_em = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    endereco = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    cep = table.Column<string>(type: "character(8)", fixedLength: true, maxLength: 8, nullable: true),
+                    latitude = table.Column<decimal>(type: "numeric(9,6)", precision: 9, scale: 6, nullable: true),
+                    longitude = table.Column<decimal>(type: "numeric(9,6)", precision: 9, scale: 6, nullable: true),
+                    codigo_emec = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_campus", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "local_oferta",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tipo = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    campus_responsavel_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    cidade_codigo_ibge = table.Column<string>(type: "character(7)", fixedLength: true, maxLength: 7, nullable: false),
+                    cidade_nome = table.Column<string>(type: "character varying(150)", maxLength: 150, nullable: false),
+                    cidade_uf = table.Column<string>(type: "character(2)", fixedLength: true, maxLength: 2, nullable: false),
+                    cidade_origem = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    cidade_display_atualizado_em = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    endereco = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    codigo_emec = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_local_oferta", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_local_oferta_campus_campus_responsavel_id",
+                        column: x => x.campus_responsavel_id,
+                        principalTable: "campus",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_campus_cidade_codigo_ibge",
+                table: "campus",
+                column: "cidade_codigo_ibge");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_campus_sigla_vivo",
+                table: "campus",
+                column: "sigla",
+                unique: true,
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_local_oferta_campus_responsavel_id",
+                table: "local_oferta",
+                column: "campus_responsavel_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_local_oferta_cidade_codigo_ibge",
+                table: "local_oferta",
+                column: "cidade_codigo_ibge");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "local_oferta");
+
+            migrationBuilder.DropTable(
+                name: "campus");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CampusRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CampusRepository.cs
@@ -1,0 +1,82 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class CampusRepository : ICampusRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public CampusRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<Campus?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Campi
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+    }
+
+    public Task<Campus?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Campi
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<Campus> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação, âncora, probe n+1, reversão e
+        // flags ficam no helper. Npgsql traduz Guid.CompareTo para o operador uuid
+        // nativo do PG (ADR-0026 + ADR-0032).
+        CursorKeysetPage<Campus> page = await CursorKeyset
+            .ApplyAsync(_dbContext.Campi.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(Campus campus, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(campus);
+        await _dbContext.Campi.AddAsync(campus, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(Campus campus)
+    {
+        ArgumentNullException.ThrowIfNull(campus);
+        _dbContext.Campi.Remove(campus);
+    }
+
+    public Task<bool> SiglaExisteEntreLivosAsync(string sigla, Guid? excluirId, CancellationToken cancellationToken)
+    {
+        // Espelha a normalização do agregado (Trim + ToUpperInvariant) para que
+        // " camar " case com o "CAMAR" persistido.
+        string siglaNorm = sigla.Trim().ToUpperInvariant();
+        return _dbContext.Campi
+            .AsNoTracking()
+            .Where(c => excluirId == null || c.Id != excluirId)
+            .AnyAsync(c => c.Sigla == siglaNorm, cancellationToken);
+    }
+
+    public Task<bool> ExisteVivoAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Campi
+            .AsNoTracking()
+            .AnyAsync(c => c.Id == id, cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/LocalOfertaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/LocalOfertaRepository.cs
@@ -1,0 +1,78 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class LocalOfertaRepository : ILocalOfertaRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public LocalOfertaRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<LocalOferta?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.LocaisOferta
+            .FirstOrDefaultAsync(l => l.Id == id, cancellationToken);
+    }
+
+    public Task<LocalOferta?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.LocaisOferta
+            .AsNoTracking()
+            .FirstOrDefaultAsync(l => l.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<LocalOferta> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        CursorKeysetPage<LocalOferta> page = await CursorKeyset
+            .ApplyAsync(_dbContext.LocaisOferta.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(LocalOferta localOferta, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(localOferta);
+        await _dbContext.LocaisOferta.AddAsync(localOferta, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(LocalOferta localOferta)
+    {
+        ArgumentNullException.ThrowIfNull(localOferta);
+        _dbContext.LocaisOferta.Remove(localOferta);
+    }
+
+    public Task<bool> ExisteVivoComCampusResponsavelAsync(Guid campusResponsavelId, CancellationToken cancellationToken)
+    {
+        return _dbContext.LocaisOferta
+            .AsNoTracking()
+            .AnyAsync(l => l.CampusResponsavelId == campusResponsavelId, cancellationToken);
+    }
+
+    public Task<bool> ReferenciadoPorOfertaCursoVivaAsync(Guid localOfertaId, CancellationToken cancellationToken)
+    {
+        // TODO(UNI-REQ-0010): quando a entidade oferta_curso existir no módulo,
+        // consultar aqui se há oferta de curso viva referenciando este local de
+        // oferta. Até lá, não há tabela a consultar — a checagem retorna false.
+        _ = localOfertaId;
+        _ = cancellationToken;
+        return Task.FromResult(false);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Unifesspa.UniPlus.Configuracao.Infrastructure.csproj
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Unifesspa.UniPlus.Configuracao.Infrastructure.csproj
@@ -11,4 +11,10 @@
     <ProjectReference Include="..\Unifesspa.UniPlus.Configuracao.Application\Unifesspa.UniPlus.Configuracao.Application.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expõe internals (ex.: CampusRepository) aos testes de integração —
+         mesmo padrão de Infrastructure.Core e OrganizacaoInstitucional. -->
+    <InternalsVisibleTo Include="Unifesspa.UniPlus.Configuracao.IntegrationTests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/OpenApiSharedSchemasInSyncTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/OpenApiSharedSchemasInSyncTests.cs
@@ -39,6 +39,7 @@ public sealed class OpenApiSharedSchemasInSyncTests
         "openapi.selecao.json",
         "openapi.ingresso.json",
         "openapi.organizacao.json",
+        "openapi.configuracao.json",
         "openapi.geo.json",
     ];
 

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarCampusCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarCampusCommandHandlerTests.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarCampusCommandHandlerTests
+{
+    private static readonly DateTimeOffset CidadeCarimbadaEm = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly ICampusRepository _repository = Substitute.For<ICampusRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private static Campus CampusExistente() =>
+        Campus.Criar(
+            "CAMar", "Campus Marabá", "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, CidadeCarimbadaEm, null, null, null, null, null).Value!;
+
+    [Fact(DisplayName = "S4: PUT sem mudar a cidade preserva cidade_display_atualizado_em")]
+    public async Task Handle_CidadeInalterada_PreservaCarimboDeCidade()
+    {
+        Campus campus = CampusExistente();
+        _repository.ObterPorIdAsync(campus.Id, Arg.Any<CancellationToken>()).Returns(campus);
+
+        // Muda só o nome do campus; o trio de cidade permanece igual.
+        AtualizarCampusCommand comando = new(
+            campus.Id, "CAMar", "Campus Marabá Renomeado", "1504208", "Marabá", "PA",
+            null, null, null, null, null);
+
+        Result resultado = await AtualizarCampusCommandHandler.Handle(
+            comando, _repository, _unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        campus.Nome.Should().Be("Campus Marabá Renomeado");
+        campus.CidadeDisplayAtualizadoEm.Should().Be(CidadeCarimbadaEm,
+            "a cidade não mudou, então o carimbo de frescura do display cache é preservado");
+    }
+
+    [Fact(DisplayName = "S4: PUT trocando a cidade recarimba cidade_display_atualizado_em")]
+    public async Task Handle_CidadeAlterada_RecarimbaCidade()
+    {
+        Campus campus = CampusExistente();
+        _repository.ObterPorIdAsync(campus.Id, Arg.Any<CancellationToken>()).Returns(campus);
+
+        AtualizarCampusCommand comando = new(
+            campus.Id, "CAMar", "Campus Marabá", "1501402", "Belém", "PA",
+            null, null, null, null, null);
+
+        Result resultado = await AtualizarCampusCommandHandler.Handle(
+            comando, _repository, _unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        campus.CidadeNome.Should().Be("Belém");
+        campus.CidadeDisplayAtualizadoEm.Should().NotBe(CidadeCarimbadaEm,
+            "a cidade mudou, então o carimbo é renovado a partir do TimeProvider");
+        campus.CidadeOrigem.Should().Be(ReferenciaCidadeGeo.OrigemGeoApi);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCampusCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCampusCommandHandlerTests.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarCampusCommandHandlerTests
+{
+    private readonly ICampusRepository _repository = Substitute.For<ICampusRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private static CriarCampusCommand ComandoValido() =>
+        new("CAMar", "Campus Marabá", "1504208", "Marabá", "PA", null, null, null, null, null);
+
+    [Fact(DisplayName = "Cria o campus, persiste e retorna o Id")]
+    public async Task Handle_SiglaLivre_CriaEPersiste()
+    {
+        _repository.SiglaExisteEntreLivosAsync("CAMar", null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarCampusCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<Campus>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Sigla já existente entre vivos retorna conflito (SiglaJaExiste)")]
+    public async Task Handle_SiglaDuplicada_RetornaConflito()
+    {
+        _repository.SiglaExisteEntreLivosAsync("CAMar", null, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarCampusCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CampusErrorCodes.SiglaJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<Campus>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Cidade malformada propaga o erro de domínio sem persistir")]
+    public async Task Handle_CidadeMalformada_RetornaErroDeFormato()
+    {
+        _repository.SiglaExisteEntreLivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        CriarCampusCommand comando = ComandoValido() with { CidadeCodigoIbge = "150420" };
+
+        Result<Guid> resultado = await CriarCampusCommandHandler.Handle(
+            comando, _repository, _unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarLocalOfertaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarLocalOfertaCommandHandlerTests.cs
@@ -1,0 +1,60 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarLocalOfertaCommandHandlerTests
+{
+    private readonly ILocalOfertaRepository _repository = Substitute.For<ILocalOfertaRepository>();
+    private readonly ICampusRepository _campusRepository = Substitute.For<ICampusRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private static CriarLocalOfertaCommand ComandoValido(Guid? campusId = null) =>
+        new(TipoLocalOferta.PoloEad, campusId, "1504208", "Marabá", "PA", null, null);
+
+    [Fact(DisplayName = "Cria sem campus responsável e persiste")]
+    public async Task Handle_SemCampusResponsavel_Cria()
+    {
+        Result<Guid> resultado = await CriarLocalOfertaCommandHandler.Handle(
+            ComandoValido(), _repository, _campusRepository, _unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _repository.Received(1).AdicionarAsync(Arg.Any<LocalOferta>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Campus responsável inexistente retorna 422 (CampusResponsavelNaoEncontrado)")]
+    public async Task Handle_CampusResponsavelInexistente_Falha()
+    {
+        Guid campusId = Guid.CreateVersion7();
+        _campusRepository.ExisteVivoAsync(campusId, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result<Guid> resultado = await CriarLocalOfertaCommandHandler.Handle(
+            ComandoValido(campusId), _repository, _campusRepository, _unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(LocalOfertaErrorCodes.CampusResponsavelNaoEncontrado);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<LocalOferta>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Campus responsável existente é aceito e persiste")]
+    public async Task Handle_CampusResponsavelExistente_Cria()
+    {
+        Guid campusId = Guid.CreateVersion7();
+        _campusRepository.ExisteVivoAsync(campusId, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result<Guid> resultado = await CriarLocalOfertaCommandHandler.Handle(
+            ComandoValido(campusId), _repository, _campusRepository, _unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _repository.Received(1).AdicionarAsync(Arg.Any<LocalOferta>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCampusCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCampusCommandHandlerTests.cs
@@ -1,0 +1,70 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverCampusCommandHandlerTests
+{
+    private readonly ICampusRepository _repository = Substitute.For<ICampusRepository>();
+    private readonly ILocalOfertaRepository _localOfertaRepository = Substitute.For<ILocalOfertaRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private static Campus NovoCampus() =>
+        Campus.Criar(
+            "CAMar", "Campus Marabá", "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, DateTimeOffset.UnixEpoch, null, null, null, null, null).Value!;
+
+    [Fact(DisplayName = "Campus inexistente retorna 404 (NaoEncontrado)")]
+    public async Task Handle_NaoEncontrado_Retorna404()
+    {
+        _repository.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((Campus?)null);
+
+        Result resultado = await RemoverCampusCommandHandler.Handle(
+            new RemoverCampusCommand(Guid.CreateVersion7()), _repository, _localOfertaRepository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CampusErrorCodes.NaoEncontrado);
+    }
+
+    [Fact(DisplayName = "Campus responsável por LocalOferta vivo bloqueia a remoção (409)")]
+    public async Task Handle_ComLocalOfertaVivo_Bloqueia()
+    {
+        Campus campus = NovoCampus();
+        _repository.ObterPorIdAsync(campus.Id, Arg.Any<CancellationToken>()).Returns(campus);
+        _localOfertaRepository.ExisteVivoComCampusResponsavelAsync(campus.Id, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result resultado = await RemoverCampusCommandHandler.Handle(
+            new RemoverCampusCommand(campus.Id), _repository, _localOfertaRepository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CampusErrorCodes.RemocaoBloqueadaPorLocalOferta);
+        _repository.DidNotReceive().Remover(Arg.Any<Campus>());
+    }
+
+    [Fact(DisplayName = "Campus sem dependentes é removido (soft-delete) e commita")]
+    public async Task Handle_SemDependentes_Remove()
+    {
+        Campus campus = NovoCampus();
+        _repository.ObterPorIdAsync(campus.Id, Arg.Any<CancellationToken>()).Returns(campus);
+        _localOfertaRepository.ExisteVivoComCampusResponsavelAsync(campus.Id, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result resultado = await RemoverCampusCommandHandler.Handle(
+            new RemoverCampusCommand(campus.Id), _repository, _localOfertaRepository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(campus);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverLocalOfertaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverLocalOfertaCommandHandlerTests.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverLocalOfertaCommandHandlerTests
+{
+    private readonly ILocalOfertaRepository _repository = Substitute.For<ILocalOfertaRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private static LocalOferta NovoLocal() =>
+        LocalOferta.Criar(
+            TipoLocalOferta.PoloEad, null, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, DateTimeOffset.UnixEpoch, null, null).Value!;
+
+    [Fact(DisplayName = "Local inexistente retorna 404 (NaoEncontrado)")]
+    public async Task Handle_NaoEncontrado_Retorna404()
+    {
+        _repository.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((LocalOferta?)null);
+
+        Result resultado = await RemoverLocalOfertaCommandHandler.Handle(
+            new RemoverLocalOfertaCommand(Guid.CreateVersion7()), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(LocalOfertaErrorCodes.NaoEncontrado);
+    }
+
+    [Fact(DisplayName = "Local sem oferta de curso viva é removido (soft-delete) e commita")]
+    public async Task Handle_SemOfertaCurso_Remove()
+    {
+        LocalOferta local = NovoLocal();
+        _repository.ObterPorIdAsync(local.Id, Arg.Any<CancellationToken>()).Returns(local);
+        // Ponto de extensão UNI-REQ-0010: oferta_curso ainda não existe → false.
+        _repository.ReferenciadoPorOfertaCursoVivaAsync(local.Id, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result resultado = await RemoverLocalOfertaCommandHandler.Handle(
+            new RemoverLocalOfertaCommand(local.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(local);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Unifesspa.UniPlus.Configuracao.Application.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Unifesspa.UniPlus.Configuracao.Application.UnitTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="NSubstitute" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Unifesspa.UniPlus.Configuracao.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CampusValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CampusValidatorTests.cs
@@ -1,0 +1,58 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+
+/// <summary>
+/// S2 (#587): o validator antecipa formato de CEP e coordenadas (além de
+/// sigla/nome/cidade), mantendo a fronteira de validação simétrica com o domínio.
+/// </summary>
+public sealed class CampusValidatorTests
+{
+    private readonly CriarCampusCommandValidator _validator = new();
+
+    private static CriarCampusCommand Base() =>
+        new("CAMar", "Campus Marabá", "1504208", "Marabá", "PA", null, null, null, null, null);
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base() with { Cep = "68507590", Latitude = -5.3m, Longitude = -49.1m })
+            .IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "CEP em formato inválido é rejeitado pelo validator")]
+    [InlineData("6850-759")]
+    [InlineData("123")]
+    [InlineData("abcdefgh")]
+    public void CepInvalido_Rejeita(string cep)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Cep = cep });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCampusCommand.Cep));
+    }
+
+    [Fact(DisplayName = "CEP ausente é aceito (campo opcional)")]
+    public void CepAusente_Aceita()
+    {
+        _validator.Validate(Base() with { Cep = null }).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Coordenada fora de faixa é rejeitada pelo validator")]
+    [InlineData(-90.1, 0, nameof(CriarCampusCommand.Latitude))]
+    [InlineData(90.1, 0, nameof(CriarCampusCommand.Latitude))]
+    [InlineData(0, -180.1, nameof(CriarCampusCommand.Longitude))]
+    [InlineData(0, 180.1, nameof(CriarCampusCommand.Longitude))]
+    public void CoordenadaForaDeFaixa_Rejeita(double latitude, double longitude, string propriedade)
+    {
+        ValidationResult resultado = _validator.Validate(
+            Base() with { Latitude = (decimal)latitude, Longitude = (decimal)longitude });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == propriedade);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/packages.lock.json
@@ -1,0 +1,206 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.4.0, )",
+        "resolved": "9.4.0",
+        "contentHash": "dJxkWiQ8D+xT6Gr2sSL83+Mar+Vpy2JTcUPxFcckpPJ8VYBfSgnk+zqpS6t7kcGnjz8NLyF14qfuoL4bKzzoew=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "unifesspa.uniplus.application.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      }
+    }
+  }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Cidades/ReferenciaCidadeGeoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Cidades/ReferenciaCidadeGeoTests.cs
@@ -1,0 +1,90 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Cidades;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// CA-03 (#587): validação de formato + coerência de UF do
+/// <c>cidade_codigo_ibge</c>, server-side, sem consultar o Geo nem validar
+/// dígito verificador.
+/// </summary>
+public sealed class ReferenciaCidadeGeoTests
+{
+    [Fact(DisplayName = "Código de 7 dígitos com prefixo de UF coerente é aceito (Marabá/PA)")]
+    public void Validar_CodigoCoerente_Aceita()
+    {
+        Result resultado = ReferenciaCidadeGeo.Validar("1504208", "Marabá", "PA");
+
+        resultado.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Código com número de dígitos diferente de 7 é rejeitado por formato")]
+    [InlineData("150420")]    // 6 dígitos
+    [InlineData("15042080")]  // 8 dígitos
+    public void Validar_QuantidadeDeDigitosInvalida_Rejeita(string codigo)
+    {
+        Result resultado = ReferenciaCidadeGeo.Validar(codigo, "Marabá", "PA");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido);
+    }
+
+    [Fact(DisplayName = "Código com caractere não-numérico é rejeitado por formato")]
+    public void Validar_CaractereNaoNumerico_Rejeita()
+    {
+        Result resultado = ReferenciaCidadeGeo.Validar("150420X", "Marabá", "PA");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido);
+    }
+
+    [Fact(DisplayName = "Prefixo que não corresponde a UF válida é rejeitado por formato")]
+    public void Validar_PrefixoUfInexistente_Rejeita()
+    {
+        // 20 não é código de UF válido (lacuna entre 17 e 21).
+        Result resultado = ReferenciaCidadeGeo.Validar("2012345", "Cidade", "PA");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido);
+    }
+
+    [Fact(DisplayName = "UF incompatível com o prefixo do código é rejeitada (15=PA, não SP)")]
+    public void Validar_UfIncoerente_Rejeita()
+    {
+        Result resultado = ReferenciaCidadeGeo.Validar("1504208", "Marabá", "SP");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.UfIncoerente);
+    }
+
+    [Fact(DisplayName = "UF coerente em caixa diferente é aceita (case-insensitive)")]
+    public void Validar_UfCaixaDiferente_Aceita()
+    {
+        Result resultado = ReferenciaCidadeGeo.Validar("1504208", "Marabá", "pa");
+
+        resultado.IsSuccess.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Campos obrigatórios vazios são rejeitados com o código apropriado")]
+    [InlineData(null, "Marabá", "PA", CidadeReferenciaErrorCodes.CodigoIbgeObrigatorio)]
+    [InlineData("", "Marabá", "PA", CidadeReferenciaErrorCodes.CodigoIbgeObrigatorio)]
+    [InlineData("1504208", "", "PA", CidadeReferenciaErrorCodes.NomeObrigatorio)]
+    [InlineData("1504208", "Marabá", "", CidadeReferenciaErrorCodes.UfObrigatoria)]
+    public void Validar_CamposObrigatoriosVazios_Rejeita(string? codigo, string nome, string uf, string esperado)
+    {
+        Result resultado = ReferenciaCidadeGeo.Validar(codigo, nome, uf);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(esperado);
+    }
+
+    [Fact(DisplayName = "EhValida é o predicado equivalente a Validar().IsSuccess")]
+    public void EhValida_EspelhaValidar()
+    {
+        ReferenciaCidadeGeo.EhValida("1504208", "Marabá", "PA").Should().BeTrue();
+        ReferenciaCidadeGeo.EhValida("150420", "Marabá", "PA").Should().BeFalse();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CampusTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CampusTests.cs
@@ -1,0 +1,106 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CampusTests
+{
+    private static readonly DateTimeOffset Agora = new(2026, 6, 17, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact(DisplayName = "Criar com dados válidos persiste a referência de cidade e o display cache")]
+    public void Criar_DadosValidos_PreencheReferenciaCidade()
+    {
+        Result<Campus> resultado = Campus.Criar(
+            "CAMar", "Campus Marabá", "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, "Folha 31", "68507590", -5.3m, -49.1m, "12345");
+
+        resultado.IsSuccess.Should().BeTrue();
+        Campus campus = resultado.Value!;
+        campus.Sigla.Should().Be("CAMAR", "a sigla é normalizada para uppercase");
+        campus.Nome.Should().Be("Campus Marabá");
+        campus.CidadeCodigoIbge.Should().Be("1504208");
+        campus.CidadeNome.Should().Be("Marabá");
+        campus.CidadeUf.Should().Be("PA");
+        campus.CidadeOrigem.Should().Be("geo-api");
+        campus.CidadeDisplayAtualizadoEm.Should().Be(Agora);
+        campus.Cep.Should().Be("68507590");
+    }
+
+    [Fact(DisplayName = "Criar com código IBGE malformado falha com erro de formato de cidade")]
+    public void Criar_CodigoIbgeMalformado_Falha()
+    {
+        Result<Campus> resultado = Campus.Criar(
+            "CAMar", "Campus Marabá", "150420", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null, null, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido);
+    }
+
+    [Fact(DisplayName = "Criar com UF incoerente com o prefixo do código falha")]
+    public void Criar_UfIncoerente_Falha()
+    {
+        Result<Campus> resultado = Campus.Criar(
+            "CAMar", "Campus Marabá", "1504208", "Marabá", "SP",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null, null, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.UfIncoerente);
+    }
+
+    [Fact(DisplayName = "Criar sem sigla falha")]
+    public void Criar_SemSigla_Falha()
+    {
+        Result<Campus> resultado = Campus.Criar(
+            "  ", "Campus Marabá", "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null, null, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CampusErrorCodes.SiglaObrigatoria);
+    }
+
+    [Fact(DisplayName = "Criar com CEP em formato inválido falha")]
+    public void Criar_CepInvalido_Falha()
+    {
+        Result<Campus> resultado = Campus.Criar(
+            "CAMar", "Campus Marabá", "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, "6850-759", null, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CampusErrorCodes.CepInvalido);
+    }
+
+    [Theory(DisplayName = "Criar com coordenada fora de faixa falha")]
+    [InlineData(-91, 0, CampusErrorCodes.LatitudeForaDeFaixa)]
+    [InlineData(0, 181, CampusErrorCodes.LongitudeForaDeFaixa)]
+    public void Criar_CoordenadaForaDeFaixa_Falha(double latitude, double longitude, string esperado)
+    {
+        Result<Campus> resultado = Campus.Criar(
+            "CAMar", "Campus Marabá", "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null, (decimal)latitude, (decimal)longitude, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(esperado);
+    }
+
+    [Fact(DisplayName = "Atualizar troca os campos e mantém validação")]
+    public void Atualizar_DadosValidos_Aplica()
+    {
+        Campus campus = Campus.Criar(
+            "CAMar", "Campus Marabá", "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null, null, null, null).Value!;
+
+        Result resultado = campus.Atualizar(
+            "CABel", "Campus Belém", "1501402", "Belém", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null, null, null, null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        campus.Sigla.Should().Be("CABEL");
+        campus.CidadeCodigoIbge.Should().Be("1501402");
+        campus.CidadeNome.Should().Be("Belém");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/LocalOfertaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/LocalOfertaTests.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class LocalOfertaTests
+{
+    private static readonly DateTimeOffset Agora = new(2026, 6, 17, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact(DisplayName = "Criar com dados válidos preenche tipo, campus responsável e referência de cidade")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        Guid campusId = Guid.CreateVersion7();
+
+        Result<LocalOferta> resultado = LocalOferta.Criar(
+            TipoLocalOferta.PoloEad, campusId, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, "Rua X", "98765");
+
+        resultado.IsSuccess.Should().BeTrue();
+        LocalOferta local = resultado.Value!;
+        local.Tipo.Should().Be(TipoLocalOferta.PoloEad);
+        local.CampusResponsavelId.Should().Be(campusId);
+        local.CidadeCodigoIbge.Should().Be("1504208");
+        local.CidadeUf.Should().Be("PA");
+        local.CidadeOrigem.Should().Be("geo-api");
+    }
+
+    [Fact(DisplayName = "Criar sem campus responsável é válido (FK intra-banco opcional, ADR-0065)")]
+    public void Criar_SemCampusResponsavel_Valido()
+    {
+        Result<LocalOferta> resultado = LocalOferta.Criar(
+            TipoLocalOferta.PoloEad, null, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.CampusResponsavelId.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Criar com tipo Nenhum (sentinela) falha")]
+    public void Criar_TipoNenhum_Falha()
+    {
+        Result<LocalOferta> resultado = LocalOferta.Criar(
+            TipoLocalOferta.Nenhum, null, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(LocalOfertaErrorCodes.TipoInvalido);
+    }
+
+    [Fact(DisplayName = "Criar com referência de cidade malformada falha")]
+    public void Criar_CidadeMalformada_Falha()
+    {
+        Result<LocalOferta> resultado = LocalOferta.Criar(
+            TipoLocalOferta.CampusSede, null, "ABCDEFG", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="AwesomeAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Unifesspa.UniPlus.Configuracao.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/packages.lock.json
@@ -1,0 +1,126 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.4.0, )",
+        "resolved": "9.4.0",
+        "contentHash": "dJxkWiQ8D+xT6Gr2sSL83+Mar+Vpy2JTcUPxFcckpPJ8VYBfSgnk+zqpS6t7kcGnjz8NLyF14qfuoL4bKzzoew=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "unifesspa.uniplus.configuracao.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Campi/CampusEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Campi/CampusEndpointTests.cs
@@ -67,6 +67,31 @@ public sealed class CampusEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
+    [Fact(DisplayName = "POST /api/admin/campi autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        var body = new
+        {
+            sigla = $"C{Guid.NewGuid().ToString("N")[..6]}",
+            nome = "Campus Sem Permissão",
+            cidadeCodigoIbge = "1504208",
+            cidadeNome = "Marabá",
+            cidadeUf = "PA",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/admin/campi", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato"); // role insuficiente
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a policy [Authorize(Roles = \"plataforma-admin\")] nega um principal autenticado sem o role");
+    }
+
     [Fact(DisplayName = "POST /api/admin/campi sem Idempotency-Key retorna 400")]
     public async Task Criar_SemIdempotencyKey_Retorna400()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Campi/CampusEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Campi/CampusEndpointTests.cs
@@ -1,0 +1,143 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Campi;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>Campus</c> (UNI-REQ #587):
+/// routing, vendor media type, HATEOAS, autenticação/autorização, idempotência e
+/// validação de formato da cidade (CA-03) com Wolverine rodando contra Postgres
+/// efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class CampusEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public CampusEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/campi retorna 200 com Content-Type vendor MIME de campus")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri("/api/campi", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.campus.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/campi/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/campi/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/admin/campi sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/admin/campi", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST /api/admin/campi sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/admin/campi", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST /api/admin/campi cria (201) e o GET subsequente retorna a cidade por código + display cache")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersisteCidade()
+    {
+        string sigla = $"C{Guid.NewGuid().ToString("N")[..6]}";
+        var body = new
+        {
+            sigla,
+            nome = "Campus de Teste",
+            cidadeCodigoIbge = "1504208",
+            cidadeNome = "Marabá",
+            cidadeUf = "PA",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, "/api/admin/campi", body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(new Uri($"/api/campi/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("cidadeCodigoIbge").GetString().Should().Be("1504208");
+        root.GetProperty("cidadeNome").GetString().Should().Be("Marabá");
+        root.GetProperty("cidadeUf").GetString().Should().Be("PA");
+        root.GetProperty("cidadeOrigem").GetString().Should().Be("geo-api");
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "CA-03: POST /api/admin/campi com código IBGE malformado retorna 422 sem consultar o Geo")]
+    public async Task Criar_CidadeMalformada_Retorna422()
+    {
+        var body = new
+        {
+            sigla = $"C{Guid.NewGuid().ToString("N")[..6]}",
+            nome = "Campus Inválido",
+            cidadeCodigoIbge = "150420", // 6 dígitos
+            cidadeNome = "Marabá",
+            cidadeUf = "PA",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, "/api/admin/campi", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, string path, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(path, UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Campi/CampusPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Campi/CampusPersistenceTests.cs
@@ -1,0 +1,181 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Campi;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Integração ponta-a-ponta dos cadastros contra Postgres real (UNI-REQ #587):
+/// CA-02 (persistência por código + display cache, sem FK ao Geo), UNIQUE parcial
+/// de sigla, soft-delete e bloqueio de remoção de Campus com LocalOferta vivo.
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class CampusPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private static readonly DateTimeOffset Agora = new(2026, 6, 17, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public CampusPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-02: criar Campus persiste a referência de cidade por código + display cache (sem FK ao Geo)")]
+    public async Task Insert_PersisteReferenciaCidadeEDisplayCache()
+    {
+        Campus campus = NovoCampus("CAMar", "Campus Marabá", "1504208", "Marabá", "PA");
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Campi.Add(campus);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        Campus persistido = await readCtx.Campi.SingleAsync(c => c.Id == campus.Id);
+
+        persistido.Sigla.Should().Be("CAMAR");
+        persistido.CidadeCodigoIbge.Should().Be("1504208");
+        persistido.CidadeNome.Should().Be("Marabá");
+        persistido.CidadeUf.Should().Be("PA");
+        persistido.CidadeOrigem.Should().Be(ReferenciaCidadeGeo.OrigemGeoApi);
+        persistido.CidadeDisplayAtualizadoEm.Should().Be(Agora);
+        persistido.CreatedBy.Should().Be(AdminA);
+        persistido.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial (sigla) rejeita segundo Campus vivo com a mesma sigla")]
+    public async Task UniquePartial_Sigla_RejeitaDuplicataAtiva()
+    {
+        Campus primeiro = NovoCampus("DUPSIG", "Campus Um", "1504208", "Marabá", "PA");
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Campi.Add(primeiro);
+            await ctx.SaveChangesAsync();
+        }
+
+        Campus segundo = NovoCampus("DUPSIG", "Campus Dois", "1501402", "Belém", "PA");
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.Campi.Add(segundo);
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>()
+            .WithInnerException(typeof(Npgsql.PostgresException));
+    }
+
+    [Fact(DisplayName = "Soft-delete liberta o slot da UNIQUE parcial de sigla")]
+    public async Task SoftDelete_LibertaUniquePartialSigla()
+    {
+        Campus campus = NovoCampus("RECSIG", "Campus Reciclado", "1504208", "Marabá", "PA");
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Campi.Add(campus);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            Campus tracked = await ctx.Campi.SingleAsync(c => c.Id == campus.Id);
+            ctx.Campi.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            Campus excluido = await ctx.Campi.IgnoreQueryFilters().SingleAsync(c => c.Id == campus.Id);
+            excluido.IsDeleted.Should().BeTrue();
+            excluido.DeletedBy.Should().Be(AdminB);
+        }
+
+        Campus novo = NovoCampus("RECSIG", "Campus Novo", "1501402", "Belém", "PA");
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.Campi.Add(novo);
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+
+        await act.Should().NotThrowAsync("o slot da sigla foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "CA-05: remover Campus responsável por LocalOferta vivo é bloqueado (409)")]
+    public async Task RemoverCampus_ComLocalOfertaVivo_Bloqueia()
+    {
+        Campus campus = NovoCampus("BLKCAM", "Campus Bloqueado", "1504208", "Marabá", "PA");
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Campi.Add(campus);
+            await ctx.SaveChangesAsync();
+        }
+
+        LocalOferta local = LocalOferta.Criar(
+            TipoLocalOferta.CursoForaDeSede, campus.Id, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null).Value!;
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.LocaisOferta.Add(local);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext handlerCtx = _fixture.CreateDbContext(AdminB);
+        var campusRepo = new CampusRepository(handlerCtx);
+        var localRepo = new LocalOfertaRepository(handlerCtx);
+
+        Result resultado = await RemoverCampusCommandHandler.Handle(
+            new RemoverCampusCommand(campus.Id), campusRepo, localRepo, handlerCtx, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CampusErrorCodes.RemocaoBloqueadaPorLocalOferta);
+    }
+
+    [Fact(DisplayName = "FK campus_responsavel_id com RESTRICT bloqueia DELETE físico do Campus com LocalOferta")]
+    public async Task FkRestrict_BloqueiaDeleteFisicoDoCampus()
+    {
+        Campus campus = NovoCampus("FKCAM", "Campus FK", "1504208", "Marabá", "PA");
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Campi.Add(campus);
+            await ctx.SaveChangesAsync();
+        }
+
+        LocalOferta local = LocalOferta.Criar(
+            TipoLocalOferta.CursoForaDeSede, campus.Id, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null).Value!;
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.LocaisOferta.Add(local);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext rawCtx = _fixture.CreateDbContext(userId: null);
+        Func<Task> act = async () =>
+            await rawCtx.Database.ExecuteSqlAsync($"DELETE FROM campus WHERE id = {campus.Id}");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "a FK campus_responsavel_id com RESTRICT impede o DELETE físico do campus referenciado");
+    }
+
+    private static Campus NovoCampus(string sigla, string nome, string codigoIbge, string cidadeNome, string uf) =>
+        Campus.Criar(
+            sigla, nome, codigoIbge, cidadeNome, uf,
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null, null, null, null).Value!;
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ConfiguracaoSemEntidadeCidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ConfiguracaoSemEntidadeCidadeTests.cs
@@ -1,0 +1,70 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests;
+
+using System.Linq;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// CA-01 (#587): a <c>Cidade</c> é dado do módulo <c>Geo</c> (ADR-0090) — o
+/// módulo Configuração não tem entidade/<c>DbSet</c>/tabela nem rota de cidade.
+/// </summary>
+public sealed class ConfiguracaoSemEntidadeCidadeTests : IClassFixture<ConfiguracaoApiFactory>
+{
+    private readonly ConfiguracaoApiFactory _factory;
+
+    public ConfiguracaoSemEntidadeCidadeTests(ConfiguracaoApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact(DisplayName = "ConfiguracaoDbContext.Model não declara nenhuma entidade/tabela 'Cidade'")]
+    public void Model_NaoTemEntidadeCidade()
+    {
+        using ConfiguracaoDbContext context = CriarContextoInMemory();
+
+        IEnumerable<Microsoft.EntityFrameworkCore.Metadata.IEntityType> tipos = context.Model.GetEntityTypes();
+
+        tipos.Select(t => t.ClrType.Name)
+            .Should().NotContain(name => name.Contains("Cidade", StringComparison.OrdinalIgnoreCase),
+                "a Cidade vive no módulo Geo — Configuração só guarda a referência por código (ADR-0090)");
+
+        tipos.Select(t => t.GetTableName())
+            .Should().NotContain(tabela => tabela != null && tabela.Contains("cidade", StringComparison.OrdinalIgnoreCase)
+                && !tabela.Contains("codigo_ibge", StringComparison.OrdinalIgnoreCase),
+                "não há tabela 'cidade' em uniplus_configuracao");
+    }
+
+    [Fact(DisplayName = "Não existe rota /api/.../cidades no módulo Configuração")]
+    public void Rotas_NaoExpoemCidades()
+    {
+        // CreateClient força a materialização do host (e do roteamento).
+        using HttpClient _ = _factory.CreateClient();
+
+        IEnumerable<EndpointDataSource> sources = _factory.Services.GetServices<EndpointDataSource>();
+
+        IEnumerable<string> rawTexts = sources
+            .SelectMany(s => s.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(e => e.RoutePattern.RawText ?? string.Empty);
+
+        rawTexts.Should().NotContain(
+            pattern => pattern.Contains("cidades", StringComparison.OrdinalIgnoreCase),
+            "Cidade não é cadastro de Configuração (ADR-0090)");
+    }
+
+    private static ConfiguracaoDbContext CriarContextoInMemory()
+    {
+        DbContextOptions<ConfiguracaoDbContext> options = new DbContextOptionsBuilder<ConfiguracaoDbContext>()
+            .UseInMemoryDatabase(nameof(ConfiguracaoSemEntidadeCidadeTests))
+            .Options;
+
+        return new ConfiguracaoDbContext(options);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoApiFactory.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// Factory HTTP-only (Wolverine + migrations desabilitados) usada por suítes que
+/// só exercitam o pipeline HTTP/OpenAPI sem Postgres real.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x IClassFixture<T> requires the fixture type to be public.")]
+public sealed class ConfiguracaoApiFactory : ApiFactoryBase<Program>
+{
+    protected override IEnumerable<KeyValuePair<string, string?>> GetConfigurationOverrides() =>
+    [
+        new("ConnectionStrings:ConfiguracaoDb", "Host=localhost;Port=5432;Database=uniplus_tests;Username=uniplus;Password=uniplus_dev"),
+        new("Auth:Authority", "http://localhost/test-realm"),
+        new("Auth:Audience", "uniplus"),
+    ];
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoDbCollection.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoDbCollection.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Coleção que compartilha um único <see cref="ConfiguracaoDbFixture"/> (Postgres
+/// efêmero) entre as suítes de persistência de Campus e LocalOferta — evita subir
+/// um container por classe de teste.
+/// </summary>
+[CollectionDefinition(Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit ICollectionFixture<T> requires the collection definition type to be public.")]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção de nome de coleção xUnit termina com 'Collection'.")]
+public sealed class ConfiguracaoDbCollection : ICollectionFixture<ConfiguracaoDbFixture>
+{
+    public const string Name = "configuracao-db";
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoDbFixture.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoDbFixture.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Testcontainers.PostgreSql;
+
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+
+/// <summary>
+/// Fixture xUnit que provisiona um Postgres efêmero (Testcontainers) com o
+/// schema do <see cref="ConfiguracaoDbContext"/> aplicado via <c>MigrateAsync</c>,
+/// e expõe uma factory de DbContext com os MESMOS interceptors de produção
+/// (SoftDelete + Auditable). Cobre os cadastros Campus e LocalOferta (UNI-REQ #587).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IAsyncLifetime + IClassFixture<T> exigem tipo público.")]
+[SuppressMessage(
+    "Reliability",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Disposable resources released by IAsyncLifetime.DisposeAsync — xUnit invoca deterministicamente.")]
+public sealed class ConfiguracaoDbFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_configuracao_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    public string ConnectionString => _postgres.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync().ConfigureAwait(false);
+
+        await using ConfiguracaoDbContext context = CreateDbContext(userId: null);
+        await context.Database.MigrateAsync().ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _postgres.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Constrói um <see cref="ConfiguracaoDbContext"/> com os interceptors de
+    /// produção. Quando <paramref name="userId"/> é informado, simula um
+    /// <c>IUserContext</c> autenticado; caso contrário, fallback <c>"system"</c>.
+    /// </summary>
+    public ConfiguracaoDbContext CreateDbContext(string? userId)
+    {
+        StubUserContext? userContext = userId is null ? null : new StubUserContext(userId);
+
+        DbContextOptions<ConfiguracaoDbContext> options =
+            new DbContextOptionsBuilder<ConfiguracaoDbContext>()
+                .UseNpgsql(ConnectionString)
+                .UseSnakeCaseNamingConvention()
+                .AddInterceptors(
+                    new SoftDeleteInterceptor(TimeProvider.System, userContext),
+                    new AuditableInterceptor(TimeProvider.System, userContext))
+                .Options;
+
+        return new ConfiguracaoDbContext(options);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoEndpointApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoEndpointApiFactory.cs
@@ -1,0 +1,93 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// Sobe o Program.cs produtivo do módulo Configuracao apontando para o Postgres
+/// efêmero da fixture, com Wolverine habilitado. Re-registra o DbContext sem
+/// <c>EnableRetryOnFailure</c> (incompatível com as transações explícitas do
+/// Wolverine).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "WebApplicationFactory<T> derivative used as collection fixture state.")]
+public sealed class ConfiguracaoEndpointApiFactory : ApiFactoryBase<Program>
+{
+    private readonly string _connectionString;
+
+    public ConfiguracaoEndpointApiFactory(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        _connectionString = connectionString;
+    }
+
+    protected override bool DisableWolverineRuntimeForTests => false;
+
+    protected override IEnumerable<KeyValuePair<string, string?>> GetConfigurationOverrides() =>
+    [
+        new("ConnectionStrings:ConfiguracaoDb", _connectionString),
+        new("Auth:Authority", "http://localhost/test-realm"),
+        new("Auth:Audience", "uniplus"),
+    ];
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.RemoveAll<DbContextOptions<ConfiguracaoDbContext>>();
+            services.RemoveAll<DbContextOptions>();
+            services.RemoveAll<ConfiguracaoDbContext>();
+            services.RemoveAll<IDbContextOptionsConfiguration<ConfiguracaoDbContext>>();
+            RemoveAllOptionsConfigurations<DbContextOptions<ConfiguracaoDbContext>>(services);
+
+            services.AddDbContext<ConfiguracaoDbContext>((sp, opts) =>
+            {
+                opts.UseNpgsql(_connectionString);
+                opts.UseSnakeCaseNamingConvention();
+                opts.AddInterceptors(
+                    sp.GetRequiredService<SoftDeleteInterceptor>(),
+                    sp.GetRequiredService<AuditableInterceptor>());
+            });
+        });
+    }
+
+    private static void RemoveAllOptionsConfigurations<TOptions>(IServiceCollection services)
+        where TOptions : class
+    {
+        Type[] configurationTypes =
+        [
+            typeof(IConfigureOptions<TOptions>),
+            typeof(IPostConfigureOptions<TOptions>),
+            typeof(IConfigureNamedOptions<TOptions>),
+            typeof(IOptionsChangeTokenSource<TOptions>),
+        ];
+
+        foreach (Type type in configurationTypes)
+        {
+            for (int i = services.Count - 1; i >= 0; i--)
+            {
+                if (services[i].ServiceType == type)
+                {
+                    services.RemoveAt(i);
+                }
+            }
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoEndpointCollection.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoEndpointCollection.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+// DisableParallelization=true protege a env var ConnectionStrings__ConfiguracaoDb
+// contra interleaving com outras coleções de teste no mesmo processo.
+[CollectionDefinition(Name, DisableParallelization = true)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit ICollectionFixture<T> requires the collection definition type to be public.")]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção de nome de coleção xUnit termina com 'Collection'.")]
+public sealed class ConfiguracaoEndpointCollection : ICollectionFixture<ConfiguracaoEndpointFixture>
+{
+    public const string Name = "configuracao-endpoint";
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoEndpointFixture.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConfiguracaoEndpointFixture.cs
@@ -1,0 +1,77 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Testcontainers.PostgreSql;
+
+/// <summary>
+/// Fixture de coleção xUnit que provisiona um Postgres efêmero (Testcontainers)
+/// e sobe o <see cref="ConfiguracaoEndpointApiFactory"/> com Wolverine habilitado
+/// — necessário para exercitar endpoints que chamam o query/command bus.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit ICollectionFixture<T> requires the fixture type to be public.")]
+[SuppressMessage(
+    "Reliability",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Disposable resources released by IAsyncLifetime.DisposeAsync — xUnit invoca deterministicamente.")]
+public sealed class ConfiguracaoEndpointFixture : IAsyncLifetime
+{
+    private const string ConnectionStringEnvVar = "ConnectionStrings__ConfiguracaoDb";
+    private const string KafkaBootstrapEnvVar = "Kafka__BootstrapServers";
+
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_configuracao_endpoint_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    private string? _connectionStringEnvVarPrevio;
+    private string? _kafkaEnvVarPrevio;
+    private ConfiguracaoEndpointApiFactory? _factory;
+
+    public string ConnectionString => _postgres.GetConnectionString();
+
+    public ConfiguracaoEndpointApiFactory Factory =>
+        _factory ?? throw new InvalidOperationException(
+            "Factory ainda não inicializada. InitializeAsync deve rodar antes do primeiro teste.");
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync().ConfigureAwait(false);
+
+        _connectionStringEnvVarPrevio = Environment.GetEnvironmentVariable(ConnectionStringEnvVar);
+        _kafkaEnvVarPrevio = Environment.GetEnvironmentVariable(KafkaBootstrapEnvVar);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(ConnectionStringEnvVar, ConnectionString);
+            // Espaço em vez de string.Empty: em runtimes < .NET 9, string.Empty apaga
+            // a variável, fazendo o appsettings voltar a ser consultado.
+            Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, " ");
+
+            _factory = new ConfiguracaoEndpointApiFactory(ConnectionString);
+        }
+        catch
+        {
+            Environment.SetEnvironmentVariable(ConnectionStringEnvVar, _connectionStringEnvVarPrevio);
+            Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, _kafkaEnvVarPrevio);
+            throw;
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync().ConfigureAwait(false);
+        }
+
+        Environment.SetEnvironmentVariable(ConnectionStringEnvVar, _connectionStringEnvVarPrevio);
+        Environment.SetEnvironmentVariable(KafkaBootstrapEnvVar, _kafkaEnvVarPrevio);
+
+        await _postgres.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/StubUserContext.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/StubUserContext.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+
+/// <summary>
+/// Stub mínimo de <see cref="IUserContext"/> para os testes de persistência —
+/// suporta apenas o caminho "autenticado com <c>sub</c> fixo" usado pelos
+/// interceptors (created_by, updated_by, deleted_by).
+/// </summary>
+internal sealed class StubUserContext : IUserContext
+{
+    public StubUserContext(string userId)
+    {
+        UserId = userId;
+    }
+
+    public bool IsAuthenticated => true;
+    public string? UserId { get; }
+    public string? Name => null;
+    public string? Email => null;
+    public string? Cpf => null;
+    public string? NomeSocial => null;
+    public IReadOnlyList<string> Roles => [];
+    public bool HasRole(string role) => false;
+    public IReadOnlyList<string> GetResourceRoles(string resourceName) => [];
+    public bool IsPlataformaAdmin => false;
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaEndpointTests.cs
@@ -80,6 +80,43 @@ public sealed class LocalOfertaEndpointTests
         doc.RootElement.GetProperty("cidadeCodigoIbge").GetString().Should().Be("1504208");
     }
 
+    [Fact(DisplayName = "POST /api/admin/locais-oferta com campus responsável existente cria (201) — FK satisfeita")]
+    public async Task Criar_ComCampusExistente_Retorna201()
+    {
+        // Cria primeiro o campus, depois um local apontando para ele (FK intra-banco).
+        var campusBody = new
+        {
+            sigla = $"C{Guid.NewGuid().ToString("N")[..6]}",
+            nome = "Campus Responsável",
+            cidadeCodigoIbge = "1504208",
+            cidadeNome = "Marabá",
+            cidadeUf = "PA",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criarCampus = await EnviarPostAdmin(client, "/api/admin/campi", campusBody);
+        criarCampus.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid campusId = await criarCampus.Content.ReadFromJsonAsync<Guid>();
+
+        var localBody = new
+        {
+            tipo = CamelCase(TipoLocalOferta.CursoForaDeSede),
+            campusResponsavelId = campusId,
+            cidadeCodigoIbge = "1504208",
+            cidadeNome = "Marabá",
+            cidadeUf = "PA",
+        };
+
+        HttpResponseMessage criarLocal = await EnviarPostAdmin(client, "/api/admin/locais-oferta", localBody);
+        criarLocal.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid localId = await criarLocal.Content.ReadFromJsonAsync<Guid>();
+
+        HttpResponseMessage obter = await client.GetAsync(new Uri($"/api/locais-oferta/{localId}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("campusResponsavelId").GetGuid().Should().Be(campusId);
+    }
+
     [Fact(DisplayName = "POST /api/admin/locais-oferta com campus responsável inexistente retorna 422")]
     public async Task Criar_CampusInexistente_Retorna422()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaEndpointTests.cs
@@ -1,0 +1,113 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.LocaisOferta;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>LocalOferta</c> (UNI-REQ #587).
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class LocalOfertaEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public LocalOfertaEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/locais-oferta retorna 200 com Content-Type vendor MIME de local-oferta")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri("/api/locais-oferta", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.local-oferta.v1+json");
+    }
+
+    [Fact(DisplayName = "POST /api/admin/locais-oferta sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/admin/locais-oferta", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST /api/admin/locais-oferta cria (201) sem campus responsável e o GET retorna a cidade")]
+    public async Task Criar_SemCampus_Retorna201()
+    {
+        var body = new
+        {
+            tipo = CamelCase(TipoLocalOferta.PoloEad),
+            campusResponsavelId = (Guid?)null,
+            cidadeCodigoIbge = "1504208",
+            cidadeNome = "Marabá",
+            cidadeUf = "PA",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, "/api/admin/locais-oferta", body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+
+        HttpResponseMessage obter = await client.GetAsync(new Uri($"/api/locais-oferta/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("tipo").GetString().Should().Be(CamelCase(TipoLocalOferta.PoloEad));
+        doc.RootElement.GetProperty("cidadeCodigoIbge").GetString().Should().Be("1504208");
+    }
+
+    [Fact(DisplayName = "POST /api/admin/locais-oferta com campus responsável inexistente retorna 422")]
+    public async Task Criar_CampusInexistente_Retorna422()
+    {
+        var body = new
+        {
+            tipo = CamelCase(TipoLocalOferta.CursoForaDeSede),
+            campusResponsavelId = Guid.NewGuid(),
+            cidadeCodigoIbge = "1504208",
+            cidadeNome = "Marabá",
+            cidadeUf = "PA",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, "/api/admin/locais-oferta", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    private static string CamelCase(TipoLocalOferta tipo) =>
+        System.Text.Json.JsonNamingPolicy.CamelCase.ConvertName(tipo.ToString());
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, string path, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(path, UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaPersistenceTests.cs
@@ -1,0 +1,111 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.LocaisOferta;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class LocalOfertaPersistenceTests
+{
+    private const string AdminA = "admin-a";
+
+    private static readonly DateTimeOffset Agora = new(2026, 6, 17, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public LocalOfertaPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-02: criar LocalOferta persiste tipo, campus responsável e referência de cidade por código")]
+    public async Task Insert_PersisteFlatComReferenciaCidade()
+    {
+        Campus campus = Campus.Criar(
+            "LOFCAM", "Campus Local", "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null, null, null, null).Value!;
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Campi.Add(campus);
+            await ctx.SaveChangesAsync();
+        }
+
+        LocalOferta local = LocalOferta.Criar(
+            TipoLocalOferta.PoloEad, campus.Id, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, "Rua das Flores", "55555").Value!;
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.LocaisOferta.Add(local);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        LocalOferta persistido = await readCtx.LocaisOferta.SingleAsync(l => l.Id == local.Id);
+
+        persistido.Tipo.Should().Be(TipoLocalOferta.PoloEad);
+        persistido.CampusResponsavelId.Should().Be(campus.Id);
+        persistido.CidadeCodigoIbge.Should().Be("1504208");
+        persistido.CidadeUf.Should().Be("PA");
+        persistido.CidadeOrigem.Should().Be(ReferenciaCidadeGeo.OrigemGeoApi);
+        persistido.CreatedBy.Should().Be(AdminA);
+    }
+
+    [Fact(DisplayName = "LocalOferta sem campus responsável persiste (FK intra-banco opcional, ADR-0065)")]
+    public async Task Insert_SemCampusResponsavel_Persiste()
+    {
+        LocalOferta local = LocalOferta.Criar(
+            TipoLocalOferta.ConvenioInteriorizacao, null, "1501402", "Belém", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null).Value!;
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.LocaisOferta.Add(local);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        LocalOferta persistido = await readCtx.LocaisOferta.SingleAsync(l => l.Id == local.Id);
+
+        persistido.CampusResponsavelId.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "FK campus_responsavel_id inexistente é rejeitada pelo banco")]
+    public async Task Insert_CampusResponsavelInexistente_RejeitadoPelaFk()
+    {
+        LocalOferta local = LocalOferta.Criar(
+            TipoLocalOferta.CursoForaDeSede, Guid.CreateVersion7(), "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null).Value!;
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.LocaisOferta.Add(local);
+
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>()
+            .WithInnerException(typeof(Npgsql.PostgresException));
+    }
+
+    [Fact(
+        Skip = "Bloqueio por oferta de curso viva depende de oferta_curso (UNI-REQ-0010), ainda inexistente no módulo. Ponto de extensão pronto: ILocalOfertaRepository.ReferenciadoPorOfertaCursoVivaAsync retorna false.",
+        DisplayName = "CA-05: remover LocalOferta referenciado por oferta de curso viva é bloqueado")]
+    public Task RemoverLocalOferta_ComOfertaCursoViva_Bloqueia()
+    {
+        // Quando oferta_curso existir, semear um local + oferta viva referenciando-o
+        // e assertar que RemoverLocalOfertaCommandHandler retorna
+        // LocalOfertaErrorCodes.RemocaoBloqueadaPorOfertaCurso.
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OpenApiEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OpenApiEndpointTests.cs
@@ -1,0 +1,96 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests;
+
+using System.IO;
+using System.Net;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Infrastructure;
+
+/// <summary>
+/// Smoke + drift check do endpoint <c>/openapi/configuracao.json</c>: runtime
+/// gera o spec OpenAPI 3.x do módulo Configuração e compara com o baseline
+/// committed em <c>contracts/openapi.configuracao.json</c> (ADR-0030).
+/// </summary>
+public sealed class OpenApiEndpointTests : IClassFixture<ConfiguracaoApiFactory>
+{
+    private const string BaselineRelativePath = "contracts/openapi.configuracao.json";
+    private const string UpdateBaselineEnvVar = "UPDATE_OPENAPI_BASELINE";
+
+    private readonly ConfiguracaoApiFactory _factory;
+
+    public OpenApiEndpointTests(ConfiguracaoApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact(DisplayName = "GET /openapi/configuracao.json retorna 200 com documento OpenAPI válido e metadata Uni+")]
+    public async Task GetOpenApiDocument_RetornaSpecJsonComMetadataInjetada()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri("/openapi/configuracao.json", UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+        JsonElement root = doc.RootElement;
+
+        root.GetProperty("openapi").GetString().Should().StartWith("3.");
+        root.GetProperty("info").GetProperty("version").GetString().Should().Be("1.0.0");
+    }
+
+    [Fact(DisplayName = "Spec runtime de Configuração bate com baseline committed em contracts/")]
+    public async Task SpecRuntime_DeveCasarComBaselineCommitted()
+    {
+        using HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("/openapi/configuracao.json", UriKind.Relative));
+        response.EnsureSuccessStatusCode();
+
+        string runtimeSpec = NormalizeJson(await response.Content.ReadAsStringAsync());
+        string baselinePath = ResolveRepoPath(BaselineRelativePath);
+
+        if (string.Equals(Environment.GetEnvironmentVariable(UpdateBaselineEnvVar), "1", StringComparison.Ordinal))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(baselinePath)!);
+            await File.WriteAllTextAsync(baselinePath, runtimeSpec + "\n");
+            return;
+        }
+
+        File.Exists(baselinePath).Should().BeTrue(
+            $"baseline {BaselineRelativePath} precisa estar committed; rode `{UpdateBaselineEnvVar}=1 dotnet test --filter SpecRuntime` e commit o arquivo gerado.");
+
+        string committedSpec = NormalizeJson(await File.ReadAllTextAsync(baselinePath));
+
+        runtimeSpec.Should().Be(committedSpec,
+            $"contrato OpenAPI mudou — regerar a baseline com `{UpdateBaselineEnvVar}=1 dotnet test --filter SpecRuntime` e revisar o diff antes de commit (ADR-0030).");
+    }
+
+    private static string NormalizeJson(string raw)
+    {
+        using JsonDocument document = JsonDocument.Parse(raw);
+        return JsonSerializer.Serialize(document.RootElement, JsonNormalizationOptions);
+    }
+
+    private static readonly JsonSerializerOptions JsonNormalizationOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    private static string ResolveRepoPath(string relative)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relative);
+        if (Path.IsPathRooted(relative))
+            throw new ArgumentException("Caminho deve ser relativo à raiz do repositório.", nameof(relative));
+
+        string? current = AppContext.BaseDirectory;
+        while (current is not null && !File.Exists(Path.Combine(current, "UniPlus.slnx")))
+            current = Path.GetDirectoryName(current);
+
+        if (current is null)
+            throw new DirectoryNotFoundException("UniPlus.slnx não encontrado a partir de AppContext.BaseDirectory.");
+
+        return Path.Combine(current, relative);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OpenApiEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OpenApiEndpointTests.cs
@@ -85,12 +85,15 @@ public sealed class OpenApiEndpointTests : IClassFixture<ConfiguracaoApiFactory>
             throw new ArgumentException("Caminho deve ser relativo à raiz do repositório.", nameof(relative));
 
         string? current = AppContext.BaseDirectory;
-        while (current is not null && !File.Exists(Path.Combine(current, "UniPlus.slnx")))
+        while (current is not null && !File.Exists(Path.Join(current, "UniPlus.slnx")))
             current = Path.GetDirectoryName(current);
 
         if (current is null)
             throw new DirectoryNotFoundException("UniPlus.slnx não encontrado a partir de AppContext.BaseDirectory.");
 
-        return Path.Combine(current, relative);
+        // Path.Join (não Combine): concatena sem a semântica de descartar o
+        // primeiro segmento quando o segundo é enraizado — o caminho relativo já
+        // é validado acima, então a junção é sempre raiz-do-repo + relativo.
+        return Path.Join(current, relative);
     }
 }

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Unifesspa.UniPlus.Configuracao.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Unifesspa.UniPlus.Configuracao.IntegrationTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
+    <PackageReference Include="WolverineFx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.API/Unifesspa.UniPlus.Configuracao.API.csproj" />
+    <ProjectReference Include="../Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
@@ -1,0 +1,1579 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.4.0, )",
+        "resolved": "9.4.0",
+        "contentHash": "dJxkWiQ8D+xT6Gr2sSL83+Mar+Vpy2JTcUPxFcckpPJ8VYBfSgnk+zqpS6t7kcGnjz8NLyF14qfuoL4bKzzoew=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "lWyzApi1g8/r0eXqZBbl5bA8zewS8koxOir83/+OvJcyn2HazdUzPFd4MWc9uMdVzCRX6Z5aY4tNK+N0pWXMLg==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.7",
+          "Microsoft.Extensions.DependencyModel": "10.0.7",
+          "Microsoft.Extensions.Hosting": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "G6yclVO5/csPzzsymV0SemY2NDqE31CP5M3jprF5IuO9wJsh4aUOfYD8HCLuDmM1D1CfReegVic48O2r79d46Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.7",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.InMemory": {
+        "type": "Direct",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "RAns8RTPymM9GsIdY5Y8wWdpdMEXputTl24+95WhYzqF4HhT0i+jFmNgDxBTy386vU9ruoUC5gcPAiuJr8SZxg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
+      },
+      "WolverineFx": {
+        "type": "Direct",
+        "requested": "[5.39.0, )",
+        "resolved": "5.39.0",
+        "contentHash": "x1aXrnxRcezLioZnesFLgGZO0BINqI4tKxiS411iaZw/z/JVtoJ575IZML4FvEBjMkFBPirrSF3hkuveL4i2sQ==",
+        "dependencies": {
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
+          "JasperFx.RuntimeCompiler": "4.5.0",
+          "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "CommunityToolkit.HighPerformance": {
+        "type": "Transitive",
+        "resolved": "8.4.0",
+        "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
+      },
+      "Confluent.SchemaRegistry.Serdes.Json": {
+        "type": "Transitive",
+        "resolved": "2.14.0",
+        "contentHash": "rymTRDrwEIzfFCDEcoV6ZvDatlVrwmMWXT93sERMLHZiEOhOCR53Jiwa9bk/OyjIRqRxiIFHOwys2qJgfN6rQQ==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0",
+          "NJsonSchema.NewtonsoftJson": "11.0.2"
+        }
+      },
+      "DistributedLock.Core": {
+        "type": "Transitive",
+        "resolved": "1.0.8",
+        "contentHash": "LAOsY8WxX8JU/n3lfXFz+f2pfnv0+4bHkCrOO3bwa28u9HrS3DlxSG6jf+u76SqesKs+KehZi0CndkfaUXBKvg=="
+      },
+      "DistributedLock.Postgres": {
+        "type": "Transitive",
+        "resolved": "1.3.0",
+        "contentHash": "CyjXmbhFgG30qPg4DwGnsmZO63y5DBRo+PI2xW0NwtFrsYsMVt/T1RcEUlb36JMKhDkf+euhnkanv/nU+W35qA==",
+        "dependencies": {
+          "DistributedLock.Core": "[1.0.8, 1.1.0)",
+          "Npgsql": "8.0.6"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
+      },
+      "FastExpressionCompiler": {
+        "type": "Transitive",
+        "resolved": "5.3.0",
+        "contentHash": "XRmGW48Gdm7B70WUtTJJUnmuc8jRDmOhhjG/a3rix/nXChnrkETaSvA0j2VrcsH4MNeYLe60LA5o5JABmbneag=="
+      },
+      "Google.Protobuf": {
+        "type": "Transitive",
+        "resolved": "3.30.1",
+        "contentHash": "HeWXDQBabQn/sCGicbeLJ0HMunknfC4FdLrOQOsaMJHcpqx3HVIpyyJqTrqJlWnza870twhOb+rBcaTiC/TlNA=="
+      },
+      "Grpc.Core.Api": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "66UotvWcSIq41oiQhLWcQACyKPM4umxXNiht5DQTLZJfNwEswWOcS7Z0xIEHyNIBE7ZpjotH22bEjTkvhPxmVw=="
+      },
+      "Grpc.Net.Client": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "xNv0FFCVJa5S1beUtye82WFCxKThuE1jbN8DO1x1Rj8VSIWXLBUmfSID5a1fGzsU2R/EMfwPoWclJ2RMfQuGXw==",
+        "dependencies": {
+          "Grpc.Net.Common": "2.70.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+        }
+      },
+      "Grpc.Net.Common": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "rBdEUMyCwa+iB8mqC6JKyPbj3SBHHkReJj/yy/XKJI63GcG6w9DJMMGTVcYHqq4Ci2W4m0HT4jt2pFfFscar8g==",
+        "dependencies": {
+          "Grpc.Core.Api": "2.70.0"
+        }
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "ImTools": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "dms0JfLKC9AQbQX/EdpRjn59EjEvaCxIgv1z9YxbEQb5SiOVoo7vlIKdEySeEwUkWhN05rZnNpUpG+aw5VqPVQ=="
+      },
+      "JasperFx": {
+        "type": "Transitive",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
+        "dependencies": {
+          "FastExpressionCompiler": "5.3.0",
+          "ImTools": "4.0.0",
+          "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
+          "Polly.Core": "8.6.5",
+          "Spectre.Console": "0.55.0"
+        }
+      },
+      "JasperFx.Events": {
+        "type": "Transitive",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
+        "dependencies": {
+          "JasperFx": "1.31.0"
+        }
+      },
+      "JasperFx.RuntimeCompiler": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "SGJlU1kD8lX8A5p0hBWTPDV7dvPzoUB37IZjprWgA+L5yZZNyBElpn6UPNo7ZuXLKKwlSSt8BWTr99vxpxT3JA==",
+        "dependencies": {
+          "JasperFx": "1.28.0",
+          "Microsoft.CodeAnalysis": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "JasperFx.SourceGeneration": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "yIOaiA/OrlXQLGPjxFDubHnOU8MCzPTz465xBGRITMm4fDf7DbWKogb2SZC2jYLWEj27q3smTz1Z7lU4h1KkOQ=="
+      },
+      "librdkafka.redist": {
+        "type": "Transitive",
+        "resolved": "2.14.0",
+        "contentHash": "jqmYswYUiW9So5lce1Upo/zm5V7p/kWaqnUqkP5Lar1Ekq2yLrORoDCJ1JIiVLD3xdVkavwqW9iFKHBfkTsS7w=="
+      },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "2UM9EtTmX6yF6Efa6WOO7wmHz2kPksmnzPmMwveuOGJQwbtNg5wKGj7usGLr8Ve3AMhIAc2yqyRXt1xNsed3hg=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bUubrBD6tRJE3V1kvRloYc6NymH3R5oFKjAS9e0ELNx6u0ZR+zjps9dDQyjgqN/rArzl7f+21KGszj3YRN7F2Q=="
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "18.0.2",
+        "contentHash": "sOSb+0J4G/jCBW/YqmRuL0eOMXgfw1KQLdC9TkbvfA5xs7uNm+PBQXJCOzSJGXtZcZrtXozcwxPmUiRUbmd7FA=="
+      },
+      "Microsoft.CodeAnalysis": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "X7vItpZDkGm4NS2wp4P1S07Z1e61LaBWDW5tPXE1c6z5/x9KbF2RymhAPoYg7Qoiyk7odEZ6EjBEJ47p3dBpYQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1sGloRYbG3743ut/+vuXy9/WaRQTm7mDtp71rBaVSmKpFntvo5Hcro1ubg6/3SeeLtiFYJl7V3Dk0Fo3CGlnHA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Scripting.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/KgZdm6kRTrR/O2jqXxU5GWREYhtVmqcNWczyPt8hsQkFGFK/C6CrLWfG44FCUn0aPHGDRBHYjXlGosQ/H8oXw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Scripting": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "XTulByMNxqXGCgMeODUoG2h4oK4/nLv1BcawRVcjv+UZHMpoaymtdaq3cJqlNrEvYEcbU48g5swJ3RhY1m3fBg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "sUBWvHs2HgHGA+b716dgjS7JiXGen5ntyohAurPLR1ZiZzFp3FlnVA7GrMTqVGdVJTVqiC3c4K8k1bk0gj6IPg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Nom4UuZVEZGaV6Qa+joJR/BawXZMtflvQJFKc0SaUc3LrZr/8LmRY5cn8mbvLOWIVfwWkQz+cVE6eQKu9qa65g==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.MSBuild": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/G+LVoAGMz6Ae8nm+PGLxSw+F5RjYx/J7irbTO5uKAPw1bxHyQJLc/YOnpDxt+EpPtYxvC9wvBsg/kETZp1F9Q==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "17.11.31",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "Microsoft.Extensions.DependencyInjection": "9.0.0",
+          "Microsoft.Extensions.Logging": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Options": "9.0.0",
+          "Microsoft.Extensions.Primitives": "9.0.0",
+          "Microsoft.VisualStudio.SolutionPersistence": "1.0.52",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TuxExnfIS/bSq3z2CbH0LwZH1oyj9iHhSGneU4fpxl3ikjZGZdSae9gcfnImV1rufH8f/ab1NnHwyL2BLyeZOg=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "eZnMyiJzo249Ejg5CaFScvJS0u7neQfS9DXknAHTO6FHVMM99gO0byNXHGZmA/BOkZ13ngeVziQLHTMOtgescg=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "pUDgQKEqNUFlerDIFRg7zzoDVRPEWIG7nR40h8Gzg8RXza4Ry0lWZ7u91bmwu3iUDCxw3Dv6TLHVFoAgY0gy7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "6eULH/sc97yfCEV31g7AgUzHc7dIm0DGBcofoE8GgBaXbdAPPhathN8rYcgi1TSiG1QucCdqKiVNaDEPAEXL5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "wZbGh7J8R1vXN525O6d8dlcDTxhRTnd5MyW4LdfP5S0tSnTwTCseYSrq6g0Mxh7W9xn8P/2xPuf0D/m6k2dy2w==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "t56nEgvECcyLPojZIUFWJknQQDAbgfTf9J+QMYJE1YYvVgz69vN6B/AKL8Grvj3Lcnp8kTpNqwmwFhb3YLJmtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "8bS1qIaRivny+WX+49pmeJ6iAylbtX8C0DLEcCQWZjdxQvLqaMssXiGD9P/6pYElrHbK5/nAHmjbQ8STqdMYeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "3lNjglxfFxOzI9zG+3HSg/YSGqo//8Fqw6u6iuIamZb4JCorbA3JLaeWOpfKTAPi2UJwaispOXWx14dUqcGz4A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "TWto3imA+mJMLZI+5sbgLiFFoOFNFkizQYNaC5jTuiHKn3diwm1RN7mWDOEZN9kG2bixw7IvgpvtUG5/teSRzA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "qbZLvLsoTdArSloEnSxs21P781YUmwVmHc5NJPQD/ezAreQ7884z+6QfAZVKi86WAZtzx83jK2uC4itxOM44gQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "64dimvyyKk0dbUbrLg/YCv4ugJ4sVz2aXLwfvZwR1EC4tJqW9ru/oVRcXwoJRa2lQGXtYtlpk4maWOeIb48tQw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YqVIICoIdl0016wkeO2WQS+uEbEXbUhMLKdC5rZNl1X3nu59F+nwaAHdHjq/4OK+Cx31DYmNUSFh+MUot8qSDw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "91F/o3emPV/+xY/ip3s2LqDNF14kjttlVtq0BXgg6p4MnCzeSZxnUJm+t6WRrtD3JdGo88/oX+z7OwK4y8PZuw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "gCglFg/9Chu3lyJNytRuQAYM3mXQKNs1i01Cz2bc545QaHQ+LbBb4O5UCfu968Gro3ZVSOZ/ktilmPcaUSGSZA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "l+smp1qPlU0OUXD0OGfdp7OUFrbdq7ZaP5T7m2WpfZ4RFKD7iG73BAT7tjSMxNmbSXkhAn1jYHOAqzYG1r9sNg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "uJ9JP677y+uy+C0vtaSfi7XXgFAdz8DhU3M9lwwIXDfQKcyQ0yxM9DVYa0NXDtdVTYA2eBUtVFZ8LY0GCdeE/w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "teioDgVpi8L186wUfrXQV1YuBt6lCSPmFZiMZo53+FZxHFjOV+f4GXo4LXgJ273Mku9//AdXWVjk9J7eJP6inw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "zhgWg/i0ECj5v0jLFBSZHplvc5ygCI91DR4nne+BP4XAKF5ycz0pEKnFiTw8C1jCABJEZsnBZh6pXAvn71kFmw==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "NTUspqB+vH9g4wAD6KPOBx01xqYuKXR/cHXm449zpbq1GqfjdAxBmg7eJXrNsPw7SKwIdT2cJ05GxYVvc+lvsA=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "M/vBpfWcschvS2EUeq7cHfscsxabiGTptXwV7GeSueovGiSoNjyo1j5PMcWuOAAQrRW3nRqxZk8NeumrmpzUBg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.7",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.7",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Json": "10.0.7",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.7",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Logging.Console": "10.0.7",
+          "Microsoft.Extensions.Logging.Debug": "10.0.7",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.7",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "5s8d6qC6EA8UOI4wR/+zlsq7SXttJMRb9d7zvVZ7+bE3CQEfVtC9ITUDCommm87R1zzj6WJBbCnztuIJXnP3DA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.7",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "hOeRIQ63GkgiYCB/MIFp+LQs8aXpJXpB55t6Aj37ab7t2/6WeFcPXxYM9hdy/o5tffzwf8mhqzLJP6mjGYCxjw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "7BBnoGF37USiu7j434put9mDp7EjdlNDIZsR4vHfC1FbLZeLqiWjgJbeEtF0p59Ryqt8AtraHawf0ZKbe5jibg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "DA++Es6v6W0HfrOrw+K8WyN6jNnZHp640PDdEvl8yfeVmgflKdn6vSSFvufNUSOuY+M2ZaSUgfY+jUKtNpXcCw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Y6DSt/JZApunYWKqTtqbdsR6iqAvHx3D0tavbNJ1rnC24MUpF+3XO/VKgFi+9PFqMyvQ2GHBBGb8H3cLSw7rDg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "1C8eTuxF6BLncNSJ1HCfmaBcjpUSqQDPlBVdYTlet9oldHTPpNh9iatxSJLs8TOqdp/FOpH+nSLdBve7fu9mTQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "System.Diagnostics.EventLog": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "YWfndnDX1jVMGCN8d5T+rO+BO8sDw6BkYlUk0BYui+WP7+HhlWx8QLdA4yUDjrkGVb3AQxIWWEPVKw5Nnfj5GQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "00SHUGTh2jSMvIr6x9Xwd2nE+B5/qFCO/9hDwUDhJsjYRDlADmaBZ7tqehXzBDsfjHSXJzuRHJzPYPPjphBQ7Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "IT7f+EMXZtkjatEcF+o6aOw/7OE4etRrMiDGEWH/iiTu2R3uhC4NEQJCfHiibtX45U3sIQ5Fh6tbb1qaOz3YAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Options": "10.0.7",
+          "Microsoft.Extensions.Primitives": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "D5M0Jr551iTgwkZMN9rm0pSkgNLj5quUWQUmQPMZh7k/bnvZTnXRGfE2KuvXf1EEjt/ofD9yw9IumpgdP9QCnw=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "OtlIWcyX01olfdevPKZdIPfBEvbcioDyBiE/Z2lHsopsMD7twcKtlN9kMevHmI5IIPhFpfwCIiR6qHQz1WHUIw=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "s6++gF9x0rQApQzOBbSyp4jUaAlwm+DroKfL8gdOHxs83k8SJfUXhuc46rDB3rNXBQ1MVRxqKUrqFhO/M0E97g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "UCPF2exZqBXe7v/6sGNiM6zCQOUXXQ9+v5VTb9gPB8ZSUPnX53BxlN78v2jsbIvK9Dq4GovQxo23x8JgWvm/Qg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "uA2vpKqU3I2mBBEaeJAWPTjT9v1TZrGWKdgK6G5qJd03CLx83kdiqO9cmiK8/n1erkHzFBwU/RphP83aAe3i3g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "kDimB6Dkd3nkW2oZPDkMkVHfQt3IDqO5gL0oa8WVy3OP4uE8Ij+8TXnqg9TOd9ufjsY3IDiGz7pCUbnfL18tjg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.VisualStudio.SolutionPersistence": {
+        "type": "Transitive",
+        "resolved": "1.0.52",
+        "contentHash": "oNv2JtYXhpdJrX63nibx1JT3uCESOBQ1LAk7Dtz/sr0+laW0KRM6eKp4CZ3MHDR2siIkKsY8MmUkeP5DKkQQ5w=="
+      },
+      "Mono.TextTemplating": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "YqueG52R/Xej4VVbKuRIodjiAhV0HR/XVbLbNrJhCZnzjnSjgMJ/dCdV0akQQxavX6hp/LC6rqLGLcXeQYU7XA==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Namotion.Reflection": {
+        "type": "Transitive",
+        "resolved": "3.1.1",
+        "contentHash": "Qn0wM7u9TpSpja2x8UVexr2bLHb1DGMNhD2TCz3woklxaY1oH+Sitrw9fg/4YbNoNtczeH2jf+yPdXMQlgvFlQ=="
+      },
+      "NetTopologySuite.IO.PostGis": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "3W8XTFz8iP6GQ5jDXK1/LANHiU+988k1kmmuPWNKcJLpmSg6CvFpbTpz+s4+LBzkAp64wHGOldSlkSuzYfrIKA==",
+        "dependencies": {
+          "NetTopologySuite": "[2.0.0, 3.0.0-A)"
+        }
+      },
+      "NewId": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "jegBasNndmG21G3BmT51suFDCIz/sLN81j+IxmkZ4iWoaDi8LygeHiyNnYbXz5OQh9nCRJFIx1+PJrlYi1Gc9Q=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NJsonSchema": {
+        "type": "Transitive",
+        "resolved": "11.0.2",
+        "contentHash": "BOgw+TOd1w7BSRIEWwkiSgHlKWC2eu0DHsSsb1LIwlC1Hq26A0ARZiMjsCsqfXqXdr7hLf1m4M84Z7LW1wmCGA==",
+        "dependencies": {
+          "NJsonSchema.Annotations": "11.0.2",
+          "Namotion.Reflection": "3.1.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "NJsonSchema.Annotations": {
+        "type": "Transitive",
+        "resolved": "11.0.2",
+        "contentHash": "VbA0fmxVyqloGXYz863g6QHyojM1tgejwPQr9LjXdubs9YJt5YfRPCQOV/hnzpP2Bqd7nZFpDn9MCImmLAmqCw=="
+      },
+      "NJsonSchema.NewtonsoftJson": {
+        "type": "Transitive",
+        "resolved": "11.0.2",
+        "contentHash": "tTVG8h7qfw6anxlhXGx3oUz7f3ig+t9jO3yrho73ypvMZ7DCyFtiaF5gG3GqBDZXM49ONogDmTZ+8HTG6AKaNQ==",
+        "dependencies": {
+          "NJsonSchema": "11.0.2",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Npgsql.NetTopologySuite": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "7AwBLPz8EPmgAXveZ55K0Tz/9bNb8j4VI4pkTOQjyHrce8wWfAA9pefm3REidy+Kt2UFiAWef34YVi7sb/kB4A==",
+        "dependencies": {
+          "NetTopologySuite": "2.5.0",
+          "NetTopologySuite.IO.PostGIS": "2.1.0",
+          "Npgsql": "9.0.4"
+        }
+      },
+      "OpenTelemetry": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "N0i6WjPoHPbZyms1ugbDIFAJFuGlpeExJMU/+XSL0lQRUkg/D0utFkDoLXf8Z1km5B+xVZ2GyMXXiX8qdeNmPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
+      "OpenTelemetry.Api.ProviderBuilderExtensions": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "SYn0lqYDwLMWhv/zlNGsQcl2yX++yTumanX46bmOZE/ZDOd1WjPBO2kZaZgKLEZTZk48pavIFGJ6vOvxXgWVFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "OpenTelemetry.Api": "1.15.3"
+        }
+      },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.8",
+        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.5",
+        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+      },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "Serilog.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Serilog.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Formatting.Compact": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "wQsv14w9cqlfB5FX2MZpNsTawckN4a8dryuNGbebB/3Nh1pXnROHZov3swtu3Nj5oNG7Ba+xdu7Et/ulAUPanQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Serilog": "4.3.0"
+        }
+      },
+      "Serilog.Sinks.Console": {
+        "type": "Transitive",
+        "resolved": "6.1.1",
+        "contentHash": "8jbqgjUyZlfCuSTaJk6lOca465OndqOz3KZP6Cryt/IqZYybyBu7GP0fE/AXBzrrQB3EBmQntBFAvMVz1COvAA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.File": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "WTlRjL6KWIMr/pAaq3rYqh0TJlzpouaQ/W1eelssHgtlwHAH25jXTkUphTYx9HaIIf7XA6qs/0+YhtLEQRkJ+Q=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "WbmDLeTPYhEzXhvYVioTVn/D1XX6bovyny9n5p8Zxtf03+eY385RB818teZm6n+fA63iZNvng0/Np4tLuhkMhQ=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
+      },
+      "System.Reactive": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "rHaWtKDwCi9qJ3ObKo8LHPMuuwv33YbmQi7TcUK1C264V3MFnOr5Im7QgCTdLniztP3GJyeiSg5x8NqYJFqRmg=="
+      },
+      "Weasel.Core": {
+        "type": "Transitive",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
+        "dependencies": {
+          "JasperFx": "1.26.0"
+        }
+      },
+      "Weasel.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
+          "Weasel.Core": "8.15.1"
+        }
+      },
+      "Weasel.Postgresql": {
+        "type": "Transitive",
+        "resolved": "8.15.1",
+        "contentHash": "YD/3CWlqCCX5dBVMZmIYvR8/flwcgDHPQq4EtUHJOlFnPrmQX4Lfd5rmFCIW3n/3F53qxMXl2HaJnxGI1Twtsw==",
+        "dependencies": {
+          "DistributedLock.Postgres": "1.3.0",
+          "Npgsql": "9.0.4",
+          "Npgsql.NetTopologySuite": "9.0.4",
+          "Weasel.Core": "8.15.1"
+        }
+      },
+      "WolverineFx.RDBMS": {
+        "type": "Transitive",
+        "resolved": "5.39.0",
+        "contentHash": "qLwcwCaQzkbcJpX3MFftHDLVXDTUFl+8XRFwLDZPwLHAf4FeRfRE/u/eOnrWyrQ/sv189WDZx5UmoEdxnRynTw==",
+        "dependencies": {
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.39.0"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "unifesspa.uniplus.application.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.api": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Postgresql": "[5.39.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.7, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.7, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
+          "Unifesspa.UniPlus.Configuracao.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.infrastructure.core": {
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.Kafka": "[2.14.0, )",
+          "Confluent.SchemaRegistry": "[2.14.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.7, )",
+          "Minio": "[7.0.0, )",
+          "Npgsql": "[10.0.2, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
+          "OpenTelemetry.Instrumentation.EntityFrameworkCore": "[1.15.1-beta.1, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
+          "StackExchange.Redis": "[2.12.14, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "VaultSharp": "[1.17.5.1, )",
+          "WolverineFx": "[5.39.0, )",
+          "WolverineFx.EntityFrameworkCore": "[5.39.0, )",
+          "WolverineFx.Kafka": "[5.39.0, )",
+          "WolverineFx.Postgresql": "[5.39.0, )"
+        }
+      },
+      "unifesspa.uniplus.integrationtests.fixtures": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.0.7, )",
+          "Testcontainers": "[4.11.0, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "WolverineFx": "[5.39.0, )",
+          "xunit": "[2.9.3, )"
+        }
+      },
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
+      "Confluent.Kafka": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "NnG0UXR9Wnup3Nvik6SBVaHRzCu0Iit8BE7ayaWsLt+yRWrI0ZY6o8pxPB6B/jyu+fbUllZ9efsbyFwrowDcpg==",
+        "dependencies": {
+          "librdkafka.redist": "2.14.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "axnbdId+V1oOKDkUK92KTzrLFLTKVJaywg+tgs3yoRImQnf+zgct4U6Y/jssNYEP0gCObgZyJgk4hWatZV00gw==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.14.0, )",
+        "resolved": "2.14.0",
+        "contentHash": "gRvhDEETEXFLvGBsMRKdODO4VI00S4zAJEs+HZg9fWKdNdm90MlScoUADYJd0F8fSl0O0Va2Iyz5KkdrKm3Oxw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Design": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.2",
+        "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "18.0.2",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
+          "Microsoft.Extensions.Caching.Memory": "10.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.DependencyModel": "10.0.2",
+          "Microsoft.Extensions.Logging": "10.0.2",
+          "Mono.TextTemplating": "3.0.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "midwPufIwXhOJcVhaZpCZGNbjy2QoPfHI+70nw2dGcoULEW9DybMvMPYkRjOJV0eI46a1oVFhU4lFYDEx6YUbg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.7",
+          "Microsoft.Extensions.Caching.Memory": "10.0.7",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.7",
+          "Microsoft.Extensions.Logging": "10.0.7"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "Minio": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "GiCD0koYBM8/VCXRkrfSzOtySEmrA2ngceJuxRO5H+/uGodiTX+XPaUHQq9/1DpaeBxWnkmrgqu52dwuZqIYgw==",
+        "dependencies": {
+          "CommunityToolkit.HighPerformance": "8.4.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.4",
+          "Microsoft.Extensions.Logging": "9.0.4",
+          "System.IO.Hashing": "9.0.4",
+          "System.Reactive": "6.0.1"
+        }
+      },
+      "NetTopologySuite": {
+        "type": "CentralTransitive",
+        "requested": "[2.6.0, )",
+        "resolved": "2.5.0",
+        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
+      },
+      "Npgsql": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.2, )",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.3, )",
+        "resolved": "1.15.3",
+        "contentHash": "FEXJepcseTGbATiCkUfP7ipoFEYYfl/0UmmUwi0KxCPg9PaUA8ab2P1LGopK+/HExasJ1ZutFhZrN6WvUIR23g==",
+        "dependencies": {
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.3, )",
+        "resolved": "1.15.3",
+        "contentHash": "u8n/W8yIlqv0BXZmvId1iVaeWXG42tGKdTkuLYg5g57Y/r9CeUNzqtrSHNdG5IoO8iPX79w3v+WsbAHgUQbfeg==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Instrumentation.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.2, )",
+        "resolved": "1.15.2",
+        "contentHash": "2nPd7r0ug/gd6/CNFL6Rlu+RSQ9WYGSGHAYQ1ssbSqyzKJpqTunfx2I/1O0WB5k+L0cyXbG4XVZpoSoUc3M7wg==",
+        "dependencies": {
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.1-beta.1, )",
+        "resolved": "1.15.1-beta.1",
+        "contentHash": "NmtYLk3HJUUkV0g2VnFLs67/PGIVbI8JXtu0g4f9bk2ZaInp211/AL2+Qcbgkb9ih/uOi8loN6E1Aw2o0YIWag==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Http": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.1, )",
+        "resolved": "1.15.1",
+        "contentHash": "vFO4Fj/dXkoVNGo/nhoGpO2zYQmZwr4jTID7oRGo+XlQ8LqksyZjUXQ4p39RfUvTID7IzzL8Qe71tW7CcAFymA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Runtime": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.1, )",
+        "resolved": "1.15.1",
+        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "dependencies": {
+          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+        }
+      },
+      "Serilog.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "a/cNa1mY4On1oJlfGG1wAvxjp5g7OEzk/Jf/nm7NF9cWoE7KlZw1GldrifUBWm9oKibHkR7Lg/l5jy3y7ACR8w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Console": "6.1.1",
+          "Serilog.Sinks.Debug": "3.0.0",
+          "Serilog.Sinks.File": "7.0.0"
+        }
+      },
+      "Serilog.Sinks.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "PzMCyE5G19tjr5IZEi5qg+4UU5QrxBEoBEMu/hhYybTrGKXqUDiSGWKZNUDBgelaVKqLADlsmlJVyKce5SyPrg==",
+        "dependencies": {
+          "Google.Protobuf": "3.30.1",
+          "Grpc.Net.Client": "2.70.0",
+          "Serilog": "4.2.0"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.12.14, )",
+        "resolved": "2.12.14",
+        "contentHash": "QiAQg40OP4Owem6/PjIbjEKq2+uIeQYeZ1TCMUnx/QvKugOPxOfC96wjlnBjWHi4Wq9pv9+fDlXGT06XkRZ6Ig==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Pipelines.Sockets.Unofficial": "2.2.8",
+          "System.IO.Hashing": "10.0.2"
+        }
+      },
+      "Testcontainers": {
+        "type": "CentralTransitive",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "VaultSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.17.5.1, )",
+        "resolved": "1.17.5.1",
+        "contentHash": "1O/F+AQCkyK4K709pBDYEbDDfJ12OlaE5lnOs9dffq+KxqrnPxh8FIdQtEst9yBJmC7I0BptftzTJyRSwhZR/A=="
+      },
+      "WolverineFx.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[5.39.0, )",
+        "resolved": "5.39.0",
+        "contentHash": "xD31lMm3aud+YL2WVy9xTEKWEOt2F4a6sYBYlRLNzgSECZUnG/1vWwCivmxMQy3YraSjB9cfqRchRTKqtN9lfA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.2",
+          "Microsoft.EntityFrameworkCore.Design": "10.0.2",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
+        }
+      },
+      "WolverineFx.Kafka": {
+        "type": "CentralTransitive",
+        "requested": "[5.39.0, )",
+        "resolved": "5.39.0",
+        "contentHash": "FqtGEBFPT7MCWmJXCPfLZqd7LzOTpL1pO2BVHVmu2tioQajAIqsngIekUYMVlxSEoIRj3/DCLKV0gbtq1fkf/A==",
+        "dependencies": {
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.14.0",
+          "Confluent.SchemaRegistry.Serdes.Json": "2.14.0",
+          "WolverineFx": "5.39.0"
+        }
+      },
+      "WolverineFx.Postgresql": {
+        "type": "CentralTransitive",
+        "requested": "[5.39.0, )",
+        "resolved": "5.39.0",
+        "contentHash": "lwKbD6hdg2sSmX+kNMfqSp6LCY8iO8s21qhn0ZxcUUx7pxMzZHC42uRxU79UPHUxTVG4QJ+lZmkHFPaz6vGBow==",
+        "dependencies": {
+          "Weasel.Postgresql": "8.15.1",
+          "WolverineFx.RDBMS": "5.39.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Objetivo

Entrega os cadastros administrativos **Campus** e **Local de Oferta** no módulo **Configuração** (banco `uniplus_configuracao`), reescopo da Story #587: a `Cidade` deixa de ser cadastro de Configuração e passa ao módulo **Geo**. `Campus`/`LocalOferta` referenciam a cidade por **`cidade_codigo_ibge` + display cache** (`cidade_nome`, `cidade_uf`, `cidade_origem`, `cidade_display_atualizado_em`), preenchido pelo frontend (composição no cliente — ADR-0090). **Sem dependência de código com o Geo** (sem `Geo.Contracts`/`Geo.Infrastructure`, sem HTTP).

## O que entra

- **Domain:** `Campus`, `LocalOferta` (flat, ADR-0065), enum `TipoLocalOferta`, `ErrorCodes`, portas de repositório e o validador de referência de cidade `ReferenciaCidadeGeo` (formato 7 dígitos + prefixo de UF coerente, **sem dígito verificador** e **sem consultar o Geo**).
- **Application:** commands/handlers Wolverine (`static`), validators FluentValidation, DTOs, mappings, queries de listagem (cursor bidirecional ADR-0089) e obtenção. O handler carimba server-side `cidade_origem = "geo-api"` + instante via `TimeProvider`.
- **Infrastructure:** EF configs (snake_case, índice único parcial de sigla `WHERE is_deleted=false`, FK intra-banco `Restrict` do campus responsável), repositórios, DbSets, DI e migration forward-only `AddCampusELocalOferta`.
- **API:** controllers MVC com GET público paginado por cursor (vendor MIME ADR-0028), admin POST/PUT/DELETE restrito a `plataforma-admin` com `Idempotency-Key` (ADR-0027), links builders HATEOAS (ADR-0029) e registro de erros de domínio. Enum em wire format **camelCase** (`JsonStringEnumConverter`, mesmo contrato de Seleção).
- **Testes:** Domain.UnitTests, Application.UnitTests e IntegrationTests (Testcontainers PostgreSQL). Baseline `contracts/openapi.configuracao.json` adicionado ao roster do fitness `OpenApiSharedSchemasInSyncTests`.

## Critérios de aceite

- **CA-01** — sem entidade/`DbSet`/tabela/rota de `Cidade` em Configuração (`ConfiguracaoSemEntidadeCidadeTests`).
- **CA-02** — criar `Campus`/`LocalOferta` persiste código + display cache, sem FK ao `uniplus_geo`.
- **CA-03** — código IBGE malformado / prefixo de UF incompatível é rejeitado (422) server-side, sem consultar o Geo nem validar DV.
- **CA-04** — sem acoplamento de código com o Geo (fitness de isolamento cross-módulo verde, sem ajuste de roster).
- **CA-05** — remover `Campus` responsável por `LocalOferta` vivo é bloqueado (409). O bloqueio de `LocalOferta` por **oferta de curso viva** é ponto de extensão pronto (`ReferenciadoPorOfertaCursoVivaAsync` retorna `false` + TODO) — `oferta_curso` (UNI-REQ-0010) ainda não existe, então o teste correspondente está `Skip`.
- **CA-06** — sem PII (dados institucionais/geográficos).

## Premissas e decisões

- **Green-field:** a `Cidade` nunca existiu em Configuração — **sem migration de remoção nem backfill**.
- **Congelamento (RN08):** permanece no Processo Seletivo (módulo Seleção, ADR-0061) — sem colunas de snapshot nos cadastros vivos.
- **Referência fraca** (código sem FK cross-banco) vale só para dado público estável (município IBGE); nunca para invariante de autorização/elegibilidade/financeiro/legal.

## Validação local

- `dotnet build UniPlus.slnx` limpo (`TreatWarningsAsErrors`, 0 warnings).
- **Suíte completa** verde: 20 projetos de teste, 0 falhas (Configuração: 24 domínio + 11 aplicação + 22 integração, 1 `Skip`).
- Fitness verdes: `SoftDeleteOptInConventionTests` (Campus/LocalOferta), isolamento cross-módulo (R8/ADR-0056), `OpenApiSharedSchemasInSyncTests`.

## Rollback

Reversível por `git revert` dos commits; a migration `AddCampusELocalOferta` tem `Down` que dropa `local_oferta` e `campus`.

Closes #587

Refs #664
Refs #661
