### PR TITLE
chore(arch): renomeia fitness para CrossModuleReadIsolationTests (#687)

### DIFF
--- a/docs/adrs/0090-modulo-geo-localidades.md
+++ b/docs/adrs/0090-modulo-geo-localidades.md
@@ -37,7 +37,7 @@ Há ainda a pergunta de **como** os demais módulos consomem localidades: por le
 **Escolhida:** "B — módulo `Geo` dedicado com banco isolado, consumido por composição no cliente", porque aplica o isolamento por contexto da ADR-0054 a um contexto transversal e elimina acoplamento de runtime desnecessário.
 
 - O `Geo` é um **bounded context próprio**: solution de 5 projetos (Clean Architecture) e banco isolado `uniplus_geo` (ADR-0054), **read-mostly**.
-- O **consumo cross-módulo é por composição no cliente**: o front envia o identificador estável da localidade (ex.: código IBGE do município) e um *display cache* já resolvido; o backend do módulo consumidor persiste o **snapshot** necessário (congelamento por edital, RN08). **Não** há leitor read-side nem chamada HTTP cross-módulo do Geo em V1 — o que mantém o módulo `Geo` fora do caminho crítico de runtime dos demais módulos e satisfaz o carve-out cross-módulo (fitness `CrossModuleReadCarveOutTests`, ao qual o `Geo` é adicionado).
+- O **consumo cross-módulo é por composição no cliente**: o front envia o identificador estável da localidade (ex.: código IBGE do município) e um *display cache* já resolvido; o backend do módulo consumidor persiste o **snapshot** necessário (congelamento por edital, RN08). **Não** há leitor read-side nem chamada HTTP cross-módulo do Geo em V1 — o que mantém o módulo `Geo` fora do caminho crítico de runtime dos demais módulos e satisfaz o isolamento de leitura cross-módulo (fitness `CrossModuleReadIsolationTests`, ao qual o `Geo` é adicionado).
 - Referências a entidades de **outros contextos** não cruzam por chave estrangeira (ADR-0054); o Geo é dono apenas de localidades.
 
 ## Consequências
@@ -59,7 +59,7 @@ Há ainda a pergunta de **como** os demais módulos consomem localidades: por le
 
 ## Confirmação
 
-- **Fitness test**: o `Geo` está no roster de `CrossModuleReadCarveOutTests` e nenhum módulo depende de `Geo.Domain`/`Geo.Application`; o `Geo` não expõe leitor read-side consumido por outro módulo em V1.
+- **Fitness test**: o `Geo` está no roster de `CrossModuleReadIsolationTests` e nenhum módulo depende de `Geo.Domain`/`Geo.Application`; o `Geo` não expõe leitor read-side consumido por outro módulo em V1.
 - **Teste de migração**: o banco `uniplus_geo` é criado e migrado isoladamente.
 
 ## Prós e contras das opções

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Caching/ICacheService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Caching/ICacheService.cs
@@ -9,7 +9,7 @@ public interface ICacheService
     /// <summary>
     /// Tenta adquirir um lease curto sobre <paramref name="chave"/> (pattern
     /// <c>SET NX EX</c>) para coordenar populadores concorrentes em cache miss
-    /// — stampede protection (ADR-0056 §"Carve-out read-side").
+    /// — stampede protection (ADR-0056 §"Desmembramento cross-módulo read-side").
     /// </summary>
     /// <param name="chave">Identificador do lease (convenção: <c>{recurso}:lease</c>).</param>
     /// <param name="ttl">Janela máxima de retenção do lease — protege contra leak por crash do caller.</param>

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/CrossModuleReadIsolationTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/CrossModuleReadIsolationTests.cs
@@ -13,7 +13,7 @@ using ReflectionAssembly = System.Reflection.Assembly;
 using ReflectionType = System.Type;
 
 /// <summary>
-/// Fitness test <strong>R8</strong> da ADR-0056 — carve-out read-side cross-módulo:
+/// Fitness test <strong>R8</strong> da ADR-0056 — isolamento de leitura cross-módulo:
 /// <list type="bullet">
 ///   <item><description>Nenhum projeto de módulo (Domain/Application/Infrastructure/API)
 ///   pode depender dos namespaces <c>.Domain</c> ou <c>.Application</c> de outro módulo.</description></item>
@@ -41,7 +41,7 @@ using ReflectionType = System.Type;
 /// pegar dependências de tipos (uso real) — ProjectReference sem uso não é dep
 /// arquitetural; uso de tipo é.</para>
 /// </remarks>
-public sealed class CrossModuleReadCarveOutTests
+public sealed class CrossModuleReadIsolationTests
 {
     /// <summary>
     /// Roster dos módulos da plataforma. Cada entrada é o namespace raiz; as


### PR DESCRIPTION
## Objetivo

Renomear a classe de fitness `CrossModuleReadCarveOutTests` → **`CrossModuleReadIsolationTests`** (nome mais claro para o que o teste garante: isolamento de leitura cross-módulo, R8 da ADR-0056) e remover o anglicismo **"carve-out"** da **prosa pt-BR** (vocabulário canônico — anglicismo evitável é banido em prosa, identificadores 100% em inglês permanecem).

Mudança puramente de **nomenclatura/documentação — sem alteração de comportamento** do fitness.

## Mudanças

- `tests/.../ArchTests/SolutionRules/CrossModuleReadCarveOutTests.cs` → `CrossModuleReadIsolationTests.cs` (rename de arquivo + classe); XML-doc passa a dizer "isolamento de leitura cross-módulo".
- `docs/adrs/0090-modulo-geo-localidades.md`: prosa "carve-out cross-módulo" → "isolamento cross-módulo"; referências ao nome da classe atualizadas.
- `src/shared/.../Caching/ICacheService.cs`: corrige referência **defasada** a ADR-0056 §"Carve-out read-side" → §"Desmembramento cross-módulo read-side" (a seção já havia sido renomeada no ADR; o comentário ficou stale).

## Validação local

- `dotnet build UniPlus.slnx` limpo — 51 projetos, 0 warnings.
- Suíte completa verde — 20 projetos, 0 falhas; `ArchTests` 24/24 (inclui o fitness renomeado).
- Nenhuma ocorrência remanescente de "carve" em código/docs.

## Concorrência

`ArchTests` é projeto compartilhado; branch criada a partir de `origin/main` atualizada (inclui o merge do #587) em worktree isolado, sem tocar no working tree principal.

Closes #687
