### PR TITLE
ci: escaneia e publica organizacao e configuracao via matriz derivada

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -15,10 +15,10 @@ name: Publish Images
 # Sem `latest`, sem `main` — ArgoCD pina semver, devs usam compose local
 # com build-by-context.
 #
-# Imagens publicadas:
-#   - ghcr.io/<owner>/uniplus-api-selecao
-#   - ghcr.io/<owner>/uniplus-api-ingresso
-#   - ghcr.io/<owner>/uniplus-api-portal
+# Imagens publicadas: uma por docker/Dockerfile.<módulo>, com a matriz
+# derivada pelo job `discover` (mesma fonte de verdade do trivy.yml):
+#   - ghcr.io/<owner>/uniplus-api-<módulo>
+# Hoje: selecao, ingresso, portal, organizacao, configuracao.
 #
 # Multi-arch: cada tag acima é publicada como manifest list cobrindo
 #   - linux/amd64  (cluster legacy GRU/E5)
@@ -48,18 +48,42 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  discover:
+    name: Descobrir módulos (Dockerfiles)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      modules: ${{ steps.list.outputs.modules }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Listar módulos a partir de docker/Dockerfile.*
+        id: list
+        # Fonte única de verdade: cada docker/Dockerfile.<módulo> vira um item
+        # da matriz `publish`, idêntico ao discover do trivy.yml. Nascer um
+        # Dockerfile novo já o publica, sem editar este workflow nem manter
+        # sincronia manual com o scan Trivy (CA-04 da issue #630).
+        run: |
+          set -euo pipefail
+          modules=$(ls docker/Dockerfile.* | sed 's#.*Dockerfile\.##' | sort | jq -R . | jq -cs .)
+          echo "modules=$modules" >> "$GITHUB_OUTPUT"
+          echo "Módulos descobertos: $modules"
+
   publish:
     name: Publish ${{ matrix.module }}
+    needs: discover
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     strategy:
       fail-fast: false
       matrix:
-        module:
-          - selecao
-          - ingresso
-          - portal
+        # Matriz derivada de docker/Dockerfile.* pelo job `discover` — mesma
+        # fonte de verdade do trivy.yml. Sem lista hard-coded para sincronizar.
+        module: ${{ fromJSON(needs.discover.outputs.modules) }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -2,7 +2,8 @@ name: Trivy
 
 # Varredura de vulnerabilidades (issue #24, ADR-0015 — "Snyk / Trivy"):
 #   1. `trivy fs` — dependências NuGet declaradas + lock files
-#   2. `trivy image` — vulnerabilidades das imagens Docker dos 3 módulos
+#   2. `trivy image` — vulnerabilidades das imagens Docker de cada módulo
+#      (matriz derivada de docker/Dockerfile.* pelo job `discover`)
 #
 # Resultados em SARIF alimentam a aba Security do GitHub via upload-sarif
 # (mesmo padrão do codeql.yml). Initial mode: alerta (não-bloqueante) —
@@ -41,6 +42,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  discover:
+    name: Descobrir módulos (Dockerfiles)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      modules: ${{ steps.list.outputs.modules }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Listar módulos a partir de docker/Dockerfile.*
+        id: list
+        # Fonte única de verdade: cada docker/Dockerfile.<módulo> vira um item
+        # da matriz `trivy-image`. Elimina o drift por construção — nascer um
+        # Dockerfile novo já o inclui no scan, sem editar este workflow nem
+        # manter sincronia manual com publish-images.yml (CA-04 da issue #630).
+        run: |
+          set -euo pipefail
+          modules=$(ls docker/Dockerfile.* | sed 's#.*Dockerfile\.##' | sort | jq -R . | jq -cs .)
+          echo "modules=$modules" >> "$GITHUB_OUTPUT"
+          echo "Módulos descobertos: $modules"
+
   trivy-fs:
     name: Trivy filesystem (NuGet + config)
     runs-on: ubuntu-latest
@@ -86,23 +111,22 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-fs.sarif
-          # `category` separa os resultados na aba Security entre os 4 scans
-          # (fs + 3 imagens), evitando que findings sobrescrevam uns aos outros.
+          # `category` separa os resultados na aba Security entre os scans
+          # (fs + uma imagem por módulo), evitando que findings se sobrescrevam.
           category: trivy-fs
 
   trivy-image:
     name: Trivy image (${{ matrix.module }})
+    needs: discover
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
-        # Mesmos 3 módulos do publish-images.yml. Mantém o set sincronizado
-        # — se um Dockerfile.X novo nascer, atualizar ambos.
-        module:
-          - selecao
-          - ingresso
-          - portal
+        # Matriz derivada de docker/Dockerfile.* pelo job `discover` — mesma
+        # fonte de verdade do publish-images.yml. Sem lista hard-coded para
+        # manter sincronizada (CA-04 da issue #630).
+        module: ${{ fromJSON(needs.discover.outputs.modules) }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Resumo

- Os módulos `organizacao` e `configuracao` passam a ser escaneados pelo Trivy e publicados no GHCR — antes ficavam de fora, embora já tivessem `docker/Dockerfile.*`.
- A matriz de módulos dos dois workflows deixa de ser uma lista hard-coded e passa a ser **derivada de `docker/Dockerfile.*`** por um job `discover`, eliminando o drift por construção.

## Contexto / Problema

As matrizes `module` de `trivy.yml` e `publish-images.yml` listavam apenas `selecao`, `ingresso` e `portal`. Quando os Dockerfiles de `organizacao` e `configuracao` (Sprint 3) nasceram, ninguém atualizou as duas listas — apesar do próprio comentário do `trivy.yml` pedir que o set ficasse sincronizado.

**Consequência:** as imagens de runtime de `organizacao-api` e `configuracao-api` não passavam pelo scan de vulnerabilidades nem eram publicadas no registry. Gap de segurança e de release, **pré-existente** (apenas evidenciado pelo PR #628, não introduzido por ele).

## Mudanças

### Modificados
- `.github/workflows/trivy.yml`
  - Novo job `discover` (checkout + lista `docker/Dockerfile.*` → JSON array via `jq`), com `permissions: contents: read`.
  - `trivy-image` agora declara `needs: discover` e usa `matrix.module: ${{ fromJSON(needs.discover.outputs.modules) }}`.
  - Comentários de cabeçalho e da `category` SARIF atualizados (não falam mais em "3 módulos / 4 scans").
- `.github/workflows/publish-images.yml`
  - Mesmo job `discover` e `publish` com `needs: discover` + matriz derivada.
  - Cabeçalho de "Imagens publicadas" atualizado para refletir "uma por `Dockerfile.<módulo>`".

## Critérios de aceite (issue #630)

- **CA-01** — CI passa a rodar `Trivy image (organizacao)` e `Trivy image (configuracao)`.
- **CA-02** — as duas matrizes cobrem os 5 módulos (na prática, **todos** os `docker/Dockerfile.*`, sempre).
- **CA-03** — `publish-images.yml` publica `uniplus-api-organizacao` e `uniplus-api-configuracao` no fluxo de release.
- **CA-04** — o drift não é apenas detectado, e sim **eliminado por construção**: o Dockerfile é a fonte única de verdade; um Dockerfile novo entra automaticamente no scan e no publish, sem editar workflow nem manter sincronia entre os dois.

## Validação (local)

A mudança é exclusivamente em workflows YAML — não toca código C#, então `dotnet build`/testes não se aplicam. Validação equivalente executada localmente, toda verde:

- Pipeline do `discover` rodada contra os Dockerfiles reais → `["configuracao","ingresso","organizacao","portal","selecao"]` (5 itens, incl. os dois novos).
- Parse YAML dos dois arquivos (`yaml.safe_load`).
- `actionlint` nos dois workflows — sem erros (valida `needs`, `fromJSON`, matriz e expressões).

## Notas para revisão

- `jq` é pré-instalado nos runners `ubuntu-latest`.
- O smoke estrutural do `publish-images.yml` (não-root + entrypoint `Unifesspa.UniPlus`) já é satisfeito por ambos os Dockerfiles novos — não exigiu ajuste.
- Não há gates de release a jusante (Helm/ArgoCD) que dependam do set de módulos neste repo; adicionar módulos não quebra nada.

Closes #630