### PR TITLE
feat(geo): adiciona API de lookup de CEP com resolução em cascata

### DIFF
--- a/contracts/openapi.geo.json
+++ b/contracts/openapi.geo.json
@@ -867,58 +867,6 @@
           }
         }
       },
-      "CandidatoLogradouroDto": {
-        "required": [
-          "tipo",
-          "logradouro",
-          "bairro",
-          "distrito",
-          "latitude",
-          "longitude"
-        ],
-        "type": "object",
-        "properties": {
-          "tipo": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "logradouro": {
-            "type": "string"
-          },
-          "bairro": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "distrito": {
-            "type": [
-              "null",
-              "string"
-            ]
-          },
-          "latitude": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
-            "type": [
-              "null",
-              "number",
-              "string"
-            ],
-            "format": "double"
-          },
-          "longitude": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
-            "type": [
-              "null",
-              "number",
-              "string"
-            ],
-            "format": "double"
-          }
-        }
-      },
       "CepResolvidoDto": {
         "required": [
           "cep",
@@ -1006,7 +954,7 @@
           "alternativos": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CandidatoLogradouroDto"
+              "$ref": "#/components/schemas/LogradouroAlternativoDto"
             }
           },
           "_links": {
@@ -1366,6 +1314,58 @@
             "additionalProperties": {
               "type": "string"
             }
+          }
+        }
+      },
+      "LogradouroAlternativoDto": {
+        "required": [
+          "tipo",
+          "logradouro",
+          "bairro",
+          "distrito",
+          "latitude",
+          "longitude"
+        ],
+        "type": "object",
+        "properties": {
+          "tipo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "logradouro": {
+            "type": "string"
+          },
+          "bairro": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "distrito": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
           }
         }
       },

--- a/contracts/openapi.geo.json
+++ b/contracts/openapi.geo.json
@@ -162,6 +162,75 @@
         }
       }
     },
+    "/api/cep/{cep}": {
+      "get": {
+        "tags": [
+          "Cep"
+        ],
+        "parameters": [
+          {
+            "name": "cep",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CepResolvidoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CepResolvidoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CepResolvidoDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/cidades": {
       "get": {
         "tags": [
@@ -798,6 +867,159 @@
           }
         }
       },
+      "CandidatoLogradouroDto": {
+        "required": [
+          "tipo",
+          "logradouro",
+          "bairro",
+          "distrito",
+          "latitude",
+          "longitude"
+        ],
+        "type": "object",
+        "properties": {
+          "tipo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "logradouro": {
+            "type": "string"
+          },
+          "bairro": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "distrito": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          }
+        }
+      },
+      "CepResolvidoDto": {
+        "required": [
+          "cep",
+          "tipo",
+          "logradouro",
+          "complemento",
+          "bairro",
+          "distrito",
+          "cidade",
+          "codigoIbge",
+          "uf",
+          "latitude",
+          "longitude",
+          "nivelResolucao",
+          "origem"
+        ],
+        "type": "object",
+        "properties": {
+          "cep": {
+            "type": "string"
+          },
+          "tipo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "logradouro": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "complemento": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "bairro": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "distrito": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidade": {
+            "type": "string"
+          },
+          "codigoIbge": {
+            "type": "string"
+          },
+          "uf": {
+            "type": "string"
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "nivelResolucao": {
+            "type": "string"
+          },
+          "origem": {
+            "type": "string"
+          },
+          "alternativos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CandidatoLogradouroDto"
+            }
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "CidadeDetalheDto": {
         "required": [
           "id",
@@ -1396,6 +1618,9 @@
     },
     {
       "name": "_smoke"
+    },
+    {
+      "name": "Cep"
     },
     {
       "name": "Cidades"

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/CepController.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/CepController.cs
@@ -1,0 +1,74 @@
+namespace Unifesspa.UniPlus.Geo.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.API.Formatting;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Queries.Cep;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Endpoint público de lookup de CEP — reference data (<c>[AllowAnonymous]</c>, sem
+/// Idempotency-Key, carga via ETL/F3): <c>GET /api/cep/{cep}</c> resolve o CEP em
+/// um endereço estruturado (logradouro/faixa/grande usuário). CEP é dado estável →
+/// cache Redis com TTL longo (cache-aside no resolver). Ver ADR-0090.
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class CepController : ControllerBase
+{
+    private readonly IQueryBus _queryBus;
+    private readonly IResourceLinksBuilder<CepResolvidoDto> _linksBuilder;
+
+    public CepController(IQueryBus queryBus, IResourceLinksBuilder<CepResolvidoDto> linksBuilder)
+    {
+        _queryBus = queryBus;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Resolve o <paramref name="cep"/> em endereço estruturado. O formato é
+    /// decodificado no boundary (ADR-0031): máscara removida e 8 dígitos exigidos —
+    /// inválido → 400. Bem-formado mas sem cobertura (logradouro/grande usuário/faixa)
+    /// → 404. Resolução positiva traz <c>_links</c> para cidade e estado (ADR-0029).
+    /// </summary>
+    [HttpGet("cep/{cep}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "cep", Versions = [1])]
+    [ProducesResponseType(typeof(CepResolvidoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> Resolver(string cep, CancellationToken cancellationToken)
+    {
+        if (!CepValido.TentarNormalizar(cep, out string? cepNormalizado))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "CEP inválido",
+                Detail = "O CEP deve ter exatamente 8 dígitos (ex.: 01001000 ou 01001-000).",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        CepResolvidoDto? endereco = await _queryBus
+            .Send(new ResolverCepQuery(cepNormalizado), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (endereco is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(endereco with { Links = _linksBuilder.Build(endereco) });
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Formatting/CepValido.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Formatting/CepValido.cs
@@ -1,0 +1,48 @@
+namespace Unifesspa.UniPlus.Geo.API.Formatting;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Decode/normalização de CEP no boundary HTTP (ADR-0031): remove a máscara
+/// (hífen e espaços) e exige exatamente 8 dígitos ASCII. O handler recebe o CEP já
+/// normalizado — nunca a string crua. Formato inválido → 400 no controller.
+/// </summary>
+internal static partial class CepValido
+{
+    /// <summary>
+    /// Tenta normalizar <paramref name="cep"/> para 8 dígitos. Aceita <strong>apenas</strong>
+    /// os formatos canônicos: <c>01001000</c>, <c>01001-000</c> ou <c>01001 000</c>
+    /// (separador único entre os 5 e os 3 dígitos). Rejeita ≠8 dígitos, não-numérico
+    /// ou separadores fora de posição (ex.: <c>0-1-0-0-1-000</c>). Retorna
+    /// <see langword="true"/> + <paramref name="normalizado"/> quando válido.
+    /// </summary>
+    public static bool TentarNormalizar(string? cep, [NotNullWhen(true)] out string? normalizado)
+    {
+        normalizado = null;
+
+        if (string.IsNullOrWhiteSpace(cep))
+        {
+            return false;
+        }
+
+        // Valida o formato CRU (já aparado) contra os padrões canônicos — não remove
+        // separadores antes, senão "0-1-0-0-1-000" passaria como se fosse 8 dígitos.
+        string bruto = cep.Trim();
+        if (!CepRegex().IsMatch(bruto))
+        {
+            return false;
+        }
+
+        normalizado = bruto
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace(" ", string.Empty, StringComparison.Ordinal);
+        return true;
+    }
+
+    // [0-9] e não \d: em .NET \d casa dígitos Unicode (ex.: árabe-índicos); o CEP é
+    // ASCII. Aceita 8 dígitos OU NNNNN-NNN OU NNNNN␠NNN — o separador só na posição
+    // 5→3, nunca interno.
+    [GeneratedRegex(@"^[0-9]{8}$|^[0-9]{5}[- ][0-9]{3}$")]
+    private static partial Regex CepRegex();
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CepResolvidoLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CepResolvidoLinksBuilder.cs
@@ -1,0 +1,58 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="CepResolvidoDto"/>. Relações: <c>cidade</c>
+/// (<c>GET /api/cidades/{codigoIbge}</c>) e <c>estado</c>
+/// (<c>GET /api/estados/{uf}</c>) — permitem navegar do CEP para a ficha completa
+/// da cidade e do estado resolvidos.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via AddSingleton<IResourceLinksBuilder<CepResolvidoDto>, CepResolvidoLinksBuilder>().")]
+internal sealed class CepResolvidoLinksBuilder : IResourceLinksBuilder<CepResolvidoDto>
+{
+    private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+    private static readonly string EstadosControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.EstadosController));
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CepResolvidoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(CepResolvidoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string cidade = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.ObterPorCodigoIbge),
+            CidadesControllerNome, new { codigoIbge = dto.CodigoIbge });
+        string estado = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.EstadosController.ObterPorUf),
+            EstadosControllerNome, new { uf = dto.Uf });
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["cidade"] = cidade,
+            ["estado"] = estado,
+        };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
@@ -15,6 +15,7 @@ using Unifesspa.UniPlus.Geo.API.Hateoas;
 using Unifesspa.UniPlus.Geo.Application;
 using Unifesspa.UniPlus.Geo.Application.DTOs;
 using Unifesspa.UniPlus.Geo.Infrastructure;
+using Unifesspa.UniPlus.Geo.Infrastructure.Cep;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 
@@ -72,6 +73,13 @@ builder.Services.AddSingleton<IResourceLinksBuilder<ImportacaoGeoDto>, Importaca
 builder.Services.AddSingleton<IResourceLinksBuilder<EstadoDto>, EstadoLinksBuilder>();
 builder.Services.AddSingleton<IResourceLinksBuilder<CidadeResumoDto>, CidadeResumoLinksBuilder>();
 builder.Services.AddSingleton<IResourceLinksBuilder<CidadeDetalheDto>, CidadeDetalheLinksBuilder>();
+
+// HATEOAS Level 1 (ADR-0029) do lookup de CEP (#676): _links para cidade e estado.
+builder.Services.AddSingleton<IResourceLinksBuilder<CepResolvidoDto>, CepResolvidoLinksBuilder>();
+
+// TTL configurável do cache-aside de CEP (#676) — default 24h (GeoCepCacheOptions).
+builder.Services.Configure<GeoCepCacheOptions>(
+    builder.Configuration.GetSection(GeoCepCacheOptions.SectionName));
 
 // Migrations EF Core aplicadas no host StartAsync via IHostedService.
 // Registrado ANTES de UseWolverineOutboxCascading + AddWolverineMessaging

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Unifesspa.UniPlus.Geo.API.csproj
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Unifesspa.UniPlus.Geo.API.csproj
@@ -12,4 +12,9 @@
     <ProjectReference Include="..\Unifesspa.UniPlus.Geo.Infrastructure\Unifesspa.UniPlus.Geo.Infrastructure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Permite testar helpers de boundary internos (ex.: CepValido) sem expô-los publicamente. -->
+    <InternalsVisibleTo Include="Unifesspa.UniPlus.Geo.IntegrationTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/ICepReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/ICepReader.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Leitor read-side da resolução de CEP sobre o <c>GeoDbContext</c>. Aplica a
+/// cascata determinística (1) <c>Logradouro</c> → (2) <c>CepGrandeUsuario</c> →
+/// (3) faixa (cidade/bairro/distrito) → (4) nada (<see langword="null"/>),
+/// projetando direto em <see cref="CepResolvidoDto"/> (sem <c>_links</c>). Só expõe
+/// reference data vigente (ADR-0092). A abstração trafega primitivas + DTOs (nunca
+/// <c>IQueryable</c>/<c>DbContext</c>), mantendo Application independente de EF Core.
+/// </summary>
+public interface ICepReader
+{
+    /// <summary>
+    /// Resolve o <paramref name="cep"/> (8 dígitos, zero-padded) pela cascata;
+    /// <see langword="null"/> quando nada o cobre. Quando o CEP casa vários
+    /// logradouros, retorna o primário nos campos de topo + os demais em
+    /// <see cref="CepResolvidoDto.Alternativos"/>, na ordem de desempate estável.
+    /// </summary>
+    Task<CepResolvidoDto?> ResolverAsync(string cep, CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/ICepResolver.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/ICepResolver.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Resolve um CEP (8 dígitos, já normalizado no boundary — ADR-0031) em um endereço
+/// estruturado, aplicando cache-aside (Redis, TTL longo) sobre o
+/// <see cref="ICepReader"/>. Só respostas positivas (200) entram no cache; ausência
+/// (404) nunca é cacheada. Quando o Redis está indisponível, degrada para o banco
+/// (a resolução não depende do cache estar de pé). Ver ADR-0090.
+/// </summary>
+public interface ICepResolver
+{
+    /// <summary>
+    /// Resolve o <paramref name="cep"/> (8 dígitos); <see langword="null"/> quando
+    /// nada casa (logradouro, grande usuário ou faixa) — o controller traduz para 404.
+    /// O DTO retornado não carrega <c>_links</c>: o controller os anexa por requisição.
+    /// </summary>
+    Task<CepResolvidoDto?> ResolverAsync(string cep, CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CandidatoLogradouroDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CandidatoLogradouroDto.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Logradouro candidato de um CEP que casa vários logradouros — entra em
+/// <see cref="CepResolvidoDto.Alternativos"/> (o primário fica nos campos de topo
+/// do <see cref="CepResolvidoDto"/>). A escolha do primário e a ordem dos
+/// alternativos seguem o desempate estável <c>(nome_normalizado, distrito_id,
+/// bairro_id, Id)</c>, determinístico entre execuções.
+/// </summary>
+public sealed record CandidatoLogradouroDto(
+    string? Tipo,
+    string Logradouro,
+    string? Bairro,
+    string? Distrito,
+    decimal? Latitude,
+    decimal? Longitude);

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CepResolucao.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CepResolucao.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Vocabulário canônico de <see cref="CepResolvidoDto.NivelResolucao"/> (até onde a
+/// resolução chegou) e <see cref="CepResolvidoDto.Origem"/> (qual estratégia
+/// resolveu). Centraliza as strings para que reader, testes e contrato OpenAPI não
+/// divirjam por literais soltos.
+/// </summary>
+public static class CepResolucao
+{
+    // NivelResolucao — granularidade territorial alcançada.
+    public const string NivelLogradouro = "logradouro";
+    public const string NivelBairro = "bairro";
+    public const string NivelDistrito = "distrito";
+    public const string NivelCidade = "cidade";
+
+    // Origem — ramo da cascata que resolveu (logradouro > grande usuário > faixa).
+    public const string OrigemLogradouro = "logradouro";
+    public const string OrigemGrandeUsuario = "grande-usuario";
+    public const string OrigemFaixaCidade = "faixa-cidade";
+    public const string OrigemFaixaBairro = "faixa-bairro";
+    public const string OrigemFaixaDistrito = "faixa-distrito";
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CepResolvidoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CepResolvidoDto.cs
@@ -39,7 +39,7 @@ public sealed record CepResolvidoDto(
     /// ou quando a resolução é por faixa/grande usuário. O primário fica nos campos
     /// de topo; os demais aqui, na mesma ordem de desempate estável.
     /// </summary>
-    public IReadOnlyList<CandidatoLogradouroDto> Alternativos { get; init; } = [];
+    public IReadOnlyList<LogradouroAlternativoDto> Alternativos { get; init; } = [];
 
     [JsonPropertyName("_links")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CepResolvidoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CepResolvidoDto.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Endereço estruturado resolvido a partir de um CEP (<c>GET /api/cep/{cep}</c>):
+/// logradouro → bairro/distrito → cidade → UF, com coordenada. Reference data
+/// público (read-only); suporta HATEOAS Level 1 via <c>_links</c> (ADR-0029). A
+/// <c>Coordenada</c> PostGIS não vaza no contrato — só <c>Latitude</c>/<c>Longitude</c>.
+/// </summary>
+/// <remarks>
+/// <para><see cref="NivelResolucao"/> (<c>logradouro|bairro|distrito|cidade</c>)
+/// indica até onde a resolução chegou; <see cref="Origem"/>
+/// (<c>logradouro|faixa-cidade|faixa-bairro|faixa-distrito|grande-usuario</c>)
+/// distingue a estratégia. Ver <see cref="CepResolucao"/>.</para>
+/// <para>Na resolução por <strong>grande usuário</strong>, o nome do órgão/empresa
+/// é exposto em <see cref="Logradouro"/> (o DTO não tem campo dedicado) e
+/// <see cref="Cidade"/>/<see cref="CodigoIbge"/>/<see cref="Uf"/> vêm da faixa CEP,
+/// não do próprio grande usuário (que só guarda <c>cep</c>+<c>nome</c>).</para>
+/// </remarks>
+public sealed record CepResolvidoDto(
+    string Cep,
+    string? Tipo,
+    string? Logradouro,
+    string? Complemento,
+    string? Bairro,
+    string? Distrito,
+    string Cidade,
+    string CodigoIbge,
+    string Uf,
+    decimal? Latitude,
+    decimal? Longitude,
+    string NivelResolucao,
+    string Origem)
+{
+    /// <summary>
+    /// Candidatos alternativos quando o CEP casa <strong>vários</strong> logradouros
+    /// (CEP de logradouro/geral compartilhado). Vazia quando há um único logradouro
+    /// ou quando a resolução é por faixa/grande usuário. O primário fica nos campos
+    /// de topo; os demais aqui, na mesma ordem de desempate estável.
+    /// </summary>
+    public IReadOnlyList<CandidatoLogradouroDto> Alternativos { get; init; } = [];
+
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/LogradouroAlternativoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/LogradouroAlternativoDto.cs
@@ -1,13 +1,17 @@
 namespace Unifesspa.UniPlus.Geo.Application.DTOs;
 
 /// <summary>
-/// Logradouro candidato de um CEP que casa vários logradouros — entra em
+/// Logradouro alternativo de um CEP que casa vários logradouros — entra em
 /// <see cref="CepResolvidoDto.Alternativos"/> (o primário fica nos campos de topo
 /// do <see cref="CepResolvidoDto"/>). A escolha do primário e a ordem dos
 /// alternativos seguem o desempate estável <c>(nome_normalizado, distrito_id,
 /// bairro_id, Id)</c>, determinístico entre execuções.
 /// </summary>
-public sealed record CandidatoLogradouroDto(
+/// <remarks>
+/// "Alternativo" (não "Candidato") evita colisão com o conceito de domínio
+/// <em>Candidato</em> — a pessoa inscrita num processo seletivo.
+/// </remarks>
+public sealed record LogradouroAlternativoDto(
     string? Tipo,
     string Logradouro,
     string? Bairro,

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cep/ResolverCepQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cep/ResolverCepQuery.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Cep;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Resolve um CEP em endereço estruturado. <paramref name="Cep"/> chega já
+/// normalizado (8 dígitos, sem máscara) — o formato é validado no boundary
+/// (ADR-0031) antes do despacho. Retorna <see langword="null"/> quando nada casa —
+/// o controller traduz para 404.
+/// </summary>
+public sealed record ResolverCepQuery(string Cep) : IQuery<CepResolvidoDto?>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cep/ResolverCepQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Cep/ResolverCepQueryHandler.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Cep;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Handler convention-based de <see cref="ResolverCepQuery"/>: delega ao
+/// <see cref="ICepResolver"/> (cache-aside + cascata) e devolve o
+/// <c>CepResolvidoDto</c> ou <see langword="null"/> (404 no controller).
+/// </summary>
+public static class ResolverCepQueryHandler
+{
+    public static async Task<CepResolvidoDto?> Handle(
+        ResolverCepQuery query,
+        ICepResolver resolver,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(resolver);
+
+        return await resolver.ResolverAsync(query.Cep, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/CepResolver.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/CepResolver.cs
@@ -1,0 +1,166 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Cep;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Infrastructure.Caching;
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+
+/// <summary>
+/// Resolve CEP com cache-aside (Redis) sobre o <see cref="ICepReader"/>. A chave
+/// compõe-se com o selo de versão vigente (<see cref="RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente"/>,
+/// #674): <c>geo:cep:v{versao}:{cep}</c>. Quando o ETL sela uma nova release, o selo
+/// muda e as entradas antigas viram inalcançáveis (invalidação O(1), sem SCAN). Só
+/// resolução positiva (200) é cacheada; 404 nunca — a ausência não pode congelar
+/// caso a base seja recarregada/enriquecida.
+/// </summary>
+/// <remarks>
+/// O <see cref="ICacheService"/> entra via <see cref="Lazy{T}"/> de propósito: o
+/// <c>IConnectionMultiplexer</c> conecta na construção, e diferir essa resolução
+/// (capturando a falha) garante que o lookup <strong>degrade para o banco</strong>
+/// quando o Redis está fora — a resolução não depende do cache estar de pé. Espelha
+/// o padrão do <c>GeoEtlOrquestrador</c> (#674).
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
+internal sealed partial class CepResolver : ICepResolver
+{
+    private readonly Lazy<ICacheService> _cache;
+    private readonly ICepReader _reader;
+    private readonly TimeSpan _ttl;
+    private readonly ILogger<CepResolver> _logger;
+
+    public CepResolver(
+        Lazy<ICacheService> cache,
+        ICepReader reader,
+        IOptions<GeoCepCacheOptions> opcoes,
+        ILogger<CepResolver> logger)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(opcoes);
+        ArgumentNullException.ThrowIfNull(logger);
+        _cache = cache;
+        _reader = reader;
+        _ttl = opcoes.Value.Ttl;
+        _logger = logger;
+    }
+
+    public async Task<CepResolvidoDto?> ResolverAsync(string cep, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(cep);
+
+        // Resolve o cache de forma resiliente (Lazy + try/catch): Redis fora → null → banco.
+        ICacheService? cache = ResolverCacheOuNulo();
+        string? chave = cache is null
+            ? null
+            : await ResolverChaveAsync(cache, cep, cancellationToken).ConfigureAwait(false);
+
+        if (cache is not null && chave is not null)
+        {
+            CepResolvidoDto? cacheado = await TentarLerCacheAsync(cache, chave, cancellationToken).ConfigureAwait(false);
+            if (cacheado is not null)
+            {
+                return cacheado;
+            }
+        }
+
+        CepResolvidoDto? resolvido = await _reader.ResolverAsync(cep, cancellationToken).ConfigureAwait(false);
+        if (resolvido is null)
+        {
+            // 404 não é cacheado — só resolução positiva entra no Redis.
+            return null;
+        }
+
+        if (cache is not null && chave is not null)
+        {
+            await TentarGravarCacheAsync(cache, chave, resolvido, cancellationToken).ConfigureAwait(false);
+        }
+
+        return resolvido;
+    }
+
+    private ICacheService? ResolverCacheOuNulo()
+    {
+        try
+        {
+            return _cache.Value;
+        }
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
+        {
+            // Redis indisponível (o .Value resolve o Connect do IConnectionMultiplexer).
+            LogCacheIndisponivel(_logger, excecao);
+            return null;
+        }
+    }
+
+    // Lê o selo de versão vigente e compõe a chave versionada. Sem selo (ETL ainda
+    // não selou) → null: não há chave determinística, segue direto ao banco sem cachear.
+    private async Task<string?> ResolverChaveAsync(ICacheService cache, string cep, CancellationToken cancellationToken)
+    {
+        try
+        {
+            string? selo = await cache
+                .ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, cancellationToken)
+                .ConfigureAwait(false);
+
+            return string.IsNullOrWhiteSpace(selo) ? null : $"geo:cep:v{selo}:{cep}";
+        }
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
+        {
+            LogFalhaLerSelo(_logger, excecao);
+            return null;
+        }
+    }
+
+    private async Task<CepResolvidoDto?> TentarLerCacheAsync(ICacheService cache, string chave, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await cache.ObterAsync<CepResolvidoDto>(chave, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
+        {
+            LogFalhaLerCache(_logger, excecao);
+            return null;
+        }
+    }
+
+    private async Task TentarGravarCacheAsync(ICacheService cache, string chave, CepResolvidoDto dto, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await cache.DefinirAsync(chave, dto, _ttl, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
+        {
+            LogFalhaGravarCache(_logger, excecao);
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Geo: cache de CEP indisponível (Redis fora); lookup degrada para o banco.")]
+    private static partial void LogCacheIndisponivel(ILogger logger, Exception excecao);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Geo: falha ao ler o selo de versão vigente do cache de CEP; lookup degrada para o banco.")]
+    private static partial void LogFalhaLerSelo(ILogger logger, Exception excecao);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Geo: falha ao ler o cache de CEP; lookup degrada para o banco.")]
+    private static partial void LogFalhaLerCache(ILogger logger, Exception excecao);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Geo: falha ao gravar o cache de CEP (best-effort); a resolução já foi devolvida.")]
+    private static partial void LogFalhaGravarCache(ILogger logger, Exception excecao);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/GeoCepCacheOptions.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/GeoCepCacheOptions.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Cep;
+
+/// <summary>
+/// Opções do cache-aside do lookup de CEP. CEP é dado estável (muda só com release
+/// DNE), então o TTL é longo por padrão. A invalidação fina vem do selo de versão
+/// vigente (ADR-0092, #674): a chave compõe-se com o selo, e trocá-lo torna as
+/// entradas antigas inalcançáveis — o TTL é só a rede de segurança.
+/// </summary>
+public sealed class GeoCepCacheOptions
+{
+    public const string SectionName = "Geo:Cep:Cache";
+
+    /// <summary>TTL das entradas <c>geo:cep:v{versao}:{cep}</c> no Redis (default 24h).</summary>
+    public TimeSpan Ttl { get; init; } = TimeSpan.FromHours(24);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -8,12 +8,14 @@ using Microsoft.Extensions.Hosting;
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Geo.Application.Abstractions;
 using Unifesspa.UniPlus.Geo.Infrastructure.Caching;
+using Unifesspa.UniPlus.Geo.Infrastructure.Cep;
 using Unifesspa.UniPlus.Geo.Infrastructure.Observability;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
@@ -46,6 +48,15 @@ public static class GeoInfrastructureRegistration
         // por cursor + detalhe por chave natural. Só expõem o que vigente (ADR-0092).
         services.AddScoped<IEstadoReader, EstadoReader>();
         services.AddScoped<ICidadeReader, CidadeReader>();
+
+        // Lookup de CEP (Story #676): reader da cascata (logradouro → grande usuário →
+        // faixa) + resolver com cache-aside por selo de versão (ADR-0090/0092). O
+        // Lazy<ICacheService> difere o Connect do Redis para o resolver degradar ao
+        // banco quando o cache está fora (espelha o Lazy do ETL, #674).
+        services.AddScoped<ICepReader, CepReader>();
+        services.AddScoped<ICepResolver, CepResolver>();
+        services.AddOptions<GeoCepCacheOptions>();
+        services.AddScoped(sp => new Lazy<ICacheService>(sp.GetRequiredService<ICacheService>));
 
         // ETL DNE (ADR-0092) — serviços de carga de reference data. O gatilho (seed
         // dev / endpoint admin) e a fonte concreta de produção entram na Story #674.

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CepReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CepReader.cs
@@ -88,9 +88,9 @@ internal sealed class CepReader : ICepReader
             .ConfigureAwait(false);
         string? complemento = complementos.Count == 1 ? complementos[0] : null;
 
-        IReadOnlyList<CandidatoLogradouroDto> alternativos = [.. linhas
+        IReadOnlyList<LogradouroAlternativoDto> alternativos = [.. linhas
             .Skip(1)
-            .Select(l => new CandidatoLogradouroDto(l.Tipo, l.Nome, l.BairroNome, l.DistritoNome, l.Latitude, l.Longitude))];
+            .Select(l => new LogradouroAlternativoDto(l.Tipo, l.Nome, l.BairroNome, l.DistritoNome, l.Latitude, l.Longitude))];
 
         return new CepResolvidoDto(
             Cep: cep,

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CepReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CepReader.cs
@@ -1,0 +1,257 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Resolve um CEP pela cascata determinística (ADR-0090) sobre o
+/// <see cref="GeoDbContext"/>, só com reference data vigente (ADR-0092):
+/// <list type="number">
+/// <item><c>Logradouro</c> pelo CEP — primário (desempate estável) + alternativos;</item>
+/// <item><c>CepGrandeUsuario</c> — nome do órgão + cidade/UF da faixa CEP;</item>
+/// <item>faixa de cidade (e bairro/distrito mais específicos) que contém o CEP;</item>
+/// <item>nada casa → <see langword="null"/> (404 no controller).</item>
+/// </list>
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
+internal sealed class CepReader : ICepReader
+{
+    private readonly GeoDbContext _dbContext;
+
+    public CepReader(GeoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<CepResolvidoDto?> ResolverAsync(string cep, CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(cep);
+
+        return await ResolverPorLogradouroAsync(cep, cancellationToken).ConfigureAwait(false)
+            ?? await ResolverPorGrandeUsuarioAsync(cep, cancellationToken).ConfigureAwait(false)
+            ?? await ResolverPorFaixaAsync(cep, cancellationToken).ConfigureAwait(false);
+    }
+
+    // (1) Logradouro pelo CEP. CEP não é único: retorna TODOS, ordenados pela chave de
+    // desempate estável (nome_normalizado, distrito_id, bairro_id, Id) — o Id (Guid v7)
+    // é o tie-breaker final, garantindo o mesmo primário/ordem entre execuções.
+    private async Task<CepResolvidoDto?> ResolverPorLogradouroAsync(string cep, CancellationToken cancellationToken)
+    {
+        List<CepLogradouroLinha> linhas = await (
+            from l in _dbContext.Logradouros.AsNoTracking()
+            where l.Vigente && l.Cep == cep
+            join c in _dbContext.Cidades.AsNoTracking().Where(c => c.Vigente) on l.CidadeId equals c.Id
+            orderby l.NomeNormalizado, l.DistritoId, l.BairroId, l.Id
+            select new CepLogradouroLinha(
+                l.Tipo,
+                l.Nome,
+                l.Latitude,
+                l.Longitude,
+                c.CodigoIbge,
+                c.Nome,
+                c.Uf,
+                _dbContext.Distritos
+                    .Where(d => d.Vigente && d.Id == l.DistritoId)
+                    .Select(d => (string?)d.Nome)
+                    .FirstOrDefault(),
+                _dbContext.Bairros
+                    .Where(b => b.Vigente && b.Id == l.BairroId)
+                    .Select(b => (string?)b.Nome)
+                    .FirstOrDefault()))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (linhas.Count == 0)
+        {
+            return null;
+        }
+
+        CepLogradouroLinha primario = linhas[0];
+
+        // Complemento (lado par/ímpar, faixa) é atributo do CEP, sem FK ao logradouro e
+        // potencialmente múltiplo. Só preenche quando há exatamente UM — escolha
+        // determinística e auditável; ambíguo (0 ou >1) fica null.
+        List<string> complementos = await _dbContext.LogradouroComplementos
+            .AsNoTracking()
+            .Where(lc => lc.Vigente && lc.Cep == cep)
+            .Select(lc => lc.Complemento)
+            .Take(2)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        string? complemento = complementos.Count == 1 ? complementos[0] : null;
+
+        IReadOnlyList<CandidatoLogradouroDto> alternativos = [.. linhas
+            .Skip(1)
+            .Select(l => new CandidatoLogradouroDto(l.Tipo, l.Nome, l.BairroNome, l.DistritoNome, l.Latitude, l.Longitude))];
+
+        return new CepResolvidoDto(
+            Cep: cep,
+            Tipo: primario.Tipo,
+            Logradouro: primario.Nome,
+            Complemento: complemento,
+            Bairro: primario.BairroNome,
+            Distrito: primario.DistritoNome,
+            Cidade: primario.CidadeNome,
+            CodigoIbge: primario.CodigoIbge,
+            Uf: primario.Uf,
+            Latitude: primario.Latitude,
+            Longitude: primario.Longitude,
+            NivelResolucao: CepResolucao.NivelLogradouro,
+            Origem: CepResolucao.OrigemLogradouro)
+        {
+            Alternativos = alternativos,
+        };
+    }
+
+    // (2) CepGrandeUsuario (CEP exclusivo de órgão). O grande usuário só guarda
+    // cep+nome — cidade/UF vêm da faixa de cidade que contém o CEP. O nome enriquece
+    // o campo Logradouro (o DTO não tem campo dedicado). Sem faixa, não há como
+    // territorializar → null (não resolve).
+    private async Task<CepResolvidoDto?> ResolverPorGrandeUsuarioAsync(string cep, CancellationToken cancellationToken)
+    {
+        string? nome = await _dbContext.CepGrandesUsuarios
+            .AsNoTracking()
+            .Where(g => g.Vigente && g.Cep == cep)
+            .Select(g => g.Nome)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (nome is null)
+        {
+            return null;
+        }
+
+        CepTerritorioCidade? cidade = await ResolverCidadePorFaixaAsync(cep, cancellationToken).ConfigureAwait(false);
+        if (cidade is null)
+        {
+            return null;
+        }
+
+        return new CepResolvidoDto(
+            Cep: cep,
+            Tipo: null,
+            Logradouro: nome,
+            Complemento: null,
+            Bairro: null,
+            Distrito: null,
+            Cidade: cidade.Nome,
+            CodigoIbge: cidade.CodigoIbge,
+            Uf: cidade.Uf,
+            Latitude: cidade.Latitude,
+            Longitude: cidade.Longitude,
+            NivelResolucao: CepResolucao.NivelCidade,
+            Origem: CepResolucao.OrigemGrandeUsuario);
+    }
+
+    // (3) Faixa: cidade que contém o CEP; enriquece com bairro/distrito quando houver
+    // faixa mais específica. Nível/origem refletem o mais específico (bairro > distrito
+    // > cidade). Logradouro ausente é esperado (CEP geral), não erro.
+    private async Task<CepResolvidoDto?> ResolverPorFaixaAsync(string cep, CancellationToken cancellationToken)
+    {
+        CepTerritorioCidade? cidade = await ResolverCidadePorFaixaAsync(cep, cancellationToken).ConfigureAwait(false);
+        if (cidade is null)
+        {
+            return null;
+        }
+
+        string? bairroNome = await ResolverNomePorFaixaBairroAsync(cep, cidade.Id, cancellationToken).ConfigureAwait(false);
+        string? distritoNome = await ResolverNomePorFaixaDistritoAsync(cep, cidade.Id, cancellationToken).ConfigureAwait(false);
+
+        (string nivel, string origem) = (bairroNome, distritoNome) switch
+        {
+            (not null, _) => (CepResolucao.NivelBairro, CepResolucao.OrigemFaixaBairro),
+            (null, not null) => (CepResolucao.NivelDistrito, CepResolucao.OrigemFaixaDistrito),
+            _ => (CepResolucao.NivelCidade, CepResolucao.OrigemFaixaCidade),
+        };
+
+        return new CepResolvidoDto(
+            Cep: cep,
+            Tipo: null,
+            Logradouro: null,
+            Complemento: null,
+            Bairro: bairroNome,
+            Distrito: distritoNome,
+            Cidade: cidade.Nome,
+            CodigoIbge: cidade.CodigoIbge,
+            Uf: cidade.Uf,
+            Latitude: cidade.Latitude,
+            Longitude: cidade.Longitude,
+            NivelResolucao: nivel,
+            Origem: origem);
+    }
+
+    // Faixa de CEP da cidade que contém o CEP. O predicado de range
+    // (cep_inicial <= cep <= cep_final) vai em SQL parametrizado (FromSqlInterpolated):
+    // comparação de string nativa do PG sobre 8 dígitos zero-padded — sargável e sem
+    // depender da tradução de string.Compare. OrderBy por Id torna a escolha
+    // determinística mesmo se faixas se sobrepuserem (dado inconsistente da fonte).
+    private Task<CepTerritorioCidade?> ResolverCidadePorFaixaAsync(string cep, CancellationToken cancellationToken)
+    {
+        FormattableString faixaSql =
+            $"SELECT * FROM cidade_faixa_cep WHERE vigente AND cep_inicial <= {cep} AND cep_final >= {cep}";
+
+        return (
+            from f in _dbContext.CidadeFaixasCep.FromSqlInterpolated(faixaSql).AsNoTracking()
+            join c in _dbContext.Cidades.AsNoTracking().Where(c => c.Vigente) on f.CidadeId equals c.Id
+            orderby c.Id
+            select new CepTerritorioCidade(c.Id, c.CodigoIbge, c.Nome, c.Uf, c.Latitude, c.Longitude))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    // Faixa de bairro restrita à cidade já resolvida (a faixa indexa BairroId, mas o
+    // bairro carrega CidadeId) + desempate estável — range sobreposto não devolve
+    // bairro de outra cidade nem varia entre execuções.
+    private Task<string?> ResolverNomePorFaixaBairroAsync(string cep, Guid cidadeId, CancellationToken cancellationToken)
+    {
+        FormattableString faixaSql =
+            $"SELECT * FROM bairro_faixa_cep WHERE vigente AND cep_inicial <= {cep} AND cep_final >= {cep}";
+
+        return (
+            from f in _dbContext.BairroFaixasCep.FromSqlInterpolated(faixaSql).AsNoTracking()
+            join b in _dbContext.Bairros.AsNoTracking().Where(b => b.Vigente && b.CidadeId == cidadeId) on f.BairroId equals b.Id
+            orderby b.NomeNormalizado, b.Id
+            select (string?)b.Nome)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    private Task<string?> ResolverNomePorFaixaDistritoAsync(string cep, Guid cidadeId, CancellationToken cancellationToken)
+    {
+        FormattableString faixaSql =
+            $"SELECT * FROM distrito_faixa_cep WHERE vigente AND cep_inicial <= {cep} AND cep_final >= {cep}";
+
+        return (
+            from f in _dbContext.DistritoFaixasCep.FromSqlInterpolated(faixaSql).AsNoTracking()
+            join d in _dbContext.Distritos.AsNoTracking().Where(d => d.Vigente && d.CidadeId == cidadeId) on f.DistritoId equals d.Id
+            orderby d.NomeNormalizado, d.Id
+            select (string?)d.Nome)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    // Projeções read-only (evitam materializar a entidade inteira).
+    private sealed record CepLogradouroLinha(
+        string? Tipo,
+        string Nome,
+        decimal? Latitude,
+        decimal? Longitude,
+        string CodigoIbge,
+        string CidadeNome,
+        string Uf,
+        string? DistritoNome,
+        string? BairroNome);
+
+    private sealed record CepTerritorioCidade(
+        Guid Id,
+        string CodigoIbge,
+        string Nome,
+        string Uf,
+        decimal? Latitude,
+        decimal? Longitude);
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CepEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CepEndpointTests.cs
@@ -1,0 +1,289 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Api;
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Lookup de CEP (#676) contra a API real + PostGIS. Read-only
+/// <c>[AllowAnonymous]</c>. Cobre CA-01..CA-06 e CA-09 (a cobertura de cache-aside
+/// CA-07/CA-08 fica nos testes de unidade do <c>CepResolver</c>, que provam "hit não
+/// toca o banco" e "404 não é cacheado" com precisão). O cache degrada para o banco
+/// (Redis vazio na <see cref="GeoApiFactory"/>). A collection é serial; cada teste
+/// TRUNCA e semeia.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class CepEndpointTests
+{
+    private readonly GeoPostgisFixture _fixture;
+
+    public CepEndpointTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01: CEP de logradouro resolve logradouro+bairro+cidade+UF+coordenada e _links")]
+    public async Task Cep_ResolveLogradouro()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/01001000");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement raiz = doc.RootElement;
+        raiz.GetProperty("cep").GetString().Should().Be("01001000");
+        raiz.GetProperty("tipo").GetString().Should().Be("Praça");
+        raiz.GetProperty("logradouro").GetString().Should().Be("Praça da Sé");
+        raiz.GetProperty("bairro").GetString().Should().Be("Sé");
+        raiz.GetProperty("cidade").GetString().Should().Be("São Paulo");
+        raiz.GetProperty("codigoIbge").GetString().Should().Be("3550308");
+        raiz.GetProperty("uf").GetString().Should().Be("SP");
+        raiz.GetProperty("latitude").GetDecimal().Should().Be(-23.55m);
+        raiz.GetProperty("longitude").GetDecimal().Should().Be(-46.63m);
+        raiz.GetProperty("nivelResolucao").GetString().Should().Be("logradouro");
+        raiz.GetProperty("origem").GetString().Should().Be("logradouro");
+        raiz.GetProperty("alternativos").GetArrayLength().Should().Be(0);
+
+        JsonElement links = raiz.GetProperty("_links");
+        links.GetProperty("cidade").GetString().Should().Be("/api/cidades/3550308");
+        links.GetProperty("estado").GetString().Should().Be("/api/estados/SP");
+    }
+
+    [Fact(DisplayName = "CA-01: complemento único do CEP é exposto")]
+    public async Task Cep_ComplementoUnico()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/01001000");
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("complemento").GetString().Should().Be("de 1 a 999 - lado ímpar");
+    }
+
+    [Fact(DisplayName = "CEP com mais de um complemento: campo complemento fica null (ambíguo)")]
+    public async Task Cep_MultiplosComplementos_Null()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/01002000");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement complemento = doc.RootElement.GetProperty("complemento");
+        complemento.ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact(DisplayName = "CA-02: CEP com vários logradouros traz primário + alternativos, estável entre execuções")]
+    public async Task Cep_MultiplosLogradouros_DesempateEstavel()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        async Task<(string Primario, IReadOnlyList<string> Alternativos)> ResolverAsync()
+        {
+            using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/01310100");
+            resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+            using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+            JsonElement raiz = doc.RootElement;
+            raiz.GetProperty("nivelResolucao").GetString().Should().Be("logradouro");
+            string primario = raiz.GetProperty("logradouro").GetString()!;
+            List<string> alternativos = [.. raiz.GetProperty("alternativos")
+                .EnumerateArray()
+                .Select(a => a.GetProperty("logradouro").GetString()!)];
+            return (primario, alternativos);
+        }
+
+        (string Primario, IReadOnlyList<string> Alternativos) primeira = await ResolverAsync();
+        (string Primario, IReadOnlyList<string> Alternativos) segunda = await ResolverAsync();
+
+        // Desempate (nome_normalizado, ...): "alameda santos" < "avenida paulista".
+        primeira.Primario.Should().Be("Alameda Santos");
+        primeira.Alternativos.Should().ContainSingle().Which.Should().Be("Avenida Paulista");
+        segunda.Primario.Should().Be(primeira.Primario, "o primário é determinístico entre execuções");
+        segunda.Alternativos.Should().Equal(primeira.Alternativos, "a ordem dos alternativos é estável");
+    }
+
+    [Fact(DisplayName = "CA-03: CEP geral sem logradouro resolve cidade por faixa (nível cidade, sem logradouro)")]
+    public async Task Cep_ResolvePorFaixaCidade()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/68500005");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement raiz = doc.RootElement;
+        raiz.GetProperty("cidade").GetString().Should().Be("Marabá");
+        raiz.GetProperty("uf").GetString().Should().Be("PA");
+        raiz.GetProperty("origem").GetString().Should().Be("faixa-cidade");
+        raiz.GetProperty("nivelResolucao").GetString().Should().Be("cidade");
+        raiz.GetProperty("logradouro").ValueKind.Should().Be(JsonValueKind.Null);
+    }
+
+    [Fact(DisplayName = "CA-03: faixa de bairro mais específica eleva o nível para bairro")]
+    public async Task Cep_ResolvePorFaixaBairro()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/68507100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement raiz = doc.RootElement;
+        raiz.GetProperty("cidade").GetString().Should().Be("Marabá");
+        raiz.GetProperty("bairro").GetString().Should().Be("Cidade Nova");
+        raiz.GetProperty("origem").GetString().Should().Be("faixa-bairro");
+        raiz.GetProperty("nivelResolucao").GetString().Should().Be("bairro");
+    }
+
+    [Fact(DisplayName = "CA-04: CEP de grande usuário traz nome + cidade/UF da faixa CEP")]
+    public async Task Cep_ResolveGrandeUsuario_CidadeDaFaixa()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/01051900");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement raiz = doc.RootElement;
+        raiz.GetProperty("origem").GetString().Should().Be("grande-usuario");
+        raiz.GetProperty("logradouro").GetString().Should().Be("Banco do Brasil Agência Centro");
+        raiz.GetProperty("cidade").GetString().Should().Be("São Paulo");
+        raiz.GetProperty("uf").GetString().Should().Be("SP");
+        raiz.GetProperty("nivelResolucao").GetString().Should().Be("cidade");
+    }
+
+    [Fact(DisplayName = "CA-05: CEP com máscara é normalizado e resolvido")]
+    public async Task Cep_ComMascara_Resolve()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/01001-000");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("logradouro").GetString().Should().Be("Praça da Sé");
+    }
+
+    [Theory(DisplayName = "CA-05: CEP malformado (≠8 dígitos, não-numérico) retorna 400")]
+    [InlineData("/api/cep/123")]
+    [InlineData("/api/cep/010010000")]
+    [InlineData("/api/cep/0100100a")]
+    [InlineData("/api/cep/abcdefgh")]
+    public async Task Cep_Malformado_400(string rota)
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, rota);
+        resposta.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "CA-06: CEP bem-formado sem cobertura retorna 404")]
+    public async Task Cep_Inexistente_404()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/99999999");
+        resposta.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "ADR-0092: logradouro stale (vigente=false) não resolve (404 quando nada mais cobre)")]
+    public async Task Cep_LogradouroStale_NaoResolve()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // 30000000 só tem um logradouro stale e não está em nenhuma faixa → 404.
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/30000000");
+        resposta.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "CA-09: Accept vendor incompatível retorna 406; vendor cep.v1 é aceito")]
+    public async Task Cep_VendorMime_406()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpRequestMessage incompativel = new(HttpMethod.Get, "/api/cep/01001000");
+        incompativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.cep.v2+json"));
+        using HttpResponseMessage resp406 = await client.SendAsync(incompativel);
+        resp406.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
+
+        using HttpRequestMessage compativel = new(HttpMethod.Get, "/api/cep/01001000");
+        compativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.cep.v1+json"));
+        using HttpResponseMessage resp200 = await client.SendAsync(compativel);
+        resp200.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private async Task SemearAsync()
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+
+        Pais brasil = GeoReferenceSeed.NovoBrasil();
+        Estado saoPaulo = GeoReferenceSeed.NovoEstado(brasil.Id, "SP", "São Paulo", regiao: "Sudeste", capital: "São Paulo");
+        Estado para = GeoReferenceSeed.NovoEstado(brasil.Id, "PA", "Pará", regiao: "Norte", capital: "Belém");
+
+        Cidade cidadeSp = GeoReferenceSeed.NovaCidade(saoPaulo.Id, "SP", "3550308", "São Paulo");
+        Cidade maraba = GeoReferenceSeed.NovaCidade(para.Id, "PA", "1500402", "Marabá");
+
+        Bairro se = GeoReferenceSeed.NovoBairro(cidadeSp.Id, "SP", "Sé");
+        Bairro belaVista = GeoReferenceSeed.NovoBairro(cidadeSp.Id, "SP", "Bela Vista");
+        Bairro jardimPaulista = GeoReferenceSeed.NovoBairro(cidadeSp.Id, "SP", "Jardim Paulista");
+        Bairro cidadeNova = GeoReferenceSeed.NovoBairro(maraba.Id, "PA", "Cidade Nova");
+
+        // (1) CEP de logradouro único (CA-01) + 1 complemento.
+        Logradouro praca = GeoReferenceSeed.NovoLogradouro(
+            cidadeSp.Id, "SP", "01001000", "Praça da Sé", tipo: "Praça",
+            bairroId: se.Id, latitude: -23.55m, longitude: -46.63m);
+        LogradouroComplemento complementoPraca = GeoReferenceSeed.NovoComplemento("01001000", "de 1 a 999 - lado ímpar");
+
+        // CEP com 2 complementos → campo complemento null.
+        Logradouro rua = GeoReferenceSeed.NovoLogradouro(
+            cidadeSp.Id, "SP", "01002000", "Rua das Flores", tipo: "Rua", bairroId: se.Id);
+        LogradouroComplemento comp1 = GeoReferenceSeed.NovoComplemento("01002000", "lado par");
+        LogradouroComplemento comp2 = GeoReferenceSeed.NovoComplemento("01002000", "lado ímpar");
+
+        // (2) CEP compartilhado por 2 logradouros (CA-02). Desempate por nome_normalizado.
+        Logradouro avPaulista = GeoReferenceSeed.NovoLogradouro(
+            cidadeSp.Id, "SP", "01310100", "Avenida Paulista", tipo: "Avenida", bairroId: belaVista.Id);
+        Logradouro alSantos = GeoReferenceSeed.NovoLogradouro(
+            cidadeSp.Id, "SP", "01310100", "Alameda Santos", tipo: "Alameda", bairroId: jardimPaulista.Id);
+
+        // Logradouro stale (não resolve) num CEP sem faixa.
+        Logradouro stale = GeoReferenceSeed.NovoLogradouro(
+            cidadeSp.Id, "SP", "30000000", "Rua Obsoleta", vigente: false);
+
+        // (3) Faixas de CEP.
+        CidadeFaixaCep faixaSp = GeoReferenceSeed.NovaCidadeFaixa(cidadeSp.Id, "01000000", "01099999");
+        CidadeFaixaCep faixaMaraba = GeoReferenceSeed.NovaCidadeFaixa(maraba.Id, "68500000", "68599999");
+        BairroFaixaCep faixaCidadeNova = GeoReferenceSeed.NovaBairroFaixa(cidadeNova.Id, "68507000", "68507999");
+
+        // (4) Grande usuário (sem logradouro próprio; cidade vem da faixa SP).
+        CepGrandeUsuario grandeUsuario = GeoReferenceSeed.NovoGrandeUsuario("01051900", "Banco do Brasil Agência Centro");
+
+        ctx.Paises.Add(brasil);
+        ctx.Estados.AddRange(saoPaulo, para);
+        ctx.Cidades.AddRange(cidadeSp, maraba);
+        ctx.Bairros.AddRange(se, belaVista, jardimPaulista, cidadeNova);
+        ctx.Logradouros.AddRange(praca, rua, avPaulista, alSantos, stale);
+        ctx.LogradouroComplementos.AddRange(complementoPraca, comp1, comp2);
+        ctx.CidadeFaixasCep.AddRange(faixaSp, faixaMaraba);
+        ctx.BairroFaixasCep.Add(faixaCidadeNova);
+        ctx.CepGrandesUsuarios.Add(grandeUsuario);
+        await ctx.SaveChangesAsync();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CepEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CepEndpointTests.cs
@@ -147,6 +147,26 @@ public sealed class CepEndpointTests
         raiz.GetProperty("nivelResolucao").GetString().Should().Be("bairro");
     }
 
+    [Fact(DisplayName = "CA-03: faixa de distrito (sem bairro cobrindo) eleva o nível para distrito")]
+    public async Task Cep_ResolvePorFaixaDistrito()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // 68508100 está na faixa de cidade (Marabá) e na faixa de distrito (Nova Marabá),
+        // mas NÃO na faixa de bairro (68507000-68507999) → resolve no nível distrito.
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, "/api/cep/68508100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement raiz = doc.RootElement;
+        raiz.GetProperty("cidade").GetString().Should().Be("Marabá");
+        raiz.GetProperty("distrito").GetString().Should().Be("Nova Marabá");
+        raiz.GetProperty("bairro").ValueKind.Should().Be(JsonValueKind.Null);
+        raiz.GetProperty("origem").GetString().Should().Be("faixa-distrito");
+        raiz.GetProperty("nivelResolucao").GetString().Should().Be("distrito");
+    }
+
     [Fact(DisplayName = "CA-04: CEP de grande usuário traz nome + cidade/UF da faixa CEP")]
     public async Task Cep_ResolveGrandeUsuario_CidadeDaFaixa()
     {
@@ -244,6 +264,7 @@ public sealed class CepEndpointTests
         Bairro belaVista = GeoReferenceSeed.NovoBairro(cidadeSp.Id, "SP", "Bela Vista");
         Bairro jardimPaulista = GeoReferenceSeed.NovoBairro(cidadeSp.Id, "SP", "Jardim Paulista");
         Bairro cidadeNova = GeoReferenceSeed.NovoBairro(maraba.Id, "PA", "Cidade Nova");
+        Distrito novaMaraba = GeoReferenceSeed.NovoDistrito(maraba.Id, "PA", "Nova Marabá");
 
         // (1) CEP de logradouro único (CA-01) + 1 complemento.
         Logradouro praca = GeoReferenceSeed.NovoLogradouro(
@@ -267,10 +288,12 @@ public sealed class CepEndpointTests
         Logradouro stale = GeoReferenceSeed.NovoLogradouro(
             cidadeSp.Id, "SP", "30000000", "Rua Obsoleta", vigente: false);
 
-        // (3) Faixas de CEP.
+        // (3) Faixas de CEP. Bairro e distrito têm faixas disjuntas dentro de Marabá:
+        // 68507xxx → bairro Cidade Nova; 68508xxx → distrito Nova Marabá (sem bairro).
         CidadeFaixaCep faixaSp = GeoReferenceSeed.NovaCidadeFaixa(cidadeSp.Id, "01000000", "01099999");
         CidadeFaixaCep faixaMaraba = GeoReferenceSeed.NovaCidadeFaixa(maraba.Id, "68500000", "68599999");
         BairroFaixaCep faixaCidadeNova = GeoReferenceSeed.NovaBairroFaixa(cidadeNova.Id, "68507000", "68507999");
+        DistritoFaixaCep faixaNovaMaraba = GeoReferenceSeed.NovaDistritoFaixa(novaMaraba.Id, "68508000", "68508999");
 
         // (4) Grande usuário (sem logradouro próprio; cidade vem da faixa SP).
         CepGrandeUsuario grandeUsuario = GeoReferenceSeed.NovoGrandeUsuario("01051900", "Banco do Brasil Agência Centro");
@@ -279,10 +302,12 @@ public sealed class CepEndpointTests
         ctx.Estados.AddRange(saoPaulo, para);
         ctx.Cidades.AddRange(cidadeSp, maraba);
         ctx.Bairros.AddRange(se, belaVista, jardimPaulista, cidadeNova);
+        ctx.Distritos.Add(novaMaraba);
         ctx.Logradouros.AddRange(praca, rua, avPaulista, alSantos, stale);
         ctx.LogradouroComplementos.AddRange(complementoPraca, comp1, comp2);
         ctx.CidadeFaixasCep.AddRange(faixaSp, faixaMaraba);
         ctx.BairroFaixasCep.Add(faixaCidadeNova);
+        ctx.DistritoFaixasCep.Add(faixaNovaMaraba);
         ctx.CepGrandesUsuarios.Add(grandeUsuario);
         await ctx.SaveChangesAsync();
     }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
@@ -27,11 +27,18 @@ internal static partial class GeoReferenceSeed
         return client.GetAsync(new Uri(rota, UriKind.RelativeOrAbsolute));
     }
 
-    /// <summary>Limpa toda a hierarquia Geo (TRUNCATE pais CASCADE derruba estado/cidade/indicador/faixas).</summary>
+    /// <summary>
+    /// Limpa toda a hierarquia Geo. <c>TRUNCATE pais CASCADE</c> derruba
+    /// estado/cidade/indicador/faixas/logradouro (ligados por FK); <c>cep_grande_usuario</c>
+    /// e <c>logradouro_complemento</c> não têm FK para a hierarquia (são atributos do
+    /// CEP), então entram explicitamente no TRUNCATE — senão acumulam entre testes
+    /// seriais e furam os índices UNIQUE de CEP.
+    /// </summary>
     public static async Task LimparAsync(GeoPostgisFixture fixture)
     {
         await using GeoDbContext ctx = fixture.CreateDbContext();
-        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE TABLE pais CASCADE");
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE TABLE pais, cep_grande_usuario, logradouro_complemento CASCADE");
     }
 
     public static Pais NovoBrasil() =>
@@ -71,6 +78,45 @@ internal static partial class GeoReferenceSeed
             null, mesorregiaoNome, null, microrregiaoNome,
             null, regiaoIntermediariaNome, null, regiaoImediataNome,
             Versao, vigente));
+
+    public static Distrito NovoDistrito(Guid cidadeId, string uf, string nome, bool vigente = true) =>
+        GeoTestKeys.Ok(Distrito.Importar(
+            cidadeId, uf, nome, Normalizar(nome), null, null, null, null, Versao, vigente));
+
+    public static Bairro NovoBairro(Guid cidadeId, string uf, string nome, bool vigente = true) =>
+        GeoTestKeys.Ok(Bairro.Importar(
+            cidadeId, uf, nome, Normalizar(nome), null, null, null, null, Versao, vigente));
+
+    public static Logradouro NovoLogradouro(
+        Guid cidadeId,
+        string uf,
+        string cep,
+        string nome,
+        string? tipo = null,
+        Guid? distritoId = null,
+        Guid? bairroId = null,
+        decimal? latitude = null,
+        decimal? longitude = null,
+        string? nomeNormalizado = null,
+        bool vigente = true) =>
+        GeoTestKeys.Ok(Logradouro.Importar(
+            cep, tipo, nome, null, nomeNormalizado ?? Normalizar(nome), cidadeId,
+            distritoId, bairroId, uf, latitude, longitude, null, true, Versao, vigente));
+
+    public static LogradouroComplemento NovoComplemento(string cep, string complemento, bool vigente = true) =>
+        GeoTestKeys.Ok(LogradouroComplemento.Importar(cep, complemento, Normalizar(complemento), Versao, vigente));
+
+    public static CepGrandeUsuario NovoGrandeUsuario(string cep, string nome, bool vigente = true) =>
+        GeoTestKeys.Ok(CepGrandeUsuario.Importar(cep, nome, Normalizar(nome), Versao, vigente));
+
+    public static CidadeFaixaCep NovaCidadeFaixa(Guid cidadeId, string cepInicial, string cepFinal, bool vigente = true) =>
+        GeoTestKeys.Ok(CidadeFaixaCep.Importar(cidadeId, cepInicial, cepFinal, Versao, vigente));
+
+    public static BairroFaixaCep NovaBairroFaixa(Guid bairroId, string cepInicial, string cepFinal, bool vigente = true) =>
+        GeoTestKeys.Ok(BairroFaixaCep.Importar(bairroId, cepInicial, cepFinal, Versao, vigente));
+
+    public static DistritoFaixaCep NovaDistritoFaixa(Guid distritoId, string cepInicial, string cepFinal, bool vigente = true) =>
+        GeoTestKeys.Ok(DistritoFaixaCep.Importar(distritoId, cepInicial, cepFinal, Versao, vigente));
 
     public static CidadeIndicador NovoIndicador(
         Guid cidadeId,

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Cep/CepResolverTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Cep/CepResolverTests.cs
@@ -1,0 +1,123 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Cep;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Infrastructure.Caching;
+using Unifesspa.UniPlus.Geo.Infrastructure.Cep;
+using Unifesspa.UniPlus.Infrastructure.Core.Caching;
+
+/// <summary>
+/// Testes de unidade do cache-aside do <see cref="CepResolver"/> (#676) — sem
+/// Redis/DB reais (substitutos NSubstitute). Provam o contrato que a integração não
+/// consegue afirmar com precisão: hit não toca o reader (CA-07), 404 nunca é
+/// cacheado (CA-08), a chave compõe-se com o selo de versão, e o lookup degrada
+/// para o banco quando o Redis está fora.
+/// </summary>
+public sealed class CepResolverTests
+{
+    private const string Selo = "202601";
+    private const string Cep = "01001000";
+    private const string ChaveCep = $"geo:cep:v{Selo}:{Cep}";
+
+    private static CepResolvidoDto Endereco() => new(
+        Cep, "Praça", "Praça da Sé", null, "Sé", null, "São Paulo", "3550308", "SP",
+        -23.55m, -46.63m, CepResolucao.NivelLogradouro, CepResolucao.OrigemLogradouro);
+
+    private static CepResolver Criar(ICacheService cache, ICepReader reader) =>
+        new(new Lazy<ICacheService>(() => cache), reader, Options.Create(new GeoCepCacheOptions()), NullLogger<CepResolver>.Instance);
+
+    [Fact(DisplayName = "CA-07: cache hit devolve do Redis e não consulta o reader (banco)")]
+    public async Task CacheHit_NaoConsultaReader()
+    {
+        ICacheService cache = Substitute.For<ICacheService>();
+        ICepReader reader = Substitute.For<ICepReader>();
+        CepResolvidoDto cacheado = Endereco();
+        cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
+            .Returns(Selo);
+        cache.ObterAsync<CepResolvidoDto>(ChaveCep, Arg.Any<CancellationToken>())
+            .Returns(cacheado);
+
+        CepResolvidoDto? resultado = await Criar(cache, reader).ResolverAsync(Cep, CancellationToken.None);
+
+        resultado.Should().Be(cacheado);
+        await reader.DidNotReceive().ResolverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Cache miss: resolve do banco e popula a chave versionada com o TTL")]
+    public async Task CacheMiss_ResolveDoBancoEPopula()
+    {
+        ICacheService cache = Substitute.For<ICacheService>();
+        ICepReader reader = Substitute.For<ICepReader>();
+        CepResolvidoDto resolvido = Endereco();
+        cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
+            .Returns(Selo);
+        cache.ObterAsync<CepResolvidoDto>(ChaveCep, Arg.Any<CancellationToken>())
+            .Returns((CepResolvidoDto?)null);
+        reader.ResolverAsync(Cep, Arg.Any<CancellationToken>()).Returns(resolvido);
+
+        CepResolvidoDto? resultado = await Criar(cache, reader).ResolverAsync(Cep, CancellationToken.None);
+
+        resultado.Should().Be(resolvido);
+        await reader.Received(1).ResolverAsync(Cep, Arg.Any<CancellationToken>());
+        await cache.Received(1).DefinirAsync(ChaveCep, resolvido, Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "CA-08: reader devolve null (404) — nada é gravado no cache")]
+    public async Task ReaderNull_NaoCacheia()
+    {
+        ICacheService cache = Substitute.For<ICacheService>();
+        ICepReader reader = Substitute.For<ICepReader>();
+        cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
+            .Returns(Selo);
+        cache.ObterAsync<CepResolvidoDto>(ChaveCep, Arg.Any<CancellationToken>())
+            .Returns((CepResolvidoDto?)null);
+        reader.ResolverAsync(Cep, Arg.Any<CancellationToken>()).Returns((CepResolvidoDto?)null);
+
+        CepResolvidoDto? resultado = await Criar(cache, reader).ResolverAsync(Cep, CancellationToken.None);
+
+        resultado.Should().BeNull();
+        await cache.DidNotReceive().DefinirAsync(Arg.Any<string>(), Arg.Any<CepResolvidoDto>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Redis indisponível (Lazy lança ao conectar): degrada para o banco sem propagar erro")]
+    public async Task CacheIndisponivel_DegradaParaBanco()
+    {
+        ICepReader reader = Substitute.For<ICepReader>();
+        CepResolvidoDto resolvido = Endereco();
+        reader.ResolverAsync(Cep, Arg.Any<CancellationToken>()).Returns(resolvido);
+
+        // Lazy que lança ao resolver — simula o IConnectionMultiplexer.Connect falhando.
+        Lazy<ICacheService> cacheQuebrado = new(() => throw new InvalidOperationException("Redis fora do ar"));
+        CepResolver resolver = new(cacheQuebrado, reader, Options.Create(new GeoCepCacheOptions()), NullLogger<CepResolver>.Instance);
+
+        CepResolvidoDto? resultado = await resolver.ResolverAsync(Cep, CancellationToken.None);
+
+        resultado.Should().Be(resolvido);
+        await reader.Received(1).ResolverAsync(Cep, Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Sem selo de versão (ETL ainda não selou): resolve do banco e não cacheia")]
+    public async Task SemSelo_NaoCacheia()
+    {
+        ICacheService cache = Substitute.For<ICacheService>();
+        ICepReader reader = Substitute.For<ICepReader>();
+        cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        CepResolvidoDto resolvido = Endereco();
+        reader.ResolverAsync(Cep, Arg.Any<CancellationToken>()).Returns(resolvido);
+
+        CepResolvidoDto? resultado = await Criar(cache, reader).ResolverAsync(Cep, CancellationToken.None);
+
+        resultado.Should().Be(resolvido);
+        await reader.Received(1).ResolverAsync(Cep, Arg.Any<CancellationToken>());
+        await cache.DidNotReceive().ObterAsync<CepResolvidoDto>(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await cache.DidNotReceive().DefinirAsync(Arg.Any<string>(), Arg.Any<CepResolvidoDto>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Cep/CepValidoTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Cep/CepValidoTests.cs
@@ -1,0 +1,46 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Cep;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Geo.API.Formatting;
+
+/// <summary>
+/// Decode/normalização de CEP no boundary (ADR-0031, #676): remove máscara e exige
+/// exatamente 8 dígitos ASCII.
+/// </summary>
+public sealed class CepValidoTests
+{
+    [Theory(DisplayName = "Normaliza CEP válido (com ou sem máscara)")]
+    [InlineData("01001000", "01001000")]
+    [InlineData("01001-000", "01001000")]
+    [InlineData(" 01001-000 ", "01001000")]
+    [InlineData("01001 000", "01001000")]
+    [InlineData("00000000", "00000000")]
+    public void TentarNormalizar_Valido(string entrada, string esperado)
+    {
+        bool ok = CepValido.TentarNormalizar(entrada, out string? normalizado);
+
+        ok.Should().BeTrue();
+        normalizado.Should().Be(esperado);
+    }
+
+    [Theory(DisplayName = "Rejeita CEP inválido (≠8 dígitos, não-numérico, separador fora de posição, vazio)")]
+    [InlineData("123")]
+    [InlineData("010010000")]
+    [InlineData("0100100a")]
+    [InlineData("abcdefgh")]
+    [InlineData("0-1-0-0-1-000")]
+    [InlineData("0100 1 000")]
+    [InlineData("01001--000")]
+    [InlineData("0100-1000")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void TentarNormalizar_Invalido(string? entrada)
+    {
+        bool ok = CepValido.TentarNormalizar(entrada, out string? normalizado);
+
+        ok.Should().BeFalse();
+        normalizado.Should().BeNull();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Infrastructure/GeoApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Infrastructure/GeoApiFactory.cs
@@ -37,5 +37,9 @@ public sealed class GeoApiFactory : ApiFactoryBase<Program>
         // Worker do ETL desligado: o disparo (POST) cria o registro EmAndamento e
         // retorna 202 sem que a carga real rode — torna 202/409 determinísticos (#674).
         new("Geo:Etl:WorkerHabilitado", "false"),
+        // Redis vazio: o lookup de CEP (#676) degrada para o banco de forma rápida e
+        // determinística (sem o connect lento ao localhost:6379 do appsettings.Development).
+        // O comportamento de cache-aside é coberto pelos testes de unidade do CepResolver.
+        new("Redis:ConnectionString", string.Empty),
     ];
 }


### PR DESCRIPTION
## Objetivo

Implementa o **lookup de CEP** (`GET /api/cep/{cep}`) do módulo Geo — a funcionalidade de maior valor de uso: resolve um CEP em endereço estruturado (logradouro → bairro/distrito → cidade → UF, com coordenada), substituindo a dependência de serviços externos (ViaCEP/BrasilAPI) por fonte autoritativa interna (DNE), sem PII transitando por terceiros.

Closes #676

## O que foi feito

- **Endpoint** `GET /api/cep/{cep}` read-only público (`[AllowAnonymous]`, vendor MIME `cep.v1`), com decode/validação no boundary (ADR-0031): máscara removida e 8 dígitos exigidos → 400.
- **Cascata determinística** (`CepReader`, só dados vigentes — ADR-0092):
  1. `Logradouro` pelo CEP — primário + `alternativos`, desempate estável `(nome_normalizado, distrito_id, bairro_id, Id)`;
  2. `CepGrandeUsuario` — nome do órgão + cidade/UF resolvidas pela faixa de CEP (o grande usuário não carrega território);
  3. faixa de cidade (e bairro/distrito mais específicos) que contém o CEP;
  4. nada casa → 404.
- **Cache-aside Redis** (`CepResolver`) com chave versionada pelo selo de versão vigente (`geo:cep:v{versao}:{cep}`, reaproveitando o selo do ETL #674): invalidação O(1) ao trocar o selo, TTL longo configurável (`GeoCepCacheOptions`, 24h). Só resolução positiva é cacheada; **404 nunca**. O `ICacheService` entra via `Lazy` — o lookup **degrada para o banco** quando o Redis está fora.
- **HATEOAS** `_links` para `cidade` e `estado` (ADR-0029).
- Predicado de faixa (`cep ∈ [inicial, final]`) em **SQL parametrizado** (`FromSqlInterpolated`): comparação nativa do PostgreSQL sobre 8 dígitos zero-padded — sargável, sem depender da tradução de `string.Compare`.

## Critérios de aceite

CA-01 a CA-06 e CA-09 cobertos por testes de integração contra PostGIS real; CA-07 (hit não toca o banco) e CA-08 (404 não cacheado) por testes de unidade do `CepResolver` (provam o contrato com precisão que o HTTP não permite — ver "Decisões").

## Testes

- **Unidade** (`CepResolverTests`, `CepValidoTests`): cache-aside (hit/miss/404-não-cacheado/degradação-sem-Redis/composição-da-chave) + decode de boundary.
- **Integração** (`CepEndpointTests`, PostGIS): cascata completa — logradouro, múltiplos/desempate estável, faixa-cidade, faixa-bairro, grande usuário, máscara, 400, 404, stale (ADR-0092), complemento (único/ambíguo), vendor 406.
- Geo: **190/190 verde**; ArchTests 24/24; baseline OpenAPI (`contracts/openapi.geo.json`) regenerada.

## Decisões e trade-offs

- **CA-07/CA-08 como testes de unidade** (não Redis Testcontainer): o padrão do projeto não provisiona Redis para o Geo no CI (a `GeoApiFactory` remove o health check de Redis e a suíte valida com/sem Redis); "hit não tocou o banco" e "404 não cacheado" são provados com precisão no nível do resolver (substitutos), mais forte que via HTTP.
- **Grande usuário** expõe o nome no campo `logradouro` (o DTO não tem campo dedicado); `origem=grande-usuario`, `nivelResolucao=cidade`.
- **Complemento** preenchido só quando há exatamente um para o CEP (escolha determinística e auditável); ambíguo (0 ou >1) → null.
- **`Ativo` (Correios) não filtra** a resolução — só `Vigente` (stale do ETL, ADR-0092), conforme a regra de vigência da issue.

## Revisão (Codex) — findings endereçados

- **P3 (corrigido):** a normalização de CEP valida o formato **cru** contra os padrões canônicos (`01001000`, `01001-000`, `01001 000`); separadores fora de posição (ex.: `0-1-0-0-1-000`) → 400.
- **P1 (inerente ao design #674, documentado):** o selo de versão é gravado pelo ETL best-effort **após** a persistência da carga (ADR-0092). Se a gravação do selo falhar, entradas cacheadas da versão anterior podem servir até o TTL (24h) ou até o próximo ETL re-selar — propriedade do mecanismo de selo (#674), não introduzida aqui; janela limitada e auto-corrige.
- **P2 (faixa determinística, documentado):** a resolução por faixa é determinística (`ORDER BY Id`); a não-sobreposição das faixas é garantia da fonte DNE e responsabilidade do ETL (ADR-0092) — o lookup não reconcilia dado inconsistente.

## Follow-up (perf/operação, fora de escopo)

- Os índices de faixa são parent-first (`cidade_id, cep_inicial, cep_final`), não ótimos para range global por CEP; o cache cobre o tráfego quente, mas o caminho frio (cache miss / Redis fora) num endpoint anônimo faz scan sobre as tabelas de faixa (reference data, milhares de linhas). Avaliar índice dedicado (ou GiST) e/ou rate-limit numa story de performance, se o `EXPLAIN` em volume real justificar.
