### PR TITLE
feat(geo): autocomplete de logradouro tolera abreviação, ordem e typo

### DIFF
--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/LogradouroReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/LogradouroReader.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
 using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 
 using Unifesspa.UniPlus.Geo.Application.Abstractions;
 using Unifesspa.UniPlus.Geo.Domain.Entities;
@@ -70,11 +71,20 @@ internal sealed class LogradouroReader : ILogradouroReader
         return (true, itens, page.PrevAfterId, page.NextAfterId);
     }
 
-    // Autocomplete (com busca): filtra por texto completo (ILIKE contém, índice trigram) e
-    // ordena por relevância (similaridade trigram) — o uso real é digitar e escolher entre
-    // os mais relevantes. O ranking por similaridade é incompatível com o keyset por Id
-    // (ADR-0089), então retorna o top-N sem âncoras de paginação (sem prev/next): a
-    // navegação profunda não faz sentido para autocomplete.
+    // Autocomplete (com busca): filtra por word_similarity (pg_trgm, operador `<%`) e
+    // ordena por relevância. Ao contrário do ILIKE (substring contígua, frágil), o
+    // word_similarity tolera abreviação de tipo ("av brasil" → "Avenida Brasil"), ordem
+    // das palavras ("paulista avenida") e pequenos erros de digitação — sem dicionário de
+    // abreviações (#709). O operador `<%` reaproveita o índice gin_trgm_ops
+    // (ix_logradouro_nome_trgm) que a #707 criou — sem migration. O ranking
+    // `word_similarity DESC, similarity DESC` coloca a match exata no topo: o desempate
+    // por `similarity` global separa "Rua das Flores" de "Rua das Flores e Jardins", que
+    // empatam em word_similarity = 1. Typo puro tem recall ok mas ranking subótimo —
+    // limitação aceita para autocomplete (ver evidência do spike na #709).
+    //
+    // O ranking por similaridade é incompatível com o keyset por Id (ADR-0089), então
+    // retorna o top-N sem âncoras de paginação (sem prev/next): a navegação profunda não
+    // faz sentido para autocomplete.
     private async Task<(bool, IReadOnlyList<LogradouroComBairro>, Guid?, Guid?)> BuscarPorRelevanciaAsync(
         IQueryable<Logradouro> escopoCidade,
         string busca,
@@ -82,15 +92,35 @@ internal sealed class LogradouroReader : ILogradouroReader
         CancellationToken cancellationToken)
     {
         string termo = BuscaTextualNormalizada.Normalizar(busca);
-        string pattern = BuscaTextualNormalizada.CriarPadraoContem(busca);
+        List<Logradouro> rankeados;
 
-        List<Logradouro> rankeados = await escopoCidade
-            .Where(l => EF.Functions.ILike(l.NomeNormalizado, pattern, BuscaTextualNormalizada.Escape))
-            .OrderByDescending(l => EF.Functions.TrigramsSimilarity(l.NomeNormalizado, termo))
-            .ThenBy(l => l.Id)
-            .Take(limit)
-            .ToListAsync(cancellationToken)
-            .ConfigureAwait(false);
+        // O filtro `<%` decide o match comparando pg_trgm.word_similarity_threshold, lido
+        // em tempo de execução. SET LOCAL o fixa em 0.6 (default do PostgreSQL; calibrado
+        // contra o DNE real na #709 — mantém a match esperada em 1º com baixo volume de
+        // falsos positivos) de forma transação-local: determinístico, sem depender da
+        // config global do servidor e sem vazar para a conexão devolvida ao pool. Exige
+        // transação explícita — SET LOCAL só vale dentro de um bloco de transação,
+        // compartilhado com o SELECT seguinte.
+        IDbContextTransaction transacao = await _dbContext.Database
+            .BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        await using (transacao.ConfigureAwait(false))
+        {
+            // String literal constante (sem interpolação) — não dispara o EF1002.
+            await _dbContext.Database
+                .ExecuteSqlRawAsync("SET LOCAL pg_trgm.word_similarity_threshold = 0.6", cancellationToken)
+                .ConfigureAwait(false);
+
+            rankeados = await escopoCidade
+                .Where(l => EF.Functions.TrigramsAreWordSimilar(termo, l.NomeNormalizado))
+                .OrderByDescending(l => EF.Functions.TrigramsWordSimilarity(termo, l.NomeNormalizado))
+                .ThenByDescending(l => EF.Functions.TrigramsSimilarity(l.NomeNormalizado, termo))
+                .ThenBy(l => l.Id)
+                .Take(limit)
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            await transacao.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
 
         IReadOnlyList<LogradouroComBairro> itens = await EnriquecerComBairroAsync(rankeados, cancellationToken)
             .ConfigureAwait(false);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/LogradouroReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/LogradouroReader.cs
@@ -92,18 +92,22 @@ internal sealed class LogradouroReader : ILogradouroReader
         CancellationToken cancellationToken)
     {
         string termo = BuscaTextualNormalizada.Normalizar(busca);
-        List<Logradouro> rankeados;
 
         // O filtro `<%` decide o match comparando pg_trgm.word_similarity_threshold, lido
         // em tempo de execução. SET LOCAL o fixa em 0.6 (default do PostgreSQL; calibrado
         // contra o DNE real na #709 — mantém a match esperada em 1º com baixo volume de
         // falsos positivos) de forma transação-local: determinístico, sem depender da
-        // config global do servidor e sem vazar para a conexão devolvida ao pool. Exige
-        // transação explícita — SET LOCAL só vale dentro de um bloco de transação,
-        // compartilhado com o SELECT seguinte.
-        IDbContextTransaction transacao = await _dbContext.Database
-            .BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-        await using (transacao.ConfigureAwait(false))
+        // config global do servidor e sem vazar para a conexão devolvida ao pool. SET LOCAL
+        // exige um bloco de transação. No caminho de query atual o handler não roda sob
+        // transação ambiente (verificado nos testes de integração, que sobem o runtime
+        // Wolverine real), então abre a sua própria; se uma transação ambiente já existir,
+        // reaproveita-a sem assumir seu ciclo de vida — evita abrir uma transação aninhada
+        // e blinda contra mudança futura no pipeline.
+        IDbContextTransaction? ambiente = _dbContext.Database.CurrentTransaction;
+        IDbContextTransaction transacao = ambiente
+            ?? await _dbContext.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        List<Logradouro> rankeados;
+        try
         {
             // String literal constante (sem interpolação) — não dispara o EF1002.
             await _dbContext.Database
@@ -119,7 +123,19 @@ internal sealed class LogradouroReader : ILogradouroReader
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            await transacao.CommitAsync(cancellationToken).ConfigureAwait(false);
+            // Commita/descarta apenas a transação que este método abriu; uma ambiente é
+            // de responsabilidade de quem a iniciou.
+            if (ambiente is null)
+            {
+                await transacao.CommitAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (ambiente is null)
+            {
+                await transacao.DisposeAsync().ConfigureAwait(false);
+            }
         }
 
         IReadOnlyList<LogradouroComBairro> itens = await EnriquecerComBairroAsync(rankeados, cancellationToken)

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CidadeHierarquiaEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CidadeHierarquiaEndpointTests.cs
@@ -164,6 +164,60 @@ public sealed class CidadeHierarquiaEndpointTests
         nomesCompletos.Should().Equal("Rua das Flores", "Rua das Flores e Jardins");
     }
 
+    [Theory(DisplayName = "CA-08 (#709): autocomplete tolera abreviação de tipo ('av') e ordem das palavras")]
+    [InlineData("av paulista")]        // abreviação de tipo (prefixo "av" → "avenida")
+    [InlineData("paulista avenida")]   // palavras fora de ordem
+    public async Task Logradouros_Autocomplete_AbreviacaoEOrdem(string termo)
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // word_similarity (#709) casa o termo contra o texto completo independentemente de
+        // abreviação ou ordem; o ILIKE da #707 rejeitaria ambos. A match esperada fica no
+        // topo do ranking (word_similarity DESC, similarity DESC).
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, $"/api/cidades/3550308/logradouros?q={Uri.EscapeDataString(termo)}&limit=100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        JsonElement itens = await LerArrayAsync(resposta);
+        itens.EnumerateArray().First().GetProperty("nomeCompleto").GetString().Should().Be("Avenida Paulista");
+    }
+
+    [Fact(DisplayName = "CA-08 (#709): autocomplete tolera abreviação que não é prefixo ('pca' → 'Praça')")]
+    public async Task Logradouros_Autocomplete_AbreviacaoNaoPrefixo()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // "pca" não é prefixo de "praça": só o word_similarity (trigram) casa; FTS-prefix e
+        // ILIKE falhariam. Confirma a escolha do spike (#709).
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, $"/api/cidades/3550308/logradouros?q={Uri.EscapeDataString("pca da se")}&limit=100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        JsonElement itens = await LerArrayAsync(resposta);
+        itens.EnumerateArray().First().GetProperty("nomeCompleto").GetString().Should().Be("Praça da Sé");
+    }
+
+    [Fact(DisplayName = "CA-08 (#709): autocomplete tolera pequeno erro de digitação (recall)")]
+    public async Task Logradouros_Autocomplete_Typo()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // O typo ("paulysta") ainda recupera o logradouro. Asserção de recall (Contains),
+        // não de ranking: em datasets grandes o typo pode ficar fora do topo — limitação
+        // aceita e documentada (#709).
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, $"/api/cidades/3550308/logradouros?q={Uri.EscapeDataString("avenida paulysta")}&limit=100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        JsonElement itens = await LerArrayAsync(resposta);
+        itens.EnumerateArray()
+            .Select(i => i.GetProperty("nomeCompleto").GetString())
+            .Should().Contain("Avenida Paulista");
+    }
+
     [Fact(DisplayName = "CA-04: cidade inexistente retorna 404; cidade existente sem filhos do filtro retorna 200 vazio")]
     public async Task Hierarquia_CidadeInexistente_404_EFiltroVazio_200()
     {
@@ -292,12 +346,19 @@ public sealed class CidadeHierarquiaEndpointTests
         Logradouro ruaFloresJardins = GeoReferenceSeed.NovoLogradouro(
             cidadeSp.Id, "SP", "01231000", "das Flores e Jardins", tipo: "Rua", nomeCompleto: "Rua das Flores e Jardins", bairroId: santaCecilia.Id);
 
+        // Uma avenida sustenta os casos da #709 (abreviação de tipo "av" e ordem das
+        // palavras) sem interferir nas contagens estritas dos casos da #707 (validado
+        // contra o DNE real: word_similarity 0.6 não casa "avenida paulista" com os termos
+        // "se"/"praca"/"rua das flores").
+        Logradouro avenidaPaulista = GeoReferenceSeed.NovoLogradouro(
+            cidadeSp.Id, "SP", "01310100", "Paulista", tipo: "Avenida", nomeCompleto: "Avenida Paulista", bairroId: santaCecilia.Id);
+
         ctx.Paises.Add(brasil);
         ctx.Estados.AddRange(saoPaulo, para);
         ctx.Cidades.AddRange(cidadeSp, maraba);
         ctx.Distritos.AddRange(seDistrito, pinheirosDistrito, novaMaraba);
         ctx.Bairros.AddRange(se, santaCecilia, saude, cidadeNova);
-        ctx.Logradouros.AddRange(pracaSe, ruaSantaCecilia, pracaMaraba, ruaFlores, ruaFloresJardins);
+        ctx.Logradouros.AddRange(pracaSe, ruaSantaCecilia, pracaMaraba, ruaFlores, ruaFloresJardins, avenidaPaulista);
         await ctx.SaveChangesAsync();
     }
 


### PR DESCRIPTION
## Contexto

Story #709 (sub de #665, Epic #661) — follow-up do PR #708 (#707), achado P2 do Codex.

O autocomplete de logradouro (#707) filtrava com `ILIKE '%termo%'` (substring contígua), o que é frágil e quebra em entradas legítimas:

| Usuário digita | Armazenado | `ILIKE` | Modo de falha |
|---|---|---|---|
| `av brasil` | `avenida brasil` | ❌ | abreviação de tipo |
| `paulista avenida` | `avenida paulista` | ❌ | ordem das palavras |
| `pca da se` | `praca da se` | ❌ | abreviação não-prefixo |
| `avenida brazil` | `avenida brasil` | ❌ | erro de digitação |

## O que muda

Substitui o filtro `ILIKE` por **`word_similarity` (pg_trgm, operador `<%`)** no `LogradouroReader.BuscarPorRelevanciaAsync`, mantendo o ranking por relevância com desempate por similaridade global (`word_similarity DESC, similarity DESC`).

- **Sem dicionário de abreviações** (decisão do TL — dívida de manutenção que nunca fica completa).
- **Sem migration**: o operador `<%` reaproveita o índice `gin_trgm_ops` (`ix_logradouro_nome_trgm`) que a #707 já criou (`Bitmap Index Scan`).
- **Limiar 0.6 por transação** (`SET LOCAL pg_trgm.word_similarity_threshold`): default do PostgreSQL, transação-local (não depende da config global do servidor nem vaza para a conexão do pool). Exige transação explícita pois `SET LOCAL` só vale dentro de um bloco de transação, compartilhado com o `SELECT`.

## Gate da issue: validação com dados reais (DNE ~1,4M)

A escolha foi validada empiricamente contra o dataset DNE real (`tbl_cep_202601_n_logradouro`, 1.674.585 logradouros), escopado a São Paulo (62.551), conforme o gate obrigatório da #709.

**Recall** — `word_similarity` é a única estratégia que cobre todos os casos:

| Caso | `ILIKE` | `word_similarity` | FTS-prefix |
|---|---|---|---|
| não-regressão (`praca da se`, `se`, `praca`) | ✅ | ✅ | ✅ |
| ordem trocada (`paulista avenida`) | ❌ | ✅ | ✅ |
| typo (`avenida brazil`) | ❌ | ✅ | ❌ |
| abreviação prefixo (`r direita`) | ❌ | ✅ | ✅ |
| abreviação não-prefixo (`pca da se`) | ❌ | ✅ | ❌ |

**Ranking** (`word_similarity DESC, similarity DESC`) coloca a match esperada em **#1** (`av brasil`→Avenida Brasil, `pca da se`→Praça da Sé, `r direita`→Rua Direita). Só o typo puro fica fora do topo (recall ok, ranking subótimo) — limitação aceita para autocomplete.

**Calibração do limiar** (0.5 vs 0.6): 0.6 mantém a match esperada em #1 cortando drasticamente o volume de falsos positivos — ex. `pca da se` cai de 106 → 8 candidatos. Por isso 0.6.

## Não-regressão (#707)

Reproduzido o seed exato dos testes (incl. a "Avenida Paulista" adicionada) num spike a 0.6: as contagens estritas de `se`/`praca`/`rua das flores` se mantêm (o `word_similarity` 0.6 não casa a avenida com esses termos), e o desempate por `similarity` preserva "Rua das Flores" antes de "Rua das Flores e Jardins".

## Testes

`tests/.../Api/CidadeHierarquiaEndpointTests.cs` (Testcontainers + PostGIS real):

- **CA-08 (#709)** abreviação de tipo (`av paulista`) e ordem (`paulista avenida`) → Avenida Paulista no topo;
- **CA-08 (#709)** abreviação não-prefixo (`pca da se`) → Praça da Sé;
- **CA-08 (#709)** typo (`avenida paulysta`) → recall (Contains), sem assertar ranking (limitação documentada);
- todos os casos da #707 preservados.

Suíte Geo completa **216/216** local (a `GeoApiFactory` roda sem Redis, espelhando o CI).

## Critérios de aceite

- [x] `q=av ...` e abreviações análogas encontram a avenida, escopado à cidade
- [x] Robustez a ordem de palavras e a pequenos erros (typo: recall ok, ranking subótimo, documentado)
- [x] Sem regressão dos casos da #707
- [x] Estratégia e limiar justificados por medição contra dados reais
- [x] Sem warnings; testes verdes

Closes #709