### PR TITLE
ci: deriva contratos do lint OpenAPI por glob em vez de lista fixa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,14 +74,25 @@ jobs:
         # Pin de versão evita regressões surpresa: novas regras `recommended`
         # ou mudanças de severity em releases minor podem bloquear PRs sem
         # mudança de código. Atualizar manualmente após validação local.
+        #
+        # A lista de contratos é descoberta por glob (contracts/openapi.*.json),
+        # não hard-coded: um contrato novo entra no lint sem editar este
+        # workflow (issue #696, mesmo padrão da matriz derivada da #630). A
+        # guarda abaixo falha se o glob não casar nada — evita "verde por
+        # vacuidade", em que o step passaria sem ter lintado nenhum arquivo.
         run: |
+          set -euo pipefail
+          shopt -s nullglob
+          contracts=(contracts/openapi.*.json)
+          if [ ${#contracts[@]} -eq 0 ]; then
+            echo "::error::Nenhum contrato encontrado em contracts/openapi.*.json"
+            exit 1
+          fi
+          echo "Lintando ${#contracts[@]} contrato(s): ${contracts[*]}"
           npx --yes @stoplight/spectral-cli@6.15.0 lint \
             --ruleset tools/spectral/.spectral.yaml \
             --fail-severity=error \
-            contracts/openapi.selecao.json \
-            contracts/openapi.ingresso.json \
-            contracts/openapi.organizacao.json \
-            contracts/openapi.geo.json
+            "${contracts[@]}"
 
   forbidden-deps:
     name: Forbidden dependencies


### PR DESCRIPTION
## Resumo

- O step `Lint OpenAPI baselines` (`ci.yml`, job `spectral`) deixa de usar uma lista hard-coded de contratos e passa a **descobri-los por glob** `contracts/openapi.*.json`.
- Corrige um drift **já existente** (não apenas previne futuro): `contracts/openapi.configuracao.json` tinha baseline registrada mas estava fora da lista — nunca era lintado.

## Contexto / Problema

A lista de contratos era enumerada à mão no workflow. Durante a #630 esse padrão hard-coded já tinha causado gap no Trivy/publish. Ao implementar esta issue, descobri que o mesmo drift **já havia ocorrido aqui**: o commit `f54b03f` adicionou `contracts/openapi.configuracao.json` (baseline da API de configuração), mas ninguém o acrescentou à lista do lint — então o Spectral nunca o validou.

## Mudança

`.github/workflows/ci.yml` — step `Lint OpenAPI baselines`:

- Glob no shell com `shopt -s nullglob` → `contracts=(contracts/openapi.*.json)`.
- **Guarda anti-vacuidade:** falha com erro explícito se o glob não casar nenhum arquivo (evita "verde por vacuidade" — passar sem ter lintado nada).
- Log de quantos/quais contratos serão lintados.
- `--ruleset` e `--fail-severity=error` inalterados.

## Critérios de aceite (issue #696)

- **CA-01** — o step linta todos os `contracts/openapi.*.json` sem lista hard-coded.
- **CA-02** — um contrato novo entra no lint sem editar o `ci.yml`.
- **CA-03** — CI verde; os contratos já cobertos continuam cobertos.

## Validação (local)

Tudo verde, executado no worktree:

- Glob expande para os **5** contratos: `configuracao, geo, ingresso, organizacao, selecao` (inclui o que faltava).
- Guarda anti-vacuidade testada em diretório sem contratos → falha com exit 1, como esperado.
- Parse YAML + `actionlint` — sem erros.
- **Spectral real** (`@stoplight/spectral-cli@6.15.0`) sobre os 5 contratos: `64 problems (0 errors, 64 warnings)`, exit `0`. Os warnings (`operation-description`/`operation-operationId`) são pré-existentes em todos os contratos e **não bloqueiam** (gate é `--fail-severity=error`). Incluir `configuracao` não introduz erro.

## Notas para revisão

- O `configuracao` passa a ser lintado pela primeira vez; como só gera warnings, não quebra o CI. Endereçar esses warnings (descrição/operationId nas operations) é assunto separado dos contratos, não deste PR de CI.

Closes #696