### PR TITLE
Endurecimento do lookup de CEP (teto de fan-out, memoização do selo, índice de range)

### DIFF
--- a/docs/adrs/0093-rate-limiting-na-borda-para-reference-data-publico.md
+++ b/docs/adrs/0093-rate-limiting-na-borda-para-reference-data-publico.md
@@ -1,0 +1,82 @@
+---
+status: "accepted"
+date: "2026-06-19"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted: []
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0093: Rate-limiting de endpoints públicos de reference data na borda, não no app
+
+## Contexto e enunciado do problema
+
+O módulo `Geo` ([ADR-0090](0090-modulo-geo-localidades.md)) expõe endpoints de consulta de reference data marcados `[AllowAnonymous]` — lookup de CEP (`GET /api/cep/{cep}`), listagens de estados/cidades, hierarquia/autocomplete e proximidade. São dados públicos (IBGE/DNE), sem autenticação, e o lookup de CEP em particular tem um **caminho frio** (cache miss / Redis fora) que encadeia consultas sobre as tabelas de faixa.
+
+Mesmo com o cache-aside por selo de versão ([#674], memoizado em processo por [#703]) e o índice de range do caminho frio ([#704]), um endpoint anônimo é alvo natural de tráfego volumétrico/abuso. A pergunta é **onde** aplicar o controle de taxa (rate-limiting): no próprio aplicativo (middleware `RateLimiter` do ASP.NET Core, por endpoint/módulo) ou na **borda** (gateway de ingresso, ex.: Traefik), e se o controle no app deve entrar já.
+
+## Drivers da decisão
+
+- **Preocupação transversal** — rate-limiting de endpoints anônimos vale para todos os módulos, não só o `Geo`; aplicá-lo por módulo gera divergência de política.
+- **Ingresso único** — todo tráfego externo passa pelo gateway, que já termina TLS e roteia; é o ponto natural para política uniforme.
+- **Defesa em profundidade** — o índice de range ([#704]) e o cache ([#674]/[#703]) já amortecem a pressão no banco; o limitador é a camada contra abuso volumétrico, não a única defesa.
+- **Simplicidade do app** — manter o app focado em lógica de domínio, sem política operacional de taxa espalhada em cada API.
+- **Reversibilidade** — não fechar a porta para um limitador no app caso políticas por endpoint (ex.: token bucket por IP atrelado à identidade) se tornem necessárias.
+
+## Opções consideradas
+
+- **A**: Rate-limiting no app (ASP.NET Core `AddRateLimiter`), por endpoint/módulo.
+- **B**: **Rate-limiting na borda (gateway/Traefik)**; controle no app adiado.
+- **C**: Ambos (borda + app) desde já.
+
+## Resultado da decisão
+
+**Escolhida:** "B — rate-limiting na borda (gateway), controle no app adiado", porque o controle de taxa de endpoints anônimos é uma preocupação transversal de infraestrutura, mais bem aplicada de forma uniforme no ingresso único do que replicada e divergente em cada módulo.
+
+A política de taxa (limite, burst, granularidade por IP) vive na configuração do gateway (Traefik), no repositório de infraestrutura, e cobre uniformemente os endpoints `[AllowAnonymous]` de reference data de todos os módulos. O caminho frio do lookup de CEP permanece protegido em profundidade pelo índice de range ([#704]) e pelo cache por selo ([#674]/[#703]). O limitador no app fica **disponível como escalonamento futuro** — se surgir necessidade de política por endpoint que o gateway não exprima bem (ex.: cota atrelada à identidade autenticada), entra com a sua própria ADR. Os controllers afetados carregam um comentário apontando para esta decisão.
+
+## Consequências
+
+### Positivas
+
+- Política única e uniforme no ingresso, sem deriva por módulo.
+- App focado em domínio, sem configuração operacional de taxa.
+- Coerente com a topologia de gateway já adotada no ambiente.
+
+### Negativas
+
+- Depende de o gateway estar corretamente configurado e de o tráfego não alcançar os pods diretamente (mitigado por política de rede; pods não são expostos diretamente).
+- A política de taxa não é visível no código do app — mitigado por esta ADR e pelo comentário-ponteiro nos controllers.
+
+### Neutras
+
+- Os valores concretos da middleware de taxa do Traefik (rate, burst) são parâmetro operacional no repositório de infraestrutura, fora do escopo desta ADR.
+
+## Confirmação
+
+- Comentário em `CepController` (e demais controllers anônimos do `Geo`, conforme evoluírem) apontando para esta ADR.
+- A configuração de taxa do gateway materializa a política; um escalonamento para limitador no app adicionaria `AddRateLimiter` com ADR própria.
+
+## Prós e contras das opções
+
+### A — rate-limiting no app
+
+- Bom, porque a política fica versionada junto do código e pode ser fina por endpoint.
+- Ruim, porque replica configuração transversal em cada módulo, com risco de divergência, e mistura preocupação operacional com domínio.
+
+### B — rate-limiting na borda (escolhida)
+
+- Bom, porque aplica política uniforme no ingresso único, mantém o app simples e cobre todos os módulos de uma vez.
+- Ruim, porque a política não é visível no código do app e depende da configuração correta do gateway.
+
+### C — ambos desde já
+
+- Bom, porque soma defesa em profundidade.
+- Ruim, porque adiciona complexidade no app antes de haver necessidade comprovada de política por endpoint — contraria o princípio de só introduzir o controle no app quando o gateway não bastar.
+
+## Mais informações
+
+- Aplica-se aos endpoints `[AllowAnonymous]` de reference data do módulo `Geo` ([ADR-0090](0090-modulo-geo-localidades.md)).
+- Mitigações de caminho frio do lookup de CEP: índice de range das faixas (#704), cache-aside por selo de versão (#674) e memoização do selo em processo (#703).
+- Origem: revisão do PR #701 (Story #676 — API de lookup de CEP).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -121,12 +121,13 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0090](0090-modulo-geo-localidades.md) | Módulo Geo como bounded context dedicado de localidades | accepted | 2026-06-17 |
 | [0091](0091-postgis-georreferencia-nts.md) | PostGIS e NetTopologySuite como mecanismo de georreferência | accepted | 2026-06-17 |
 | [0092](0092-etl-carga-dne-reference-data.md) | Reference data do Geo sem soft-delete, recarregado por upsert | accepted | 2026-06-17 |
+| [0093](0093-rate-limiting-na-borda-para-reference-data-publico.md) | Rate-limiting de endpoints públicos de reference data na borda (gateway), não no app | accepted | 2026-06-19 |
 
-> **Nota de numeração:** a `0077` (identidade de `Unidade`) foi **publicada** — a sequência de `0001` a `0092` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0093+`.
+> **Nota de numeração:** a `0077` (identidade de `Unidade`) foi **publicada** — a sequência de `0001` a `0093` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0094+`.
 
 ## Como adicionar um novo ADR
 
-1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0092`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
+1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0093`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
 2. Copie [`_template.md`](_template.md).
 3. Renomeie para `NNNN-titulo-em-slug.md` (slug ASCII em minúsculas, hífens como separador).
 4. Preencha frontmatter, contexto, drivers, opções, resultado da decisão (única), consequências.

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/CepController.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Controllers/CepController.cs
@@ -18,6 +18,11 @@ using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 /// um endereço estruturado (logradouro/faixa/grande usuário). CEP é dado estável →
 /// cache Redis com TTL longo (cache-aside no resolver). Ver ADR-0090.
 /// </summary>
+/// <remarks>
+/// Rate-limiting deste endpoint anônimo é aplicado na <strong>borda</strong>
+/// (gateway/Traefik), não no app — defesa em profundidade uniforme para todos os
+/// endpoints públicos de reference data; controle no app fica adiado (ADR-0093).
+/// </remarks>
 [ApiController]
 [Route("api")]
 [SuppressMessage(

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
@@ -107,6 +107,9 @@ builder.Services.AddOptions<GeoProximidadeOptions>()
 // TTL configurável do cache-aside de CEP (#676) — default 24h (GeoCepCacheOptions).
 builder.Services.Configure<GeoCepCacheOptions>(
     builder.Configuration.GetSection(GeoCepCacheOptions.SectionName));
+// Teto de fan-out de logradouros do reader de CEP (#705) — default 50 (GeoCepLookupOptions).
+builder.Services.Configure<GeoCepLookupOptions>(
+    builder.Configuration.GetSection(GeoCepLookupOptions.SectionName));
 
 // Migrations EF Core aplicadas no host StartAsync via IHostedService.
 // Registrado ANTES de UseWolverineOutboxCascading + AddWolverineMessaging

--- a/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.API/Program.cs
@@ -104,7 +104,8 @@ builder.Services.AddOptions<GeoProximidadeOptions>()
         "Geo:Proximidade — RaioMaxKm > 0, LimitMax >= 1 e 1 <= LimitPadrao <= LimitMax.")
     .ValidateOnStart();
 
-// TTL configurável do cache-aside de CEP (#676) — default 24h (GeoCepCacheOptions).
+// TTL configurável do cache-aside de CEP (#676) — default 24h; também a memoização
+// em processo do selo de versão (#703, SeloTtl default 15s). Ambos em GeoCepCacheOptions.
 builder.Services.Configure<GeoCepCacheOptions>(
     builder.Configuration.GetSection(GeoCepCacheOptions.SectionName));
 // Teto de fan-out de logradouros do reader de CEP (#705) — default 50 (GeoCepLookupOptions).

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/CepResolver.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/CepResolver.cs
@@ -2,6 +2,7 @@ namespace Unifesspa.UniPlus.Geo.Infrastructure.Cep;
 
 using System.Diagnostics.CodeAnalysis;
 
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -31,24 +32,38 @@ using Unifesspa.UniPlus.Infrastructure.Core.Caching;
     Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
 internal sealed partial class CepResolver : ICepResolver
 {
+    // Chave da memoização em processo do selo de versão vigente (#703). Única (um selo
+    // global por instância de cache em memória), distinta das chaves de CEP do Redis.
+    private const string ChaveMemoSelo = "geo:cep:selo-vigente-memo";
+
     private readonly Lazy<ICacheService> _cache;
     private readonly ICepReader _reader;
+    private readonly IMemoryCache _memoria;
+    private readonly TimeProvider _relogio;
     private readonly TimeSpan _ttl;
+    private readonly TimeSpan _seloTtl;
     private readonly ILogger<CepResolver> _logger;
 
     public CepResolver(
         Lazy<ICacheService> cache,
         ICepReader reader,
+        IMemoryCache memoria,
+        TimeProvider relogio,
         IOptions<GeoCepCacheOptions> opcoes,
         ILogger<CepResolver> logger)
     {
         ArgumentNullException.ThrowIfNull(cache);
         ArgumentNullException.ThrowIfNull(reader);
+        ArgumentNullException.ThrowIfNull(memoria);
+        ArgumentNullException.ThrowIfNull(relogio);
         ArgumentNullException.ThrowIfNull(opcoes);
         ArgumentNullException.ThrowIfNull(logger);
         _cache = cache;
         _reader = reader;
+        _memoria = memoria;
+        _relogio = relogio;
         _ttl = opcoes.Value.Ttl;
+        _seloTtl = opcoes.Value.SeloTtl;
         _logger = logger;
     }
 
@@ -100,17 +115,50 @@ internal sealed partial class CepResolver : ICepResolver
         }
     }
 
-    // Lê o selo de versão vigente e compõe a chave versionada. Sem selo (ETL ainda
+    // Compõe a chave versionada a partir do selo de versão vigente. Sem selo (ETL ainda
     // não selou) → null: não há chave determinística, segue direto ao banco sem cachear.
     private async Task<string?> ResolverChaveAsync(ICacheService cache, string cep, CancellationToken cancellationToken)
     {
+        string? selo = await ObterSeloVigenteAsync(cache, cancellationToken).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(selo) ? null : $"geo:cep:v{selo}:{cep}";
+    }
+
+    // Memoiza o selo em processo (IMemoryCache) por uma janela curta (SeloTtl, #703): o
+    // selo só muda em re-selagem do ETL (#674), então no hot path o lookup faz 1
+    // round-trip ao Redis (a entrada) em vez de 2 (selo + entrada). A expiração é
+    // governada pelo TimeProvider injetado (testável); a expiração do IMemoryCache é a
+    // rede de segurança contra leak de memória. Só um selo presente é memoizado — a
+    // ausência (bootstrap antes da 1ª selagem) é relida a cada request até selar.
+    private async Task<string?> ObterSeloVigenteAsync(ICacheService cache, CancellationToken cancellationToken)
+    {
+        DateTimeOffset agora = _relogio.GetUtcNow();
+        if (_memoria.TryGetValue(ChaveMemoSelo, out SeloMemoizado? memo)
+            && memo is not null
+            && agora < memo.ExpiraEm)
+        {
+            return memo.Valor;
+        }
+
+        string? selo = await LerSeloDoCacheAsync(cache, cancellationToken).ConfigureAwait(false);
+
+        if (_seloTtl > TimeSpan.Zero && !string.IsNullOrWhiteSpace(selo))
+        {
+            _memoria.Set(
+                ChaveMemoSelo,
+                new SeloMemoizado(selo, agora + _seloTtl),
+                new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = _seloTtl });
+        }
+
+        return selo;
+    }
+
+    private async Task<string?> LerSeloDoCacheAsync(ICacheService cache, CancellationToken cancellationToken)
+    {
         try
         {
-            string? selo = await cache
+            return await cache
                 .ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, cancellationToken)
                 .ConfigureAwait(false);
-
-            return string.IsNullOrWhiteSpace(selo) ? null : $"geo:cep:v{selo}:{cep}";
         }
         catch (Exception excecao) when (excecao is not OperationCanceledException)
         {
@@ -118,6 +166,9 @@ internal sealed partial class CepResolver : ICepResolver
             return null;
         }
     }
+
+    // Selo memoizado + instante de expiração (governado pelo TimeProvider).
+    private sealed record SeloMemoizado(string Valor, DateTimeOffset ExpiraEm);
 
     private async Task<CepResolvidoDto?> TentarLerCacheAsync(ICacheService cache, string chave, CancellationToken cancellationToken)
     {

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/GeoCepCacheOptions.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/GeoCepCacheOptions.cs
@@ -12,4 +12,14 @@ public sealed class GeoCepCacheOptions
 
     /// <summary>TTL das entradas <c>geo:cep:v{versao}:{cep}</c> no Redis (default 24h).</summary>
     public TimeSpan Ttl { get; init; } = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// TTL da memoização em processo do selo de versão vigente (#703, default 15s). O
+    /// selo só muda em re-selagem do ETL (#674), evento raríssimo, então memoizá-lo
+    /// reduz o hot path (cache hit) de 2 round-trips ao Redis (selo + entrada) para 1
+    /// (só a entrada). Janela de staleness: após uma re-selagem, a versão anterior do
+    /// cache pode ser servida por até este TTL. <c>TimeSpan.Zero</c> (ou negativo)
+    /// desliga a memoização — o selo é relido a cada request.
+    /// </summary>
+    public TimeSpan SeloTtl { get; init; } = TimeSpan.FromSeconds(15);
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/GeoCepLookupOptions.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Cep/GeoCepLookupOptions.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Cep;
+
+/// <summary>
+/// Opções do reader do lookup de CEP (cascata determinística, ADR-0090). Separadas
+/// do <see cref="GeoCepCacheOptions"/> (cache-aside) por serem comportamento de
+/// leitura do banco, não de cache.
+/// </summary>
+public sealed class GeoCepLookupOptions
+{
+    public const string SectionName = "Geo:Cep:Lookup";
+
+    /// <summary>
+    /// Teto de logradouros materializados por CEP (#705). Um CEP tem cardinalidade
+    /// baixa de logradouros na prática — só interessam o primário + alternativos —,
+    /// mas um CEP patológico (anomalia da fonte DNE) materializaria todas as linhas
+    /// num endpoint <c>[AllowAnonymous]</c>, risco de memória/payload. O teto corta a
+    /// materialização; atingi-lo é logado como aviso (não mascara a anomalia).
+    /// Default 50. Valores &lt; 1 são tratados como 1 pelo reader (defensivo).
+    /// </summary>
+    public int MaxLogradourosPorCep { get; init; } = 50;
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -65,6 +65,9 @@ public static class GeoInfrastructureRegistration
         services.AddOptions<GeoCepCacheOptions>();
         services.AddOptions<GeoCepLookupOptions>();
         services.AddScoped(sp => new Lazy<ICacheService>(sp.GetRequiredService<ICacheService>));
+        // Memoização em processo do selo de versão vigente do cache de CEP (#703):
+        // 1 round-trip ao Redis no hot path em vez de 2. AddMemoryCache é idempotente.
+        services.AddMemoryCache();
 
         // ETL DNE (ADR-0092) — serviços de carga de reference data. O gatilho (seed
         // dev / endpoint admin) e a fonte concreta de produção entram na Story #674.

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -63,6 +63,7 @@ public static class GeoInfrastructureRegistration
         services.AddScoped<ICepReader, CepReader>();
         services.AddScoped<ICepResolver, CepResolver>();
         services.AddOptions<GeoCepCacheOptions>();
+        services.AddOptions<GeoCepLookupOptions>();
         services.AddScoped(sp => new Lazy<ICacheService>(sp.GetRequiredService<ICacheService>));
 
         // ETL DNE (ADR-0092) — serviços de carga de reference data. O gatilho (seed

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/BairroFaixaCepConfiguration.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/BairroFaixaCepConfiguration.cs
@@ -38,6 +38,12 @@ internal sealed class BairroFaixaCepConfiguration : IEntityTypeConfiguration<Bai
             .IsUnique()
             .HasDatabaseName("ix_bairro_faixa_cep_natural");
 
+        // Índice de range parcial para o caminho frio do lookup de CEP (#704) — ver
+        // CidadeFaixaCepConfiguration. B-tree (cep_inicial, cep_final) só sobre vigentes.
+        builder.HasIndex(f => new { f.CepInicial, f.CepFinal })
+            .HasFilter("vigente")
+            .HasDatabaseName("ix_bairro_faixa_cep_range");
+
         builder.ConfigurarProveniencia(f => f.VersaoDataset, f => f.Vigente);
         builder.HasIndex(f => f.VersaoDataset)
             .HasDatabaseName("ix_bairro_faixa_cep_versao_dataset");

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/CidadeFaixaCepConfiguration.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/CidadeFaixaCepConfiguration.cs
@@ -41,6 +41,14 @@ internal sealed class CidadeFaixaCepConfiguration : IEntityTypeConfiguration<Cid
             .IsUnique()
             .HasDatabaseName("ix_cidade_faixa_cep_natural");
 
+        // Índice de range parcial para o caminho frio do lookup de CEP (#704): o
+        // predicado global por CEP (cep_inicial <= @cep AND cep_final >= @cep) não casa
+        // com o índice natural parent-first (cidade_id à esquerda). B-tree
+        // (cep_inicial, cep_final) só sobre linhas vigentes — o lookup filtra vigente.
+        builder.HasIndex(f => new { f.CepInicial, f.CepFinal })
+            .HasFilter("vigente")
+            .HasDatabaseName("ix_cidade_faixa_cep_range");
+
         builder.ConfigurarProveniencia(f => f.VersaoDataset, f => f.Vigente);
         builder.HasIndex(f => f.VersaoDataset)
             .HasDatabaseName("ix_cidade_faixa_cep_versao_dataset");

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/DistritoFaixaCepConfiguration.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Configurations/DistritoFaixaCepConfiguration.cs
@@ -38,6 +38,12 @@ internal sealed class DistritoFaixaCepConfiguration : IEntityTypeConfiguration<D
             .IsUnique()
             .HasDatabaseName("ix_distrito_faixa_cep_natural");
 
+        // Índice de range parcial para o caminho frio do lookup de CEP (#704) — ver
+        // CidadeFaixaCepConfiguration. B-tree (cep_inicial, cep_final) só sobre vigentes.
+        builder.HasIndex(f => new { f.CepInicial, f.CepFinal })
+            .HasFilter("vigente")
+            .HasDatabaseName("ix_distrito_faixa_cep_range");
+
         builder.ConfigurarProveniencia(f => f.VersaoDataset, f => f.Vigente);
         builder.HasIndex(f => f.VersaoDataset)
             .HasDatabaseName("ix_distrito_faixa_cep_versao_dataset");

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Migrations/20260619184905_AddFaixaCepRangeIndex.Designer.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Migrations/20260619184905_AddFaixaCepRangeIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeoDbContext))]
-    partial class GeoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260619184905_AddFaixaCepRangeIndex")]
+    partial class AddFaixaCepRangeIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Migrations/20260619184905_AddFaixaCepRangeIndex.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Migrations/20260619184905_AddFaixaCepRangeIndex.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFaixaCepRangeIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_distrito_faixa_cep_range",
+                table: "distrito_faixa_cep",
+                columns: new[] { "cep_inicial", "cep_final" },
+                filter: "vigente");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_cidade_faixa_cep_range",
+                table: "cidade_faixa_cep",
+                columns: new[] { "cep_inicial", "cep_final" },
+                filter: "vigente");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_bairro_faixa_cep_range",
+                table: "bairro_faixa_cep",
+                columns: new[] { "cep_inicial", "cep_final" },
+                filter: "vigente");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_distrito_faixa_cep_range",
+                table: "distrito_faixa_cep");
+
+            migrationBuilder.DropIndex(
+                name: "ix_cidade_faixa_cep_range",
+                table: "cidade_faixa_cep");
+
+            migrationBuilder.DropIndex(
+                name: "ix_bairro_faixa_cep_range",
+                table: "bairro_faixa_cep");
+        }
+    }
+}

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CepReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CepReader.cs
@@ -3,9 +3,12 @@ namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
 using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 using Unifesspa.UniPlus.Geo.Application.Abstractions;
 using Unifesspa.UniPlus.Geo.Application.DTOs;
+using Unifesspa.UniPlus.Geo.Infrastructure.Cep;
 
 /// <summary>
 /// Resolve um CEP pela cascata determinística (ADR-0090) sobre o
@@ -21,14 +24,21 @@ using Unifesspa.UniPlus.Geo.Application.DTOs;
     "Performance",
     "CA1812:Avoid uninstantiated internal classes",
     Justification = "Instanciada via DI em GeoInfrastructureRegistration.")]
-internal sealed class CepReader : ICepReader
+internal sealed partial class CepReader : ICepReader
 {
     private readonly GeoDbContext _dbContext;
+    private readonly int _tetoLogradouros;
+    private readonly ILogger<CepReader> _logger;
 
-    public CepReader(GeoDbContext dbContext)
+    public CepReader(GeoDbContext dbContext, IOptions<GeoCepLookupOptions> opcoes, ILogger<CepReader> logger)
     {
         ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(opcoes);
+        ArgumentNullException.ThrowIfNull(logger);
         _dbContext = dbContext;
+        // Teto < 1 esvaziaria o lookup (Take(0) → null para CEP válido); clamp defensivo.
+        _tetoLogradouros = Math.Max(1, opcoes.Value.MaxLogradourosPorCep);
+        _logger = logger;
     }
 
     public async Task<CepResolvidoDto?> ResolverAsync(string cep, CancellationToken cancellationToken)
@@ -40,9 +50,12 @@ internal sealed class CepReader : ICepReader
             ?? await ResolverPorFaixaAsync(cep, cancellationToken).ConfigureAwait(false);
     }
 
-    // (1) Logradouro pelo CEP. CEP não é único: retorna TODOS, ordenados pela chave de
-    // desempate estável (nome_normalizado, distrito_id, bairro_id, Id) — o Id (Guid v7)
-    // é o tie-breaker final, garantindo o mesmo primário/ordem entre execuções.
+    // (1) Logradouro pelo CEP. CEP não é único: retorna os logradouros ordenados pela
+    // chave de desempate estável (nome_normalizado, distrito_id, bairro_id, Id) — o Id
+    // (Guid v7) é o tie-breaker final, garantindo o mesmo primário/ordem entre execuções.
+    // A materialização é limitada ao teto defensivo (#705): um CEP patológico (anomalia
+    // da fonte) não materializa milhares de linhas num endpoint anônimo. Probe n+1 para
+    // distinguir truncamento real de cardinalidade igual ao teto.
     private async Task<CepResolvidoDto?> ResolverPorLogradouroAsync(string cep, CancellationToken cancellationToken)
     {
         List<CepLogradouroLinha> linhas = await (
@@ -66,12 +79,20 @@ internal sealed class CepReader : ICepReader
                     .Where(b => b.Vigente && b.Id == l.BairroId)
                     .Select(b => (string?)b.Nome)
                     .FirstOrDefault()))
+            .Take(_tetoLogradouros + 1)
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
         if (linhas.Count == 0)
         {
             return null;
+        }
+
+        // Probe excedeu o teto → trunca o extra e sinaliza (não mascara a anomalia).
+        if (linhas.Count > _tetoLogradouros)
+        {
+            linhas.RemoveAt(linhas.Count - 1);
+            LogFanOutTruncado(_logger, cep, _tetoLogradouros);
         }
 
         CepLogradouroLinha primario = linhas[0];
@@ -254,4 +275,9 @@ internal sealed class CepReader : ICepReader
         string Uf,
         decimal? Latitude,
         decimal? Longitude);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Geo: lookup de CEP {Cep} truncou o fan-out de logradouros no teto de {Teto} — possível anomalia da fonte DNE.")]
+    private static partial void LogFanOutTruncado(ILogger logger, string cep, int teto);
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CepReader.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Readers/CepReader.cs
@@ -20,6 +20,21 @@ using Unifesspa.UniPlus.Geo.Infrastructure.Cep;
 /// <item>nada casa → <see langword="null"/> (404 no controller).</item>
 /// </list>
 /// </summary>
+/// <remarks>
+/// <para><strong>Invariante 8 dígitos zero-padded (#704):</strong> o predicado de range
+/// das faixas (<c>cep_inicial &lt;= @cep AND cep_final &gt;= @cep</c>) usa a comparação
+/// lexicográfica de string nativa do Postgres. Ela só equivale à comparação
+/// <em>numérica</em> de CEP porque os três lados (o CEP de entrada e os limites das
+/// faixas) são <strong>exatamente 8 dígitos com zero à esquerda</strong>. Para o CEP de
+/// entrada, isso é garantido por <c>CepValido</c> no boundary (ADR-0031); para os limites,
+/// pela carga do ETL (ADR-0092). Um CEP de comprimento diferente quebraria a ordenação
+/// lexicográfica (ex.: <c>"9" &gt; "10"</c>) — por isso o boundary é a única porta.</para>
+/// <para><strong>Dependência de nomes físicos:</strong> os <c>FromSqlInterpolated</c> das
+/// faixas fixam os nomes físicos de tabela/coluna (<c>cidade_faixa_cep</c>,
+/// <c>cep_inicial</c>, ...) em SQL cru — fora do alcance do mapeamento EF. Um rename de
+/// tabela/coluna no mapeamento <strong>quebra em runtime</strong>, sem aviso de
+/// compilação. Ao renomear, atualizar também estes literais.</para>
+/// </remarks>
 [SuppressMessage(
     "Performance",
     "CA1812:Avoid uninstantiated internal classes",

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CepEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Api/CepEndpointTests.cs
@@ -7,8 +7,14 @@ using System.Text.Json;
 
 using AwesomeAssertions;
 
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Geo.Application.DTOs;
 using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Cep;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Readers;
 using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
 
 /// <summary>
@@ -248,6 +254,61 @@ public sealed class CepEndpointTests
         resp200.StatusCode.Should().Be(HttpStatusCode.OK);
     }
 
+    [Fact(DisplayName = "#705: fan-out acima do teto trunca os logradouros e loga aviso, sem erro")]
+    public async Task Cep_FanOutAcimaDoTeto_TruncaELoga()
+    {
+        await SemearAsync();
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        FakeLogger<CepReader> logger = new();
+        // 01310100 tem 2 logradouros (CA-02); teto 1 força truncamento determinístico.
+        CepReader reader = new(
+            ctx,
+            Options.Create(new GeoCepLookupOptions { MaxLogradourosPorCep = 1 }),
+            logger);
+
+        CepResolvidoDto? resolvido = await reader.ResolverAsync("01310100", CancellationToken.None);
+
+        resolvido.Should().NotBeNull();
+        // Desempate estável: "alameda santos" < "avenida paulista" → primário Alameda Santos.
+        resolvido!.Logradouro.Should().Be("Alameda Santos");
+        resolvido.Alternativos.Should().BeEmpty("o teto 1 trunca o segundo logradouro");
+        logger.Entradas.Should().ContainSingle(e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact(DisplayName = "#705: fan-out abaixo do teto não trunca nem loga")]
+    public async Task Cep_FanOutAbaixoDoTeto_NaoTrunca()
+    {
+        await SemearAsync();
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        FakeLogger<CepReader> logger = new();
+        CepReader reader = new(
+            ctx,
+            Options.Create(new GeoCepLookupOptions { MaxLogradourosPorCep = 50 }),
+            logger);
+
+        CepResolvidoDto? resolvido = await reader.ResolverAsync("01310100", CancellationToken.None);
+
+        resolvido.Should().NotBeNull();
+        resolvido!.Alternativos.Should().ContainSingle("os 2 logradouros cabem no teto");
+        logger.Entradas.Should().NotContain(e => e.Level == LogLevel.Warning);
+    }
+
+    [Fact(DisplayName = "#705: teto < 1 é tratado como 1 (clamp defensivo), sem esvaziar o lookup")]
+    public async Task Cep_TetoInvalido_ClampParaUm()
+    {
+        await SemearAsync();
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        CepReader reader = new(
+            ctx,
+            Options.Create(new GeoCepLookupOptions { MaxLogradourosPorCep = 0 }),
+            new FakeLogger<CepReader>());
+
+        CepResolvidoDto? resolvido = await reader.ResolverAsync("01310100", CancellationToken.None);
+
+        resolvido.Should().NotBeNull("teto 0 seria Take(0) → null; o clamp para 1 preserva a resolução");
+        resolvido!.Logradouro.Should().Be("Alameda Santos");
+    }
+
     private async Task SemearAsync()
     {
         await GeoReferenceSeed.LimparAsync(_fixture);
@@ -310,5 +371,26 @@ public sealed class CepEndpointTests
         ctx.DistritoFaixasCep.Add(faixaNovaMaraba);
         ctx.CepGrandesUsuarios.Add(grandeUsuario);
         await ctx.SaveChangesAsync();
+    }
+
+    // Captura entradas de log para afirmar o aviso de truncamento (#705).
+    private sealed class FakeLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entradas { get; } = [];
+
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+            Entradas.Add((logLevel, formatter(state, exception)));
+        }
     }
 }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Cep/CepResolverTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Cep/CepResolverTests.cs
@@ -2,6 +2,7 @@ namespace Unifesspa.UniPlus.Geo.IntegrationTests.Cep;
 
 using AwesomeAssertions;
 
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -17,8 +18,9 @@ using Unifesspa.UniPlus.Infrastructure.Core.Caching;
 /// Testes de unidade do cache-aside do <see cref="CepResolver"/> (#676) — sem
 /// Redis/DB reais (substitutos NSubstitute). Provam o contrato que a integração não
 /// consegue afirmar com precisão: hit não toca o reader (CA-07), 404 nunca é
-/// cacheado (CA-08), a chave compõe-se com o selo de versão, e o lookup degrada
-/// para o banco quando o Redis está fora.
+/// cacheado (CA-08), a chave compõe-se com o selo de versão, o lookup degrada
+/// para o banco quando o Redis está fora, e a memoização do selo (#703) poupa
+/// round-trips ao Redis dentro do TTL.
 /// </summary>
 public sealed class CepResolverTests
 {
@@ -30,21 +32,35 @@ public sealed class CepResolverTests
         Cep, "Praça", "Praça da Sé", null, "Sé", null, "São Paulo", "3550308", "SP",
         -23.55m, -46.63m, CepResolucao.NivelLogradouro, CepResolucao.OrigemLogradouro);
 
-    private static CepResolver Criar(ICacheService cache, ICepReader reader) =>
-        new(new Lazy<ICacheService>(() => cache), reader, Options.Create(new GeoCepCacheOptions()), NullLogger<CepResolver>.Instance);
+    private static CepResolver Criar(
+        ICacheService cache,
+        ICepReader reader,
+        IMemoryCache memoria,
+        TimeProvider? relogio = null,
+        GeoCepCacheOptions? opcoes = null) =>
+        new(
+            new Lazy<ICacheService>(() => cache),
+            reader,
+            memoria,
+            relogio ?? TimeProvider.System,
+            Options.Create(opcoes ?? new GeoCepCacheOptions()),
+            NullLogger<CepResolver>.Instance);
+
+    private static MemoryCache NovaMemoria() => new(new MemoryCacheOptions());
 
     [Fact(DisplayName = "CA-07: cache hit devolve do Redis e não consulta o reader (banco)")]
     public async Task CacheHit_NaoConsultaReader()
     {
         ICacheService cache = Substitute.For<ICacheService>();
         ICepReader reader = Substitute.For<ICepReader>();
+        using MemoryCache memoria = NovaMemoria();
         CepResolvidoDto cacheado = Endereco();
         cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
             .Returns(Selo);
         cache.ObterAsync<CepResolvidoDto>(ChaveCep, Arg.Any<CancellationToken>())
             .Returns(cacheado);
 
-        CepResolvidoDto? resultado = await Criar(cache, reader).ResolverAsync(Cep, CancellationToken.None);
+        CepResolvidoDto? resultado = await Criar(cache, reader, memoria).ResolverAsync(Cep, CancellationToken.None);
 
         resultado.Should().Be(cacheado);
         await reader.DidNotReceive().ResolverAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
@@ -55,6 +71,7 @@ public sealed class CepResolverTests
     {
         ICacheService cache = Substitute.For<ICacheService>();
         ICepReader reader = Substitute.For<ICepReader>();
+        using MemoryCache memoria = NovaMemoria();
         CepResolvidoDto resolvido = Endereco();
         cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
             .Returns(Selo);
@@ -62,7 +79,7 @@ public sealed class CepResolverTests
             .Returns((CepResolvidoDto?)null);
         reader.ResolverAsync(Cep, Arg.Any<CancellationToken>()).Returns(resolvido);
 
-        CepResolvidoDto? resultado = await Criar(cache, reader).ResolverAsync(Cep, CancellationToken.None);
+        CepResolvidoDto? resultado = await Criar(cache, reader, memoria).ResolverAsync(Cep, CancellationToken.None);
 
         resultado.Should().Be(resolvido);
         await reader.Received(1).ResolverAsync(Cep, Arg.Any<CancellationToken>());
@@ -74,13 +91,14 @@ public sealed class CepResolverTests
     {
         ICacheService cache = Substitute.For<ICacheService>();
         ICepReader reader = Substitute.For<ICepReader>();
+        using MemoryCache memoria = NovaMemoria();
         cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
             .Returns(Selo);
         cache.ObterAsync<CepResolvidoDto>(ChaveCep, Arg.Any<CancellationToken>())
             .Returns((CepResolvidoDto?)null);
         reader.ResolverAsync(Cep, Arg.Any<CancellationToken>()).Returns((CepResolvidoDto?)null);
 
-        CepResolvidoDto? resultado = await Criar(cache, reader).ResolverAsync(Cep, CancellationToken.None);
+        CepResolvidoDto? resultado = await Criar(cache, reader, memoria).ResolverAsync(Cep, CancellationToken.None);
 
         resultado.Should().BeNull();
         await cache.DidNotReceive().DefinirAsync(Arg.Any<string>(), Arg.Any<CepResolvidoDto>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
@@ -90,12 +108,15 @@ public sealed class CepResolverTests
     public async Task CacheIndisponivel_DegradaParaBanco()
     {
         ICepReader reader = Substitute.For<ICepReader>();
+        using MemoryCache memoria = NovaMemoria();
         CepResolvidoDto resolvido = Endereco();
         reader.ResolverAsync(Cep, Arg.Any<CancellationToken>()).Returns(resolvido);
 
         // Lazy que lança ao resolver — simula o IConnectionMultiplexer.Connect falhando.
         Lazy<ICacheService> cacheQuebrado = new(() => throw new InvalidOperationException("Redis fora do ar"));
-        CepResolver resolver = new(cacheQuebrado, reader, Options.Create(new GeoCepCacheOptions()), NullLogger<CepResolver>.Instance);
+        CepResolver resolver = new(
+            cacheQuebrado, reader, memoria, TimeProvider.System,
+            Options.Create(new GeoCepCacheOptions()), NullLogger<CepResolver>.Instance);
 
         CepResolvidoDto? resultado = await resolver.ResolverAsync(Cep, CancellationToken.None);
 
@@ -108,16 +129,89 @@ public sealed class CepResolverTests
     {
         ICacheService cache = Substitute.For<ICacheService>();
         ICepReader reader = Substitute.For<ICepReader>();
+        using MemoryCache memoria = NovaMemoria();
         cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
             .Returns((string?)null);
         CepResolvidoDto resolvido = Endereco();
         reader.ResolverAsync(Cep, Arg.Any<CancellationToken>()).Returns(resolvido);
 
-        CepResolvidoDto? resultado = await Criar(cache, reader).ResolverAsync(Cep, CancellationToken.None);
+        CepResolvidoDto? resultado = await Criar(cache, reader, memoria).ResolverAsync(Cep, CancellationToken.None);
 
         resultado.Should().Be(resolvido);
         await reader.Received(1).ResolverAsync(Cep, Arg.Any<CancellationToken>());
         await cache.DidNotReceive().ObterAsync<CepResolvidoDto>(Arg.Any<string>(), Arg.Any<CancellationToken>());
         await cache.DidNotReceive().DefinirAsync(Arg.Any<string>(), Arg.Any<CepResolvidoDto>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "#703: 2º lookup dentro do TTL não relê o selo do Redis (memoização em processo)")]
+    public async Task SeloMemoizado_NaoReleDentroDoTtl()
+    {
+        ICacheService cache = Substitute.For<ICacheService>();
+        ICepReader reader = Substitute.For<ICepReader>();
+        using MemoryCache memoria = NovaMemoria();
+        MutableTimeProvider relogio = new();
+        cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
+            .Returns(Selo);
+        cache.ObterAsync<CepResolvidoDto>(ChaveCep, Arg.Any<CancellationToken>())
+            .Returns(Endereco());
+
+        // Dois resolvers compartilhando o IMemoryCache singleton (topologia produtiva:
+        // resolver scoped por request, cache em memória singleton).
+        await Criar(cache, reader, memoria, relogio).ResolverAsync(Cep, CancellationToken.None);
+        await Criar(cache, reader, memoria, relogio).ResolverAsync(Cep, CancellationToken.None);
+
+        await cache.Received(1)
+            .ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "#703: após a expiração do TTL o selo é relido do Redis")]
+    public async Task SeloMemoizado_ReleAposExpiracao()
+    {
+        ICacheService cache = Substitute.For<ICacheService>();
+        ICepReader reader = Substitute.For<ICepReader>();
+        using MemoryCache memoria = NovaMemoria();
+        MutableTimeProvider relogio = new();
+        GeoCepCacheOptions opcoes = new() { SeloTtl = TimeSpan.FromSeconds(15) };
+        cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
+            .Returns(Selo);
+        cache.ObterAsync<CepResolvidoDto>(ChaveCep, Arg.Any<CancellationToken>())
+            .Returns(Endereco());
+
+        await Criar(cache, reader, memoria, relogio, opcoes).ResolverAsync(Cep, CancellationToken.None);
+        relogio.Advance(TimeSpan.FromSeconds(20));
+        await Criar(cache, reader, memoria, relogio, opcoes).ResolverAsync(Cep, CancellationToken.None);
+
+        await cache.Received(2)
+            .ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "#703: SeloTtl = Zero desliga a memoização (relê a cada request)")]
+    public async Task SeloTtlZero_DesligaMemoizacao()
+    {
+        ICacheService cache = Substitute.For<ICacheService>();
+        ICepReader reader = Substitute.For<ICepReader>();
+        using MemoryCache memoria = NovaMemoria();
+        GeoCepCacheOptions opcoes = new() { SeloTtl = TimeSpan.Zero };
+        cache.ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>())
+            .Returns(Selo);
+        cache.ObterAsync<CepResolvidoDto>(ChaveCep, Arg.Any<CancellationToken>())
+            .Returns(Endereco());
+
+        await Criar(cache, reader, memoria, opcoes: opcoes).ResolverAsync(Cep, CancellationToken.None);
+        await Criar(cache, reader, memoria, opcoes: opcoes).ResolverAsync(Cep, CancellationToken.None);
+
+        await cache.Received(2)
+            .ObterAsync<string>(RedisGeoCepCacheInvalidador.ChaveSeloVersaoVigente, Arg.Any<CancellationToken>());
+    }
+
+    // TimeProvider mutável para exercitar a expiração do TTL de memoização sem esperar
+    // tempo real (espelha o helper de CursorEncoderTests).
+    private sealed class MutableTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now = new(2026, 6, 19, 12, 0, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan span) => _now = _now.Add(span);
     }
 }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/GeoSchemaDdlTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/GeoSchemaDdlTests.cs
@@ -86,6 +86,24 @@ public sealed class GeoSchemaDdlTests
         unicosSoCep.Should().Be(0, "cep isolado não pode ser único na tabela logradouro");
     }
 
+    [Theory(DisplayName = "#704: índice de range das faixas de CEP é B-tree parcial sobre (cep_inicial, cep_final) WHERE vigente")]
+    [InlineData("ix_cidade_faixa_cep_range")]
+    [InlineData("ix_bairro_faixa_cep_range")]
+    [InlineData("ix_distrito_faixa_cep_range")]
+    public async Task IndicesRangeFaixaCep_ParciaisSobreCep(string indexName)
+    {
+        string? indexDef = await ObterIndexDefAsync(indexName);
+
+        indexDef.Should().NotBeNull($"o índice de range {indexName} deve existir (caminho frio do lookup, #704)");
+        indexDef!.Should().Contain("cep_inicial", "o range parte de cep_inicial (predicado cep_inicial <= @cep)");
+        indexDef.Should().Contain("cep_final");
+        // Parcial: o lookup só consulta faixas vigentes. O Postgres pode renderizar o
+        // predicado como "WHERE vigente" ou "WHERE (vigente)".
+        indexDef.Should().Contain("WHERE", "o índice é parcial");
+        indexDef.Should().Contain("vigente", "o predicado parcial filtra vigente");
+        indexDef.Should().Contain("USING btree", "o range usa B-tree, não GiST");
+    }
+
     [Fact(DisplayName = "extensão pg_trgm está instalada (sustenta o índice trigram)")]
     public async Task ExtensaoPgTrgm_Instalada()
     {


### PR DESCRIPTION
## Contexto

Endurecimento do lookup de CEP (`GET /api/cep/{cep}`, story #676), absorvendo os três follow-ups de revisão do PR #701 — todos não-bloqueantes, agora consolidados num PR só por tocarem o mesmo eixo (`CepReader`/`CepResolver` + faixas de CEP). Fecha a robustez do endpoint anônimo de reference data, parte do encerramento da Feature #665 (Geo F4).

## O que muda

### `fix(geo)` — teto de fan-out de logradouros (#705)
- `CepReader.ResolverPorLogradouroAsync` materializava todos os logradouros de um CEP sem teto. Um CEP patológico (anomalia da fonte DNE) materializaria milhares de linhas num endpoint `[AllowAnonymous]`.
- Teto configurável (`GeoCepLookupOptions.MaxLogradourosPorCep`, default 50) via probe `n+1` — distingue truncamento real de cardinalidade igual ao teto e **loga aviso** quando trunca (não mascara a anomalia). Teto `< 1` é clampado para 1 (defensivo).

### `perf(geo)` — memoiza o selo de versão do cache de CEP (#703)
- O `CepResolver` fazia **dois** GET ao Redis por request (selo + entrada) mesmo em cache hit. O selo só muda em re-selagem do ETL (#674), evento raríssimo.
- Memoiza o selo em processo (`IMemoryCache`) por janela curta configurável (`GeoCepCacheOptions.SeloTtl`, default 15s) → hot path com **1 round-trip**. Expiração governada pelo `TimeProvider` injetado (testável); `SeloTtl = Zero` desliga a memoização.
- **Janela de staleness:** após uma re-selagem, a versão anterior pode ser servida por até `SeloTtl`. Degradação sem Redis e invalidação O(1) por selo preservadas.

### `perf(geo)` — índice de range nas faixas de CEP (#704)
- No caminho frio, o predicado global por CEP (`cep_inicial <= @cep AND cep_final >= @cep`) não casa com o índice natural parent-first das faixas.
- Migration adiciona índice **B-tree parcial `(cep_inicial, cep_final) WHERE vigente`** em `cidade_faixa_cep`, `bairro_faixa_cep` e `distrito_faixa_cep` (só ADICIONA índices → reversão trivial).
- Documenta no `CepReader` os invariantes do SQL cru: comparação lexicográfica de CEP só equivale à numérica por serem 8 dígitos zero-padded (boundary `CepValido`); nomes físicos fixados no `FromSqlInterpolated` (rename quebra em runtime).

### `docs(adr)` — ADR-0093 rate-limiting na borda (#704)
- Registra a decisão: rate-limiting dos endpoints `[AllowAnonymous]` de reference data aplicado na **borda (gateway/Traefik)**, uniforme no ingresso único; controle no app adiado como escalonamento futuro. Comentário-ponteiro no `CepController`.

## Testes
- `#705`: teto trunca + loga (teto 1), abaixo do teto não trunca, teto inválido clampa para 1.
- `#703`: 2º lookup dentro do TTL não relê o selo; expiração relê; `SeloTtl=Zero` desliga.
- `#704`: os três índices de range existem como B-tree parcial sobre `(cep_inicial, cep_final) WHERE vigente` (inspeção `pg_indexes.indexdef`).
- **Suíte Geo completa: 265/265 verde** (com e sem Redis — o módulo degrada para o banco por design).

## Issues
Closes #703
Closes #704
Closes #705
