### PR TITLE
feat(geo): API de proximidade geoespacial de cidades e logradouros

### DIFF
--- a/contracts/openapi.geo.json
+++ b/contracts/openapi.geo.json
@@ -1269,6 +1269,222 @@
           }
         }
       }
+    },
+    "/api/cidades/proximas": {
+      "get": {
+        "tags": [
+          "Proximidade"
+        ],
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
+              "type": [
+                "number",
+                "string"
+              ],
+              "format": "double"
+            }
+          },
+          {
+            "name": "long",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
+              "type": [
+                "number",
+                "string"
+              ],
+              "format": "double"
+            }
+          },
+          {
+            "name": "raioKm",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
+              "type": [
+                "number",
+                "string"
+              ],
+              "format": "double"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CidadeProximaDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CidadeProximaDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CidadeProximaDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/logradouros/proximos": {
+      "get": {
+        "tags": [
+          "Proximidade"
+        ],
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
+              "type": [
+                "number",
+                "string"
+              ],
+              "format": "double"
+            }
+          },
+          {
+            "name": "long",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
+              "type": [
+                "number",
+                "string"
+              ],
+              "format": "double"
+            }
+          },
+          {
+            "name": "raioKm",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
+              "type": [
+                "number",
+                "string"
+              ],
+              "format": "double"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": [
+                "integer",
+                "string"
+              ],
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogradouroProximoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogradouroProximoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogradouroProximoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1627,6 +1843,66 @@
           }
         }
       },
+      "CidadeProximaDto": {
+        "required": [
+          "id",
+          "codigoIbge",
+          "nome",
+          "uf",
+          "latitude",
+          "longitude",
+          "distanciaKm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigoIbge": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "uf": {
+            "type": "string"
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "distanciaKm": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "CidadeResumoDto": {
         "required": [
           "id",
@@ -1918,6 +2194,81 @@
               "string"
             ],
             "format": "double"
+          }
+        }
+      },
+      "LogradouroProximoDto": {
+        "required": [
+          "id",
+          "cep",
+          "tipo",
+          "nome",
+          "cidadeNome",
+          "cidadeCodigoIbge",
+          "uf",
+          "latitude",
+          "longitude",
+          "distanciaKm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cep": {
+            "type": "string"
+          },
+          "tipo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "nome": {
+            "type": "string"
+          },
+          "cidadeNome": {
+            "type": "string"
+          },
+          "cidadeCodigoIbge": {
+            "type": "string"
+          },
+          "uf": {
+            "type": "string"
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "distanciaKm": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },
@@ -2243,6 +2594,9 @@
     },
     {
       "name": "GeoImportacoes"
+    },
+    {
+      "name": "Proximidade"
     }
   ]
 }

--- a/contracts/openapi.geo.json
+++ b/contracts/openapi.geo.json
@@ -1279,6 +1279,7 @@
           {
             "name": "lat",
             "in": "query",
+            "required": true,
             "schema": {
               "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
               "type": [
@@ -1291,6 +1292,7 @@
           {
             "name": "long",
             "in": "query",
+            "required": true,
             "schema": {
               "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
               "type": [
@@ -1303,6 +1305,7 @@
           {
             "name": "raioKm",
             "in": "query",
+            "required": true,
             "schema": {
               "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
               "type": [
@@ -1387,6 +1390,7 @@
           {
             "name": "lat",
             "in": "query",
+            "required": true,
             "schema": {
               "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
               "type": [
@@ -1399,6 +1403,7 @@
           {
             "name": "long",
             "in": "query",
+            "required": true,
             "schema": {
               "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
               "type": [
@@ -1411,6 +1416,7 @@
           {
             "name": "raioKm",
             "in": "query",
+            "required": true,
             "schema": {
               "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?(?:[eE][\u002B-]?\\d\u002B)?$",
               "type": [

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/ProximidadeController.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/ProximidadeController.cs
@@ -1,0 +1,115 @@
+namespace Unifesspa.UniPlus.Geo.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.API.Formatting;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Application.Queries.Proximidade;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Consultas geoespaciais de proximidade (ADR-0091) — reference data
+/// (<c>[AllowAnonymous]</c>, sem Idempotency-Key): dado um ponto (lat/long) e um raio,
+/// devolve as cidades (<c>GET /api/cidades/proximas</c>) ou logradouros
+/// (<c>GET /api/logradouros/proximos</c>) dentro do raio, ordenados por distância
+/// crescente (top-N). Filtro por <c>ST_DWithin</c> (índice GIST) + ordenação por
+/// <c>ST_Distance</c>. Ranking por distância — sem cursor/paginação (ADR-0026/0089
+/// não se aplicam).
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class ProximidadeController : ControllerBase
+{
+    private readonly IQueryBus _queryBus;
+    private readonly IResourceLinksBuilder<CidadeProximaDto> _cidadeLinks;
+    private readonly IResourceLinksBuilder<LogradouroProximoDto> _logradouroLinks;
+    private readonly GeoProximidadeOptions _opcoes;
+
+    public ProximidadeController(
+        IQueryBus queryBus,
+        IResourceLinksBuilder<CidadeProximaDto> cidadeLinks,
+        IResourceLinksBuilder<LogradouroProximoDto> logradouroLinks,
+        IOptions<GeoProximidadeOptions> opcoes)
+    {
+        ArgumentNullException.ThrowIfNull(opcoes);
+        _queryBus = queryBus;
+        _cidadeLinks = cidadeLinks;
+        _logradouroLinks = logradouroLinks;
+        _opcoes = opcoes.Value;
+    }
+
+    /// <summary>
+    /// Cidades vigentes cuja coordenada está a até <c>raioKm</c> do ponto
+    /// (<c>lat</c>, <c>long</c> em graus decimais, <c>InvariantCulture</c>), ordenadas
+    /// por distância crescente. Parâmetro ausente ou fora de faixa → 400 (ADR-0031).
+    /// </summary>
+    [HttpGet("cidades/proximas")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "cidade-proxima", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<CidadeProximaDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> CidadesProximas(
+        [FromQuery] double? lat,
+        [FromQuery(Name = "long")] double? longitude,
+        [FromQuery] double? raioKm,
+        [FromQuery] int? limit,
+        CancellationToken cancellationToken)
+    {
+        if (!ConsultaProximidade.TentarCriar(
+                lat, longitude, raioKm, limit, _opcoes, out ConsultaProximidade? consulta, out ProblemDetails? erro))
+        {
+            return BadRequest(erro);
+        }
+
+        IReadOnlyList<CidadeProximaDto> itens = await _queryBus
+            .Send(new BuscarCidadesProximasQuery(consulta.Latitude, consulta.Longitude, consulta.RaioKm, consulta.Limit), cancellationToken)
+            .ConfigureAwait(false);
+
+        // HATEOAS Level 1 (ADR-0029): cada item leva _links para a cidade canônica.
+        CidadeProximaDto[] comLinks = [.. itens.Select(c => c with { Links = _cidadeLinks.Build(c) })];
+        return Ok(comLinks);
+    }
+
+    /// <summary>
+    /// Logradouros vigentes (em cidade vigente) cuja coordenada está a até <c>raioKm</c>
+    /// do ponto, ordenados por distância crescente. Útil para "qual a rua/CEP mais
+    /// próximo deste ponto". Parâmetro ausente ou fora de faixa → 400 (ADR-0031).
+    /// </summary>
+    [HttpGet("logradouros/proximos")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "logradouro-proximo", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<LogradouroProximoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> LogradourosProximos(
+        [FromQuery] double? lat,
+        [FromQuery(Name = "long")] double? longitude,
+        [FromQuery] double? raioKm,
+        [FromQuery] int? limit,
+        CancellationToken cancellationToken)
+    {
+        if (!ConsultaProximidade.TentarCriar(
+                lat, longitude, raioKm, limit, _opcoes, out ConsultaProximidade? consulta, out ProblemDetails? erro))
+        {
+            return BadRequest(erro);
+        }
+
+        IReadOnlyList<LogradouroProximoDto> itens = await _queryBus
+            .Send(new BuscarLogradourosProximosQuery(consulta.Latitude, consulta.Longitude, consulta.RaioKm, consulta.Limit), cancellationToken)
+            .ConfigureAwait(false);
+
+        LogradouroProximoDto[] comLinks = [.. itens.Select(l => l with { Links = _logradouroLinks.Build(l) })];
+        return Ok(comLinks);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Formatting/ConsultaProximidade.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Formatting/ConsultaProximidade.cs
@@ -1,0 +1,106 @@
+namespace Unifesspa.UniPlus.Geo.API.Formatting;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+/// <summary>
+/// Validação no boundary HTTP (ADR-0031) dos parâmetros da consulta de proximidade:
+/// <c>lat</c>/<c>long</c>/<c>raioKm</c> obrigatórios e em faixa, <c>limit</c> com
+/// default e teto. O handler recebe a consulta já validada (nunca a entrada crua);
+/// qualquer parâmetro ausente, não finito ou fora de faixa vira 400 (<c>ProblemDetails</c>).
+/// </summary>
+internal sealed class ConsultaProximidade
+{
+    private ConsultaProximidade(double latitude, double longitude, double raioKm, int limit)
+    {
+        Latitude = latitude;
+        Longitude = longitude;
+        RaioKm = raioKm;
+        Limit = limit;
+    }
+
+    public double Latitude { get; }
+
+    public double Longitude { get; }
+
+    public double RaioKm { get; }
+
+    public int Limit { get; }
+
+    /// <summary>
+    /// Valida os parâmetros contra <paramref name="opcoes"/> (teto de raio, default/teto
+    /// de limit) e devolve <see langword="true"/> + <paramref name="consulta"/> quando
+    /// válidos; caso contrário <see langword="false"/> + <paramref name="erro"/> (400).
+    /// </summary>
+    public static bool TentarCriar(
+        double? lat,
+        double? @long,
+        double? raioKm,
+        int? limit,
+        GeoProximidadeOptions opcoes,
+        [NotNullWhen(true)] out ConsultaProximidade? consulta,
+        [NotNullWhen(false)] out ProblemDetails? erro)
+    {
+        ArgumentNullException.ThrowIfNull(opcoes);
+
+        consulta = null;
+        erro = null;
+
+        if (lat is null || @long is null || raioKm is null)
+        {
+            erro = Problema(
+                "Parâmetros obrigatórios ausentes",
+                "Informe os parâmetros 'lat', 'long' e 'raioKm'.");
+            return false;
+        }
+
+        double latitude = lat.Value;
+        double longitude = @long.Value;
+        double raio = raioKm.Value;
+
+        if (!double.IsFinite(latitude) || latitude is < -90 or > 90)
+        {
+            erro = Problema("Latitude inválida", "A latitude deve estar entre -90 e 90 graus.");
+            return false;
+        }
+
+        if (!double.IsFinite(longitude) || longitude is < -180 or > 180)
+        {
+            erro = Problema("Longitude inválida", "A longitude deve estar entre -180 e 180 graus.");
+            return false;
+        }
+
+        if (!double.IsFinite(raio) || raio <= 0 || raio > opcoes.RaioMaxKm)
+        {
+            erro = Problema(
+                "Raio inválido",
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"O raio (raioKm) deve ser maior que 0 e no máximo {opcoes.RaioMaxKm} km."));
+            return false;
+        }
+
+        // limit negativo/zero é entrada inválida → 400 (não silenciar com clamp);
+        // ausente → default; acima do teto → trunca para o teto (top-N defensivo).
+        if (limit is <= 0)
+        {
+            erro = Problema("Limite inválido", "O parâmetro 'limit' deve ser maior que 0.");
+            return false;
+        }
+
+        int limitEfetivo = Math.Min(limit ?? opcoes.LimitPadrao, opcoes.LimitMax);
+
+        consulta = new ConsultaProximidade(latitude, longitude, raio, limitEfetivo);
+        return true;
+    }
+
+    private static ProblemDetails Problema(string titulo, string detalhe) => new()
+    {
+        Title = titulo,
+        Detail = detalhe,
+        Status = StatusCodes.Status400BadRequest,
+    };
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Formatting/GeoProximidadeOptions.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Formatting/GeoProximidadeOptions.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Geo.API.Formatting;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Limites configuráveis da consulta de proximidade (ADR-0091): teto de raio (defesa
+/// contra varredura nacional) e limites do top-N. Bindável da seção
+/// <c>Geo:Proximidade</c>; os defaults cobrem o caso comum sem configuração.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Bindável via Configure<T> e injetada como IOptions<T> no ctor público do ProximidadeController — internal quebraria a acessibilidade do ctor (CS0051).")]
+public sealed class GeoProximidadeOptions
+{
+    public const string SectionName = "Geo:Proximidade";
+
+    /// <summary>Raio máximo aceito, em km (acima → 400). Evita varredura de cobertura nacional.</summary>
+    public double RaioMaxKm { get; set; } = 500.0;
+
+    /// <summary>Quantidade de resultados quando o cliente não informa <c>limit</c>.</summary>
+    public int LimitPadrao { get; set; } = 50;
+
+    /// <summary>Teto do top-N. <c>limit</c> acima deste valor é truncado (não é erro).</summary>
+    public int LimitMax { get; set; } = 200;
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Formatting/GeoProximidadeOptions.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Formatting/GeoProximidadeOptions.cs
@@ -23,4 +23,12 @@ public sealed class GeoProximidadeOptions
 
     /// <summary>Teto do top-N. <c>limit</c> acima deste valor é truncado (não é erro).</summary>
     public int LimitMax { get; set; } = 200;
+
+    /// <summary>
+    /// Limites coerentes: teto de raio positivo, top-N de ao menos 1 e default no
+    /// intervalo <c>[1, LimitMax]</c>. Usado na validação fail-fast no boot (config
+    /// inválida como <c>LimitMax=0</c> faria <c>Take(limit)</c> esvaziar buscas válidas).
+    /// </summary>
+    public bool LimitesValidos() =>
+        RaioMaxKm > 0 && LimitMax >= 1 && LimitPadrao >= 1 && LimitPadrao <= LimitMax;
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CidadeProximaLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/CidadeProximaLinksBuilder.cs
@@ -1,0 +1,52 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="CidadeProximaDto"/> (item de ranking por distância). Relação
+/// <c>cidade</c> (<c>GET /api/cidades/{codigoIbge}</c>) — leva ao detalhe completo da
+/// cidade. Sem <c>self</c>: o item de proximidade não é um recurso canônico próprio.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via AddSingleton<IResourceLinksBuilder<CidadeProximaDto>, CidadeProximaLinksBuilder>().")]
+internal sealed class CidadeProximaLinksBuilder : IResourceLinksBuilder<CidadeProximaDto>
+{
+    private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CidadeProximaLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(CidadeProximaDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string cidade = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.ObterPorCodigoIbge),
+            CidadesControllerNome, new { codigoIbge = dto.CodigoIbge });
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["cidade"] = cidade,
+        };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/LogradouroProximoLinksBuilder.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Hateoas/LogradouroProximoLinksBuilder.cs
@@ -1,0 +1,58 @@
+namespace Unifesspa.UniPlus.Geo.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="LogradouroProximoDto"/> (item de ranking por distância). Relações
+/// <c>cidade</c> (<c>GET /api/cidades/{codigoIbge}</c>) e <c>cep</c>
+/// (<c>GET /api/cep/{cep}</c>) — leva ao lookup completo do endereço. Sem <c>self</c>:
+/// a API não expõe detalhe de logradouro por Id.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via AddSingleton<IResourceLinksBuilder<LogradouroProximoDto>, LogradouroProximoLinksBuilder>().")]
+internal sealed class LogradouroProximoLinksBuilder : IResourceLinksBuilder<LogradouroProximoDto>
+{
+    private static readonly string CidadesControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CidadesController));
+    private static readonly string CepControllerNome = GeoLinkPathResolver.ControllerName(nameof(Controllers.CepController));
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public LogradouroProximoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(LogradouroProximoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string cidade = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CidadesController.ObterPorCodigoIbge),
+            CidadesControllerNome, new { codigoIbge = dto.CidadeCodigoIbge });
+        string cep = GeoLinkPathResolver.Resolver(
+            _linkGenerator, httpContext, nameof(Controllers.CepController.Resolver),
+            CepControllerNome, new { cep = dto.Cep });
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["cidade"] = cidade,
+            ["cep"] = cep,
+        };
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/OpenApi/ProximidadeRequiredParametrosTransformer.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/OpenApi/ProximidadeRequiredParametrosTransformer.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Geo.API.OpenApi;
+
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+using Unifesspa.UniPlus.Geo.API.Controllers;
+
+/// <summary>
+/// Operation transformer que marca como <c>required</c> no contrato OpenAPI os
+/// parâmetros de query obrigatórios da consulta de proximidade (#678): <c>lat</c>,
+/// <c>long</c> e <c>raioKm</c>. Eles são validados no boundary
+/// (<see cref="Formatting.ConsultaProximidade"/>) — ausência → 400 — mas, como o
+/// ApiExplorer descreve query params <c>double?</c> como opcionais, sem este transformer
+/// o contrato (e os clientes gerados a partir dele) os trataria como omissíveis e o erro
+/// só apareceria em runtime. <c>limit</c> permanece opcional (tem default).
+/// </summary>
+internal sealed class ProximidadeRequiredParametrosTransformer : IOpenApiOperationTransformer
+{
+    private static readonly string[] ParametrosObrigatorios = ["lat", "long", "raioKm"];
+
+    public Task TransformAsync(
+        OpenApiOperation operation,
+        OpenApiOperationTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(context);
+
+        // Só as operações do ProximidadeController — não toca os demais endpoints do Geo.
+        if (context.Description.ActionDescriptor is not ControllerActionDescriptor descriptor
+            || descriptor.ControllerTypeInfo.AsType() != typeof(ProximidadeController))
+        {
+            return Task.CompletedTask;
+        }
+
+        if (operation.Parameters is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (IOpenApiParameter parametro in operation.Parameters)
+        {
+            if (parametro is OpenApiParameter concreto
+                && concreto.In == ParameterLocation.Query
+                && ParametrosObrigatorios.Contains(concreto.Name, StringComparer.Ordinal))
+            {
+                concreto.Required = true;
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.API/OpenApi/ProximidadeRequiredParametrosTransformer.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/OpenApi/ProximidadeRequiredParametrosTransformer.cs
@@ -39,14 +39,14 @@ internal sealed class ProximidadeRequiredParametrosTransformer : IOpenApiOperati
             return Task.CompletedTask;
         }
 
-        foreach (IOpenApiParameter parametro in operation.Parameters)
+        IEnumerable<OpenApiParameter> obrigatorios = operation.Parameters
+            .OfType<OpenApiParameter>()
+            .Where(p => p.In == ParameterLocation.Query
+                     && ParametrosObrigatorios.Contains(p.Name, StringComparer.Ordinal));
+
+        foreach (OpenApiParameter parametro in obrigatorios)
         {
-            if (parametro is OpenApiParameter concreto
-                && concreto.In == ParameterLocation.Query
-                && ParametrosObrigatorios.Contains(concreto.Name, StringComparer.Ordinal))
-            {
-                concreto.Required = true;
-            }
+            parametro.Required = true;
         }
 
         return Task.CompletedTask;

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
@@ -95,8 +95,14 @@ builder.Services.AddSingleton<IResourceLinksBuilder<CepResolvidoDto>, CepResolvi
 // configuráveis via seção Geo:Proximidade (GeoProximidadeOptions), com defaults.
 builder.Services.AddSingleton<IResourceLinksBuilder<CidadeProximaDto>, CidadeProximaLinksBuilder>();
 builder.Services.AddSingleton<IResourceLinksBuilder<LogradouroProximoDto>, LogradouroProximoLinksBuilder>();
-builder.Services.Configure<GeoProximidadeOptions>(
-    builder.Configuration.GetSection(GeoProximidadeOptions.SectionName));
+// Validação fail-fast dos limites: config inválida (ex.: LimitMax=0) faria
+// Take(limit) receber 0 e esvaziar buscas válidas — falha no boot, não em runtime.
+builder.Services.AddOptions<GeoProximidadeOptions>()
+    .Bind(builder.Configuration.GetSection(GeoProximidadeOptions.SectionName))
+    .Validate(
+        static o => o.LimitesValidos(),
+        "Geo:Proximidade — RaioMaxKm > 0, LimitMax >= 1 e 1 <= LimitPadrao <= LimitMax.")
+    .ValidateOnStart();
 
 // TTL configurável do cache-aside de CEP (#676) — default 24h (GeoCepCacheOptions).
 builder.Services.Configure<GeoCepCacheOptions>(

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.OpenApi;
+
 using Serilog;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
@@ -13,6 +15,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Smoke;
 using Unifesspa.UniPlus.Geo.API.Errors;
 using Unifesspa.UniPlus.Geo.API.Formatting;
 using Unifesspa.UniPlus.Geo.API.Hateoas;
+using Unifesspa.UniPlus.Geo.API.OpenApi;
 using Unifesspa.UniPlus.Geo.Application;
 using Unifesspa.UniPlus.Geo.Application.DTOs;
 using Unifesspa.UniPlus.Geo.Infrastructure;
@@ -44,6 +47,12 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 builder.Services.AddEndpointsApiExplorer();
 // OpenAPI 3.1 (ADR-0030) — spec em /openapi/geo.json.
 builder.Services.AddUniPlusOpenApi("geo", builder.Configuration);
+// Marca lat/long/raioKm da proximidade (#678) como required no contrato — são
+// validados em runtime (400 se ausentes), mas como query params double? o
+// ApiExplorer os descreveria como opcionais. AddOpenApi para o mesmo documento é
+// aditivo: anexa o transformer ao pipeline do doc "geo".
+builder.Services.AddOpenApi("geo", options =>
+    options.AddOperationTransformer<ProximidadeRequiredParametrosTransformer>());
 
 builder.Services.AddSingleton<IDomainErrorRegistration, GeoDomainErrorRegistration>();
 builder.Services.AddDomainErrorMapper();

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
@@ -11,6 +11,7 @@ using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
 using Unifesspa.UniPlus.Infrastructure.Core.Smoke;
 using Unifesspa.UniPlus.Geo.API.Errors;
+using Unifesspa.UniPlus.Geo.API.Formatting;
 using Unifesspa.UniPlus.Geo.API.Hateoas;
 using Unifesspa.UniPlus.Geo.Application;
 using Unifesspa.UniPlus.Geo.Application.DTOs;
@@ -79,6 +80,14 @@ builder.Services.AddSingleton<IResourceLinksBuilder<LogradouroResumoDto>, Lograd
 
 // HATEOAS Level 1 (ADR-0029) do lookup de CEP (#676): _links para cidade e estado.
 builder.Services.AddSingleton<IResourceLinksBuilder<CepResolvidoDto>, CepResolvidoLinksBuilder>();
+
+// HATEOAS Level 1 (ADR-0029) da proximidade geoespacial (#678): _links para cidade
+// (e CEP no caso de logradouro). Limites (teto de raio, default/teto de top-N)
+// configuráveis via seção Geo:Proximidade (GeoProximidadeOptions), com defaults.
+builder.Services.AddSingleton<IResourceLinksBuilder<CidadeProximaDto>, CidadeProximaLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<LogradouroProximoDto>, LogradouroProximoLinksBuilder>();
+builder.Services.Configure<GeoProximidadeOptions>(
+    builder.Configuration.GetSection(GeoProximidadeOptions.SectionName));
 
 // TTL configurável do cache-aside de CEP (#676) — default 24h (GeoCepCacheOptions).
 builder.Services.Configure<GeoCepCacheOptions>(

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IGeoProximidadeReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Abstractions/IGeoProximidadeReader.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Geo.Application.Abstractions;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Leitor read-side de consultas geoespaciais de proximidade (ADR-0091) sobre o
+/// reference data vigente (ADR-0092): dado um ponto (latitude/longitude em graus
+/// decimais) e um raio, devolve as entidades dentro do raio ordenadas por distância
+/// crescente (top-N). Filtro por <c>ST_DWithin</c> (índice GIST) e ordenação por
+/// <c>ST_Distance</c> sobre <c>geography</c> (metros).
+/// </summary>
+public interface IGeoProximidadeReader
+{
+    /// <summary>Cidades vigentes a até <paramref name="raioKm"/> do ponto, ordenadas por distância.</summary>
+    Task<IReadOnlyList<CidadeProximaDto>> BuscarCidadesProximasAsync(
+        double latitude,
+        double longitude,
+        double raioKm,
+        int limit,
+        CancellationToken cancellationToken);
+
+    /// <summary>Logradouros vigentes (em cidade vigente) a até <paramref name="raioKm"/> do ponto, ordenados por distância.</summary>
+    Task<IReadOnlyList<LogradouroProximoDto>> BuscarLogradourosProximosAsync(
+        double latitude,
+        double longitude,
+        double raioKm,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CidadeProximaDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/CidadeProximaDto.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Item de resultado da consulta de proximidade de cidades
+/// (<c>GET /api/cidades/proximas</c>): a Cidade encontrada dentro do raio mais a
+/// <see cref="DistanciaKm"/> ao ponto consultado. É uma projeção de <em>ranking</em>
+/// por distância (não um recurso canônico próprio) — os <c>_links</c> navegam ao
+/// detalhe da cidade (ADR-0029), sem <c>self</c>.
+/// </summary>
+/// <remarks>
+/// <see cref="DistanciaKm"/> vem de <c>ST_Distance</c> (metros sobre o esferoide) / 1000.
+/// <see cref="Latitude"/>/<see cref="Longitude"/> espelham as colunas materializadas
+/// <c>decimal(9,6)</c> (ADR-0091); só entram cidades cujas três coordenadas
+/// (coordenada geográfica + lat + long) estão preenchidas.
+/// </remarks>
+public sealed record CidadeProximaDto(
+    Guid Id,
+    string CodigoIbge,
+    string Nome,
+    string Uf,
+    decimal Latitude,
+    decimal Longitude,
+    double DistanciaKm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/LogradouroProximoDto.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/DTOs/LogradouroProximoDto.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Geo.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Item de resultado da consulta de proximidade de logradouros
+/// (<c>GET /api/logradouros/proximos</c>): o Logradouro encontrado dentro do raio,
+/// enriquecido com a cidade (nome + código IBGE) e a <see cref="DistanciaKm"/> ao
+/// ponto consultado. Projeção de <em>ranking</em> por distância — os <c>_links</c>
+/// navegam à cidade e ao lookup de CEP (ADR-0029), sem <c>self</c>.
+/// </summary>
+/// <remarks>
+/// <see cref="DistanciaKm"/> vem de <c>ST_Distance</c> (metros) / 1000;
+/// <see cref="Latitude"/>/<see cref="Longitude"/> espelham as colunas
+/// <c>decimal(9,6)</c> (ADR-0091). Só entram logradouros com coordenada e lat/long
+/// preenchidos, vinculados a uma cidade vigente.
+/// </remarks>
+public sealed record LogradouroProximoDto(
+    Guid Id,
+    string Cep,
+    string? Tipo,
+    string Nome,
+    string CidadeNome,
+    string CidadeCodigoIbge,
+    string Uf,
+    decimal Latitude,
+    decimal Longitude,
+    double DistanciaKm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Proximidade/BuscarCidadesProximasQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Proximidade/BuscarCidadesProximasQuery.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Proximidade;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Busca as cidades vigentes dentro de <see cref="RaioKm"/> do ponto
+/// (<see cref="Latitude"/>, <see cref="Longitude"/>), ordenadas por distância
+/// crescente, limitadas ao top-<see cref="Limit"/> (ranking por distância — sem cursor).
+/// </summary>
+public sealed record BuscarCidadesProximasQuery(
+    double Latitude,
+    double Longitude,
+    double RaioKm,
+    int Limit) : IQuery<IReadOnlyList<CidadeProximaDto>>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Proximidade/BuscarCidadesProximasQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Proximidade/BuscarCidadesProximasQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Proximidade;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Handler convention-based de <see cref="BuscarCidadesProximasQuery"/>: delega ao
+/// <see cref="IGeoProximidadeReader"/> (filtro <c>ST_DWithin</c> + ordenação
+/// <c>ST_Distance</c>). Os <c>_links</c> são montados no controller.
+/// </summary>
+public static class BuscarCidadesProximasQueryHandler
+{
+    public static async Task<IReadOnlyList<CidadeProximaDto>> Handle(
+        BuscarCidadesProximasQuery query,
+        IGeoProximidadeReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        return await reader
+            .BuscarCidadesProximasAsync(query.Latitude, query.Longitude, query.RaioKm, query.Limit, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Proximidade/BuscarLogradourosProximosQuery.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Proximidade/BuscarLogradourosProximosQuery.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Proximidade;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Busca os logradouros vigentes (em cidade vigente) dentro de <see cref="RaioKm"/>
+/// do ponto (<see cref="Latitude"/>, <see cref="Longitude"/>), ordenados por distância
+/// crescente, limitados ao top-<see cref="Limit"/> (ranking por distância — sem cursor).
+/// </summary>
+public sealed record BuscarLogradourosProximosQuery(
+    double Latitude,
+    double Longitude,
+    double RaioKm,
+    int Limit) : IQuery<IReadOnlyList<LogradouroProximoDto>>;

--- a/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Proximidade/BuscarLogradourosProximosQueryHandler.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Application/Queries/Proximidade/BuscarLogradourosProximosQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Geo.Application.Queries.Proximidade;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Handler convention-based de <see cref="BuscarLogradourosProximosQuery"/>: delega
+/// ao <see cref="IGeoProximidadeReader"/> (filtro <c>ST_DWithin</c> + ordenação
+/// <c>ST_Distance</c>). Os <c>_links</c> são montados no controller.
+/// </summary>
+public static class BuscarLogradourosProximosQueryHandler
+{
+    public static async Task<IReadOnlyList<LogradouroProximoDto>> Handle(
+        BuscarLogradourosProximosQuery query,
+        IGeoProximidadeReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        return await reader
+            .BuscarLogradourosProximosAsync(query.Latitude, query.Longitude, query.RaioKm, query.Limit, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -52,6 +52,10 @@ public static class GeoInfrastructureRegistration
         services.AddScoped<IBairroReader, BairroReader>();
         services.AddScoped<ILogradouroReader, LogradouroReader>();
 
+        // Proximidade geoespacial (Story #678): filtro ST_DWithin (índice GIST) +
+        // ordenação ST_Distance sobre geography (ADR-0091). Só reference data vigente.
+        services.AddScoped<IGeoProximidadeReader, GeoProximidadeReader>();
+
         // Lookup de CEP (Story #676): reader da cascata (logradouro → grande usuário →
         // faixa) + resolver com cache-aside por selo de versão (ADR-0090/0092). O
         // Lazy<ICacheService> difere o Connect do Redis para o resolver degradar ao

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/GeoProximidadeReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/GeoProximidadeReader.cs
@@ -1,0 +1,115 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using NetTopologySuite.Geometries;
+
+using Unifesspa.UniPlus.Geo.Application.Abstractions;
+using Unifesspa.UniPlus.Geo.Application.DTOs;
+
+/// <summary>
+/// Leitor geoespacial de proximidade (ADR-0091) sobre o <see cref="GeoDbContext"/>.
+/// Só expõe reference data vigente (ADR-0092). O filtro de raio usa
+/// <c>IsWithinDistance</c> → <c>ST_DWithin</c> (<em>index-friendly</em>, usa o índice
+/// GIST da coordenada), e a ordenação usa <c>Distance</c> → <c>ST_Distance</c>
+/// (metros sobre o esferoide, pois a coluna é <c>geography</c>). O ponto é sempre
+/// construído como <c>Point(longitude, latitude)</c> (X=long, Y=lat) — invertê-los
+/// é silenciosamente errado.
+/// </summary>
+/// <remarks>
+/// Registros sem coordenada (<c>Coordenada</c>/<c>Latitude</c>/<c>Longitude</c> nulos)
+/// são excluídos: o DTO expõe <c>Latitude</c>/<c>Longitude</c> como <c>decimal</c> não
+/// nulo, então o guard explícito evita materializar linha incompleta. O desempate
+/// estável por <c>Id</c> torna o top-N determinístico quando distâncias empatam.
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
+internal sealed class GeoProximidadeReader : IGeoProximidadeReader
+{
+    private readonly GeoDbContext _dbContext;
+
+    public GeoProximidadeReader(GeoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<CidadeProximaDto>> BuscarCidadesProximasAsync(
+        double latitude,
+        double longitude,
+        double raioKm,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        Point ponto = CriarPonto(longitude, latitude);
+        double raioMetros = raioKm * 1000.0;
+
+        return await _dbContext.Cidades
+            .AsNoTracking()
+            .Where(c => c.Vigente
+                     && c.Coordenada != null
+                     && c.Latitude != null
+                     && c.Longitude != null
+                     && c.Coordenada.IsWithinDistance(ponto, raioMetros))
+            .OrderBy(c => c.Coordenada!.Distance(ponto))
+            .ThenBy(c => c.Id)
+            .Take(limit)
+            .Select(c => new CidadeProximaDto(
+                c.Id,
+                c.CodigoIbge,
+                c.Nome,
+                c.Uf,
+                c.Latitude!.Value,
+                c.Longitude!.Value,
+                c.Coordenada!.Distance(ponto) / 1000.0))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<LogradouroProximoDto>> BuscarLogradourosProximosAsync(
+        double latitude,
+        double longitude,
+        double raioKm,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        Point ponto = CriarPonto(longitude, latitude);
+        double raioMetros = raioKm * 1000.0;
+
+        // Join com a cidade vigente para enriquecer com nome + código IBGE (padrão
+        // CepReader): o Logradouro guarda só CidadeId/Uf, não o nome/código da cidade.
+        IQueryable<LogradouroProximoDto> consulta =
+            from l in _dbContext.Logradouros.AsNoTracking()
+            where l.Vigente
+               && l.Coordenada != null
+               && l.Latitude != null
+               && l.Longitude != null
+               && l.Coordenada.IsWithinDistance(ponto, raioMetros)
+            join c in _dbContext.Cidades.AsNoTracking().Where(c => c.Vigente) on l.CidadeId equals c.Id
+            orderby l.Coordenada!.Distance(ponto), l.Id
+            select new LogradouroProximoDto(
+                l.Id,
+                l.Cep,
+                l.Tipo,
+                l.Nome,
+                c.Nome,
+                c.CodigoIbge,
+                l.Uf,
+                l.Latitude!.Value,
+                l.Longitude!.Value,
+                l.Coordenada!.Distance(ponto) / 1000.0);
+
+        return await consulta
+            .Take(limit)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    // Convenção NetTopologySuite/PostGIS: X = longitude, Y = latitude. SRID 4326 (WGS84).
+    private static Point CriarPonto(double longitude, double latitude) =>
+        new(longitude, latitude) { SRID = 4326 };
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/GeoReferenceSeed.cs
@@ -7,6 +7,8 @@ using System.Text.RegularExpressions;
 
 using Microsoft.EntityFrameworkCore;
 
+using NetTopologySuite.Geometries;
+
 using Unifesspa.UniPlus.Geo.Domain.Entities;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
@@ -71,10 +73,11 @@ internal static partial class GeoReferenceSeed
         string? microrregiaoNome = null,
         string? regiaoIntermediariaNome = null,
         string? regiaoImediataNome = null,
+        Point? coordenada = null,
         bool vigente = true) =>
         GeoTestKeys.Ok(Cidade.Importar(
             estadoId, uf, codigoIbge, nome,
-            nomeNormalizado ?? Normalizar(nome), ddd, latitude, longitude, null,
+            nomeNormalizado ?? Normalizar(nome), ddd, latitude, longitude, coordenada,
             null, mesorregiaoNome, null, microrregiaoNome,
             null, regiaoIntermediariaNome, null, regiaoImediataNome,
             Versao, vigente));
@@ -111,13 +114,14 @@ internal static partial class GeoReferenceSeed
         decimal? latitude = null,
         decimal? longitude = null,
         string? nomeNormalizado = null,
+        Point? coordenada = null,
         bool vigente = true) =>
         // Espelha o ETL real (#673 + #707): Nome é o nome sem o tipo; NomeCompleto (origem
         // logradouro) carrega o texto cheio; NomeNormalizado vem de logradouro_sem_acento —
         // o TEXTO COMPLETO sem acento (tipo + nome), coluna de busca e chave de upsert.
         GeoTestKeys.Ok(Logradouro.Importar(
             cep, tipo, nome, nomeCompleto, nomeNormalizado ?? Normalizar(nomeCompleto ?? nome), cidadeId,
-            distritoId, bairroId, uf, latitude, longitude, null, true, Versao, vigente));
+            distritoId, bairroId, uf, latitude, longitude, coordenada, true, Versao, vigente));
 
     public static LogradouroComplemento NovoComplemento(string cep, string complemento, bool vigente = true) =>
         GeoTestKeys.Ok(LogradouroComplemento.Importar(cep, complemento, Normalizar(complemento), Versao, vigente));

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/ProximidadeEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/ProximidadeEndpointTests.cs
@@ -1,0 +1,240 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Api;
+
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using NetTopologySuite.Geometries;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Consulta de proximidade geoespacial (#678) contra a API real + PostGIS. Read-only
+/// <c>[AllowAnonymous]</c>. Ponto de referência fixo próximo a Marabá
+/// (<c>lat=-5.35</c>, <c>long=-49.13</c>). A collection é serial; cada teste TRUNCA e
+/// semeia cidades/logradouros com coordenada (<c>geography(Point,4326)</c>).
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class ProximidadeEndpointTests
+{
+    private readonly GeoPostgisFixture _fixture;
+
+    public ProximidadeEndpointTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01: cidades dentro do raio, ordenadas por distância, com DistanciaKm e _links")]
+    public async Task CidadesProximas_OrdenaPorDistancia()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, "/api/cidades/proximas?lat=-5.35&long=-49.13&raioKm=100");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement raiz = doc.RootElement;
+        raiz.ValueKind.Should().Be(JsonValueKind.Array);
+
+        List<string> nomes = [.. raiz.EnumerateArray().Select(c => c.GetProperty("nome").GetString()!)];
+        nomes.Should().Equal("Marabá", "Eldorado dos Carajás");
+        nomes.Should().NotContain("São Paulo");                  // > 100 km
+        nomes.Should().NotContain("Bom Jesus do Tocantins");     // sem coordenada
+
+        JsonElement primeiro = raiz[0];
+        primeiro.GetProperty("distanciaKm").GetDouble().Should().BeGreaterThan(0);
+        primeiro.GetProperty("_links").GetProperty("cidade").GetString().Should().Be("/api/cidades/1500402");
+
+        double d0 = raiz[0].GetProperty("distanciaKm").GetDouble();
+        double d1 = raiz[1].GetProperty("distanciaKm").GetDouble();
+        d0.Should().BeLessThan(d1, "a lista é ordenada por distância crescente");
+    }
+
+    [Fact(DisplayName = "CA-03: logradouros dentro do raio, ordenados por distância, com cidade e _links.cep")]
+    public async Task LogradourosProximos_PorPonto()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, "/api/logradouros/proximos?lat=-5.35&long=-49.13&raioKm=50");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        JsonElement raiz = doc.RootElement;
+
+        List<string> nomes = [.. raiz.EnumerateArray().Select(l => l.GetProperty("nome").GetString()!)];
+        nomes.Should().Equal("A", "B");          // Rua A (~1 km) antes de Avenida B (~9 km)
+        nomes.Should().NotContain("da Sé");      // São Paulo, longe
+
+        JsonElement primeiro = raiz[0];
+        primeiro.GetProperty("cidadeNome").GetString().Should().Be("Marabá");
+        primeiro.GetProperty("cidadeCodigoIbge").GetString().Should().Be("1500402");
+        primeiro.GetProperty("distanciaKm").GetDouble().Should().BeGreaterThan(0);
+
+        JsonElement links = primeiro.GetProperty("_links");
+        links.GetProperty("cidade").GetString().Should().Be("/api/cidades/1500402");
+        links.GetProperty("cep").GetString().Should().Be("/api/cep/68500000");
+    }
+
+    [Theory(DisplayName = "CA-04: parâmetro ausente ou fora de faixa retorna 400")]
+    [InlineData("/api/cidades/proximas?long=-49.13&raioKm=100")]            // sem lat
+    [InlineData("/api/cidades/proximas?lat=-5.35&raioKm=100")]              // sem long
+    [InlineData("/api/cidades/proximas?lat=-5.35&long=-49.13")]            // sem raioKm
+    [InlineData("/api/cidades/proximas?lat=200&long=-49.13&raioKm=10")]    // lat fora de faixa
+    [InlineData("/api/cidades/proximas?lat=-5.35&long=-200&raioKm=10")]    // long fora de faixa
+    [InlineData("/api/cidades/proximas?lat=-5.35&long=-49.13&raioKm=0")]   // raio = 0
+    [InlineData("/api/cidades/proximas?lat=-5.35&long=-49.13&raioKm=9999")] // raio > teto
+    [InlineData("/api/cidades/proximas?lat=-5.35&long=-49.13&raioKm=10&limit=0")] // limit <= 0
+    public async Task CidadesProximas_Validacao_400(string rota)
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(client, rota);
+        resposta.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "CA-05: registro sem coordenada (ou sem lat/long) não aparece no resultado")]
+    public async Task CidadesProximas_SemCoordenada_Exclui()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, "/api/cidades/proximas?lat=-5.35&long=-49.13&raioKm=100");
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+
+        List<string> nomes = [.. doc.RootElement.EnumerateArray().Select(c => c.GetProperty("nome").GetString()!)];
+        nomes.Should().NotContain("Bom Jesus do Tocantins", "Coordenada null não entra (ST_DWithin sobre NULL é falso)");
+        nomes.Should().NotContain("Brejo Grande do Araguaia", "Coordenada presente mas lat/long nulos também é excluída");
+    }
+
+    [Fact(DisplayName = "CA-06: ponto no oceano com raio pequeno retorna 200 com lista vazia")]
+    public async Task CidadesProximas_RaioVazio_ListaVazia()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, "/api/cidades/proximas?lat=0&long=-30&raioKm=10");
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        doc.RootElement.GetArrayLength().Should().Be(0);
+    }
+
+    [Fact(DisplayName = "CA-06: limit=1 devolve apenas a cidade mais próxima (top-N por distância)")]
+    public async Task CidadesProximas_Limit_RespeitaTopN()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage resposta = await GeoReferenceSeed.Obter(
+            client, "/api/cidades/proximas?lat=-5.35&long=-49.13&raioKm=200&limit=1");
+        using JsonDocument doc = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+
+        doc.RootElement.GetArrayLength().Should().Be(1);
+        doc.RootElement[0].GetProperty("nome").GetString().Should().Be("Marabá");
+    }
+
+    [Fact(DisplayName = "CA-07: Accept vendor incompatível retorna 406; cidade-proxima.v1 é aceito")]
+    public async Task CidadesProximas_VendorMime_406()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+        const string rota = "/api/cidades/proximas?lat=-5.35&long=-49.13&raioKm=100";
+
+        using HttpRequestMessage incompativel = new(HttpMethod.Get, rota);
+        incompativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.cidade-proxima.v2+json"));
+        using HttpResponseMessage resp406 = await client.SendAsync(incompativel);
+        resp406.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
+
+        using HttpRequestMessage compativel = new(HttpMethod.Get, rota);
+        compativel.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.uniplus.cidade-proxima.v1+json"));
+        using HttpResponseMessage resp200 = await client.SendAsync(compativel);
+        resp200.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(DisplayName = "CA-08: ponto é Point(long,lat); inverter lat/long muda o resultado; precisão decimal(9,6)")]
+    public async Task CidadesProximas_OrdemCoordenadas_LongLat()
+    {
+        await SemearAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // Correto: (lat=-5.35, long=-49.13) próximo a Marabá.
+        using HttpResponseMessage correto = await GeoReferenceSeed.Obter(
+            client, "/api/cidades/proximas?lat=-5.35&long=-49.13&raioKm=50");
+        using JsonDocument docOk = JsonDocument.Parse(await correto.Content.ReadAsStringAsync());
+        JsonElement maraba = docOk.RootElement.EnumerateArray()
+            .First(c => c.GetProperty("nome").GetString() == "Marabá");
+
+        // Precisão: Latitude/Longitude espelham o seed em decimal(9,6).
+        maraba.GetProperty("latitude").GetDecimal().Should().Be(-5.36867m);
+        maraba.GetProperty("longitude").GetDecimal().Should().Be(-49.11731m);
+
+        // Invertido (lat=-49.13, long=-5.35): ambos válidos, mas caem no Atlântico Sul,
+        // longe de Marabá → a cidade não aparece. Prova a convenção X=long, Y=lat.
+        using HttpResponseMessage invertido = await GeoReferenceSeed.Obter(
+            client, "/api/cidades/proximas?lat=-49.13&long=-5.35&raioKm=50");
+        using JsonDocument docInv = JsonDocument.Parse(await invertido.Content.ReadAsStringAsync());
+        List<string> nomesInv = [.. docInv.RootElement.EnumerateArray().Select(c => c.GetProperty("nome").GetString()!)];
+        nomesInv.Should().NotContain("Marabá");
+    }
+
+    private static Point Ponto(decimal latitude, decimal longitude) =>
+        new((double)longitude, (double)latitude) { SRID = 4326 };
+
+    private async Task SemearAsync()
+    {
+        await GeoReferenceSeed.LimparAsync(_fixture);
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+
+        Pais brasil = GeoReferenceSeed.NovoBrasil();
+        Estado para = GeoReferenceSeed.NovoEstado(brasil.Id, "PA", "Pará");
+        Estado saoPauloUf = GeoReferenceSeed.NovoEstado(brasil.Id, "SP", "São Paulo");
+
+        // Próximas ao ponto de consulta (-5.35, -49.13):
+        Cidade maraba = GeoReferenceSeed.NovaCidade(
+            para.Id, "PA", "1500402", "Marabá",
+            latitude: -5.36867m, longitude: -49.11731m, coordenada: Ponto(-5.36867m, -49.11731m));
+        Cidade eldorado = GeoReferenceSeed.NovaCidade(
+            para.Id, "PA", "1502608", "Eldorado dos Carajás",
+            latitude: -6.10m, longitude: -49.36m, coordenada: Ponto(-6.10m, -49.36m));
+        // Longe (> 100 km):
+        Cidade saoPaulo = GeoReferenceSeed.NovaCidade(
+            saoPauloUf.Id, "SP", "3550308", "São Paulo",
+            latitude: -23.55m, longitude: -46.63m, coordenada: Ponto(-23.55m, -46.63m));
+        // Sem coordenada (CA-05): próxima ao ponto mas Coordenada null → não aparece.
+        Cidade semCoordenada = GeoReferenceSeed.NovaCidade(
+            para.Id, "PA", "1500800", "Bom Jesus do Tocantins");
+        // Coordenada presente mas lat/long nulos (P2 do review): também excluída.
+        Cidade coordSemLatLong = GeoReferenceSeed.NovaCidade(
+            para.Id, "PA", "1500909", "Brejo Grande do Araguaia",
+            coordenada: Ponto(-5.36m, -49.12m));
+
+        // Logradouros próximos (cidade Marabá):
+        Logradouro ruaA = GeoReferenceSeed.NovoLogradouro(
+            maraba.Id, "PA", "68500000", "A", tipo: "Rua", nomeCompleto: "Rua A",
+            latitude: -5.355m, longitude: -49.135m, coordenada: Ponto(-5.355m, -49.135m));
+        Logradouro avenidaB = GeoReferenceSeed.NovoLogradouro(
+            maraba.Id, "PA", "68500100", "B", tipo: "Avenida", nomeCompleto: "Avenida B",
+            latitude: -5.40m, longitude: -49.20m, coordenada: Ponto(-5.40m, -49.20m));
+        // Logradouro longe (São Paulo):
+        Logradouro pracaSe = GeoReferenceSeed.NovoLogradouro(
+            saoPaulo.Id, "SP", "01001000", "da Sé", tipo: "Praça", nomeCompleto: "Praça da Sé",
+            latitude: -23.55m, longitude: -46.63m, coordenada: Ponto(-23.55m, -46.63m));
+
+        ctx.Paises.Add(brasil);
+        ctx.Estados.AddRange(para, saoPauloUf);
+        ctx.Cidades.AddRange(maraba, eldorado, saoPaulo, semCoordenada, coordSemLatLong);
+        ctx.Logradouros.AddRange(ruaA, avenidaB, pracaSe);
+        await ctx.SaveChangesAsync();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/ProximidadeEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/ProximidadeEndpointTests.cs
@@ -188,6 +188,34 @@ public sealed class ProximidadeEndpointTests
         nomesInv.Should().NotContain("Marabá");
     }
 
+    [Fact(DisplayName = "Contrato: lat/long/raioKm são required no OpenAPI; limit é opcional")]
+    public async Task Contrato_ParametrosObrigatorios_MarcadosRequired()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        using HttpResponseMessage spec = await GeoReferenceSeed.Obter(client, "/openapi/geo.json");
+        spec.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await spec.Content.ReadAsStringAsync());
+        JsonElement parametros = doc.RootElement
+            .GetProperty("paths")
+            .GetProperty("/api/cidades/proximas")
+            .GetProperty("get")
+            .GetProperty("parameters");
+
+        Dictionary<string, bool> required = [];
+        foreach (JsonElement p in parametros.EnumerateArray())
+        {
+            string nome = p.GetProperty("name").GetString()!;
+            required[nome] = p.TryGetProperty("required", out JsonElement r) && r.GetBoolean();
+        }
+
+        required["lat"].Should().BeTrue();
+        required["long"].Should().BeTrue();
+        required["raioKm"].Should().BeTrue();
+        required["limit"].Should().BeFalse("limit tem default — permanece opcional");
+    }
+
     private static Point Ponto(decimal latitude, decimal longitude) =>
         new((double)longitude, (double)latitude) { SRID = 4326 };
 

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Proximidade/ConsultaProximidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Proximidade/ConsultaProximidadeTests.cs
@@ -1,0 +1,115 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Proximidade;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Geo.API.Formatting;
+
+/// <summary>
+/// Validação no boundary HTTP (ADR-0031, #678) dos parâmetros de proximidade:
+/// lat/long/raioKm obrigatórios e em faixa, limit com default e teto. Cobre o lado
+/// unitário do CA-04 e CA-06 (sem banco).
+/// </summary>
+public sealed class ConsultaProximidadeTests
+{
+    private static readonly GeoProximidadeOptions Opcoes = new();
+
+    [Fact(DisplayName = "CA-04: parâmetros válidos criam a consulta com limit default")]
+    public void TentarCriar_Valido_UsaLimitDefault()
+    {
+        bool ok = ConsultaProximidade.TentarCriar(
+            -5.35, -49.13, 100, null, Opcoes, out ConsultaProximidade? consulta, out ProblemDetails? erro);
+
+        ok.Should().BeTrue();
+        erro.Should().BeNull();
+        consulta!.Latitude.Should().Be(-5.35);
+        consulta.Longitude.Should().Be(-49.13);
+        consulta.RaioKm.Should().Be(100);
+        consulta.Limit.Should().Be(Opcoes.LimitPadrao);
+    }
+
+    [Fact(DisplayName = "CA-06: limit acima do teto é truncado para o máximo")]
+    public void TentarCriar_LimitAcimaDoTeto_Trunca()
+    {
+        bool ok = ConsultaProximidade.TentarCriar(0, 0, 10, 100_000, Opcoes, out ConsultaProximidade? consulta, out _);
+
+        ok.Should().BeTrue();
+        consulta!.Limit.Should().Be(Opcoes.LimitMax);
+    }
+
+    [Fact(DisplayName = "limit informado dentro do teto é preservado")]
+    public void TentarCriar_LimitValido_Preserva()
+    {
+        bool ok = ConsultaProximidade.TentarCriar(0, 0, 10, 7, Opcoes, out ConsultaProximidade? consulta, out _);
+
+        ok.Should().BeTrue();
+        consulta!.Limit.Should().Be(7);
+    }
+
+    [Theory(DisplayName = "CA-04: parâmetro obrigatório ausente retorna 400")]
+    [InlineData(null, -49.13, 100.0)]
+    [InlineData(-5.35, null, 100.0)]
+    [InlineData(-5.35, -49.13, null)]
+    public void TentarCriar_ObrigatorioAusente_Falha(double? lat, double? lon, double? raio)
+    {
+        bool ok = ConsultaProximidade.TentarCriar(
+            lat, lon, raio, null, Opcoes, out ConsultaProximidade? consulta, out ProblemDetails? erro);
+
+        ok.Should().BeFalse();
+        consulta.Should().BeNull();
+        erro!.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Theory(DisplayName = "CA-04: lat/long/raio fora de faixa retornam 400")]
+    [InlineData(91.0, 0.0, 10.0)]     // lat > 90
+    [InlineData(-91.0, 0.0, 10.0)]    // lat < -90
+    [InlineData(0.0, 181.0, 10.0)]    // long > 180
+    [InlineData(0.0, -181.0, 10.0)]   // long < -180
+    [InlineData(0.0, 0.0, 0.0)]       // raio = 0
+    [InlineData(0.0, 0.0, -5.0)]      // raio < 0
+    [InlineData(0.0, 0.0, 600.0)]     // raio > teto (500)
+    public void TentarCriar_ForaDeFaixa_Falha(double lat, double lon, double raio)
+    {
+        bool ok = ConsultaProximidade.TentarCriar(
+            lat, lon, raio, null, Opcoes, out ConsultaProximidade? consulta, out ProblemDetails? erro);
+
+        ok.Should().BeFalse();
+        consulta.Should().BeNull();
+        erro!.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact(DisplayName = "CA-04: lat/long/raio NaN ou infinito retornam 400")]
+    public void TentarCriar_NaoFinito_Falha()
+    {
+        ConsultaProximidade.TentarCriar(double.NaN, 0, 10, null, Opcoes, out _, out ProblemDetails? eLat)
+            .Should().BeFalse();
+        eLat!.Status.Should().Be(StatusCodes.Status400BadRequest);
+
+        ConsultaProximidade.TentarCriar(0, double.PositiveInfinity, 10, null, Opcoes, out _, out _)
+            .Should().BeFalse();
+        ConsultaProximidade.TentarCriar(0, 0, double.PositiveInfinity, null, Opcoes, out _, out _)
+            .Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "CA-04/CA-06: limit <= 0 é inválido (400), não é silenciado por clamp")]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void TentarCriar_LimitInvalido_Falha(int limit)
+    {
+        bool ok = ConsultaProximidade.TentarCriar(
+            0, 0, 10, limit, Opcoes, out ConsultaProximidade? consulta, out ProblemDetails? erro);
+
+        ok.Should().BeFalse();
+        consulta.Should().BeNull();
+        erro!.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact(DisplayName = "Boundaries de faixa (±90 lat, ±180 long, teto de raio) são aceitos")]
+    public void TentarCriar_Boundaries_Ok()
+    {
+        ConsultaProximidade.TentarCriar(90, 180, Opcoes.RaioMaxKm, null, Opcoes, out _, out _).Should().BeTrue();
+        ConsultaProximidade.TentarCriar(-90, -180, Opcoes.RaioMaxKm, null, Opcoes, out _, out _).Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Proximidade/ConsultaProximidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Proximidade/ConsultaProximidadeTests.cs
@@ -112,4 +112,29 @@ public sealed class ConsultaProximidadeTests
         ConsultaProximidade.TentarCriar(90, 180, Opcoes.RaioMaxKm, null, Opcoes, out _, out _).Should().BeTrue();
         ConsultaProximidade.TentarCriar(-90, -180, Opcoes.RaioMaxKm, null, Opcoes, out _, out _).Should().BeTrue();
     }
+
+    [Fact(DisplayName = "Options: defaults são válidos (validação fail-fast no boot)")]
+    public void Options_Defaults_SaoValidos()
+    {
+        new GeoProximidadeOptions().LimitesValidos().Should().BeTrue();
+    }
+
+    // Parâmetros: (raioMaxKm, limitPadrao, limitMax).
+    [Theory(DisplayName = "Options: configuração inválida é rejeitada (RaioMaxKm/LimitMax/LimitPadrao)")]
+    [InlineData(0, 50, 200)]      // RaioMaxKm = 0
+    [InlineData(-1, 50, 200)]     // RaioMaxKm < 0
+    [InlineData(500, 50, 0)]      // LimitMax < 1
+    [InlineData(500, 0, 200)]     // LimitPadrao < 1
+    [InlineData(500, 300, 200)]   // LimitPadrao > LimitMax
+    public void Options_Invalida_Rejeitada(double raioMaxKm, int limitPadrao, int limitMax)
+    {
+        GeoProximidadeOptions opcoes = new()
+        {
+            RaioMaxKm = raioMaxKm,
+            LimitPadrao = limitPadrao,
+            LimitMax = limitMax,
+        };
+
+        opcoes.LimitesValidos().Should().BeFalse();
+    }
 }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Proximidade/GeoProximidadeReaderSqlTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Proximidade/GeoProximidadeReaderSqlTests.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Proximidade;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using NetTopologySuite.Geometries;
+
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Teste de tradução EF Core/Npgsql (CA-02): prova que o filtro de raio vira
+/// <c>ST_DWithin</c> (index-friendly, usa o índice GIST) e a ordenação vira
+/// <c>ST_Distance</c>. Espelha a consulta de <c>GeoProximidadeReader</c> e inspeciona
+/// o SQL via <c>ToQueryString()</c> — sem executar contra o banco.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class GeoProximidadeReaderSqlTests
+{
+    private readonly GeoPostgisFixture _fixture;
+
+    public GeoProximidadeReaderSqlTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-02: filtro de raio usa ST_DWithin (GIST) no WHERE; ordenação usa ST_Distance")]
+    public async Task ProximidadeQuery_TraduzParaStDWithinNoFiltroEStDistanceNaOrdenacao()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+
+        Point ponto = new(-49.13, -5.35) { SRID = 4326 };
+        const double raioMetros = 100 * 1000.0;
+
+        // Espelha GeoProximidadeReader.BuscarCidadesProximasAsync.
+        var consulta = ctx.Cidades
+            .AsNoTracking()
+            .Where(c => c.Vigente
+                     && c.Coordenada != null
+                     && c.Latitude != null
+                     && c.Longitude != null
+                     && c.Coordenada.IsWithinDistance(ponto, raioMetros))
+            .OrderBy(c => c.Coordenada!.Distance(ponto))
+            .ThenBy(c => c.Id)
+            .Select(c => new { c.Id, Distancia = c.Coordenada!.Distance(ponto) });
+
+        string sql = consulta.ToQueryString();
+
+        // Isola o predicado de filtragem (WHERE … ORDER BY): deve usar ST_DWithin
+        // (index-friendly, GIST) e NÃO ST_Distance (a projeção/ordenação é que usa
+        // ST_Distance, não o filtro de raio).
+        int idxWhere = sql.IndexOf("WHERE", StringComparison.Ordinal);
+        int idxOrderBy = sql.IndexOf("ORDER BY", StringComparison.Ordinal);
+        idxWhere.Should().BeGreaterThanOrEqualTo(0);
+        idxOrderBy.Should().BeGreaterThan(idxWhere);
+        string whereClause = sql[idxWhere..idxOrderBy];
+        whereClause.Should().Contain("ST_DWithin", "o filtro de raio deve usar ST_DWithin (índice GIST)");
+        whereClause.Should().NotContain("ST_Distance", "o filtro NÃO deve usar ST_Distance no WHERE");
+
+        // ST_Distance aparece na ordenação por distância.
+        string orderByClause = sql[idxOrderBy..];
+        orderByClause.Should().Contain("ST_Distance", "a ordenação por distância deve usar ST_Distance");
+    }
+}


### PR DESCRIPTION
## Contexto

Estreia a **consulta geoespacial** do módulo Geo ([ADR-0091](docs/adrs/0091-postgis-georreferencia-nts.md)): dois endpoints `[AllowAnonymous]` de reference data que, dado um ponto (lat/long) e um raio, devolvem as entidades dentro do raio ordenadas por distância crescente (top-N).

- `GET /api/cidades/proximas?lat=&long=&raioKm=&limit=` — cidades a até `raioKm` do ponto.
- `GET /api/logradouros/proximos?lat=&long=&raioKm=&limit=` — logradouros a até `raioKm` do ponto (com cidade enriquecida via join).

Habilita, no futuro, o cálculo candidato → polo do ensalamento e relatórios geográficos — sem que os módulos consumidores reimplementem geometria. Esta entrega só prova o wiring PostGIS e o contrato genérico.

## Decisões

- **PostGIS/NTS:** filtro por `ST_DWithin` sobre `geography` (index-friendly, usa o índice GIST da coordenada); ordenação por `ST_Distance` (metros sobre o esferoide). Ponto construído como `Point(longitude, latitude)` (X=long, Y=lat) — invertê-los é silenciosamente errado e está selado por teste (CA-08).
- **Sem cursor:** é *ranking* por distância, não keyset por `Id` — ADR-0026/0089 não se aplicam (sem `prev`/`next`).
- **Exclusão robusta:** registros sem coordenada — ou com coordenada mas `latitude`/`longitude` nulas — são excluídos (o DTO expõe lat/long como `decimal` não nulo).
- **Validação no boundary** (`ConsultaProximidade`, ADR-0031): `lat ∈ [-90,90]`, `long ∈ [-180,180]`, `raioKm` finito, `> 0` e `≤` teto; ausência/fora de faixa → 400. `limit ≤ 0` → 400; acima do teto → trunca.
- **Limites configuráveis** via seção `Geo:Proximidade` (`GeoProximidadeOptions`: teto de raio 500 km, default 50, teto 200), com defaults.
- **HATEOAS** ([ADR-0029](docs/adrs/0029-hateoas-level-1-links.md)): `_links.cidade` (e `_links.cep` no logradouro). **Vendor MIME** ([ADR-0031]): `cidade-proxima`/`logradouro-proximo` v1; 406 se incompatível.

## Critérios de aceite (#678)

- [x] **CA-01** raio + ordenação por distância + `DistanciaKm` + `_links`
- [x] **CA-02** filtro traduz para `ST_DWithin` (GIST) no WHERE, `ST_Distance` na ordenação (via `ToQueryString`)
- [x] **CA-03** logradouros próximos + `_links.cep` + cidade do join
- [x] **CA-04** validação de lat/long/raio (ausente, fora de faixa, não finito) → 400 (unit + integração)
- [x] **CA-05** registro sem coordenada (e com coordenada mas lat/long nulos) não aparece
- [x] **CA-06** raio sem resultados → 200 lista vazia; `limit` respeita default e teto
- [x] **CA-07** vendor MIME incompatível → 406
- [x] **CA-08** ordem `Point(long,lat)` (inverter muda o resultado) + precisão `decimal(9,6)`

## Testes

- 16 testes novos: integração contra PostGIS (Testcontainers), tradução SQL e validação unitária do boundary.
- **Suíte Geo: 249/249** verde **com e sem Redis** (`docker stop docker-redis-1`), 0 warnings (`TreatWarningsAsErrors`).
- Baseline OpenAPI regenerada ([ADR-0030](docs/adrs/0030-openapi-3-1-contract-first-microsoft-aspnetcore-openapi.md), `contracts/openapi.geo.json`).

## Notas de revisão

- Plano revisado antes da implementação (sem bloqueadores); aplicados os ajustes apontados: guard de `latitude/longitude != null` no reader, `GeoProximidadeOptions` configurável, teste de `ToQueryString` no nível de reader/infra (`ST_DWithin` + `ST_Distance`), binding `[FromQuery(Name="long")]`.
- Sem mudança em arquivos compartilhados (`shared/`/kernel) — impacto isolado ao módulo Geo.

Closes #678
Refs #665
Refs #661