### PR TITLE
feat(configuracao): cadastro de Referência de reserva demográfica (#593)

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -1101,6 +1101,476 @@
           }
         }
       }
+    },
+    "/api/referencias-reserva-demografica": {
+      "get": {
+        "tags": [
+          "ReferenciasReservaDemografica"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReferenciaReservaDemograficaDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReferenciaReservaDemograficaDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReferenciaReservaDemograficaDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/referencias-reserva-demografica/{id}": {
+      "get": {
+        "tags": [
+          "ReferenciasReservaDemografica"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenciaReservaDemograficaDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenciaReservaDemograficaDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenciaReservaDemograficaDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/referencias-reserva-demografica": {
+      "post": {
+        "tags": [
+          "ReferenciasReservaDemografica"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarReferenciaReservaDemograficaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarReferenciaReservaDemograficaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarReferenciaReservaDemograficaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/admin/referencias-reserva-demografica/{id}": {
+      "put": {
+        "tags": [
+          "ReferenciasReservaDemografica"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarReferenciaReservaDemograficaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarReferenciaReservaDemograficaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarReferenciaReservaDemograficaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "ReferenciasReservaDemografica"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1225,6 +1695,53 @@
               "null",
               "string"
             ]
+          }
+        }
+      },
+      "AtualizarReferenciaReservaDemograficaCommand": {
+        "required": [
+          "id",
+          "censoReferencia",
+          "ppiPercentual",
+          "quilombolaPercentual",
+          "pcdPercentual",
+          "baseLegal"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "censoReferencia": {
+            "type": "string"
+          },
+          "ppiPercentual": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "quilombolaPercentual": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pcdPercentual": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "baseLegal": {
+            "type": "string"
           }
         }
       },
@@ -1483,6 +2000,48 @@
           }
         }
       },
+      "CriarReferenciaReservaDemograficaCommand": {
+        "required": [
+          "censoReferencia",
+          "ppiPercentual",
+          "quilombolaPercentual",
+          "pcdPercentual",
+          "baseLegal"
+        ],
+        "type": "object",
+        "properties": {
+          "censoReferencia": {
+            "type": "string"
+          },
+          "ppiPercentual": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "quilombolaPercentual": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pcdPercentual": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "baseLegal": {
+            "type": "string"
+          }
+        }
+      },
       "IFormFile": {
         "type": "string",
         "format": "binary"
@@ -1604,6 +2163,67 @@
           }
         }
       },
+      "ReferenciaReservaDemograficaDto": {
+        "required": [
+          "id",
+          "censoReferencia",
+          "ppiPercentual",
+          "quilombolaPercentual",
+          "pcdPercentual",
+          "baseLegal",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "censoReferencia": {
+            "type": "string"
+          },
+          "ppiPercentual": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "quilombolaPercentual": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pcdPercentual": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "baseLegal": {
+            "type": "string"
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "TipoLocalOferta": {
         "enum": [
           "nenhum",
@@ -1689,6 +2309,9 @@
     },
     {
       "name": "LocaisOferta"
+    },
+    {
+      "name": "ReferenciasReservaDemografica"
     }
   ]
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/ReferenciasReservaDemograficaController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/ReferenciasReservaDemograficaController.cs
@@ -1,0 +1,186 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.ReferenciasReservaDemografica;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/referencias-reserva-demografica</c>,
+/// <c>GET /api/referencias-reserva-demografica/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/admin/referencias-reserva-demografica</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ-0065).
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class ReferenciasReservaDemograficaController : ControllerBase
+{
+    private const string ResourceTag = "referencias-reserva-demografica";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<ReferenciaReservaDemograficaDto> _linksBuilder;
+
+    public ReferenciasReservaDemograficaController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<ReferenciaReservaDemograficaDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista as referências de reserva demográfica ativas, paginadas por cursor
+    /// opaco bidirecional (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>;
+    /// cada item carrega seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("referencias-reserva-demografica")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "referencia-reserva-demografica", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<ReferenciaReservaDemograficaDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarReferenciasReservaDemograficaResult resultado = await _queryBus
+            .Send(new ListarReferenciasReservaDemograficaQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        ReferenciaReservaDemograficaDto[] comLinks =
+            [.. resultado.Items.Select(r => r with { Links = _linksBuilder.Build(r) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém uma referência pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("referencias-reserva-demografica/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "referencia-reserva-demografica", Versions = [1])]
+    [ProducesResponseType(typeof(ReferenciaReservaDemograficaDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        ReferenciaReservaDemograficaDto? referencia = await _queryBus
+            .Send(new ObterReferenciaReservaDemograficaPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (referencia is null)
+        {
+            return NotFound();
+        }
+
+        ReferenciaReservaDemograficaDto comLinks = referencia with { Links = _linksBuilder.Build(referencia) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria uma nova referência. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/referencias-reserva-demografica")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarReferenciaReservaDemograficaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza uma referência existente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/referencias-reserva-demografica/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarReferenciaReservaDemograficaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) uma referência. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/referencias-reserva-demografica/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverReferenciaReservaDemograficaCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -167,5 +167,48 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status409Conflict,
                 "uniplus.configuracao.local_oferta.remocao_bloqueada_por_oferta_curso",
                 "Não é possível remover um local de oferta referenciado por oferta de curso ativa")),
+
+        // ── Referência de reserva demográfica (UNI-REQ-0065) ──────────────
+        new(ReferenciaReservaDemograficaErrorCodes.CensoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.referencia_reserva_demografica.censo_obrigatorio",
+                "Censo de referência é obrigatório")),
+
+        new(ReferenciaReservaDemograficaErrorCodes.CensoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.referencia_reserva_demografica.censo_tamanho",
+                "Tamanho do Censo de referência inválido")),
+
+        new(ReferenciaReservaDemograficaErrorCodes.CensoJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.referencia_reserva_demografica.censo_ja_existe",
+                "Já existe uma referência ativa para este Censo")),
+
+        new(ReferenciaReservaDemograficaErrorCodes.PercentualForaDeFaixa,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.referencia_reserva_demografica.percentual_fora_de_faixa",
+                "Percentual fora do intervalo válido (0 a 100)")),
+
+        new(ReferenciaReservaDemograficaErrorCodes.BaseLegalObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.referencia_reserva_demografica.base_legal_obrigatoria",
+                "Base legal é obrigatória")),
+
+        new(ReferenciaReservaDemograficaErrorCodes.BaseLegalTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.referencia_reserva_demografica.base_legal_tamanho",
+                "Tamanho da base legal inválido")),
+
+        new(ReferenciaReservaDemograficaErrorCodes.NaoEncontrada,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.referencia_reserva_demografica.nao_encontrada",
+                "Referência de reserva demográfica não encontrada")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/ReferenciaReservaDemograficaLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/ReferenciaReservaDemograficaLinksBuilder.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="ReferenciaReservaDemograficaDto"/>. Relações em V1: <c>self</c> e
+/// <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<ReferenciaReservaDemograficaDto>, ReferenciaReservaDemograficaLinksBuilder>().")]
+internal sealed class ReferenciaReservaDemograficaLinksBuilder : IResourceLinksBuilder<ReferenciaReservaDemograficaDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public ReferenciaReservaDemograficaLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(ReferenciaReservaDemograficaDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "ReferenciasReservaDemografica";
+
+        string self = ResolverPath(
+            httpContext, nameof(ReferenciasReservaDemograficaController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(ReferenciasReservaDemograficaController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Program.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Program.cs
@@ -56,6 +56,7 @@ builder.Services.AddDomainErrorMapper();
 // HATEOAS Level 1 (ADR-0029) — builders de _links dos cadastros (UNI-REQ #587).
 builder.Services.AddSingleton<IResourceLinksBuilder<CampusDto>, CampusLinksBuilder>();
 builder.Services.AddSingleton<IResourceLinksBuilder<LocalOfertaDto>, LocalOfertaLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<ReferenciaReservaDemograficaDto>, ReferenciaReservaDemograficaLinksBuilder>();
 
 // Idempotency-Key (ADR-0027) + criptografia para entries at-rest. Filter global
 // se ativa apenas em endpoints com [RequiresIdempotencyKey] — os controllers

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommand.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed record AtualizarReferenciaReservaDemograficaCommand(
+    Guid Id,
+    string CensoReferencia,
+    decimal PpiPercentual,
+    decimal QuilombolaPercentual,
+    decimal PcdPercentual,
+    string BaseLegal) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommandHandler.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public static class AtualizarReferenciaReservaDemograficaCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarReferenciaReservaDemograficaCommand command,
+        IReferenciaReservaDemograficaRepository repository,
+        IUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        ReferenciaReservaDemografica? referencia = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (referencia is null)
+        {
+            return Result.Failure(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.NaoEncontrada,
+                "Referência de reserva demográfica não encontrada."));
+        }
+
+        // O Censo é a chave de negócio única entre vivos — só checa colisão quando muda.
+        if (!string.Equals(command.CensoReferencia.Trim(), referencia.CensoReferencia, StringComparison.OrdinalIgnoreCase)
+            && await repository.CensoExisteEntreLivosAsync(command.CensoReferencia, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.CensoJaExiste,
+                $"Já existe uma Referência de reserva demográfica viva para o Censo '{command.CensoReferencia}'."));
+        }
+
+        Result atualizarResult = referencia.Atualizar(
+            command.CensoReferencia,
+            command.PpiPercentual,
+            command.QuilombolaPercentual,
+            command.PcdPercentual,
+            command.BaseLegal);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommandHandler.cs
@@ -33,8 +33,10 @@ public static class AtualizarReferenciaReservaDemograficaCommandHandler
         // no snapshot de publicação (ADR-0061) — editar a fonte viva não retroage sobre
         // nada já publicado. Diferente do `codigo` da Modalidade (#589), que é imutável
         // por participar do hash de publicação (RN08). Como é a chave de negócio única
-        // entre vivos, só checamos colisão quando o Censo muda.
-        if (!string.Equals(command.CensoReferencia.Trim(), referencia.CensoReferencia, StringComparison.OrdinalIgnoreCase)
+        // entre vivos, só checamos colisão quando o Censo muda. A comparação é
+        // case-sensitive (Ordinal) para casar com o repositório e o índice único
+        // parcial — ambos comparam o valor bruto; não há semântica de maiúsculas no Censo.
+        if (!string.Equals(command.CensoReferencia.Trim(), referencia.CensoReferencia, StringComparison.Ordinal)
             && await repository.CensoExisteEntreLivosAsync(command.CensoReferencia, command.Id, cancellationToken).ConfigureAwait(false))
         {
             return Result.Failure(new DomainError(
@@ -54,7 +56,21 @@ public static class AtualizarReferenciaReservaDemograficaCommandHandler
             return atualizarResult;
         }
 
-        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCensoConflict(constraint))
+        {
+            // Corrida entre CensoExisteEntreLivosAsync e o UPDATE: o índice único
+            // parcial dispara 23505 e viramos o mesmo CensoJaExiste do caminho
+            // não-race — 409 consistente em vez de 500. O `when` deixa outras
+            // exceções propagarem.
+            return Result.Failure(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.CensoJaExiste,
+                $"Já existe uma Referência de reserva demográfica viva para o Censo '{command.CensoReferencia}'."));
+        }
 
         return Result.Success();
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommandHandler.cs
@@ -28,7 +28,12 @@ public static class AtualizarReferenciaReservaDemograficaCommandHandler
                 "Referência de reserva demográfica não encontrada."));
         }
 
-        // O Censo é a chave de negócio única entre vivos — só checa colisão quando muda.
+        // O Censo é mutável de propósito (decisão do P.O., #593): não precisa ser
+        // imutável porque o Processo Seletivo congela o Censo + percentuais por valor
+        // no snapshot de publicação (ADR-0061) — editar a fonte viva não retroage sobre
+        // nada já publicado. Diferente do `codigo` da Modalidade (#589), que é imutável
+        // por participar do hash de publicação (RN08). Como é a chave de negócio única
+        // entre vivos, só checamos colisão quando o Censo muda.
         if (!string.Equals(command.CensoReferencia.Trim(), referencia.CensoReferencia, StringComparison.OrdinalIgnoreCase)
             && await repository.CensoExisteEntreLivosAsync(command.CensoReferencia, command.Id, cancellationToken).ConfigureAwait(false))
         {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/AtualizarReferenciaReservaDemograficaCommandValidator.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+public sealed class AtualizarReferenciaReservaDemograficaCommandValidator
+    : AbstractValidator<AtualizarReferenciaReservaDemograficaCommand>
+{
+    public AtualizarReferenciaReservaDemograficaCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id da Referência de reserva demográfica é obrigatório.");
+
+        RuleFor(x => x.CensoReferencia)
+            .NotEmpty().WithMessage("Censo de referência é obrigatório.")
+            .MaximumLength(20).WithMessage("Censo de referência deve ter no máximo 20 caracteres.");
+
+        RuleFor(x => x.PpiPercentual)
+            .InclusiveBetween(Percentual.Minimo, Percentual.Maximo)
+            .WithMessage("Percentual de PPI deve estar entre 0 e 100.");
+
+        RuleFor(x => x.QuilombolaPercentual)
+            .InclusiveBetween(Percentual.Minimo, Percentual.Maximo)
+            .WithMessage("Percentual de quilombolas deve estar entre 0 e 100.");
+
+        RuleFor(x => x.PcdPercentual)
+            .InclusiveBetween(Percentual.Minimo, Percentual.Maximo)
+            .WithMessage("Percentual de PcD deve estar entre 0 e 100.");
+
+        RuleFor(x => x.BaseLegal)
+            .NotEmpty().WithMessage("Base legal é obrigatória.")
+            .MaximumLength(500).WithMessage("Base legal deve ter no máximo 500 caracteres.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/CriarReferenciaReservaDemograficaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/CriarReferenciaReservaDemograficaCommand.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria uma Referência de reserva demográfica: um Censo com os três percentuais
+/// demográficos (PPI, quilombola, PcD) e a base legal. Os atores de auditoria
+/// (<c>created_by</c>) são carimbados server-side via <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarReferenciaReservaDemograficaCommand(
+    string CensoReferencia,
+    decimal PpiPercentual,
+    decimal QuilombolaPercentual,
+    decimal PcdPercentual,
+    string BaseLegal) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/CriarReferenciaReservaDemograficaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/CriarReferenciaReservaDemograficaCommandHandler.cs
@@ -44,7 +44,23 @@ public static class CriarReferenciaReservaDemograficaCommandHandler
 
         ReferenciaReservaDemografica referencia = referenciaResult.Value!;
         await repository.AdicionarAsync(referencia, cancellationToken).ConfigureAwait(false);
-        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCensoConflict(constraint))
+        {
+            // Corrida entre CensoExisteEntreLivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo CensoJaExiste do
+            // caminho não-race — 409 consistente, em vez de deixar o DbUpdateException
+            // virar 500 no middleware global. O filtro do `when` garante que outras
+            // exceções propagam intactas.
+            return Result<Guid>.Failure(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.CensoJaExiste,
+                $"Já existe uma Referência de reserva demográfica viva para o Censo '{command.CensoReferencia}'."));
+        }
 
         return Result<Guid>.Success(referencia.Id);
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/CriarReferenciaReservaDemograficaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/CriarReferenciaReservaDemograficaCommandHandler.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarReferenciaReservaDemograficaCommand"/>
+/// (convention-based Wolverine): confere a unicidade do Censo entre referências
+/// vivas, cria o agregado, persiste e commita.
+/// </summary>
+public static class CriarReferenciaReservaDemograficaCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarReferenciaReservaDemograficaCommand command,
+        IReferenciaReservaDemograficaRepository repository,
+        IUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.CensoExisteEntreLivosAsync(command.CensoReferencia, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.CensoJaExiste,
+                $"Já existe uma Referência de reserva demográfica viva para o Censo '{command.CensoReferencia}'."));
+        }
+
+        Result<ReferenciaReservaDemografica> referenciaResult = ReferenciaReservaDemografica.Criar(
+            command.CensoReferencia,
+            command.PpiPercentual,
+            command.QuilombolaPercentual,
+            command.PcdPercentual,
+            command.BaseLegal);
+
+        if (referenciaResult.IsFailure)
+        {
+            return Result<Guid>.Failure(referenciaResult.Error!);
+        }
+
+        ReferenciaReservaDemografica referencia = referenciaResult.Value!;
+        await repository.AdicionarAsync(referencia, cancellationToken).ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<Guid>.Success(referencia.Id);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/CriarReferenciaReservaDemograficaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/CriarReferenciaReservaDemograficaCommandValidator.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+public sealed class CriarReferenciaReservaDemograficaCommandValidator
+    : AbstractValidator<CriarReferenciaReservaDemograficaCommand>
+{
+    public CriarReferenciaReservaDemograficaCommandValidator()
+    {
+        RuleFor(x => x.CensoReferencia)
+            .NotEmpty().WithMessage("Censo de referência é obrigatório.")
+            .MaximumLength(20).WithMessage("Censo de referência deve ter no máximo 20 caracteres.");
+
+        RuleFor(x => x.PpiPercentual)
+            .InclusiveBetween(Percentual.Minimo, Percentual.Maximo)
+            .WithMessage("Percentual de PPI deve estar entre 0 e 100.");
+
+        RuleFor(x => x.QuilombolaPercentual)
+            .InclusiveBetween(Percentual.Minimo, Percentual.Maximo)
+            .WithMessage("Percentual de quilombolas deve estar entre 0 e 100.");
+
+        RuleFor(x => x.PcdPercentual)
+            .InclusiveBetween(Percentual.Minimo, Percentual.Maximo)
+            .WithMessage("Percentual de PcD deve estar entre 0 e 100.");
+
+        RuleFor(x => x.BaseLegal)
+            .NotEmpty().WithMessage("Base legal é obrigatória.")
+            .MaximumLength(500).WithMessage("Base legal deve ter no máximo 500 caracteres.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/RemoverReferenciaReservaDemograficaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/RemoverReferenciaReservaDemograficaCommand.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed record RemoverReferenciaReservaDemograficaCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/RemoverReferenciaReservaDemograficaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/RemoverReferenciaReservaDemograficaCommandHandler.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverReferenciaReservaDemograficaCommand"/>.
+/// Soft-delete via <c>SoftDeleteInterceptor</c>. Cadastro flat: não há vínculo
+/// intra-banco que bloqueie a remoção, e referências congeladas por valor em
+/// outro banco (ADR-0061) são desacopladas e nunca bloqueiam (CA-05).
+/// </summary>
+public static class RemoverReferenciaReservaDemograficaCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverReferenciaReservaDemograficaCommand command,
+        IReferenciaReservaDemograficaRepository repository,
+        IUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        ReferenciaReservaDemografica? referencia = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (referencia is null)
+        {
+            return Result.Failure(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.NaoEncontrada,
+                "Referência de reserva demográfica não encontrada."));
+        }
+
+        repository.Remover(referencia);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/ReferenciasReservaDemografica/UniqueConstraintViolation.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do Censo
+/// (<c>ix_referencia_reserva_demografica_censo_vivo</c>) para o
+/// <c>DomainError</c> apropriado. Acessa <c>SqlState</c> e <c>ConstraintName</c>
+/// por reflection no inner exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção por
+/// <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch —
+/// Application referencia apenas Domain + SharedKernel + abstrações).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão de <c>UniqueConstraintViolation</c> dos módulos Seleção
+/// (ObrigatoriedadesLegais) e Organização (Instituicoes). A tradução cross-cutting
+/// de 23505 → 409 via <c>GlobalExceptionMiddleware</c> permanece como follow-up
+/// separado (#504); este helper cobre o caso específico da unicidade de Censo (CA-02).
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string CensoConstraint = "ix_referencia_reserva_demografica_censo_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o
+    /// caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único
+    /// parcial que garante uma única referência viva por Censo.
+    /// </summary>
+    public static bool IsCensoConflict(string? constraint) =>
+        string.Equals(constraint, CensoConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/ReferenciaReservaDemograficaDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/ReferenciaReservaDemograficaDto.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>ReferenciaReservaDemografica</c>. Suporta
+/// HATEOAS Level 1 via <c>_links</c> (ADR-0029). Os percentuais são expostos
+/// como <c>decimal</c> (valor do value object <c>Percentual</c>).
+/// </summary>
+public sealed record ReferenciaReservaDemograficaDto(
+    Guid Id,
+    string CensoReferencia,
+    decimal PpiPercentual,
+    decimal QuilombolaPercentual,
+    decimal PcdPercentual,
+    string BaseLegal,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/ReferenciaReservaDemograficaMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/ReferenciaReservaDemograficaMapping.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+public static class ReferenciaReservaDemograficaMapping
+{
+    public static ReferenciaReservaDemograficaDto ToDto(this ReferenciaReservaDemografica referencia)
+    {
+        ArgumentNullException.ThrowIfNull(referencia);
+        return new ReferenciaReservaDemograficaDto(
+            referencia.Id,
+            referencia.CensoReferencia,
+            referencia.PpiPercentual.Valor,
+            referencia.QuilombolaPercentual.Valor,
+            referencia.PcdPercentual.Valor,
+            referencia.BaseLegal,
+            referencia.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ListarReferenciasReservaDemograficaQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ListarReferenciasReservaDemograficaQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista referências de reserva demográfica vivas paginadas por cursor
+/// bidirecional (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e
+/// valida limit/direction antes de despachar.
+/// </summary>
+public sealed record ListarReferenciasReservaDemograficaQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarReferenciasReservaDemograficaResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ListarReferenciasReservaDemograficaQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ListarReferenciasReservaDemograficaQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarReferenciasReservaDemograficaQueryHandler
+{
+    public static async Task<ListarReferenciasReservaDemograficaResult> Handle(
+        ListarReferenciasReservaDemograficaQuery query,
+        IReferenciaReservaDemograficaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<ReferenciaReservaDemografica> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        ReferenciaReservaDemograficaDto[] items = [.. itens.Select(r => r.ToDto())];
+        return new ListarReferenciasReservaDemograficaResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ListarReferenciasReservaDemograficaResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ListarReferenciasReservaDemograficaResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarReferenciasReservaDemograficaQuery"/>: lote de
+/// referências projetadas + âncoras opcionais para o controller construir os
+/// cursores prev/next (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarReferenciasReservaDemograficaResult(
+    IReadOnlyList<ReferenciaReservaDemograficaDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ObterReferenciaReservaDemograficaPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ObterReferenciaReservaDemograficaPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterReferenciaReservaDemograficaPorIdQuery(Guid Id) : IQuery<ReferenciaReservaDemograficaDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ObterReferenciaReservaDemograficaPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/ReferenciasReservaDemografica/ObterReferenciaReservaDemograficaPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.ReferenciasReservaDemografica;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterReferenciaReservaDemograficaPorIdQueryHandler
+{
+    public static async Task<ReferenciaReservaDemograficaDto?> Handle(
+        ObterReferenciaReservaDemograficaPorIdQuery query,
+        IReferenciaReservaDemograficaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        ReferenciaReservaDemografica? referencia = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return referencia?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IReferenciaReservaDemograficaReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IReferenciaReservaDemograficaReader.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>ReferenciaReservaDemografica</c> (ADR-0056). Expõe
+/// o estado vivo das referências de reserva demográfica para consumo por outros
+/// bounded contexts (ex.: a frente de distribuição de vagas do Módulo Seleção)
+/// sem acesso direto ao banco de Configuração (ADR-0054).
+/// </summary>
+public interface IReferenciaReservaDemograficaReader
+{
+    /// <summary>
+    /// Lista todas as referências vivas (não soft-deleted), ordenadas por
+    /// <c>CensoReferencia</c> ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<ReferenciaReservaDemograficaView>> ListarVivasAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém uma referência pelo <paramref name="id"/>, ou
+    /// <see langword="null"/> se inexistente / soft-deleted.
+    /// </summary>
+    Task<ReferenciaReservaDemograficaView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ReferenciaReservaDemograficaView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ReferenciaReservaDemograficaView.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>ReferenciaReservaDemografica</c> para consumo cross-módulo
+/// via <see cref="IReferenciaReservaDemograficaReader"/> (ADR-0056). Expõe a
+/// referência viva (Censo + os três percentuais demográficos + base legal) que o
+/// Módulo Seleção lê ao montar a distribuição de vagas, antes de congelar por
+/// valor no snapshot de publicação (ADR-0061).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="CensoReferencia">Censo de referência (chave de negócio, ex.: "2022").</param>
+/// <param name="PpiPercentual">Percentual de pretos, pardos e indígenas (art. 10, III, "a").</param>
+/// <param name="QuilombolaPercentual">Percentual de quilombolas (art. 10, III, "b").</param>
+/// <param name="PcdPercentual">Percentual de pessoas com deficiência (art. 10, III, "c", p.u.).</param>
+/// <param name="BaseLegal">Dispositivo legal que fundamenta a referência.</param>
+public sealed record ReferenciaReservaDemograficaView(
+    Guid Id,
+    string CensoReferencia,
+    decimal PpiPercentual,
+    decimal QuilombolaPercentual,
+    decimal PcdPercentual,
+    string BaseLegal);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/ReferenciaReservaDemografica.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/ReferenciaReservaDemografica.cs
@@ -1,0 +1,178 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Referência de reserva demográfica (UNI-REQ-0065, módulo Configuração) —
+/// registra, por Censo, os percentuais demográficos do estado que dimensionam
+/// as sub-reservas internas da reserva de vagas da Lei 12.711/2012 (red. Lei
+/// 14.723/2023, art. 10, III): pretos/pardos/indígenas (alínea "a"),
+/// quilombolas (alínea "b") e pessoas com deficiência (alínea "c", p.u.).
+/// </summary>
+/// <remarks>
+/// <para>Cadastro <b>flat</b>: sem FK intra-banco nem auto-referência. O
+/// <c>CensoReferencia</c> é a chave de negócio, única entre referências vivas
+/// (não soft-deleted) — a unicidade é validada pelo handler e reforçada por
+/// índice único parcial de banco (<c>WHERE is_deleted = false</c>).</para>
+/// <para>São agregados públicos do IBGE — nenhum dado pessoal (LGPD inaplicável).
+/// O congelamento por valor (snapshot RN08) no bloco de distribuição é
+/// responsabilidade do Processo Seletivo (módulo Selecao, ADR-0061); não há
+/// colunas de snapshot aqui, e a remoção lógica nunca é bloqueada por cópias
+/// congeladas em outro banco.</para>
+/// </remarks>
+public sealed class ReferenciaReservaDemografica : SoftDeletableEntity, IAuditableEntity
+{
+    private const int CensoReferenciaMinLength = 1;
+    private const int CensoReferenciaMaxLength = 20;
+    private const int BaseLegalMaxLength = 500;
+
+    public string CensoReferencia { get; private set; } = string.Empty;
+    public Percentual PpiPercentual { get; private set; } = null!;
+    public Percentual QuilombolaPercentual { get; private set; } = null!;
+    public Percentual PcdPercentual { get; private set; } = null!;
+    public string BaseLegal { get; private set; } = string.Empty;
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private ReferenciaReservaDemografica()
+    {
+    }
+
+    /// <summary>
+    /// Cria uma nova Referência de reserva demográfica. Valida o Censo, os três
+    /// percentuais (intervalo fechado 0–100) e a base legal. A unicidade de
+    /// <paramref name="censoReferencia"/> entre referências vivas é
+    /// responsabilidade do handler.
+    /// </summary>
+    public static Result<ReferenciaReservaDemografica> Criar(
+        string censoReferencia,
+        decimal ppiPercentual,
+        decimal quilombolaPercentual,
+        decimal pcdPercentual,
+        string baseLegal)
+    {
+        ArgumentNullException.ThrowIfNull(censoReferencia);
+        ArgumentNullException.ThrowIfNull(baseLegal);
+
+        Result<(Percentual Ppi, Percentual Quilombola, Percentual Pcd)> validacao =
+            ValidarCampos(censoReferencia, ppiPercentual, quilombolaPercentual, pcdPercentual, baseLegal);
+        if (validacao.IsFailure)
+        {
+            return Result<ReferenciaReservaDemografica>.Failure(validacao.Error!);
+        }
+
+        var referencia = new ReferenciaReservaDemografica();
+        referencia.AplicarCampos(censoReferencia, validacao.Value, baseLegal);
+
+        return Result<ReferenciaReservaDemografica>.Success(referencia);
+    }
+
+    /// <summary>
+    /// Atualiza os percentuais e a base legal da referência. Nunca altera o
+    /// <c>Id</c>. Revalida o intervalo de cada percentual e a presença da base
+    /// legal. A unicidade de <paramref name="censoReferencia"/> (quando
+    /// alterada) é responsabilidade do handler.
+    /// </summary>
+    public Result Atualizar(
+        string censoReferencia,
+        decimal ppiPercentual,
+        decimal quilombolaPercentual,
+        decimal pcdPercentual,
+        string baseLegal)
+    {
+        ArgumentNullException.ThrowIfNull(censoReferencia);
+        ArgumentNullException.ThrowIfNull(baseLegal);
+
+        Result<(Percentual Ppi, Percentual Quilombola, Percentual Pcd)> validacao =
+            ValidarCampos(censoReferencia, ppiPercentual, quilombolaPercentual, pcdPercentual, baseLegal);
+        if (validacao.IsFailure)
+        {
+            return Result.Failure(validacao.Error!);
+        }
+
+        AplicarCampos(censoReferencia, validacao.Value, baseLegal);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(
+        string censoReferencia,
+        (Percentual Ppi, Percentual Quilombola, Percentual Pcd) percentuais,
+        string baseLegal)
+    {
+        CensoReferencia = censoReferencia.Trim();
+        PpiPercentual = percentuais.Ppi;
+        QuilombolaPercentual = percentuais.Quilombola;
+        PcdPercentual = percentuais.Pcd;
+        BaseLegal = baseLegal.Trim();
+    }
+
+    private static Result<(Percentual Ppi, Percentual Quilombola, Percentual Pcd)> ValidarCampos(
+        string censoReferencia,
+        decimal ppiPercentual,
+        decimal quilombolaPercentual,
+        decimal pcdPercentual,
+        string baseLegal)
+    {
+        if (string.IsNullOrWhiteSpace(censoReferencia))
+        {
+            return Falha(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.CensoObrigatorio,
+                "Censo de referência é obrigatório."));
+        }
+
+        if (censoReferencia.Trim().Length is < CensoReferenciaMinLength or > CensoReferenciaMaxLength)
+        {
+            return Falha(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.CensoTamanho,
+                $"Censo de referência deve ter entre {CensoReferenciaMinLength} e {CensoReferenciaMaxLength} caracteres."));
+        }
+
+        Result<Percentual> ppi = Percentual.Criar(ppiPercentual);
+        if (ppi.IsFailure)
+        {
+            return Falha(ComCodigoForaDeFaixa(ppi.Error!));
+        }
+
+        Result<Percentual> quilombola = Percentual.Criar(quilombolaPercentual);
+        if (quilombola.IsFailure)
+        {
+            return Falha(ComCodigoForaDeFaixa(quilombola.Error!));
+        }
+
+        Result<Percentual> pcd = Percentual.Criar(pcdPercentual);
+        if (pcd.IsFailure)
+        {
+            return Falha(ComCodigoForaDeFaixa(pcd.Error!));
+        }
+
+        if (string.IsNullOrWhiteSpace(baseLegal))
+        {
+            return Falha(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.BaseLegalObrigatoria,
+                "Base legal é obrigatória."));
+        }
+
+        if (baseLegal.Trim().Length > BaseLegalMaxLength)
+        {
+            return Falha(new DomainError(
+                ReferenciaReservaDemograficaErrorCodes.BaseLegalTamanho,
+                $"Base legal deve ter no máximo {BaseLegalMaxLength} caracteres."));
+        }
+
+        return Result<(Percentual, Percentual, Percentual)>.Success((ppi.Value!, quilombola.Value!, pcd.Value!));
+    }
+
+    // Reetiqueta o erro genérico do value object com o código de domínio do cadastro.
+    private static DomainError ComCodigoForaDeFaixa(DomainError erro) =>
+        new(ReferenciaReservaDemograficaErrorCodes.PercentualForaDeFaixa, erro.Message);
+
+    private static Result<(Percentual Ppi, Percentual Quilombola, Percentual Pcd)> Falha(DomainError erro) =>
+        Result<(Percentual, Percentual, Percentual)>.Failure(erro);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/ReferenciaReservaDemograficaErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/ReferenciaReservaDemograficaErrorCodes.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+public static class ReferenciaReservaDemograficaErrorCodes
+{
+    public const string CensoObrigatorio = "ReferenciaReservaDemografica.CensoObrigatorio";
+    public const string CensoTamanho = "ReferenciaReservaDemografica.CensoTamanho";
+    public const string CensoJaExiste = "ReferenciaReservaDemografica.CensoJaExiste";
+    public const string PercentualForaDeFaixa = "ReferenciaReservaDemografica.PercentualForaDeFaixa";
+    public const string BaseLegalObrigatoria = "ReferenciaReservaDemografica.BaseLegalObrigatoria";
+    public const string BaseLegalTamanho = "ReferenciaReservaDemografica.BaseLegalTamanho";
+    public const string NaoEncontrada = "ReferenciaReservaDemografica.NaoEncontrada";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IReferenciaReservaDemograficaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IReferenciaReservaDemograficaRepository.cs
@@ -1,0 +1,40 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="ReferenciaReservaDemografica"/>
+/// (ADR-0054: banco isolado <c>uniplus_configuracao</c>). Todas as leituras
+/// excluem registros soft-deleted via query filter por convenção.
+/// </summary>
+public interface IReferenciaReservaDemograficaRepository
+{
+    /// <summary>Carrega a referência rastreada pelo contexto, para mutação.</summary>
+    Task<ReferenciaReservaDemografica?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega a referência para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<ReferenciaReservaDemografica?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista referências vivas paginadas por cursor keyset bidirecional (ADR-0026 +
+    /// ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras
+    /// de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<ReferenciaReservaDemografica> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(ReferenciaReservaDemografica referencia, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca a referência para remoção; o <c>SoftDeleteInterceptor</c> converte em
+    /// soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(ReferenciaReservaDemografica referencia);
+
+    /// <summary>Verifica se existe referência viva para o Censo informado (case-insensitive), excluindo opcionalmente um Id.</summary>
+    Task<bool> CensoExisteEntreLivosAsync(string censoReferencia, Guid? excluirId, CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -3,9 +3,11 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Contracts;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 
 /// <summary>
@@ -32,6 +34,10 @@ public static class ConfiguracaoInfrastructureRegistration
 
         services.AddScoped<ICampusRepository, CampusRepository>();
         services.AddScoped<ILocalOfertaRepository, LocalOfertaRepository>();
+        services.AddScoped<IReferenciaReservaDemograficaRepository, ReferenciaReservaDemograficaRepository>();
+
+        // Reader cross-módulo (ADR-0056) da Referência de reserva demográfica.
+        services.AddScoped<IReferenciaReservaDemograficaReader, ReferenciaReservaDemograficaReader>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -26,6 +26,8 @@ public sealed class ConfiguracaoDbContext : DbContext, IUnitOfWork
 
     public DbSet<LocalOferta> LocaisOferta => Set<LocalOferta>();
 
+    public DbSet<ReferenciaReservaDemografica> ReferenciasReservaDemografica => Set<ReferenciaReservaDemografica>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/ReferenciaReservaDemograficaConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/ReferenciaReservaDemograficaConfiguration.cs
@@ -43,19 +43,18 @@ internal sealed class ReferenciaReservaDemograficaConfiguration
 
         // Percentual é value object — persistido por valor como numeric(5,2).
         // A reconstrução confia no CHECK de banco (0–100), por isso usa Value!.
+        // Os nomes de coluna (ppi_percentual, ...) vêm da convenção snake_case
+        // global — alinhado ao CampusConfiguration, sem HasColumnName explícito.
         builder.Property(r => r.PpiPercentual)
             .HasConversion(p => p.Valor, v => Percentual.Criar(v).Value!)
-            .HasColumnName("ppi_percentual")
             .HasPrecision(5, 2)
             .IsRequired();
         builder.Property(r => r.QuilombolaPercentual)
             .HasConversion(p => p.Valor, v => Percentual.Criar(v).Value!)
-            .HasColumnName("quilombola_percentual")
             .HasPrecision(5, 2)
             .IsRequired();
         builder.Property(r => r.PcdPercentual)
             .HasConversion(p => p.Valor, v => Percentual.Criar(v).Value!)
-            .HasColumnName("pcd_percentual")
             .HasPrecision(5, 2)
             .IsRequired();
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/ReferenciaReservaDemograficaConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/ReferenciaReservaDemograficaConfiguration.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
-using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
 
 [System.Diagnostics.CodeAnalysis.SuppressMessage(
     "Performance",
@@ -41,20 +41,19 @@ internal sealed class ReferenciaReservaDemograficaConfiguration
             .HasMaxLength(CensoReferenciaMaxLength)
             .IsRequired();
 
-        // Percentual é value object — persistido por valor como numeric(5,2).
-        // A reconstrução confia no CHECK de banco (0–100), por isso usa Value!.
-        // Os nomes de coluna (ppi_percentual, ...) vêm da convenção snake_case
-        // global — alinhado ao CampusConfiguration, sem HasColumnName explícito.
+        // Percentual é value object — persistido por valor como numeric(5,2)
+        // via PercentualValueConverter (reidratação fail-fast, ADR de VOs). O
+        // nome de coluna snake_case vem da convenção global.
         builder.Property(r => r.PpiPercentual)
-            .HasConversion(p => p.Valor, v => Percentual.Criar(v).Value!)
+            .HasConversion<PercentualValueConverter>()
             .HasPrecision(5, 2)
             .IsRequired();
         builder.Property(r => r.QuilombolaPercentual)
-            .HasConversion(p => p.Valor, v => Percentual.Criar(v).Value!)
+            .HasConversion<PercentualValueConverter>()
             .HasPrecision(5, 2)
             .IsRequired();
         builder.Property(r => r.PcdPercentual)
-            .HasConversion(p => p.Valor, v => Percentual.Criar(v).Value!)
+            .HasConversion<PercentualValueConverter>()
             .HasPrecision(5, 2)
             .IsRequired();
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/ReferenciaReservaDemograficaConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/ReferenciaReservaDemograficaConfiguration.cs
@@ -1,0 +1,75 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class ReferenciaReservaDemograficaConfiguration
+    : IEntityTypeConfiguration<ReferenciaReservaDemografica>
+{
+    private const int CensoReferenciaMaxLength = 20;
+    private const int BaseLegalMaxLength = 500;
+
+    public void Configure(EntityTypeBuilder<ReferenciaReservaDemografica> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            "referencia_reserva_demografica",
+            t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_referencia_reserva_demografica_ppi_percentual",
+                    "ppi_percentual >= 0 AND ppi_percentual <= 100");
+                t.HasCheckConstraint(
+                    "ck_referencia_reserva_demografica_quilombola_percentual",
+                    "quilombola_percentual >= 0 AND quilombola_percentual <= 100");
+                t.HasCheckConstraint(
+                    "ck_referencia_reserva_demografica_pcd_percentual",
+                    "pcd_percentual >= 0 AND pcd_percentual <= 100");
+            });
+
+        builder.HasKey(r => r.Id);
+
+        builder.Property(r => r.CensoReferencia)
+            .HasMaxLength(CensoReferenciaMaxLength)
+            .IsRequired();
+
+        // Percentual é value object — persistido por valor como numeric(5,2).
+        // A reconstrução confia no CHECK de banco (0–100), por isso usa Value!.
+        builder.Property(r => r.PpiPercentual)
+            .HasConversion(p => p.Valor, v => Percentual.Criar(v).Value!)
+            .HasColumnName("ppi_percentual")
+            .HasPrecision(5, 2)
+            .IsRequired();
+        builder.Property(r => r.QuilombolaPercentual)
+            .HasConversion(p => p.Valor, v => Percentual.Criar(v).Value!)
+            .HasColumnName("quilombola_percentual")
+            .HasPrecision(5, 2)
+            .IsRequired();
+        builder.Property(r => r.PcdPercentual)
+            .HasConversion(p => p.Valor, v => Percentual.Criar(v).Value!)
+            .HasColumnName("pcd_percentual")
+            .HasPrecision(5, 2)
+            .IsRequired();
+
+        builder.Property(r => r.BaseLegal).HasMaxLength(BaseLegalMaxLength).IsRequired();
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(r => r.CreatedBy).HasMaxLength(255);
+        builder.Property(r => r.UpdatedBy).HasMaxLength(255);
+
+        // Unicidade do Censo entre referências vivas (índice parcial) — uma linha
+        // por Censo; soft-delete libera o slot para recriação.
+        builder.HasIndex(r => r.CensoReferencia)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_referencia_reserva_demografica_censo_vivo");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260622135120_AdicionaReferenciaReservaDemografica.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260622135120_AdicionaReferenciaReservaDemografica.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260622135120_AdicionaReferenciaReservaDemografica")]
+    partial class AdicionaReferenciaReservaDemografica
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260622135120_AdicionaReferenciaReservaDemografica.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260622135120_AdicionaReferenciaReservaDemografica.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionaReferenciaReservaDemografica : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "referencia_reserva_demografica",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    censo_referencia = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    ppi_percentual = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false),
+                    quilombola_percentual = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false),
+                    pcd_percentual = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false),
+                    base_legal = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_referencia_reserva_demografica", x => x.id);
+                    table.CheckConstraint("ck_referencia_reserva_demografica_pcd_percentual", "pcd_percentual >= 0 AND pcd_percentual <= 100");
+                    table.CheckConstraint("ck_referencia_reserva_demografica_ppi_percentual", "ppi_percentual >= 0 AND ppi_percentual <= 100");
+                    table.CheckConstraint("ck_referencia_reserva_demografica_quilombola_percentual", "quilombola_percentual >= 0 AND quilombola_percentual <= 100");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_referencia_reserva_demografica_censo_vivo",
+                table: "referencia_reserva_demografica",
+                column: "censo_referencia",
+                unique: true,
+                filter: "is_deleted = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "referencia_reserva_demografica");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/ReferenciaReservaDemograficaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/ReferenciaReservaDemograficaRepository.cs
@@ -1,0 +1,72 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class ReferenciaReservaDemograficaRepository : IReferenciaReservaDemograficaRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public ReferenciaReservaDemograficaRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<ReferenciaReservaDemografica?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.ReferenciasReservaDemografica
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+    }
+
+    public Task<ReferenciaReservaDemografica?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.ReferenciasReservaDemografica
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<ReferenciaReservaDemografica> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<ReferenciaReservaDemografica> page = await CursorKeyset
+            .ApplyAsync(_dbContext.ReferenciasReservaDemografica.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(ReferenciaReservaDemografica referencia, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(referencia);
+        await _dbContext.ReferenciasReservaDemografica.AddAsync(referencia, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(ReferenciaReservaDemografica referencia)
+    {
+        ArgumentNullException.ThrowIfNull(referencia);
+        _dbContext.ReferenciasReservaDemografica.Remove(referencia);
+    }
+
+    public Task<bool> CensoExisteEntreLivosAsync(string censoReferencia, Guid? excluirId, CancellationToken cancellationToken)
+    {
+        // Espelha a normalização do agregado (Trim) para casar com o valor persistido.
+        string censoNorm = censoReferencia.Trim();
+        return _dbContext.ReferenciasReservaDemografica
+            .AsNoTracking()
+            .Where(r => excluirId == null || r.Id != excluirId)
+            .AnyAsync(r => r.CensoReferencia == censoNorm, cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/ReferenciaReservaDemograficaReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/ReferenciaReservaDemograficaReader.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="IReferenciaReservaDemograficaReader"/> (ADR-0056):
+/// leitura direta do banco de Configuração (<c>AsNoTracking</c>, query filter de
+/// soft-delete por convenção). Sem cache — o cadastro é de baixo volume e baixa
+/// frequência de leitura viva; o congelamento por valor no consumidor (ADR-0061)
+/// dispensa releitura quente.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class ReferenciaReservaDemograficaReader : IReferenciaReservaDemograficaReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public ReferenciaReservaDemograficaReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<ReferenciaReservaDemograficaView>> ListarVivasAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<ReferenciaReservaDemografica> entidades = await _dbContext.ReferenciasReservaDemografica
+            .AsNoTracking()
+            .OrderBy(r => r.CensoReferencia)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<ReferenciaReservaDemograficaView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        ReferenciaReservaDemografica? entidade = await _dbContext.ReferenciasReservaDemografica
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static ReferenciaReservaDemograficaView ParaView(ReferenciaReservaDemografica r) =>
+        new(
+            r.Id,
+            r.CensoReferencia,
+            r.PpiPercentual.Valor,
+            r.QuilombolaPercentual.Valor,
+            r.PcdPercentual.Valor,
+            r.BaseLegal);
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/PercentualValueConverter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Converters/PercentualValueConverter.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+// Mapeia Percentual ↔ decimal. A precisão (5,2) é definida na própria
+// propriedade via HasPrecision no IEntityTypeConfiguration. A reidratação
+// passa por ValueObjectMaterialization para falhar explicitamente (com
+// contexto) caso a coluna seja corrompida fora do fluxo da aplicação, em vez
+// do NullReferenceException tardio de `Percentual.Criar(v).Value!`.
+public sealed class PercentualValueConverter : ValueConverter<Percentual, decimal>
+{
+    public PercentualValueConverter()
+        : base(
+            percentual => percentual.Valor,
+            valor => ValueObjectMaterialization.Reidratar(Percentual.Criar(valor), nameof(Percentual)))
+    {
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/ValueObjects/Percentual.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/ValueObjects/Percentual.cs
@@ -1,0 +1,45 @@
+namespace Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+
+using Results;
+
+/// <summary>
+/// Percentual no intervalo fechado de 0 a 100 (inclusive). Value object de
+/// domínio reutilizável por cadastros que armazenam proporções — ex.: os
+/// percentuais demográficos da reserva de vagas (PPI, quilombola, PcD) da
+/// Lei 12.711/2012. Persistido como <c>numeric(5,2)</c>.
+/// </summary>
+public sealed record Percentual
+{
+    /// <summary>Limite inferior inclusivo do intervalo válido.</summary>
+    public const decimal Minimo = 0m;
+
+    /// <summary>Limite superior inclusivo do intervalo válido.</summary>
+    public const decimal Maximo = 100m;
+
+    public decimal Valor { get; }
+
+    private Percentual(decimal valor) => Valor = valor;
+
+    /// <summary>
+    /// Cria um <see cref="Percentual"/> validando o intervalo fechado
+    /// [<see cref="Minimo"/>, <see cref="Maximo"/>]. Valor fora da faixa
+    /// retorna falha de domínio; os limites 0 e 100 são aceitos.
+    /// </summary>
+    public static Result<Percentual> Criar(decimal valor)
+    {
+        if (valor is < Minimo or > Maximo)
+        {
+            return Result<Percentual>.Failure(new DomainError(
+                "Percentual.ForaDeFaixa",
+                $"Percentual deve estar entre {Minimo} e {Maximo}."));
+        }
+
+        return Result<Percentual>.Success(new Percentual(valor));
+    }
+
+    /// <summary>Indica se <paramref name="valor"/> está no intervalo válido, sem alocar.</summary>
+    public static bool EhValido(decimal valor) => valor is >= Minimo and <= Maximo;
+
+    public override string ToString() =>
+        Valor.ToString("F2", System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/ValueObjects/Percentual.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/ValueObjects/Percentual.cs
@@ -20,10 +20,16 @@ public sealed record Percentual
 
     private Percentual(decimal valor) => Valor = valor;
 
+    /// <summary>Escala decimal persistida (<c>numeric(5,2)</c>).</summary>
+    private const int Escala = 2;
+
     /// <summary>
     /// Cria um <see cref="Percentual"/> validando o intervalo fechado
     /// [<see cref="Minimo"/>, <see cref="Maximo"/>]. Valor fora da faixa
-    /// retorna falha de domínio; os limites 0 e 100 são aceitos.
+    /// retorna falha de domínio; os limites 0 e 100 são aceitos. O valor é
+    /// arredondado para a escala persistida (2 casas, banker's rounding) na
+    /// origem — espelhando <c>NotaFinal</c> — para que o validado case com o
+    /// persistido em <c>numeric(5,2)</c> sem divergência até o reload.
     /// </summary>
     public static Result<Percentual> Criar(decimal valor)
     {
@@ -34,7 +40,7 @@ public sealed record Percentual
                 $"Percentual deve estar entre {Minimo} e {Maximo}."));
         }
 
-        return Result<Percentual>.Success(new Percentual(valor));
+        return Result<Percentual>.Success(new Percentual(Math.Round(valor, Escala, MidpointRounding.ToEven)));
     }
 
     /// <summary>Indica se <paramref name="valor"/> está no intervalo válido, sem alocar.</summary>

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarReferenciaReservaDemograficaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarReferenciaReservaDemograficaCommandHandlerTests.cs
@@ -1,0 +1,70 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarReferenciaReservaDemograficaCommandHandlerTests
+{
+    private const string BaseLegal = "Lei 12.711/2012, art. 10, III";
+
+    private readonly IReferenciaReservaDemograficaRepository _repository =
+        Substitute.For<IReferenciaReservaDemograficaRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private static ReferenciaReservaDemografica Existente() =>
+        ReferenciaReservaDemografica.Criar("2022", 78.50m, 1.20m, 8.40m, BaseLegal).Value!;
+
+    [Fact(DisplayName = "Referência inexistente retorna NaoEncontrada")]
+    public async Task Handle_NaoEncontrada_RetornaErro()
+    {
+        Guid id = Guid.NewGuid();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns((ReferenciaReservaDemografica?)null);
+
+        Result resultado = await AtualizarReferenciaReservaDemograficaCommandHandler.Handle(
+            new AtualizarReferenciaReservaDemograficaCommand(id, "2022", 79m, 1.3m, 8.5m, BaseLegal),
+            _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ReferenciaReservaDemograficaErrorCodes.NaoEncontrada);
+    }
+
+    [Fact(DisplayName = "Edição válida persiste e mantém sucesso")]
+    public async Task Handle_DadosValidos_Persiste()
+    {
+        ReferenciaReservaDemografica existente = Existente();
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarReferenciaReservaDemograficaCommandHandler.Handle(
+            new AtualizarReferenciaReservaDemograficaCommand(existente.Id, "2022", 79m, 1.3m, 8.5m, BaseLegal),
+            _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.PpiPercentual.Valor.Should().Be(79m);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Novo Censo já usado por outra referência viva retorna conflito")]
+    public async Task Handle_CensoDuplicado_RetornaConflito()
+    {
+        ReferenciaReservaDemografica existente = Existente();
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.CensoExisteEntreLivosAsync("2010", existente.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result resultado = await AtualizarReferenciaReservaDemograficaCommandHandler.Handle(
+            new AtualizarReferenciaReservaDemograficaCommand(existente.Id, "2010", 79m, 1.3m, 8.5m, BaseLegal),
+            _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ReferenciaReservaDemograficaErrorCodes.CensoJaExiste);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarReferenciaReservaDemograficaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarReferenciaReservaDemograficaCommandHandlerTests.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarReferenciaReservaDemograficaCommandHandlerTests
+{
+    private readonly IReferenciaReservaDemograficaRepository _repository =
+        Substitute.For<IReferenciaReservaDemograficaRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private static CriarReferenciaReservaDemograficaCommand ComandoValido() =>
+        new("2022", 78.50m, 1.20m, 8.40m, "Lei 12.711/2012, art. 10, III");
+
+    [Fact(DisplayName = "Cria a referência, persiste e retorna o Id")]
+    public async Task Handle_CensoLivre_CriaEPersiste()
+    {
+        _repository.CensoExisteEntreLivosAsync("2022", null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarReferenciaReservaDemograficaCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<ReferenciaReservaDemografica>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Censo já existente entre vivos retorna conflito (CensoJaExiste)")]
+    public async Task Handle_CensoDuplicado_RetornaConflito()
+    {
+        _repository.CensoExisteEntreLivosAsync("2022", null, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarReferenciaReservaDemograficaCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ReferenciaReservaDemograficaErrorCodes.CensoJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<ReferenciaReservaDemografica>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Percentual inválido propaga o erro de domínio sem persistir")]
+    public async Task Handle_PercentualInvalido_RetornaErroSemPersistir()
+    {
+        _repository.CensoExisteEntreLivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        CriarReferenciaReservaDemograficaCommand comando = ComandoValido() with { PcdPercentual = 120m };
+
+        Result<Guid> resultado = await CriarReferenciaReservaDemograficaCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ReferenciaReservaDemograficaErrorCodes.PercentualForaDeFaixa);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverReferenciaReservaDemograficaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverReferenciaReservaDemograficaCommandHandlerTests.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverReferenciaReservaDemograficaCommandHandlerTests
+{
+    private readonly IReferenciaReservaDemograficaRepository _repository =
+        Substitute.For<IReferenciaReservaDemograficaRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    [Fact(DisplayName = "Referência inexistente retorna NaoEncontrada")]
+    public async Task Handle_NaoEncontrada_RetornaErro()
+    {
+        Guid id = Guid.NewGuid();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns((ReferenciaReservaDemografica?)null);
+
+        Result resultado = await RemoverReferenciaReservaDemograficaCommandHandler.Handle(
+            new RemoverReferenciaReservaDemograficaCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ReferenciaReservaDemograficaErrorCodes.NaoEncontrada);
+        _repository.DidNotReceive().Remover(Arg.Any<ReferenciaReservaDemografica>());
+    }
+
+    [Fact(DisplayName = "Cadastro flat: remoção é soft-delete e nunca é bloqueada (CA-05)")]
+    public async Task Handle_Existente_RemoveESoftDelete()
+    {
+        ReferenciaReservaDemografica existente =
+            ReferenciaReservaDemografica.Criar("2022", 78.50m, 1.20m, 8.40m, "Lei 12.711/2012").Value!;
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await RemoverReferenciaReservaDemograficaCommandHandler.Handle(
+            new RemoverReferenciaReservaDemograficaCommand(existente.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(existente);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/ReferenciaReservaDemograficaValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/ReferenciaReservaDemograficaValidatorTests.cs
@@ -1,0 +1,68 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.ReferenciasReservaDemografica;
+
+/// <summary>
+/// O validator antecipa o intervalo dos três percentuais (0–100), a presença do
+/// Censo e da base legal, mantendo a fronteira simétrica com o domínio (#593).
+/// </summary>
+public sealed class ReferenciaReservaDemograficaValidatorTests
+{
+    private readonly CriarReferenciaReservaDemograficaCommandValidator _validator = new();
+
+    private static CriarReferenciaReservaDemograficaCommand Base() =>
+        new("2022", 78.50m, 1.20m, 8.40m, "Lei 12.711/2012, art. 10, III");
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Censo ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CensoVazio_Rejeita(string censo)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { CensoReferencia = censo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarReferenciaReservaDemograficaCommand.CensoReferencia));
+    }
+
+    [Fact(DisplayName = "Base legal ausente é rejeitada")]
+    public void BaseLegalVazia_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { BaseLegal = "  " });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarReferenciaReservaDemograficaCommand.BaseLegal));
+    }
+
+    [Theory(DisplayName = "Percentual fora do intervalo é rejeitado pelo validator")]
+    [InlineData(-0.01, 10, 10, nameof(CriarReferenciaReservaDemograficaCommand.PpiPercentual))]
+    [InlineData(100.01, 10, 10, nameof(CriarReferenciaReservaDemograficaCommand.PpiPercentual))]
+    [InlineData(10, -1, 10, nameof(CriarReferenciaReservaDemograficaCommand.QuilombolaPercentual))]
+    [InlineData(10, 10, 150, nameof(CriarReferenciaReservaDemograficaCommand.PcdPercentual))]
+    public void PercentualForaDeFaixa_Rejeita(decimal ppi, decimal quilombola, decimal pcd, string propriedade)
+    {
+        ValidationResult resultado = _validator.Validate(
+            Base() with { PpiPercentual = ppi, QuilombolaPercentual = quilombola, PcdPercentual = pcd });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == propriedade);
+    }
+
+    [Theory(DisplayName = "Percentual no limite (0 e 100) é aceito")]
+    [InlineData(0)]
+    [InlineData(100)]
+    public void PercentualNoLimite_Aceita(decimal valor)
+    {
+        _validator.Validate(Base() with { PpiPercentual = valor, QuilombolaPercentual = valor, PcdPercentual = valor })
+            .IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/ReferenciaReservaDemograficaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/ReferenciaReservaDemograficaTests.cs
@@ -1,0 +1,104 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class ReferenciaReservaDemograficaTests
+{
+    private const string BaseLegal = "Lei 12.711/2012, art. 10, III";
+
+    [Fact(DisplayName = "Criar com dados válidos preenche os percentuais e fica ativa")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        Result<ReferenciaReservaDemografica> resultado =
+            ReferenciaReservaDemografica.Criar("2022", 78.50m, 1.20m, 8.40m, BaseLegal);
+
+        resultado.IsSuccess.Should().BeTrue();
+        ReferenciaReservaDemografica referencia = resultado.Value!;
+        referencia.Id.Should().NotBe(Guid.Empty);
+        referencia.CensoReferencia.Should().Be("2022");
+        referencia.PpiPercentual.Valor.Should().Be(78.50m);
+        referencia.QuilombolaPercentual.Valor.Should().Be(1.20m);
+        referencia.PcdPercentual.Valor.Should().Be(8.40m);
+        referencia.BaseLegal.Should().Be(BaseLegal);
+        referencia.IsDeleted.Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "Criar com Censo ausente ou em branco falha")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemCenso_Falha(string censo)
+    {
+        Result<ReferenciaReservaDemografica> resultado =
+            ReferenciaReservaDemografica.Criar(censo, 10m, 10m, 10m, BaseLegal);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ReferenciaReservaDemograficaErrorCodes.CensoObrigatorio);
+    }
+
+    [Fact(DisplayName = "Criar sem base legal falha")]
+    public void Criar_SemBaseLegal_Falha()
+    {
+        Result<ReferenciaReservaDemografica> resultado =
+            ReferenciaReservaDemografica.Criar("2022", 10m, 10m, 10m, "   ");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ReferenciaReservaDemograficaErrorCodes.BaseLegalObrigatoria);
+    }
+
+    [Theory(DisplayName = "Criar com percentual fora do intervalo falha (um por percentual e limite)")]
+    [InlineData(-0.01, 10, 10)]
+    [InlineData(100.01, 10, 10)]
+    [InlineData(10, -5, 10)]
+    [InlineData(10, 100.01, 10)]
+    [InlineData(10, 10, -0.01)]
+    [InlineData(10, 10, 150)]
+    public void Criar_PercentualForaDeFaixa_Falha(decimal ppi, decimal quilombola, decimal pcd)
+    {
+        Result<ReferenciaReservaDemografica> resultado =
+            ReferenciaReservaDemografica.Criar("2022", ppi, quilombola, pcd, BaseLegal);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ReferenciaReservaDemograficaErrorCodes.PercentualForaDeFaixa);
+    }
+
+    [Theory(DisplayName = "Criar com percentual no limite (0 e 100) é aceito")]
+    [InlineData(0)]
+    [InlineData(100)]
+    public void Criar_PercentualNoLimite_Aceita(decimal valor)
+    {
+        Result<ReferenciaReservaDemografica> resultado =
+            ReferenciaReservaDemografica.Criar("2022", valor, valor, valor, BaseLegal);
+
+        resultado.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Atualizar aplica novos percentuais e preserva o identificador")]
+    public void Atualizar_DadosValidos_PreservaId()
+    {
+        ReferenciaReservaDemografica referencia =
+            ReferenciaReservaDemografica.Criar("2022", 78.50m, 1.20m, 8.40m, BaseLegal).Value!;
+        Guid idOriginal = referencia.Id;
+
+        Result resultado = referencia.Atualizar("2022", 79.00m, 1.30m, 8.50m, BaseLegal);
+
+        resultado.IsSuccess.Should().BeTrue();
+        referencia.Id.Should().Be(idOriginal);
+        referencia.PpiPercentual.Valor.Should().Be(79.00m);
+    }
+
+    [Fact(DisplayName = "Atualizar com percentual inválido falha")]
+    public void Atualizar_PercentualInvalido_Falha()
+    {
+        ReferenciaReservaDemografica referencia =
+            ReferenciaReservaDemografica.Criar("2022", 78.50m, 1.20m, 8.40m, BaseLegal).Value!;
+
+        Result resultado = referencia.Atualizar("2022", 120.00m, 1.20m, 8.40m, BaseLegal);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ReferenciaReservaDemograficaErrorCodes.PercentualForaDeFaixa);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ReferenciasReservaDemografica/ReferenciaReservaDemograficaEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ReferenciasReservaDemografica/ReferenciaReservaDemograficaEndpointTests.cs
@@ -1,0 +1,147 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.ReferenciasReservaDemografica;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>ReferenciaReservaDemografica</c>
+/// (UNI-REQ-0065): routing, vendor media type, HATEOAS, autenticação/autorização,
+/// idempotência e validação de percentual (CA-03) com Wolverine rodando contra
+/// Postgres efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class ReferenciaReservaDemograficaEndpointTests
+{
+    private const string VendorMime = "application/vnd.uniplus.referencia-reserva-demografica.v1+json";
+    private const string ColecaoPath = "/api/referencias-reserva-demografica";
+    private const string AdminPath = "/api/admin/referencias-reserva-demografica";
+
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public ReferenciaReservaDemograficaEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET coleção retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri(ColecaoPath, UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be(VendorMime);
+    }
+
+    [Fact(DisplayName = "GET por id retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{ColecaoPath}/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST admin sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminPath, UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST admin autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminPath, UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(CorpoValido());
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "POST admin cria (201) e o GET subsequente retorna os percentuais + _links")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, AdminPath, CorpoValido(CensoUnico()));
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(new Uri($"{ColecaoPath}/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("ppiPercentual").GetDecimal().Should().Be(78.50m);
+        root.GetProperty("baseLegal").GetString().Should().Be("Lei 12.711/2012, art. 10, III");
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "CA-03: POST admin com percentual fora do intervalo retorna 422")]
+    public async Task Criar_PercentualInvalido_Retorna422()
+    {
+        var body = new
+        {
+            censoReferencia = CensoUnico(),
+            ppiPercentual = 120.0m,
+            quilombolaPercentual = 1.2m,
+            pcdPercentual = 8.4m,
+            baseLegal = "Lei 12.711/2012, art. 10, III",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, AdminPath, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    private static object CorpoValido(string? censo = null) => new
+    {
+        censoReferencia = censo ?? "2022",
+        ppiPercentual = 78.50m,
+        quilombolaPercentual = 1.20m,
+        pcdPercentual = 8.40m,
+        baseLegal = "Lei 12.711/2012, art. 10, III",
+    };
+
+    // Censo de até 20 chars, único por teste para não colidir na UNIQUE parcial entre casos.
+    private static string CensoUnico() => Guid.NewGuid().ToString("N")[..12];
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, string path, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(path, UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ReferenciasReservaDemografica/ReferenciaReservaDemograficaPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ReferenciasReservaDemografica/ReferenciaReservaDemograficaPersistenceTests.cs
@@ -79,8 +79,13 @@ public sealed class ReferenciaReservaDemograficaPersistenceTests
 
         Func<Task> act = async () => await ctx2.SaveChangesAsync();
 
-        await act.Should().ThrowAsync<DbUpdateException>()
-            .WithInnerException(typeof(Npgsql.PostgresException));
+        // Trava as constantes que o handler usa para traduzir a corrida concorrente
+        // (UniqueConstraintViolation.GetViolatedConstraint/IsCensoConflict) em
+        // CensoJaExiste/409: SqlState 23505 + nome do índice único parcial.
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_referencia_reserva_demografica_censo_vivo");
     }
 
     [Fact(DisplayName = "CA-05: soft-delete preserva a trilha e liberta o slot da UNIQUE parcial de Censo")]

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ReferenciasReservaDemografica/ReferenciaReservaDemograficaPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ReferenciasReservaDemografica/ReferenciaReservaDemograficaPersistenceTests.cs
@@ -1,0 +1,133 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.ReferenciasReservaDemografica;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta da Referência de reserva demográfica contra Postgres
+/// real (UNI-REQ-0065): persistência dos percentuais, UNIQUE parcial de Censo,
+/// liberação do slot por soft-delete, leitura cross-módulo (CA-01) e soft-delete
+/// preservando a trilha (CA-05).
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class ReferenciaReservaDemograficaPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+    private const string BaseLegal = "Lei 12.711/2012, art. 10, III";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public ReferenciaReservaDemograficaPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01: criar persiste os percentuais e fica visível pelo leitor cross-módulo")]
+    public async Task Insert_PersisteEFicaVisivelPeloReader()
+    {
+        ReferenciaReservaDemografica referencia = Nova("2022", 78.50m, 1.20m, 8.40m);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.ReferenciasReservaDemografica.Add(referencia);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        ReferenciaReservaDemografica persistida = await readCtx.ReferenciasReservaDemografica
+            .SingleAsync(r => r.Id == referencia.Id);
+
+        persistida.CensoReferencia.Should().Be("2022");
+        persistida.PpiPercentual.Valor.Should().Be(78.50m);
+        persistida.QuilombolaPercentual.Valor.Should().Be(1.20m);
+        persistida.PcdPercentual.Valor.Should().Be(8.40m);
+        persistida.CreatedBy.Should().Be(AdminA);
+        persistida.IsDeleted.Should().BeFalse();
+
+        var reader = new ReferenciaReservaDemograficaReader(readCtx);
+        ReferenciaReservaDemograficaView? view = await reader.ObterPorIdAsync(referencia.Id);
+        view.Should().NotBeNull();
+        view!.CensoReferencia.Should().Be("2022");
+        view.PpiPercentual.Should().Be(78.50m);
+    }
+
+    [Fact(DisplayName = "CA-02: UNIQUE parcial (censo) rejeita segunda referência viva para o mesmo Censo")]
+    public async Task UniquePartial_Censo_RejeitaDuplicataAtiva()
+    {
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.ReferenciasReservaDemografica.Add(Nova("2000", 50m, 1m, 5m));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.ReferenciasReservaDemografica.Add(Nova("2000", 60m, 2m, 6m));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        await act.Should().ThrowAsync<DbUpdateException>()
+            .WithInnerException(typeof(Npgsql.PostgresException));
+    }
+
+    [Fact(DisplayName = "CA-05: soft-delete preserva a trilha e liberta o slot da UNIQUE parcial de Censo")]
+    public async Task SoftDelete_PreservaTrilhaELibertaSlot()
+    {
+        ReferenciaReservaDemografica referencia = Nova("1991", 40m, 1m, 4m);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.ReferenciasReservaDemografica.Add(referencia);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            ReferenciaReservaDemografica tracked = await ctx.ReferenciasReservaDemografica
+                .SingleAsync(r => r.Id == referencia.Id);
+            ctx.ReferenciasReservaDemografica.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            ReferenciaReservaDemografica excluida = await ctx.ReferenciasReservaDemografica
+                .IgnoreQueryFilters().SingleAsync(r => r.Id == referencia.Id);
+            excluida.IsDeleted.Should().BeTrue();
+            excluida.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.ReferenciasReservaDemografica.Add(Nova("1991", 41m, 2m, 5m));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do Censo foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita percentual fora do intervalo via SQL cru")]
+    public async Task Check_RejeitaPercentualForaDeFaixaViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO referencia_reserva_demografica (id, censo_referencia, ppi_percentual, quilombola_percentual, pcd_percentual, base_legal, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"9999"}, {120.0m}, {1.0m}, {5.0m}, {BaseLegal}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK ppi_percentual <= 100 impede o INSERT direto");
+    }
+
+    private static ReferenciaReservaDemografica Nova(string censo, decimal ppi, decimal quilombola, decimal pcd) =>
+        ReferenciaReservaDemografica.Criar(censo, ppi, quilombola, pcd, BaseLegal).Value!;
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ReferenciasReservaDemografica/ReferenciaReservaDemograficaPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/ReferenciasReservaDemografica/ReferenciaReservaDemograficaPersistenceTests.cs
@@ -128,6 +128,46 @@ public sealed class ReferenciaReservaDemograficaPersistenceTests
             "o CHECK ppi_percentual <= 100 impede o INSERT direto");
     }
 
+    [Fact(DisplayName = "Reader.ListarVivasAsync ordena por Censo e exclui soft-deleted")]
+    public async Task ListarVivas_OrdenaPorCensoEExcluiSoftDeleted()
+    {
+        // Prefixo único por execução: o banco é compartilhado na collection, então
+        // filtramos o resultado às linhas deste teste para asserções determinísticas.
+        string prefixo = Guid.NewGuid().ToString("N")[..12];
+        string censoA = $"{prefixo}-a";
+        string censoB = $"{prefixo}-b";
+        string censoExcluido = $"{prefixo}-d";
+
+        // Insere fora de ordem (B antes de A) para provar a ordenação do reader.
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.ReferenciasReservaDemografica.Add(Nova(censoB, 60m, 2m, 6m));
+            ctx.ReferenciasReservaDemografica.Add(Nova(censoA, 50m, 1m, 5m));
+            ctx.ReferenciasReservaDemografica.Add(Nova(censoExcluido, 40m, 1m, 4m));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            ReferenciaReservaDemografica aExcluir = await ctx.ReferenciasReservaDemografica
+                .SingleAsync(r => r.CensoReferencia == censoExcluido);
+            ctx.ReferenciasReservaDemografica.Remove(aExcluir);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new ReferenciaReservaDemograficaReader(readCtx);
+        IReadOnlyList<ReferenciaReservaDemograficaView> todas = await reader.ListarVivasAsync();
+
+        string[] meus = [.. todas
+            .Select(v => v.CensoReferencia)
+            .Where(c => c.StartsWith(prefixo, StringComparison.Ordinal))];
+
+        // O reader ordena por CensoReferencia ascendente e exclui o soft-deleted:
+        // exatamente [censoA, censoB], nessa ordem (inserimos B antes de A).
+        meus.Should().Equal([censoA, censoB]);
+    }
+
     private static ReferenciaReservaDemografica Nova(string censo, decimal ppi, decimal quilombola, decimal pcd) =>
         ReferenciaReservaDemografica.Criar(censo, ppi, quilombola, pcd, BaseLegal).Value!;
 }

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/PercentualTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/ValueObjects/PercentualTests.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Kernel.UnitTests.Domain.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class PercentualTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(0.01)]
+    [InlineData(78.50)]
+    [InlineData(100)]
+    public void Criar_DadoValorNoIntervalo_DeveRetornarSucesso(decimal valor)
+    {
+        Result<Percentual> resultado = Percentual.Criar(valor);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Valor.Should().Be(valor);
+    }
+
+    [Theory]
+    [InlineData(-0.01)]
+    [InlineData(-1)]
+    [InlineData(100.01)]
+    [InlineData(150)]
+    public void Criar_DadoValorForaDoIntervalo_DeveRetornarFailure(decimal valor)
+    {
+        Result<Percentual> resultado = Percentual.Criar(valor);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Percentual.ForaDeFaixa");
+    }
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(100, true)]
+    [InlineData(-0.01, false)]
+    [InlineData(100.01, false)]
+    public void EhValido_RefleteOIntervaloFechado(decimal valor, bool esperado)
+    {
+        Percentual.EhValido(valor).Should().Be(esperado);
+    }
+
+    [Fact]
+    public void ToString_DeveRetornarFormatoF2EmInvariantCulture()
+    {
+        Percentual percentual = Percentual.Criar(8.4m).Value!;
+
+        percentual.ToString().Should().Be("8.40");
+    }
+}


### PR DESCRIPTION
## Contexto

Implementa a story **#593 — Cadastro de Referência de reserva demográfica** (UNI-REQ-0065), na Feature #584 (Cadastros de referência de Configuração) do Epic #582. É um cadastro **flat** no banco de Configuração: uma linha por Censo (`censo_referencia` único entre vivos) com os três percentuais demográficos do IBGE (PPI, quilombola, PcD), cada um no intervalo fechado 0–100, e `base_legal` obrigatória. Materializa a Lei 12.711/2012 (art. 10, III, red. Lei 14.723/2023).

Replica o slice de referência **Campus/LocalOferta** (#587). Commits por camada: domínio → application → infraestrutura/migration → API → testes.

## O que mudou

- **Domínio:** entidade `ReferenciaReservaDemografica` (`SoftDeletableEntity, IAuditableEntity`, factory `Criar`/`Atualizar`) + novo value object compartilhado **`Percentual`** (intervalo 0–100) no Kernel, reutilizável pelos três percentuais.
- **Application (CQRS Wolverine):** commands Criar/Atualizar/Remover + handlers + validators; queries Obter por id e Listar (cursor keyset bidirecional); DTO com HATEOAS `_links` + mapping.
- **Infraestrutura:** EF Configuration com `Percentual` persistido como `numeric(5,2)`, **índice único parcial** de Censo (`WHERE is_deleted = false`) e três **CHECKs** de intervalo; repositório; leitor read-side cross-módulo `IReferenciaReservaDemograficaReader` + `ReferenciaReservaDemograficaView` (ADR-0056); migration `AdicionaReferenciaReservaDemografica` (forward-only, ADR-0054).
- **API:** `GET` público (listar paginado + obter por id) e `POST/PUT/DELETE` admin restritos a `plataforma-admin` com Idempotency-Key; mapeamento de erros de domínio → 422/409/404.

## Critérios de aceite

- [x] **CA-01** criação válida + visível pelo leitor cross-módulo
- [x] **CA-02** unicidade de Censo entre vivos (índice parcial + handler)
- [x] **CA-03** percentual fora do intervalo rejeitado na validação (criação e edição); limites 0/100 aceitos
- [x] **CA-04** Censo e base legal obrigatórios; edição preserva o `Id`
- [x] **CA-05** remoção é soft-delete (trilha preservada); referência congelada por valor em outro banco não bloqueia
- [x] **CA-06 (a11y)** sem UI neste PR (backend)
- [x] **CA-07 (LGPD)** *inaplicável* — apenas agregados públicos do IBGE, nenhum dado pessoal

## Verificação

```
dotnet build UniPlus.slnx            # 0 warnings (TreatWarningsAsErrors)
Kernel.UnitTests (Percentual)        # 13 ✅
Configuracao.Domain.UnitTests        # 14 ✅
Configuracao.Application.UnitTests   # 18 ✅
Configuracao.IntegrationTests        # 10 ✅ (Postgres 18 via Testcontainers)
ArchTests                            # 24 ✅
```

## Fora de escopo

Motor de distribuição de vagas que consome estes percentuais (frente do Módulo Seleção), seleção do Censo por edital e o tratamento SiSU — citados na spec §3/§8 como consumo posterior.

Closes #593
