### PR TITLE
fix(geo): fecha a cauda de operabilidade e cobertura do ETL periódico (#674)

### DIFF
--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/DependencyInjection.cs
@@ -98,12 +98,14 @@ public static class GeoInfrastructureRegistration
     }
 
     /// <summary>
-    /// Registra os gatilhos hospedados do ETL (#674): o <c>BackgroundService</c> que
-    /// executa as cargas enfileiradas e o seed de desenvolvimento. <strong>Deve ser
-    /// chamado no Program APÓS <c>AddDbContextMigrationsOnStartup&lt;GeoDbContext&gt;()</c></strong>
-    /// — como <c>HostOptions.ServicesStartConcurrently</c> é <see langword="false"/>, a
-    /// ordem de registro é a ordem de start, e tanto o seed quanto a reconciliação do
-    /// worker tocam o banco (a tabela precisa já existir).
+    /// Registra os gatilhos hospedados do ETL (#674): a reconciliação de órfãs no startup
+    /// (#695), o <c>BackgroundService</c> que executa as cargas enfileiradas e o seed de
+    /// desenvolvimento. <strong>Deve ser chamado no Program APÓS
+    /// <c>AddDbContextMigrationsOnStartup&lt;GeoDbContext&gt;()</c></strong> — como
+    /// <c>HostOptions.ServicesStartConcurrently</c> é <see langword="false"/>, a ordem de
+    /// registro é a ordem de start: migrations → reconciliação → worker → seed. A
+    /// reconciliação (cujo <c>StartAsync</c> é aguardado) conclui antes de o seed/HTTP
+    /// aceitarem disparos, e tanto ela quanto o seed tocam o banco (a tabela precisa já existir).
     /// </summary>
     public static IServiceCollection AddGeoEtlGatilhos(
         this IServiceCollection services,
@@ -120,6 +122,10 @@ public static class GeoInfrastructureRegistration
 
         if (opcoes.WorkerHabilitado)
         {
+            // Reconciliação de órfãs ANTES do worker e do seed (#695): hosted service cujo
+            // StartAsync é aguardado pelo host, liberando o índice único parcial de execuções
+            // EmAndamento abandonadas antes que qualquer disparo possa colidir nele.
+            services.AddHostedService<GeoReconciliacaoStartupHostedService>();
             services.AddHostedService<GeoImportacaoBackgroundService>();
         }
 

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoBackgroundService.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoImportacaoBackgroundService.cs
@@ -3,47 +3,37 @@ namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 /// <summary>
 /// Consome a fila de disparos do ETL (Story #674) e executa cada carga num escopo de DI
-/// próprio (o orquestrador e o <c>GeoDbContext</c> são scoped). No startup, reconcilia
-/// execuções <c>EmAndamento</c> abandonadas por crash/restart anterior — marca-as
-/// <c>Falhou</c> antes de aceitar novos disparos, senão o índice único parcial as deixaria
-/// bloqueando todos os 409 indefinidamente.
+/// próprio (o orquestrador e o <c>GeoDbContext</c> são scoped). A reconciliação de execuções
+/// <c>EmAndamento</c> abandonadas por crash/restart roda <strong>antes</strong> deste worker,
+/// no <see cref="GeoReconciliacaoStartupHostedService"/> (#695), cujo <c>StartAsync</c> é
+/// aguardado — então quando o worker começa a consumir a fila o índice único parcial já foi
+/// liberado das órfãs.
 /// </summary>
 internal sealed partial class GeoImportacaoBackgroundService : BackgroundService
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IGeoImportacaoFila _fila;
-    private readonly TimeProvider _relogio;
-    private readonly TimeSpan _limiteAbandono;
     private readonly ILogger<GeoImportacaoBackgroundService> _logger;
 
     public GeoImportacaoBackgroundService(
         IServiceScopeFactory scopeFactory,
         IGeoImportacaoFila fila,
-        TimeProvider relogio,
-        IOptions<EtlOpcoes> opcoes,
         ILogger<GeoImportacaoBackgroundService> logger)
     {
         ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(fila);
-        ArgumentNullException.ThrowIfNull(relogio);
-        ArgumentNullException.ThrowIfNull(opcoes);
         ArgumentNullException.ThrowIfNull(logger);
 
         _scopeFactory = scopeFactory;
         _fila = fila;
-        _relogio = relogio;
-        _limiteAbandono = opcoes.Value.LimiteAbandono;
         _logger = logger;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await ReconciliarOrfasAsync(stoppingToken).ConfigureAwait(false);
-
         await foreach (Guid execucaoId in _fila.LerAsync(stoppingToken).ConfigureAwait(false))
         {
             try
@@ -118,36 +108,6 @@ internal sealed partial class GeoImportacaoBackgroundService : BackgroundService
         }
 #pragma warning restore CA1031
     }
-
-    private async Task ReconciliarOrfasAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            using IServiceScope escopo = _scopeFactory.CreateScope();
-            GeoDbContext contexto = escopo.ServiceProvider.GetRequiredService<GeoDbContext>();
-
-            int afetadas = await GeoExecucaoReconciliador
-                .ReclamarAbandonadasAsync(contexto, _relogio.GetUtcNow(), _limiteAbandono, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (afetadas > 0)
-            {
-                LogOrfasReconciliadas(_logger, afetadas);
-            }
-        }
-#pragma warning disable CA1031 // Reconciliação best-effort no startup: uma falha aqui não pode impedir o worker de subir.
-        catch (Exception excecao) when (excecao is not OperationCanceledException)
-        {
-            LogErroReconciliar(_logger, excecao);
-        }
-#pragma warning restore CA1031
-    }
-
-    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: {Afetadas} execução(ões) em andamento reconciliada(s) como falha no startup (abandonadas por reinício).")]
-    private static partial void LogOrfasReconciliadas(ILogger logger, int afetadas);
-
-    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: falha ao reconciliar execuções em andamento no startup.")]
-    private static partial void LogErroReconciliar(ILogger logger, Exception excecao);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: erro ao processar a execução {ExecucaoId} na fila.")]
     private static partial void LogErroProcessando(ILogger logger, Guid execucaoId, Exception excecao);

--- a/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoReconciliacaoStartupHostedService.cs
+++ b/src/geo/Unifesspa.UniPlus.Geo.Infrastructure/Persistence/Etl/GeoReconciliacaoStartupHostedService.cs
@@ -1,0 +1,74 @@
+namespace Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+/// <summary>
+/// Reconcilia execuções <c>EmAndamento</c> abandonadas por crash/restart (Story #674) ANTES
+/// de o host aceitar disparos (#695). Diferente de um <see cref="BackgroundService"/> — cujo
+/// <c>StartAsync</c> retorna no primeiro <c>await</c> do <c>ExecuteAsync</c>, deixando a
+/// reconciliação correr concorrente ao seed e ao servidor HTTP — este é um
+/// <see cref="IHostedService"/> simples cujo <see cref="StartAsync"/> é <strong>aguardado</strong>
+/// pelo host. Com <c>HostOptions.ServicesStartConcurrently = false</c> (default), a ordem de
+/// start é a de registro: registrado antes do worker e do seed, garante que a reconciliação
+/// conclua antes de qualquer disparo — fechando a janela em que um seed/disparo imediato
+/// colidiria no índice único parcial com uma órfã ainda não marcada <c>Falhou</c>.
+/// </summary>
+internal sealed partial class GeoReconciliacaoStartupHostedService : IHostedService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _relogio;
+    private readonly TimeSpan _limiteAbandono;
+    private readonly ILogger<GeoReconciliacaoStartupHostedService> _logger;
+
+    public GeoReconciliacaoStartupHostedService(
+        IServiceScopeFactory scopeFactory,
+        TimeProvider relogio,
+        IOptions<EtlOpcoes> opcoes,
+        ILogger<GeoReconciliacaoStartupHostedService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(relogio);
+        ArgumentNullException.ThrowIfNull(opcoes);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _scopeFactory = scopeFactory;
+        _relogio = relogio;
+        _limiteAbandono = opcoes.Value.LimiteAbandono;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using IServiceScope escopo = _scopeFactory.CreateScope();
+            GeoDbContext contexto = escopo.ServiceProvider.GetRequiredService<GeoDbContext>();
+
+            int afetadas = await GeoExecucaoReconciliador
+                .ReclamarAbandonadasAsync(contexto, _relogio.GetUtcNow(), _limiteAbandono, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (afetadas > 0)
+            {
+                LogOrfasReconciliadas(_logger, afetadas);
+            }
+        }
+#pragma warning disable CA1031 // Reconciliação best-effort no startup: uma falha aqui (ex.: banco transitório) não pode impedir o host de subir.
+        catch (Exception excecao) when (excecao is not OperationCanceledException)
+        {
+            LogErroReconciliar(_logger, excecao);
+        }
+#pragma warning restore CA1031
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ETL Geo: {Afetadas} execução(ões) em andamento reconciliada(s) como falha no startup (abandonadas por reinício).")]
+    private static partial void LogOrfasReconciliadas(ILogger logger, int afetadas);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "ETL Geo: falha ao reconciliar execuções em andamento no startup.")]
+    private static partial void LogErroReconciliar(ILogger logger, Exception excecao);
+}

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
 
+using System.Diagnostics.Metrics;
 using System.Text.Json;
 
 using AwesomeAssertions;
@@ -21,6 +22,7 @@ using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
 using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
@@ -343,6 +345,111 @@ public sealed class EtlAtualizacaoPeriodicaTests
         execucao.Status.Should().Be(StatusImportacao.Concluida, "o worker consumiu a fila e o executor rodou a carga até concluir");
         execucao.ConcluidoEm.Should().NotBeNull();
     }
+
+    [Fact(DisplayName = "#693: carga concluída emite geo.etl.* com status=concluida e linhas coerentes com o relatório")]
+    public async Task Metricas_CargaConcluida_EmiteInstrumentos()
+    {
+        await LimparAsync();
+        Guid id = await CriarExecucaoAsync("202601");
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
+        {
+            ["202601"] = FonteCompleta("202601"),
+        });
+
+        List<MedidaMetrica<long>> longs = [];
+        List<MedidaMetrica<double>> doubles = [];
+
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        using GeoEtlMetrics metricas = new();
+        using MeterListener listener = CriarListener(longs, doubles);
+        listener.Start();
+
+        Lazy<IGeoCepCacheInvalidador> cacheLazy = new(() => Substitute.For<IGeoCepCacheInvalidador>());
+        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas, new GeoImportacaoFila());
+        await orquestrador.ExecutarAsync(id, CancellationToken.None);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+        execucao.Status.Should().Be(StatusImportacao.Concluida);
+
+        RelatorioImportacaoDto relatorio = JsonSerializer.Deserialize<RelatorioImportacaoDto>(
+            execucao.RelatorioJson!, RelatorioJsonCamelCase)!;
+        long linhasEsperadas = relatorio.Inseridos + relatorio.Atualizados;
+
+        List<MedidaMetrica<long>> execucoes = [.. longs.Where(m => m.Nome == "geo.etl.execucoes")];
+        execucoes.Should().ContainSingle();
+        execucoes[0].Valor.Should().Be(1);
+        Status(execucoes[0].Tags).Should().Be("concluida");
+
+        List<MedidaMetrica<long>> linhas = [.. longs.Where(m => m.Nome == "geo.etl.linhas")];
+        linhas.Should().ContainSingle();
+        linhas[0].Valor.Should().Be(linhasEsperadas, "as linhas reportadas batem com inseridos + atualizados do relatório");
+
+        doubles.Should().Contain(m => m.Nome == "geo.etl.duracao" && Status(m.Tags) == "concluida");
+    }
+
+    [Fact(DisplayName = "#693: carga falhada emite geo.etl.execucoes/duracao com status=falhou (sem linhas)")]
+    public async Task Metricas_CargaFalhada_EmiteStatusFalhou()
+    {
+        await LimparAsync();
+        Guid id = await CriarExecucaoAsync("202601");
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
+        {
+            ["202601"] = new FonteComFalhaNasCidades(FonteCompleta("202601")),
+        });
+
+        List<MedidaMetrica<long>> longs = [];
+        List<MedidaMetrica<double>> doubles = [];
+
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        using GeoEtlMetrics metricas = new();
+        using MeterListener listener = CriarListener(longs, doubles);
+        listener.Start();
+
+        Lazy<IGeoCepCacheInvalidador> cacheLazy = new(() => Substitute.For<IGeoCepCacheInvalidador>());
+        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas, new GeoImportacaoFila());
+        await orquestrador.ExecutarAsync(id, CancellationToken.None);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+        execucao.Status.Should().Be(StatusImportacao.Falhou);
+
+        List<MedidaMetrica<long>> execucoes = [.. longs.Where(m => m.Nome == "geo.etl.execucoes")];
+        execucoes.Should().ContainSingle();
+        execucoes[0].Valor.Should().Be(1);
+        Status(execucoes[0].Tags).Should().Be("falhou");
+
+        doubles.Should().Contain(m => m.Nome == "geo.etl.duracao" && Status(m.Tags) == "falhou");
+        longs.Should().NotContain(m => m.Nome == "geo.etl.linhas", "RegistrarFalha não contabiliza linhas");
+    }
+
+    // Escuta apenas os instrumentos geo.etl.* do Meter do serviço Geo, copiando as tags do span
+    // (não capturável em lambda) para um array. xUnit serializa os testes da coleção, então só a
+    // carga sob teste emite enquanto este listener está vivo.
+    private static MeterListener CriarListener(List<MedidaMetrica<long>> longs, List<MedidaMetrica<double>> doubles)
+    {
+        MeterListener listener = new()
+        {
+            InstrumentPublished = (instrumento, l) =>
+            {
+                if (instrumento.Meter.Name == UniPlusServiceNames.Geo &&
+                    instrumento.Name.StartsWith("geo.etl.", StringComparison.Ordinal))
+                {
+                    l.EnableMeasurementEvents(instrumento);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((instrumento, medida, tags, estado) =>
+            longs.Add(new MedidaMetrica<long>(instrumento.Name, medida, tags.ToArray())));
+        listener.SetMeasurementEventCallback<double>((instrumento, medida, tags, estado) =>
+            doubles.Add(new MedidaMetrica<double>(instrumento.Name, medida, tags.ToArray())));
+        return listener;
+    }
+
+    private static string? Status(KeyValuePair<string, object?>[] tags) =>
+        tags.SingleOrDefault(t => t.Key == "status").Value as string;
+
+    private readonly record struct MedidaMetrica<T>(string Nome, T Valor, KeyValuePair<string, object?>[] Tags);
 
     private static GeoImportacaoBackgroundService CriarWorker(IGeoImportacaoFila fila, IGeoImportacaoExecutor executor)
     {

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -14,12 +14,14 @@ using NSubstitute;
 using Unifesspa.UniPlus.Geo.Application.Abstractions;
 using Unifesspa.UniPlus.Geo.Application.DTOs;
 using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Domain.Errors;
 using Unifesspa.UniPlus.Geo.Infrastructure.Observability;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Bulk;
 using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl.Fonte;
 using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Atualização periódica do ETL (Story #674) sobre Postgres+PostGIS real: orquestra os
@@ -260,7 +262,7 @@ public sealed class EtlAtualizacaoPeriodicaTests
         using GeoEtlMetrics metricas = new();
         FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal));
         Lazy<IGeoCepCacheInvalidador> cacheLazy = new(() => Substitute.For<IGeoCepCacheInvalidador>());
-        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas);
+        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas, new GeoImportacaoFila());
 
         using GeoImportacaoBackgroundService worker = CriarWorker(fila, orquestrador);
 
@@ -276,6 +278,33 @@ public sealed class EtlAtualizacaoPeriodicaTests
         // Índice único parcial liberado: um novo disparo (mesma versão) não colide na UNIQUE.
         Guid novo = await CriarExecucaoAsync("202601");
         novo.Should().NotBeEmpty();
+    }
+
+    [Fact(DisplayName = "#691: disparo com a fila fechada (serviço em desligamento) retorna NaoEnfileirada e marca a execução Falhou")]
+    public async Task Disparo_ComFilaFechada_RetornaNaoEnfileirada_E_MarcaFalhou()
+    {
+        await LimparAsync();
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal));
+
+        // Writer completado: o próximo EnfileirarAsync lança ChannelClosedException — o caminho
+        // que o endpoint admin mapeia para 503 (serviço em desligamento).
+        GeoImportacaoFila fila = new();
+        fila.Completar();
+
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        using GeoEtlMetrics metricas = new();
+        Lazy<IGeoCepCacheInvalidador> cacheLazy = new(() => Substitute.For<IGeoCepCacheInvalidador>());
+        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas, fila);
+
+        Result<Guid> resultado = await orquestrador.IniciarAsync("202601", "teste", CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(GeoImportacaoErrorCodes.NaoEnfileirada);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.VersaoDataset == "202601");
+        execucao.Status.Should().Be(StatusImportacao.Falhou, "registrada mas não enfileirada: marcada Falhou para não bloquear o índice único parcial");
+        execucao.Mensagem.Should().Contain("desligamento");
     }
 
     private static GeoImportacaoBackgroundService CriarWorker(IGeoImportacaoFila fila, IGeoImportacaoExecutor executor)
@@ -312,7 +341,7 @@ public sealed class EtlAtualizacaoPeriodicaTests
     {
         await using GeoDbContext ctx = _fixture.CreateDbContext();
         using GeoEtlMetrics metricas = new();
-        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas);
+        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas, new GeoImportacaoFila());
         await orquestrador.ExecutarAsync(execucaoId, CancellationToken.None);
     }
 
@@ -320,7 +349,8 @@ public sealed class EtlAtualizacaoPeriodicaTests
         GeoDbContext ctx,
         IGeoFonteDadosFactory fonteFactory,
         Lazy<IGeoCepCacheInvalidador> cacheLazy,
-        GeoEtlMetrics metricas)
+        GeoEtlMetrics metricas,
+        IGeoImportacaoFila fila)
     {
         IConfiguration configuracao = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:GeoDb"] = _fixture.ConnectionString })
@@ -337,7 +367,7 @@ public sealed class EtlAtualizacaoPeriodicaTests
             folhas,
             fonteFactory,
             cacheLazy,
-            new GeoImportacaoFila(),
+            fila,
             metricas,
             TimeProvider.System,
             NullLogger<GeoEtlOrquestrador>.Instance);

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 using NSubstitute;
 
@@ -292,8 +291,6 @@ public sealed class EtlAtualizacaoPeriodicaTests
         return new GeoImportacaoBackgroundService(
             scopeFactory,
             fila,
-            TimeProvider.System,
-            Options.Create(new EtlOpcoes()),
             NullLogger<GeoImportacaoBackgroundService>.Instance);
     }
 

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/EtlAtualizacaoPeriodicaTests.cs
@@ -307,6 +307,43 @@ public sealed class EtlAtualizacaoPeriodicaTests
         execucao.Mensagem.Should().Contain("desligamento");
     }
 
+    [Fact(DisplayName = "#692: wiring fila → worker → executor — o disparo enfileirado é consumido e executado em segundo plano até concluir")]
+    public async Task Wiring_FilaWorkerExecutor_ProcessaAteConcluir()
+    {
+        await LimparAsync();
+        Guid id = await CriarExecucaoAsync("202601");
+
+        FonteFactoryFake fonteFactory = new(new Dictionary<string, IGeoFonteDados>(StringComparer.Ordinal)
+        {
+            ["202601"] = FonteCompleta("202601"),
+        });
+
+        GeoImportacaoFila fila = new();
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        using GeoEtlMetrics metricas = new();
+        Lazy<IGeoCepCacheInvalidador> cacheLazy = new(() => Substitute.For<IGeoCepCacheInvalidador>());
+        GeoEtlOrquestrador orquestrador = CriarOrquestrador(ctx, fonteFactory, cacheLazy, metricas, fila);
+
+        // O worker resolve IGeoImportacaoExecutor de um escopo novo por item; aqui o scope
+        // factory devolve este decorator, que sinaliza quando a carga termina.
+        ExecutorComSinal executor = new(orquestrador);
+        using GeoImportacaoBackgroundService worker = CriarWorker(fila, executor);
+
+        await fila.EnfileirarAsync(id, CancellationToken.None);
+        await worker.StartAsync(CancellationToken.None);
+
+        // Espera determinística (sem Sleep): o sinal dispara no finally do ExecutarAsync, após
+        // a carga concluir. WaitAsync limita o tempo para não pendurar o CI se o wiring quebrar.
+        await executor.Concluido.WaitAsync(TimeSpan.FromSeconds(30));
+
+        await worker.StopAsync(CancellationToken.None);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == id);
+        execucao.Status.Should().Be(StatusImportacao.Concluida, "o worker consumiu a fila e o executor rodou a carga até concluir");
+        execucao.ConcluidoEm.Should().NotBeNull();
+    }
+
     private static GeoImportacaoBackgroundService CriarWorker(IGeoImportacaoFila fila, IGeoImportacaoExecutor executor)
     {
         // Scope factory mínimo: o dreno do StopAsync resolve IGeoImportacaoExecutor do escopo.
@@ -436,5 +473,35 @@ public sealed class EtlAtualizacaoPeriodicaTests
     private sealed class FonteFactoryCancelada : IGeoFonteDadosFactory
     {
         public IGeoFonteDados Criar(string versao) => throw new OperationCanceledException();
+    }
+
+    // Decora o executor sinalizando o fim de ExecutarAsync — permite ao teste do wiring
+    // (#692) aguardar a execução em segundo plano de forma determinística, sem Sleep.
+    private sealed class ExecutorComSinal : IGeoImportacaoExecutor
+    {
+        private readonly IGeoImportacaoExecutor _interno;
+        private readonly TaskCompletionSource _concluido = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ExecutorComSinal(IGeoImportacaoExecutor interno)
+        {
+            _interno = interno;
+        }
+
+        public Task Concluido => _concluido.Task;
+
+        public async Task ExecutarAsync(Guid execucaoId, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _interno.ExecutarAsync(execucaoId, cancellationToken);
+            }
+            finally
+            {
+                _concluido.TrySetResult();
+            }
+        }
+
+        public Task MarcarInterrompidaNoDesligamentoAsync(Guid execucaoId, CancellationToken cancellationToken) =>
+            _interno.MarcarInterrompidaNoDesligamentoAsync(execucaoId, cancellationToken);
     }
 }

--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/GeoReconciliacaoStartupHostedServiceTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Etl/GeoReconciliacaoStartupHostedServiceTests.cs
@@ -1,0 +1,97 @@
+namespace Unifesspa.UniPlus.Geo.IntegrationTests.Etl;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Geo.Domain.Entities;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Geo.Infrastructure.Persistence.Etl;
+using Unifesspa.UniPlus.Geo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Reconciliação de órfãs no startup aguardado (#695): o <see cref="GeoReconciliacaoStartupHostedService"/>
+/// é um <c>IHostedService</c> cujo <c>StartAsync</c> conclui a reclamação ANTES de o host
+/// aceitar disparos (registrado antes do worker e do seed). Cobre que uma órfã antiga é
+/// marcada <c>Falhou</c> no <c>StartAsync</c> — liberando o índice único parcial para um novo
+/// disparo, sem 409 espúrio — e que uma execução recente (possivelmente ativa em outra
+/// réplica) é preservada. O índice único parcial impede dois registros EmAndamento ao mesmo
+/// tempo, então os cenários são testados isoladamente.
+/// </summary>
+[Collection(GeoPostgisCollection.Name)]
+public sealed class GeoReconciliacaoStartupHostedServiceTests
+{
+    private readonly GeoPostgisFixture _fixture;
+
+    public GeoReconciliacaoStartupHostedServiceTests(GeoPostgisFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "#695: órfã EmAndamento antiga é reconciliada no StartAsync, liberando novos disparos (sem 409 espúrio)")]
+    public async Task Startup_ReconciliaOrfaAntiga_E_LiberaDisparos()
+    {
+        await LimparAsync();
+        DateTimeOffset agora = TimeProvider.System.GetUtcNow();
+        Guid orfa = await CriarEmAndamentoAsync(agora - TimeSpan.FromHours(10));
+
+        GeoReconciliacaoStartupHostedService hosted = CriarHostedService();
+        await hosted.StartAsync(CancellationToken.None);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == orfa);
+        execucao.Status.Should().Be(StatusImportacao.Falhou, "a órfã antiga é reconciliada antes de aceitar disparos");
+        execucao.ConcluidoEm.Should().NotBeNull();
+
+        // Índice único parcial liberado: um novo disparo (mesma versão) não colide na UNIQUE —
+        // sem a reconciliação aguardada, o seed/disparo imediato bateria 409 contra a órfã.
+        Guid novo = await CriarEmAndamentoAsync(agora);
+        novo.Should().NotBeEmpty();
+    }
+
+    [Fact(DisplayName = "#695: execução EmAndamento recente (possivelmente ativa em outra réplica) é preservada no StartAsync")]
+    public async Task Startup_PreservaExecucaoRecente()
+    {
+        await LimparAsync();
+        DateTimeOffset agora = TimeProvider.System.GetUtcNow();
+        Guid recente = await CriarEmAndamentoAsync(agora - TimeSpan.FromMinutes(1));
+
+        GeoReconciliacaoStartupHostedService hosted = CriarHostedService();
+        await hosted.StartAsync(CancellationToken.None);
+
+        await using GeoDbContext leitura = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = await leitura.ImportacaoExecucoes.SingleAsync(e => e.Id == recente);
+        execucao.Status.Should().Be(StatusImportacao.EmAndamento, "uma carga recente (sob o limite de abandono) não é reclamada");
+    }
+
+    private GeoReconciliacaoStartupHostedService CriarHostedService()
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => _fixture.CreateDbContext());
+        ServiceProvider provider = services.BuildServiceProvider();
+
+        return new GeoReconciliacaoStartupHostedService(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            TimeProvider.System,
+            Options.Create(new EtlOpcoes()),
+            NullLogger<GeoReconciliacaoStartupHostedService>.Instance);
+    }
+
+    private async Task<Guid> CriarEmAndamentoAsync(DateTimeOffset iniciadoEm)
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        GeoImportacaoExecucao execucao = GeoImportacaoExecucao.Iniciar("202601", "teste", iniciadoEm).Value!;
+        ctx.ImportacaoExecucoes.Add(execucao);
+        await ctx.SaveChangesAsync();
+        return execucao.Id;
+    }
+
+    private async Task LimparAsync()
+    {
+        await using GeoDbContext ctx = _fixture.CreateDbContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE TABLE geo_importacao_execucao");
+    }
+}


### PR DESCRIPTION
## Contexto

Fecha a cauda de follow-ups levantados na revisão da Story **#674** (ETL de atualização periódica do Geo, PR #689): uma correção de operabilidade no startup e três lacunas de cobertura — todos não-bloqueantes acordados na revisão. Com isso, a Feature **F4 #665** fica sem pendências de ETL.

## O que muda

### `fix(geo)` — reconciliação de órfãs em startup aguardado (#695)
`BackgroundService.StartAsync` retorna no primeiro `await` de `ExecuteAsync`, então a reconciliação de execuções `EmAndamento` abandonadas corria **concorrente** ao seed de dev e ao servidor HTTP. Uma órfã elegível ainda não marcada `Falhou` colidia no índice único parcial com um seed/disparo imediato (409), deixando a base vazia até o próximo disparo.

A reconciliação passa para o novo `GeoReconciliacaoStartupHostedService` — um `IHostedService` cujo `StartAsync` é **aguardado** pelo host. Registrado antes do worker e do seed (`ServicesStartConcurrently=false` ⇒ ordem de start = ordem de registro: migrations → reconciliação → worker → seed), garante que a reclamação conclua antes de qualquer disparo. O worker deixa de reconciliar no `ExecuteAsync`.

### `test(geo)` — cobertura do ETL periódico
- **#691** — disparo não enfileirado: força `ChannelClosedException` (fila com o writer completado) e assere que `IniciarAsync` retorna `Failure(NaoEnfileirada)` — o caminho que o endpoint admin mapeia para **503** — e que a execução é marcada `Falhou`.
- **#692** — wiring real fila → worker → executor: sobe o `GeoImportacaoBackgroundService`, dispara via fila e aguarda a conclusão de forma **determinística** (`TaskCompletionSource` no fim do `ExecutarAsync`, sem `Sleep`). A reconciliação no startup, antes parte desta lacuna, é coberta agora pela #695.
- **#693** — métricas `geo.etl.*`: `MeterListener` asserindo a emissão dos instrumentos em carga **concluída** (`status=concluida`, `linhas` coerentes com inseridos+atualizados do relatório) e em carga **falhada** (`status=falhou`, sem `linhas`).

## Validação local
- Build limpo (0 avisos / 0 erros); API Geo compila.
- `Geo.IntegrationTests`: **281/281** com Redis e **281/281** sem Redis (`docker stop docker-redis-1`).
- `ArchTests`: 24/24.

## Issues
Closes #695
Closes #691
Closes #692
Closes #693
