### PR TITLE
Drena a fila do ETL no desligamento do worker (libera o índice único parcial)

### DIFF
--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoEtlOrquestrador.cs
@@ -295,11 +295,20 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         }
     }
 
+    // Drenagem de desligamento (#694): marca Falhou uma execução enfileirada e não
+    // processada. Reusa o ExecuteUpdate idempotente filtrado por status = EmAndamento — só
+    // afeta a linha se ela ainda não terminou, liberando o índice único parcial.
+    public Task MarcarInterrompidaNoDesligamentoAsync(Guid execucaoId, CancellationToken cancellationToken) =>
+        MarcarFalhaPorIdAsync(execucaoId, "Carga interrompida no desligamento do worker.", cancellationToken);
+
+    private Task MarcarFalhaAsync(GeoImportacaoExecucao execucao, string mensagem, CancellationToken cancellationToken) =>
+        MarcarFalhaPorIdAsync(execucao.Id, mensagem, cancellationToken);
+
     [SuppressMessage(
         "Design",
         "CA1031:Do not catch general exception types",
         Justification = "Persistir o estado de falha é best-effort à beira do worker; um erro aqui não pode escalar (a carga já terminou).")]
-    private async Task MarcarFalhaAsync(GeoImportacaoExecucao execucao, string mensagem, CancellationToken cancellationToken)
+    private async Task MarcarFalhaPorIdAsync(Guid execucaoId, string mensagem, CancellationToken cancellationToken)
     {
         // ExecuteUpdate direto, filtrando status = EmAndamento no banco — NÃO muta/flusha a
         // entidade rastreada. Crítico quando o commit da conclusão falhou: a entidade está
@@ -310,7 +319,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         try
         {
             await _contexto.Set<GeoImportacaoExecucao>()
-                .Where(e => e.Id == execucao.Id && e.Status == StatusImportacao.EmAndamento)
+                .Where(e => e.Id == execucaoId && e.Status == StatusImportacao.EmAndamento)
                 .ExecuteUpdateAsync(
                     s => s
                         .SetProperty(e => e.Status, StatusImportacao.Falhou)
@@ -322,7 +331,7 @@ internal sealed partial class GeoEtlOrquestrador : IGeoImportacaoService, IGeoIm
         }
         catch (Exception excecao) when (excecao is not OperationCanceledException)
         {
-            LogFalhaPersistir(_logger, execucao.Id, excecao);
+            LogFalhaPersistir(_logger, execucaoId, excecao);
         }
     }
 

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoBackgroundService.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoBackgroundService.cs
@@ -65,6 +65,55 @@ internal sealed partial class GeoImportacaoBackgroundService : BackgroundService
         }
     }
 
+    /// <summary>
+    /// No desligamento, drena a fila e marca <c>Falhou</c> as execuções enfileiradas que
+    /// não chegaram a ser processadas (#694). O <c>stoppingToken</c> é cancelado antes de o
+    /// writer fechar, então um disparo enfileirado na janela imediatamente anterior ao
+    /// shutdown pode não ser entregue pelo <c>ReadAllAsync(stoppingToken)</c>; sem este
+    /// dreno, a linha ficaria <c>EmAndamento</c> bloqueando novos disparos (409) até a
+    /// reconciliação por idade (<c>LimiteAbandono</c>, default 6h).
+    /// </summary>
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // Encerra o loop do ExecuteAsync (cancela o stoppingToken e aguarda). Uma execução
+        // em voo é marcada Falhou pelo próprio ExecutarAsync (catch de cancelamento).
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        // Fecha o writer (sem novos enfileiramentos — IniciarAsync trata ChannelClosedException)
+        // e drena o que sobrou de forma não-bloqueante.
+        _fila.Completar();
+        IReadOnlyList<Guid> pendentes = _fila.DrenarRestante();
+        if (pendentes.Count == 0)
+        {
+            return;
+        }
+
+        await FalharPendentesAsync(pendentes).ConfigureAwait(false);
+    }
+
+    private async Task FalharPendentesAsync(IReadOnlyList<Guid> pendentes)
+    {
+        try
+        {
+            using IServiceScope escopo = _scopeFactory.CreateScope();
+            IGeoImportacaoExecutor executor = escopo.ServiceProvider.GetRequiredService<IGeoImportacaoExecutor>();
+
+            foreach (Guid execucaoId in pendentes)
+            {
+                // CancellationToken.None: o token de shutdown já está cancelado; este dreno
+                // precisa concluir para deixar as linhas num estado terminal consistente.
+                await executor.MarcarInterrompidaNoDesligamentoAsync(execucaoId, CancellationToken.None).ConfigureAwait(false);
+                LogInterrompidaNoDesligamento(_logger, execucaoId);
+            }
+        }
+#pragma warning disable CA1031 // Dreno best-effort no desligamento: uma falha aqui não pode impedir o host de parar; a reconciliação por idade ainda reclama a linha.
+        catch (Exception excecao)
+        {
+            LogErroDrenarFila(_logger, excecao);
+        }
+#pragma warning restore CA1031
+    }
+
     private async Task ReconciliarOrfasAsync(CancellationToken cancellationToken)
     {
         try
@@ -97,4 +146,10 @@ internal sealed partial class GeoImportacaoBackgroundService : BackgroundService
 
     [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: erro ao processar a execução {ExecucaoId} na fila.")]
     private static partial void LogErroProcessando(ILogger logger, Guid execucaoId, Exception excecao);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: execução {ExecucaoId} enfileirada e não processada foi marcada como falha no desligamento do worker.")]
+    private static partial void LogInterrompidaNoDesligamento(ILogger logger, Guid execucaoId);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: falha ao drenar a fila no desligamento do worker.")]
+    private static partial void LogErroDrenarFila(ILogger logger, Exception excecao);
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoBackgroundService.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoBackgroundService.cs
@@ -88,10 +88,10 @@ internal sealed partial class GeoImportacaoBackgroundService : BackgroundService
             return;
         }
 
-        await FalharPendentesAsync(pendentes).ConfigureAwait(false);
+        await FalharPendentesAsync(pendentes, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task FalharPendentesAsync(IReadOnlyList<Guid> pendentes)
+    private async Task FalharPendentesAsync(IReadOnlyList<Guid> pendentes, CancellationToken cancellationToken)
     {
         try
         {
@@ -100,14 +100,19 @@ internal sealed partial class GeoImportacaoBackgroundService : BackgroundService
 
             foreach (Guid execucaoId in pendentes)
             {
-                // CancellationToken.None: o token de shutdown já está cancelado; este dreno
-                // precisa concluir para deixar as linhas num estado terminal consistente.
-                await executor.MarcarInterrompidaNoDesligamentoAsync(execucaoId, CancellationToken.None).ConfigureAwait(false);
+                // Honra o token de desligamento do host: se o timeout de shutdown estourar
+                // (ex.: banco lento), o dreno cede em vez de prender o processo. A
+                // reconciliação por idade reclama qualquer execução não marcada (rede de
+                // segurança), então ceder aqui não deixa a linha presa além do limite.
+                cancellationToken.ThrowIfCancellationRequested();
+                await executor.MarcarInterrompidaNoDesligamentoAsync(execucaoId, cancellationToken).ConfigureAwait(false);
                 LogInterrompidaNoDesligamento(_logger, execucaoId);
             }
         }
-#pragma warning disable CA1031 // Dreno best-effort no desligamento: uma falha aqui não pode impedir o host de parar; a reconciliação por idade ainda reclama a linha.
-        catch (Exception excecao)
+        // Cancelamento (timeout de shutdown) é esperado — não é falha de dreno; propaga
+        // silenciosamente. Outras exceções são best-effort: logam sem impedir o host de parar.
+#pragma warning disable CA1031 // Dreno best-effort no desligamento; a reconciliação por idade ainda reclama a linha.
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
         {
             LogErroDrenarFila(_logger, excecao);
         }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoFila.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoFila.cs
@@ -19,6 +19,20 @@ internal interface IGeoImportacaoFila
 
     /// <summary>Sequência das execuções enfileiradas, em ordem de chegada.</summary>
     IAsyncEnumerable<Guid> LerAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Fecha o writer: novos <see cref="EnfileirarAsync"/> passam a lançar
+    /// <c>ChannelClosedException</c> (tratado em <c>IniciarAsync</c> como falha), evitando
+    /// corrida com a drenagem de desligamento (#694). Idempotente.
+    /// </summary>
+    void Completar();
+
+    /// <summary>
+    /// Drena de forma não-bloqueante (<c>TryRead</c>) os Ids ainda na fila — usado no
+    /// desligamento do worker (#694) para marcar como falha as execuções enfileiradas e
+    /// não processadas, liberando o índice único parcial.
+    /// </summary>
+    IReadOnlyList<Guid> DrenarRestante();
 }
 
 /// <inheritdoc />
@@ -38,4 +52,17 @@ internal sealed class GeoImportacaoFila : IGeoImportacaoFila
 
     public IAsyncEnumerable<Guid> LerAsync(CancellationToken cancellationToken) =>
         _canal.Reader.ReadAllAsync(cancellationToken);
+
+    public void Completar() => _canal.Writer.TryComplete();
+
+    public IReadOnlyList<Guid> DrenarRestante()
+    {
+        List<Guid> restante = [];
+        while (_canal.Reader.TryRead(out Guid execucaoId))
+        {
+            restante.Add(execucaoId);
+        }
+
+        return restante;
+    }
 }

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/IGeoImportacaoExecutor.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/IGeoImportacaoExecutor.cs
@@ -15,4 +15,12 @@ internal interface IGeoImportacaoExecutor
     /// <c>Falhou</c> e registra a métrica/log.
     /// </summary>
     Task ExecutarAsync(Guid execucaoId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca como <c>Falhou</c> uma execução enfileirada que não chegou a ser processada
+    /// antes do desligamento do worker (#694). Idempotente — só afeta a linha se ainda
+    /// estiver <c>EmAndamento</c>, liberando o índice único parcial para novos disparos
+    /// (senão a reconciliação por idade só a reclamaria após o limite de abandono).
+    /// </summary>
+    Task MarcarInterrompidaNoDesligamentoAsync(Guid execucaoId, CancellationToken cancellationToken);
 }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -6,7 +6,9 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 using NSubstitute;
 
@@ -244,6 +246,55 @@ public sealed class EtlAtualizacaoPeriodicaTests
         ruaA.Vigente.Should().BeTrue("a release sem logradouros não pode marcar o CEP existente como obsoleto");
         ruaA.VersaoDataset.Should().Be("202601");
         await cache.DidNotReceive().InvalidarAsync("202602", Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "#694: desligamento drena a fila e marca execuções enfileiradas como Falhou, liberando novos disparos")]
+    public async Task Desligamento_DrenaFila_MarcaEnfileiradasFalhou()
+    {
+        await LimparAsync();
+        Guid id = await CriarExecucaoAsync("202601"); // EmAndamento, nunca processada pelo worker
+
+        GeoImportacaoFila fila = new();
+        await fila.EnfileirarAsync(id, CancellationToken.None);
+
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        using GeoEtlMetrics metricas = new();
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal));
+        Lazy<IGeoCepCacheInvalidador> cacheLazy = new(() => Substitute.For<IGeoCepCacheInvalidador>());
+        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas);
+
+        using GeoImportacaoBackgroundService worker = CriarWorker(fila, orquestrador);
+
+        // Sem StartAsync: base.StopAsync retorna cedo (executeTask null) e o dreno roda —
+        // simula o item enfileirado na janela imediatamente anterior ao shutdown.
+        await worker.StopAsync(CancellationToken.None);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+        execucao.Status.Should().Be(StatusImportacao.Falhou, "a execução enfileirada e não processada é falhada no desligamento");
+        execucao.Mensagem.Should().Contain("desligamento");
+
+        // Índice único parcial liberado: um novo disparo (mesma versão) não colide na UNIQUE.
+        Guid novo = await CriarExecucaoAsync("202601");
+        novo.Should().NotBeEmpty();
+    }
+
+    private static GeoImportacaoBackgroundService CriarWorker(IGeoImportacaoFila fila, IGeoImportacaoExecutor executor)
+    {
+        // Scope factory mínimo: o dreno do StopAsync resolve IGeoImportacaoExecutor do escopo.
+        IServiceProvider sp = Substitute.For<IServiceProvider>();
+        sp.GetService(typeof(IGeoImportacaoExecutor)).Returns(executor);
+        IServiceScope escopo = Substitute.For<IServiceScope>();
+        escopo.ServiceProvider.Returns(sp);
+        IServiceScopeFactory scopeFactory = Substitute.For<IServiceScopeFactory>();
+        scopeFactory.CreateScope().Returns(escopo);
+
+        return new GeoImportacaoBackgroundService(
+            scopeFactory,
+            fila,
+            TimeProvider.System,
+            Options.Create(new EtlOpcoes()),
+            NullLogger<GeoImportacaoBackgroundService>.Instance);
     }
 
     private async Task<Guid> CriarExecucaoAsync(string versao)


### PR DESCRIPTION
## Contexto

Follow-up de robustez levantado na revisão da Story #674 (PR #689). Não-bloqueante (edge case de operabilidade, sem corromper dados).

No desligamento gracioso, o `stoppingToken` é cancelado antes de o writer do canal fechar. Se um `POST /api/admin/geo/importacoes` enfileirou uma execução (com `CancellationToken.None`) na janela imediatamente anterior ao shutdown, o `ReadAllAsync(stoppingToken)` do `GeoImportacaoBackgroundService` pode encerrar sem entregar esse Id — a execução nunca entra no `ExecutarAsync`, permanece `EmAndamento`, e a reconciliação por idade só a reclama após o `LimiteAbandono` (default 6h), bloqueando novos disparos com 409 nesse intervalo.

## O que muda

- `GeoImportacaoBackgroundService.StopAsync` (novo override): após encerrar o loop do `ExecuteAsync`, **fecha o writer** da fila (novos `EnfileirarAsync` viram `ChannelClosedException`, já tratado em `IniciarAsync`) e **drena o restante de forma não-bloqueante** (`Channel.Reader.TryRead`), marcando cada execução enfileirada e não processada como `Falhou`.
- `IGeoImportacaoFila`: novos `Completar()` (fecha o writer, idempotente) e `DrenarRestante()` (drain `TryRead`).
- `IGeoImportacaoExecutor.MarcarInterrompidaNoDesligamentoAsync(Guid, ct)`: marca `Falhou` por Id, **idempotente** (só afeta a linha se ainda `EmAndamento`), reusando o `ExecuteUpdate` filtrado por status do orquestrador — libera o índice único parcial.
- A reconciliação por idade permanece como rede de segurança.

## Testes
- `#694`: item enfileirado + `StopAsync` → execução marcada `Falhou` (não fica `EmAndamento`); um novo disparo da mesma versão não colide na UNIQUE parcial (índice liberado).
- **Suíte Geo completa: 257/257 verde.**

## Issues
Closes #694
