### PR TITLE
feat(geo): API de hierarquia e autocomplete por cidade (#677)

### DIFF
--- a/contracts/openapi.geo.json
+++ b/contracts/openapi.geo.json
@@ -231,6 +231,452 @@
         }
       }
     },
+    "/api/cidades/{codigoIbge}/distritos": {
+      "get": {
+        "tags": [
+          "CidadeHierarquia"
+        ],
+        "parameters": [
+          {
+            "name": "codigoIbge",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DistritoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DistritoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DistritoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/cidades/{codigoIbge}/bairros": {
+      "get": {
+        "tags": [
+          "CidadeHierarquia"
+        ],
+        "parameters": [
+          {
+            "name": "codigoIbge",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BairroDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BairroDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BairroDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/cidades/{codigoIbge}/logradouros": {
+      "get": {
+        "tags": [
+          "CidadeHierarquia"
+        ],
+        "parameters": [
+          {
+            "name": "codigoIbge",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogradouroResumoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogradouroResumoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogradouroResumoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
     "/api/cidades": {
       "get": {
         "tags": [
@@ -867,6 +1313,59 @@
           }
         }
       },
+      "BairroDto": {
+        "required": [
+          "id",
+          "nome",
+          "uf",
+          "cidadeCodigoIbge",
+          "latitude",
+          "longitude"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "uf": {
+            "type": "string"
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "CepResolvidoDto": {
         "required": [
           "cep",
@@ -1179,6 +1678,59 @@
           }
         }
       },
+      "DistritoDto": {
+        "required": [
+          "id",
+          "nome",
+          "uf",
+          "cidadeCodigoIbge",
+          "latitude",
+          "longitude"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "uf": {
+            "type": "string"
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "EstadoDto": {
         "required": [
           "id",
@@ -1366,6 +1918,64 @@
               "string"
             ],
             "format": "double"
+          }
+        }
+      },
+      "LogradouroResumoDto": {
+        "required": [
+          "id",
+          "cep",
+          "tipo",
+          "nome",
+          "nomeCompleto",
+          "bairro",
+          "cidadeCodigoIbge",
+          "uf"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cep": {
+            "type": "string"
+          },
+          "tipo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "nome": {
+            "type": "string"
+          },
+          "nomeCompleto": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "bairro": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "uf": {
+            "type": "string"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },
@@ -1621,6 +2231,9 @@
     },
     {
       "name": "Cep"
+    },
+    {
+      "name": "CidadeHierarquia"
     },
     {
       "name": "Cidades"

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/CidadeHierarquiaController.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/CidadeHierarquiaController.cs
@@ -1,0 +1,205 @@
+namespace Unifesspa.UniPlus.Geo.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+
+/// <summary>
+/// Endpoints públicos de navegação descendente da Cidade: distritos, bairros e
+/// autocomplete de logradouros.
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed partial class CidadeHierarquiaController : ControllerBase
+{
+    private const string DistritosResourceTag = "distritos";
+    private const string BairrosResourceTag = "bairros";
+    private const string LogradourosResourceTag = "logradouros";
+    private const int BuscaMaxLength = 256;
+
+    private readonly IQueryBus _queryBus;
+    private readonly IResourceLinksBuilder<DistritoDto> _distritoLinks;
+    private readonly IResourceLinksBuilder<BairroDto> _bairroLinks;
+    private readonly IResourceLinksBuilder<LogradouroResumoDto> _logradouroLinks;
+
+    public CidadeHierarquiaController(
+        IQueryBus queryBus,
+        IResourceLinksBuilder<DistritoDto> distritoLinks,
+        IResourceLinksBuilder<BairroDto> bairroLinks,
+        IResourceLinksBuilder<LogradouroResumoDto> logradouroLinks)
+    {
+        _queryBus = queryBus;
+        _distritoLinks = distritoLinks;
+        _bairroLinks = bairroLinks;
+        _logradouroLinks = logradouroLinks;
+    }
+
+    /// <summary>
+    /// Lista distritos vigentes de uma Cidade vigente, paginados por cursor opaco.
+    /// Código IBGE malformado retorna 400; cidade-pai inexistente retorna 404.
+    /// </summary>
+    [HttpGet("cidades/{codigoIbge}/distritos")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "distrito", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<DistritoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> ListarDistritos(
+        string codigoIbge,
+        [FromCursor(DistritosResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        if (!CodigoIbgeTemFormatoValido(codigoIbge))
+        {
+            return CodigoIbgeInvalido();
+        }
+
+        ListarDistritosResult resultado = await _queryBus
+            .Send(new ListarDistritosQuery(codigoIbge, page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!resultado.CidadeExiste)
+        {
+            return NotFound();
+        }
+
+        DistritoDto[] comLinks = [.. resultado.Items.Select(d => d with { Links = _distritoLinks.Build(d) })];
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, DistritosResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Lista bairros vigentes de uma Cidade vigente, com busca textual opcional por
+    /// <paramref name="q"/> e paginação por cursor opaco.
+    /// </summary>
+    [HttpGet("cidades/{codigoIbge}/bairros")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "bairro", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<BairroDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> ListarBairros(
+        string codigoIbge,
+        [FromCursor(BairrosResourceTag)] PageRequest page,
+        [FromQuery(Name = "q")] string? q,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        if (!CodigoIbgeTemFormatoValido(codigoIbge))
+        {
+            return CodigoIbgeInvalido();
+        }
+
+        if (q is { Length: > BuscaMaxLength })
+        {
+            return TermoBuscaMuitoLongo();
+        }
+
+        ListarBairrosResult resultado = await _queryBus
+            .Send(new ListarBairrosQuery(codigoIbge, page.AfterId, page.Limit, page.Direction, q), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!resultado.CidadeExiste)
+        {
+            return NotFound();
+        }
+
+        BairroDto[] comLinks = [.. resultado.Items.Select(b => b with { Links = _bairroLinks.Build(b) })];
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, BairrosResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Lista logradouros vigentes de uma Cidade vigente, com busca textual opcional
+    /// por <paramref name="q"/> e paginação por cursor opaco. O uso principal é
+    /// autocomplete de endereço quando o usuário não sabe o CEP.
+    /// </summary>
+    [HttpGet("cidades/{codigoIbge}/logradouros")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "logradouro", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<LogradouroResumoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> ListarLogradouros(
+        string codigoIbge,
+        [FromCursor(LogradourosResourceTag)] PageRequest page,
+        [FromQuery(Name = "q")] string? q,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        if (!CodigoIbgeTemFormatoValido(codigoIbge))
+        {
+            return CodigoIbgeInvalido();
+        }
+
+        if (q is { Length: > BuscaMaxLength })
+        {
+            return TermoBuscaMuitoLongo();
+        }
+
+        ListarLogradourosResult resultado = await _queryBus
+            .Send(new ListarLogradourosQuery(codigoIbge, page.AfterId, page.Limit, page.Direction, q), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!resultado.CidadeExiste)
+        {
+            return NotFound();
+        }
+
+        LogradouroResumoDto[] comLinks = [.. resultado.Items.Select(l => l with { Links = _logradouroLinks.Build(l) })];
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, LogradourosResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private BadRequestObjectResult CodigoIbgeInvalido() =>
+        BadRequest(new ProblemDetails
+        {
+            Title = "Código IBGE inválido",
+            Detail = "O código IBGE deve ter exatamente 7 dígitos.",
+            Status = StatusCodes.Status400BadRequest,
+        });
+
+    private BadRequestObjectResult TermoBuscaMuitoLongo() =>
+        BadRequest(new ProblemDetails
+        {
+            Title = "Termo de busca muito longo",
+            Detail = $"O parâmetro 'q' não pode exceder {BuscaMaxLength} caracteres.",
+            Status = StatusCodes.Status400BadRequest,
+        });
+
+    private static bool CodigoIbgeTemFormatoValido(string codigoIbge) =>
+        !string.IsNullOrWhiteSpace(codigoIbge) && CodigoIbgeRegex().IsMatch(codigoIbge);
+
+    // [0-9] e não \d: em .NET \d casa dígitos Unicode; o código IBGE é ASCII.
+    [GeneratedRegex(@"^[0-9]{7}$")]
+    private static partial Regex CodigoIbgeRegex();
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/BairroLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/BairroLinksBuilder.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> para itens de bairro. Não emite <c>self</c>, pois a API
+/// ainda não expõe detalhe de bairro por Id.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via AddSingleton<IResourceLinksBuilder<BairroDto>, BairroLinksBuilder>().")]
+internal sealed class BairroLinksBuilder : IResourceLinksBuilder<BairroDto>
+{
+    private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+    private static readonly string HierarquiaControllerNome = GeoLinkPathResolver.ControllerName(nameof(CidadeHierarquiaController));
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public BairroLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(BairroDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string cidade = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.ObterPorCodigoIbge),
+            CidadesControllerNome, new { codigoIbge = dto.CidadeCodigoIbge });
+        string collection = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(CidadeHierarquiaController.ListarBairros),
+            HierarquiaControllerNome, new { codigoIbge = dto.CidadeCodigoIbge });
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["cidade"] = cidade,
+            ["collection"] = collection,
+        };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CidadeDetalheLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CidadeDetalheLinksBuilder.cs
@@ -13,14 +13,9 @@ using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 /// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
 /// <see cref="CidadeDetalheDto"/>. Relações: <c>self</c>
 /// (<c>GET /api/cidades/{codigoIbge}</c>), <c>estado</c>
-/// (<c>GET /api/estados/{uf}</c>) e <c>collection</c> (<c>GET /api/cidades</c>).
+/// (<c>GET /api/estados/{uf}</c>), <c>collection</c> (<c>GET /api/cidades</c>) e
+/// coleções descendentes da cidade.
 /// </summary>
-/// <remarks>
-/// As relações <c>distritos</c> e <c>bairros</c> (endpoints de hierarquia/autocomplete)
-/// ficam fora desta fatia: seus endpoints só existem na Story irmã da F4. Emitir
-/// <c>_links</c> para rotas inexistentes violaria a ADR-0029 (links devem ser
-/// navegáveis — resolveriam 404). Entram quando os endpoints forem entregues.
-/// </remarks>
 [SuppressMessage(
     "Performance",
     "CA1812:Avoid uninstantiated internal classes",
@@ -28,6 +23,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 internal sealed class CidadeDetalheLinksBuilder : IResourceLinksBuilder<CidadeDetalheDto>
 {
     private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+    private static readonly string HierarquiaControllerNome = GeoLinkPathResolver.ControllerName(nameof(CidadeHierarquiaController));
     private static readonly string EstadosControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.EstadosController));
 
     private readonly LinkGenerator _linkGenerator;
@@ -56,12 +52,24 @@ internal sealed class CidadeDetalheLinksBuilder : IResourceLinksBuilder<CidadeDe
         string collection = GeoLinkPathResolver.Resolver(
             _linkGenerator, httpContext, nameof(Controllers.CidadesController.Listar),
             CidadesControllerNome, values: null);
+        string distritos = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(CidadeHierarquiaController.ListarDistritos),
+            HierarquiaControllerNome, new { codigoIbge = dto.CodigoIbge });
+        string bairros = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(CidadeHierarquiaController.ListarBairros),
+            HierarquiaControllerNome, new { codigoIbge = dto.CodigoIbge });
+        string logradouros = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(CidadeHierarquiaController.ListarLogradouros),
+            HierarquiaControllerNome, new { codigoIbge = dto.CodigoIbge });
 
         return new Dictionary<string, string>(StringComparer.Ordinal)
         {
             ["self"] = self,
             ["estado"] = estado,
             ["collection"] = collection,
+            ["distritos"] = distritos,
+            ["bairros"] = bairros,
+            ["logradouros"] = logradouros,
         };
     }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/DistritoLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/DistritoLinksBuilder.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> para itens de distrito. Não emite <c>self</c>, pois a
+/// API ainda não expõe detalhe de distrito por Id.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via AddSingleton<IResourceLinksBuilder<DistritoDto>, DistritoLinksBuilder>().")]
+internal sealed class DistritoLinksBuilder : IResourceLinksBuilder<DistritoDto>
+{
+    private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+    private static readonly string HierarquiaControllerNome = GeoLinkPathResolver.ControllerName(nameof(CidadeHierarquiaController));
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public DistritoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(DistritoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string cidade = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.ObterPorCodigoIbge),
+            CidadesControllerNome, new { codigoIbge = dto.CidadeCodigoIbge });
+        string collection = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(CidadeHierarquiaController.ListarDistritos),
+            HierarquiaControllerNome, new { codigoIbge = dto.CidadeCodigoIbge });
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["cidade"] = cidade,
+            ["collection"] = collection,
+        };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/LogradouroResumoLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/LogradouroResumoLinksBuilder.cs
@@ -1,0 +1,60 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> para itens de autocomplete de logradouro. Não emite
+/// <c>self</c>, pois a API ainda não expõe detalhe de logradouro por Id.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via AddSingleton<IResourceLinksBuilder<LogradouroResumoDto>, LogradouroResumoLinksBuilder>().")]
+internal sealed class LogradouroResumoLinksBuilder : IResourceLinksBuilder<LogradouroResumoDto>
+{
+    private static readonly string CepControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CepController));
+    private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+    private static readonly string HierarquiaControllerNome = GeoLinkPathResolver.ControllerName(nameof(CidadeHierarquiaController));
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public LogradouroResumoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(LogradouroResumoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string cidade = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.ObterPorCodigoIbge),
+            CidadesControllerNome, new { codigoIbge = dto.CidadeCodigoIbge });
+        string cep = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CepController.Resolver),
+            CepControllerNome, new { cep = dto.Cep });
+        string collection = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(CidadeHierarquiaController.ListarLogradouros),
+            HierarquiaControllerNome, new { codigoIbge = dto.CidadeCodigoIbge });
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["cidade"] = cidade,
+            ["cep"] = cep,
+            ["collection"] = collection,
+        };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
@@ -73,6 +73,9 @@ builder.Services.AddSingleton<IResourceLinksBuilder<ImportacaoGeoDto>, Importaca
 builder.Services.AddSingleton<IResourceLinksBuilder<EstadoDto>, EstadoLinksBuilder>();
 builder.Services.AddSingleton<IResourceLinksBuilder<CidadeResumoDto>, CidadeResumoLinksBuilder>();
 builder.Services.AddSingleton<IResourceLinksBuilder<CidadeDetalheDto>, CidadeDetalheLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<DistritoDto>, DistritoLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<BairroDto>, BairroLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<LogradouroResumoDto>, LogradouroResumoLinksBuilder>();
 
 // HATEOAS Level 1 (ADR-0029) do lookup de CEP (#676): _links para cidade e estado.
 builder.Services.AddSingleton<IResourceLinksBuilder<CepResolvidoDto>, CepResolvidoLinksBuilder>();

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IBairroReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IBairroReader.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de bairros vinculados a uma Cidade vigente, com busca textual
+/// acento/caixa-insensível sobre o nome normalizado.
+/// </summary>
+public interface IBairroReader
+{
+    Task<(bool CidadeExiste, IReadOnlyList<Bairro> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPorCidadeAsync(
+        string codigoIbge,
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        string? busca,
+        CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IDistritoReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IDistritoReader.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de distritos vinculados a uma Cidade vigente.
+/// </summary>
+public interface IDistritoReader
+{
+    Task<(bool CidadeExiste, IReadOnlyList<Distrito> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPorCidadeAsync(
+        string codigoIbge,
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/ILogradouroReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/ILogradouroReader.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de logradouros vinculados a uma Cidade vigente, com busca textual
+/// acento/caixa-insensível sobre o nome normalizado.
+/// </summary>
+public interface ILogradouroReader
+{
+    Task<(bool CidadeExiste, IReadOnlyList<LogradouroComBairro> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPorCidadeAsync(
+        string codigoIbge,
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        string? busca,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Linha de autocomplete de logradouro enriquecida com o nome do bairro vigente,
+/// quando o logradouro aponta para um bairro.
+/// </summary>
+public sealed record LogradouroComBairro(Logradouro Logradouro, string? BairroNome);

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/BairroDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/BairroDto.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de item da coleção <c>GET /api/cidades/{codigoIbge}/bairros</c>.
+/// Bairro não tem código IBGE próprio na fonte; é identificado pelo Id intra-banco
+/// e pelo vínculo com a cidade-pai.
+/// </summary>
+public sealed record BairroDto(
+    Guid Id,
+    string Nome,
+    string Uf,
+    string CidadeCodigoIbge,
+    decimal? Latitude,
+    decimal? Longitude)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/DistritoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/DistritoDto.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de item da coleção <c>GET /api/cidades/{codigoIbge}/distritos</c>.
+/// Distrito não tem código IBGE próprio na fonte; é identificado pelo Id intra-banco
+/// e pelo vínculo com a cidade-pai.
+/// </summary>
+public sealed record DistritoDto(
+    Guid Id,
+    string Nome,
+    string Uf,
+    string CidadeCodigoIbge,
+    decimal? Latitude,
+    decimal? Longitude)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/LogradouroResumoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/LogradouroResumoDto.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de item da coleção <c>GET /api/cidades/{codigoIbge}/logradouros</c>.
+/// Representa o resultado enxuto do autocomplete de endereço, com CEP para salto ao
+/// lookup completo de CEP.
+/// </summary>
+public sealed record LogradouroResumoDto(
+    Guid Id,
+    string Cep,
+    string? Tipo,
+    string Nome,
+    string? NomeCompleto,
+    string? Bairro,
+    string CidadeCodigoIbge,
+    string Uf)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Mappings/HierarquiaMapping.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Mappings/HierarquiaMapping.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Geo.Application.Mappings;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+public static class HierarquiaMapping
+{
+    public static DistritoDto ToDto(this Distrito distrito, string cidadeCodigoIbge)
+    {
+        ArgumentNullException.ThrowIfNull(distrito);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cidadeCodigoIbge);
+
+        return new DistritoDto(
+            distrito.Id,
+            distrito.Nome,
+            distrito.Uf,
+            cidadeCodigoIbge,
+            distrito.Latitude,
+            distrito.Longitude);
+    }
+
+    public static BairroDto ToDto(this Bairro bairro, string cidadeCodigoIbge)
+    {
+        ArgumentNullException.ThrowIfNull(bairro);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cidadeCodigoIbge);
+
+        return new BairroDto(
+            bairro.Id,
+            bairro.Nome,
+            bairro.Uf,
+            cidadeCodigoIbge,
+            bairro.Latitude,
+            bairro.Longitude);
+    }
+
+    public static LogradouroResumoDto ToDto(this LogradouroComBairro linha, string cidadeCodigoIbge)
+    {
+        ArgumentNullException.ThrowIfNull(linha);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cidadeCodigoIbge);
+
+        Logradouro logradouro = linha.Logradouro;
+        return new LogradouroResumoDto(
+            logradouro.Id,
+            logradouro.Cep,
+            logradouro.Tipo,
+            logradouro.Nome,
+            logradouro.NomeCompleto,
+            linha.BairroNome,
+            cidadeCodigoIbge,
+            logradouro.Uf);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarBairrosQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarBairrosQuery.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista bairros vigentes de uma Cidade vigente, paginados por cursor e filtrados
+/// opcionalmente por busca textual.
+/// </summary>
+public sealed record ListarBairrosQuery(
+    string CodigoIbge,
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction,
+    string? Busca) : IQuery<ListarBairrosResult>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarBairrosQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarBairrosQueryHandler.cs
@@ -1,0 +1,34 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Mappings;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+public static class ListarBairrosQueryHandler
+{
+    public static async Task<ListarBairrosResult> Handle(
+        ListarBairrosQuery query,
+        IBairroReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        string? busca = string.IsNullOrWhiteSpace(query.Busca) ? null : query.Busca;
+
+        (bool cidadeExiste, IReadOnlyList<Bairro> itens, Guid? anteriorAfterId, Guid? proximoAfterId) =
+            await reader
+                .ListarPorCidadeAsync(
+                    query.CodigoIbge, query.AfterId, query.Limit, query.Direction, busca, cancellationToken)
+                .ConfigureAwait(false);
+
+        if (!cidadeExiste)
+        {
+            return new ListarBairrosResult(false, [], anteriorAfterId, proximoAfterId);
+        }
+
+        BairroDto[] items = [.. itens.Select(b => b.ToDto(query.CodigoIbge))];
+        return new ListarBairrosResult(true, items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarBairrosResult.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarBairrosResult.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Resultado da listagem/autocomplete de bairros de uma Cidade.
+/// </summary>
+public sealed record ListarBairrosResult(
+    bool CidadeExiste,
+    IReadOnlyList<BairroDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarDistritosQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarDistritosQuery.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista distritos vigentes de uma Cidade vigente, paginados por cursor.
+/// </summary>
+public sealed record ListarDistritosQuery(
+    string CodigoIbge,
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarDistritosResult>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarDistritosQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarDistritosQueryHandler.cs
@@ -1,0 +1,31 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Mappings;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+
+public static class ListarDistritosQueryHandler
+{
+    public static async Task<ListarDistritosResult> Handle(
+        ListarDistritosQuery query,
+        IDistritoReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        (bool cidadeExiste, IReadOnlyList<Distrito> itens, Guid? anteriorAfterId, Guid? proximoAfterId) =
+            await reader
+                .ListarPorCidadeAsync(query.CodigoIbge, query.AfterId, query.Limit, query.Direction, cancellationToken)
+                .ConfigureAwait(false);
+
+        if (!cidadeExiste)
+        {
+            return new ListarDistritosResult(false, [], anteriorAfterId, proximoAfterId);
+        }
+
+        DistritoDto[] items = [.. itens.Select(d => d.ToDto(query.CodigoIbge))];
+        return new ListarDistritosResult(true, items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarDistritosResult.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarDistritosResult.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Resultado da listagem de distritos de uma Cidade.
+/// </summary>
+public sealed record ListarDistritosResult(
+    bool CidadeExiste,
+    IReadOnlyList<DistritoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarLogradourosQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarLogradourosQuery.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista logradouros vigentes de uma Cidade vigente, paginados por cursor e
+/// filtrados opcionalmente por busca textual.
+/// </summary>
+public sealed record ListarLogradourosQuery(
+    string CodigoIbge,
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction,
+    string? Busca) : IQuery<ListarLogradourosResult>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarLogradourosQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarLogradourosQueryHandler.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Mappings;
+
+public static class ListarLogradourosQueryHandler
+{
+    public static async Task<ListarLogradourosResult> Handle(
+        ListarLogradourosQuery query,
+        ILogradouroReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        string? busca = string.IsNullOrWhiteSpace(query.Busca) ? null : query.Busca;
+
+        (bool cidadeExiste, IReadOnlyList<LogradouroComBairro> itens, Guid? anteriorAfterId, Guid? proximoAfterId) =
+            await reader
+                .ListarPorCidadeAsync(
+                    query.CodigoIbge, query.AfterId, query.Limit, query.Direction, busca, cancellationToken)
+                .ConfigureAwait(false);
+
+        if (!cidadeExiste)
+        {
+            return new ListarLogradourosResult(false, [], anteriorAfterId, proximoAfterId);
+        }
+
+        LogradouroResumoDto[] items = [.. itens.Select(l => l.ToDto(query.CodigoIbge))];
+        return new ListarLogradourosResult(true, items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarLogradourosResult.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/CidadeHierarquia/ListarLogradourosResult.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.CidadeHierarquia;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Resultado da listagem/autocomplete de logradouros de uma Cidade.
+/// </summary>
+public sealed record ListarLogradourosResult(
+    bool CidadeExiste,
+    IReadOnlyList<LogradouroResumoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -48,6 +48,9 @@ public static class GeoInfrastructureRegistration
         // por cursor + detalhe por chave natural. Só expõem o que vigente (ADR-0092).
         services.AddScoped<IEstadoReader, EstadoReader>();
         services.AddScoped<ICidadeReader, CidadeReader>();
+        services.AddScoped<IDistritoReader, DistritoReader>();
+        services.AddScoped<IBairroReader, BairroReader>();
+        services.AddScoped<ILogradouroReader, LogradouroReader>();
 
         // Lookup de CEP (Story #676): reader da cascata (logradouro → grande usuário →
         // faixa) + resolver com cache-aside por selo de versão (ADR-0090/0092). O

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/BairroConfiguration.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/BairroConfiguration.cs
@@ -38,7 +38,10 @@ internal sealed class BairroConfiguration : IEntityTypeConfiguration<Bairro>
             .HasForeignKey(b => b.CidadeId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        // Chave natural única (cidade + nome). cidade_id à esquerda cobre a FK.
+        // Chave natural única (cidade + nome). cidade_id à esquerda cobre a FK e
+        // também restringe o autocomplete de bairro antes do ILIKE. Diferente de
+        // logradouro, o volume por cidade é baixo, então não há índice trigram
+        // dedicado para bairro.nome_normalizado nesta fatia.
         builder.HasIndex(b => new { b.CidadeId, b.NomeNormalizado })
             .IsUnique()
             .HasDatabaseName("ix_bairro_cidade_nome");

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/BairroReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/BairroReader.cs
@@ -1,0 +1,72 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de <see cref="Bairro"/> sobre o <see cref="GeoDbContext"/>,
+/// sempre restrito a uma Cidade vigente e com busca textual opcional.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
+internal sealed class BairroReader : IBairroReader
+{
+    private readonly GeoDbContext _dbContext;
+
+    public BairroReader(GeoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<(bool CidadeExiste, IReadOnlyList<Bairro> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPorCidadeAsync(
+        string codigoIbge,
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        string? busca,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(codigoIbge);
+
+        if (await ResolverCidadeIdAsync(codigoIbge, cancellationToken).ConfigureAwait(false) is not { } cidadeId)
+        {
+            return (false, [], null, null);
+        }
+
+        IQueryable<Bairro> query = _dbContext.Bairros
+            .AsNoTracking()
+            .Where(b => b.Vigente && b.CidadeId == cidadeId);
+
+        if (!string.IsNullOrWhiteSpace(busca))
+        {
+            string pattern = BuscaTextualNormalizada.CriarPadraoContem(busca);
+            query = query.Where(b =>
+                EF.Functions.ILike(b.NomeNormalizado, pattern, BuscaTextualNormalizada.Escape));
+        }
+
+        CursorKeysetPage<Bairro> page = await CursorKeyset
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (true, page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    private Task<Guid?> ResolverCidadeIdAsync(string codigoIbge, CancellationToken cancellationToken)
+    {
+        string codigo = codigoIbge.Trim();
+        return _dbContext.Cidades
+            .AsNoTracking()
+            .Where(c => c.Vigente && c.CodigoIbge == codigo)
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/BuscaTextualNormalizada.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/BuscaTextualNormalizada.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
+
+using System.Globalization;
+using System.Text;
+
+/// <summary>
+/// Normalização do termo de busca usado contra colunas <c>*_normalizado</c>:
+/// remove diacríticos no app e escapa curingas de LIKE antes de montar o padrão
+/// <c>%termo%</c>.
+/// </summary>
+internal static class BuscaTextualNormalizada
+{
+    public const string Escape = @"\";
+
+    public static string CriarPadraoContem(string termo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(termo);
+        return "%" + EscaparCuringasLike(RemoverDiacriticos(termo.Trim())) + "%";
+    }
+
+    private static string RemoverDiacriticos(string texto)
+    {
+        string decomposto = texto.Normalize(NormalizationForm.FormD);
+        return new string([.. decomposto.Where(c =>
+            CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)]);
+    }
+
+    private static string EscaparCuringasLike(string termo) =>
+        termo
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CidadeReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CidadeReader.cs
@@ -1,9 +1,6 @@
 namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
 
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Text;
-
 using Microsoft.EntityFrameworkCore;
 
 using Unifesspa.UniPlus.Geo.Application.Abstractions;
@@ -62,12 +59,10 @@ internal sealed class CidadeReader : ICidadeReader
             // (a sobrecarga de 2 args do ILike emite ESCAPE '', desligando o \).
             // Guard NomeNormalizado != null: ILIKE NULL não casa — cidades sem
             // nome_normalizado simplesmente não aparecem na busca (aparecem sem filtro).
-            string termo = EscaparCuringasLike(RemoverDiacriticos(filtro.Termo!.Trim()));
-            string pattern = "%" + termo + "%";
-            const string escape = @"\";
+            string pattern = BuscaTextualNormalizada.CriarPadraoContem(filtro.Termo!);
             query = query.Where(c =>
                 c.NomeNormalizado != null &&
-                EF.Functions.ILike(c.NomeNormalizado, pattern, escape));
+                EF.Functions.ILike(c.NomeNormalizado, pattern, BuscaTextualNormalizada.Escape));
         }
 
         // Keyset bidirecional (ADR-0089) sobre a query JÁ filtrada — ordenação,
@@ -103,24 +98,4 @@ internal sealed class CidadeReader : ICidadeReader
             .ConfigureAwait(false);
     }
 
-    // Aplica a mesma transformação que produz nome_normalizado na fonte: decompõe em
-    // NFD e descarta NonSpacingMark (diacríticos). Normaliza o TERMO de busca em C#
-    // antes de montar o padrão ILIKE — a coluna já está sem acento, então não há
-    // chamada de DB function no lado do parâmetro. (Espelha UnidadeRepository.)
-    private static string RemoverDiacriticos(string texto)
-    {
-        string decomposto = texto.Normalize(NormalizationForm.FormD);
-        return new string([.. decomposto.Where(c =>
-            CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)]);
-    }
-
-    // Escapa os curingas do LIKE/ILIKE (\ % _) para que metacaracteres digitados
-    // pelo usuário sejam comparados como texto literal, não como wildcards — sem
-    // isso, q="_" ou q="%" casaria quase qualquer registro. A barra é escapada
-    // primeiro para não duplicar as inseridas adiante em % e _. (Espelha UnidadeRepository.)
-    private static string EscaparCuringasLike(string termo) =>
-        termo
-            .Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("%", "\\%", StringComparison.Ordinal)
-            .Replace("_", "\\_", StringComparison.Ordinal);
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/DistritoReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/DistritoReader.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de <see cref="Distrito"/> sobre o <see cref="GeoDbContext"/>,
+/// sempre restrito a uma Cidade vigente.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
+internal sealed class DistritoReader : IDistritoReader
+{
+    private readonly GeoDbContext _dbContext;
+
+    public DistritoReader(GeoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<(bool CidadeExiste, IReadOnlyList<Distrito> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPorCidadeAsync(
+        string codigoIbge,
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(codigoIbge);
+
+        if (await ResolverCidadeIdAsync(codigoIbge, cancellationToken).ConfigureAwait(false) is not { } cidadeId)
+        {
+            return (false, [], null, null);
+        }
+
+        IQueryable<Distrito> query = _dbContext.Distritos
+            .AsNoTracking()
+            .Where(d => d.Vigente && d.CidadeId == cidadeId);
+
+        CursorKeysetPage<Distrito> page = await CursorKeyset
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (true, page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    private Task<Guid?> ResolverCidadeIdAsync(string codigoIbge, CancellationToken cancellationToken)
+    {
+        string codigo = codigoIbge.Trim();
+        return _dbContext.Cidades
+            .AsNoTracking()
+            .Where(c => c.Vigente && c.CodigoIbge == codigo)
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/LogradouroReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/LogradouroReader.cs
@@ -1,0 +1,103 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Leitor read-side de <see cref="Logradouro"/> sobre o <see cref="GeoDbContext"/>,
+/// sempre restrito a uma Cidade vigente e com busca textual opcional.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
+internal sealed class LogradouroReader : ILogradouroReader
+{
+    private readonly GeoDbContext _dbContext;
+
+    public LogradouroReader(GeoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<(bool CidadeExiste, IReadOnlyList<LogradouroComBairro> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPorCidadeAsync(
+        string codigoIbge,
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        string? busca,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(codigoIbge);
+
+        if (await ResolverCidadeIdAsync(codigoIbge, cancellationToken).ConfigureAwait(false) is not { } cidadeId)
+        {
+            return (false, [], null, null);
+        }
+
+        IQueryable<Logradouro> query = _dbContext.Logradouros
+            .AsNoTracking()
+            .Where(l => l.Vigente && l.CidadeId == cidadeId);
+
+        if (!string.IsNullOrWhiteSpace(busca))
+        {
+            string pattern = BuscaTextualNormalizada.CriarPadraoContem(busca);
+            query = query.Where(l =>
+                EF.Functions.ILike(l.NomeNormalizado, pattern, BuscaTextualNormalizada.Escape));
+        }
+
+        CursorKeysetPage<Logradouro> page = await CursorKeyset
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        IReadOnlyList<LogradouroComBairro> itens = await EnriquecerComBairroAsync(page.Items, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (true, itens, page.PrevAfterId, page.NextAfterId);
+    }
+
+    private async Task<IReadOnlyList<LogradouroComBairro>> EnriquecerComBairroAsync(
+        IReadOnlyList<Logradouro> logradouros,
+        CancellationToken cancellationToken)
+    {
+        if (logradouros.Count == 0)
+        {
+            return [];
+        }
+
+        Guid[] bairroIds = [.. logradouros
+            .Select(l => l.BairroId)
+            .OfType<Guid>()
+            .Distinct()];
+
+        Dictionary<Guid, string> bairros = bairroIds.Length == 0
+            ? []
+            : await _dbContext.Bairros
+                .AsNoTracking()
+                .Where(b => b.Vigente && bairroIds.Contains(b.Id))
+                .ToDictionaryAsync(b => b.Id, b => b.Nome, cancellationToken)
+                .ConfigureAwait(false);
+
+        return [.. logradouros.Select(l =>
+            new LogradouroComBairro(
+                l,
+                l.BairroId is { } bairroId && bairros.TryGetValue(bairroId, out string? nome) ? nome : null))];
+    }
+
+    private Task<Guid?> ResolverCidadeIdAsync(string codigoIbge, CancellationToken cancellationToken)
+    {
+        string codigo = codigoIbge.Trim();
+        return _dbContext.Cidades
+            .AsNoTracking()
+            .Where(c => c.Vigente && c.CodigoIbge == codigo)
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CidadeHierarquiaEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CidadeHierarquiaEndpointTests.cs
@@ -1,0 +1,261 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Api;
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Endpoints públicos de hierarquia/autocomplete Geo (#677) contra API real +
+/// PostGIS. Cobre Cidade → Distrito/Bairro/Logradouro, cursor, HATEOAS e boundary.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class CidadeHierarquiaEndpointTests
+{
+    private readonly GeoPostgisFixture _fixture;
+
+    public CidadeHierarquiaEndpointTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01: distritos de uma cidade são paginados e têm _links cidade+collection sem self")]
+    public async Task Distritos_PorCidade_Paginado()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage pagina1 = await GeoReferenceSeed.Obter(client, "/api/cidades/3550308/distritos?limit=1");
+        pagina1.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        JsonElement itensPagina1 = await LerArrayAsync(pagina1);
+        itensPagina1.GetArrayLength().Should().Be(1);
+        JsonElement primeiro = itensPagina1.EnumerateArray().Single();
+        primeiro.GetProperty("cidadeCodigoIbge").GetString().Should().Be("3550308");
+        JsonElement links = primeiro.GetProperty("_links");
+        links.GetProperty("cidade").GetString().Should().Be("/api/cidades/3550308");
+        links.GetProperty("collection").GetString().Should().Be("/api/cidades/3550308/distritos");
+        links.TryGetProperty("self", out _).Should().BeFalse();
+        primeiro.GetProperty("latitude").ValueKind.Should().Be(JsonValueKind.Number);
+        primeiro.GetProperty("longitude").ValueKind.Should().Be(JsonValueKind.Number);
+
+        string? proximo = GeoReferenceSeed.ExtrairLink(pagina1, "next");
+        proximo.Should().NotBeNull();
+        proximo.Should().Contain("/api/cidades/3550308/distritos");
+
+        List<string> nomes = [.. LerNomes(itensPagina1)];
+        using HttpResponseMessage pagina2 = await GeoReferenceSeed.Obter(client, proximo!);
+        pagina2.StatusCode.Should().Be(HttpStatusCode.OK);
+        nomes.AddRange(LerNomes(await LerArrayAsync(pagina2)));
+
+        nomes.Should().BeEquivalentTo(["Sé", "Pinheiros"]);
+    }
+
+    [Theory(DisplayName = "CA-02: busca de bairro é acento e caixa-insensível")]
+    [InlineData("sa")]
+    [InlineData("SÁ")]
+    public async Task Bairros_Busca_AcentoInsensivel(string termo)
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, $"/api/cidades/3550308/bairros?q={Uri.EscapeDataString(termo)}&limit=100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        JsonElement itens = await LerArrayAsync(resposta);
+        List<string> nomes = LerNomes(itens);
+        nomes.Should().BeEquivalentTo(["Santa Cecília", "Saúde"]);
+        nomes.Should().NotContain("Sé");
+
+        JsonElement links = itens.EnumerateArray().First().GetProperty("_links");
+        links.GetProperty("cidade").GetString().Should().Be("/api/cidades/3550308");
+        links.GetProperty("collection").GetString().Should().Be("/api/cidades/3550308/bairros");
+        links.TryGetProperty("self", out _).Should().BeFalse();
+        itens.EnumerateArray()
+            .Single(b => b.GetProperty("nome").GetString() == "Saúde")
+            .GetProperty("latitude").GetDecimal().Should().Be(-23.61811m);
+    }
+
+    [Fact(DisplayName = "CA-03: autocomplete de logradouro busca por nome (acento-insensível), escopado à cidade, com _links.cep")]
+    public async Task Logradouros_Autocomplete_PorCidade()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // A busca corre sobre NomeNormalizado (= nome sem o tipo, como o ETL grava),
+        // então casa pelo NOME do logradouro acento/caixa-insensível: "sé" → "Sé".
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, "/api/cidades/3550308/logradouros?q=s%C3%A9&limit=100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        JsonElement itens = await LerArrayAsync(resposta);
+        itens.GetArrayLength().Should().Be(1);
+        JsonElement item = itens.EnumerateArray().Single();
+        item.GetProperty("cep").GetString().Should().Be("01001000");
+        item.GetProperty("tipo").GetString().Should().Be("Praça");
+        item.GetProperty("nome").GetString().Should().Be("Sé");
+        item.GetProperty("nomeCompleto").GetString().Should().Be("Praça da Sé");
+        item.GetProperty("bairro").GetString().Should().Be("Sé");
+        item.GetProperty("cidadeCodigoIbge").GetString().Should().Be("3550308");
+        item.GetProperty("uf").GetString().Should().Be("SP");
+
+        JsonElement links = item.GetProperty("_links");
+        links.GetProperty("cidade").GetString().Should().Be("/api/cidades/3550308");
+        links.GetProperty("cep").GetString().Should().Be("/api/cep/01001000");
+        links.GetProperty("collection").GetString().Should().Be("/api/cidades/3550308/logradouros");
+        links.TryGetProperty("self", out _).Should().BeFalse();
+
+        // Limitação conhecida (rastreada em #707): a busca não casa o TIPO ("Praça"),
+        // que vive em coluna separada e não compõe NomeNormalizado. Quando #707 entregar
+        // a busca por texto completo + ranking por similaridade, este assert deve mudar.
+        using HttpResponseMessage porTipo = await GeoReferenceSeed.Obter(
+            client, "/api/cidades/3550308/logradouros?q=pra%C3%A7a&limit=100");
+        porTipo.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await LerArrayAsync(porTipo)).GetArrayLength().Should().Be(0);
+    }
+
+    [Fact(DisplayName = "CA-04: cidade inexistente retorna 404; cidade existente sem filhos do filtro retorna 200 vazio")]
+    public async Task Hierarquia_CidadeInexistente_404_EFiltroVazio_200()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage inexistente = await GeoReferenceSeed.Obter(client, "/api/cidades/9999999/distritos");
+        inexistente.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        using HttpResponseMessage vazio = await GeoReferenceSeed.Obter(client, "/api/cidades/3550308/bairros?q=zzzzz");
+        vazio.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await LerArrayAsync(vazio)).GetArrayLength().Should().Be(0);
+    }
+
+    [Theory(DisplayName = "CA-05: código IBGE malformado retorna 400")]
+    [InlineData("/api/cidades/abc/distritos")]
+    [InlineData("/api/cidades/123/bairros")]
+    [InlineData("/api/cidades/35503080/logradouros")]
+    public async Task Hierarquia_CodigoIbgeInvalido_400(string rota)
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, rota);
+        resposta.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "CA-06: cursor preserva escopo da cidade e q no header Link")]
+    public async Task Hierarquia_Cursor_PreservaEscopoEFiltro()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage pagina1 = await GeoReferenceSeed.Obter(client, "/api/cidades/3550308/bairros?q=sa&limit=1");
+        pagina1.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string? proximo = GeoReferenceSeed.ExtrairLink(pagina1, "next");
+        proximo.Should().NotBeNull();
+        proximo.Should().Contain("/api/cidades/3550308/bairros").And.Contain("q=sa");
+
+        List<string> primeiraPagina = LerNomes(await LerArrayAsync(pagina1));
+        using HttpResponseMessage pagina2 = await GeoReferenceSeed.Obter(client, proximo!);
+        pagina2.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string? anterior = GeoReferenceSeed.ExtrairLink(pagina2, "prev");
+        anterior.Should().NotBeNull();
+        anterior.Should().Contain("/api/cidades/3550308/bairros").And.Contain("q=sa");
+
+        using HttpResponseMessage volta = await GeoReferenceSeed.Obter(client, anterior!);
+        volta.StatusCode.Should().Be(HttpStatusCode.OK);
+        LerNomes(await LerArrayAsync(volta)).Should().Equal(primeiraPagina);
+
+        List<string> nomes = [.. primeiraPagina, .. LerNomes(await LerArrayAsync(pagina2))];
+        proximo = GeoReferenceSeed.ExtrairLink(pagina2, "next");
+        while (proximo is not null)
+        {
+            using HttpResponseMessage pagina = await GeoReferenceSeed.Obter(client, proximo);
+            pagina.StatusCode.Should().Be(HttpStatusCode.OK);
+            nomes.AddRange(LerNomes(await LerArrayAsync(pagina)));
+            proximo = GeoReferenceSeed.ExtrairLink(pagina, "next");
+        }
+
+        nomes.Should().BeEquivalentTo(["Santa Cecília", "Saúde"]);
+    }
+
+    [Fact(DisplayName = "CA-07: Accept vendor incompatível retorna 406; termo q longo retorna 400")]
+    public async Task Hierarquia_VendorMime_TermoLongo()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpRequestMessage incompativel = new(HttpMethod.Get, "/api/cidades/3550308/logradouros?q=praca");
+        incompativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.logradouro.v2+json"));
+        using HttpResponseMessage resp406 = await client.SendAsync(incompativel);
+        resp406.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
+
+        using HttpRequestMessage compativel = new(HttpMethod.Get, "/api/cidades/3550308/logradouros?q=praca");
+        compativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.logradouro.v1+json"));
+        using HttpResponseMessage resp200 = await client.SendAsync(compativel);
+        resp200.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string termoLongo = new('a', 257);
+        using HttpResponseMessage longo = await GeoReferenceSeed.Obter(
+            client, $"/api/cidades/3550308/logradouros?q={termoLongo}");
+        longo.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    private async Task SemearAsync()
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+
+        Pais brasil = GeoReferenceSeed.NovoBrasil();
+        Estado saoPaulo = GeoReferenceSeed.NovoEstado(brasil.Id, "SP", "São Paulo");
+        Estado para = GeoReferenceSeed.NovoEstado(brasil.Id, "PA", "Pará");
+
+        Cidade cidadeSp = GeoReferenceSeed.NovaCidade(saoPaulo.Id, "SP", "3550308", "São Paulo");
+        Cidade maraba = GeoReferenceSeed.NovaCidade(para.Id, "PA", "1500402", "Marabá");
+
+        Distrito seDistrito = GeoReferenceSeed.NovoDistrito(
+            cidadeSp.Id, "SP", "Sé", latitude: -23.55052m, longitude: -46.63331m);
+        Distrito pinheirosDistrito = GeoReferenceSeed.NovoDistrito(
+            cidadeSp.Id, "SP", "Pinheiros", latitude: -23.56723m, longitude: -46.70103m);
+        Distrito novaMaraba = GeoReferenceSeed.NovoDistrito(maraba.Id, "PA", "Nova Marabá");
+
+        Bairro se = GeoReferenceSeed.NovoBairro(cidadeSp.Id, "SP", "Sé");
+        Bairro santaCecilia = GeoReferenceSeed.NovoBairro(cidadeSp.Id, "SP", "Santa Cecília");
+        Bairro saude = GeoReferenceSeed.NovoBairro(
+            cidadeSp.Id, "SP", "Saúde", latitude: -23.61811m, longitude: -46.63878m);
+        Bairro cidadeNova = GeoReferenceSeed.NovoBairro(maraba.Id, "PA", "Cidade Nova");
+
+        // Espelha o ETL real (#673): nome_logradouro NÃO inclui o tipo; o texto cheio
+        // (com o tipo) vive em nome_completo. A busca atual roda sobre NomeNormalizado
+        // (= nome sem tipo), então casa por NOME — busca por tipo/texto-completo é #707.
+        Logradouro pracaSe = GeoReferenceSeed.NovoLogradouro(
+            cidadeSp.Id, "SP", "01001000", "Sé", tipo: "Praça", nomeCompleto: "Praça da Sé", bairroId: se.Id);
+        Logradouro ruaSantaCecilia = GeoReferenceSeed.NovoLogradouro(
+            cidadeSp.Id, "SP", "01225000", "Santa Cecília", tipo: "Rua", nomeCompleto: "Rua Santa Cecília", bairroId: santaCecilia.Id);
+        Logradouro pracaMaraba = GeoReferenceSeed.NovoLogradouro(
+            maraba.Id, "PA", "68500010", "São Félix", tipo: "Praça", nomeCompleto: "Praça São Félix", bairroId: cidadeNova.Id);
+
+        ctx.Paises.Add(brasil);
+        ctx.Estados.AddRange(saoPaulo, para);
+        ctx.Cidades.AddRange(cidadeSp, maraba);
+        ctx.Distritos.AddRange(seDistrito, pinheirosDistrito, novaMaraba);
+        ctx.Bairros.AddRange(se, santaCecilia, saude, cidadeNova);
+        ctx.Logradouros.AddRange(pracaSe, ruaSantaCecilia, pracaMaraba);
+        await ctx.SaveChangesAsync();
+    }
+
+    private static async Task<JsonElement> LerArrayAsync(HttpResponseMessage resposta)
+    {
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        return doc.RootElement.Clone();
+    }
+
+    private static List<string> LerNomes(JsonElement array) =>
+        [.. array.EnumerateArray().Select(item => item.GetProperty("nome").GetString()!)];
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
@@ -79,13 +79,25 @@ internal static partial class GeoReferenceSeed
             null, regiaoIntermediariaNome, null, regiaoImediataNome,
             Versao, vigente));
 
-    public static Distrito NovoDistrito(Guid cidadeId, string uf, string nome, bool vigente = true) =>
+    public static Distrito NovoDistrito(
+        Guid cidadeId,
+        string uf,
+        string nome,
+        decimal? latitude = null,
+        decimal? longitude = null,
+        bool vigente = true) =>
         GeoTestKeys.Ok(Distrito.Importar(
-            cidadeId, uf, nome, Normalizar(nome), null, null, null, null, Versao, vigente));
+            cidadeId, uf, nome, Normalizar(nome), latitude, longitude, null, null, Versao, vigente));
 
-    public static Bairro NovoBairro(Guid cidadeId, string uf, string nome, bool vigente = true) =>
+    public static Bairro NovoBairro(
+        Guid cidadeId,
+        string uf,
+        string nome,
+        decimal? latitude = null,
+        decimal? longitude = null,
+        bool vigente = true) =>
         GeoTestKeys.Ok(Bairro.Importar(
-            cidadeId, uf, nome, Normalizar(nome), null, null, null, null, Versao, vigente));
+            cidadeId, uf, nome, Normalizar(nome), latitude, longitude, null, null, Versao, vigente));
 
     public static Logradouro NovoLogradouro(
         Guid cidadeId,
@@ -93,14 +105,17 @@ internal static partial class GeoReferenceSeed
         string cep,
         string nome,
         string? tipo = null,
+        string? nomeCompleto = null,
         Guid? distritoId = null,
         Guid? bairroId = null,
         decimal? latitude = null,
         decimal? longitude = null,
         string? nomeNormalizado = null,
         bool vigente = true) =>
+        // Espelha o ETL real (#673): NomeNormalizado vem de nome_logradouro_sem_acento
+        // — o NOME, sem o tipo. NomeCompleto (origem logradouro) carrega o texto cheio.
         GeoTestKeys.Ok(Logradouro.Importar(
-            cep, tipo, nome, null, nomeNormalizado ?? Normalizar(nome), cidadeId,
+            cep, tipo, nome, nomeCompleto, nomeNormalizado ?? Normalizar(nome), cidadeId,
             distritoId, bairroId, uf, latitude, longitude, null, true, Versao, vigente));
 
     public static LogradouroComplemento NovoComplemento(string cep, string complemento, bool vigente = true) =>


### PR DESCRIPTION
## Contexto

Completa a navegação **descendente** da hierarquia geográfica (Cidade → Distrito/Bairro) e entrega o **autocomplete de logradouro** que um formulário de endereço usa quando o usuário não sabe o CEP. Fecha o trio de consulta da F4 junto com estados/cidades (#675) e o lookup de CEP (#676).

Closes #677

## Endpoints (públicos, read-only, sem CRUD/Idempotency-Key)

- `GET /api/cidades/{codigoIbge}/distritos` — distritos da cidade, paginado por cursor
- `GET /api/cidades/{codigoIbge}/bairros?q=` — bairros + autocomplete de bairro
- `GET /api/cidades/{codigoIbge}/logradouros?q=` — autocomplete de logradouro escopado à cidade

## Decisões

- **Padrão das stories irmãs:** cursor opaco bidirecional (ADR-0089), vendor MIME versionado (ADR-0031), filtro `vigente` (ADR-0092) e HATEOAS por item (ADR-0029) — espelha `EstadosController`/`CidadesController`/`CepController`.
- **`_links` sem `self`:** não há detalhe por `id` para distrito/bairro/logradouro nesta fatia, então os itens omitem `self` e carregam só links navegáveis: `cidade` + `collection` (distrito/bairro) e, no logradouro, também `cep` (salto ao lookup completo).
- **`CidadeDetalheLinksBuilder`** passa a emitir os links descendentes (`distritos`, `bairros`, `logradouros`), antes adiados por ausência de rota.
- **Busca:** termo normalizado no app + `ILIKE` sobre `nome_normalizado`, extraído para o helper compartilhado `BuscaTextualNormalizada`. Logradouro tem índice trigram `gin_trgm_ops` dedicado; bairro reusa o composto `(cidade_id, nome_normalizado)` (volume por cidade baixo; o predicado de cidade restringe antes do `ILIKE` — documentado na config).
- **Boundary:** `codigo_ibge` malformado → 400; cidade-pai inexistente → 404 (≠ lista vazia, 200); `q` acima de 256 chars → 400.

## Recorte do autocomplete de logradouro (e follow-up #707)

O autocomplete de logradouro casa pelo **nome** do logradouro. No ETL (#673) `nome_normalizado` vem de `nome_logradouro_sem_acento` — **sem o tipo** (na fonte DNE `tipo`/`nome_logradouro`/`logradouro` são colunas separadas). Logo, busca por **tipo** ou **texto completo** (ex.: `q=praça`, `q=rua das flores`) e **ranking por similaridade** (`pg_trgm`) ficam para o follow-up prioritário **#707** (sub de #665, `priority:high`). O seed dos testes reflete o ETL real e a CA-03 documenta esse recorte (achado P2 do Codex acatado e rastreado).

## Critérios de aceite

- [x] CA-01 distritos paginados com `_links` (`cidade` + `collection`, sem `self`)
- [x] CA-02 busca de bairro acento/caixa-insensível
- [x] CA-03 autocomplete de logradouro **por nome** (acento-insensível), escopado à cidade, com `_links.cep` — busca por tipo/texto-completo em #707
- [x] CA-04 cidade inexistente → 404; existente sem filhos → 200 vazio
- [x] CA-05 código IBGE malformado → 400
- [x] CA-06 cursor `prev`/`next` preserva escopo + `q` (round-trip validado)
- [x] CA-07 vendor MIME incompatível → 406; termo longo → 400

## Validação local

- `Geo.IntegrationTests` (PostGIS via Testcontainers): **205/205** aprovados
- `ArchTests` (Clean Architecture): **24/24** aprovados
- Build da solution: 0 erros, **0 avisos** (`TreatWarningsAsErrors`)
- OpenAPI regenerado (ADR-0030)

## Commits

- `refactor(geo): extrai normalização de busca textual para helper compartilhado`
- `feat(geo): adiciona API de hierarquia e autocomplete por cidade`