### PR TITLE
feat(geo): API pública de leitura de estados e cidades

### DIFF
--- a/contracts/openapi.geo.json
+++ b/contracts/openapi.geo.json
@@ -162,6 +162,410 @@
         }
       }
     },
+    "/api/cidades": {
+      "get": {
+        "tags": [
+          "Cidades"
+        ],
+        "parameters": [
+          {
+            "name": "uf",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CidadeResumoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CidadeResumoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CidadeResumoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/cidades/{codigoIbge}": {
+      "get": {
+        "tags": [
+          "Cidades"
+        ],
+        "parameters": [
+          {
+            "name": "codigoIbge",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CidadeDetalheDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CidadeDetalheDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CidadeDetalheDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/estados": {
+      "get": {
+        "tags": [
+          "Estados"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EstadoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EstadoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EstadoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/estados/{uf}": {
+      "get": {
+        "tags": [
+          "Estados"
+        ],
+        "parameters": [
+          {
+            "name": "uf",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstadoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstadoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EstadoDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/admin/geo/importacoes": {
       "post": {
         "tags": [
@@ -394,6 +798,206 @@
           }
         }
       },
+      "CidadeDetalheDto": {
+        "required": [
+          "id",
+          "codigoIbge",
+          "nome",
+          "uf",
+          "ddd",
+          "latitude",
+          "longitude",
+          "mesorregiaoNome",
+          "microrregiaoNome",
+          "regiaoIntermediariaNome",
+          "regiaoImediataNome",
+          "indicador"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigoIbge": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "uf": {
+            "type": "string"
+          },
+          "ddd": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "mesorregiaoNome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "microrregiaoNome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "regiaoIntermediariaNome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "regiaoImediataNome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "indicador": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CidadeIndicadorDto"
+              }
+            ]
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CidadeIndicadorDto": {
+        "required": [
+          "gentilico",
+          "areaKm2",
+          "populacaoResidente",
+          "densidadeDemografica",
+          "idh",
+          "aniversario"
+        ],
+        "type": "object",
+        "properties": {
+          "gentilico": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "areaKm2": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "populacaoResidente": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "densidadeDemografica": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "idh": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "aniversario": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "CidadeResumoDto": {
+        "required": [
+          "id",
+          "codigoIbge",
+          "nome",
+          "uf",
+          "ddd"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigoIbge": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "uf": {
+            "type": "string"
+          },
+          "ddd": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "DispararImportacaoRequest": {
         "required": [
           "versao"
@@ -402,6 +1006,76 @@
         "properties": {
           "versao": {
             "type": "string"
+          }
+        }
+      },
+      "EstadoDto": {
+        "required": [
+          "id",
+          "uf",
+          "nome",
+          "regiao",
+          "capital",
+          "codigoIbge",
+          "latitude",
+          "longitude"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "uf": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "regiao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "capital": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "codigoIbge": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },
@@ -722,6 +1396,12 @@
     },
     {
       "name": "_smoke"
+    },
+    {
+      "name": "Cidades"
+    },
+    {
+      "name": "Estados"
     },
     {
       "name": "GeoImportacoes"

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/CidadesController.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/CidadesController.cs
@@ -1,0 +1,134 @@
+namespace Unifesspa.UniPlus.Geo.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Queries.Cidades;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+
+/// <summary>
+/// Endpoints públicos de leitura de Cidades — reference data
+/// (<c>[AllowAnonymous]</c>, sem Idempotency-Key, carga via ETL/F3):
+/// <c>GET /api/cidades?uf=&amp;q=</c> (lista paginada com filtro por UF e busca
+/// textual) e <c>GET /api/cidades/{codigoIbge}</c> (detalhe pela chave natural).
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed partial class CidadesController : ControllerBase
+{
+    private const string ResourceTag = "cidades";
+
+    /// <summary>Limite defensivo de comprimento do termo de busca (cobre o Nome máximo + margem).</summary>
+    private const int BuscaMaxLength = 256;
+
+    private readonly IQueryBus _queryBus;
+    private readonly IResourceLinksBuilder<CidadeResumoDto> _resumoLinks;
+    private readonly IResourceLinksBuilder<CidadeDetalheDto> _detalheLinks;
+
+    public CidadesController(
+        IQueryBus queryBus,
+        IResourceLinksBuilder<CidadeResumoDto> resumoLinks,
+        IResourceLinksBuilder<CidadeDetalheDto> detalheLinks)
+    {
+        _queryBus = queryBus;
+        _resumoLinks = resumoLinks;
+        _detalheLinks = detalheLinks;
+    }
+
+    /// <summary>
+    /// Lista as Cidades vigentes, paginadas por cursor opaco bidirecional (ADR-0026 +
+    /// ADR-0089), com filtros opcionais: <c>uf</c> (filtro por UF) e <c>q</c> (busca
+    /// textual acento/caixa-insensível sobre o nome). Os filtros viajam como query
+    /// params e combinam com o cursor — o cliente reanexa-os a cada página ao seguir
+    /// o <c>cursor</c> do header <c>Link</c>.
+    /// </summary>
+    [HttpGet("cidades")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "cidade", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<CidadeResumoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        [FromQuery(Name = "uf")] string? uf,
+        [FromQuery(Name = "q")] string? q,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        if (q is { Length: > BuscaMaxLength })
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Termo de busca muito longo",
+                Detail = $"O parâmetro 'q' não pode exceder {BuscaMaxLength} caracteres.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        ListarCidadesResult resultado = await _queryBus
+            .Send(new ListarCidadesQuery(page.AfterId, page.Limit, page.Direction, uf, q), cancellationToken)
+            .ConfigureAwait(false);
+
+        // HATEOAS Level 1 (ADR-0029 §"Coleção"): cada item carrega seu _links.self.
+        CidadeResumoDto[] comLinks = [.. resultado.Items.Select(c => c with { Links = _resumoLinks.Build(c) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Obtém uma Cidade pela chave natural <paramref name="codigoIbge"/> (7 dígitos),
+    /// com territorial embutido + indicador 1:1. Formato inválido → 400 (decode no
+    /// boundary, ADR-0031); bem-formado e inexistente → 404.
+    /// </summary>
+    [HttpGet("cidades/{codigoIbge}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "cidade", Versions = [1])]
+    [ProducesResponseType(typeof(CidadeDetalheDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorCodigoIbge(string codigoIbge, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(codigoIbge) || !CodigoIbgeRegex().IsMatch(codigoIbge))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Código IBGE inválido",
+                Detail = "O código IBGE deve ter exatamente 7 dígitos.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        CidadeDetalheDto? cidade = await _queryBus
+            .Send(new ObterCidadePorCodigoIbgeQuery(codigoIbge), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (cidade is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(cidade with { Links = _detalheLinks.Build(cidade) });
+    }
+
+    // [0-9] e não \d: em .NET \d casa dígitos Unicode (ex.: árabe-índicos); a chave
+    // IBGE é ASCII — um "7 dígitos" não-ASCII deve ser 400 (formato), não 404.
+    [GeneratedRegex(@"^[0-9]{7}$")]
+    private static partial Regex CodigoIbgeRegex();
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/EstadosController.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/EstadosController.cs
@@ -1,0 +1,109 @@
+namespace Unifesspa.UniPlus.Geo.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Queries.Estados;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+
+/// <summary>
+/// Endpoints públicos de leitura de Estados (UFs) — reference data
+/// (<c>[AllowAnonymous]</c>, sem Idempotency-Key, carga via ETL/F3):
+/// <c>GET /api/estados</c> (lista paginada por cursor) e
+/// <c>GET /api/estados/{uf}</c> (detalhe pela chave natural <c>uf</c>).
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed partial class EstadosController : ControllerBase
+{
+    private const string ResourceTag = "estados";
+
+    private readonly IQueryBus _queryBus;
+    private readonly IResourceLinksBuilder<EstadoDto> _linksBuilder;
+
+    public EstadosController(IQueryBus queryBus, IResourceLinksBuilder<EstadoDto> linksBuilder)
+    {
+        _queryBus = queryBus;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista as UFs vigentes, paginadas por cursor opaco bidirecional (ADR-0026 +
+    /// ADR-0089). Navegação via header <c>Link</c> (RFC 5988/8288); cada item
+    /// carrega seu <c>_links.self</c> resolvível para <c>GET /api/estados/{uf}</c>.
+    /// </summary>
+    [HttpGet("estados")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "estado", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<EstadoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarEstadosResult resultado = await _queryBus
+            .Send(new ListarEstadosQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        // HATEOAS Level 1 (ADR-0029 §"Coleção"): cada item carrega seu _links.self.
+        EstadoDto[] comLinks = [.. resultado.Items.Select(e => e with { Links = _linksBuilder.Build(e) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Obtém um Estado pela chave natural <paramref name="uf"/> (2 letras). Formato
+    /// inválido → 400 (decode no boundary, ADR-0031); bem-formado e inexistente → 404.
+    /// </summary>
+    [HttpGet("estados/{uf}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "estado", Versions = [1])]
+    [ProducesResponseType(typeof(EstadoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorUf(string uf, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(uf) || !UfRegex().IsMatch(uf))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "UF inválida",
+                Detail = "A UF deve ter exatamente 2 letras (ex.: PA).",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        EstadoDto? estado = await _queryBus
+            .Send(new ObterEstadoPorUfQuery(uf), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (estado is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(estado with { Links = _linksBuilder.Build(estado) });
+    }
+
+    [GeneratedRegex(@"^[A-Za-z]{2}$")]
+    private static partial Regex UfRegex();
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CidadeDetalheLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CidadeDetalheLinksBuilder.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="CidadeDetalheDto"/>. Relações: <c>self</c>
+/// (<c>GET /api/cidades/{codigoIbge}</c>), <c>estado</c>
+/// (<c>GET /api/estados/{uf}</c>) e <c>collection</c> (<c>GET /api/cidades</c>).
+/// </summary>
+/// <remarks>
+/// As relações <c>distritos</c> e <c>bairros</c> (endpoints de hierarquia/autocomplete)
+/// ficam fora desta fatia: seus endpoints só existem na Story irmã da F4. Emitir
+/// <c>_links</c> para rotas inexistentes violaria a ADR-0029 (links devem ser
+/// navegáveis — resolveriam 404). Entram quando os endpoints forem entregues.
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via AddSingleton<IResourceLinksBuilder<CidadeDetalheDto>, CidadeDetalheLinksBuilder>().")]
+internal sealed class CidadeDetalheLinksBuilder : IResourceLinksBuilder<CidadeDetalheDto>
+{
+    private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+    private static readonly string EstadosControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.EstadosController));
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CidadeDetalheLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(CidadeDetalheDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string self = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.ObterPorCodigoIbge),
+            CidadesControllerNome, new { codigoIbge = dto.CodigoIbge });
+        string estado = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.EstadosController.ObterPorUf),
+            EstadosControllerNome, new { uf = dto.Uf });
+        string collection = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.Listar),
+            CidadesControllerNome, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["estado"] = estado,
+            ["collection"] = collection,
+        };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CidadeResumoLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CidadeResumoLinksBuilder.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="CidadeResumoDto"/> (item de coleção). Relação <c>self</c>
+/// (<c>GET /api/cidades/{codigoIbge}</c>) — leva ao detalhe completo da cidade.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via AddSingleton<IResourceLinksBuilder<CidadeResumoDto>, CidadeResumoLinksBuilder>().")]
+internal sealed class CidadeResumoLinksBuilder : IResourceLinksBuilder<CidadeResumoDto>
+{
+    private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CidadeResumoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(CidadeResumoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string self = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.ObterPorCodigoIbge),
+            CidadesControllerNome, new { codigoIbge = dto.CodigoIbge });
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+        };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/EstadoLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/EstadoLinksBuilder.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="EstadoDto"/>. Relações: <c>self</c> (<c>GET /api/estados/{uf}</c>),
+/// <c>cidades</c> (lista de cidades da UF, <c>GET /api/cidades?uf={uf}</c>) e
+/// <c>collection</c> (<c>GET /api/estados</c>).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via AddSingleton<IResourceLinksBuilder<EstadoDto>, EstadoLinksBuilder>().")]
+internal sealed class EstadoLinksBuilder : IResourceLinksBuilder<EstadoDto>
+{
+    private static readonly string EstadosControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.EstadosController));
+    private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public EstadoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(EstadoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string self = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.EstadosController.ObterPorUf), EstadosControllerNome, new { uf = dto.Uf });
+        string collection = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.EstadosController.Listar), EstadosControllerNome, values: null);
+
+        // A lista de cidades da UF é o endpoint de cidades com o filtro uf= anexado
+        // (uf é query param, não rota — o LinkGenerator não a inclui em values).
+        string cidadesBase = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.Listar), CidadesControllerNome, values: null);
+        string cidades = $"{cidadesBase}?uf={Uri.EscapeDataString(dto.Uf)}";
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["cidades"] = cidades,
+            ["collection"] = collection,
+        };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/GeoLinkPathResolver.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/GeoLinkPathResolver.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+/// <summary>
+/// Resolve URIs relativas (sem scheme/host) de actions dos controllers do Geo via
+/// <see cref="LinkGenerator"/>, para os <c>_links</c> hypermedia (HATEOAS Level 1,
+/// ADR-0029). Centraliza a derivação por route template e a regra de "controller
+/// sem sufixo" usada pelos builders de Estado e Cidade.
+/// </summary>
+internal static class GeoLinkPathResolver
+{
+    private const string ControllerSuffix = "Controller";
+
+    /// <summary>Nome do controller sem o sufixo <c>Controller</c> (ex.: <c>EstadosController</c> → <c>Estados</c>).</summary>
+    public static string ControllerName(string fullControllerName) =>
+        fullControllerName.EndsWith(ControllerSuffix, StringComparison.Ordinal)
+            ? fullControllerName[..^ControllerSuffix.Length]
+            : fullControllerName;
+
+    /// <summary>
+    /// Resolve o path da action; lança se a rota não for resolvível (config de
+    /// rota inconsistente — falha cedo em vez de emitir link quebrado).
+    /// </summary>
+    public static string Resolver(
+        LinkGenerator linkGenerator,
+        HttpContext? httpContext,
+        string action,
+        string controller,
+        object? values)
+    {
+        string? path = httpContext is not null
+            ? linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {controller}.{action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
@@ -68,6 +68,11 @@ builder.Services.AddGeoInfrastructure();
 // HATEOAS Level 1 (ADR-0029) do registro de execução do ETL (#674).
 builder.Services.AddSingleton<IResourceLinksBuilder<ImportacaoGeoDto>, ImportacaoGeoLinksBuilder>();
 
+// HATEOAS Level 1 (ADR-0029) das leituras de reference data (#675): Estado e Cidade.
+builder.Services.AddSingleton<IResourceLinksBuilder<EstadoDto>, EstadoLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<CidadeResumoDto>, CidadeResumoLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<CidadeDetalheDto>, CidadeDetalheLinksBuilder>();
+
 // Migrations EF Core aplicadas no host StartAsync via IHostedService.
 // Registrado ANTES de UseWolverineOutboxCascading + AddWolverineMessaging
 // (invariante #419) — fitness MigrationBeforeWolverineRuntimeOrderTests cobre

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/FiltroListagemCidades.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/FiltroListagemCidades.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+/// <summary>
+/// Critérios opcionais da listagem de cidades (<c>GET /api/cidades?uf=&amp;q=</c>),
+/// aplicados no read-side sobre a paginação por cursor keyset. Ambos combinam (AND)
+/// e são ortogonais ao cursor: como o keyset ordena por <c>Id</c>, a janela
+/// permanece coerente sobre o conjunto já filtrado.
+/// </summary>
+/// <param name="Uf">
+/// UF do filtro (<c>case-insensitive</c>, normalizada para maiúsculas no reader);
+/// <see langword="null"/>/vazio = sem filtro por UF. UF inexistente resulta em
+/// lista vazia (não é erro — é filtro, não recurso).
+/// </param>
+/// <param name="Termo">
+/// Termo de busca bruto do usuário; <see langword="null"/>/vazio = sem filtro
+/// textual. A normalização (remoção de diacríticos) e o <c>ILIKE</c> sobre
+/// <c>nome_normalizado</c> são aplicados no reader.
+/// </param>
+public sealed record FiltroListagemCidades(string? Uf, string? Termo)
+{
+    /// <summary>Filtro sem critérios — equivalente a listar tudo (vigente).</summary>
+    public static FiltroListagemCidades Nenhum { get; } = new(null, null);
+
+    /// <summary>Indica se há filtro por UF aplicável.</summary>
+    public bool TemUf => !string.IsNullOrWhiteSpace(Uf);
+
+    /// <summary>Indica se há termo de busca textual aplicável.</summary>
+    public bool TemBusca => !string.IsNullOrWhiteSpace(Termo);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/ICidadeReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/ICidadeReader.cs
@@ -1,0 +1,39 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de <see cref="Cidade"/> para a API pública de reference data
+/// (ADR-0090). Expõe só o que vigente (ADR-0092). A abstração trafega primitivas +
+/// <see cref="FiltroListagemCidades"/> + entidades de domínio (nunca
+/// <c>IQueryable</c>/<c>DbContext</c>), mantendo Application independente de EF Core.
+/// </summary>
+public interface ICidadeReader
+{
+    /// <summary>
+    /// Lista as Cidades vigentes paginadas por keyset bidirecional sobre <c>Id</c>
+    /// (ADR-0026 + ADR-0089), aplicando o <paramref name="filtro"/> (UF + busca
+    /// textual). Os <c>EXISTS</c> do keyset herdam o mesmo <c>WHERE</c> filtrado.
+    /// </summary>
+    Task<(IReadOnlyList<Cidade> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        FiltroListagemCidades filtro,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Obtém a Cidade vigente pela chave natural <paramref name="codigoIbge"/>,
+    /// acompanhada do indicador socioeconômico 1:1 (quando existir), num único
+    /// snapshot consistente; <see langword="null"/> quando a cidade inexiste.
+    /// </summary>
+    Task<CidadeComIndicador?> ObterDetalhePorCodigoIbgeAsync(string codigoIbge, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Cidade + seu indicador socioeconômico 1:1 (<see langword="null"/> quando o
+/// município não tem satélite). Retorno read-only do <see cref="ICidadeReader"/>;
+/// o handler projeta em <c>CidadeDetalheDto</c>.
+/// </summary>
+public sealed record CidadeComIndicador(Cidade Cidade, CidadeIndicador? Indicador);

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IEstadoReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IEstadoReader.cs
@@ -1,0 +1,31 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de <see cref="Estado"/> (UF) para a API pública de reference
+/// data (ADR-0090). Expõe só o que vigente (<c>vigente=true</c>) — linhas stale do
+/// ETL (ADR-0092) não vazam. A abstração trafega primitivas + entidades de
+/// domínio (nunca <c>IQueryable</c>/<c>DbContext</c>), mantendo Application
+/// independente de EF Core.
+/// </summary>
+public interface IEstadoReader
+{
+    /// <summary>
+    /// Lista os Estados vigentes paginados por keyset bidirecional sobre <c>Id</c>
+    /// (ADR-0026 + ADR-0089). Retorna as âncoras para o controller emitir os
+    /// cursores <c>prev</c>/<c>next</c>.
+    /// </summary>
+    Task<(IReadOnlyList<Estado> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Obtém um Estado vigente pela chave natural <paramref name="uf"/>
+    /// (normalizada para maiúsculas); <see langword="null"/> quando inexistente.
+    /// </summary>
+    Task<Estado?> ObterPorUfAsync(string uf, CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CidadeDetalheDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CidadeDetalheDto.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de detalhe para <c>Cidade</c> (<c>GET /api/cidades/{codigoIbge}</c>):
+/// núcleo + territorial IBGE embutido (meso/micro/região intermediária e imediata)
+/// + indicador socioeconômico 1:1 (<see cref="CidadeIndicadorDto"/>, pode ser
+/// <see langword="null"/>). Suporta HATEOAS Level 1 via <c>_links</c> (ADR-0029).
+/// </summary>
+public sealed record CidadeDetalheDto(
+    Guid Id,
+    string CodigoIbge,
+    string Nome,
+    string Uf,
+    string? Ddd,
+    decimal? Latitude,
+    decimal? Longitude,
+    string? MesorregiaoNome,
+    string? MicrorregiaoNome,
+    string? RegiaoIntermediariaNome,
+    string? RegiaoImediataNome,
+    CidadeIndicadorDto? Indicador)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CidadeIndicadorDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CidadeIndicadorDto.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Indicadores socioeconômicos de uma <c>Cidade</c> (satélite 1:1), embutidos no
+/// <see cref="CidadeDetalheDto"/>. Todos os campos são <c>nullable</c> — a fonte
+/// IBGE traz <c>'-'</c> para parte dos municípios (parse tolerante degrada para
+/// <see langword="null"/>). <c>Aniversario</c> é <c>string</c> "DD/MM" (sem ano,
+/// não é data). Não carrega <c>_links</c> (é embutido, não recurso navegável).
+/// </summary>
+public sealed record CidadeIndicadorDto(
+    string? Gentilico,
+    decimal? AreaKm2,
+    int? PopulacaoResidente,
+    decimal? DensidadeDemografica,
+    decimal? Idh,
+    string? Aniversario);

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CidadeResumoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CidadeResumoDto.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de item de coleção para <c>Cidade</c> (listagem <c>GET /api/cidades</c>).
+/// Núcleo enxuto para popular combos; o detalhe completo vem em
+/// <see cref="CidadeDetalheDto"/>. Suporta HATEOAS Level 1 via <c>_links</c>.
+/// </summary>
+public sealed record CidadeResumoDto(
+    Guid Id,
+    string CodigoIbge,
+    string Nome,
+    string Uf,
+    string? Ddd)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/EstadoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/EstadoDto.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para um <c>Estado</c> (UF). Reference data público
+/// (read-only); suporta HATEOAS Level 1 via <c>_links</c> (ADR-0029). A
+/// <c>Coordenada</c> PostGIS não vaza no contrato — só <c>Latitude</c>/<c>Longitude</c>.
+/// </summary>
+public sealed record EstadoDto(
+    Guid Id,
+    string Uf,
+    string Nome,
+    string? Regiao,
+    string? Capital,
+    string? CodigoIbge,
+    decimal? Latitude,
+    decimal? Longitude)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Mappings/CidadeMapping.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Mappings/CidadeMapping.cs
@@ -1,0 +1,48 @@
+namespace Unifesspa.UniPlus.Geo.Application.Mappings;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+public static class CidadeMapping
+{
+    public static CidadeResumoDto ToResumoDto(this Cidade cidade)
+    {
+        ArgumentNullException.ThrowIfNull(cidade);
+        return new CidadeResumoDto(
+            cidade.Id,
+            cidade.CodigoIbge,
+            cidade.Nome,
+            cidade.Uf,
+            cidade.Ddd);
+    }
+
+    public static CidadeDetalheDto ToDetalheDto(this Cidade cidade, CidadeIndicador? indicador)
+    {
+        ArgumentNullException.ThrowIfNull(cidade);
+        return new CidadeDetalheDto(
+            cidade.Id,
+            cidade.CodigoIbge,
+            cidade.Nome,
+            cidade.Uf,
+            cidade.Ddd,
+            cidade.Latitude,
+            cidade.Longitude,
+            cidade.MesorregiaoNome,
+            cidade.MicrorregiaoNome,
+            cidade.RegiaoIntermediariaNome,
+            cidade.RegiaoImediataNome,
+            indicador?.ToIndicadorDto());
+    }
+
+    public static CidadeIndicadorDto ToIndicadorDto(this CidadeIndicador indicador)
+    {
+        ArgumentNullException.ThrowIfNull(indicador);
+        return new CidadeIndicadorDto(
+            indicador.Gentilico,
+            indicador.AreaKm2,
+            indicador.PopulacaoResidente,
+            indicador.DensidadeDemografica,
+            indicador.Idh,
+            indicador.Aniversario);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Mappings/EstadoMapping.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Mappings/EstadoMapping.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Geo.Application.Mappings;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+public static class EstadoMapping
+{
+    public static EstadoDto ToDto(this Estado estado)
+    {
+        ArgumentNullException.ThrowIfNull(estado);
+        return new EstadoDto(
+            estado.Id,
+            estado.Uf,
+            estado.Nome,
+            estado.Regiao,
+            estado.Capital,
+            estado.CodigoIbge,
+            estado.Latitude,
+            estado.Longitude);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ListarCidadesQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ListarCidadesQuery.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Cidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista as Cidades vigentes paginadas por cursor bidirecional (ADR-0026 +
+/// ADR-0089), com filtro opcional por <paramref name="Uf"/> e busca textual
+/// <paramref name="Busca"/> (acento/caixa-insensível). Os parâmetros já chegam
+/// decodificados — o controller decifra o cursor no boundary (ADR-0031).
+/// </summary>
+/// <param name="AfterId">Âncora da página; <see langword="null"/> retorna a primeira janela.</param>
+/// <param name="Limit">Tamanho máximo da página.</param>
+/// <param name="Direction">Direção de navegação (<c>Next</c>/<c>Prev</c>).</param>
+/// <param name="Uf">Filtro por UF; <see langword="null"/>/vazio = sem filtro.</param>
+/// <param name="Busca">Termo de busca sobre o nome; <see langword="null"/>/vazio = sem filtro.</param>
+public sealed record ListarCidadesQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction,
+    string? Uf,
+    string? Busca) : IQuery<ListarCidadesResult>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ListarCidadesQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ListarCidadesQueryHandler.cs
@@ -1,0 +1,36 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Cidades;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Mappings;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+/// <summary>
+/// Handler convention-based de <see cref="ListarCidadesQuery"/>: monta o
+/// <see cref="FiltroListagemCidades"/> (UF + busca) e delega ao reader a paginação
+/// keyset bidirecional sobre <c>Cidade</c>. A normalização acento/caixa da busca é
+/// feita no reader (termo normalizado no app + <c>ILIKE</c> sobre
+/// <c>nome_normalizado</c>). Projeta as entidades vigentes em DTO de resumo.
+/// </summary>
+public static class ListarCidadesQueryHandler
+{
+    public static async Task<ListarCidadesResult> Handle(
+        ListarCidadesQuery query,
+        ICidadeReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        FiltroListagemCidades filtro = new(
+            string.IsNullOrWhiteSpace(query.Uf) ? null : query.Uf,
+            string.IsNullOrWhiteSpace(query.Busca) ? null : query.Busca);
+
+        (IReadOnlyList<Cidade> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await reader
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, filtro, cancellationToken)
+            .ConfigureAwait(false);
+
+        CidadeResumoDto[] items = [.. itens.Select(c => c.ToResumoDto())];
+        return new ListarCidadesResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ListarCidadesResult.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ListarCidadesResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Cidades;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarCidadesQuery"/>: lote de Cidades já projetadas em
+/// resumo + âncoras opcionais para o controller construir os cursores de página
+/// anterior/próxima (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarCidadesResult(
+    IReadOnlyList<CidadeResumoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ObterCidadePorCodigoIbgeQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ObterCidadePorCodigoIbgeQuery.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Cidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Obtém uma Cidade vigente pela chave natural <paramref name="CodigoIbge"/> (7
+/// dígitos), com territorial embutido + indicador 1:1. Retorna
+/// <see langword="null"/> quando inexistente — o controller traduz para 404. O
+/// formato é validado no boundary (ADR-0031) antes do despacho.
+/// </summary>
+public sealed record ObterCidadePorCodigoIbgeQuery(string CodigoIbge) : IQuery<CidadeDetalheDto?>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ObterCidadePorCodigoIbgeQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ObterCidadePorCodigoIbgeQueryHandler.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Cidades;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Mappings;
+
+/// <summary>
+/// Handler convention-based de <see cref="ObterCidadePorCodigoIbgeQuery"/>: lê a
+/// Cidade vigente + indicador 1:1 num único snapshot e projeta em
+/// <c>CidadeDetalheDto</c>; <see langword="null"/> quando o município inexiste.
+/// </summary>
+public static class ObterCidadePorCodigoIbgeQueryHandler
+{
+    public static async Task<CidadeDetalheDto?> Handle(
+        ObterCidadePorCodigoIbgeQuery query,
+        ICidadeReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        CidadeComIndicador? dados = await reader
+            .ObterDetalhePorCodigoIbgeAsync(query.CodigoIbge, cancellationToken)
+            .ConfigureAwait(false);
+
+        return dados?.Cidade.ToDetalheDto(dados.Indicador);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ObterCidadePorCodigoIbgeQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cidades/ObterCidadePorCodigoIbgeQueryHandler.cs
@@ -23,6 +23,13 @@ public static class ObterCidadePorCodigoIbgeQueryHandler
             .ObterDetalhePorCodigoIbgeAsync(query.CodigoIbge, cancellationToken)
             .ConfigureAwait(false);
 
-        return dados?.Cidade.ToDetalheDto(dados.Indicador);
+        // Guard explícito: município inexistente → null (404 no controller). Evita o
+        // null-conditional encadeado, que a análise estática lê como possível deref nulo.
+        if (dados is null)
+        {
+            return null;
+        }
+
+        return dados.Cidade.ToDetalheDto(dados.Indicador);
     }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ListarEstadosQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ListarEstadosQuery.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Estados;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista os Estados (UFs) vigentes paginados por cursor bidirecional (ADR-0026 +
+/// ADR-0089). Os parâmetros já chegam decodificados — o controller decifra o
+/// cursor opaco no boundary (ADR-0031) antes de despachar, mantendo Application
+/// independente de Infrastructure.Core.
+/// </summary>
+/// <param name="AfterId">Âncora da página; <see langword="null"/> retorna a primeira janela.</param>
+/// <param name="Limit">Tamanho máximo da página.</param>
+/// <param name="Direction">Direção de navegação (<c>Next</c>/<c>Prev</c>).</param>
+public sealed record ListarEstadosQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarEstadosResult>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ListarEstadosQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ListarEstadosQueryHandler.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Estados;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Mappings;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+/// <summary>
+/// Handler convention-based de <see cref="ListarEstadosQuery"/>: paginação keyset
+/// bidirecional (cursor) sobre <c>Estado</c>. A mecânica de keyset vive no reader
+/// via <c>CursorKeyset</c>; o handler apenas projeta as entidades vigentes em DTO.
+/// </summary>
+public static class ListarEstadosQueryHandler
+{
+    public static async Task<ListarEstadosResult> Handle(
+        ListarEstadosQuery query,
+        IEstadoReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        (IReadOnlyList<Estado> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await reader
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        EstadoDto[] items = [.. itens.Select(e => e.ToDto())];
+        return new ListarEstadosResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ListarEstadosResult.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ListarEstadosResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Estados;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarEstadosQuery"/>: lote de Estados já projetados +
+/// âncoras opcionais para o controller construir os cursores de página
+/// anterior/próxima (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarEstadosResult(
+    IReadOnlyList<EstadoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ObterEstadoPorUfQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ObterEstadoPorUfQuery.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Estados;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Obtém um Estado vigente pela chave natural <paramref name="Uf"/> (2 letras,
+/// normalizada para maiúsculas no reader). Retorna <see langword="null"/> quando
+/// inexistente — o controller traduz para 404. O formato da UF é validado no
+/// boundary (ADR-0031) antes do despacho.
+/// </summary>
+public sealed record ObterEstadoPorUfQuery(string Uf) : IQuery<EstadoDto?>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ObterEstadoPorUfQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Estados/ObterEstadoPorUfQueryHandler.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Estados;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Mappings;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+/// <summary>
+/// Handler convention-based de <see cref="ObterEstadoPorUfQuery"/>: projeção
+/// <c>AsNoTracking</c> pela chave natural <c>uf</c>; <see langword="null"/> quando
+/// o Estado vigente inexiste.
+/// </summary>
+public static class ObterEstadoPorUfQueryHandler
+{
+    public static async Task<EstadoDto?> Handle(
+        ObterEstadoPorUfQuery query,
+        IEstadoReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        Estado? estado = await reader
+            .ObterPorUfAsync(query.Uf, cancellationToken)
+            .ConfigureAwait(false);
+
+        return estado?.ToDto();
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -13,6 +13,7 @@ using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
@@ -40,6 +41,11 @@ public static class GeoInfrastructureRegistration
 
         services.AddScoped<IUnitOfWork>(serviceProvider =>
             serviceProvider.GetRequiredService<GeoDbContext>());
+
+        // Readers read-side da API pública de reference data (Story #675): listagem
+        // por cursor + detalhe por chave natural. Só expõem o que vigente (ADR-0092).
+        services.AddScoped<IEstadoReader, EstadoReader>();
+        services.AddScoped<ICidadeReader, CidadeReader>();
 
         // ETL DNE (ADR-0092) — serviços de carga de reference data. O gatilho (seed
         // dev / endpoint admin) e a fonte concreta de produção entram na Story #674.

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CidadeReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CidadeReader.cs
@@ -1,0 +1,126 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de <see cref="Cidade"/> sobre o <see cref="GeoDbContext"/>.
+/// Só expõe reference data vigente (ADR-0092). Listagem por keyset bidirecional
+/// (<see cref="CursorKeyset"/>) com filtro por UF e busca textual acento/caixa-
+/// insensível sobre <c>nome_normalizado</c> (índice trigram <c>gin_trgm_ops</c>).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
+internal sealed class CidadeReader : ICidadeReader
+{
+    private readonly GeoDbContext _dbContext;
+
+    public CidadeReader(GeoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<(IReadOnlyList<Cidade> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        FiltroListagemCidades filtro,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(filtro);
+
+        IQueryable<Cidade> query = _dbContext.Cidades
+            .AsNoTracking()
+            .Where(c => c.Vigente);
+
+        if (filtro.TemUf)
+        {
+            // UF normalizada para maiúsculas (espelha Cidade.Importar); inexistente
+            // produz lista vazia, não erro — UF é filtro, não recurso.
+            string ufNormalizada = filtro.Uf!.Trim().ToUpperInvariant();
+            query = query.Where(c => c.Uf == ufNormalizada);
+        }
+
+        if (filtro.TemBusca)
+        {
+            // Busca acento/caixa-insensível: nome_normalizado já vem sem acento da
+            // fonte (cidade_sem_acento) — NÃO há immutable_unaccent em runtime. O termo
+            // é normalizado no app (NFD + remoção de NonSpacingMark) e comparado via
+            // ILIKE (cuida da caixa). Os curingas %, _ e \ são escapados para serem
+            // tratados como texto literal; o escape char é passado explicitamente
+            // (a sobrecarga de 2 args do ILike emite ESCAPE '', desligando o \).
+            // Guard NomeNormalizado != null: ILIKE NULL não casa — cidades sem
+            // nome_normalizado simplesmente não aparecem na busca (aparecem sem filtro).
+            string termo = EscaparCuringasLike(RemoverDiacriticos(filtro.Termo!.Trim()));
+            string pattern = "%" + termo + "%";
+            const string escape = @"\";
+            query = query.Where(c =>
+                c.NomeNormalizado != null &&
+                EF.Functions.ILike(c.NomeNormalizado, pattern, escape));
+        }
+
+        // Keyset bidirecional (ADR-0089) sobre a query JÁ filtrada — ordenação,
+        // âncora, probe n+1, reversão e flags ficam no helper; os EXISTS herdam o WHERE.
+        CursorKeysetPage<Cidade> page = await CursorKeyset
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task<CidadeComIndicador?> ObterDetalhePorCodigoIbgeAsync(
+        string codigoIbge,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(codigoIbge);
+
+        string codigo = codigoIbge.Trim();
+
+        // Projeção única (um round-trip, snapshot consistente sob READ COMMITTED):
+        // cidade vigente + indicador 1:1 vigente via subconsulta correlacionada —
+        // Cidade e CidadeIndicador não têm navigation property (ver
+        // CidadeIndicadorConfiguration), então o vínculo é resolvido por CidadeId.
+        return await _dbContext.Cidades
+            .AsNoTracking()
+            .Where(c => c.Vigente && c.CodigoIbge == codigo)
+            .Select(c => new CidadeComIndicador(
+                c,
+                _dbContext.CidadeIndicadores
+                    .Where(i => i.Vigente && i.CidadeId == c.Id)
+                    .FirstOrDefault()))
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    // Aplica a mesma transformação que produz nome_normalizado na fonte: decompõe em
+    // NFD e descarta NonSpacingMark (diacríticos). Normaliza o TERMO de busca em C#
+    // antes de montar o padrão ILIKE — a coluna já está sem acento, então não há
+    // chamada de DB function no lado do parâmetro. (Espelha UnidadeRepository.)
+    private static string RemoverDiacriticos(string texto)
+    {
+        string decomposto = texto.Normalize(NormalizationForm.FormD);
+        return new string([.. decomposto.Where(c =>
+            CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)]);
+    }
+
+    // Escapa os curingas do LIKE/ILIKE (\ % _) para que metacaracteres digitados
+    // pelo usuário sejam comparados como texto literal, não como wildcards — sem
+    // isso, q="_" ou q="%" casaria quase qualquer registro. A barra é escapada
+    // primeiro para não duplicar as inseridas adiante em % e _. (Espelha UnidadeRepository.)
+    private static string EscaparCuringasLike(string termo) =>
+        termo
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/EstadoReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/EstadoReader.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de <see cref="Estado"/> sobre o <see cref="GeoDbContext"/>.
+/// Só expõe reference data vigente (<c>vigente=true</c>, ADR-0092) — linhas stale
+/// do ETL não vazam na API pública. Listagem por keyset bidirecional
+/// (<see cref="CursorKeyset"/>); os <c>EXISTS</c> do keyset herdam o filtro de
+/// vigência por operarem sobre a mesma query base.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
+internal sealed class EstadoReader : IEstadoReader
+{
+    private readonly GeoDbContext _dbContext;
+
+    public EstadoReader(GeoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<(IReadOnlyList<Estado> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        IQueryable<Estado> query = _dbContext.Estados
+            .AsNoTracking()
+            .Where(e => e.Vigente);
+
+        CursorKeysetPage<Estado> page = await CursorKeyset
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public Task<Estado?> ObterPorUfAsync(string uf, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(uf);
+
+        // Chave natural normalizada para maiúsculas (espelha Estado.Importar).
+        string ufNormalizada = uf.Trim().ToUpperInvariant();
+
+        return _dbContext.Estados
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Vigente && e.Uf == ufNormalizada, cancellationToken);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CidadesEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CidadesEndpointTests.cs
@@ -1,0 +1,305 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Api;
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Endpoints públicos de leitura de Cidades (#675) contra a API real + PostGIS.
+/// Read-only <c>[AllowAnonymous]</c>. Cobre CA-02 a CA-08. A collection é serial;
+/// cada teste TRUNCA e semeia.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class CidadesEndpointTests
+{
+    private readonly GeoPostgisFixture _fixture;
+
+    public CidadesEndpointTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-02: filtro por UF retorna só cidades da UF; UF inexistente é lista vazia (200)")]
+    public async Task Cidades_FiltraPorUf()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage soPara = await GeoReferenceSeed.Obter(client,"/api/cidades?uf=PA&limit=100");
+        soPara.StatusCode.Should().Be(HttpStatusCode.OK);
+        JsonElement itensPa = await LerArrayAsync(soPara);
+        itensPa.EnumerateArray().Select(c => c.GetProperty("uf").GetString())
+            .Should().OnlyContain(uf => uf == "PA").And.HaveCountGreaterThan(1);
+
+        using HttpResponseMessage inexistente = await GeoReferenceSeed.Obter(client,"/api/cidades?uf=ZZ&limit=100");
+        inexistente.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await LerArrayAsync(inexistente)).GetArrayLength().Should().Be(0);
+    }
+
+    [Theory(DisplayName = "CA-03: busca por nome é acento e caixa-insensível")]
+    [InlineData("maraba")]
+    [InlineData("MARABÁ")]
+    [InlineData("marabá")]
+    public async Task Cidades_Busca_AcentoInsensivel(string termo)
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,$"/api/cidades?q={Uri.EscapeDataString(termo)}&limit=100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        JsonElement itens = await LerArrayAsync(resposta);
+        itens.EnumerateArray().Select(c => c.GetProperty("nome").GetString())
+            .Should().Contain("Marabá");
+    }
+
+    [Fact(DisplayName = "CA-04: filtros uf+q são preservados no cursor (header Link de next)")]
+    public async Task Cidades_FiltroMaisCursor_Persiste()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // 'a' casa Marabá e Parauapebas (PA); Óbidos (PA, "obidos") NÃO casa.
+        // limit=1 força paginação — exercita o filtro em cada página seguida.
+        using HttpResponseMessage pagina1 = await GeoReferenceSeed.Obter(client,"/api/cidades?uf=PA&q=a&limit=1");
+        pagina1.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string? proximo = GeoReferenceSeed.ExtrairLink(pagina1, "next");
+        proximo.Should().NotBeNull("há mais de uma cidade PA casando 'a'");
+        proximo.Should().Contain("uf=PA").And.Contain("q=a");
+
+        // Percorre TODAS as páginas seguindo o cursor: o conjunto coletado deve ser
+        // exatamente {Marabá, Parauapebas} — Óbidos nunca aparece (prova que q segue
+        // filtrando após o cursor, não só na primeira página).
+        List<string> nomes = [.. LerNomes(await LerArrayAsync(pagina1))];
+        while (proximo is not null)
+        {
+            using HttpResponseMessage pagina = await GeoReferenceSeed.Obter(client, proximo);
+            pagina.StatusCode.Should().Be(HttpStatusCode.OK);
+            nomes.AddRange(LerNomes(await LerArrayAsync(pagina)));
+            proximo = GeoReferenceSeed.ExtrairLink(pagina, "next");
+        }
+
+        nomes.Should().BeEquivalentTo(["Marabá", "Parauapebas"]);
+        nomes.Should().NotContain("Óbidos");
+    }
+
+    [Theory(DisplayName = "Segurança ILIKE: metacaractere de busca é tratado como literal (não casa tudo)")]
+    [InlineData("%")]
+    [InlineData("_")]
+    public async Task Cidades_Busca_MetacaractereLiteral(string termo)
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // Sem escape, "%"/"_" casariam quase tudo. Com o escape do reader, são texto
+        // literal: nenhum nome contém '%' ou '_', então o resultado é vazio.
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, $"/api/cidades?q={Uri.EscapeDataString(termo)}&limit=100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await LerArrayAsync(resposta)).GetArrayLength().Should().Be(0);
+    }
+
+    [Fact(DisplayName = "CA-05: detalhe por código IBGE traz territorial + indicador 1:1 + _links")]
+    public async Task Cidade_Detalhe_PorCodigoIbge()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,"/api/cidades/1500402");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement raiz = doc.RootElement;
+        raiz.GetProperty("codigoIbge").GetString().Should().Be("1500402");
+        raiz.GetProperty("nome").GetString().Should().Be("Marabá");
+        raiz.GetProperty("uf").GetString().Should().Be("PA");
+        raiz.GetProperty("mesorregiaoNome").GetString().Should().Be("Sudeste Paraense");
+
+        JsonElement indicador = raiz.GetProperty("indicador");
+        indicador.GetProperty("gentilico").GetString().Should().Be("marabaense");
+        indicador.GetProperty("idh").GetDecimal().Should().Be(0.668m);
+        indicador.GetProperty("aniversario").GetString().Should().Be("05/04");
+
+        JsonElement links = raiz.GetProperty("_links");
+        links.GetProperty("self").GetString().Should().Be("/api/cidades/1500402");
+        links.GetProperty("estado").GetString().Should().Be("/api/estados/PA");
+        links.GetProperty("collection").GetString().Should().Be("/api/cidades");
+    }
+
+    [Fact(DisplayName = "CA-05: cidade sem indicador omite o campo indicador (null) sem erro")]
+    public async Task Cidade_Detalhe_SemIndicador()
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            Pais brasil = GeoReferenceSeed.NovoBrasil();
+            Estado para = GeoReferenceSeed.NovoEstado(brasil.Id, "PA", "Pará");
+            Cidade semIndicador = GeoReferenceSeed.NovaCidade(para.Id, "PA", "1500701", "Abel Figueiredo");
+            ctx.Paises.Add(brasil);
+            ctx.Estados.Add(para);
+            ctx.Cidades.Add(semIndicador);
+            await ctx.SaveChangesAsync();
+        }
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,"/api/cidades/1500701");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        doc.RootElement.TryGetProperty("indicador", out JsonElement indicador).Should().BeTrue();
+        indicador.ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact(DisplayName = "CA-06: código IBGE bem-formado e inexistente retorna 404")]
+    public async Task Cidade_Detalhe_Inexistente_404()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,"/api/cidades/9999999");
+        resposta.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Theory(DisplayName = "CA-06: código IBGE malformado (≠7 dígitos) retorna 400")]
+    [InlineData("/api/cidades/abc")]
+    [InlineData("/api/cidades/123")]
+    [InlineData("/api/cidades/15004020")]
+    public async Task Cidade_Detalhe_Malformado_400(string rota)
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,rota);
+        resposta.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "CA-07: Accept vendor incompatível retorna 406; vendor cidade.v1 é aceito")]
+    public async Task Cidades_VendorMime_406()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpRequestMessage incompativel = new(HttpMethod.Get, "/api/cidades");
+        incompativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.cidade.v2+json"));
+        using HttpResponseMessage resp406 = await client.SendAsync(incompativel);
+        resp406.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
+
+        using HttpRequestMessage compativel = new(HttpMethod.Get, "/api/cidades");
+        compativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.cidade.v1+json"));
+        using HttpResponseMessage resp200 = await client.SendAsync(compativel);
+        resp200.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(DisplayName = "CA-08: termo de busca acima do limite retorna 400")]
+    public async Task Cidades_Busca_Longa_400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        string termoLongo = new('a', 257);
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,$"/api/cidades?q={termoLongo}");
+        resposta.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "Busca sobre nome_normalizado null: cidade não aparece na busca, mas aparece sem filtro")]
+    public async Task Cidades_Busca_NomeNormalizadoNulo()
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            Pais brasil = GeoReferenceSeed.NovoBrasil();
+            Estado para = GeoReferenceSeed.NovoEstado(brasil.Id, "PA", "Pará");
+            // nomeNormalizado explicitamente vazio → normalizado para null pela entidade.
+            Cidade semNorm = GeoReferenceSeed.NovaCidade(para.Id, "PA", "1500800", "Acará", nomeNormalizado: "");
+            ctx.Paises.Add(brasil);
+            ctx.Estados.Add(para);
+            ctx.Cidades.Add(semNorm);
+            await ctx.SaveChangesAsync();
+        }
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage busca = await GeoReferenceSeed.Obter(client,"/api/cidades?q=acara&limit=100");
+        (await LerArrayAsync(busca)).GetArrayLength().Should().Be(0, "ILIKE sobre coluna NULL não casa");
+
+        using HttpResponseMessage semFiltro = await GeoReferenceSeed.Obter(client,"/api/cidades?limit=100");
+        (await LerArrayAsync(semFiltro)).EnumerateArray()
+            .Select(c => c.GetProperty("codigoIbge").GetString())
+            .Should().Contain("1500800", "sem filtro a cidade aparece normalmente");
+    }
+
+    [Fact(DisplayName = "ADR-0092: cidade stale (vigente=false) não aparece na lista nem no detalhe")]
+    public async Task Cidades_NaoVigente_NaoVaza()
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            Pais brasil = GeoReferenceSeed.NovoBrasil();
+            Estado para = GeoReferenceSeed.NovoEstado(brasil.Id, "PA", "Pará");
+            Cidade vigente = GeoReferenceSeed.NovaCidade(para.Id, "PA", "1500402", "Marabá");
+            Cidade stale = GeoReferenceSeed.NovaCidade(para.Id, "PA", "1599999", "Obsoleta", vigente: false);
+            ctx.Paises.Add(brasil);
+            ctx.Estados.Add(para);
+            ctx.Cidades.AddRange(vigente, stale);
+            await ctx.SaveChangesAsync();
+        }
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage lista = await GeoReferenceSeed.Obter(client,"/api/cidades?limit=100");
+        (await LerArrayAsync(lista)).EnumerateArray()
+            .Select(c => c.GetProperty("codigoIbge").GetString())
+            .Should().Contain("1500402").And.NotContain("1599999");
+
+        using HttpResponseMessage detalhe = await GeoReferenceSeed.Obter(client,"/api/cidades/1599999");
+        detalhe.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private async Task SemearAsync()
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+
+        Pais brasil = GeoReferenceSeed.NovoBrasil();
+        Estado para = GeoReferenceSeed.NovoEstado(brasil.Id, "PA", "Pará", regiao: "Norte", capital: "Belém");
+        Estado saoPaulo = GeoReferenceSeed.NovoEstado(brasil.Id, "SP", "São Paulo", regiao: "Sudeste", capital: "São Paulo");
+
+        Cidade maraba = GeoReferenceSeed.NovaCidade(
+            para.Id, "PA", "1500402", "Marabá", nomeNormalizado: "maraba", ddd: "94",
+            latitude: -5.36867m, longitude: -49.11731m,
+            mesorregiaoNome: "Sudeste Paraense", microrregiaoNome: "Marabá",
+            regiaoIntermediariaNome: "Marabá", regiaoImediataNome: "Marabá");
+        Cidade parauapebas = GeoReferenceSeed.NovaCidade(
+            para.Id, "PA", "1505536", "Parauapebas", nomeNormalizado: "parauapebas", ddd: "94");
+        // Óbidos (PA) NÃO contém "a" no nome normalizado — prova negativa da busca q=a.
+        Cidade obidos = GeoReferenceSeed.NovaCidade(
+            para.Id, "PA", "1505106", "Óbidos", nomeNormalizado: "obidos", ddd: "93");
+        Cidade saoPauloCidade = GeoReferenceSeed.NovaCidade(
+            saoPaulo.Id, "SP", "3550308", "São Paulo", nomeNormalizado: "sao paulo", ddd: "11");
+
+        CidadeIndicador indicadorMaraba = GeoReferenceSeed.NovoIndicador(
+            maraba.Id, gentilico: "marabaense", areaKm2: 15128.058m, populacaoResidente: 233669,
+            densidadeDemografica: 15.45m, idh: 0.668m, aniversario: "05/04");
+
+        ctx.Paises.Add(brasil);
+        ctx.Estados.AddRange(para, saoPaulo);
+        ctx.Cidades.AddRange(maraba, parauapebas, obidos, saoPauloCidade);
+        ctx.CidadeIndicadores.Add(indicadorMaraba);
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task<JsonElement> LerArrayAsync(HttpResponseMessage resposta)
+    {
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        return doc.RootElement.Clone();
+    }
+
+    private static List<string> LerNomes(JsonElement array) =>
+        [.. array.EnumerateArray().Select(item => item.GetProperty("nome").GetString()!)];
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/EstadosEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/EstadosEndpointTests.cs
@@ -1,0 +1,214 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Api;
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Endpoints públicos de leitura de Estados (#675) contra a API real + PostGIS.
+/// Read-only <c>[AllowAnonymous]</c> — sem autenticação. Cobre CA-01, CA-07,
+/// CA-09 e CA-10. A collection é serial; cada teste TRUNCA e semeia.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class EstadosEndpointTests
+{
+    private readonly GeoPostgisFixture _fixture;
+
+    public EstadosEndpointTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01/CA-10: lista de estados pagina por cursor estável e cada item tem _links.self")]
+    public async Task Estados_Lista_Paginada()
+    {
+        IReadOnlyList<string> ufsSemeadas = ["AC", "AL", "AM", "BA", "CE"];
+        await SemearEstadosAsync(ufsSemeadas);
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // Página 1 (limit=2) — espera-se header Link com next e _links.self por item.
+        using HttpResponseMessage pagina1 = await GeoReferenceSeed.Obter(client,"/api/estados?limit=2");
+        pagina1.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        JsonElement itens1 = await LerArrayAsync(pagina1);
+        itens1.GetArrayLength().Should().Be(2);
+        foreach (JsonElement item in itens1.EnumerateArray())
+        {
+            string uf = item.GetProperty("uf").GetString()!;
+            item.GetProperty("_links").GetProperty("self").GetString()
+                .Should().Be($"/api/estados/{uf}");
+        }
+
+        GeoReferenceSeed.ExtrairLink(pagina1, "next").Should().NotBeNull("há mais páginas");
+
+        // Percorre todas as páginas seguindo o cursor 'next': união = conjunto semeado,
+        // sem duplicatas (keyset estável por Id — ADR-0089). Não assume ordem alfabética.
+        List<string> coletadas = [];
+        coletadas.AddRange(ExtrairUfs(itens1));
+
+        string? proximo = GeoReferenceSeed.ExtrairLink(pagina1, "next");
+        bool viuPrevEmPaginaSeguinte = false;
+        while (proximo is not null)
+        {
+            using HttpResponseMessage pagina = await GeoReferenceSeed.Obter(client,proximo);
+            pagina.StatusCode.Should().Be(HttpStatusCode.OK);
+            JsonElement itens = await LerArrayAsync(pagina);
+            coletadas.AddRange(ExtrairUfs(itens));
+
+            if (GeoReferenceSeed.ExtrairLink(pagina, "prev") is not null)
+            {
+                viuPrevEmPaginaSeguinte = true;
+            }
+
+            proximo = GeoReferenceSeed.ExtrairLink(pagina, "next");
+        }
+
+        coletadas.Should().BeEquivalentTo(ufsSemeadas, "a paginação cobre todo o conjunto sem repetir/saltar");
+        coletadas.Should().OnlyHaveUniqueItems();
+        viuPrevEmPaginaSeguinte.Should().BeTrue("páginas após a primeira emitem rel=prev");
+    }
+
+    [Fact(DisplayName = "CA-09: detalhe do estado por UF traz núcleo + região + capital + coordenadas + _links")]
+    public async Task Estado_Detalhe_PorUf()
+    {
+        await SemearParaAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,"/api/estados/PA");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement raiz = doc.RootElement;
+        raiz.GetProperty("uf").GetString().Should().Be("PA");
+        raiz.GetProperty("nome").GetString().Should().Be("Pará");
+        raiz.GetProperty("regiao").GetString().Should().Be("Norte");
+        raiz.GetProperty("capital").GetString().Should().Be("Belém");
+        raiz.GetProperty("latitude").GetDecimal().Should().Be(-3.79m);
+
+        JsonElement links = raiz.GetProperty("_links");
+        links.GetProperty("self").GetString().Should().Be("/api/estados/PA");
+        links.GetProperty("cidades").GetString().Should().Be("/api/cidades?uf=PA");
+        links.GetProperty("collection").GetString().Should().Be("/api/estados");
+    }
+
+    [Theory(DisplayName = "CA-09: UF case-insensitive resolve o mesmo estado")]
+    [InlineData("pa")]
+    [InlineData("Pa")]
+    public async Task Estado_Detalhe_PorUf_CaseInsensitive(string uf)
+    {
+        await SemearParaAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,$"/api/estados/{uf}");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("uf").GetString().Should().Be("PA");
+    }
+
+    [Fact(DisplayName = "CA-09: UF bem-formada mas inexistente retorna 404")]
+    public async Task Estado_Detalhe_Inexistente_404()
+    {
+        await SemearParaAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,"/api/estados/ZZ");
+        resposta.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Theory(DisplayName = "CA-09: UF malformada (≠2 letras) retorna 400")]
+    [InlineData("/api/estados/X")]
+    [InlineData("/api/estados/ABC")]
+    [InlineData("/api/estados/12")]
+    public async Task Estado_Detalhe_Malformada_400(string rota)
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client,rota);
+        resposta.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "CA-07: Accept vendor incompatível retorna 406; vendor estado.v1 é aceito")]
+    public async Task Estados_VendorMime()
+    {
+        await SemearParaAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpRequestMessage incompativel = new(HttpMethod.Get, "/api/estados");
+        incompativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.estado.v2+json"));
+        using HttpResponseMessage resp406 = await client.SendAsync(incompativel);
+        resp406.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
+
+        using HttpRequestMessage compativel = new(HttpMethod.Get, "/api/estados");
+        compativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.estado.v1+json"));
+        using HttpResponseMessage resp200 = await client.SendAsync(compativel);
+        resp200.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(DisplayName = "ADR-0092: estado stale (vigente=false) não aparece na lista nem no detalhe")]
+    public async Task Estados_NaoVigente_NaoVaza()
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            Pais brasil = GeoReferenceSeed.NovoBrasil();
+            Estado vigente = GeoReferenceSeed.NovoEstado(brasil.Id, "PA", "Pará");
+            Estado stale = GeoReferenceSeed.NovoEstado(brasil.Id, "ZZ", "Obsoleto", vigente: false);
+            ctx.Paises.Add(brasil);
+            ctx.Estados.AddRange(vigente, stale);
+            await ctx.SaveChangesAsync();
+        }
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage lista = await GeoReferenceSeed.Obter(client,"/api/estados?limit=100");
+        JsonElement itens = await LerArrayAsync(lista);
+        ExtrairUfs(itens).Should().Contain("PA").And.NotContain("ZZ");
+
+        using HttpResponseMessage detalhe = await GeoReferenceSeed.Obter(client,"/api/estados/ZZ");
+        detalhe.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    private async Task SemearEstadosAsync(IReadOnlyList<string> ufs)
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        Pais brasil = GeoReferenceSeed.NovoBrasil();
+        ctx.Paises.Add(brasil);
+        foreach (string uf in ufs)
+        {
+            ctx.Estados.Add(GeoReferenceSeed.NovoEstado(brasil.Id, uf, $"Estado {uf}"));
+        }
+
+        await ctx.SaveChangesAsync();
+    }
+
+    private async Task SemearParaAsync()
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        Pais brasil = GeoReferenceSeed.NovoBrasil();
+        Estado para = GeoReferenceSeed.NovoEstado(
+            brasil.Id, "PA", "Pará", regiao: "Norte", capital: "Belém", codigoIbge: "15",
+            latitude: -3.79m, longitude: -52.48m);
+        ctx.Paises.Add(brasil);
+        ctx.Estados.Add(para);
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task<JsonElement> LerArrayAsync(HttpResponseMessage resposta)
+    {
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        return doc.RootElement.Clone();
+    }
+
+    private static List<string> ExtrairUfs(JsonElement array) =>
+        [.. array.EnumerateArray().Select(item => item.GetProperty("uf").GetString()!)];
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
@@ -1,0 +1,118 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Api;
+
+using System.Globalization;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Semeadura determinística (chaves naturais fixas) de reference data Geo para os
+/// testes de API #675. Cada teste TRUNCA antes de semear — a collection é serial
+/// e compartilhada, então a janela não pode depender de estado de outro teste.
+/// </summary>
+internal static partial class GeoReferenceSeed
+{
+    public const string Versao = "202601";
+
+    /// <summary>GET por rota relativa ou absoluta (satisfaz CA2234 — <c>GetAsync(Uri)</c>).</summary>
+    public static Task<HttpResponseMessage> Obter(HttpClient client, string rota)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        return client.GetAsync(new Uri(rota, UriKind.RelativeOrAbsolute));
+    }
+
+    /// <summary>Limpa toda a hierarquia Geo (TRUNCATE pais CASCADE derruba estado/cidade/indicador/faixas).</summary>
+    public static async Task LimparAsync(GeoPostgisFixture fixture)
+    {
+        await using GeoDbContext ctx = fixture.CreateDbContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE TABLE pais CASCADE");
+    }
+
+    public static Pais NovoBrasil() =>
+        GeoTestKeys.Ok(Pais.Importar("BRA", "BR", "Brasil", null, null, null, null, Versao));
+
+    public static Estado NovoEstado(
+        Guid paisId,
+        string uf,
+        string nome,
+        string? regiao = null,
+        string? capital = null,
+        string? codigoIbge = null,
+        decimal? latitude = null,
+        decimal? longitude = null,
+        bool vigente = true) =>
+        GeoTestKeys.Ok(Estado.Importar(
+            paisId, uf, nome, Normalizar(nome), regiao, capital, codigoIbge,
+            latitude, longitude, null, null, null, Versao, vigente));
+
+    public static Cidade NovaCidade(
+        Guid estadoId,
+        string uf,
+        string codigoIbge,
+        string nome,
+        string? nomeNormalizado = null,
+        string? ddd = null,
+        decimal? latitude = null,
+        decimal? longitude = null,
+        string? mesorregiaoNome = null,
+        string? microrregiaoNome = null,
+        string? regiaoIntermediariaNome = null,
+        string? regiaoImediataNome = null,
+        bool vigente = true) =>
+        GeoTestKeys.Ok(Cidade.Importar(
+            estadoId, uf, codigoIbge, nome,
+            nomeNormalizado ?? Normalizar(nome), ddd, latitude, longitude, null,
+            null, mesorregiaoNome, null, microrregiaoNome,
+            null, regiaoIntermediariaNome, null, regiaoImediataNome,
+            Versao, vigente));
+
+    public static CidadeIndicador NovoIndicador(
+        Guid cidadeId,
+        string? gentilico = null,
+        decimal? areaKm2 = null,
+        int? populacaoResidente = null,
+        decimal? densidadeDemografica = null,
+        decimal? idh = null,
+        string? aniversario = null) =>
+        GeoTestKeys.Ok(CidadeIndicador.Importar(
+            cidadeId, gentilico, null, areaKm2, populacaoResidente, densidadeDemografica,
+            null, idh, null, null, null, null, aniversario, Versao));
+
+    /// <summary>Extrai a URL de um <c>rel</c> específico do header <c>Link</c> (RFC 5988/8288), ou <see langword="null"/>.</summary>
+    public static string? ExtrairLink(HttpResponseMessage resposta, string rel)
+    {
+        if (!resposta.Headers.TryGetValues("Link", out IEnumerable<string>? values))
+        {
+            return null;
+        }
+
+        string header = string.Join(", ", values);
+        foreach (Match match in LinkHeaderRegex().Matches(header))
+        {
+            if (string.Equals(match.Groups["rel"].Value, rel, StringComparison.Ordinal))
+            {
+                return match.Groups["url"].Value;
+            }
+        }
+
+        return null;
+    }
+
+    // Remove os diacríticos (como a fonte faz em *_sem_acento). O ToLower fica por
+    // conta da própria entidade (GeoTexto.NormalizarBuscaOpcional) — evita CA1308 aqui.
+    private static string Normalizar(string nome)
+    {
+        string decomposto = nome.Normalize(NormalizationForm.FormD);
+        return new string([.. decomposto.Where(c =>
+            CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)]);
+    }
+
+    [GeneratedRegex("<(?<url>[^>]+)>;\\s*rel=\"(?<rel>[^\"]+)\"")]
+    private static partial Regex LinkHeaderRegex();
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
@@ -93,15 +93,10 @@ internal static partial class GeoReferenceSeed
         }
 
         string header = string.Join(", ", values);
-        foreach (Match match in LinkHeaderRegex().Matches(header))
-        {
-            if (string.Equals(match.Groups["rel"].Value, rel, StringComparison.Ordinal))
-            {
-                return match.Groups["url"].Value;
-            }
-        }
-
-        return null;
+        return LinkHeaderRegex().Matches(header)
+            .Where(match => string.Equals(match.Groups["rel"].Value, rel, StringComparison.Ordinal))
+            .Select(match => match.Groups["url"].Value)
+            .FirstOrDefault();
     }
 
     // Remove os diacríticos (como a fonte faz em *_sem_acento). O ToLower fica por


### PR DESCRIPTION
## Contexto

Story #665 / Epic #661 (módulo Geo). Primeira fatia de **consulta pública** do Geo: a lista de estados e a lista/detalhe de cidades — o que os formulários de cadastro (Campus, Local de Oferta, endereço de candidato) precisam para popular combos de UF/cidade e exibir a ficha territorial de um município.

API **read-only** (`[AllowAnonymous]`, reference data público): sem CRUD de usuário (dados vêm do ETL/F3) e, sem escrita, sem Idempotency-Key. Espelha o controller canônico de `Unidade` (cursor opaco bidirecional, vendor MIME, `_links` por item).

## Endpoints

| Método | Rota | Descrição |
|---|---|---|
| GET | `/api/estados` | Lista das UFs, cursor bidirecional |
| GET | `/api/estados/{uf}` | Detalhe pela chave natural `uf` (2 letras) |
| GET | `/api/cidades?uf=&q=` | Lista com filtro por UF + busca textual acento/caixa-insensível |
| GET | `/api/cidades/{codigoIbge}` | Detalhe pela chave natural `codigo_ibge` (7 dígitos) + indicador 1:1 |

## Decisões de implementação

- **Vigência (ADR-0092):** os readers só expõem reference data vigente (`vigente=true`) — linhas stale do ETL não vazam na API pública. Coberto por prova negativa nos testes.
- **Busca textual:** termo normalizado no app (NFD + remoção de diacríticos) + `ILIKE` sobre `nome_normalizado` (já sem acento na origem) com índice trigram `gin_trgm_ops`; sem `immutable_unaccent` em runtime. Curingas `%`, `_`, `\` escapados (regressão de segurança coberta por teste).
- **Detalhe da cidade:** lê cidade + indicador 1:1 num único snapshot via subconsulta correlacionada (não há navigation property entre `Cidade` e `CidadeIndicador`), evitando inconsistência de leitura sob recarga do ETL.
- **Validação de formato no boundary (ADR-0031):** `uf` (`[A-Za-z]{2}`) e `codigoIbge` (`[0-9]{7}`, ASCII) — formato inválido → 400; bem-formado e inexistente → 404.
- **HATEOAS (ADR-0029):** `self`, `estado`/`cidades`, `collection`. As relações `distritos`/`bairros` **ficam fora desta fatia** — seus endpoints só existem na story irmã de hierarquia/autocomplete; emiti-los para rotas inexistentes violaria a ADR-0029 (links navegáveis). Entram com os endpoints.
- **Cursor x filtros:** os filtros `uf`/`q` viajam como query params e são preservados nos links de navegação (paridade com o controller canônico de Unidade). O cliente os reanexa ao seguir o cursor.
- **Baseline OpenAPI (ADR-0030):** `contracts/openapi.geo.json` regenerado com os 4 endpoints + 4 schemas.

## Critérios de aceite

CA-01 a CA-10 cobertos por testes de integração contra a API real + PostGIS (27 testes novos). Suíte completa do módulo Geo: 158/158 verde. Arch tests: 24/24.

Closes #675