### PR TITLE
feat(organizacao): adota referência de cidade do Geo em Instituicao (#686)

### DIFF
--- a/contracts/openapi.organizacao.json
+++ b/contracts/openapi.organizacao.json
@@ -1008,7 +1008,9 @@
           "igc",
           "website",
           "enderecoSede",
-          "municipioSede",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf",
           "unidadeRaizId"
         ],
         "type": "object",
@@ -1092,7 +1094,19 @@
               "string"
             ]
           },
-          "municipioSede": {
+          "cidadeCodigoIbge": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeNome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeUf": {
             "type": [
               "null",
               "string"
@@ -1229,7 +1243,9 @@
           "igc",
           "website",
           "enderecoSede",
-          "municipioSede",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf",
           "unidadeRaizId"
         ],
         "type": "object",
@@ -1309,7 +1325,19 @@
               "string"
             ]
           },
-          "municipioSede": {
+          "cidadeCodigoIbge": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeNome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeUf": {
             "type": [
               "null",
               "string"
@@ -1409,7 +1437,11 @@
           "igc",
           "website",
           "enderecoSede",
-          "municipioSede",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf",
+          "cidadeOrigem",
+          "cidadeDisplayAtualizadoEm",
           "unidadeRaizId",
           "criadoEm"
         ],
@@ -1494,11 +1526,36 @@
               "string"
             ]
           },
-          "municipioSede": {
+          "cidadeCodigoIbge": {
             "type": [
               "null",
               "string"
             ]
+          },
+          "cidadeNome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeUf": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeOrigem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeDisplayAtualizadoEm": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
           },
           "unidadeRaizId": {
             "type": [

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 
 /// <summary>
 /// Registry de mapeamentos de erros de domínio do Configuracao para wire codes

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -52,6 +52,12 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 "uniplus.configuracao.cidade_referencia.nome_obrigatorio",
                 "Nome da cidade é obrigatório")),
 
+        new(CidadeReferenciaErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.cidade_referencia.nome_tamanho",
+                "Nome da cidade excede o tamanho máximo")),
+
         // ── Campus ────────────────────────────────────────────────────────
         new(CampusErrorCodes.SiglaObrigatoria,
             new DomainErrorMapping(

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandHandler.cs
@@ -1,7 +1,7 @@
 namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/AtualizarCampusCommandValidator.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
 
 using FluentValidation;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 
 public sealed class AtualizarCampusCommandValidator : AbstractValidator<AtualizarCampusCommand>
 {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandHandler.cs
@@ -1,7 +1,7 @@
 namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Campi/CriarCampusCommandValidator.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
 
 using FluentValidation;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 
 public sealed class CriarCampusCommandValidator : AbstractValidator<CriarCampusCommand>
 {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandHandler.cs
@@ -1,7 +1,7 @@
 namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/AtualizarLocalOfertaCommandValidator.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
 
 using FluentValidation;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 
 public sealed class AtualizarLocalOfertaCommandValidator : AbstractValidator<AtualizarLocalOfertaCommand>

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommandHandler.cs
@@ -1,7 +1,7 @@
 namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/CriarLocalOfertaCommandValidator.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
 
 using FluentValidation;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 
 public sealed class CriarLocalOfertaCommandValidator : AbstractValidator<CriarLocalOfertaCommand>

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Campus.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Campus.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Domain.Interfaces;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/LocalOferta.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/LocalOferta.cs
@@ -1,6 +1,6 @@
 namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CampusConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CampusConfiguration.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configuratio
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage(

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/LocalOfertaConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/LocalOfertaConfiguration.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configuratio
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage(

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Errors/OrganizacaoDomainErrorRegistration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Errors/OrganizacaoDomainErrorRegistration.cs
@@ -262,5 +262,11 @@ internal sealed class OrganizacaoDomainErrorRegistration : IDomainErrorRegistrat
                 StatusCodes.Status422UnprocessableEntity,
                 "uniplus.organizacao.cidade_referencia.nome_obrigatorio",
                 "Nome da cidade é obrigatório")),
+
+        new(CidadeReferenciaErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.cidade_referencia.nome_tamanho",
+                "Nome da cidade excede o tamanho máximo")),
     ];
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Errors/OrganizacaoDomainErrorRegistration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Errors/OrganizacaoDomainErrorRegistration.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Http;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes",
@@ -230,5 +231,36 @@ internal sealed class OrganizacaoDomainErrorRegistration : IDomainErrorRegistrat
                 StatusCodes.Status422UnprocessableEntity,
                 "uniplus.organizacao.instituicao.unidade_raiz_nao_eh_reitoria",
                 "A unidade informada como raiz da instituição deve ser do tipo reitoria")),
+
+        // ── Referência de cidade do Geo (sede da Instituição) ─────────────
+        new(CidadeReferenciaErrorCodes.CodigoIbgeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.cidade_referencia.codigo_ibge_obrigatorio",
+                "Código IBGE da cidade é obrigatório")),
+
+        new(CidadeReferenciaErrorCodes.CodigoIbgeFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.cidade_referencia.codigo_ibge_formato_invalido",
+                "Código IBGE da cidade em formato inválido")),
+
+        new(CidadeReferenciaErrorCodes.UfObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.cidade_referencia.uf_obrigatoria",
+                "UF da cidade é obrigatória")),
+
+        new(CidadeReferenciaErrorCodes.UfIncoerente,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.cidade_referencia.uf_incoerente",
+                "UF informada incompatível com o prefixo do código IBGE")),
+
+        new(CidadeReferenciaErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.organizacao.cidade_referencia.nome_obrigatorio",
+                "Nome da cidade é obrigatório")),
     ];
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommand.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommand.cs
@@ -5,7 +5,10 @@ using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Edita os dados regulatórios e o vínculo com a reitoria da Instituição
-/// existente.
+/// existente. A referência de cidade da sede é opcional (all-or-nothing): o trio
+/// <c>CidadeCodigoIbge</c>/<c>CidadeNome</c>/<c>CidadeUf</c> viaja no payload; a
+/// proveniência/frescura do display cache é recarimbada server-side pelo handler
+/// apenas quando o trio muda (ADR-0090).
 /// </summary>
 public sealed record AtualizarInstituicaoCommand(
     Guid Id,
@@ -24,5 +27,7 @@ public sealed record AtualizarInstituicaoCommand(
     string? Igc,
     string? Website,
     string? EnderecoSede,
-    string? MunicipioSede,
+    string? CidadeCodigoIbge,
+    string? CidadeNome,
+    string? CidadeUf,
     Guid? UnidadeRaizId) : ICommand<Result>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommandHandler.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
@@ -15,6 +16,7 @@ public static class AtualizarInstituicaoCommandHandler
         IUnidadeRepository unidadeRepository,
         IUnitOfWork unitOfWork,
         IInstituicaoCacheInvalidator cacheInvalidator,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -22,6 +24,7 @@ public static class AtualizarInstituicaoCommandHandler
         ArgumentNullException.ThrowIfNull(unidadeRepository);
         ArgumentNullException.ThrowIfNull(unitOfWork);
         ArgumentNullException.ThrowIfNull(cacheInvalidator);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
         Instituicao? instituicao = await repository
             .ObterPorIdAsync(command.Id, cancellationToken)
@@ -41,6 +44,19 @@ public static class AtualizarInstituicaoCommandHandler
             return Result.Failure(vinculoInvalido);
         }
 
+        // Só recarimba a proveniência/frescura do display cache quando o trio de
+        // cidade efetivamente muda — assim cidade_display_atualizado_em rastreia a
+        // última reconciliação da cidade, não qualquer edição de outro campo. Sem
+        // cidade no payload, ambos zeram (a entidade também zera o trio).
+        bool temCidade = !string.IsNullOrWhiteSpace(command.CidadeCodigoIbge);
+        bool cidadeMudou = CidadeReferenciaMudou(command, instituicao);
+        string? cidadeOrigem = temCidade
+            ? (cidadeMudou ? ReferenciaCidadeGeo.OrigemGeoApi : instituicao.CidadeOrigem)
+            : null;
+        DateTimeOffset? cidadeAtualizadoEm = temCidade
+            ? (cidadeMudou ? timeProvider.GetUtcNow() : instituicao.CidadeDisplayAtualizadoEm)
+            : null;
+
         Result atualizarResult = instituicao.Atualizar(
             command.CodigoEmec,
             command.Nome,
@@ -57,7 +73,11 @@ public static class AtualizarInstituicaoCommandHandler
             command.Igc,
             command.Website,
             command.EnderecoSede,
-            command.MunicipioSede,
+            command.CidadeCodigoIbge,
+            command.CidadeNome,
+            command.CidadeUf,
+            cidadeOrigem,
+            cidadeAtualizadoEm,
             command.UnidadeRaizId);
 
         if (atualizarResult.IsFailure)
@@ -70,4 +90,23 @@ public static class AtualizarInstituicaoCommandHandler
 
         return Result.Success();
     }
+
+    /// <summary>
+    /// Indica se o trio de referência de cidade do comando difere do estado
+    /// persistido, comparando os valores já normalizados (código/nome aparados,
+    /// UF em caixa alta). Cobre transições presente→ausente e ausente→presente.
+    /// </summary>
+    private static bool CidadeReferenciaMudou(AtualizarInstituicaoCommand command, Instituicao instituicao)
+    {
+        string? codigo = NormalizarOpcional(command.CidadeCodigoIbge);
+        string? nome = NormalizarOpcional(command.CidadeNome);
+        string? uf = NormalizarOpcional(command.CidadeUf)?.ToUpperInvariant();
+
+        return !string.Equals(codigo, instituicao.CidadeCodigoIbge, StringComparison.Ordinal)
+            || !string.Equals(nome, instituicao.CidadeNome, StringComparison.Ordinal)
+            || !string.Equals(uf, instituicao.CidadeUf, StringComparison.Ordinal);
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommandValidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/AtualizarInstituicaoCommandValidator.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instit
 
 using FluentValidation;
 
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
+
 /// <summary>
 /// Validação de formato dos campos da atualização da Instituição. As regras que
 /// dependem do banco (existência, tipo da Unidade raiz) ficam no handler.
@@ -36,5 +38,14 @@ public sealed class AtualizarInstituicaoCommandValidator : AbstractValidator<Atu
         RuleFor(x => x.Website)
             .MaximumLength(255).WithMessage("Website deve ter no máximo 255 caracteres.")
             .When(x => x.Website is not null);
+
+        // Referência de cidade do Geo (ADR-0090): opcional all-or-nothing — só
+        // valida quando algum fragmento do trio veio; aí exige o trio coerente.
+        RuleFor(x => x)
+            .Must(x => ReferenciaCidadeGeo.EhValida(x.CidadeCodigoIbge, x.CidadeNome, x.CidadeUf))
+            .WithMessage("Referência de cidade inválida: informe o trio código IBGE (7 dígitos), nome e UF, com prefixo de UF coerente.")
+            .When(x => !string.IsNullOrWhiteSpace(x.CidadeCodigoIbge)
+                || !string.IsNullOrWhiteSpace(x.CidadeNome)
+                || !string.IsNullOrWhiteSpace(x.CidadeUf));
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommand.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommand.cs
@@ -5,7 +5,11 @@ using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Cria a Instituição singleton. Rejeitado se já existe uma Instituição viva
-/// (ADR-0055 · CA-02).
+/// (ADR-0055 · CA-02). A referência de cidade da sede é opcional (all-or-nothing)
+/// e segue o padrão Geo (ADR-0090): o trio <c>CidadeCodigoIbge</c>/<c>CidadeNome</c>/
+/// <c>CidadeUf</c> viaja no payload (composição no cliente); a proveniência
+/// (<c>cidade_origem</c>) e o instante (<c>cidade_display_atualizado_em</c>) são
+/// carimbados server-side pelo handler.
 /// </summary>
 public sealed record CriarInstituicaoCommand(
     string CodigoEmec,
@@ -23,5 +27,7 @@ public sealed record CriarInstituicaoCommand(
     string? Igc,
     string? Website,
     string? EnderecoSede,
-    string? MunicipioSede,
+    string? CidadeCodigoIbge,
+    string? CidadeNome,
+    string? CidadeUf,
     Guid? UnidadeRaizId) : ICommand<Result<Guid>>;

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommandHandler.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommandHandler.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
@@ -30,6 +31,7 @@ public static class CriarInstituicaoCommandHandler
         IUnidadeRepository unidadeRepository,
         IUnitOfWork unitOfWork,
         IInstituicaoCacheInvalidator cacheInvalidator,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -37,6 +39,7 @@ public static class CriarInstituicaoCommandHandler
         ArgumentNullException.ThrowIfNull(unidadeRepository);
         ArgumentNullException.ThrowIfNull(unitOfWork);
         ArgumentNullException.ThrowIfNull(cacheInvalidator);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
         if (await repository.ExisteAlgumaVivaAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -52,6 +55,12 @@ public static class CriarInstituicaoCommandHandler
         {
             return Result<Guid>.Failure(vinculoInvalido);
         }
+
+        // Carimbo server-side do display cache da cidade (ADR-0090): com cidade
+        // informada, proveniência geo-api + instante atual; sem cidade, ambos nulos.
+        bool temCidade = !string.IsNullOrWhiteSpace(command.CidadeCodigoIbge);
+        string? cidadeOrigem = temCidade ? ReferenciaCidadeGeo.OrigemGeoApi : null;
+        DateTimeOffset? cidadeAtualizadoEm = temCidade ? timeProvider.GetUtcNow() : null;
 
         Result<Instituicao> instituicaoResult = Instituicao.Criar(
             command.CodigoEmec,
@@ -69,7 +78,11 @@ public static class CriarInstituicaoCommandHandler
             command.Igc,
             command.Website,
             command.EnderecoSede,
-            command.MunicipioSede,
+            command.CidadeCodigoIbge,
+            command.CidadeNome,
+            command.CidadeUf,
+            cidadeOrigem,
+            cidadeAtualizadoEm,
             command.UnidadeRaizId);
 
         if (instituicaoResult.IsFailure)

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommandValidator.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Commands/Instituicoes/CriarInstituicaoCommandValidator.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instit
 
 using FluentValidation;
 
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
+
 /// <summary>
 /// Validação de formato dos campos da criação da Instituição (CA-03). As regras
 /// que dependem do banco — singleton (CA-02) e tipo da Unidade raiz (CA-04) —
@@ -34,5 +36,14 @@ public sealed class CriarInstituicaoCommandValidator : AbstractValidator<CriarIn
         RuleFor(x => x.Website)
             .MaximumLength(255).WithMessage("Website deve ter no máximo 255 caracteres.")
             .When(x => x.Website is not null);
+
+        // Referência de cidade do Geo (ADR-0090): opcional all-or-nothing — só
+        // valida quando algum fragmento do trio veio; aí exige o trio coerente.
+        RuleFor(x => x)
+            .Must(x => ReferenciaCidadeGeo.EhValida(x.CidadeCodigoIbge, x.CidadeNome, x.CidadeUf))
+            .WithMessage("Referência de cidade inválida: informe o trio código IBGE (7 dígitos), nome e UF, com prefixo de UF coerente.")
+            .When(x => !string.IsNullOrWhiteSpace(x.CidadeCodigoIbge)
+                || !string.IsNullOrWhiteSpace(x.CidadeNome)
+                || !string.IsNullOrWhiteSpace(x.CidadeUf));
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/DTOs/InstituicaoDto.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/DTOs/InstituicaoDto.cs
@@ -23,7 +23,11 @@ public sealed record InstituicaoDto(
     string? Igc,
     string? Website,
     string? EnderecoSede,
-    string? MunicipioSede,
+    string? CidadeCodigoIbge,
+    string? CidadeNome,
+    string? CidadeUf,
+    string? CidadeOrigem,
+    DateTimeOffset? CidadeDisplayAtualizadoEm,
     Guid? UnidadeRaizId,
     DateTimeOffset CriadoEm)
 {

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Mappings/InstituicaoMapping.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Mappings/InstituicaoMapping.cs
@@ -26,7 +26,11 @@ public static class InstituicaoMapping
             instituicao.Igc,
             instituicao.Website,
             instituicao.EnderecoSede,
-            instituicao.MunicipioSede,
+            instituicao.CidadeCodigoIbge,
+            instituicao.CidadeNome,
+            instituicao.CidadeUf,
+            instituicao.CidadeOrigem,
+            instituicao.CidadeDisplayAtualizadoEm,
             instituicao.UnidadeRaizId,
             instituicao.CreatedAt);
     }
@@ -42,7 +46,9 @@ public static class InstituicaoMapping
             instituicao.Cnpj,
             instituicao.OrganizacaoAcademica,
             instituicao.CategoriaAdministrativa,
-            instituicao.MunicipioSede,
+            instituicao.CidadeCodigoIbge,
+            instituicao.CidadeNome,
+            instituicao.CidadeUf,
             instituicao.UnidadeRaizId);
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Instituicao.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Entities/Instituicao.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
 
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
 using Unifesspa.UniPlus.Kernel.Results;
@@ -27,6 +28,13 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
 /// <c>UnidadeRaizId</c> — FK intra-banco (ADR-0054). A conferência de que a
 /// Unidade referenciada é viva e do tipo reitoria é responsabilidade do handler
 /// (via repositório); esta entidade recebe o Id já validado.</para>
+/// <para>O município da sede é uma <strong>referência de cidade do Geo</strong>
+/// (ADR-0090): <c>CidadeCodigoIbge</c> (código IBGE de 7 dígitos) + display cache
+/// (<c>CidadeNome</c>, <c>CidadeUf</c>), preenchido pelo frontend via composição
+/// no cliente — sem FK cross-banco nem chamada ao Geo. É <strong>opcional</strong>
+/// (all-or-nothing): ou o trio completo e coerente, ou ausente por completo. O
+/// <c>EnderecoSede</c> (logradouro) permanece texto livre — o Geo não modela
+/// endereço pontual.</para>
 /// </remarks>
 public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
 {
@@ -54,7 +62,15 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
     public string? Igc { get; private set; }
     public string? Website { get; private set; }
     public string? EnderecoSede { get; private set; }
-    public string? MunicipioSede { get; private set; }
+
+    // Referência de cidade do Geo (ADR-0090) — código + display cache, opcional
+    // (all-or-nothing). Substitui o antigo MunicipioSede texto livre.
+    public string? CidadeCodigoIbge { get; private set; }
+    public string? CidadeNome { get; private set; }
+    public string? CidadeUf { get; private set; }
+    public string? CidadeOrigem { get; private set; }
+    public DateTimeOffset? CidadeDisplayAtualizadoEm { get; private set; }
+
     public Guid? UnidadeRaizId { get; private set; }
 
     /// <summary>
@@ -75,9 +91,13 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
     }
 
     /// <summary>
-    /// Cria a Instituição. Valida apenas formato e domínio local — o invariante
-    /// singleton (no máximo uma viva) e a conferência do tipo da Unidade raiz são
-    /// responsabilidade do handler chamador (dependem do repositório).
+    /// Cria a Instituição. Valida apenas formato e domínio local (incluindo a
+    /// referência de cidade opcional via <see cref="ReferenciaCidadeGeo"/>) — o
+    /// invariante singleton (no máximo uma viva) e a conferência do tipo da
+    /// Unidade raiz são responsabilidade do handler chamador (dependem do
+    /// repositório). A proveniência/frescura do display cache
+    /// (<paramref name="cidadeOrigem"/>, <paramref name="cidadeDisplayAtualizadoEm"/>)
+    /// é carimbada server-side pelo handler (ADR-0090).
     /// </summary>
     public static Result<Instituicao> Criar(
         string codigoEmec,
@@ -95,7 +115,11 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
         string? igc,
         string? website,
         string? enderecoSede,
-        string? municipioSede,
+        string? cidadeCodigoIbge,
+        string? cidadeNome,
+        string? cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm,
         Guid? unidadeRaizId)
     {
         ArgumentNullException.ThrowIfNull(codigoEmec);
@@ -107,7 +131,8 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
         Result validacao = ValidarCampos(
             codigoEmec, nome, sigla, organizacaoAcademica, categoriaAdministrativa,
             cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
-            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede, municipioSede);
+            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede,
+            cidadeCodigoIbge, cidadeNome, cidadeUf);
         if (validacao.IsFailure)
         {
             return Result<Instituicao>.Failure(validacao.Error!);
@@ -118,14 +143,16 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
             codigoEmec, nome, sigla, organizacaoAcademica, categoriaAdministrativa,
             cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
             atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede,
-            municipioSede, unidadeRaizId);
+            cidadeCodigoIbge, cidadeNome, cidadeUf, cidadeOrigem, cidadeDisplayAtualizadoEm,
+            unidadeRaizId);
 
         return Result<Instituicao>.Success(instituicao);
     }
 
     /// <summary>
     /// Atualiza os dados regulatórios e o vínculo com a reitoria. A conferência
-    /// do tipo da Unidade raiz informada é responsabilidade do handler.
+    /// do tipo da Unidade raiz informada é responsabilidade do handler, assim
+    /// como o carimbo da proveniência/frescura do display cache da cidade.
     /// </summary>
     public Result Atualizar(
         string codigoEmec,
@@ -143,7 +170,11 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
         string? igc,
         string? website,
         string? enderecoSede,
-        string? municipioSede,
+        string? cidadeCodigoIbge,
+        string? cidadeNome,
+        string? cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm,
         Guid? unidadeRaizId)
     {
         ArgumentNullException.ThrowIfNull(codigoEmec);
@@ -155,7 +186,8 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
         Result validacao = ValidarCampos(
             codigoEmec, nome, sigla, organizacaoAcademica, categoriaAdministrativa,
             cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
-            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede, municipioSede);
+            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede,
+            cidadeCodigoIbge, cidadeNome, cidadeUf);
         if (validacao.IsFailure)
         {
             return validacao;
@@ -165,7 +197,8 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
             codigoEmec, nome, sigla, organizacaoAcademica, categoriaAdministrativa,
             cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
             atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede,
-            municipioSede, unidadeRaizId);
+            cidadeCodigoIbge, cidadeNome, cidadeUf, cidadeOrigem, cidadeDisplayAtualizadoEm,
+            unidadeRaizId);
 
         return Result.Success();
     }
@@ -186,7 +219,11 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
         string? igc,
         string? website,
         string? enderecoSede,
-        string? municipioSede,
+        string? cidadeCodigoIbge,
+        string? cidadeNome,
+        string? cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm,
         Guid? unidadeRaizId)
     {
         CodigoEmec = codigoEmec.Trim();
@@ -204,8 +241,30 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
         Igc = NormalizarOpcional(igc);
         Website = NormalizarOpcional(website);
         EnderecoSede = NormalizarOpcional(enderecoSede);
-        MunicipioSede = NormalizarOpcional(municipioSede);
+        AplicarReferenciaCidade(
+            cidadeCodigoIbge, cidadeNome, cidadeUf, cidadeOrigem, cidadeDisplayAtualizadoEm);
         UnidadeRaizId = unidadeRaizId;
+    }
+
+    /// <summary>
+    /// Normaliza a referência de cidade já validada (all-or-nothing): com cidade
+    /// presente grava o trio normalizado (UF em caixa alta) + display cache; sem
+    /// cidade, zera os cinco campos. O gate canônico é o código IBGE — a validação
+    /// garante que, se qualquer fragmento veio, o trio completo veio.
+    /// </summary>
+    private void AplicarReferenciaCidade(
+        string? cidadeCodigoIbge,
+        string? cidadeNome,
+        string? cidadeUf,
+        string? cidadeOrigem,
+        DateTimeOffset? cidadeDisplayAtualizadoEm)
+    {
+        bool temCidade = !string.IsNullOrWhiteSpace(cidadeCodigoIbge);
+        CidadeCodigoIbge = temCidade ? cidadeCodigoIbge!.Trim() : null;
+        CidadeNome = temCidade ? cidadeNome!.Trim() : null;
+        CidadeUf = temCidade ? cidadeUf!.Trim().ToUpperInvariant() : null;
+        CidadeOrigem = temCidade ? NormalizarOpcional(cidadeOrigem) : null;
+        CidadeDisplayAtualizadoEm = temCidade ? cidadeDisplayAtualizadoEm : null;
     }
 
     private static string? NormalizarOpcional(string? valor)
@@ -234,7 +293,9 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
         string? igc,
         string? website,
         string? enderecoSede,
-        string? municipioSede)
+        string? cidadeCodigoIbge,
+        string? cidadeNome,
+        string? cidadeUf)
     {
         if (string.IsNullOrWhiteSpace(codigoEmec))
         {
@@ -306,9 +367,36 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
                 $"Categoria administrativa deve ter no máximo {CategoriaAdministrativaMaxLength} caracteres."));
         }
 
+        Result cidade = ValidarReferenciaCidade(cidadeCodigoIbge, cidadeNome, cidadeUf);
+        if (cidade.IsFailure)
+        {
+            return cidade;
+        }
+
         return ValidarOpcionais(
             cnpj, mantenedora, codigoMantenedoraEmec, situacao, atoCredenciamento,
-            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede, municipioSede);
+            atoRecredenciamento, conceitoInstitucional, igc, website, enderecoSede);
+    }
+
+    /// <summary>
+    /// Valida a referência de cidade do Geo (ADR-0090) como opcional
+    /// <strong>all-or-nothing</strong>: ausente por completo é válido; qualquer
+    /// fragmento presente exige o trio (código IBGE + nome + UF) com formato e
+    /// coerência de UF — delegado ao <see cref="ReferenciaCidadeGeo"/>, que
+    /// reporta o campo faltante quando o preenchimento é parcial.
+    /// </summary>
+    private static Result ValidarReferenciaCidade(
+        string? cidadeCodigoIbge,
+        string? cidadeNome,
+        string? cidadeUf)
+    {
+        bool algumPresente = !string.IsNullOrWhiteSpace(cidadeCodigoIbge)
+            || !string.IsNullOrWhiteSpace(cidadeNome)
+            || !string.IsNullOrWhiteSpace(cidadeUf);
+
+        return algumPresente
+            ? ReferenciaCidadeGeo.Validar(cidadeCodigoIbge, cidadeNome, cidadeUf)
+            : Result.Success();
     }
 
     private static Result ValidarOpcionais(
@@ -321,8 +409,7 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
         string? conceitoInstitucional,
         string? igc,
         string? website,
-        string? enderecoSede,
-        string? municipioSede)
+        string? enderecoSede)
     {
         (string? valor, int max)[] opcionais =
         [
@@ -336,7 +423,6 @@ public sealed class Instituicao : SoftDeletableEntity, IAuditableEntity
             (igc, CampoOpcionalCurtoMaxLength),
             (website, CampoOpcionalMedioMaxLength),
             (enderecoSede, CampoOpcionalLongoMaxLength),
-            (municipioSede, CampoOpcionalCurtoMaxLength),
         ];
 
         foreach ((string? valor, int max) in opcionais)

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/InstituicaoConfiguration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Configurations/InstituicaoConfiguration.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage(
@@ -39,7 +40,18 @@ internal sealed class InstituicaoConfiguration : IEntityTypeConfiguration<Instit
         builder.Property(i => i.Igc).HasMaxLength(100);
         builder.Property(i => i.Website).HasMaxLength(255);
         builder.Property(i => i.EnderecoSede).HasMaxLength(500);
-        builder.Property(i => i.MunicipioSede).HasMaxLength(100);
+
+        // Referência de cidade do Geo (ADR-0090): código + display cache, opcional
+        // (all-or-nothing), sem FK cross-banco para uniplus_geo.
+        builder.Property(i => i.CidadeCodigoIbge)
+            .HasMaxLength(ReferenciaCidadeGeo.CodigoIbgeLength)
+            .IsFixedLength();
+        builder.Property(i => i.CidadeNome).HasMaxLength(ReferenciaCidadeGeo.NomeMaxLength);
+        builder.Property(i => i.CidadeUf)
+            .HasMaxLength(ReferenciaCidadeGeo.UfLength)
+            .IsFixedLength();
+        builder.Property(i => i.CidadeOrigem).HasMaxLength(ReferenciaCidadeGeo.OrigemMaxLength);
+        builder.Property(i => i.CidadeDisplayAtualizadoEm);
 
         // Auditoria (IAuditableEntity)
         builder.Property(i => i.CreatedBy).HasMaxLength(255);
@@ -71,5 +83,9 @@ internal sealed class InstituicaoConfiguration : IEntityTypeConfiguration<Instit
             .IsUnique()
             .HasFilter("is_deleted = false")
             .HasDatabaseName("ix_instituicao_singleton_vivo");
+
+        // Índice de relatório/filtro pela cidade da sede (ADR-0090).
+        builder.HasIndex(i => i.CidadeCodigoIbge)
+            .HasDatabaseName("ix_instituicao_cidade_codigo_ibge");
     }
 }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260620020302_AdotaReferenciaCidadeGeoNaInstituicao.Designer.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260620020302_AdotaReferenciaCidadeGeoNaInstituicao.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(OrganizacaoInstitucionalDbContext))]
-    partial class OrganizacaoInstitucionalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260620020302_AdotaReferenciaCidadeGeoNaInstituicao")]
+    partial class AdotaReferenciaCidadeGeoNaInstituicao
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260620020302_AdotaReferenciaCidadeGeoNaInstituicao.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260620020302_AdotaReferenciaCidadeGeoNaInstituicao.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdotaReferenciaCidadeGeoNaInstituicao : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "municipio_sede",
+                table: "instituicao");
+
+            migrationBuilder.AddColumn<string>(
+                name: "cidade_codigo_ibge",
+                table: "instituicao",
+                type: "character(7)",
+                fixedLength: true,
+                maxLength: 7,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "cidade_display_atualizado_em",
+                table: "instituicao",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "cidade_nome",
+                table: "instituicao",
+                type: "character varying(150)",
+                maxLength: 150,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "cidade_origem",
+                table: "instituicao",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "cidade_uf",
+                table: "instituicao",
+                type: "character(2)",
+                fixedLength: true,
+                maxLength: 2,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_instituicao_cidade_codigo_ibge",
+                table: "instituicao",
+                column: "cidade_codigo_ibge");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_instituicao_cidade_codigo_ibge",
+                table: "instituicao");
+
+            migrationBuilder.DropColumn(
+                name: "cidade_codigo_ibge",
+                table: "instituicao");
+
+            migrationBuilder.DropColumn(
+                name: "cidade_display_atualizado_em",
+                table: "instituicao");
+
+            migrationBuilder.DropColumn(
+                name: "cidade_nome",
+                table: "instituicao");
+
+            migrationBuilder.DropColumn(
+                name: "cidade_origem",
+                table: "instituicao");
+
+            migrationBuilder.DropColumn(
+                name: "cidade_uf",
+                table: "instituicao");
+
+            migrationBuilder.AddColumn<string>(
+                name: "municipio_sede",
+                table: "instituicao",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+    }
+}

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260620020302_AdotaReferenciaCidadeGeoNaInstituicao.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Persistence/Migrations/20260620020302_AdotaReferenciaCidadeGeoNaInstituicao.cs
@@ -11,6 +11,12 @@ namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Sem backfill: municipio_sede era texto livre (apenas o nome do
+            // município), sem código IBGE nem UF — não há como derivar a referência
+            // estruturada cidade_codigo_ibge sem geocodificação não confiável. A
+            // composição no cliente (ADR-0090) passa a ser a fonte da cidade daqui
+            // pra frente. Em fase de scaffolding não há dado semeado em
+            // municipio_sede a preservar; a coluna é descartada.
             migrationBuilder.DropColumn(
                 name: "municipio_sede",
                 table: "instituicao");
@@ -60,36 +66,12 @@ namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence.
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "ix_instituicao_cidade_codigo_ibge",
-                table: "instituicao");
-
-            migrationBuilder.DropColumn(
-                name: "cidade_codigo_ibge",
-                table: "instituicao");
-
-            migrationBuilder.DropColumn(
-                name: "cidade_display_atualizado_em",
-                table: "instituicao");
-
-            migrationBuilder.DropColumn(
-                name: "cidade_nome",
-                table: "instituicao");
-
-            migrationBuilder.DropColumn(
-                name: "cidade_origem",
-                table: "instituicao");
-
-            migrationBuilder.DropColumn(
-                name: "cidade_uf",
-                table: "instituicao");
-
-            migrationBuilder.AddColumn<string>(
-                name: "municipio_sede",
-                table: "instituicao",
-                type: "character varying(100)",
-                maxLength: 100,
-                nullable: true);
+            // Forward-only per ADR-0054 §J: nova migration "Reverte..." é o
+            // mecanismo canônico de revert. Dropar as colunas cidade_* aqui
+            // destruiria a referência de cidade capturada e recriaria um
+            // municipio_sede vazio — perda silenciosa de dado num
+            // `database update <baseline>`, caminho proibido.
+            throw new NotSupportedException("Forward-only migration per ADR-0054 §J.");
         }
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Governance.Contracts/InstituicaoView.cs
+++ b/src/shared/Unifesspa.UniPlus.Governance.Contracts/InstituicaoView.cs
@@ -14,7 +14,9 @@ namespace Unifesspa.UniPlus.Governance.Contracts;
 /// <param name="Cnpj">CNPJ da pessoa jurídica, ou <see langword="null"/> se não informado.</param>
 /// <param name="OrganizacaoAcademica">Classificação e-MEC de organização acadêmica.</param>
 /// <param name="CategoriaAdministrativa">Classificação e-MEC de categoria administrativa.</param>
-/// <param name="MunicipioSede">Município da sede, ou <see langword="null"/> se não informado.</param>
+/// <param name="CidadeCodigoIbge">Código IBGE (7 dígitos) do município da sede, ou <see langword="null"/> se não informado. Referência de cidade do Geo (ADR-0090) — composição no cliente, sem FK cross-banco.</param>
+/// <param name="CidadeNome">Nome do município da sede (display cache), ou <see langword="null"/> se não informado.</param>
+/// <param name="CidadeUf">UF do município da sede (display cache), ou <see langword="null"/> se não informado.</param>
 /// <param name="UnidadeRaizId">Id da Unidade raiz (reitoria), ou <see langword="null"/> se ainda não vinculada.</param>
 public sealed record InstituicaoView(
     Guid Id,
@@ -24,5 +26,7 @@ public sealed record InstituicaoView(
     string? Cnpj,
     string OrganizacaoAcademica,
     string CategoriaAdministrativa,
-    string? MunicipioSede,
+    string? CidadeCodigoIbge,
+    string? CidadeNome,
+    string? CidadeUf,
     Guid? UnidadeRaizId);

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/CidadeReferenciaErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/CidadeReferenciaErrorCodes.cs
@@ -15,4 +15,5 @@ public static class CidadeReferenciaErrorCodes
     public const string UfObrigatoria = "CidadeReferencia.UfObrigatoria";
     public const string UfIncoerente = "CidadeReferencia.UfIncoerente";
     public const string NomeObrigatorio = "CidadeReferencia.NomeObrigatorio";
+    public const string NomeTamanho = "CidadeReferencia.NomeTamanho";
 }

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/CidadeReferenciaErrorCodes.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/CidadeReferenciaErrorCodes.cs
@@ -1,9 +1,10 @@
-namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+namespace Unifesspa.UniPlus.Kernel.Domain.Cidades;
 
 /// <summary>
 /// Códigos de erro da validação da referência de cidade do Geo (ADR-0090):
-/// compartilhados por <c>Campus</c> e <c>LocalOferta</c>, que guardam
-/// <c>cidade_codigo_ibge</c> + display cache em vez de uma FK cross-banco.
+/// compartilhados por qualquer módulo que guarde <c>cidade_codigo_ibge</c> +
+/// display cache em vez de uma FK cross-banco (ex.: <c>Campus</c>/
+/// <c>LocalOferta</c> em Configuração, <c>Instituicao</c> em Organização).
 /// A validação é apenas de formato + coerência de UF (sem dígito verificador,
 /// sem consultar o Geo).
 /// </summary>

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/ReferenciaCidadeGeo.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/ReferenciaCidadeGeo.cs
@@ -1,16 +1,16 @@
-namespace Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+namespace Unifesspa.UniPlus.Kernel.Domain.Cidades;
 
 using System.Collections.Frozen;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Validação server-side da referência de cidade do módulo <c>Geo</c>
-/// (ADR-0090). <c>Campus</c> e <c>LocalOferta</c> guardam
-/// <c>cidade_codigo_ibge</c> (código IBGE de 7 dígitos) + display cache
-/// (<c>cidade_nome</c>, <c>cidade_uf</c>) preenchido pelo frontend a partir da
-/// API do Geo — composição no cliente, sem FK cross-banco nem chamada ao Geo.
+/// (ADR-0090). Entidades de outros módulos (<c>Campus</c>, <c>LocalOferta</c>,
+/// <c>Instituicao</c>) guardam <c>cidade_codigo_ibge</c> (código IBGE de 7
+/// dígitos) + display cache (<c>cidade_nome</c>, <c>cidade_uf</c>) preenchido
+/// pelo frontend a partir da API do Geo — composição no cliente, sem FK
+/// cross-banco nem chamada ao Geo.
 /// </summary>
 /// <remarks>
 /// <para>A validação é apenas de <strong>formato</strong>: 7 dígitos numéricos,

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/ReferenciaCidadeGeo.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/ReferenciaCidadeGeo.cs
@@ -100,6 +100,13 @@ public static class ReferenciaCidadeGeo
                 "Nome da cidade é obrigatório."));
         }
 
+        if (cidadeNome.Trim().Length > NomeMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                CidadeReferenciaErrorCodes.NomeTamanho,
+                $"Nome da cidade deve ter no máximo {NomeMaxLength} caracteres."));
+        }
+
         if (string.IsNullOrWhiteSpace(cidadeUf))
         {
             return Result.Failure(new DomainError(

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarCampusCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarCampusCommandHandlerTests.cs
@@ -6,7 +6,7 @@ using NSubstitute;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
 using Unifesspa.UniPlus.Kernel.Results;

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCampusCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCampusCommandHandlerTests.cs
@@ -9,6 +9,7 @@ using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Kernel.Results;
 
 public sealed class CriarCampusCommandHandlerTests

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCampusCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCampusCommandHandlerTests.cs
@@ -6,7 +6,7 @@ using NSubstitute;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverLocalOfertaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverLocalOfertaCommandHandlerTests.cs
@@ -6,7 +6,7 @@ using NSubstitute;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 using Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CampusTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CampusTests.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
 
 using AwesomeAssertions;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Kernel.Results;

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/LocalOfertaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/LocalOfertaTests.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
 
 using AwesomeAssertions;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Campi/CampusPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Campi/CampusPersistenceTests.cs
@@ -7,7 +7,7 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 
 using Unifesspa.UniPlus.Configuracao.Application.Commands.Campi;
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaPersistenceTests.cs
@@ -6,7 +6,7 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Cidades/ReferenciaCidadeGeoTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Cidades/ReferenciaCidadeGeoTests.cs
@@ -1,15 +1,15 @@
-namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Cidades;
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.Cidades;
 
 using AwesomeAssertions;
 
-using Unifesspa.UniPlus.Configuracao.Domain.Cidades;
-using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// CA-03 (#587): validação de formato + coerência de UF do
 /// <c>cidade_codigo_ibge</c>, server-side, sem consultar o Geo nem validar
-/// dígito verificador.
+/// dígito verificador. Referência de cidade compartilhada (ADR-0090), promovida
+/// ao Kernel para consumo cross-módulo (Configuração e Organização).
 /// </summary>
 public sealed class ReferenciaCidadeGeoTests
 {

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Cidades/ReferenciaCidadeGeoTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Cidades/ReferenciaCidadeGeoTests.cs
@@ -81,6 +81,27 @@ public sealed class ReferenciaCidadeGeoTests
         resultado.Error!.Code.Should().Be(esperado);
     }
 
+    [Fact(DisplayName = "Nome acima do tamanho máximo é rejeitado por formato (evita 500 no SaveChanges)")]
+    public void Validar_NomeMuitoLongo_Rejeita()
+    {
+        string nomeLongo = new('A', ReferenciaCidadeGeo.NomeMaxLength + 1);
+
+        Result resultado = ReferenciaCidadeGeo.Validar("1504208", nomeLongo, "PA");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.NomeTamanho);
+    }
+
+    [Fact(DisplayName = "Nome exatamente no tamanho máximo é aceito (limite inclusivo)")]
+    public void Validar_NomeNoLimite_Aceita()
+    {
+        string nomeNoLimite = new('A', ReferenciaCidadeGeo.NomeMaxLength);
+
+        Result resultado = ReferenciaCidadeGeo.Validar("1504208", nomeNoLimite, "PA");
+
+        resultado.IsSuccess.Should().BeTrue();
+    }
+
     [Fact(DisplayName = "EhValida é o predicado equivalente a Validar().IsSuccess")]
     public void EhValida_EspelhaValidar()
     {

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarInstituicaoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/AtualizarInstituicaoCommandHandlerTests.cs
@@ -5,6 +5,7 @@ using AwesomeAssertions;
 using NSubstitute;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Abstractions;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Commands.Instituicoes;
@@ -16,16 +17,30 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
 
 public sealed class AtualizarInstituicaoCommandHandlerTests
 {
-    private static Instituicao InstituicaoExistente() =>
+    private static readonly DateTimeOffset CidadeCarimbadaEm = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    private static Instituicao InstituicaoExistente(
+        string? cidadeCodigoIbge = null,
+        string? cidadeNome = null,
+        string? cidadeUf = null,
+        string? cidadeOrigem = null,
+        DateTimeOffset? cidadeDisplayAtualizadoEm = null) =>
         Instituicao.Criar(
             "3990", "Universidade Federal do Sul e Sudeste do Pará", "Unifesspa", "Universidade", "Pública Federal",
-            null, null, null, null, null, null, null, null, null, null, null, null).Value!;
+            cnpj: null, mantenedora: null, codigoMantenedoraEmec: null, situacao: null, atoCredenciamento: null,
+            atoRecredenciamento: null, conceitoInstitucional: null, igc: null, website: null, enderecoSede: null,
+            cidadeCodigoIbge, cidadeNome, cidadeUf, cidadeOrigem, cidadeDisplayAtualizadoEm, unidadeRaizId: null).Value!;
 
-    private static AtualizarInstituicaoCommand CommandValido(Guid id, Guid? unidadeRaizId = null) => new(
+    private static AtualizarInstituicaoCommand CommandValido(
+        Guid id,
+        Guid? unidadeRaizId = null,
+        string? cidadeCodigoIbge = null,
+        string? cidadeNome = null,
+        string? cidadeUf = null) => new(
         id, "3990", "Universidade Federal do Sul e Sudeste do Pará", "Unifesspa", "Universidade", "Pública Federal",
         Cnpj: null, Mantenedora: null, CodigoMantenedoraEmec: null, Situacao: null, AtoCredenciamento: null,
         AtoRecredenciamento: null, ConceitoInstitucional: null, Igc: null, Website: null, EnderecoSede: null,
-        MunicipioSede: null, unidadeRaizId);
+        CidadeCodigoIbge: cidadeCodigoIbge, CidadeNome: cidadeNome, CidadeUf: cidadeUf, unidadeRaizId);
 
     private static Unidade NovaUnidade(TipoUnidade tipo) =>
         Unidade.Criar(
@@ -42,7 +57,7 @@ public sealed class AtualizarInstituicaoCommandHandlerTests
         repo.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((Instituicao?)null);
 
         Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
-            CommandValido(Guid.CreateVersion7()), repo, unidadeRepo, uow, cache, CancellationToken.None);
+            CommandValido(Guid.CreateVersion7()), repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.NaoEncontrada);
@@ -60,7 +75,7 @@ public sealed class AtualizarInstituicaoCommandHandlerTests
         repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
 
         Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
-            CommandValido(existente.Id), repo, unidadeRepo, uow, cache, CancellationToken.None);
+            CommandValido(existente.Id), repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsSuccess.Should().BeTrue();
         await uow.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
@@ -80,7 +95,7 @@ public sealed class AtualizarInstituicaoCommandHandlerTests
         unidadeRepo.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(reitoria);
 
         Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
-            CommandValido(existente.Id, reitoria.Id), repo, unidadeRepo, uow, cache, CancellationToken.None);
+            CommandValido(existente.Id, reitoria.Id), repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsSuccess.Should().BeTrue();
         existente.UnidadeRaizId.Should().Be(reitoria.Id);
@@ -99,10 +114,83 @@ public sealed class AtualizarInstituicaoCommandHandlerTests
         unidadeRepo.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(centro);
 
         Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
-            CommandValido(existente.Id, Guid.CreateVersion7()), repo, unidadeRepo, uow, cache, CancellationToken.None);
+            CommandValido(existente.Id, Guid.CreateVersion7()), repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.UnidadeRaizNaoEhReitoria);
         await uow.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "PUT sem mudar a cidade preserva cidade_display_atualizado_em (ADR-0090)")]
+    public async Task Handle_CidadeInalterada_PreservaCarimboDeCidade()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        Instituicao existente = InstituicaoExistente(
+            "1504208", "Marabá", "PA", ReferenciaCidadeGeo.OrigemGeoApi, CidadeCarimbadaEm);
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        // Muda só o vínculo de raiz (deixado nulo aqui); o trio de cidade permanece igual.
+        AtualizarInstituicaoCommand comando = CommandValido(
+            existente.Id, cidadeCodigoIbge: "1504208", cidadeNome: "Marabá", cidadeUf: "PA");
+
+        Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
+            comando, repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.CidadeDisplayAtualizadoEm.Should().Be(CidadeCarimbadaEm,
+            "a cidade não mudou, então o carimbo de frescura do display cache é preservado");
+        existente.CidadeOrigem.Should().Be(ReferenciaCidadeGeo.OrigemGeoApi);
+    }
+
+    [Fact(DisplayName = "PUT trocando a cidade recarimba cidade_display_atualizado_em (ADR-0090)")]
+    public async Task Handle_CidadeAlterada_RecarimbaCidade()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        Instituicao existente = InstituicaoExistente(
+            "1504208", "Marabá", "PA", ReferenciaCidadeGeo.OrigemGeoApi, CidadeCarimbadaEm);
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        AtualizarInstituicaoCommand comando = CommandValido(
+            existente.Id, cidadeCodigoIbge: "1501402", cidadeNome: "Belém", cidadeUf: "PA");
+
+        Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
+            comando, repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.CidadeNome.Should().Be("Belém");
+        existente.CidadeDisplayAtualizadoEm.Should().NotBe(CidadeCarimbadaEm,
+            "a cidade mudou, então o carimbo é renovado a partir do TimeProvider");
+        existente.CidadeOrigem.Should().Be(ReferenciaCidadeGeo.OrigemGeoApi);
+    }
+
+    [Fact(DisplayName = "PUT removendo a cidade zera o trio e o display cache (all-or-nothing)")]
+    public async Task Handle_CidadeRemovida_ZeraTrioEDisplayCache()
+    {
+        IInstituicaoRepository repo = Substitute.For<IInstituicaoRepository>();
+        IUnidadeRepository unidadeRepo = Substitute.For<IUnidadeRepository>();
+        IUnitOfWork uow = Substitute.For<IUnitOfWork>();
+        IInstituicaoCacheInvalidator cache = Substitute.For<IInstituicaoCacheInvalidator>();
+        Instituicao existente = InstituicaoExistente(
+            "1504208", "Marabá", "PA", ReferenciaCidadeGeo.OrigemGeoApi, CidadeCarimbadaEm);
+        repo.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        // Trio ausente no payload → remove a referência de cidade.
+        AtualizarInstituicaoCommand comando = CommandValido(existente.Id);
+
+        Result resultado = await AtualizarInstituicaoCommandHandler.Handle(
+            comando, repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.CidadeCodigoIbge.Should().BeNull();
+        existente.CidadeNome.Should().BeNull();
+        existente.CidadeUf.Should().BeNull();
+        existente.CidadeOrigem.Should().BeNull();
+        existente.CidadeDisplayAtualizadoEm.Should().BeNull();
     }
 }

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/CriarInstituicaoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/CriarInstituicaoCommandHandlerTests.cs
@@ -32,7 +32,9 @@ public sealed class CriarInstituicaoCommandHandlerTests
         Igc: null,
         Website: null,
         EnderecoSede: null,
-        MunicipioSede: null,
+        CidadeCodigoIbge: null,
+        CidadeNome: null,
+        CidadeUf: null,
         unidadeRaizId);
 
     private static Unidade NovaUnidade(TipoUnidade tipo) =>
@@ -50,7 +52,7 @@ public sealed class CriarInstituicaoCommandHandlerTests
         repo.ExisteAlgumaVivaAsync(Arg.Any<CancellationToken>()).Returns(false);
 
         Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
-            CommandValido(), repo, unidadeRepo, uow, cache, CancellationToken.None);
+            CommandValido(), repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsSuccess.Should().BeTrue();
         resultado.Value.Should().NotBeEmpty();
@@ -69,7 +71,7 @@ public sealed class CriarInstituicaoCommandHandlerTests
         repo.ExisteAlgumaVivaAsync(Arg.Any<CancellationToken>()).Returns(true);
 
         Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
-            CommandValido(), repo, unidadeRepo, uow, cache, CancellationToken.None);
+            CommandValido(), repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.JaExisteInstituicaoViva);
@@ -89,7 +91,7 @@ public sealed class CriarInstituicaoCommandHandlerTests
         unidadeRepo.ObterPorIdParaLeituraAsync(raizId, Arg.Any<CancellationToken>()).Returns((Unidade?)null);
 
         Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
-            CommandValido(raizId), repo, unidadeRepo, uow, cache, CancellationToken.None);
+            CommandValido(raizId), repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.UnidadeRaizNaoEncontrada);
@@ -108,7 +110,7 @@ public sealed class CriarInstituicaoCommandHandlerTests
         unidadeRepo.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(centro);
 
         Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
-            CommandValido(Guid.CreateVersion7()), repo, unidadeRepo, uow, cache, CancellationToken.None);
+            CommandValido(Guid.CreateVersion7()), repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.UnidadeRaizNaoEhReitoria);
@@ -127,7 +129,7 @@ public sealed class CriarInstituicaoCommandHandlerTests
         unidadeRepo.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(reitoria);
 
         Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
-            CommandValido(reitoria.Id), repo, unidadeRepo, uow, cache, CancellationToken.None);
+            CommandValido(reitoria.Id), repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsSuccess.Should().BeTrue();
         await repo.Received(1).AdicionarAsync(Arg.Any<Instituicao>(), Arg.Any<CancellationToken>());
@@ -144,7 +146,7 @@ public sealed class CriarInstituicaoCommandHandlerTests
         CriarInstituicaoCommand command = CommandValido() with { CodigoEmec = "" };
 
         Result<Guid> resultado = await CriarInstituicaoCommandHandler.Handle(
-            command, repo, unidadeRepo, uow, cache, CancellationToken.None);
+            command, repo, unidadeRepo, uow, cache, TimeProvider.System, CancellationToken.None);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.CodigoEmecObrigatorio);

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/RemoverInstituicaoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.UnitTests/Commands/RemoverInstituicaoCommandHandlerTests.cs
@@ -17,7 +17,10 @@ public sealed class RemoverInstituicaoCommandHandlerTests
     private static Instituicao InstituicaoExistente() =>
         Instituicao.Criar(
             "3990", "Universidade Federal do Sul e Sudeste do Pará", "Unifesspa", "Universidade", "Pública Federal",
-            null, null, null, null, null, null, null, null, null, null, null, null).Value!;
+            cnpj: null, mantenedora: null, codigoMantenedoraEmec: null, situacao: null, atoCredenciamento: null,
+            atoRecredenciamento: null, conceitoInstitucional: null, igc: null, website: null, enderecoSede: null,
+            cidadeCodigoIbge: null, cidadeNome: null, cidadeUf: null, cidadeOrigem: null,
+            cidadeDisplayAtualizadoEm: null, unidadeRaizId: null).Value!;
 
     [Fact(DisplayName = "Handle com Instituição existente faz soft-delete e invalida cache (CA-05)")]
     public async Task Handle_ComInstituicaoExistente_RemoveEInvalidaCache()

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/InstituicaoTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/InstituicaoTests.cs
@@ -143,6 +143,18 @@ public sealed class InstituicaoTests
         resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.UfIncoerente);
     }
 
+    [Fact(DisplayName = "Criar com nome de cidade acima do limite retorna erro de domínio (422), não estoura na persistência")]
+    public void Criar_ComCidadeNomeMuitoLongo_RetornaNomeTamanho()
+    {
+        string nomeLongo = new('A', ReferenciaCidadeGeo.NomeMaxLength + 1);
+
+        Result<Instituicao> resultado = CriarValida(
+            cidadeCodigoIbge: "1504208", cidadeNome: nomeLongo, cidadeUf: "PA");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.NomeTamanho);
+    }
+
     [Fact(DisplayName = "Atualizar com campos válidos altera o estado regulatório e o vínculo")]
     public void Atualizar_ComCamposValidos_AlteraEstado()
     {

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/InstituicaoTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests/Entities/InstituicaoTests.cs
@@ -2,13 +2,15 @@ namespace Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.UnitTests.Entities;
 
 using AwesomeAssertions;
 
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Errors;
 
 /// <summary>
-/// Testes de unidade do agregado <see cref="Instituicao"/> (Story #585):
-/// validação de formato na factory e na atualização. O invariante singleton e a
+/// Testes de unidade do agregado <see cref="Instituicao"/> (Story #585 · #686):
+/// validação de formato na factory e na atualização, incluindo a referência de
+/// cidade do Geo (ADR-0090) opcional all-or-nothing. O invariante singleton e a
 /// conferência do tipo da Unidade raiz são responsabilidade do handler e estão
 /// cobertos nos testes de Application/Integration.
 /// </summary>
@@ -20,6 +22,9 @@ public sealed class InstituicaoTests
         string sigla = "Unifesspa",
         string organizacaoAcademica = "Universidade",
         string categoriaAdministrativa = "Pública Federal",
+        string? cidadeCodigoIbge = null,
+        string? cidadeNome = null,
+        string? cidadeUf = null,
         Guid? unidadeRaizId = null) =>
         Instituicao.Criar(
             codigoEmec,
@@ -37,7 +42,11 @@ public sealed class InstituicaoTests
             igc: null,
             website: null,
             enderecoSede: null,
-            municipioSede: null,
+            cidadeCodigoIbge,
+            cidadeNome,
+            cidadeUf,
+            cidadeOrigem: null,
+            cidadeDisplayAtualizadoEm: null,
             unidadeRaizId);
 
     [Fact(DisplayName = "Criar com campos válidos retorna sucesso com Id Guid v7 não vazio (CA-01)")]
@@ -82,7 +91,9 @@ public sealed class InstituicaoTests
             "  3990  ", "  Universidade  ", "  Unifesspa  ", "  Universidade  ", "  Pública Federal  ",
             cnpj: "   ", mantenedora: "  Fundação  ", codigoMantenedoraEmec: null, situacao: null,
             atoCredenciamento: null, atoRecredenciamento: null, conceitoInstitucional: null, igc: null,
-            website: null, enderecoSede: null, municipioSede: "  Marabá  ", unidadeRaizId: null);
+            website: null, enderecoSede: "  Rua A, 100  ",
+            cidadeCodigoIbge: "1504208", cidadeNome: "  Marabá  ", cidadeUf: "pa",
+            cidadeOrigem: null, cidadeDisplayAtualizadoEm: null, unidadeRaizId: null);
 
         resultado.IsSuccess.Should().BeTrue();
         Instituicao instituicao = resultado.Value!;
@@ -90,7 +101,46 @@ public sealed class InstituicaoTests
         instituicao.Nome.Should().Be("Universidade");
         instituicao.Cnpj.Should().BeNull("string só com espaços vira null");
         instituicao.Mantenedora.Should().Be("Fundação");
-        instituicao.MunicipioSede.Should().Be("Marabá");
+        instituicao.EnderecoSede.Should().Be("Rua A, 100");
+        instituicao.CidadeCodigoIbge.Should().Be("1504208");
+        instituicao.CidadeNome.Should().Be("Marabá");
+        instituicao.CidadeUf.Should().Be("PA", "a UF é normalizada para caixa alta");
+    }
+
+    [Fact(DisplayName = "Criar sem referência de cidade é válido e deixa o trio nulo (opcional)")]
+    public void Criar_SemReferenciaDeCidade_DeixaTrioNulo()
+    {
+        Instituicao instituicao = CriarValida().Value!;
+
+        instituicao.CidadeCodigoIbge.Should().BeNull();
+        instituicao.CidadeNome.Should().BeNull();
+        instituicao.CidadeUf.Should().BeNull();
+        instituicao.CidadeOrigem.Should().BeNull();
+        instituicao.CidadeDisplayAtualizadoEm.Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Criar com referência de cidade parcial retorna o campo faltante (all-or-nothing)")]
+    [InlineData(null, "Marabá", "PA", CidadeReferenciaErrorCodes.CodigoIbgeObrigatorio)]
+    [InlineData("1504208", null, "PA", CidadeReferenciaErrorCodes.NomeObrigatorio)]
+    [InlineData("1504208", "Marabá", null, CidadeReferenciaErrorCodes.UfObrigatoria)]
+    public void Criar_ComCidadeParcial_RetornaErro(
+        string? cidadeCodigoIbge, string? cidadeNome, string? cidadeUf, string codigoEsperado)
+    {
+        Result<Instituicao> resultado = CriarValida(
+            cidadeCodigoIbge: cidadeCodigoIbge, cidadeNome: cidadeNome, cidadeUf: cidadeUf);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(codigoEsperado);
+    }
+
+    [Fact(DisplayName = "Criar com UF incoerente com o prefixo do código IBGE é rejeitado (15=PA, não SP)")]
+    public void Criar_ComCidadeIncoerente_RetornaUfIncoerente()
+    {
+        Result<Instituicao> resultado = CriarValida(
+            cidadeCodigoIbge: "1504208", cidadeNome: "Marabá", cidadeUf: "SP");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CidadeReferenciaErrorCodes.UfIncoerente);
     }
 
     [Fact(DisplayName = "Atualizar com campos válidos altera o estado regulatório e o vínculo")]
@@ -103,12 +153,16 @@ public sealed class InstituicaoTests
             "4000", "Universidade Federal Renomeada", "UFR", "Universidade", "Pública Federal",
             cnpj: "12.345.678/0001-99", mantenedora: null, codigoMantenedoraEmec: null, situacao: "Credenciada",
             atoCredenciamento: "Portaria 123", atoRecredenciamento: null, conceitoInstitucional: "4", igc: "4",
-            website: "https://unifesspa.edu.br", enderecoSede: null, municipioSede: "Marabá", unidadeRaizId: novaRaiz);
+            website: "https://unifesspa.edu.br", enderecoSede: null,
+            cidadeCodigoIbge: "1504208", cidadeNome: "Marabá", cidadeUf: "PA",
+            cidadeOrigem: ReferenciaCidadeGeo.OrigemGeoApi, cidadeDisplayAtualizadoEm: null, unidadeRaizId: novaRaiz);
 
         resultado.IsSuccess.Should().BeTrue();
         instituicao.CodigoEmec.Should().Be("4000");
         instituicao.Sigla.Should().Be("UFR");
         instituicao.Situacao.Should().Be("Credenciada");
+        instituicao.CidadeCodigoIbge.Should().Be("1504208");
+        instituicao.CidadeUf.Should().Be("PA");
         instituicao.UnidadeRaizId.Should().Be(novaRaiz);
     }
 
@@ -121,7 +175,9 @@ public sealed class InstituicaoTests
             "3990", "", "Unifesspa", "Universidade", "Pública Federal",
             cnpj: null, mantenedora: null, codigoMantenedoraEmec: null, situacao: null,
             atoCredenciamento: null, atoRecredenciamento: null, conceitoInstitucional: null, igc: null,
-            website: null, enderecoSede: null, municipioSede: null, unidadeRaizId: null);
+            website: null, enderecoSede: null,
+            cidadeCodigoIbge: null, cidadeNome: null, cidadeUf: null,
+            cidadeOrigem: null, cidadeDisplayAtualizadoEm: null, unidadeRaizId: null);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(InstituicaoErrorCodes.NomeObrigatorio);

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/Instituicoes/InstituicaoPersistenceTests.cs
@@ -61,6 +61,34 @@ public sealed class InstituicaoPersistenceTests : IClassFixture<InstituicaoDbFix
         persistida.UpdatedBy.Should().BeNull("apenas criação — sem update ainda");
     }
 
+    [Fact(DisplayName = "Insert persiste a referência de cidade do Geo e faz round-trip do trio + display cache (#686)")]
+    public async Task Insert_ComReferenciaDeCidade_RoundTrip()
+    {
+        await using OrganizacaoInstitucionalDbContext fresh = _fixture.CreateDbContext(AdminA);
+        await LimparInstituicoesAsync(fresh);
+
+        DateTimeOffset carimbo = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        Instituicao instituicao = NovaInstituicao(
+            "9002", "INS-GEO",
+            cidadeCodigoIbge: "1504208", cidadeNome: "Marabá", cidadeUf: "PA",
+            cidadeOrigem: "geo-api", cidadeDisplayAtualizadoEm: carimbo);
+
+        await using (OrganizacaoInstitucionalDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Instituicoes.Add(instituicao);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using OrganizacaoInstitucionalDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        Instituicao persistida = await readCtx.Instituicoes.SingleAsync(i => i.Id == instituicao.Id);
+
+        persistida.CidadeCodigoIbge.Should().Be("1504208");
+        persistida.CidadeNome.Should().Be("Marabá");
+        persistida.CidadeUf.Should().Be("PA");
+        persistida.CidadeOrigem.Should().Be("geo-api");
+        persistida.CidadeDisplayAtualizadoEm.Should().Be(carimbo);
+    }
+
     [Fact(DisplayName = "Índice único parcial rejeita uma segunda Instituição viva (singleton — CA-02)")]
     public async Task Singleton_SegundaInstituicaoVivaRejeitada()
     {
@@ -229,7 +257,15 @@ public sealed class InstituicaoPersistenceTests : IClassFixture<InstituicaoDbFix
         await ctx.Database.ExecuteSqlRawAsync("DELETE FROM instituicao");
     }
 
-    private static Instituicao NovaInstituicao(string codigoEmec, string sigla, Guid? unidadeRaizId = null) =>
+    private static Instituicao NovaInstituicao(
+        string codigoEmec,
+        string sigla,
+        Guid? unidadeRaizId = null,
+        string? cidadeCodigoIbge = null,
+        string? cidadeNome = null,
+        string? cidadeUf = null,
+        string? cidadeOrigem = null,
+        DateTimeOffset? cidadeDisplayAtualizadoEm = null) =>
         Instituicao.Criar(
             codigoEmec,
             $"Instituição {sigla}",
@@ -246,7 +282,11 @@ public sealed class InstituicaoPersistenceTests : IClassFixture<InstituicaoDbFix
             igc: null,
             website: null,
             enderecoSede: null,
-            municipioSede: null,
+            cidadeCodigoIbge,
+            cidadeNome,
+            cidadeUf,
+            cidadeOrigem,
+            cidadeDisplayAtualizadoEm,
             unidadeRaizId).Value!;
 
     private static Unidade NovaReitoria(string slug, string sigla, string codigo) =>


### PR DESCRIPTION
## Contexto

Adota na entidade **Instituicao** (módulo `organizacao-institucional`) o mesmo padrão de referência de cidade do Geo já aplicado em `Campus`/`LocalOferta` (ADR-0090, composição no cliente): substitui o campo **`MunicipioSede`** (texto livre, `string?`, sem UF/código/validação) por uma referência estruturada **`cidade_codigo_ibge` + display cache** (`cidade_nome`, `cidade_uf`, `cidade_origem`, `cidade_display_atualizado_em`).

`EnderecoSede` (logradouro da sede) **permanece texto livre** — o Geo não modela endereço pontual.

## Decisões de design

- **Referência opcional (all-or-nothing):** ou o trio completo e coerente (formato 7 dígitos + prefixo de UF coerente), ou ausente por completo. Preserva a semântica do antigo `MunicipioSede` opcional — diferente do pilot `Campus`, onde a cidade é obrigatória.
- **Contrato cross-módulo `InstituicaoView` (Governance):** passa a expor o trio estruturado (`CidadeCodigoIbge`/`CidadeNome`/`CidadeUf`) em vez do município textual, habilitando reconciliação/filtros futuros.
- **Carimbo server-side:** `cidade_origem`/`cidade_display_atualizado_em` são carimbados pelo handler (não viajam no payload), recarimbados apenas quando o trio muda — mesma semântica de `AtualizarCampusCommandHandler`.

## Pré-condição — promoção do `ReferenciaCidadeGeo` (1º commit)

`organizacao-institucional` não pode depender de `Configuracao` (R8 / ADR-0056). O validador `ReferenciaCidadeGeo` + `CidadeReferenciaErrorCodes` foi **promovido de `Configuracao.Domain` para o Kernel** (`Unifesspa.UniPlus.Kernel.Domain.Cidades`), ao lado dos value objects de domínio compartilhados já existentes (`Cpf`, `Email`, `NomeSocial`). `Campus`/`LocalOferta` re-apontam os `using`; o teste migra para `Kernel.UnitTests`. Refactor puro, sem mudança de comportamento.

## Mudanças por camada (2º commit)

| Camada | Mudança |
|---|---|
| **Domain** `Instituicao` | Remove `MunicipioSede`; adiciona o trio + display cache; validação all-or-nothing via `ReferenciaCidadeGeo`. |
| **Infra** `InstituicaoConfiguration` + migration | Colunas `cidade_*` (char(7)/varchar/char(2), nullable) + `ix_instituicao_cidade_codigo_ibge`. Migration forward-only em `uniplus_organizacao` (drop `municipio_sede`; sem backfill — scaffolding). |
| **Application** commands/validators/handlers | Trio no payload; carimbo/recarimbo server-side. |
| **DTO** `InstituicaoDto` | Expõe os 5 campos `Cidade*`. |
| **Contract** `InstituicaoView` | Trio estruturado. |
| **API** `OrganizacaoDomainErrorRegistration` | Mapeia os 5 codes de referência de cidade → wire codes da organização (422). |
| **OpenAPI** `contracts/openapi.organizacao.json` | Baseline regerada. |

## Critérios de aceite

- [x] `Instituicao` guarda `cidade_codigo_ibge` + display cache; `EnderecoSede` permanece livre.
- [x] Validação reaproveita o validador compartilhado (promovido ao Kernel); sem FK cross-banco, sem dígito verificador, sem consultar o Geo.
- [x] `cidade_origem`/`cidade_display_atualizado_em` carimbados server-side; recarimbados só quando o trio muda.
- [x] Migration forward-only; sem backfill (scaffolding).
- [x] `organizacao-institucional` não depende de `Geo.*` nem de `Configuracao.*` (fitness R8/ADR-0056 verde).
- [x] DTO/command/validator/baseline OpenAPI atualizados; testes (domínio + aplicação + integração) cobrindo o novo campo.

## Validação local

- Build da solution: **51 projetos, 0 warnings, 0 erros**.
- Kernel.UnitTests 113 · Configuracao Domain 12 / Application 22 / Integração (Campi+LocaisOferta) 20.
- Organizacao Domain 51 · Application 32 · **Integração 42** (inclui round-trip da cidade persistida + drift check OpenAPI).
- Solution ArchTests 24 (isolamento cross-módulo verde).

Closes #686