### PR TITLE
test(ci): estabiliza testes de integração flaky (outbox V9 e Geo CA-06)

### DIFF
--- a/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Geo.IntegrationTests/Admin/GeoImportacoesEndpointTests.cs
@@ -19,8 +19,10 @@ using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 /// <summary>
 /// Endpoint admin de disparo/acompanhamento do ETL (Story #674, CA-02/CA-06) contra a
 /// API real. O worker fica desligado (<c>GeoApiFactory</c>), então o disparo registra a
-/// execução EmAndamento e responde 202 sem rodar a carga — tornando 202/409
-/// determinísticos. Autorização por role <c>plataforma-admin</c> (401/403).
+/// execução EmAndamento e responde 202 sem rodar a carga. O conflito de concorrência
+/// (CA-06) é exercitado a partir de uma execução EmAndamento semeada diretamente — não da
+/// corrida contra a conclusão de uma primeira carga (#718) — tornando o 409 determinístico.
+/// Autorização por role <c>plataforma-admin</c> (401/403).
 /// </summary>
 [Collection(GeoPostgisCollection.Name)]
 public sealed class GeoImportacoesEndpointTests
@@ -81,19 +83,30 @@ public sealed class GeoImportacoesEndpointTests
         resposta.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
-    [Fact(DisplayName = "CA-06: com uma carga em andamento, um segundo disparo retorna 409 (sem Idempotency-Key)")]
+    [Fact(DisplayName = "CA-06: com uma carga em andamento, um novo disparo retorna 409 (sem Idempotency-Key)")]
     public async Task Disparar_ComCargaEmAndamento_Retorna409()
     {
         await LimparExecucoesAsync();
+
+        // Estado "em andamento" determinístico: semeia diretamente uma execução EmAndamento
+        // (mesmo padrão dos cenários CA-03), em vez de disparar uma primeira carga e depender de
+        // "vencer a corrida" contra a sua conclusão antes do segundo disparo (#718). O índice
+        // único parcial (status = 0) garante que, enquanto essa linha existir, qualquer novo
+        // disparo colida na UNIQUE (23505) e vire 409 — sem nenhuma dependência de timing.
+        // O caminho real "disparo → 202 + execução EmAndamento registrada" já é coberto por CA-02.
+        await using (GeoDbContext ctx = _fixture.CreateDbContext())
+        {
+            GeoImportacaoExecucao emAndamento = GeoImportacaoExecucao
+                .Iniciar("202601", "teste", TimeProvider.System.GetUtcNow()).Value!;
+            ctx.ImportacaoExecucoes.Add(emAndamento);
+            await ctx.SaveChangesAsync();
+        }
+
         using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage disparo = RequisicaoDisparo("202602", admin: true);
+        using HttpResponseMessage resposta = await client.SendAsync(disparo);
 
-        using HttpRequestMessage disparo1 = RequisicaoDisparo("202601", admin: true);
-        using HttpResponseMessage primeira = await client.SendAsync(disparo1);
-        primeira.StatusCode.Should().Be(HttpStatusCode.Accepted);
-
-        using HttpRequestMessage disparo2 = RequisicaoDisparo("202602", admin: true);
-        using HttpResponseMessage segunda = await client.SendAsync(disparo2);
-        segunda.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        resposta.StatusCode.Should().Be(HttpStatusCode.Conflict);
     }
 
     [Theory(DisplayName = "CA-02: versão fora do formato AAAAMM (ou ausente) é rejeitada na borda com 422")]

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Observability/OpenTelemetryWiringTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Observability/OpenTelemetryWiringTests.cs
@@ -64,12 +64,11 @@ public sealed class OpenTelemetryWiringTests(OtelCollectorContainerFixture colle
             // handshake + envio em runners CI mais lentos.
             tracerProvider!.ForceFlush(timeoutMilliseconds: 5_000).Should().BeTrue();
 
-            // Buffer extra (200ms) para o Collector processar o batch recebido e
-            // emitir no exporter debug. Heurística: na prática 50ms basta, 200ms
-            // dá folga sem aumentar tempo do teste materialmente.
-            await Task.Delay(TimeSpan.FromMilliseconds(200));
-
-            string collectorOutput = await collector.GetLogsAsync();
+            // O Collector grava no exporter debug de forma assíncrona ao ForceFlush; em vez de um
+            // delay fixo curto (flaky em runners lentos, #718), faz polling até os tokens
+            // esperados aparecerem no output — ou retorna o que houver, p/ uma falha legível.
+            string collectorOutput = await collector.WaitForLogsContainingAsync(
+                ["ResourceSpans", ServiceName, "test-wiring-span", OpenTelemetryConfiguration.ServiceNamespaceResourceValue]);
 
             collectorOutput.Should().Contain("ResourceSpans", because: "o exporter debug do Collector escreve o nome do tipo OTLP recebido em stderr");
             collectorOutput.Should().Contain(ServiceName, because: $"o Resource attribute service.name precisa chegar até o Collector — confirma que ConfigureResource(...AddService(\"{ServiceName}\")) está wired");
@@ -120,11 +119,10 @@ public sealed class OpenTelemetryWiringTests(OtelCollectorContainerFixture colle
             // + envio em runners CI mais lentos.
             meterProvider!.ForceFlush(timeoutMilliseconds: 5_000).Should().BeTrue();
 
-            // Buffer extra (200ms) para o Collector processar o batch e emitir no
-            // exporter debug. Heurística: na prática 50ms basta, 200ms dá folga.
-            await Task.Delay(TimeSpan.FromMilliseconds(200));
-
-            string collectorOutput = await collector.GetLogsAsync();
+            // Polling até os tokens chegarem ao exporter debug (escrita assíncrona ao ForceFlush),
+            // no lugar de um delay fixo curto sujeito a flakiness em runners lentos (#718).
+            string collectorOutput = await collector.WaitForLogsContainingAsync(
+                ["test.wiring.counter", "ResourceMetrics", ServiceName]);
 
             // Instrumento específico criado neste teste — assert discriminante real de
             // AddMeter(nomeServico). ResourceMetrics pode ser satisfeito por runtime

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/MinioContainerFixture.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/MinioContainerFixture.cs
@@ -36,9 +36,13 @@ public sealed class MinioContainerFixture : IAsyncLifetime
             .WithCommand("server", "/data", "--console-address", $":{ConsolePort}")
             .WithWaitStrategy(
                 Wait.ForUnixContainer()
+                    // /minio/health/ready (não /live): live só confirma que o processo subiu, mas a
+                    // object layer pode ainda não servir a API S3 — ListBucketsAsync intermitente
+                    // retornava Unhealthy logo após o start (corrida liveness x readiness, #718).
+                    // O probe de readiness só passa quando o servidor já atende requisições.
                     .UntilHttpRequestIsSucceeded(r => r
                         .ForPort(ApiPort)
-                        .ForPath("/minio/health/live")))
+                        .ForPath("/minio/health/ready")))
             .Build();
     }
 

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/OtelCollectorContainerFixture.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/OtelCollectorContainerFixture.cs
@@ -72,6 +72,38 @@ public sealed class OtelCollectorContainerFixture : IAsyncLifetime
         return string.Concat(logs.Stdout, logs.Stderr);
     }
 
+    /// <summary>
+    /// Faz polling de <see cref="GetLogsAsync"/> até que todos os <paramref name="tokensEsperados"/>
+    /// apareçam no output do Collector, ou até esgotar <paramref name="timeout"/> (default 10s).
+    /// Substitui a espera fixa pós-<c>ForceFlush</c>: o exporter <c>debug</c> grava em stderr de
+    /// forma assíncrona ao flush, então um delay fixo curto é flaky em runners lentos (#718).
+    /// Retorna o último output lido — sob timeout, as asserts do chamador ainda produzem mensagem
+    /// de falha útil apontando o token ausente.
+    /// </summary>
+    public async Task<string> WaitForLogsContainingAsync(
+        IReadOnlyCollection<string> tokensEsperados,
+        TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(tokensEsperados);
+
+        TimeSpan limite = timeout ?? TimeSpan.FromSeconds(10);
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + limite;
+
+        while (true)
+        {
+            string output = await GetLogsAsync().ConfigureAwait(false);
+            bool todosPresentes = tokensEsperados.All(
+                token => output.Contains(token, StringComparison.Ordinal));
+
+            if (todosPresentes || DateTimeOffset.UtcNow >= deadline)
+            {
+                return output;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+        }
+    }
+
     public Task InitializeAsync() => _container.StartAsync();
 
     public async Task DisposeAsync() =>

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
@@ -54,7 +54,13 @@ public sealed class CascadingScenariosTests
         DomainEventCollector collector = api.Services.GetRequiredService<DomainEventCollector>();
         collector.Clear();
 
-        Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: 80, ano: 2026);
+        // Ano reservado (2099) p/ os cenários V8/V9: o DomainEventCollector é um singleton
+        // compartilhado por toda a coleção e os testes-irmãos (EditalEndpointTests,
+        // PublicarEditalEndpointTests) sorteiam o numero por um contador % 9999 + 1 SEMPRE no
+        // ano 2026 — podendo emitir o mesmo (numero, ano) destes cenários e contaminar o coletor
+        // (e o LIKE de envelopes) de forma assíncrona. Fixar o ano fora dessa faixa torna o par
+        // (numero, ano) exclusivo destes testes e a verificação determinística (#718).
+        Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: 80, ano: 2099);
         numeroResult.IsSuccess.Should().BeTrue();
         NumeroEdital numero = numeroResult.Value!;
 
@@ -97,7 +103,10 @@ public sealed class CascadingScenariosTests
         IMessageBus bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
         SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
 
-        Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: 89, ano: 2026);
+        // Ano reservado (2099) — ver V8: isola (numero, ano) do contador % 9999 dos testes-irmãos
+        // (que rodam no ano 2026), garantindo que nenhum evento alheio com este par contamine o
+        // coletor singleton durante a janela de verificação de ausência abaixo (#718).
+        Result<NumeroEdital> numeroResult = NumeroEdital.Criar(numero: 89, ano: 2099);
         numeroResult.IsSuccess.Should().BeTrue();
         NumeroEdital numero = numeroResult.Value!;
 
@@ -126,7 +135,8 @@ public sealed class CascadingScenariosTests
             numero,
             TimeSpan.FromSeconds(3));
         evento.Should().BeNull(
-            "sem envelope no outbox, o listener não tem o que entregar — collector permanece vazio para esse numero");
+            "sem envelope no outbox o listener não tem o que entregar e, como o par (numero, ano) é " +
+            "exclusivo deste cenário, nenhum evento alheio pode preencher o coletor — a ausência é determinística");
     }
 
     internal static async Task<EditalPublicadoEvent?> EsperarEventoAsync(


### PR DESCRIPTION
## Contexto

Estabiliza os testes de integração que oscilavam em rerun durante os PRs de junho/2026 (#638, #717), sempre falhando em testes de natureza concorrência/timing — flakiness, não regressão. Closes #718.

## Mudanças

### 1. Geo CA-06 — `Disparar_ComCargaEmAndamento_Retorna409`
A versão antiga disparava uma primeira carga e assumia que ela ainda estaria "em andamento" quando o segundo disparo chegasse — uma corrida contra a conclusão da carga (sintoma do #717: `409` esperado, `202` observado).

Agora o estado "em andamento" é **determinístico**: semeia diretamente uma execução `EmAndamento` (mesmo padrão dos cenários CA-03) e afirma que um novo disparo colide no índice único parcial (`status = 0`) → `409`. Sem dependência de timing. O caminho real `disparo → 202 + registro EmAndamento` permanece coberto por CA-02.

### 2. Outbox V8/V9 — `CascadingScenariosTests`
O `DomainEventCollector` é um singleton compartilhado por toda a coleção, e os testes-irmãos (`EditalEndpointTests`, `PublicarEditalEndpointTests`) sorteiam o `numero` por um contador `% 9999 + 1` **sempre no ano 2026** — podendo emitir o mesmo `(numero, ano)` dos cenários e contaminar o coletor (e o `LIKE` de envelopes) de forma assíncrona, quebrando a verificação de ausência do V9.

Fixa os cenários no **ano reservado 2099**, tornando o par `(numero, ano)` exclusivo destes testes e a verificação determinística.

### 3. Varredura — mesmo padrão de espera fixa
`OpenTelemetryWiringTests` trocava o `ForceFlush` por um `Task.Delay(200ms)` fixo antes de ler o output do Collector (escrita assíncrona ao flush → flaky em runners lentos). Substituído por `OtelCollectorContainerFixture.WaitForLogsContainingAsync`, que faz **polling** até os tokens esperados aparecerem (timeout generoso de 10s) — mais robusto e mais rápido no caminho feliz (~400ms vs. 400ms+ fixos).

## Critérios de aceite

- [x] `V9_RollbackCascading_...` e `Disparar_ComCargaEmAndamento_Retorna409` deterministicamente verdes em execuções repetidas
- [x] CA-06 não depende de "vencer a corrida" — estado "em andamento" determinístico via seed
- [x] V9 isolado de contaminação cruzada (par `(numero, ano)` exclusivo; espera já era polling)
- [x] Varredura por outros testes com espera fixa (`Task.Delay` curto) — `OpenTelemetryWiringTests` corrigido

## Verificação

- Build: 0 avisos / 0 erros (`TreatWarningsAsErrors`)
- Coleção `Outbox.Cascading` verde **3×** (23 testes cada)
- Coleção `geo-postgis` verde **2×** (281 testes cada)
- `OpenTelemetryWiringTests` verde