### PR TITLE
feat(geo): ETL de atualização periódica + política de stale (#674)

### DIFF
--- a/contracts/openapi.geo.json
+++ b/contracts/openapi.geo.json
@@ -161,6 +161,185 @@
           }
         }
       }
+    },
+    "/api/admin/geo/importacoes": {
+      "post": {
+        "tags": [
+          "GeoImportacoes"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DispararImportacaoRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DispararImportacaoRequest"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/DispararImportacaoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportacaoGeoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportacaoGeoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportacaoGeoDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service Unavailable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/geo/importacoes/{id}": {
+      "get": {
+        "tags": [
+          "GeoImportacoes"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportacaoGeoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportacaoGeoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportacaoGeoDto"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -205,9 +384,84 @@
           }
         }
       },
+      "DispararImportacaoRequest": {
+        "required": [
+          "versao"
+        ],
+        "type": "object",
+        "properties": {
+          "versao": {
+            "type": "string"
+          }
+        }
+      },
       "IFormFile": {
         "type": "string",
         "format": "binary"
+      },
+      "ImportacaoGeoDto": {
+        "required": [
+          "id",
+          "versaoDataset",
+          "status",
+          "iniciadoEm",
+          "concluidoEm",
+          "disparadoPor",
+          "mensagem",
+          "relatorio"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "versaoDataset": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "iniciadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "concluidoEm": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "disparadoPor": {
+            "type": "string"
+          },
+          "mensagem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "relatorio": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RelatorioImportacaoDto"
+              }
+            ]
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
       },
       "ProblemDetails": {
         "type": "object",
@@ -244,6 +498,150 @@
               "null",
               "string"
             ]
+          }
+        }
+      },
+      "RelatorioImportacaoDto": {
+        "required": [
+          "versaoDataset",
+          "lidos",
+          "inseridos",
+          "atualizados",
+          "orfaos",
+          "degradados",
+          "tabelas"
+        ],
+        "type": "object",
+        "properties": {
+          "versaoDataset": {
+            "type": "string"
+          },
+          "lidos": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "inseridos": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "atualizados": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "orfaos": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "degradados": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "tabelas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TabelaImportacaoDto"
+            }
+          }
+        }
+      },
+      "TabelaImportacaoDto": {
+        "required": [
+          "tabela",
+          "lidos",
+          "inseridos",
+          "atualizados",
+          "ignoradosSemChave",
+          "orfaos",
+          "duplicados",
+          "parsesDegradados",
+          "amostras"
+        ],
+        "type": "object",
+        "properties": {
+          "tabela": {
+            "type": "string"
+          },
+          "lidos": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "inseridos": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "atualizados": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "ignoradosSemChave": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "orfaos": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "duplicados": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "parsesDegradados": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "amostras": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
@@ -314,6 +712,9 @@
     },
     {
       "name": "_smoke"
+    },
+    {
+      "name": "GeoImportacoes"
     }
   ]
 }

--- a/contracts/openapi.geo.json
+++ b/contracts/openapi.geo.json
@@ -258,6 +258,16 @@
               }
             }
           },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "503": {
             "description": "Service Unavailable",
             "content": {

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/GeoImportacoesController.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/GeoImportacoesController.cs
@@ -61,6 +61,7 @@ public sealed class GeoImportacoesController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> Disparar(
         [FromBody] DispararImportacaoRequest request,
@@ -82,8 +83,11 @@ public sealed class GeoImportacoesController : ControllerBase
         ImportacaoGeoDto? dto = await _servico.ObterAsync(resultado.Value, cancellationToken).ConfigureAwait(false);
         if (dto is null)
         {
-            // A execução acabou de ser registrada; ausência aqui seria um erro interno.
-            return Accepted();
+            // A execução acabou de ser registrada (mesmo contexto); não recuperá-la é uma
+            // inconsistência interna — 500 explícito, não um 202 degradado sem corpo/Location.
+            return Problem(
+                title: "Falha ao recuperar a execução recém-registrada.",
+                statusCode: StatusCodes.Status500InternalServerError);
         }
 
         ImportacaoGeoDto comLinks = dto with { Links = _linksBuilder.Build(dto) };

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/GeoImportacoesController.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/GeoImportacoesController.cs
@@ -1,0 +1,114 @@
+namespace Unifesspa.UniPlus.Geo.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Gatilho administrativo da atualização periódica do ETL DNE (Story #674), sob o
+/// prefixo <c>/api/admin/...</c> e restrito ao role <c>plataforma-admin</c>. Dispara uma
+/// carga (<c>202 Accepted</c>, execução em segundo plano) e expõe o acompanhamento. Um
+/// job externo (cron de infra) chama o disparo mensalmente — não há scheduler embutido.
+/// </summary>
+/// <remarks>
+/// Não usa <c>Idempotency-Key</c> (ADR-0027): a proteção contra disparos duplicados é o
+/// lock de concorrência (índice único parcial → <c>409</c> enquanto há carga em
+/// andamento) e a idempotência de fundo vem do upsert por chave natural do ETL.
+/// </remarks>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class GeoImportacoesController : ControllerBase
+{
+    private readonly IGeoImportacaoService _servico;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<ImportacaoGeoDto> _linksBuilder;
+    private readonly IUserContext _userContext;
+
+    public GeoImportacoesController(
+        IGeoImportacaoService servico,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<ImportacaoGeoDto> linksBuilder,
+        IUserContext userContext)
+    {
+        _servico = servico;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+        _userContext = userContext;
+    }
+
+    /// <summary>
+    /// Dispara a importação de uma versão (AAAAMM) do dataset DNE. Restrito a
+    /// <c>plataforma-admin</c>. Retorna <c>202 Accepted</c> com link de acompanhamento;
+    /// <c>409</c> se já houver uma carga em andamento.
+    /// </summary>
+    [HttpPost("admin/geo/importacoes")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(typeof(ImportacaoGeoDto), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status503ServiceUnavailable)]
+    public async Task<IActionResult> Disparar(
+        [FromBody] DispararImportacaoRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        string disparadoPor = _userContext.UserId ?? "desconhecido";
+
+        Result<Guid> resultado = await _servico
+            .IniciarAsync(request.Versao, disparadoPor, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsFailure)
+        {
+            return resultado.ToActionResult(_mapper);
+        }
+
+        ImportacaoGeoDto? dto = await _servico.ObterAsync(resultado.Value, cancellationToken).ConfigureAwait(false);
+        if (dto is null)
+        {
+            // A execução acabou de ser registrada; ausência aqui seria um erro interno.
+            return Accepted();
+        }
+
+        ImportacaoGeoDto comLinks = dto with { Links = _linksBuilder.Build(dto) };
+        return AcceptedAtAction(nameof(Obter), routeValues: new { id = resultado.Value }, value: comLinks);
+    }
+
+    /// <summary>
+    /// Obtém o estado e o relatório de uma execução do ETL pelo Id. Restrito a
+    /// <c>plataforma-admin</c>.
+    /// </summary>
+    [HttpGet("admin/geo/importacoes/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(typeof(ImportacaoGeoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Obter(Guid id, CancellationToken cancellationToken)
+    {
+        ImportacaoGeoDto? dto = await _servico.ObterAsync(id, cancellationToken).ConfigureAwait(false);
+        if (dto is null)
+        {
+            return NotFound();
+        }
+
+        ImportacaoGeoDto comLinks = dto with { Links = _linksBuilder.Build(dto) };
+        return Ok(comLinks);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Errors/GeoDomainErrorRegistration.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Errors/GeoDomainErrorRegistration.cs
@@ -50,6 +50,12 @@ internal sealed class GeoDomainErrorRegistration : IDomainErrorRegistration
                 "uniplus.geo.importacao.nao_enfileirada",
                 "Não foi possível enfileirar a importação (serviço em desligamento)")),
 
+        new(GeoImportacaoErrorCodes.VersaoNaoProgressiva,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.geo.importacao.versao_nao_progressiva",
+                "A versão informada é anterior à última release já aplicada")),
+
         new(GeoImportacaoErrorCodes.TransicaoInvalida,
             new DomainErrorMapping(
                 StatusCodes.Status409Conflict,

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Errors/GeoDomainErrorRegistration.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Errors/GeoDomainErrorRegistration.cs
@@ -52,7 +52,7 @@ internal sealed class GeoDomainErrorRegistration : IDomainErrorRegistration
 
         new(GeoImportacaoErrorCodes.VersaoNaoProgressiva,
             new DomainErrorMapping(
-                StatusCodes.Status422UnprocessableEntity,
+                StatusCodes.Status409Conflict,
                 "uniplus.geo.importacao.versao_nao_progressiva",
                 "A versão informada é anterior à última release já aplicada")),
 

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Errors/GeoDomainErrorRegistration.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Errors/GeoDomainErrorRegistration.cs
@@ -2,12 +2,15 @@ namespace Unifesspa.UniPlus.Geo.API.Errors;
 
 using System.Diagnostics.CodeAnalysis;
 
+using Microsoft.AspNetCore.Http;
+
+using Unifesspa.UniPlus.Geo.Domain.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 
 /// <summary>
 /// Registry de mapeamentos de erros de domínio do módulo Geo para wire codes /
-/// status HTTP. Vazio em V1 — as entidades de localidade entram nas Stories de
-/// domínio/API com seus próprios códigos <c>uniplus.geo.*</c>.
+/// status HTTP. As entidades de localidade (reference data) não têm CRUD de usuário;
+/// os mapeamentos são do registro de execução do ETL (Story #674).
 /// </summary>
 [SuppressMessage(
     "Performance",
@@ -15,5 +18,42 @@ using Unifesspa.UniPlus.Infrastructure.Core.Errors;
     Justification = "Instanciada via IServiceProvider.AddSingleton<IDomainErrorRegistration, GeoDomainErrorRegistration>().")]
 internal sealed class GeoDomainErrorRegistration : IDomainErrorRegistration
 {
-    public IEnumerable<KeyValuePair<string, DomainErrorMapping>> GetMappings() => [];
+    public IEnumerable<KeyValuePair<string, DomainErrorMapping>> GetMappings() =>
+    [
+        new(GeoImportacaoErrorCodes.VersaoObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.geo.importacao.versao_obrigatoria",
+                "Versão do dataset é obrigatória")),
+
+        new(GeoImportacaoErrorCodes.VersaoFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.geo.importacao.versao_formato_invalido",
+                "Versão do dataset deve estar no formato AAAAMM")),
+
+        new(GeoImportacaoErrorCodes.DisparadoPorObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.geo.importacao.disparado_por_obrigatorio",
+                "A identificação de quem disparou a carga é obrigatória")),
+
+        new(GeoImportacaoErrorCodes.ImportacaoEmAndamento,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.geo.importacao.em_andamento",
+                "Já existe uma importação do Geo em andamento")),
+
+        new(GeoImportacaoErrorCodes.NaoEnfileirada,
+            new DomainErrorMapping(
+                StatusCodes.Status503ServiceUnavailable,
+                "uniplus.geo.importacao.nao_enfileirada",
+                "Não foi possível enfileirar a importação (serviço em desligamento)")),
+
+        new(GeoImportacaoErrorCodes.TransicaoInvalida,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.geo.importacao.transicao_invalida",
+                "Transição de estado da importação inválida")),
+    ];
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/ImportacaoGeoLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/ImportacaoGeoLinksBuilder.cs
@@ -1,0 +1,60 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="ImportacaoGeoDto"/>. Relação em V1: <c>self</c> (URI de acompanhamento da
+/// execução). Action links não aparecem aqui (ADR-0029).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<ImportacaoGeoDto>, ImportacaoGeoLinksBuilder>().")]
+internal sealed class ImportacaoGeoLinksBuilder : IResourceLinksBuilder<ImportacaoGeoDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public ImportacaoGeoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(ImportacaoGeoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controller = "GeoImportacoes";
+
+        string self = ResolverPath(httpContext, nameof(GeoImportacoesController.Obter), controller, new { id = dto.Id });
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
@@ -11,9 +11,12 @@ using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Infrastructure.Core.Smoke;
 using Unifesspa.UniPlus.Geo.API.Errors;
+using Unifesspa.UniPlus.Geo.API.Hateoas;
 using Unifesspa.UniPlus.Geo.Application;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
 using Unifesspa.UniPlus.Geo.Infrastructure;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -62,11 +65,21 @@ builder.Services.AdicionarObservabilidade(nomeServico, builder.Configuration, bu
 builder.Services.AddGeoApplication();
 builder.Services.AddGeoInfrastructure();
 
+// HATEOAS Level 1 (ADR-0029) do registro de execução do ETL (#674).
+builder.Services.AddSingleton<IResourceLinksBuilder<ImportacaoGeoDto>, ImportacaoGeoLinksBuilder>();
+
 // Migrations EF Core aplicadas no host StartAsync via IHostedService.
 // Registrado ANTES de UseWolverineOutboxCascading + AddWolverineMessaging
 // (invariante #419) — fitness MigrationBeforeWolverineRuntimeOrderTests cobre
 // os entry points com a regra.
 builder.Services.AddDbContextMigrationsOnStartup<GeoDbContext>();
+
+// Gatilhos hospedados do ETL periódico (#674): worker que executa as cargas
+// enfileiradas + seed de dev. Registrado APÓS as migrations de propósito — seed e
+// reconciliação do worker tocam o banco, que precisa já ter a tabela
+// geo_importacao_execucao (ServicesStartConcurrently=false ⇒ ordem de start = ordem
+// de registro). Mantém-se antes do Wolverine, coerente com o invariante de ordem.
+builder.Services.AddGeoEtlGatilhos(builder.Configuration, builder.Environment);
 
 // Wolverine como backbone CQRS/messaging (ADR-0003/0004/0005). Sem roteamento
 // específico em V1 — handlers de localidade entram nas Stories de API; o

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IGeoCepCacheInvalidador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IGeoCepCacheInvalidador.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+/// <summary>
+/// Invalida o cache local de lookup de CEP da própria API do Geo após uma recarga do
+/// ETL (Story #674, CA-05). A invalidação é por <strong>selo de versão</strong> (O(1)):
+/// grava-se a versão vigente numa única chave; o lookup (F4, #676) compõe a chave de
+/// cache com esse selo, de modo que entradas de versões antigas viram <em>miss</em> e
+/// expiram por TTL — sem varredura (<c>SCAN</c>/<c>KEYS</c>) do keyspace compartilhado
+/// e sem tocar cache de outro módulo. O consumo cross-módulo do Geo é por composição no
+/// cliente; não há reader cross-módulo que mantenha cache derivado a invalidar.
+/// </summary>
+public interface IGeoCepCacheInvalidador
+{
+    /// <summary>
+    /// Sela <paramref name="versaoVigente"/> (AAAAMM) como a versão corrente do lookup de
+    /// CEP. Best-effort: uma falha de cache não deve abortar a carga (que já concluiu).
+    /// </summary>
+    Task InvalidarAsync(string versaoVigente, CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IGeoImportacaoService.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IGeoImportacaoService.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Porta da API para o ETL de atualização periódica do Geo (Story #674). O ETL é um
+/// serviço transacional de Infrastructure (ADR-0092), não um command Wolverine — não
+/// há regra de negócio nem evento de domínio, é carga de reference data autoritativo.
+/// Esta porta expõe à borda apenas o <strong>disparo</strong> e o
+/// <strong>acompanhamento</strong>; a execução pesada roda em segundo plano.
+/// </summary>
+public interface IGeoImportacaoService
+{
+    /// <summary>
+    /// Registra uma carga da <paramref name="versao"/> (AAAAMM) no estado "em andamento"
+    /// e a enfileira para execução em segundo plano. Retorna o Id da execução para
+    /// acompanhamento. Falha com erro de conflito quando já há uma carga em andamento
+    /// (uma execução por vez), ou de validação quando a versão é inválida.
+    /// </summary>
+    /// <param name="versao">Release DNE no formato AAAAMM.</param>
+    /// <param name="disparadoPor">Subject do administrador, ou <c>seed</c> no boot de dev.</param>
+    Task<Result<Guid>> IniciarAsync(string versao, string disparadoPor, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Obtém o estado e o relatório de uma execução pelo Id, ou <see langword="null"/>
+    /// quando não existe.
+    /// </summary>
+    Task<ImportacaoGeoDto?> ObterAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IGeoImportacaoService.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IGeoImportacaoService.cs
@@ -5,8 +5,8 @@ using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Porta da API para o ETL de atualização periódica do Geo (Story #674). O ETL é um
-/// serviço transacional de Infrastructure (ADR-0092), não um command Wolverine — não
-/// há regra de negócio nem evento de domínio, é carga de reference data autoritativo.
+/// serviço de Infrastructure (ADR-0092), não um command Wolverine — não há regra de
+/// negócio nem evento de domínio, é carga de reference data autoritativo.
 /// Esta porta expõe à borda apenas o <strong>disparo</strong> e o
 /// <strong>acompanhamento</strong>; a execução pesada roda em segundo plano.
 /// </summary>

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/DispararImportacaoRequest.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/DispararImportacaoRequest.cs
@@ -1,0 +1,8 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Corpo da requisição para disparar uma carga do ETL DNE (Story #674):
+/// <c>POST /api/admin/geo/importacoes</c>. A versão é a release DNE no formato
+/// AAAAMM (ex.: <c>202602</c>) a ser aplicada.
+/// </summary>
+public sealed record DispararImportacaoRequest(string Versao);

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/ImportacaoGeoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/ImportacaoGeoDto.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP de uma execução do ETL DNE (Story #674). Devolvido pelo
+/// endpoint admin de acompanhamento (<c>GET /api/admin/geo/importacoes/{id}</c>);
+/// suporta HATEOAS Level 1 via <c>_links</c> (ADR-0029). Sem PII.
+/// </summary>
+public sealed record ImportacaoGeoDto(
+    Guid Id,
+    string VersaoDataset,
+    string Status,
+    DateTimeOffset IniciadoEm,
+    DateTimeOffset? ConcluidoEm,
+    string DisparadoPor,
+    string? Mensagem,
+    RelatorioImportacaoDto? Relatorio)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/RelatorioImportacaoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/RelatorioImportacaoDto.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Forma serializável do relatório de uma carga do ETL DNE (Story #674): é tanto o
+/// que se persiste em <c>geo_importacao_execucao.relatorio_json</c> quanto o que o
+/// endpoint admin devolve. <strong>Reference data público — nunca carrega PII.</strong>
+/// </summary>
+public sealed record RelatorioImportacaoDto(
+    string VersaoDataset,
+    int Lidos,
+    int Inseridos,
+    int Atualizados,
+    int Orfaos,
+    int Degradados,
+    IReadOnlyList<TabelaImportacaoDto> Tabelas);
+
+/// <summary>Contadores e amostras de divergência (sem PII) de uma tabela na carga.</summary>
+public sealed record TabelaImportacaoDto(
+    string Tabela,
+    int Lidos,
+    int Inseridos,
+    int Atualizados,
+    int IgnoradosSemChave,
+    int Orfaos,
+    int Duplicados,
+    int ParsesDegradados,
+    IReadOnlyList<string> Amostras);

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/GeoImportacaoExecucao.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/GeoImportacaoExecucao.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Geo.Domain.Entities;
 
+using System.Linq;
+
 using Unifesspa.UniPlus.Geo.Domain.Errors;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Results;
@@ -138,17 +140,9 @@ public sealed class GeoImportacaoExecucao : EntityBase
     // versões é lexicográfica (válida porque o comprimento é fixo).
     private static bool EhVersaoValida(string versao)
     {
-        if (versao.Length != 6)
+        if (versao.Length != 6 || !versao.All(char.IsAsciiDigit))
         {
             return false;
-        }
-
-        foreach (char c in versao)
-        {
-            if (!char.IsAsciiDigit(c))
-            {
-                return false;
-            }
         }
 
         int mes = ((versao[4] - '0') * 10) + (versao[5] - '0');

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/GeoImportacaoExecucao.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/GeoImportacaoExecucao.cs
@@ -1,0 +1,157 @@
+namespace Unifesspa.UniPlus.Geo.Domain.Entities;
+
+using Unifesspa.UniPlus.Geo.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Trilha de uma execução do ETL DNE (Story #674): qual versão (<c>AAAAMM</c>) foi
+/// carregada, quando, por quem e com qual resultado. É dado operacional do módulo
+/// (não reference data), <see cref="EntityBase"/> puro — sem soft-delete; cada
+/// carga é um fato append-only. O relatório por tabela (contadores, sem PII) é
+/// persistido como JSON ao concluir.
+/// </summary>
+/// <remarks>
+/// A concorrência (no máximo uma carga em andamento) é garantida no banco por um
+/// índice único parcial sobre <see cref="Status"/> = <see cref="StatusImportacao.EmAndamento"/>;
+/// o segundo disparo simultâneo colide na UNIQUE e vira <c>409 Conflict</c>.
+/// </remarks>
+public sealed class GeoImportacaoExecucao : EntityBase
+{
+    /// <summary>Release DNE (AAAAMM) que esta execução aplica.</summary>
+    public string VersaoDataset { get; private set; } = string.Empty;
+
+    /// <summary>Estado atual da carga.</summary>
+    public StatusImportacao Status { get; private set; }
+
+    /// <summary>Instante de início (relógio do orquestrador via <c>TimeProvider</c>).</summary>
+    public DateTimeOffset IniciadoEm { get; private set; }
+
+    /// <summary>Instante de término (conclusão ou falha); <see langword="null"/> enquanto em andamento.</summary>
+    public DateTimeOffset? ConcluidoEm { get; private set; }
+
+    /// <summary>Subject do administrador que disparou, ou <c>seed</c> no boot de desenvolvimento. Nunca PII de candidato.</summary>
+    public string DisparadoPor { get; private set; } = string.Empty;
+
+    /// <summary>Relatório por tabela (contadores, sem PII) serializado em JSON; preenchido ao terminar.</summary>
+    public string? RelatorioJson { get; private set; }
+
+    /// <summary>Resumo ou motivo da falha (sem PII).</summary>
+    public string? Mensagem { get; private set; }
+
+    // Construtor privado para materialização do EF Core.
+    private GeoImportacaoExecucao()
+    {
+    }
+
+    /// <summary>
+    /// Abre uma execução no estado <see cref="StatusImportacao.EmAndamento"/>. Valida o
+    /// formato da versão (AAAAMM) e a identificação do disparador antes de criar.
+    /// </summary>
+    /// <param name="versao">Release DNE no formato AAAAMM (6 dígitos, mês 01–12).</param>
+    /// <param name="disparadoPor">Subject do administrador ou <c>seed</c>.</param>
+    /// <param name="iniciadoEm">Instante de início (relógio injetado).</param>
+    public static Result<GeoImportacaoExecucao> Iniciar(string versao, string disparadoPor, DateTimeOffset iniciadoEm)
+    {
+        // Diferente das entidades reference data (criadas por ETL controlado), esta nasce de
+        // entrada da API — versão/disparador ausentes são erro de validação (→ 422), não de
+        // schema: null cai no IsNullOrWhiteSpace abaixo e vira Failure, sem lançar.
+        if (string.IsNullOrWhiteSpace(versao))
+        {
+            return Result<GeoImportacaoExecucao>.Failure(new DomainError(
+                GeoImportacaoErrorCodes.VersaoObrigatoria,
+                "Versão (AAAAMM) do dataset é obrigatória."));
+        }
+
+        string versaoNormalizada = versao.Trim();
+        if (!EhVersaoValida(versaoNormalizada))
+        {
+            return Result<GeoImportacaoExecucao>.Failure(new DomainError(
+                GeoImportacaoErrorCodes.VersaoFormatoInvalido,
+                "Versão do dataset deve estar no formato AAAAMM (6 dígitos, mês 01–12)."));
+        }
+
+        if (string.IsNullOrWhiteSpace(disparadoPor))
+        {
+            return Result<GeoImportacaoExecucao>.Failure(new DomainError(
+                GeoImportacaoErrorCodes.DisparadoPorObrigatorio,
+                "A identificação de quem disparou a carga é obrigatória."));
+        }
+
+        var execucao = new GeoImportacaoExecucao
+        {
+            VersaoDataset = versaoNormalizada,
+            DisparadoPor = disparadoPor.Trim(),
+            Status = StatusImportacao.EmAndamento,
+            IniciadoEm = iniciadoEm,
+        };
+
+        return Result<GeoImportacaoExecucao>.Success(execucao);
+    }
+
+    /// <summary>
+    /// Marca a execução como concluída com sucesso, gravando o relatório. Só é válido
+    /// a partir de <see cref="StatusImportacao.EmAndamento"/> (idempotência da transição).
+    /// </summary>
+    public Result Concluir(DateTimeOffset concluidoEm, string relatorioJson, string? mensagem)
+    {
+        ArgumentNullException.ThrowIfNull(relatorioJson);
+
+        if (Status != StatusImportacao.EmAndamento)
+        {
+            return TransicaoInvalida();
+        }
+
+        Status = StatusImportacao.Concluida;
+        ConcluidoEm = concluidoEm;
+        RelatorioJson = relatorioJson;
+        Mensagem = mensagem;
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Marca a execução como falha, registrando o motivo (sem PII) e, quando houver,
+    /// o relatório parcial. Só é válido a partir de <see cref="StatusImportacao.EmAndamento"/>.
+    /// </summary>
+    public Result Falhar(DateTimeOffset concluidoEm, string mensagem, string? relatorioJson = null)
+    {
+        ArgumentNullException.ThrowIfNull(mensagem);
+
+        if (Status != StatusImportacao.EmAndamento)
+        {
+            return TransicaoInvalida();
+        }
+
+        Status = StatusImportacao.Falhou;
+        ConcluidoEm = concluidoEm;
+        Mensagem = mensagem;
+        RelatorioJson = relatorioJson;
+        return Result.Success();
+    }
+
+    private static Result TransicaoInvalida() =>
+        Result.Failure(new DomainError(
+            GeoImportacaoErrorCodes.TransicaoInvalida,
+            "A execução não está em andamento; transição de estado inválida."));
+
+    // AAAAMM: 6 dígitos, ano qualquer, mês 01–12. A comparação de stale entre
+    // versões é lexicográfica (válida porque o comprimento é fixo).
+    private static bool EhVersaoValida(string versao)
+    {
+        if (versao.Length != 6)
+        {
+            return false;
+        }
+
+        foreach (char c in versao)
+        {
+            if (!char.IsAsciiDigit(c))
+            {
+                return false;
+            }
+        }
+
+        int mes = ((versao[4] - '0') * 10) + (versao[5] - '0');
+        return mes is >= 1 and <= 12;
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/StatusImportacao.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Entities/StatusImportacao.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Geo.Domain.Entities;
+
+/// <summary>
+/// Estado de uma execução do ETL DNE (Story #674). O valor inteiro é estável e
+/// faz parte do contrato de persistência: <see cref="EmAndamento"/> é
+/// <strong>0</strong> porque o índice único parcial de concorrência filtra por
+/// <c>status = 0</c> (no máximo uma carga em andamento) — não reordenar.
+/// </summary>
+public enum StatusImportacao
+{
+    /// <summary>Carga em curso. No máximo uma linha pode estar neste estado (índice único parcial).</summary>
+    EmAndamento = 0,
+
+    /// <summary>Carga concluída com sucesso; o relatório está persistido.</summary>
+    Concluida = 1,
+
+    /// <summary>Carga abortada por falha de infraestrutura ou abandonada por reinício do serviço.</summary>
+    Falhou = 2,
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Errors/GeoImportacaoErrorCodes.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Errors/GeoImportacaoErrorCodes.cs
@@ -22,6 +22,9 @@ public static class GeoImportacaoErrorCodes
     /// <summary>A carga foi registrada mas não pôde ser enfileirada (serviço em desligamento → 503).</summary>
     public const string NaoEnfileirada = "GeoImportacao.NaoEnfileirada";
 
+    /// <summary>Versão anterior à última já aplicada — aplicar rebaixaria os dados (→ 422).</summary>
+    public const string VersaoNaoProgressiva = "GeoImportacao.VersaoNaoProgressiva";
+
     /// <summary>Transição de estado inválida (ex.: concluir uma execução que não está em andamento).</summary>
     public const string TransicaoInvalida = "GeoImportacao.TransicaoInvalida";
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Domain/Errors/GeoImportacaoErrorCodes.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Domain/Errors/GeoImportacaoErrorCodes.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Geo.Domain.Errors;
+
+/// <summary>
+/// Códigos de erro de domínio do registro de execução do ETL DNE (Story #674).
+/// Seguem o padrão <c>{Entidade}.{Falha}</c> dos demais módulos; o mapeamento para
+/// status HTTP / wire code vive em <c>Geo.API/Errors/GeoDomainErrorRegistration</c>.
+/// </summary>
+public static class GeoImportacaoErrorCodes
+{
+    /// <summary>Versão (AAAAMM) do dataset não informada.</summary>
+    public const string VersaoObrigatoria = "GeoImportacao.VersaoObrigatoria";
+
+    /// <summary>Versão fora do formato AAAAMM (6 dígitos, mês 01–12).</summary>
+    public const string VersaoFormatoInvalido = "GeoImportacao.VersaoFormatoInvalido";
+
+    /// <summary>Identificação de quem disparou a carga ausente.</summary>
+    public const string DisparadoPorObrigatorio = "GeoImportacao.DisparadoPorObrigatorio";
+
+    /// <summary>Já existe uma carga em andamento — uma execução por vez (concorrência → 409).</summary>
+    public const string ImportacaoEmAndamento = "GeoImportacao.ImportacaoEmAndamento";
+
+    /// <summary>A carga foi registrada mas não pôde ser enfileirada (serviço em desligamento → 503).</summary>
+    public const string NaoEnfileirada = "GeoImportacao.NaoEnfileirada";
+
+    /// <summary>Transição de estado inválida (ex.: concluir uma execução que não está em andamento).</summary>
+    public const string TransicaoInvalida = "GeoImportacao.TransicaoInvalida";
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Caching/RedisGeoCepCacheInvalidador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Caching/RedisGeoCepCacheInvalidador.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Caching;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+
+/// <summary>
+/// Invalida o cache local de lookup de CEP por <strong>selo de versão</strong> (Story
+/// #674, CA-05): grava a versão vigente numa única chave (<see cref="ChaveSeloVersaoVigente"/>).
+/// O lookup de CEP (F4, #676) compõe a chave de cache com esse selo; trocar o selo torna
+/// todas as entradas de versões anteriores um <em>miss</em> (recomputadas do banco já na
+/// nova versão), que expiram por TTL. É O(1) e não varre o keyspace (<c>SCAN</c>/<c>KEYS</c>
+/// são proibidos em produção — o Redis é compartilhado entre módulos) nem toca cache de
+/// outro módulo.
+/// </summary>
+internal sealed partial class RedisGeoCepCacheInvalidador : IGeoCepCacheInvalidador
+{
+    /// <summary>Chave do selo de versão vigente do lookup de CEP. O reader (F4) compõe suas chaves com este selo.</summary>
+    public const string ChaveSeloVersaoVigente = "geo:cep:versao-vigente";
+
+    private readonly ICacheService _cache;
+    private readonly ILogger<RedisGeoCepCacheInvalidador> _logger;
+
+    public RedisGeoCepCacheInvalidador(ICacheService cache, ILogger<RedisGeoCepCacheInvalidador> logger)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(logger);
+        _cache = cache;
+        _logger = logger;
+    }
+
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Invalidação best-effort: a carga já concluiu; qualquer falha de cache (Redis fora, timeout) degrada o lookup para leitura do banco, não pode falhar a carga.")]
+    public async Task InvalidarAsync(string versaoVigente, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(versaoVigente);
+
+        try
+        {
+            await _cache.DefinirAsync(ChaveSeloVersaoVigente, versaoVigente, expiracao: null, cancellationToken).ConfigureAwait(false);
+            LogSeloAtualizado(_logger, versaoVigente);
+        }
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
+        {
+            LogFalhaSelo(_logger, versaoVigente, excecao);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Geo: selo de versão vigente do cache de CEP atualizado para {Versao}.")]
+    private static partial void LogSeloAtualizado(ILogger logger, string versao);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Geo: falha ao selar versão vigente {Versao} no cache de CEP (best-effort; lookup degrada para o banco).")]
+    private static partial void LogFalhaSelo(ILogger logger, string versao, Exception excecao);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -1,12 +1,18 @@
 namespace Unifesspa.UniPlus.Geo.Infrastructure;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Infrastructure.Caching;
+using Unifesspa.UniPlus.Geo.Infrastructure.Observability;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
@@ -45,6 +51,53 @@ public static class GeoInfrastructureRegistration
         services.AddScoped<GeoImportadorDistritoBairro>();
         services.AddScoped<LogradouroCopyImporter>();
         services.AddScoped<IGeoImportadorLocalidades, GeoImportadorLocalidades>();
+
+        // Atualização periódica (#674): orquestrador (uma instância scoped por escopo,
+        // exposta às duas portas — API e worker), fila in-process, fonte por versão,
+        // invalidação do cache de CEP por selo de versão e métricas do ETL.
+        services.AddScoped<GeoEtlOrquestrador>();
+        services.AddScoped<IGeoImportacaoService>(sp => sp.GetRequiredService<GeoEtlOrquestrador>());
+        services.AddScoped<IGeoImportacaoExecutor>(sp => sp.GetRequiredService<GeoEtlOrquestrador>());
+        services.AddSingleton<IGeoImportacaoFila, GeoImportacaoFila>();
+        services.AddSingleton<IGeoFonteDadosFactory, DneStagingFonteFactory>();
+        services.AddScoped<IGeoCepCacheInvalidador, RedisGeoCepCacheInvalidador>();
+        services.AddSingleton<GeoEtlMetrics>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registra os gatilhos hospedados do ETL (#674): o <c>BackgroundService</c> que
+    /// executa as cargas enfileiradas e o seed de desenvolvimento. <strong>Deve ser
+    /// chamado no Program APÓS <c>AddDbContextMigrationsOnStartup&lt;GeoDbContext&gt;()</c></strong>
+    /// — como <c>HostOptions.ServicesStartConcurrently</c> é <see langword="false"/>, a
+    /// ordem de registro é a ordem de start, e tanto o seed quanto a reconciliação do
+    /// worker tocam o banco (a tabela precisa já existir).
+    /// </summary>
+    public static IServiceCollection AddGeoEtlGatilhos(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        services.AddOptions<EtlOpcoes>().Bind(configuration.GetSection(EtlOpcoes.SectionName));
+
+        EtlOpcoes opcoes = configuration.GetSection(EtlOpcoes.SectionName).Get<EtlOpcoes>() ?? new EtlOpcoes();
+
+        if (opcoes.WorkerHabilitado)
+        {
+            services.AddHostedService<GeoImportacaoBackgroundService>();
+        }
+
+        // Seed só em Development e com a flag ligada (default off) — os testes rodam como
+        // Development mas não ligam a flag, então nunca semeiam.
+        if (environment.IsDevelopment() && opcoes.SeedHabilitado)
+        {
+            services.AddHostedService<GeoSeedHostedService>();
+        }
 
         return services;
     }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -61,6 +61,9 @@ public static class GeoInfrastructureRegistration
         services.AddSingleton<IGeoImportacaoFila, GeoImportacaoFila>();
         services.AddSingleton<IGeoFonteDadosFactory, DneStagingFonteFactory>();
         services.AddScoped<IGeoCepCacheInvalidador, RedisGeoCepCacheInvalidador>();
+        // Lazy para o orquestrador: difere a resolução da cadeia Redis (IConnectionMultiplexer
+        // conecta na construção) até o momento de selar — só no worker, nunca no disparo.
+        services.AddScoped(sp => new Lazy<IGeoCepCacheInvalidador>(sp.GetRequiredService<IGeoCepCacheInvalidador>));
         services.AddSingleton<GeoEtlMetrics>();
 
         return services;

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Observability/GeoEtlMetrics.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Observability/GeoEtlMetrics.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Observability;
+
+using System.Diagnostics.Metrics;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Observability;
+
+/// <summary>
+/// Métricas OpenTelemetry da carga do ETL DNE (Story #674, CA-07). O <see cref="Meter"/>
+/// usa o nome canônico do serviço (<see cref="UniPlusServiceNames.Geo"/>), já coletado
+/// por <c>AdicionarObservabilidade</c> via <c>AddMeter(nomeServico)</c> — sem registro
+/// extra no Program. Sem PII (reference data público); as tags são versão e status.
+/// </summary>
+internal sealed class GeoEtlMetrics : IDisposable
+{
+    private readonly Meter _meter;
+    private readonly Histogram<double> _duracao;
+    private readonly Counter<long> _linhas;
+    private readonly Counter<long> _degradados;
+    private readonly Counter<long> _execucoes;
+
+    public GeoEtlMetrics()
+    {
+        _meter = new Meter(UniPlusServiceNames.Geo);
+        _duracao = _meter.CreateHistogram<double>("geo.etl.duracao", unit: "ms", description: "Duração da carga do ETL DNE.");
+        _linhas = _meter.CreateCounter<long>("geo.etl.linhas", unit: "{linha}", description: "Linhas inseridas + atualizadas pela carga.");
+        _degradados = _meter.CreateCounter<long>("geo.etl.degradados", unit: "{linha}", description: "Valores externos degradados para null no parse tolerante.");
+        _execucoes = _meter.CreateCounter<long>("geo.etl.execucoes", unit: "{execucao}", description: "Execuções do ETL por status.");
+    }
+
+    /// <summary>Registra uma carga concluída com sucesso.</summary>
+    public void RegistrarConclusao(string versao, double duracaoMs, long linhas, long degradados)
+    {
+        KeyValuePair<string, object?> tagVersao = new("versao", versao);
+        KeyValuePair<string, object?> tagStatus = new("status", "concluida");
+        _duracao.Record(duracaoMs, tagVersao, tagStatus);
+        _linhas.Add(linhas, tagVersao);
+        _degradados.Add(degradados, tagVersao);
+        _execucoes.Add(1, tagVersao, tagStatus);
+    }
+
+    /// <summary>Registra uma carga que falhou.</summary>
+    public void RegistrarFalha(string versao, double duracaoMs)
+    {
+        KeyValuePair<string, object?> tagVersao = new("versao", versao);
+        KeyValuePair<string, object?> tagStatus = new("status", "falhou");
+        _duracao.Record(duracaoMs, tagVersao, tagStatus);
+        _execucoes.Add(1, tagVersao, tagStatus);
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/GeoImportacaoExecucaoConfiguration.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/GeoImportacaoExecucaoConfiguration.cs
@@ -1,0 +1,48 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Configurations;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+/// <summary>
+/// Mapeamento do registro de execução do ETL DNE (Story #674). O destaque é o índice
+/// único parcial que garante <strong>no máximo uma</strong> execução em andamento
+/// (concorrência → 409): UNIQUE sobre <c>status</c> filtrado por <c>status = 0</c>
+/// (<see cref="StatusImportacao.EmAndamento"/>) — por isso o enum não pode ser reordenado.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflexão.")]
+internal sealed class GeoImportacaoExecucaoConfiguration : IEntityTypeConfiguration<GeoImportacaoExecucao>
+{
+    public void Configure(EntityTypeBuilder<GeoImportacaoExecucao> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("geo_importacao_execucao");
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.VersaoDataset).HasMaxLength(20).IsRequired();
+        builder.Property(e => e.Status).IsRequired();
+        builder.Property(e => e.IniciadoEm).IsRequired();
+        builder.Property(e => e.DisparadoPor).HasMaxLength(200).IsRequired();
+        builder.Property(e => e.RelatorioJson).HasColumnType("jsonb");
+        builder.Property(e => e.Mensagem).HasMaxLength(1000);
+
+        // Concorrência (CA-06): no máximo uma execução em andamento. UNIQUE parcial sobre
+        // status filtrado por status = 0 (EmAndamento) — entre as linhas EmAndamento o valor
+        // de status é constante (0), então só uma pode existir. O segundo disparo colide na
+        // UNIQUE (23505) e vira 409. O valor 0 do enum é parte do contrato (não reordenar).
+        builder.HasIndex(e => e.Status)
+            .IsUnique()
+            .HasFilter("status = 0")
+            .HasDatabaseName("ux_geo_importacao_execucao_em_andamento");
+
+        builder.HasIndex(e => e.IniciadoEm)
+            .HasDatabaseName("ix_geo_importacao_execucao_iniciado_em");
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/EtlOpcoes.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/EtlOpcoes.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+/// <summary>
+/// Configuração do ETL de atualização periódica do Geo (Story #674), seção
+/// <c>Geo:Etl</c>. Os defaults são seguros para produção/teste: o worker fica ligado
+/// (consome disparos do endpoint admin) e o seed de desenvolvimento fica
+/// <strong>desligado</strong> — só a compose de dev o liga, garantindo que os testes
+/// (que rodam como <c>Development</c>) nunca semeiem.
+/// </summary>
+public sealed class EtlOpcoes
+{
+    /// <summary>Caminho da seção de configuração.</summary>
+    public const string SectionName = "Geo:Etl";
+
+    /// <summary>
+    /// Liga o <c>BackgroundService</c> que consome a fila e executa as cargas. Default
+    /// <see langword="true"/> — manter ligado em produção: com ele desligado, o endpoint ainda
+    /// registra a execução <c>EmAndamento</c> e responde <c>202</c>, mas nada a consome, e ela
+    /// bloqueia novos disparos por <c>409</c> até a reconciliação por idade. Só desligar em
+    /// teste (determinismo de 202/409) ou janela de manutenção controlada.
+    /// </summary>
+    public bool WorkerHabilitado { get; set; } = true;
+
+    /// <summary>Liga o seed automático no boot de desenvolvimento (base vazia). Default <see langword="false"/>.</summary>
+    public bool SeedHabilitado { get; set; }
+
+    /// <summary>Versão (AAAAMM) do dataset usada pelo seed de desenvolvimento.</summary>
+    public string VersaoSeed { get; set; } = "202601";
+
+    /// <summary>Schema de staging onde os dumps DNE são restaurados (lido pela <c>DneStagingFonte</c>).</summary>
+    public string StagingSchema { get; set; } = "dne_staging";
+
+    /// <summary>
+    /// Idade a partir da qual uma execução <c>EmAndamento</c> é considerada abandonada
+    /// (crash/restart) e reconciliada como falha no startup do worker. O limite folgado
+    /// (default 6h, &gt;&gt; a duração esperada de uma carga) evita que, num rolling deploy
+    /// multi-réplica, uma instância nova marque como falha uma carga ainda ativa em outra
+    /// — a reconciliação só toca execuções antigas o bastante para serem seguramente órfãs.
+    /// </summary>
+    public TimeSpan LimiteAbandono { get; set; } = TimeSpan.FromHours(6);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/DneStagingFonteFactory.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/DneStagingFonteFactory.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// <see cref="IGeoFonteDadosFactory"/> de produção: constrói uma <see cref="DneStagingFonte"/>
+/// sobre o banco do Geo (schema de staging configurável). A connection string vem da
+/// <c>ConnectionStrings:GeoDb</c> — <strong>nunca</strong> de
+/// <c>DbContext.Database.GetConnectionString()</c>, que o Npgsql devolve sem a senha após
+/// a primeira abertura (lição da Story #673).
+/// </summary>
+internal sealed class DneStagingFonteFactory : IGeoFonteDadosFactory
+{
+    private readonly string _connectionString;
+    private readonly string _schema;
+
+    public DneStagingFonteFactory(IConfiguration configuration, IOptions<EtlOpcoes> opcoes)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(opcoes);
+
+        _connectionString = configuration.GetConnectionString("GeoDb")
+            ?? throw new InvalidOperationException(
+                "ConnectionStrings:GeoDb não configurada — necessária para o ETL DNE do Geo.");
+        _schema = opcoes.Value.StagingSchema;
+    }
+
+    public IGeoFonteDados Criar(string versao) => new DneStagingFonte(_connectionString, versao, _schema);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/IGeoFonteDadosFactory.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/Fonte/IGeoFonteDadosFactory.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+
+/// <summary>
+/// Cria a <see cref="IGeoFonteDados"/> de uma versão (AAAAMM) sob demanda. Desacopla o
+/// orquestrador (#674) de como a fonte é construída: em produção/dev resolve a
+/// <see cref="DneStagingFonte"/> a partir do schema de staging; em teste, uma fonte em
+/// memória.
+/// </summary>
+internal interface IGeoFonteDadosFactory
+{
+    /// <summary>Cria a fonte do dataset DNE da <paramref name="versao"/> informada.</summary>
+    IGeoFonteDados Criar(string versao);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -212,6 +212,20 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
             RelatorioImportacao relTopo = await _importadorTopo.ImportarAsync(fonte, cancellationToken).ConfigureAwait(false);
             RelatorioImportacao relFolhas = await _importadorFolhas.ImportarAsync(fonte, modo, cancellationToken).ConfigureAwait(false);
 
+            // Guarda de release vazia/sem âncora: se a topo não persistiu nenhuma cidade
+            // (staging não restaurado, sem o país-âncora BRA, ou sem cidades), prosseguir numa
+            // recarga marcaria TODA a base existente como vigente=false e selaria uma versão
+            // vazia, reportando sucesso. Falha explícita antes de qualquer stale/conclusão — os
+            // importadores não commitaram nada, então a base permanece intacta.
+            ContadorTabela cidade = relTopo.Tabela("cidade");
+            if (cidade.Inseridos + cidade.Atualizados == 0)
+            {
+                await MarcarFalhaAsync(execucao, "Release vazia ou sem âncora (BRA/cidades) — carga recusada.", CancellationToken.None).ConfigureAwait(false);
+                _metricas.RegistrarFalha(versao, _relogio.GetElapsedTime(inicio).TotalMilliseconds);
+                LogReleaseVazia(_logger, execucaoId, versao);
+                return;
+            }
+
             // A partir daqui os importadores já commitaram os dados — a finalização (stale +
             // conclusão + selo) roda com CancellationToken.None para deixar um estado terminal
             // consistente: um cancelamento de shutdown não pode gravar Concluída sem selar o
@@ -430,6 +444,9 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: carga {ExecucaoId} interrompida por cancelamento/desligamento (versão {Versao}).")]
     private static partial void LogCancelada(ILogger logger, Guid execucaoId, string versao);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: carga {ExecucaoId} recusada — release {Versao} vazia ou sem âncora (nenhuma cidade aplicada).")]
+    private static partial void LogReleaseVazia(ILogger logger, Guid execucaoId, string versao);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: falha ao selar a versão vigente {Versao} no cache (best-effort; carga já concluída).")]
     private static partial void LogFalhaSeloCache(ILogger logger, string versao, Exception excecao);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -210,13 +210,13 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
             IGeoFonteDados fonte = _fonteFactory.Criar(versao);
 
             RelatorioImportacao relTopo = await _importadorTopo.ImportarAsync(fonte, cancellationToken).ConfigureAwait(false);
-            RelatorioImportacao relFolhas = await _importadorFolhas.ImportarAsync(fonte, modo, cancellationToken).ConfigureAwait(false);
 
-            // Guarda de release vazia/sem âncora: se a topo não persistiu nenhuma cidade
-            // (staging não restaurado, sem o país-âncora BRA, ou sem cidades), prosseguir numa
-            // recarga marcaria TODA a base existente como vigente=false e selaria uma versão
-            // vazia, reportando sucesso. Falha explícita antes de qualquer stale/conclusão — os
-            // importadores não commitaram nada, então a base permanece intacta.
+            // Guarda de release vazia/sem âncora — ANTES das folhas: se a topo não persistiu
+            // nenhuma cidade (staging não restaurado, sem o país-âncora BRA, ou sem cidades),
+            // abortar já. Rodar as folhas marcaria logradouros/complementos com a nova versão
+            // (resolvendo cidade_id pelas cidades existentes) e a recarga marcaria TODA a base
+            // existente como vigente=false, selando uma versão vazia. A topo é transação única;
+            // com zero cidades ela não publicou release, então a base permanece intacta.
             ContadorTabela cidade = relTopo.Tabela("cidade");
             if (cidade.Inseridos + cidade.Atualizados == 0)
             {
@@ -225,6 +225,8 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
                 LogReleaseVazia(_logger, execucaoId, versao);
                 return;
             }
+
+            RelatorioImportacao relFolhas = await _importadorFolhas.ImportarAsync(fonte, modo, cancellationToken).ConfigureAwait(false);
 
             // A partir daqui os importadores já commitaram os dados — a finalização (stale +
             // conclusão + selo) roda com CancellationToken.None para deixar um estado terminal

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -228,6 +228,20 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
 
             RelatorioImportacao relFolhas = await _importadorFolhas.ImportarAsync(fonte, modo, cancellationToken).ConfigureAwait(false);
 
+            // Guarda de folhas vazias — antes do stale: se nenhum logradouro foi aplicado, o
+            // dump das tabelas-folha (CEP/logradouro) está incompleto. Numa recarga, o stale
+            // marcaria TODOS os logradouros existentes vigente=false, quebrando o lookup de CEP
+            // (o coração do módulo) até um rerun. DNE sempre traz logradouros; zero = dump
+            // corrompido — falha antes de qualquer stale/conclusão.
+            ContadorTabela logradouro = relFolhas.Tabela("logradouro");
+            if (logradouro.Inseridos + logradouro.Atualizados == 0)
+            {
+                await MarcarFalhaAsync(execucao, "Tabelas-folha (logradouro) vazias — carga recusada.", CancellationToken.None).ConfigureAwait(false);
+                _metricas.RegistrarFalha(versao, _relogio.GetElapsedTime(inicio).TotalMilliseconds);
+                LogFolhasVazias(_logger, execucaoId, versao);
+                return;
+            }
+
             // A partir daqui os importadores já commitaram os dados — a finalização (stale +
             // conclusão + selo) roda com CancellationToken.None para deixar um estado terminal
             // consistente: um cancelamento de shutdown não pode gravar Concluída sem selar o
@@ -449,6 +463,9 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
 
     [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: carga {ExecucaoId} recusada — release {Versao} vazia ou sem âncora (nenhuma cidade aplicada).")]
     private static partial void LogReleaseVazia(ILogger logger, Guid execucaoId, string versao);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: carga {ExecucaoId} recusada — release {Versao} com tabelas-folha vazias (nenhum logradouro aplicado).")]
+    private static partial void LogFolhasVazias(ILogger logger, Guid execucaoId, string versao);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: falha ao selar a versão vigente {Versao} no cache (best-effort; carga já concluída).")]
     private static partial void LogFalhaSeloCache(ILogger logger, string versao, Exception excecao);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -22,11 +22,29 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// garante uma carga por vez (índice único parcial → 409), executa os importadores de
 /// topo (#672) e folhas (#673) em segundo plano, aplica a política de stale na recarga,
 /// sela a versão vigente do cache de CEP e persiste status + relatório (sem PII). É
-/// serviço transacional de Infrastructure — não um command Wolverine (ADR-0092).
+/// serviço de Infrastructure — não um command Wolverine (ADR-0092).
 /// </summary>
+/// <remarks>
+/// O <strong>registro</strong> de execução é gravado de forma transacional, mas a
+/// <strong>carga</strong> não é atômica entre fases: topo, folhas (COPY com transação
+/// própria), os UPDATEs de stale (autocommit por tabela) e a conclusão commitam em
+/// separado. Um crash no meio deixa o dataset em estado parcial (versões mistas) — isso é
+/// <strong>tolerado por design</strong>: a carga é idempotente por reaplicação (upsert por
+/// chave natural), e a guarda de versão progressiva força reaplicar a mesma versão (ou mais
+/// nova) para reconciliar. Transação única sobre milhões de linhas seria impraticável.
+/// </remarks>
 internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoImportacaoExecutor
 {
     private const string PostgresUniqueViolation = "23505";
+
+    // Amostras de divergência já vêm limitadas da fonte (ContadorTabela); o cap aqui mantém
+    // o limite explícito e consistente ao montar (ParaDto) e mesclar (Somar) o DTO.
+    private const int MaxAmostrasPorTabela = 25;
+
+    // Formato do relatorio_json persistido: camelCase, alinhado ao wire format da API
+    // (ConfigureHttpJsonOptions) — round-trip consistente e jsonb consultável no mesmo padrão.
+    private static readonly JsonSerializerOptions RelatorioJsonOptions =
+        new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
     private readonly GeoDbContext _contexto;
     private readonly IGeoImportador _importadorTopo;
@@ -196,7 +214,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
             }
 
             RelatorioImportacaoDto relatorio = CombinarRelatorios(versao, relTopo, relFolhas);
-            string relatorioJson = JsonSerializer.Serialize(relatorio);
+            string relatorioJson = JsonSerializer.Serialize(relatorio, RelatorioJsonOptions);
             double duracaoMs = _relogio.GetElapsedTime(inicio).TotalMilliseconds;
 
             Result conclusao = execucao.Concluir(_relogio.GetUtcNow(), relatorioJson, ResumoConclusao(relatorio, modo));
@@ -282,7 +300,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
     {
         RelatorioImportacaoDto? relatorio = execucao.RelatorioJson is null
             ? null
-            : JsonSerializer.Deserialize<RelatorioImportacaoDto>(execucao.RelatorioJson);
+            : JsonSerializer.Deserialize<RelatorioImportacaoDto>(execucao.RelatorioJson, RelatorioJsonOptions);
 
         return new ImportacaoGeoDto(
             execucao.Id,
@@ -324,15 +342,15 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
     }
 
     private static TabelaImportacaoDto ParaDto(string nome, ContadorTabela c) =>
-        new(nome, c.Lidos, c.Inseridos, c.Atualizados, c.IgnoradosSemChave, c.Orfaos, c.Duplicados, c.ParsesDegradados, [.. c.Amostras]);
+        new(nome, c.Lidos, c.Inseridos, c.Atualizados, c.IgnoradosSemChave, c.Orfaos, c.Duplicados, c.ParsesDegradados,
+            [.. c.Amostras.Take(MaxAmostrasPorTabela)]);
 
     private static TabelaImportacaoDto Somar(TabelaImportacaoDto a, ContadorTabela c)
     {
-        const int MaxAmostras = 25;
         List<string> amostras = [.. a.Amostras];
         foreach (string amostra in c.Amostras)
         {
-            if (amostras.Count >= MaxAmostras)
+            if (amostras.Count >= MaxAmostrasPorTabela)
             {
                 break;
             }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -108,16 +108,23 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         // concluída — aplicá-la rebaixaria o versao_dataset das linhas presentes e misturaria
         // datasets (a política de stale pressupõe versões não-decrescentes). Reaplicar a mesma
         // versão é permitido (idempotente). Comparação ordinal == numérica para AAAAMM fixo.
-        // Considera Concluída E Falhou: uma carga que falhou numa versão mais nova pode ter
-        // commitado dados parciais (as folhas commitam em fases), então voltar a uma versão
-        // anterior misturaria datasets. Após uma falha, o caminho são é reaplicar a mesma
-        // versão (ou mais nova), nunca regredir.
-        string? ultimaAplicada = await _contexto.Set<GeoImportacaoExecucao>()
-            .Where(e => e.Status == StatusImportacao.Concluida || e.Status == StatusImportacao.Falhou)
-            .Select(e => e.VersaoDataset)
-            .OrderByDescending(v => v)
-            .FirstOrDefaultAsync(cancellationToken)
+        // Guarda de versão progressiva: recusa aplicar uma release anterior à mais nova já
+        // presente. O baseline vem de duas fontes para cobrir todos os casos:
+        //  - os próprios dados (max(versao_dataset) das cidades): cobre um deploy novo sobre
+        //    uma base já carregada (#672/#673) sem histórico de execução, e dados parciais de
+        //    uma carga que falhou após commitar (as folhas commitam em fases);
+        //  - o histórico de execuções terminais: cobre uma falha cujo topo deu rollback (sem
+        //    dado novo persistido), mas cuja versão já foi atentada.
+        // Reaplicar a mesma versão é permitido (idempotente). Comparação ordinal == numérica
+        // para AAAAMM de comprimento fixo.
+        string? versaoDados = await _contexto.Cidades
+            .MaxAsync(c => (string?)c.VersaoDataset, cancellationToken)
             .ConfigureAwait(false);
+        string? versaoHistorico = await _contexto.Set<GeoImportacaoExecucao>()
+            .Where(e => e.Status == StatusImportacao.Concluida || e.Status == StatusImportacao.Falhou)
+            .MaxAsync(e => (string?)e.VersaoDataset, cancellationToken)
+            .ConfigureAwait(false);
+        string? ultimaAplicada = MaiorVersao(versaoDados, versaoHistorico);
         if (ultimaAplicada is not null && string.CompareOrdinal(execucao.VersaoDataset, ultimaAplicada) < 0)
         {
             LogVersaoNaoProgressiva(_logger, execucao.VersaoDataset, ultimaAplicada);
@@ -153,7 +160,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         }
         catch (ChannelClosedException ex)
         {
-            await MarcarFalhaAsync(execucao, "Serviço em desligamento; carga não enfileirada.", relatorioJson: null, CancellationToken.None).ConfigureAwait(false);
+            await MarcarFalhaAsync(execucao, "Serviço em desligamento; carga não enfileirada.", CancellationToken.None).ConfigureAwait(false);
             LogNaoEnfileirada(_logger, execucao.Id, ex);
             return Result<Guid>.Failure(new DomainError(
                 GeoImportacaoErrorCodes.NaoEnfileirada,
@@ -178,8 +185,12 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
 
     public async Task ExecutarAsync(Guid execucaoId, CancellationToken cancellationToken)
     {
+        // Lookup inicial com None: um cancelamento de shutdown aqui não pode escapar antes do
+        // try (que marca a execução Falhou) — senão a linha ficaria EmAndamento bloqueando
+        // disparos até a reconciliação por idade. O cancelamento passa a ser observado no
+        // AnyAsync/importadores dentro do try.
         GeoImportacaoExecucao? execucao = await _contexto.Set<GeoImportacaoExecucao>()
-            .FirstOrDefaultAsync(e => e.Id == execucaoId, cancellationToken)
+            .FirstOrDefaultAsync(e => e.Id == execucaoId, CancellationToken.None)
             .ConfigureAwait(false);
 
         if (execucao is null || execucao.Status != StatusImportacao.EmAndamento)
@@ -239,7 +250,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
             // em vez de deixá-la EmAndamento bloqueando disparos até a reconciliação por idade.
             // Persiste com None (o token de operação já está cancelado) e repropaga para o worker
             // tratar o shutdown.
-            await MarcarFalhaAsync(execucao, "Carga interrompida (cancelamento/desligamento).", relatorioJson: null, CancellationToken.None).ConfigureAwait(false);
+            await MarcarFalhaAsync(execucao, "Carga interrompida (cancelamento/desligamento).", CancellationToken.None).ConfigureAwait(false);
             _metricas.RegistrarFalha(versao, _relogio.GetElapsedTime(inicio).TotalMilliseconds);
             LogCancelada(_logger, execucaoId, versao);
             throw;
@@ -248,7 +259,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         {
             double duracaoMs = _relogio.GetElapsedTime(inicio).TotalMilliseconds;
             // Mensagem genérica persistida (sem detalhe de infra/PII); a exceção vai ao log.
-            await MarcarFalhaAsync(execucao, "Falha na carga do ETL DNE.", relatorioJson: null, CancellationToken.None).ConfigureAwait(false);
+            await MarcarFalhaAsync(execucao, "Falha na carga do ETL DNE.", CancellationToken.None).ConfigureAwait(false);
             _metricas.RegistrarFalha(versao, duracaoMs);
             LogFalhou(_logger, execucaoId, versao, excecao);
         }
@@ -258,13 +269,26 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         "Design",
         "CA1031:Do not catch general exception types",
         Justification = "Persistir o estado de falha é best-effort à beira do worker; um erro aqui não pode escalar (a carga já terminou).")]
-    private async Task MarcarFalhaAsync(GeoImportacaoExecucao execucao, string mensagem, string? relatorioJson, CancellationToken cancellationToken)
+    private async Task MarcarFalhaAsync(GeoImportacaoExecucao execucao, string mensagem, CancellationToken cancellationToken)
     {
-        // Falhar é idempotente: se a execução já saiu de EmAndamento, retorna failure e nada muda.
-        execucao.Falhar(_relogio.GetUtcNow(), mensagem, relatorioJson);
+        // ExecuteUpdate direto, filtrando status = EmAndamento no banco — NÃO muta/flusha a
+        // entidade rastreada. Crítico quando o commit da conclusão falhou: a entidade está
+        // Concluída in-memory, mas a linha continua EmAndamento no banco; um SaveChanges aqui
+        // persistiria Concluída sem selar o cache. O filtro pelo estado real evita isso e é
+        // idempotente (0 linhas se a execução já não está EmAndamento).
+        DateTimeOffset agora = _relogio.GetUtcNow();
         try
         {
-            await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _contexto.Set<GeoImportacaoExecucao>()
+                .Where(e => e.Id == execucao.Id && e.Status == StatusImportacao.EmAndamento)
+                .ExecuteUpdateAsync(
+                    s => s
+                        .SetProperty(e => e.Status, StatusImportacao.Falhou)
+                        .SetProperty(e => e.ConcluidoEm, agora)
+                        .SetProperty(e => e.Mensagem, mensagem)
+                        .SetProperty(e => e.UpdatedAt, agora),
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (Exception excecao) when (excecao is not OperationCanceledException)
         {
@@ -291,6 +315,22 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         {
             LogFalhaSeloCache(_logger, versao, excecao);
         }
+    }
+
+    // Maior das duas versões AAAAMM (ordinal == numérica), tolerando nulos.
+    private static string? MaiorVersao(string? a, string? b)
+    {
+        if (a is null)
+        {
+            return b;
+        }
+
+        if (b is null)
+        {
+            return a;
+        }
+
+        return string.CompareOrdinal(a, b) >= 0 ? a : b;
     }
 
     private static bool EhViolacaoUnica(DbUpdateException ex) =>

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -90,18 +90,22 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         // concluída — aplicá-la rebaixaria o versao_dataset das linhas presentes e misturaria
         // datasets (a política de stale pressupõe versões não-decrescentes). Reaplicar a mesma
         // versão é permitido (idempotente). Comparação ordinal == numérica para AAAAMM fixo.
-        string? ultimaConcluida = await _contexto.Set<GeoImportacaoExecucao>()
-            .Where(e => e.Status == StatusImportacao.Concluida)
+        // Considera Concluída E Falhou: uma carga que falhou numa versão mais nova pode ter
+        // commitado dados parciais (as folhas commitam em fases), então voltar a uma versão
+        // anterior misturaria datasets. Após uma falha, o caminho são é reaplicar a mesma
+        // versão (ou mais nova), nunca regredir.
+        string? ultimaAplicada = await _contexto.Set<GeoImportacaoExecucao>()
+            .Where(e => e.Status == StatusImportacao.Concluida || e.Status == StatusImportacao.Falhou)
             .Select(e => e.VersaoDataset)
             .OrderByDescending(v => v)
             .FirstOrDefaultAsync(cancellationToken)
             .ConfigureAwait(false);
-        if (ultimaConcluida is not null && string.CompareOrdinal(execucao.VersaoDataset, ultimaConcluida) < 0)
+        if (ultimaAplicada is not null && string.CompareOrdinal(execucao.VersaoDataset, ultimaAplicada) < 0)
         {
-            LogVersaoNaoProgressiva(_logger, execucao.VersaoDataset, ultimaConcluida);
+            LogVersaoNaoProgressiva(_logger, execucao.VersaoDataset, ultimaAplicada);
             return Result<Guid>.Failure(new DomainError(
                 GeoImportacaoErrorCodes.VersaoNaoProgressiva,
-                $"A versão {execucao.VersaoDataset} é anterior à última aplicada ({ultimaConcluida})."));
+                $"A versão {execucao.VersaoDataset} é anterior à última aplicada ({ultimaAplicada})."));
         }
 
         _contexto.Set<GeoImportacaoExecucao>().Add(execucao);
@@ -179,11 +183,16 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
             RelatorioImportacao relTopo = await _importadorTopo.ImportarAsync(fonte, cancellationToken).ConfigureAwait(false);
             RelatorioImportacao relFolhas = await _importadorFolhas.ImportarAsync(fonte, modo, cancellationToken).ConfigureAwait(false);
 
+            // A partir daqui os importadores já commitaram os dados — a finalização (stale +
+            // conclusão + selo) roda com CancellationToken.None para deixar um estado terminal
+            // consistente: um cancelamento de shutdown não pode gravar Concluída sem selar o
+            // cache nem interromper a marcação de stale no meio.
+
             // Política de stale: só na recarga (a inicial parte de base vazia). Marca
             // vigente=false nas linhas não revistas nesta versão (versao_dataset anterior).
             if (modo == ModoCarga.Recarga)
             {
-                await GeoStaleMarker.MarcarStaleAsync(_contexto, versao, _relogio.GetUtcNow(), cancellationToken).ConfigureAwait(false);
+                await GeoStaleMarker.MarcarStaleAsync(_contexto, versao, _relogio.GetUtcNow(), CancellationToken.None).ConfigureAwait(false);
             }
 
             RelatorioImportacaoDto relatorio = CombinarRelatorios(versao, relTopo, relFolhas);
@@ -196,7 +205,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
                 LogTransicaoInesperada(_logger, execucaoId, conclusao.Error!.Code);
             }
 
-            await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _contexto.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
 
             // Só após a conclusão estar persistida: sela a versão vigente do cache de CEP,
             // de forma totalmente best-effort (ver SelarCacheVigenteAsync).
@@ -260,7 +269,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         {
             await _cacheInvalidador.Value.InvalidarAsync(versao, CancellationToken.None).ConfigureAwait(false);
         }
-        catch (Exception excecao)
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
         {
             LogFalhaSeloCache(_logger, versao, excecao);
         }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -1,0 +1,313 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Threading.Channels;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using Npgsql;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Domain.Errors;
+using Unifesspa.UniPlus.Geo.Infrastructure.Observability;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Orquestra a atualização periódica do ETL DNE (Story #674): regista o disparo,
+/// garante uma carga por vez (índice único parcial → 409), executa os importadores de
+/// topo (#672) e folhas (#673) em segundo plano, aplica a política de stale na recarga,
+/// sela a versão vigente do cache de CEP e persiste status + relatório (sem PII). É
+/// serviço transacional de Infrastructure — não um command Wolverine (ADR-0092).
+/// </summary>
+internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoImportacaoExecutor
+{
+    private const string PostgresUniqueViolation = "23505";
+
+    private readonly GeoDbContext _contexto;
+    private readonly IGeoImportador _importadorTopo;
+    private readonly IGeoImportadorLocalidades _importadorFolhas;
+    private readonly IGeoFonteDadosFactory _fonteFactory;
+    private readonly IGeoCepCacheInvalidador _cacheInvalidador;
+    private readonly IGeoImportacaoFila _fila;
+    private readonly GeoEtlMetrics _metricas;
+    private readonly TimeProvider _relogio;
+    private readonly ILogger<GeoEtlOrquestrador> _logger;
+
+    public GeoEtlOrquestrador(
+        GeoDbContext contexto,
+        IGeoImportador importadorTopo,
+        IGeoImportadorLocalidades importadorFolhas,
+        IGeoFonteDadosFactory fonteFactory,
+        IGeoCepCacheInvalidador cacheInvalidador,
+        IGeoImportacaoFila fila,
+        GeoEtlMetrics metricas,
+        TimeProvider relogio,
+        ILogger<GeoEtlOrquestrador> logger)
+    {
+        ArgumentNullException.ThrowIfNull(contexto);
+        ArgumentNullException.ThrowIfNull(importadorTopo);
+        ArgumentNullException.ThrowIfNull(importadorFolhas);
+        ArgumentNullException.ThrowIfNull(fonteFactory);
+        ArgumentNullException.ThrowIfNull(cacheInvalidador);
+        ArgumentNullException.ThrowIfNull(fila);
+        ArgumentNullException.ThrowIfNull(metricas);
+        ArgumentNullException.ThrowIfNull(relogio);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _contexto = contexto;
+        _importadorTopo = importadorTopo;
+        _importadorFolhas = importadorFolhas;
+        _fonteFactory = fonteFactory;
+        _cacheInvalidador = cacheInvalidador;
+        _fila = fila;
+        _metricas = metricas;
+        _relogio = relogio;
+        _logger = logger;
+    }
+
+    public async Task<Result<Guid>> IniciarAsync(string versao, string disparadoPor, CancellationToken cancellationToken)
+    {
+        Result<GeoImportacaoExecucao> criacao =
+            GeoImportacaoExecucao.Iniciar(versao, disparadoPor, _relogio.GetUtcNow());
+        if (criacao.IsFailure)
+        {
+            return Result<Guid>.Failure(criacao.Error!);
+        }
+
+        GeoImportacaoExecucao execucao = criacao.Value!;
+        _contexto.Set<GeoImportacaoExecucao>().Add(execucao);
+
+        try
+        {
+            await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (EhViolacaoUnica(ex))
+        {
+            // Índice único parcial (status = EmAndamento): já há uma carga em andamento.
+            // Mesmo tratamento do EfCoreIdempotencyStore — só 23505 vira conflito; demais
+            // DbUpdateException propagam como 5xx.
+            _contexto.Set<GeoImportacaoExecucao>().Entry(execucao).State = EntityState.Detached;
+            LogConflito(_logger, execucao.VersaoDataset);
+            return Result<Guid>.Failure(new DomainError(
+                GeoImportacaoErrorCodes.ImportacaoEmAndamento,
+                "Já existe uma importação do Geo em andamento."));
+        }
+
+        // Enfileira com CancellationToken.None: a linha já está persistida, então cancelar
+        // o request não pode deixar a execução órfã (registrada mas sem item na fila). Se o
+        // canal estiver fechado (serviço desligando), marca a execução como falha.
+        try
+        {
+            await _fila.EnfileirarAsync(execucao.Id, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (ChannelClosedException ex)
+        {
+            await MarcarFalhaAsync(execucao, "Serviço em desligamento; carga não enfileirada.", relatorioJson: null, CancellationToken.None).ConfigureAwait(false);
+            LogNaoEnfileirada(_logger, execucao.Id, ex);
+            return Result<Guid>.Failure(new DomainError(
+                GeoImportacaoErrorCodes.NaoEnfileirada,
+                "Não foi possível enfileirar a importação (serviço em desligamento)."));
+        }
+
+        // O subject do disparador fica no registro auditável (disparado_por), não no log
+        // estruturado — minimiza identificadores pessoais/operacionais em logs (CA-08).
+        LogDisparada(_logger, execucao.Id, execucao.VersaoDataset);
+        return Result<Guid>.Success(execucao.Id);
+    }
+
+    public async Task<ImportacaoGeoDto?> ObterAsync(Guid id, CancellationToken cancellationToken)
+    {
+        GeoImportacaoExecucao? execucao = await _contexto.Set<GeoImportacaoExecucao>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return execucao is null ? null : MapearDto(execucao);
+    }
+
+    public async Task ExecutarAsync(Guid execucaoId, CancellationToken cancellationToken)
+    {
+        GeoImportacaoExecucao? execucao = await _contexto.Set<GeoImportacaoExecucao>()
+            .FirstOrDefaultAsync(e => e.Id == execucaoId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (execucao is null || execucao.Status != StatusImportacao.EmAndamento)
+        {
+            LogExecucaoIgnorada(_logger, execucaoId);
+            return;
+        }
+
+        string versao = execucao.VersaoDataset;
+        long inicio = _relogio.GetTimestamp();
+
+        try
+        {
+            bool baseVazia = !await _contexto.Cidades.AnyAsync(cancellationToken).ConfigureAwait(false);
+            ModoCarga modo = baseVazia ? ModoCarga.Inicial : ModoCarga.Recarga;
+
+            IGeoFonteDados fonte = _fonteFactory.Criar(versao);
+
+            RelatorioImportacao relTopo = await _importadorTopo.ImportarAsync(fonte, cancellationToken).ConfigureAwait(false);
+            RelatorioImportacao relFolhas = await _importadorFolhas.ImportarAsync(fonte, modo, cancellationToken).ConfigureAwait(false);
+
+            // Política de stale: só na recarga (a inicial parte de base vazia). Marca
+            // vigente=false nas linhas não revistas nesta versão (versao_dataset anterior).
+            if (modo == ModoCarga.Recarga)
+            {
+                await GeoStaleMarker.MarcarStaleAsync(_contexto, versao, _relogio.GetUtcNow(), cancellationToken).ConfigureAwait(false);
+            }
+
+            RelatorioImportacaoDto relatorio = CombinarRelatorios(versao, relTopo, relFolhas);
+            string relatorioJson = JsonSerializer.Serialize(relatorio);
+            double duracaoMs = _relogio.GetElapsedTime(inicio).TotalMilliseconds;
+
+            Result conclusao = execucao.Concluir(_relogio.GetUtcNow(), relatorioJson, ResumoConclusao(relatorio, modo));
+            if (conclusao.IsFailure)
+            {
+                LogTransicaoInesperada(_logger, execucaoId, conclusao.Error!.Code);
+            }
+
+            await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // Só após a conclusão estar persistida: sela a versão vigente do cache de CEP
+            // (best-effort). Se o SaveChanges acima falhasse, o cache não apontaria para uma
+            // versão cuja execução não foi confirmada como Concluída.
+            await _cacheInvalidador.InvalidarAsync(versao, cancellationToken).ConfigureAwait(false);
+
+            _metricas.RegistrarConclusao(versao, duracaoMs, relatorio.Inseridos + relatorio.Atualizados, relatorio.Degradados);
+            LogConcluida(_logger, execucaoId, versao, relatorio.Inseridos, relatorio.Atualizados, relatorio.Degradados);
+        }
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
+        {
+            double duracaoMs = _relogio.GetElapsedTime(inicio).TotalMilliseconds;
+            // Mensagem genérica persistida (sem detalhe de infra/PII); a exceção vai ao log.
+            await MarcarFalhaAsync(execucao, "Falha na carga do ETL DNE.", relatorioJson: null, CancellationToken.None).ConfigureAwait(false);
+            _metricas.RegistrarFalha(versao, duracaoMs);
+            LogFalhou(_logger, execucaoId, versao, excecao);
+        }
+    }
+
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Persistir o estado de falha é best-effort à beira do worker; um erro aqui não pode escalar (a carga já terminou).")]
+    private async Task MarcarFalhaAsync(GeoImportacaoExecucao execucao, string mensagem, string? relatorioJson, CancellationToken cancellationToken)
+    {
+        // Falhar é idempotente: se a execução já saiu de EmAndamento, retorna failure e nada muda.
+        execucao.Falhar(_relogio.GetUtcNow(), mensagem, relatorioJson);
+        try
+        {
+            await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
+        {
+            LogFalhaPersistir(_logger, execucao.Id, excecao);
+        }
+    }
+
+    private static bool EhViolacaoUnica(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pg && pg.SqlState == PostgresUniqueViolation;
+
+    private static ImportacaoGeoDto MapearDto(GeoImportacaoExecucao execucao)
+    {
+        RelatorioImportacaoDto? relatorio = execucao.RelatorioJson is null
+            ? null
+            : JsonSerializer.Deserialize<RelatorioImportacaoDto>(execucao.RelatorioJson);
+
+        return new ImportacaoGeoDto(
+            execucao.Id,
+            execucao.VersaoDataset,
+            execucao.Status.ToString(),
+            execucao.IniciadoEm,
+            execucao.ConcluidoEm,
+            execucao.DisparadoPor,
+            execucao.Mensagem,
+            relatorio);
+    }
+
+    private static string ResumoConclusao(RelatorioImportacaoDto relatorio, ModoCarga modo) =>
+        $"Modo {modo}: {relatorio.Inseridos} inseridos, {relatorio.Atualizados} atualizados, " +
+        $"{relatorio.Orfaos} órfãos, {relatorio.Degradados} degradados.";
+
+    private static RelatorioImportacaoDto CombinarRelatorios(string versao, params RelatorioImportacao[] relatorios)
+    {
+        Dictionary<string, TabelaImportacaoDto> mapa = new(StringComparer.Ordinal);
+        foreach (RelatorioImportacao relatorio in relatorios)
+        {
+            foreach ((string nome, ContadorTabela contador) in relatorio.Tabelas)
+            {
+                mapa[nome] = mapa.TryGetValue(nome, out TabelaImportacaoDto? existente)
+                    ? Somar(existente, contador)
+                    : ParaDto(nome, contador);
+            }
+        }
+
+        List<TabelaImportacaoDto> tabelas = [.. mapa.Values.OrderBy(t => t.Tabela, StringComparer.Ordinal)];
+        return new RelatorioImportacaoDto(
+            versao,
+            tabelas.Sum(t => t.Lidos),
+            tabelas.Sum(t => t.Inseridos),
+            tabelas.Sum(t => t.Atualizados),
+            tabelas.Sum(t => t.Orfaos),
+            tabelas.Sum(t => t.ParsesDegradados),
+            tabelas);
+    }
+
+    private static TabelaImportacaoDto ParaDto(string nome, ContadorTabela c) =>
+        new(nome, c.Lidos, c.Inseridos, c.Atualizados, c.IgnoradosSemChave, c.Orfaos, c.Duplicados, c.ParsesDegradados, [.. c.Amostras]);
+
+    private static TabelaImportacaoDto Somar(TabelaImportacaoDto a, ContadorTabela c)
+    {
+        const int MaxAmostras = 25;
+        List<string> amostras = [.. a.Amostras];
+        foreach (string amostra in c.Amostras)
+        {
+            if (amostras.Count >= MaxAmostras)
+            {
+                break;
+            }
+
+            amostras.Add(amostra);
+        }
+
+        return new TabelaImportacaoDto(
+            a.Tabela,
+            a.Lidos + c.Lidos,
+            a.Inseridos + c.Inseridos,
+            a.Atualizados + c.Atualizados,
+            a.IgnoradosSemChave + c.IgnoradosSemChave,
+            a.Orfaos + c.Orfaos,
+            a.Duplicados + c.Duplicados,
+            a.ParsesDegradados + c.ParsesDegradados,
+            amostras);
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: carga {ExecucaoId} disparada (versão {Versao}).")]
+    private static partial void LogDisparada(ILogger logger, Guid execucaoId, string versao);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: disparo recusado (versão {Versao}) — já há uma carga em andamento.")]
+    private static partial void LogConflito(ILogger logger, string versao);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: execução {ExecucaoId} não enfileirada (serviço em desligamento).")]
+    private static partial void LogNaoEnfileirada(ILogger logger, Guid execucaoId, Exception excecao);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: execução {ExecucaoId} ignorada (inexistente ou já finalizada).")]
+    private static partial void LogExecucaoIgnorada(ILogger logger, Guid execucaoId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ETL Geo: carga {ExecucaoId} concluída (versão {Versao}, inseridos={Inseridos}, atualizados={Atualizados}, degradados={Degradados}).")]
+    private static partial void LogConcluida(ILogger logger, Guid execucaoId, string versao, int inseridos, int atualizados, int degradados);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: carga {ExecucaoId} falhou (versão {Versao}).")]
+    private static partial void LogFalhou(ILogger logger, Guid execucaoId, string versao, Exception excecao);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: transição inesperada na execução {ExecucaoId} ({Codigo}).")]
+    private static partial void LogTransicaoInesperada(ILogger logger, Guid execucaoId, string codigo);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: falha ao persistir o estado de falha da execução {ExecucaoId}.")]
+    private static partial void LogFalhaPersistir(ILogger logger, Guid execucaoId, Exception excecao);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -32,7 +32,12 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
     private readonly IGeoImportador _importadorTopo;
     private readonly IGeoImportadorLocalidades _importadorFolhas;
     private readonly IGeoFonteDadosFactory _fonteFactory;
-    private readonly IGeoCepCacheInvalidador _cacheInvalidador;
+
+    // Lazy de propósito: o invalidador resolve a cadeia Redis (IConnectionMultiplexer
+    // conecta na construção). Só o ExecutarAsync (worker) usa o cache; manter Lazy evita
+    // que o disparo/consulta (IniciarAsync/ObterAsync, caminho do endpoint) dependam do
+    // Redis estar de pé — a borda continua respondendo 202/409/404 mesmo com cache fora.
+    private readonly Lazy<IGeoCepCacheInvalidador> _cacheInvalidador;
     private readonly IGeoImportacaoFila _fila;
     private readonly GeoEtlMetrics _metricas;
     private readonly TimeProvider _relogio;
@@ -43,7 +48,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         IGeoImportador importadorTopo,
         IGeoImportadorLocalidades importadorFolhas,
         IGeoFonteDadosFactory fonteFactory,
-        IGeoCepCacheInvalidador cacheInvalidador,
+        Lazy<IGeoCepCacheInvalidador> cacheInvalidador,
         IGeoImportacaoFila fila,
         GeoEtlMetrics metricas,
         TimeProvider relogio,
@@ -175,12 +180,26 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
             await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             // Só após a conclusão estar persistida: sela a versão vigente do cache de CEP
-            // (best-effort). Se o SaveChanges acima falhasse, o cache não apontaria para uma
-            // versão cuja execução não foi confirmada como Concluída.
-            await _cacheInvalidador.InvalidarAsync(versao, cancellationToken).ConfigureAwait(false);
+            // (best-effort). Usa CancellationToken.None de propósito: a execução já está
+            // Concluída no banco, então o selo não pode ser abortado por um cancelamento de
+            // shutdown — senão o cache ficaria na versão antiga sem que a reconciliação o
+            // retentasse. O .Value resolve a cadeia Redis aqui (worker), não no disparo.
+            await _cacheInvalidador.Value.InvalidarAsync(versao, CancellationToken.None).ConfigureAwait(false);
 
             _metricas.RegistrarConclusao(versao, duracaoMs, relatorio.Inseridos + relatorio.Atualizados, relatorio.Degradados);
             LogConcluida(_logger, execucaoId, versao, relatorio.Inseridos, relatorio.Atualizados, relatorio.Degradados);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancelamento/desligamento durante a carga: esta instância é dona desta execução
+            // e sabe que foi interrompida — marca-a terminal já (libera o índice único parcial),
+            // em vez de deixá-la EmAndamento bloqueando disparos até a reconciliação por idade.
+            // Persiste com None (o token de operação já está cancelado) e repropaga para o worker
+            // tratar o shutdown.
+            await MarcarFalhaAsync(execucao, "Carga interrompida (cancelamento/desligamento).", relatorioJson: null, CancellationToken.None).ConfigureAwait(false);
+            _metricas.RegistrarFalha(versao, _relogio.GetElapsedTime(inicio).TotalMilliseconds);
+            LogCancelada(_logger, execucaoId, versao);
+            throw;
         }
         catch (Exception excecao) when (excecao is not OperationCanceledException)
         {
@@ -304,6 +323,9 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
 
     [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: carga {ExecucaoId} falhou (versão {Versao}).")]
     private static partial void LogFalhou(ILogger logger, Guid execucaoId, string versao, Exception excecao);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: carga {ExecucaoId} interrompida por cancelamento/desligamento (versão {Versao}).")]
+    private static partial void LogCancelada(ILogger logger, Guid execucaoId, string versao);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: transição inesperada na execução {ExecucaoId} ({Codigo}).")]
     private static partial void LogTransicaoInesperada(ILogger logger, Guid execucaoId, string codigo);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -85,6 +85,25 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         }
 
         GeoImportacaoExecucao execucao = criacao.Value!;
+
+        // Guarda de versão progressiva: recusa aplicar uma release anterior à última
+        // concluída — aplicá-la rebaixaria o versao_dataset das linhas presentes e misturaria
+        // datasets (a política de stale pressupõe versões não-decrescentes). Reaplicar a mesma
+        // versão é permitido (idempotente). Comparação ordinal == numérica para AAAAMM fixo.
+        string? ultimaConcluida = await _contexto.Set<GeoImportacaoExecucao>()
+            .Where(e => e.Status == StatusImportacao.Concluida)
+            .Select(e => e.VersaoDataset)
+            .OrderByDescending(v => v)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (ultimaConcluida is not null && string.CompareOrdinal(execucao.VersaoDataset, ultimaConcluida) < 0)
+        {
+            LogVersaoNaoProgressiva(_logger, execucao.VersaoDataset, ultimaConcluida);
+            return Result<Guid>.Failure(new DomainError(
+                GeoImportacaoErrorCodes.VersaoNaoProgressiva,
+                $"A versão {execucao.VersaoDataset} é anterior à última aplicada ({ultimaConcluida})."));
+        }
+
         _contexto.Set<GeoImportacaoExecucao>().Add(execucao);
 
         try
@@ -179,12 +198,9 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
 
             await _contexto.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-            // Só após a conclusão estar persistida: sela a versão vigente do cache de CEP
-            // (best-effort). Usa CancellationToken.None de propósito: a execução já está
-            // Concluída no banco, então o selo não pode ser abortado por um cancelamento de
-            // shutdown — senão o cache ficaria na versão antiga sem que a reconciliação o
-            // retentasse. O .Value resolve a cadeia Redis aqui (worker), não no disparo.
-            await _cacheInvalidador.Value.InvalidarAsync(versao, CancellationToken.None).ConfigureAwait(false);
+            // Só após a conclusão estar persistida: sela a versão vigente do cache de CEP,
+            // de forma totalmente best-effort (ver SelarCacheVigenteAsync).
+            await SelarCacheVigenteAsync(versao).ConfigureAwait(false);
 
             _metricas.RegistrarConclusao(versao, duracaoMs, relatorio.Inseridos + relatorio.Atualizados, relatorio.Degradados);
             LogConcluida(_logger, execucaoId, versao, relatorio.Inseridos, relatorio.Atualizados, relatorio.Degradados);
@@ -226,6 +242,27 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         catch (Exception excecao) when (excecao is not OperationCanceledException)
         {
             LogFalhaPersistir(_logger, execucao.Id, excecao);
+        }
+    }
+
+    // Selo do cache totalmente best-effort: o .Value resolve a cadeia Redis (o Connect do
+    // IConnectionMultiplexer pode lançar se o Redis estiver fora) FORA do catch interno do
+    // invalidador, então o try aqui também o cobre. A execução já está Concluída no banco —
+    // uma falha de cache/Redis não pode reverter o sucesso nem marcar falsa falha. Usa None:
+    // a conclusão já está commitada e o selo não deve ser abortado por cancelamento.
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "Selo de cache best-effort após carga concluída: Redis/cache fora (inclusive no Connect resolvido pelo Lazy) não pode escalar para o caminho de falha.")]
+    private async Task SelarCacheVigenteAsync(string versao)
+    {
+        try
+        {
+            await _cacheInvalidador.Value.InvalidarAsync(versao, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception excecao)
+        {
+            LogFalhaSeloCache(_logger, versao, excecao);
         }
     }
 
@@ -326,6 +363,12 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: carga {ExecucaoId} interrompida por cancelamento/desligamento (versão {Versao}).")]
     private static partial void LogCancelada(ILogger logger, Guid execucaoId, string versao);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: falha ao selar a versão vigente {Versao} no cache (best-effort; carga já concluída).")]
+    private static partial void LogFalhaSeloCache(ILogger logger, string versao, Exception excecao);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: disparo recusado — versão {Versao} anterior à última aplicada {UltimaVersao}.")]
+    private static partial void LogVersaoNaoProgressiva(ILogger logger, string versao, string ultimaVersao);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: transição inesperada na execução {ExecucaoId} ({Codigo}).")]
     private static partial void LogTransicaoInesperada(ILogger logger, Guid execucaoId, string codigo);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoExecucaoReconciliador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoExecucaoReconciliador.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+/// <summary>
+/// Reconcilia execuções do ETL abandonadas por crash/restart (Story #674): marca
+/// <c>Falhou</c> as que estão <c>EmAndamento</c> há mais que o limite de abandono,
+/// liberando o índice único parcial para novos disparos.
+/// </summary>
+/// <remarks>
+/// O filtro por idade (<c>iniciado_em &lt; agora - limite</c>) é deliberado: numa topologia
+/// multi-réplica, uma carga recém-iniciada em outra instância tem <c>iniciado_em</c> recente
+/// e <strong>não</strong> é reclamada — só execuções antigas o bastante para serem
+/// seguramente órfãs. Single-flight estrito (uma carga por vez no cluster) é garantido pelo
+/// índice único parcial no banco; correção total de recuperação multi-réplica (lease/heartbeat)
+/// fica como evolução futura — o limite folgado cobre o caso comum de operação.
+/// </remarks>
+internal static class GeoExecucaoReconciliador
+{
+    public static Task<int> ReclamarAbandonadasAsync(
+        GeoDbContext contexto,
+        DateTimeOffset agora,
+        TimeSpan limiteAbandono,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(contexto);
+
+        DateTimeOffset limite = agora - limiteAbandono;
+
+        return contexto.Set<GeoImportacaoExecucao>()
+            .Where(e => e.Status == StatusImportacao.EmAndamento && e.IniciadoEm < limite)
+            .ExecuteUpdateAsync(
+                s => s
+                    .SetProperty(e => e.Status, StatusImportacao.Falhou)
+                    .SetProperty(e => e.ConcluidoEm, agora)
+                    .SetProperty(e => e.Mensagem, "Carga reconciliada como abandonada (sem conclusão além do limite).")
+                    .SetProperty(e => e.UpdatedAt, agora),
+                cancellationToken);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoBackgroundService.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoBackgroundService.cs
@@ -1,0 +1,100 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Consome a fila de disparos do ETL (Story #674) e executa cada carga num escopo de DI
+/// próprio (o orquestrador e o <c>GeoDbContext</c> são scoped). No startup, reconcilia
+/// execuções <c>EmAndamento</c> abandonadas por crash/restart anterior — marca-as
+/// <c>Falhou</c> antes de aceitar novos disparos, senão o índice único parcial as deixaria
+/// bloqueando todos os 409 indefinidamente.
+/// </summary>
+internal sealed partial class GeoImportacaoBackgroundService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IGeoImportacaoFila _fila;
+    private readonly TimeProvider _relogio;
+    private readonly TimeSpan _limiteAbandono;
+    private readonly ILogger<GeoImportacaoBackgroundService> _logger;
+
+    public GeoImportacaoBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IGeoImportacaoFila fila,
+        TimeProvider relogio,
+        IOptions<EtlOpcoes> opcoes,
+        ILogger<GeoImportacaoBackgroundService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(fila);
+        ArgumentNullException.ThrowIfNull(relogio);
+        ArgumentNullException.ThrowIfNull(opcoes);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _scopeFactory = scopeFactory;
+        _fila = fila;
+        _relogio = relogio;
+        _limiteAbandono = opcoes.Value.LimiteAbandono;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await ReconciliarOrfasAsync(stoppingToken).ConfigureAwait(false);
+
+        await foreach (Guid execucaoId in _fila.LerAsync(stoppingToken).ConfigureAwait(false))
+        {
+            try
+            {
+                using IServiceScope escopo = _scopeFactory.CreateScope();
+                IGeoImportacaoExecutor executor = escopo.ServiceProvider.GetRequiredService<IGeoImportacaoExecutor>();
+                await executor.ExecutarAsync(execucaoId, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+#pragma warning disable CA1031 // O executor já marca a execução como falha; aqui só evitamos derrubar o loop do worker.
+            catch (Exception excecao)
+            {
+                LogErroProcessando(_logger, execucaoId, excecao);
+            }
+#pragma warning restore CA1031
+        }
+    }
+
+    private async Task ReconciliarOrfasAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using IServiceScope escopo = _scopeFactory.CreateScope();
+            GeoDbContext contexto = escopo.ServiceProvider.GetRequiredService<GeoDbContext>();
+
+            int afetadas = await GeoExecucaoReconciliador
+                .ReclamarAbandonadasAsync(contexto, _relogio.GetUtcNow(), _limiteAbandono, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (afetadas > 0)
+            {
+                LogOrfasReconciliadas(_logger, afetadas);
+            }
+        }
+#pragma warning disable CA1031 // Reconciliação best-effort no startup: uma falha aqui não pode impedir o worker de subir.
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
+        {
+            LogErroReconciliar(_logger, excecao);
+        }
+#pragma warning restore CA1031
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: {Afetadas} execução(ões) em andamento reconciliada(s) como falha no startup (abandonadas por reinício).")]
+    private static partial void LogOrfasReconciliadas(ILogger logger, int afetadas);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: falha ao reconciliar execuções em andamento no startup.")]
+    private static partial void LogErroReconciliar(ILogger logger, Exception excecao);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: erro ao processar a execução {ExecucaoId} na fila.")]
+    private static partial void LogErroProcessando(ILogger logger, Guid execucaoId, Exception excecao);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoFila.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoFila.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using System.Threading.Channels;
+
+/// <summary>
+/// Fila in-process de disparos do ETL (Story #674): o endpoint admin / o seed
+/// enfileiram o Id da execução já registrada; o <see cref="GeoImportacaoBackgroundService"/>
+/// consome e roda a carga fora do request (resposta <c>202 Accepted</c>).
+/// </summary>
+/// <remarks>
+/// Não é durável: uma execução enfileirada e não consumida por crash/restart é
+/// reconciliada (marcada <c>Falhou</c>) no startup do worker — o índice único parcial
+/// de "em andamento" garante que ela não bloqueie disparos futuros indefinidamente.
+/// </remarks>
+internal interface IGeoImportacaoFila
+{
+    /// <summary>Enfileira o Id de uma execução para processamento em segundo plano.</summary>
+    ValueTask EnfileirarAsync(Guid execucaoId, CancellationToken cancellationToken);
+
+    /// <summary>Sequência das execuções enfileiradas, em ordem de chegada.</summary>
+    IAsyncEnumerable<Guid> LerAsync(CancellationToken cancellationToken);
+}
+
+/// <inheritdoc />
+internal sealed class GeoImportacaoFila : IGeoImportacaoFila
+{
+    // Capacidade pequena: o índice único parcial garante ≤1 carga em andamento, então a
+    // fila raramente passa de um item. FullMode.Wait dá backpressure se ainda assim encher.
+    private readonly Channel<Guid> _canal = Channel.CreateBounded<Guid>(
+        new BoundedChannelOptions(16)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+        });
+
+    public ValueTask EnfileirarAsync(Guid execucaoId, CancellationToken cancellationToken) =>
+        _canal.Writer.WriteAsync(execucaoId, cancellationToken);
+
+    public IAsyncEnumerable<Guid> LerAsync(CancellationToken cancellationToken) =>
+        _canal.Reader.ReadAllAsync(cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoSeedHostedService.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoSeedHostedService.cs
@@ -65,7 +65,7 @@ internal sealed partial class GeoSeedHostedService : IHostedService
 
         if (resultado.IsSuccess)
         {
-            LogSeedDisparado(_logger, _opcoes.VersaoSeed, resultado.Value);
+            LogSeedDisparado(_logger, resultado.Value, _opcoes.VersaoSeed);
         }
         else
         {
@@ -82,7 +82,7 @@ internal sealed partial class GeoSeedHostedService : IHostedService
     private static partial void LogBasePopulada(ILogger logger);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Seed do Geo: carga {ExecucaoId} disparada para a versão {Versao}.")]
-    private static partial void LogSeedDisparado(ILogger logger, string versao, Guid execucaoId);
+    private static partial void LogSeedDisparado(ILogger logger, Guid execucaoId, string versao);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Seed do Geo: carga da versão {Versao} não disparada ({Codigo}).")]
     private static partial void LogSeedNaoDisparado(ILogger logger, string versao, string codigo);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoSeedHostedService.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoSeedHostedService.cs
@@ -1,0 +1,89 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Seed automático do Geo em desenvolvimento (Story #674, CA-01): no boot, se a base
+/// estiver vazia, dispara a carga da versão configurada pelo mesmo caminho do endpoint
+/// admin (não bloqueia o boot — a carga roda no worker). Gate duplo: ambiente
+/// <see cref="IHostEnvironment.IsDevelopment"/> <strong>e</strong>
+/// <see cref="EtlOpcoes.SeedHabilitado"/> (default <see langword="false"/>) — produção
+/// nunca semeia, e os testes (que rodam como <c>Development</c>) também não, por não
+/// ligarem a flag.
+/// </summary>
+internal sealed partial class GeoSeedHostedService : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IHostEnvironment _ambiente;
+    private readonly EtlOpcoes _opcoes;
+    private readonly ILogger<GeoSeedHostedService> _logger;
+
+    public GeoSeedHostedService(
+        IServiceScopeFactory scopeFactory,
+        IHostEnvironment ambiente,
+        IOptions<EtlOpcoes> opcoes,
+        ILogger<GeoSeedHostedService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(ambiente);
+        ArgumentNullException.ThrowIfNull(opcoes);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _scopeFactory = scopeFactory;
+        _ambiente = ambiente;
+        _opcoes = opcoes.Value;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_ambiente.IsDevelopment() || !_opcoes.SeedHabilitado)
+        {
+            LogSeedDesabilitado(_logger);
+            return;
+        }
+
+        using IServiceScope escopo = _scopeFactory.CreateScope();
+        GeoDbContext contexto = escopo.ServiceProvider.GetRequiredService<GeoDbContext>();
+
+        bool baseVazia = !await contexto.Cidades.AnyAsync(cancellationToken).ConfigureAwait(false);
+        if (!baseVazia)
+        {
+            LogBasePopulada(_logger);
+            return;
+        }
+
+        IGeoImportacaoService servico = escopo.ServiceProvider.GetRequiredService<IGeoImportacaoService>();
+        Result<Guid> resultado = await servico.IniciarAsync(_opcoes.VersaoSeed, "seed", cancellationToken).ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            LogSeedDisparado(_logger, _opcoes.VersaoSeed, resultado.Value);
+        }
+        else
+        {
+            LogSeedNaoDisparado(_logger, _opcoes.VersaoSeed, resultado.Error!.Code);
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Seed do Geo desabilitado (ambiente não-Development ou flag desligada).")]
+    private static partial void LogSeedDesabilitado(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Seed do Geo: base já populada — nada a semear.")]
+    private static partial void LogBasePopulada(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Seed do Geo: carga {ExecucaoId} disparada para a versão {Versao}.")]
+    private static partial void LogSeedDisparado(ILogger logger, string versao, Guid execucaoId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Seed do Geo: carga da versão {Versao} não disparada ({Codigo}).")]
+    private static partial void LogSeedNaoDisparado(ILogger logger, string versao, string codigo);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoStaleMarker.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoStaleMarker.cs
@@ -14,6 +14,12 @@ using Npgsql;
 /// logradouro retirado). A comparação <c>versao_dataset &lt; @versao</c> é lexicográfica,
 /// válida porque o formato AAAAMM tem comprimento fixo.
 /// </summary>
+/// <remarks>
+/// O predicado pressupõe versões <strong>não-decrescentes</strong>: aplicar uma release
+/// anterior à última já aplicada deixaria linhas órfãs de uma versão mais nova
+/// (<c>versao_dataset</c> maior) sem serem marcadas. Essa regressão é barrada antes, no
+/// disparo (guarda de versão progressiva em <c>GeoEtlOrquestrador.IniciarAsync</c>).
+/// </remarks>
 internal static class GeoStaleMarker
 {
     // As 14 tabelas de reference data com proveniência (versao_dataset/vigente). É uma

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoStaleMarker.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoStaleMarker.cs
@@ -1,0 +1,75 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Npgsql;
+
+/// <summary>
+/// Política de linhas obsoletas (stale) da recarga periódica (Story #674, CA-04): ao
+/// aplicar uma nova versão, as linhas de reference data cuja <c>versao_dataset</c> ficou
+/// <strong>anterior</strong> à versão recém-aplicada (não foram revistas nesta release)
+/// são marcadas <c>vigente = false</c> — sem remoção física (rastreabilidade de CEP/
+/// logradouro retirado). A comparação <c>versao_dataset &lt; @versao</c> é lexicográfica,
+/// válida porque o formato AAAAMM tem comprimento fixo.
+/// </summary>
+internal static class GeoStaleMarker
+{
+    // As 14 tabelas de reference data com proveniência (versao_dataset/vigente). É uma
+    // whitelist CONSTANTE (nenhum dado de usuário entra no nome interpolado); os valores
+    // (versão, instante) são parametrizados.
+    private static readonly string[] Tabelas =
+    [
+        "pais",
+        "estado",
+        "estado_indicador",
+        "estado_faixa_cep",
+        "cidade",
+        "cidade_indicador",
+        "cidade_faixa_cep",
+        "distrito",
+        "distrito_faixa_cep",
+        "bairro",
+        "bairro_faixa_cep",
+        "logradouro",
+        "logradouro_complemento",
+        "cep_grande_usuario",
+    ];
+
+    [SuppressMessage(
+        "Security",
+        "CA2100:Review SQL queries for security vulnerabilities",
+        Justification = "O nome da tabela vem de whitelist constante; versão e instante são parametrizados (@versao/@agora).")]
+    public static async Task<int> MarcarStaleAsync(
+        GeoDbContext contexto,
+        string versaoAplicada,
+        DateTimeOffset agora,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(contexto);
+        ArgumentException.ThrowIfNullOrWhiteSpace(versaoAplicada);
+
+        int total = 0;
+        foreach (string tabela in Tabelas)
+        {
+            // Parâmetros novos por iteração: um NpgsqlParameter não pode ser reusado em
+            // múltiplos comandos.
+            NpgsqlParameter pAgora = new("agora", agora);
+            NpgsqlParameter pVersao = new("versao", versaoAplicada);
+
+            // Concatenação (não interpolação) para o nome da tabela — evita o EF1002, que
+            // só dispara em strings interpoladas; os valores seguem parametrizados.
+            string sql = "UPDATE " + tabela
+                + " SET vigente = false, updated_at = @agora"
+                + " WHERE versao_dataset < @versao AND vigente = true";
+
+            total += await contexto.Database.ExecuteSqlRawAsync(
+                sql,
+                [pAgora, pVersao],
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return total;
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/IGeoImportacaoExecutor.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/IGeoImportacaoExecutor.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+/// <summary>
+/// Executa a carga pesada de uma execução já registrada (Story #674). Porta interna
+/// usada pelo <c>BackgroundService</c> — separada de <c>IGeoImportacaoService</c> (a
+/// porta da API, que só dispara e acompanha), para que a borda não exponha a execução
+/// longa. Implementada pelo mesmo orquestrador.
+/// </summary>
+internal interface IGeoImportacaoExecutor
+{
+    /// <summary>
+    /// Executa a carga da execução <paramref name="execucaoId"/> (deriva o modo do estado
+    /// da base, roda os importadores, marca linhas obsoletas, sela a versão vigente do cache
+    /// e grava status + relatório). Não lança em falha de carga: marca a execução como
+    /// <c>Falhou</c> e registra a métrica/log.
+    /// </summary>
+    Task ExecutarAsync(Guid execucaoId, CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/GeoDbContext.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/GeoDbContext.cs
@@ -71,6 +71,9 @@ public sealed class GeoDbContext : DbContext, IUnitOfWork
     /// <summary>CEPs exclusivos de grandes usuários (órgãos/empresas).</summary>
     public DbSet<CepGrandeUsuario> CepGrandesUsuarios => Set<CepGrandeUsuario>();
 
+    /// <summary>Trilha de execuções do ETL DNE — versão, quem disparou, status e relatório (Story #674).</summary>
+    public DbSet<GeoImportacaoExecucao> ImportacaoExecucoes => Set<GeoImportacaoExecucao>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Migrations/20260618124158_AddGeoImportacaoExecucao.Designer.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Migrations/20260618124158_AddGeoImportacaoExecucao.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeoDbContext))]
-    partial class GeoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618124158_AddGeoImportacaoExecucao")]
+    partial class AddGeoImportacaoExecucao
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Migrations/20260618124158_AddGeoImportacaoExecucao.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Migrations/20260618124158_AddGeoImportacaoExecucao.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGeoImportacaoExecucao : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "geo_importacao_execucao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    versao_dataset = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    iniciado_em = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    concluido_em = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    disparado_por = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    relatorio_json = table.Column<string>(type: "jsonb", nullable: true),
+                    mensagem = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_geo_importacao_execucao", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_geo_importacao_execucao_iniciado_em",
+                table: "geo_importacao_execucao",
+                column: "iniciado_em");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_geo_importacao_execucao_em_andamento",
+                table: "geo_importacao_execucao",
+                column: "status",
+                unique: true,
+                filter: "status = 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "geo_importacao_execucao");
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
@@ -1,0 +1,138 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Admin;
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Endpoint admin de disparo/acompanhamento do ETL (Story #674, CA-02/CA-06) contra a
+/// API real. O worker fica desligado (<c>GeoApiFactory</c>), então o disparo registra a
+/// execução EmAndamento e responde 202 sem rodar a carga — tornando 202/409
+/// determinísticos. Autorização por role <c>plataforma-admin</c> (401/403).
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class GeoImportacoesEndpointTests
+{
+    private const string Rota = "/api/admin/geo/importacoes";
+
+    private readonly GeoPostgisFixture _fixture;
+
+    public GeoImportacoesEndpointTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-02: POST com plataforma-admin retorna 202, Location e registra a execução EmAndamento")]
+    public async Task Disparar_ComAdmin_Retorna202_E_Registra()
+    {
+        await LimparExecucoesAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpRequestMessage disparo = RequisicaoDisparo("202601", admin: true);
+        using HttpResponseMessage resposta = await client.SendAsync(disparo);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        resposta.Headers.Location.Should().NotBeNull();
+
+        using JsonDocument corpo = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        corpo.RootElement.GetProperty("status").GetString().Should().Be("EmAndamento");
+        corpo.RootElement.GetProperty("versaoDataset").GetString().Should().Be("202601");
+        Guid id = corpo.RootElement.GetProperty("id").GetGuid();
+
+        using HttpRequestMessage consulta = RequisicaoGet(id, admin: true);
+        using HttpResponseMessage acompanhamento = await client.SendAsync(consulta);
+        acompanhamento.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(DisplayName = "CA-02: POST sem autenticação retorna 401")]
+    public async Task Disparar_SemAutenticacao_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpRequestMessage requisicao = new(HttpMethod.Post, Rota)
+        {
+            Content = CorpoJson("202601"),
+        };
+        using HttpResponseMessage resposta = await client.SendAsync(requisicao);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "CA-02: POST autenticado sem o role plataforma-admin retorna 403")]
+    public async Task Disparar_SemRole_Retorna403()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpRequestMessage requisicao = RequisicaoDisparo("202601", admin: false);
+        using HttpResponseMessage resposta = await client.SendAsync(requisicao);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "CA-06: com uma carga em andamento, um segundo disparo retorna 409 (sem Idempotency-Key)")]
+    public async Task Disparar_ComCargaEmAndamento_Retorna409()
+    {
+        await LimparExecucoesAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpRequestMessage disparo1 = RequisicaoDisparo("202601", admin: true);
+        using HttpResponseMessage primeira = await client.SendAsync(disparo1);
+        primeira.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        using HttpRequestMessage disparo2 = RequisicaoDisparo("202602", admin: true);
+        using HttpResponseMessage segunda = await client.SendAsync(disparo2);
+        segunda.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Theory(DisplayName = "CA-02: versão fora do formato AAAAMM (ou ausente) é rejeitada na borda com 422")]
+    [InlineData("209913")]
+    [InlineData("20260")]
+    [InlineData("")]
+    public async Task Disparar_VersaoInvalida_Retorna422(string versao)
+    {
+        await LimparExecucoesAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpRequestMessage requisicao = RequisicaoDisparo(versao, admin: true);
+        using HttpResponseMessage resposta = await client.SendAsync(requisicao);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    private static HttpRequestMessage RequisicaoDisparo(string versao, bool admin)
+    {
+        HttpRequestMessage requisicao = new(HttpMethod.Post, Rota) { Content = CorpoJson(versao) };
+        Autenticar(requisicao, admin);
+        return requisicao;
+    }
+
+    private static HttpRequestMessage RequisicaoGet(Guid id, bool admin)
+    {
+        HttpRequestMessage requisicao = new(HttpMethod.Get, $"{Rota}/{id}");
+        Autenticar(requisicao, admin);
+        return requisicao;
+    }
+
+    private static void Autenticar(HttpRequestMessage requisicao, bool admin)
+    {
+        requisicao.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        requisicao.Headers.Add(TestAuthHandler.RolesHeader, admin ? "plataforma-admin" : "operador-geo");
+    }
+
+    private static StringContent CorpoJson(string versao) =>
+        new($"{{\"versao\":\"{versao}\"}}", Encoding.UTF8, "application/json");
+
+    private async Task LimparExecucoesAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE TABLE geo_importacao_execucao");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
@@ -7,9 +7,12 @@ using System.Text.Json;
 using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 
 using Unifesspa.UniPlus.Geo.Domain.Entities;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
 using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 
@@ -148,6 +151,19 @@ public sealed class GeoImportacoesEndpointTests
         resposta.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
+    [Fact(DisplayName = "CA-03: versão anterior aos dados já carregados (sem histórico de execução) é recusada com 409")]
+    public async Task Disparar_VersaoAnteriorAosDados_SemHistorico_Retorna409()
+    {
+        await LimparExecucoesAsync();
+        await SemearCidadeAsync("202602");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage requisicao = RequisicaoDisparo("202601", admin: true);
+        using HttpResponseMessage resposta = await client.SendAsync(requisicao);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
     private static HttpRequestMessage RequisicaoDisparo(string versao, bool admin)
     {
         HttpRequestMessage requisicao = new(HttpMethod.Post, Rota) { Content = CorpoJson(versao) };
@@ -174,6 +190,24 @@ public sealed class GeoImportacoesEndpointTests
     private async Task LimparExecucoesAsync()
     {
         await using GeoDbContext ctx = _fixture.CreateDbContext();
-        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE TABLE geo_importacao_execucao");
+        // Trunca também o reference data: a guarda de versão progressiva lê max(cidade.versao),
+        // que seria poluído por outros testes da coleção (que carregam cidades).
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE pais, logradouro_complemento, cep_grande_usuario, geo_importacao_execucao CASCADE");
+    }
+
+    // Carrega uma cidade na versão informada (topo do ETL) — para exercitar a guarda de versão
+    // a partir do reference data, sem nenhum histórico de execução.
+    private async Task SemearCidadeAsync(string versao)
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        FonteEmMemoria fonte = new() { Versao = versao };
+        fonte.Paises.Add(DadosDne.Pais("BRA", "Brasil", "BR"));
+        fonte.Estados.Add(DadosDne.Estado("PA", "Pará"));
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador("PA", "15"));
+        fonte.Cidades.Add(DadosDne.Cidade("1500402", "Marabá", "PA"));
+
+        GeoImportadorPaisEstadoCidade importador = new(ctx, NullLogger<GeoImportadorPaisEstadoCidade>.Instance);
+        await importador.ImportarAsync(fonte, CancellationToken.None);
     }
 }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
@@ -108,8 +108,8 @@ public sealed class GeoImportacoesEndpointTests
         resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
     }
 
-    [Fact(DisplayName = "CA-03: versão anterior à última release concluída é recusada com 422 (não rebaixa o dataset)")]
-    public async Task Disparar_VersaoAnteriorAUltimaConcluida_Retorna422()
+    [Fact(DisplayName = "CA-03: versão anterior à última release concluída é recusada com 409 (não rebaixa o dataset)")]
+    public async Task Disparar_VersaoAnteriorAUltimaConcluida_Retorna409()
     {
         await LimparExecucoesAsync();
         await using (GeoDbContext ctx = _fixture.CreateDbContext())
@@ -125,11 +125,11 @@ public sealed class GeoImportacoesEndpointTests
         using HttpRequestMessage requisicao = RequisicaoDisparo("202601", admin: true);
         using HttpResponseMessage resposta = await client.SendAsync(requisicao);
 
-        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        resposta.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
-    [Fact(DisplayName = "CA-03: versão anterior a uma release que falhou (pode ter dados parciais) também é recusada com 422")]
-    public async Task Disparar_VersaoAnteriorAUltimaFalha_Retorna422()
+    [Fact(DisplayName = "CA-03: versão anterior a uma release que falhou (pode ter dados parciais) também é recusada com 409")]
+    public async Task Disparar_VersaoAnteriorAUltimaFalha_Retorna409()
     {
         await LimparExecucoesAsync();
         await using (GeoDbContext ctx = _fixture.CreateDbContext())
@@ -145,7 +145,7 @@ public sealed class GeoImportacoesEndpointTests
         using HttpRequestMessage requisicao = RequisicaoDisparo("202601", admin: true);
         using HttpResponseMessage resposta = await client.SendAsync(requisicao);
 
-        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        resposta.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
     private static HttpRequestMessage RequisicaoDisparo(string versao, bool admin)

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
@@ -8,6 +8,7 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Unifesspa.UniPlus.Geo.Domain.Entities;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
@@ -102,6 +103,26 @@ public sealed class GeoImportacoesEndpointTests
         using HttpClient client = _fixture.Factory.CreateClient();
 
         using HttpRequestMessage requisicao = RequisicaoDisparo(versao, admin: true);
+        using HttpResponseMessage resposta = await client.SendAsync(requisicao);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "CA-03: versão anterior à última release concluída é recusada com 422 (não rebaixa o dataset)")]
+    public async Task Disparar_VersaoAnteriorAUltimaConcluida_Retorna422()
+    {
+        await LimparExecucoesAsync();
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            GeoImportacaoExecucao concluida = GeoImportacaoExecucao
+                .Iniciar("202602", "teste", TimeProvider.System.GetUtcNow()).Value!;
+            concluida.Concluir(TimeProvider.System.GetUtcNow(), "{}", "ok");
+            ctx.ImportacaoExecucoes.Add(concluida);
+            await ctx.SaveChangesAsync();
+        }
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage requisicao = RequisicaoDisparo("202601", admin: true);
         using HttpResponseMessage resposta = await client.SendAsync(requisicao);
 
         resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
@@ -128,6 +128,26 @@ public sealed class GeoImportacoesEndpointTests
         resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
     }
 
+    [Fact(DisplayName = "CA-03: versão anterior a uma release que falhou (pode ter dados parciais) também é recusada com 422")]
+    public async Task Disparar_VersaoAnteriorAUltimaFalha_Retorna422()
+    {
+        await LimparExecucoesAsync();
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            GeoImportacaoExecucao falhou = GeoImportacaoExecucao
+                .Iniciar("202602", "teste", TimeProvider.System.GetUtcNow()).Value!;
+            falhou.Falhar(TimeProvider.System.GetUtcNow(), "falha parcial nas folhas");
+            ctx.ImportacaoExecucoes.Add(falhou);
+            await ctx.SaveChangesAsync();
+        }
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage requisicao = RequisicaoDisparo("202601", admin: true);
+        using HttpResponseMessage resposta = await client.SendAsync(requisicao);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
     private static HttpRequestMessage RequisicaoDisparo(string versao, bool admin)
     {
         HttpRequestMessage requisicao = new(HttpMethod.Post, Rota) { Content = CorpoJson(versao) };

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -178,10 +178,18 @@ public sealed class EtlAtualizacaoPeriodicaTests
     {
         await LimparAsync();
         IGeoCepCacheInvalidador cache = Substitute.For<IGeoCepCacheInvalidador>();
+
+        // Staging corrompido: topo sem cidades, mas com uma folha (logradouro) referenciando
+        // uma cidade existente. A guarda deve abortar ANTES das folhas, então "Rua Nova" não
+        // pode ser commitada.
+        FonteEmMemoria recargaCorrompida = new() { Versao = "202602" };
+        recargaCorrompida.CidadeIds.Add(DadosDne.CidadeId(1, Maraba));
+        recargaCorrompida.Logradouros.Add(DadosDne.Logradouro("68500999", "Rua Nova", 1));
+
         FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
         {
             ["202601"] = FonteCompleta("202601"),
-            ["202602"] = new FonteEmMemoria { Versao = "202602" }, // staging vazio (não restaurado)
+            ["202602"] = recargaCorrompida,
         });
 
         Guid id1 = await CriarExecucaoAsync("202601");
@@ -192,11 +200,13 @@ public sealed class EtlAtualizacaoPeriodicaTests
 
         await using GeoDbContext leitura = _fixture.CreateDbContext();
         GeoImportacaoExecucao exec2 = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id2);
-        exec2.Status.Should().Be(StatusImportacao.Falhou, "uma release vazia não pode concluir");
+        exec2.Status.Should().Be(StatusImportacao.Falhou, "uma release vazia/sem âncora não pode concluir");
 
         Cidade maraba = await leitura.Cidades.SingleAsync(c => c.CodigoIbge == Maraba);
         maraba.Vigente.Should().BeTrue("a release vazia não pode marcar a base existente como obsoleta");
         maraba.VersaoDataset.Should().Be("202601");
+        (await leitura.Logradouros.AnyAsync(l => l.Nome == "Rua Nova")).Should()
+            .BeFalse("as folhas não podem rodar quando a topo não trouxe cidades");
         await cache.DidNotReceive().InvalidarAsync("202602", Arg.Any<CancellationToken>());
     }
 

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -210,6 +210,42 @@ public sealed class EtlAtualizacaoPeriodicaTests
         await cache.DidNotReceive().InvalidarAsync("202602", Arg.Any<CancellationToken>());
     }
 
+    [Fact(DisplayName = "Integridade: recarga com cidades mas sem logradouros (dump-folha vazio) falha e NÃO marca o CEP existente como obsoleto")]
+    public async Task RecargaSemLogradouros_Falha_PreservaLookup()
+    {
+        await LimparAsync();
+        IGeoCepCacheInvalidador cache = Substitute.For<IGeoCepCacheInvalidador>();
+
+        // Topo restaurado (cidades), mas dump das tabelas-folha vazio (sem logradouros).
+        FonteEmMemoria folhasVazias = new() { Versao = "202602" };
+        folhasVazias.Paises.Add(DadosDne.Pais("BRA", "Brasil", "BR"));
+        folhasVazias.Estados.Add(DadosDne.Estado("PA", "Pará", capital: "Belém", faixaIni: "66000000", faixaFim: "68899999"));
+        folhasVazias.EstadoIndicadores.Add(DadosDne.EstadoIndicador("PA", "15"));
+        folhasVazias.Cidades.Add(DadosDne.Cidade(Maraba, "Marabá", "PA", ddd: "94"));
+        folhasVazias.CidadeIds.Add(DadosDne.CidadeId(1, Maraba));
+
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
+        {
+            ["202601"] = FonteCompleta("202601"),
+            ["202602"] = folhasVazias,
+        });
+
+        Guid id1 = await CriarExecucaoAsync("202601");
+        await ExecutarAsync(id1, fonteFactory, cache);
+
+        Guid id2 = await CriarExecucaoAsync("202602");
+        await ExecutarAsync(id2, fonteFactory, cache);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao exec2 = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id2);
+        exec2.Status.Should().Be(StatusImportacao.Falhou, "uma release sem logradouros não pode concluir");
+
+        Logradouro ruaA = await leitura.Logradouros.SingleAsync(l => l.Cep == CepMaraba);
+        ruaA.Vigente.Should().BeTrue("a release sem logradouros não pode marcar o CEP existente como obsoleto");
+        ruaA.VersaoDataset.Should().Be("202601");
+        await cache.DidNotReceive().InvalidarAsync("202602", Arg.Any<CancellationToken>());
+    }
+
     private async Task<Guid> CriarExecucaoAsync(string versao)
     {
         await using GeoDbContext ctx = _fixture.CreateDbContext();

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -129,6 +129,24 @@ public sealed class EtlAtualizacaoPeriodicaTests
         await cache.DidNotReceive().InvalidarAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact(DisplayName = "Robustez: cancelamento/desligamento durante a carga marca a execução Falhou (libera o índice) e não sela o cache")]
+    public async Task Cancelamento_MarcaFalhou_E_NaoSelaCache()
+    {
+        await LimparAsync();
+        IGeoCepCacheInvalidador cache = Substitute.For<IGeoCepCacheInvalidador>();
+        FonteFactoryCancelada fonteFactory = new();
+
+        Guid id = await CriarExecucaoAsync("202601");
+        Func<Task> acao = () => ExecutarAsync(id, fonteFactory, cache);
+
+        await acao.Should().ThrowAsync<OperationCanceledException>();
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+        execucao.Status.Should().Be(StatusImportacao.Falhou, "a instância dona marca terminal já, não deixa EmAndamento bloqueando");
+        await cache.DidNotReceive().InvalidarAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
     private async Task<Guid> CriarExecucaoAsync(string versao)
     {
         await using GeoDbContext ctx = _fixture.CreateDbContext();
@@ -168,7 +186,7 @@ public sealed class EtlAtualizacaoPeriodicaTests
             topo,
             folhas,
             fonteFactory,
-            cache,
+            new Lazy<IGeoCepCacheInvalidador>(() => cache),
             new GeoImportacaoFila(),
             metricas,
             TimeProvider.System,
@@ -231,5 +249,12 @@ public sealed class EtlAtualizacaoPeriodicaTests
         }
 
         public IGeoFonteDados Criar(string versao) => _porVersao[versao];
+    }
+
+    // Simula cancelamento (shutdown) no meio da carga: o orquestrador deve marcar a execução
+    // terminal e repropagar o OperationCanceledException.
+    private sealed class FonteFactoryCancelada : IGeoFonteDadosFactory
+    {
+        public IGeoFonteDados Criar(string versao) => throw new OperationCanceledException();
     }
 }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -35,6 +35,9 @@ public sealed class EtlAtualizacaoPeriodicaTests
     private const string CepMaraba = "68500000";
     private const string CepSaoPaulo = "01000000";
 
+    private static readonly JsonSerializerOptions RelatorioJsonCamelCase =
+        new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
     private readonly GeoPostgisFixture _fixture;
 
     public EtlAtualizacaoPeriodicaTests(GeoPostgisFixture fixture)
@@ -101,7 +104,9 @@ public sealed class EtlAtualizacaoPeriodicaTests
         execucao.DisparadoPor.Should().Be("teste");
         execucao.RelatorioJson.Should().NotBeNullOrWhiteSpace();
 
-        RelatorioImportacaoDto? relatorio = JsonSerializer.Deserialize<RelatorioImportacaoDto>(execucao.RelatorioJson!);
+        // O relatorio_json é persistido em camelCase (alinhado ao wire da API); lê no mesmo formato.
+        RelatorioImportacaoDto? relatorio = JsonSerializer.Deserialize<RelatorioImportacaoDto>(
+            execucao.RelatorioJson!, RelatorioJsonCamelCase);
         relatorio.Should().NotBeNull();
         relatorio!.VersaoDataset.Should().Be("202601");
         relatorio.Tabelas.Should().Contain(t => t.Tabela == "cidade" && t.Inseridos >= 2);

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -1,0 +1,235 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Observability;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Atualização periódica do ETL (Story #674) sobre Postgres+PostGIS real: orquestra os
+/// importadores de topo (#672) e folhas (#673), aplica a política de stale na recarga,
+/// sela a versão vigente do cache de CEP e persiste status + relatório. Cobre CA-03
+/// (versionamento/idempotência), CA-04 (linhas obsoletas), CA-05 (invalidação do cache),
+/// CA-07 (observabilidade/registro) e CA-08 (sem PII).
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class EtlAtualizacaoPeriodicaTests
+{
+    private const string Maraba = "1500402";
+    private const string SaoPaulo = "3550308";
+    private const string CepMaraba = "68500000";
+    private const string CepSaoPaulo = "01000000";
+
+    private readonly GeoPostgisFixture _fixture;
+
+    public EtlAtualizacaoPeriodicaTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-03/04/05: recarga atualiza por chave natural, marca linhas ausentes como vigente=false (sem remover) e sela a versão vigente do cache")]
+    public async Task Recarga_AtualizaPorChaveNatural_MarcaStale_E_SelaCache()
+    {
+        await LimparAsync();
+        IGeoCepCacheInvalidador cache = Substitute.For<IGeoCepCacheInvalidador>();
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
+        {
+            ["202601"] = FonteCompleta("202601"),
+            ["202602"] = FonteSomenteMaraba("202602"),
+        });
+
+        Guid id1 = await CriarExecucaoAsync("202601");
+        await ExecutarAsync(id1, fonteFactory, cache);
+
+        Guid id2 = await CriarExecucaoAsync("202602");
+        await ExecutarAsync(id2, fonteFactory, cache);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+
+        Cidade maraba = await leitura.Cidades.SingleAsync(c => c.CodigoIbge == Maraba);
+        maraba.VersaoDataset.Should().Be("202602", "Marabá foi revisto na nova release");
+        maraba.Vigente.Should().BeTrue();
+
+        Cidade saoPaulo = await leitura.Cidades.SingleAsync(c => c.CodigoIbge == SaoPaulo);
+        saoPaulo.VersaoDataset.Should().Be("202601", "São Paulo não consta na release 202602");
+        saoPaulo.Vigente.Should().BeFalse("linha ausente na nova release é marcada obsoleta");
+        (await leitura.Cidades.CountAsync()).Should().Be(2, "stale não remove fisicamente (rastreabilidade)");
+
+        Logradouro avPaulista = await leitura.Logradouros.SingleAsync(l => l.Cep == CepSaoPaulo);
+        avPaulista.Vigente.Should().BeFalse("o CEP ausente na nova release fica obsoleto, sem remoção");
+
+        Logradouro ruaA = await leitura.Logradouros.SingleAsync(l => l.Cep == CepMaraba);
+        ruaA.VersaoDataset.Should().Be("202602");
+        ruaA.Vigente.Should().BeTrue();
+
+        await cache.Received(1).InvalidarAsync("202602", Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "CA-07/08: a carga conclui registrando status, relatório por tabela (contadores) e disparador — sem PII")]
+    public async Task Carga_RegistraRelatorio_SemPii()
+    {
+        await LimparAsync();
+        IGeoCepCacheInvalidador cache = Substitute.For<IGeoCepCacheInvalidador>();
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
+        {
+            ["202601"] = FonteCompleta("202601"),
+        });
+
+        Guid id = await CriarExecucaoAsync("202601");
+        await ExecutarAsync(id, fonteFactory, cache);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+
+        execucao.Status.Should().Be(StatusImportacao.Concluida);
+        execucao.ConcluidoEm.Should().NotBeNull();
+        execucao.DisparadoPor.Should().Be("teste");
+        execucao.RelatorioJson.Should().NotBeNullOrWhiteSpace();
+
+        RelatorioImportacaoDto? relatorio = JsonSerializer.Deserialize<RelatorioImportacaoDto>(execucao.RelatorioJson!);
+        relatorio.Should().NotBeNull();
+        relatorio!.VersaoDataset.Should().Be("202601");
+        relatorio.Tabelas.Should().Contain(t => t.Tabela == "cidade" && t.Inseridos >= 2);
+        relatorio.Inseridos.Should().BeGreaterThan(0);
+    }
+
+    [Fact(DisplayName = "Robustez: falha na carga marca a execução como Falhou e NÃO sela o cache (a versão vigente não mudou)")]
+    public async Task Falha_MarcaFalhou_E_NaoSelaCache()
+    {
+        await LimparAsync();
+        IGeoCepCacheInvalidador cache = Substitute.For<IGeoCepCacheInvalidador>();
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
+        {
+            ["202601"] = new FonteComFalhaNasCidades(FonteCompleta("202601")),
+        });
+
+        Guid id = await CriarExecucaoAsync("202601");
+        await ExecutarAsync(id, fonteFactory, cache);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+
+        execucao.Status.Should().Be(StatusImportacao.Falhou);
+        execucao.ConcluidoEm.Should().NotBeNull();
+        await cache.DidNotReceive().InvalidarAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    private async Task<Guid> CriarExecucaoAsync(string versao)
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = GeoImportacaoExecucao
+            .Iniciar(versao, "teste", TimeProvider.System.GetUtcNow())
+            .Value!;
+        ctx.ImportacaoExecucoes.Add(execucao);
+        await ctx.SaveChangesAsync();
+        return execucao.Id;
+    }
+
+    private async Task ExecutarAsync(Guid execucaoId, IGeoFonteDadosFactory fonteFactory, IGeoCepCacheInvalidador cache)
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        using GeoEtlMetrics metricas = new();
+        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cache, metricas);
+        await orquestrador.ExecutarAsync(execucaoId, CancellationToken.None);
+    }
+
+    private GeoEtlOrquestrador CriarOrquestrador(
+        GeoDbContext ctx,
+        IGeoFonteDadosFactory fonteFactory,
+        IGeoCepCacheInvalidador cache,
+        GeoEtlMetrics metricas)
+    {
+        IConfiguration configuracao = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:GeoDb"] = _fixture.ConnectionString })
+            .Build();
+
+        GeoImportadorPaisEstadoCidade topo = new(ctx, NullLogger<GeoImportadorPaisEstadoCidade>.Instance);
+        GeoImportadorDistritoBairro distritoBairro = new(ctx);
+        LogradouroCopyImporter logradouro = new(configuracao, TimeProvider.System, NullLogger<LogradouroCopyImporter>.Instance);
+        GeoImportadorLocalidades folhas = new(distritoBairro, logradouro, NullLogger<GeoImportadorLocalidades>.Instance);
+
+        return new GeoEtlOrquestrador(
+            ctx,
+            topo,
+            folhas,
+            fonteFactory,
+            cache,
+            new GeoImportacaoFila(),
+            metricas,
+            TimeProvider.System,
+            NullLogger<GeoEtlOrquestrador>.Instance);
+    }
+
+    private async Task LimparAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE pais, logradouro_complemento, cep_grande_usuario, geo_importacao_execucao CASCADE");
+    }
+
+    private static FonteEmMemoria FonteCompleta(string versao)
+    {
+        FonteEmMemoria fonte = new() { Versao = versao };
+
+        fonte.Paises.Add(DadosDne.Pais("BRA", "Brasil", "BR"));
+        fonte.Estados.Add(DadosDne.Estado("PA", "Pará", capital: "Belém", faixaIni: "66000000", faixaFim: "68899999"));
+        fonte.Estados.Add(DadosDne.Estado("SP", "São Paulo", regiao: "Sudeste", capital: "São Paulo", faixaIni: "01000000", faixaFim: "19999999"));
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador("PA", "15"));
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador("SP", "35"));
+        fonte.Cidades.Add(DadosDne.Cidade(Maraba, "Marabá", "PA", ddd: "94"));
+        fonte.Cidades.Add(DadosDne.Cidade(SaoPaulo, "São Paulo", "SP", ddd: "11"));
+        fonte.CidadeIds.Add(DadosDne.CidadeId(1, Maraba));
+        fonte.CidadeIds.Add(DadosDne.CidadeId(2, SaoPaulo));
+
+        fonte.Distritos.Add(DadosDne.Distrito(10, "Cidade Nova", 1));
+        fonte.Distritos.Add(DadosDne.Distrito(20, "Centro", 2));
+        fonte.Logradouros.Add(DadosDne.Logradouro(CepMaraba, "Rua A", 1, distritoIdDne: 10));
+        fonte.Logradouros.Add(DadosDne.Logradouro(CepSaoPaulo, "Av Paulista", 2, distritoIdDne: 20));
+
+        return fonte;
+    }
+
+    // Release seguinte sem São Paulo (cidade + CEP somem) — exercita a política de stale.
+    private static FonteEmMemoria FonteSomenteMaraba(string versao)
+    {
+        FonteEmMemoria fonte = new() { Versao = versao };
+
+        fonte.Paises.Add(DadosDne.Pais("BRA", "Brasil", "BR"));
+        fonte.Estados.Add(DadosDne.Estado("PA", "Pará", capital: "Belém", faixaIni: "66000000", faixaFim: "68899999"));
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador("PA", "15"));
+        fonte.Cidades.Add(DadosDne.Cidade(Maraba, "Marabá", "PA", ddd: "94"));
+        fonte.CidadeIds.Add(DadosDne.CidadeId(1, Maraba));
+
+        fonte.Distritos.Add(DadosDne.Distrito(10, "Cidade Nova", 1));
+        fonte.Logradouros.Add(DadosDne.Logradouro(CepMaraba, "Rua A", 1, distritoIdDne: 10));
+
+        return fonte;
+    }
+
+    private sealed class FonteFactoryFake : IGeoFonteDadosFactory
+    {
+        private readonly IReadOnlyDictionary<string, IGeoFonteDados> _porVersao;
+
+        public FonteFactoryFake(IReadOnlyDictionary<string, IGeoFonteDados> porVersao)
+        {
+            _porVersao = porVersao;
+        }
+
+        public IGeoFonteDados Criar(string versao) => _porVersao[versao];
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -147,6 +147,27 @@ public sealed class EtlAtualizacaoPeriodicaTests
         await cache.DidNotReceive().InvalidarAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact(DisplayName = "Robustez: cache indisponível ao selar (ex.: Redis fora resolvido pelo Lazy) não reverte a carga já concluída")]
+    public async Task SeloComCacheIndisponivel_NaoFalhaCarga()
+    {
+        await LimparAsync();
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
+        {
+            ["202601"] = FonteCompleta("202601"),
+        });
+        // Lazy que lança ao resolver — simula o IConnectionMultiplexer.Connect falhando no .Value.
+        Lazy<IGeoCepCacheInvalidador> cacheQuebrado = new(() => throw new InvalidOperationException("Redis fora do ar"));
+
+        Guid id = await CriarExecucaoAsync("202601");
+        Func<Task> acao = () => ExecutarComLazyAsync(id, fonteFactory, cacheQuebrado);
+
+        await acao.Should().NotThrowAsync();
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+        execucao.Status.Should().Be(StatusImportacao.Concluida, "falha de cache ao selar é best-effort, não pode reverter a carga");
+    }
+
     private async Task<Guid> CriarExecucaoAsync(string versao)
     {
         await using GeoDbContext ctx = _fixture.CreateDbContext();
@@ -158,18 +179,21 @@ public sealed class EtlAtualizacaoPeriodicaTests
         return execucao.Id;
     }
 
-    private async Task ExecutarAsync(Guid execucaoId, IGeoFonteDadosFactory fonteFactory, IGeoCepCacheInvalidador cache)
+    private Task ExecutarAsync(Guid execucaoId, IGeoFonteDadosFactory fonteFactory, IGeoCepCacheInvalidador cache) =>
+        ExecutarComLazyAsync(execucaoId, fonteFactory, new Lazy<IGeoCepCacheInvalidador>(() => cache));
+
+    private async Task ExecutarComLazyAsync(Guid execucaoId, IGeoFonteDadosFactory fonteFactory, Lazy<IGeoCepCacheInvalidador> cacheLazy)
     {
         await using GeoDbContext ctx = _fixture.CreateDbContext();
         using GeoEtlMetrics metricas = new();
-        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cache, metricas);
+        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas);
         await orquestrador.ExecutarAsync(execucaoId, CancellationToken.None);
     }
 
     private GeoEtlOrquestrador CriarOrquestrador(
         GeoDbContext ctx,
         IGeoFonteDadosFactory fonteFactory,
-        IGeoCepCacheInvalidador cache,
+        Lazy<IGeoCepCacheInvalidador> cacheLazy,
         GeoEtlMetrics metricas)
     {
         IConfiguration configuracao = new ConfigurationBuilder()
@@ -186,7 +210,7 @@ public sealed class EtlAtualizacaoPeriodicaTests
             topo,
             folhas,
             fonteFactory,
-            new Lazy<IGeoCepCacheInvalidador>(() => cache),
+            cacheLazy,
             new GeoImportacaoFila(),
             metricas,
             TimeProvider.System,

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -173,6 +173,33 @@ public sealed class EtlAtualizacaoPeriodicaTests
         execucao.Status.Should().Be(StatusImportacao.Concluida, "falha de cache ao selar é best-effort, não pode reverter a carga");
     }
 
+    [Fact(DisplayName = "Integridade: recarga com release vazia/sem âncora falha e NÃO marca a base existente como obsoleta")]
+    public async Task RecargaVazia_Falha_SemMarcarStale()
+    {
+        await LimparAsync();
+        IGeoCepCacheInvalidador cache = Substitute.For<IGeoCepCacheInvalidador>();
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
+        {
+            ["202601"] = FonteCompleta("202601"),
+            ["202602"] = new FonteEmMemoria { Versao = "202602" }, // staging vazio (não restaurado)
+        });
+
+        Guid id1 = await CriarExecucaoAsync("202601");
+        await ExecutarAsync(id1, fonteFactory, cache);
+
+        Guid id2 = await CriarExecucaoAsync("202602");
+        await ExecutarAsync(id2, fonteFactory, cache);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao exec2 = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id2);
+        exec2.Status.Should().Be(StatusImportacao.Falhou, "uma release vazia não pode concluir");
+
+        Cidade maraba = await leitura.Cidades.SingleAsync(c => c.CodigoIbge == Maraba);
+        maraba.Vigente.Should().BeTrue("a release vazia não pode marcar a base existente como obsoleta");
+        maraba.VersaoDataset.Should().Be("202601");
+        await cache.DidNotReceive().InvalidarAsync("202602", Arg.Any<CancellationToken>());
+    }
+
     private async Task<Guid> CriarExecucaoAsync(string versao)
     {
         await using GeoDbContext ctx = _fixture.CreateDbContext();

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/GeoExecucaoReconciliadorTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/GeoExecucaoReconciliadorTests.cs
@@ -1,0 +1,83 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Reconciliação de execuções abandonadas (Story #674): só execuções <c>EmAndamento</c>
+/// mais velhas que o limite de abandono são reclamadas como falha — uma carga recém-iniciada
+/// (possivelmente ativa em outra réplica) é preservada. O índice único parcial impede dois
+/// registros EmAndamento ao mesmo tempo, então os dois cenários são testados isoladamente.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class GeoExecucaoReconciliadorTests
+{
+    private static readonly TimeSpan Limite = TimeSpan.FromHours(6);
+
+    private readonly GeoPostgisFixture _fixture;
+
+    public GeoExecucaoReconciliadorTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Execução EmAndamento mais velha que o limite é reclamada como falha")]
+    public async Task ExecucaoAntiga_Reclamada()
+    {
+        await LimparAsync();
+        DateTimeOffset agora = TimeProvider.System.GetUtcNow();
+        Guid id = await CriarEmAndamentoAsync(agora - TimeSpan.FromHours(10));
+
+        int afetadas;
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            afetadas = await GeoExecucaoReconciliador.ReclamarAbandonadasAsync(ctx, agora, Limite, CancellationToken.None);
+        }
+
+        afetadas.Should().Be(1);
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+        execucao.Status.Should().Be(StatusImportacao.Falhou);
+        execucao.ConcluidoEm.Should().NotBeNull();
+    }
+
+    [Fact(DisplayName = "Execução EmAndamento recente é preservada (não reclamada)")]
+    public async Task ExecucaoRecente_Preservada()
+    {
+        await LimparAsync();
+        DateTimeOffset agora = TimeProvider.System.GetUtcNow();
+        Guid id = await CriarEmAndamentoAsync(agora - TimeSpan.FromMinutes(1));
+
+        int afetadas;
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            afetadas = await GeoExecucaoReconciliador.ReclamarAbandonadasAsync(ctx, agora, Limite, CancellationToken.None);
+        }
+
+        afetadas.Should().Be(0);
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+        execucao.Status.Should().Be(StatusImportacao.EmAndamento);
+    }
+
+    private async Task<Guid> CriarEmAndamentoAsync(DateTimeOffset iniciadoEm)
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = GeoImportacaoExecucao.Iniciar("202601", "teste", iniciadoEm).Value!;
+        ctx.ImportacaoExecucoes.Add(execucao);
+        await ctx.SaveChangesAsync();
+        return execucao.Id;
+    }
+
+    private async Task LimparAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE TABLE geo_importacao_execucao");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/GeoImportacaoUnitTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/GeoImportacaoUnitTests.cs
@@ -1,0 +1,131 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Domain.Errors;
+using Unifesspa.UniPlus.Geo.Infrastructure.Caching;
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Transições do registro de execução do ETL — Story #674.</summary>
+public sealed class GeoImportacaoExecucaoTests
+{
+    private static readonly DateTimeOffset Agora = new(2026, 6, 18, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact(DisplayName = "Iniciar com dados válidos cria a execução em andamento")]
+    public void Iniciar_Valido_CriaEmAndamento()
+    {
+        Result<GeoImportacaoExecucao> resultado = GeoImportacaoExecucao.Iniciar("202601", "admin-123", Agora);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Status.Should().Be(StatusImportacao.EmAndamento);
+        resultado.Value.VersaoDataset.Should().Be("202601");
+        resultado.Value.IniciadoEm.Should().Be(Agora);
+    }
+
+    [Theory(DisplayName = "Iniciar com versão fora de AAAAMM falha")]
+    [InlineData("20260")]
+    [InlineData("202600")]
+    [InlineData("202613")]
+    [InlineData("abcdef")]
+    public void Iniciar_VersaoInvalida_Falha(string versao)
+    {
+        Result<GeoImportacaoExecucao> resultado = GeoImportacaoExecucao.Iniciar(versao, "admin", Agora);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(GeoImportacaoErrorCodes.VersaoFormatoInvalido);
+    }
+
+    [Fact(DisplayName = "Iniciar com versão nula/vazia falha (entrada de API, não lança)")]
+    public void Iniciar_VersaoNula_Falha()
+    {
+        Result<GeoImportacaoExecucao> resultado = GeoImportacaoExecucao.Iniciar(null!, "admin", Agora);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(GeoImportacaoErrorCodes.VersaoObrigatoria);
+    }
+
+    [Fact(DisplayName = "Iniciar sem disparador falha")]
+    public void Iniciar_SemDisparador_Falha()
+    {
+        Result<GeoImportacaoExecucao> resultado = GeoImportacaoExecucao.Iniciar("202601", "  ", Agora);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(GeoImportacaoErrorCodes.DisparadoPorObrigatorio);
+    }
+
+    [Fact(DisplayName = "Concluir a partir de EmAndamento grava status e relatório")]
+    public void Concluir_DeEmAndamento_Sucede()
+    {
+        GeoImportacaoExecucao execucao = GeoImportacaoExecucao.Iniciar("202601", "admin", Agora).Value!;
+
+        Result resultado = execucao.Concluir(Agora.AddMinutes(5), "{}", "ok");
+
+        resultado.IsSuccess.Should().BeTrue();
+        execucao.Status.Should().Be(StatusImportacao.Concluida);
+        execucao.ConcluidoEm.Should().Be(Agora.AddMinutes(5));
+        execucao.RelatorioJson.Should().Be("{}");
+    }
+
+    [Fact(DisplayName = "Concluir duas vezes é rejeitado na segunda (transição inválida)")]
+    public void Concluir_Duplicado_Rejeita()
+    {
+        GeoImportacaoExecucao execucao = GeoImportacaoExecucao.Iniciar("202601", "admin", Agora).Value!;
+        execucao.Concluir(Agora, "{}", null);
+
+        Result segunda = execucao.Concluir(Agora, "{}", null);
+
+        segunda.IsFailure.Should().BeTrue();
+        segunda.Error!.Code.Should().Be(GeoImportacaoErrorCodes.TransicaoInvalida);
+    }
+
+    [Fact(DisplayName = "Falhar a partir de EmAndamento grava status e mensagem")]
+    public void Falhar_DeEmAndamento_Sucede()
+    {
+        GeoImportacaoExecucao execucao = GeoImportacaoExecucao.Iniciar("202601", "admin", Agora).Value!;
+
+        Result resultado = execucao.Falhar(Agora, "erro de infra");
+
+        resultado.IsSuccess.Should().BeTrue();
+        execucao.Status.Should().Be(StatusImportacao.Falhou);
+        execucao.Mensagem.Should().Be("erro de infra");
+    }
+}
+
+/// <summary>Invalidação do cache de CEP por selo de versão — Story #674, CA-05.</summary>
+public sealed class RedisGeoCepCacheInvalidadorTests
+{
+    [Fact(DisplayName = "Grava o selo da versão vigente numa única chave (sem varredura, sem tocar outras chaves)")]
+    public async Task Invalidar_GravaSeloDaVersao()
+    {
+        ICacheService cache = Substitute.For<ICacheService>();
+        RedisGeoCepCacheInvalidador invalidador = new(cache, NullLogger<RedisGeoCepCacheInvalidador>.Instance);
+
+        await invalidador.InvalidarAsync("202602", CancellationToken.None);
+
+        await cache.Received(1).DefinirAsync(
+            RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente,
+            "202602",
+            Arg.Any<TimeSpan?>(),
+            Arg.Any<CancellationToken>());
+        await cache.DidNotReceive().RemoverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Falha de cache é best-effort — não propaga (a carga já concluiu)")]
+    public async Task Invalidar_FalhaDeCache_NaoPropaga()
+    {
+        ICacheService cache = Substitute.For<ICacheService>();
+        cache.When(c => c.DefinirAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>()))
+            .Do(_ => throw new InvalidOperationException("Redis fora do ar"));
+        RedisGeoCepCacheInvalidador invalidador = new(cache, NullLogger<RedisGeoCepCacheInvalidador>.Instance);
+
+        Func<Task> acao = () => invalidador.InvalidarAsync("202602", CancellationToken.None);
+
+        await acao.Should().NotThrowAsync();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/GeoSeedHostedServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/GeoSeedHostedServiceTests.cs
@@ -1,0 +1,137 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Seed automático do Geo em desenvolvimento (Story #674, CA-01). Gate duplo (ambiente
+/// Development + flag) e disparo só com base vazia, validados com um serviço de
+/// importação espião — sem rodar a carga real.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class GeoSeedHostedServiceTests
+{
+    private readonly GeoPostgisFixture _fixture;
+
+    public GeoSeedHostedServiceTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01: em produção, o seed nunca dispara (mesmo com a flag ligada)")]
+    public async Task Producao_NaoSemeia()
+    {
+        await LimparAsync();
+        IGeoImportacaoService servico = ServicoEspiao();
+        GeoSeedHostedService seed = CriarSeed(servico, ambiente: "Production", flagLigada: true);
+
+        await seed.StartAsync(CancellationToken.None);
+
+        await servico.DidNotReceive().IniciarAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "CA-01: em desenvolvimento com a flag desligada, o seed não dispara")]
+    public async Task Desenvolvimento_FlagDesligada_NaoSemeia()
+    {
+        await LimparAsync();
+        IGeoImportacaoService servico = ServicoEspiao();
+        GeoSeedHostedService seed = CriarSeed(servico, ambiente: "Development", flagLigada: false);
+
+        await seed.StartAsync(CancellationToken.None);
+
+        await servico.DidNotReceive().IniciarAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "CA-01: em desenvolvimento com base já populada, o seed não recarrega")]
+    public async Task Desenvolvimento_BasePopulada_NaoSemeia()
+    {
+        await LimparAsync();
+        await SemearUmaCidadeAsync();
+        IGeoImportacaoService servico = ServicoEspiao();
+        GeoSeedHostedService seed = CriarSeed(servico, ambiente: "Development", flagLigada: true);
+
+        await seed.StartAsync(CancellationToken.None);
+
+        await servico.DidNotReceive().IniciarAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "CA-01: em desenvolvimento com base vazia e flag ligada, o seed dispara a versão configurada")]
+    public async Task Desenvolvimento_BaseVazia_Semeia()
+    {
+        await LimparAsync();
+        IGeoImportacaoService servico = ServicoEspiao();
+        GeoSeedHostedService seed = CriarSeed(servico, ambiente: "Development", flagLigada: true, versaoSeed: "202601");
+
+        await seed.StartAsync(CancellationToken.None);
+
+        await servico.Received(1).IniciarAsync("202601", "seed", Arg.Any<CancellationToken>());
+    }
+
+    private static IGeoImportacaoService ServicoEspiao()
+    {
+        IGeoImportacaoService servico = Substitute.For<IGeoImportacaoService>();
+        servico.IniciarAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Guid>.Success(Guid.CreateVersion7()));
+        return servico;
+    }
+
+    private GeoSeedHostedService CriarSeed(
+        IGeoImportacaoService servico,
+        string ambiente,
+        bool flagLigada,
+        string versaoSeed = "202601")
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => _fixture.CreateDbContext());
+        services.AddSingleton(servico);
+        ServiceProvider provider = services.BuildServiceProvider();
+
+        IHostEnvironment hostEnvironment = Substitute.For<IHostEnvironment>();
+        hostEnvironment.EnvironmentName.Returns(ambiente);
+
+        IOptions<EtlOpcoes> opcoes = Options.Create(new EtlOpcoes
+        {
+            SeedHabilitado = flagLigada,
+            VersaoSeed = versaoSeed,
+        });
+
+        return new GeoSeedHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            hostEnvironment,
+            opcoes,
+            NullLogger<GeoSeedHostedService>.Instance);
+    }
+
+    private async Task SemearUmaCidadeAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        FonteEmMemoria fonte = new() { Versao = "202601" };
+        fonte.Paises.Add(DadosDne.Pais("BRA", "Brasil", "BR"));
+        fonte.Estados.Add(DadosDne.Estado("PA", "Pará"));
+        fonte.EstadoIndicadores.Add(DadosDne.EstadoIndicador("PA", "15"));
+        fonte.Cidades.Add(DadosDne.Cidade("1500402", "Marabá", "PA"));
+
+        GeoImportadorPaisEstadoCidade importador = new(ctx, NullLogger<GeoImportadorPaisEstadoCidade>.Instance);
+        await importador.ImportarAsync(fonte, CancellationToken.None);
+    }
+
+    private async Task LimparAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE pais, logradouro_complemento, cep_grande_usuario, geo_importacao_execucao CASCADE");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Infrastructure/GeoApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Infrastructure/GeoApiFactory.cs
@@ -34,5 +34,8 @@ public sealed class GeoApiFactory : ApiFactoryBase<Program>
     [
         new("Auth:Authority", "http://localhost/test-realm"),
         new("Auth:Audience", "uniplus"),
+        // Worker do ETL desligado: o disparo (POST) cria o registro EmAndamento e
+        // retorna 202 sem que a carga real rode — torna 202/409 determinísticos (#674).
+        new("Geo:Etl:WorkerHabilitado", "false"),
     ];
 }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Infrastructure/GeoOpenApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Infrastructure/GeoOpenApiFactory.cs
@@ -21,5 +21,7 @@ public sealed class GeoOpenApiFactory : ApiFactoryBase<Program>
         new("ConnectionStrings:GeoDb", "Host=localhost;Port=5432;Database=uniplus_tests;Username=uniplus;Password=uniplus_dev"),
         new("Auth:Authority", "http://localhost/test-realm"),
         new("Auth:Audience", "uniplus"),
+        // Sem worker do ETL: a connection string é sintética (não há banco a tocar).
+        new("Geo:Etl:WorkerHabilitado", "false"),
     ];
 }


### PR DESCRIPTION
## Contexto

Última story da F3 do módulo **Geo** (#664). As irmãs entregaram **como** carregar (topo #672, folhas #673); esta entrega **quando, por quem e com qual rastreabilidade** reaplicar releases mensais da DNE — sem intervenção em banco e sem divergir (ADR-0092).

## O que muda

- **Registro de execução** `GeoImportacaoExecucao` (`EntityBase`) + migration `AddGeoImportacaoExecucao`: versão, status, disparador e relatório (`jsonb`). **Índice único parcial** sobre `status = EmAndamento` garante **uma carga por vez** (2º disparo → `409`), sem `Idempotency-Key`.
- **Orquestrador transacional** (`GeoEtlOrquestrador`, em `Geo.Infrastructure` — não é command Wolverine, ADR-0092): deriva o modo (inicial/recarga) do estado da base, roda os importadores de topo e folhas, e na recarga aplica a **política de stale** (`vigente=false` nas linhas ausentes na nova release, sem remoção física).
- **Gatilhos**: endpoint admin `POST/GET /api/admin/geo/importacoes` (`plataforma-admin`, `202 Accepted` + acompanhamento via `_links`) e **seed de desenvolvimento** (só em `Development` com flag e base vazia). Execução em segundo plano via fila in-process + `BackgroundService`, com **reconciliação por idade** das execuções abandonadas por reinício.
- **Invalidação do cache de CEP por selo de versão O(1)** (`SET geo:cep:versao-vigente`): sem `SCAN`/`KEYS` no Redis compartilhado, isolado de outros módulos. A F4 (#676) comporá a chave de lookup com o selo; entradas antigas viram *miss* e expiram por TTL.
- **Observabilidade**: métricas OpenTelemetry (`geo.etl.duracao/linhas/degradados/execucoes`) e logs `[LoggerMessage]`. Sem PII (reference data público).

## Critérios de aceite

| CA | Cobertura |
|----|-----------|
| CA-01 seed dev | `GeoSeedHostedServiceTests` (produção/flag/base populada/base vazia) |
| CA-02 endpoint admin | `GeoImportacoesEndpointTests` (202 + Location, 401, 403, 422) |
| CA-03 versionamento/idempotência | `EtlAtualizacaoPeriodicaTests.Recarga_*` |
| CA-04 linhas obsoletas | idem (cidade + CEP ausentes → `vigente=false`, sem remoção) |
| CA-05 invalidação cache | spy + `RedisGeoCepCacheInvalidadorTests` (selo O(1), best-effort) |
| CA-06 concorrência 409 | `GeoImportacoesEndpointTests` + índice único parcial |
| CA-07 observabilidade | `Carga_RegistraRelatorio_SemPii` + métricas |
| CA-08 LGPD | relatório/log sem PII; subject só no registro auditável |

## Decisões de arquitetura

- **Selo de versão O(1)** em vez de `DELETE` por `SCAN` (decisão do Tech Lead): o Redis é compartilhado entre módulos; varrer o keyspace bloquearia/custaria proporcional ao total e tocaria chaves alheias. O selo é atômico, isolado e cluster-safe.
- **Concorrência por índice único parcial** (a "linha EmAndamento" da spec, tornada race-safe): captura de `23505` → `409`, no padrão do `EfCoreIdempotencyStore`.
- **Reconciliação por idade**: só execuções `EmAndamento` mais velhas que o limite são reclamadas — uma carga recém-iniciada em outra réplica é preservada. Single-flight estrito é garantido pelo índice no banco; recuperação multi-réplica fina (lease/heartbeat) fica como evolução futura.

## Validação local

- `dotnet build UniPlus.slnx` — 51 projetos, **0 warnings** (`TreatWarningsAsErrors`).
- Geo: **124/124**; ArchTests: **24/24** (inclui ordem migration→Wolverine com os novos hosted services).
- Baseline `contracts/openapi.geo.json` regenerado com os endpoints admin.
- Revisão Codex (plano + diff) aplicada: race multi-réplica → reconciliação por idade; ordem selo-após-conclusão; subject fora do log; remoção de validator não exercido (entidade valida, → 422).

## Notas operacionais

- `Geo:Etl:WorkerHabilitado` (default `true`) deve permanecer ligado em produção; o job externo (cron de infra) chama o endpoint mensalmente.
- `Geo:Etl:SeedHabilitado` (default `false`) só liga na compose de dev.

Closes #674

Refs #664 #661