### PR TITLE
feat(configuracao): cadastro de Pesos do ENEM por grupo de área (Res. 805) — #594

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -2147,6 +2147,7 @@
           "pesoCienciasHumanas",
           "pesoLinguagens",
           "pesoMatematica",
+          "corteRedacao",
           "baseLegal"
         ],
         "type": "object",
@@ -2195,17 +2196,16 @@
             ],
             "format": "double"
           },
-          "baseLegal": {
-            "type": "string"
-          },
           "corteRedacao": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
             "type": [
-              "null",
               "number",
               "string"
             ],
             "format": "double"
+          },
+          "baseLegal": {
+            "type": "string"
           }
         }
       },

--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -2147,7 +2147,6 @@
           "pesoCienciasHumanas",
           "pesoLinguagens",
           "pesoMatematica",
-          "corteRedacao",
           "baseLegal"
         ],
         "type": "object",
@@ -2196,6 +2195,9 @@
             ],
             "format": "double"
           },
+          "baseLegal": {
+            "type": "string"
+          },
           "corteRedacao": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
             "type": [
@@ -2204,9 +2206,6 @@
               "string"
             ],
             "format": "double"
-          },
-          "baseLegal": {
-            "type": "string"
           }
         }
       },
@@ -2516,7 +2515,6 @@
           "pesoCienciasHumanas",
           "pesoLinguagens",
           "pesoMatematica",
-          "corteRedacao",
           "baseLegal"
         ],
         "type": "object",
@@ -2567,6 +2565,9 @@
             ],
             "format": "double"
           },
+          "baseLegal": {
+            "type": "string"
+          },
           "corteRedacao": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
             "type": [
@@ -2575,9 +2576,6 @@
               "string"
             ],
             "format": "double"
-          },
-          "baseLegal": {
-            "type": "string"
           }
         }
       },

--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -1102,6 +1102,466 @@
         }
       }
     },
+    "/api/pesos-area-enem": {
+      "get": {
+        "tags": [
+          "PesosAreaEnem"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PesoAreaEnemDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PesoAreaEnemDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PesoAreaEnemDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/pesos-area-enem/{id}": {
+      "get": {
+        "tags": [
+          "PesosAreaEnem"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/PesoAreaEnemDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PesoAreaEnemDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PesoAreaEnemDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/pesos-area-enem": {
+      "post": {
+        "tags": [
+          "PesosAreaEnem"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarPesoAreaEnemCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarPesoAreaEnemCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarPesoAreaEnemCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/admin/pesos-area-enem/{id}": {
+      "put": {
+        "tags": [
+          "PesosAreaEnem"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarPesoAreaEnemCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarPesoAreaEnemCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarPesoAreaEnemCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "PesosAreaEnem"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/referencias-reserva-demografica": {
       "get": {
         "tags": [
@@ -1679,6 +2139,77 @@
           }
         }
       },
+      "AtualizarPesoAreaEnemCommand": {
+        "required": [
+          "id",
+          "pesoRedacao",
+          "pesoCienciasNatureza",
+          "pesoCienciasHumanas",
+          "pesoLinguagens",
+          "pesoMatematica",
+          "corteRedacao",
+          "baseLegal"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "pesoRedacao": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoCienciasNatureza": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoCienciasHumanas": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoLinguagens": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoMatematica": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "corteRedacao": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "baseLegal": {
+            "type": "string"
+          }
+        }
+      },
       "AtualizarReferenciaReservaDemograficaCommand": {
         "required": [
           "id",
@@ -1976,6 +2507,80 @@
           }
         }
       },
+      "CriarPesoAreaEnemCommand": {
+        "required": [
+          "resolucao",
+          "grupoCurso",
+          "pesoRedacao",
+          "pesoCienciasNatureza",
+          "pesoCienciasHumanas",
+          "pesoLinguagens",
+          "pesoMatematica",
+          "corteRedacao",
+          "baseLegal"
+        ],
+        "type": "object",
+        "properties": {
+          "resolucao": {
+            "type": "string"
+          },
+          "grupoCurso": {
+            "type": "string"
+          },
+          "pesoRedacao": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoCienciasNatureza": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoCienciasHumanas": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoLinguagens": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoMatematica": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "corteRedacao": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "baseLegal": {
+            "type": "string"
+          }
+        }
+      },
       "CriarReferenciaReservaDemograficaCommand": {
         "required": [
           "censoReferencia",
@@ -2262,6 +2867,98 @@
           }
         }
       },
+      "PesoAreaEnemDto": {
+        "required": [
+          "id",
+          "resolucao",
+          "grupoCurso",
+          "pesoRedacao",
+          "pesoCienciasNatureza",
+          "pesoCienciasHumanas",
+          "pesoLinguagens",
+          "pesoMatematica",
+          "corteRedacao",
+          "baseLegal",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "resolucao": {
+            "type": "string"
+          },
+          "grupoCurso": {
+            "type": "string"
+          },
+          "pesoRedacao": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoCienciasNatureza": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoCienciasHumanas": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoLinguagens": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "pesoMatematica": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "corteRedacao": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "baseLegal": {
+            "type": "string"
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "ProblemDetails": {
         "type": "object",
         "properties": {
@@ -2446,6 +3143,9 @@
     },
     {
       "name": "LocaisOferta"
+    },
+    {
+      "name": "PesosAreaEnem"
     },
     {
       "name": "ReferenciasReservaDemografica"

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/PesosAreaEnemController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/PesosAreaEnemController.cs
@@ -1,0 +1,185 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.PesosAreaEnem;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/pesos-area-enem</c>,
+/// <c>GET /api/pesos-area-enem/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/admin/pesos-area-enem</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ-0066).
+/// </summary>
+[ApiController]
+[Route("api")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class PesosAreaEnemController : ControllerBase
+{
+    private const string ResourceTag = "pesos-area-enem";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<PesoAreaEnemDto> _linksBuilder;
+
+    public PesosAreaEnemController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<PesoAreaEnemDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista as linhas de pesos do ENEM ativas, paginadas por cursor opaco
+    /// bidirecional (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada
+    /// item carrega seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("pesos-area-enem")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "peso-area-enem", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<PesoAreaEnemDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarPesosAreaEnemResult resultado = await _queryBus
+            .Send(new ListarPesosAreaEnemQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        PesoAreaEnemDto[] comLinks =
+            [.. resultado.Items.Select(p => p with { Links = _linksBuilder.Build(p) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém uma linha de pesos pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("pesos-area-enem/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "peso-area-enem", Versions = [1])]
+    [ProducesResponseType(typeof(PesoAreaEnemDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        PesoAreaEnemDto? peso = await _queryBus
+            .Send(new ObterPesoAreaEnemPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (peso is null)
+        {
+            return NotFound();
+        }
+
+        PesoAreaEnemDto comLinks = peso with { Links = _linksBuilder.Build(peso) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria uma nova linha de pesos. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/pesos-area-enem")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarPesoAreaEnemCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza uma linha de pesos existente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/pesos-area-enem/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarPesoAreaEnemCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) uma linha de pesos. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/pesos-area-enem/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverPesoAreaEnemCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -272,5 +272,60 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status404NotFound,
                 "uniplus.configuracao.referencia_reserva_demografica.nao_encontrada",
                 "Referência de reserva demográfica não encontrada")),
+
+        // ── Pesos do ENEM por grupo de área (UNI-REQ-0066) ────────────────
+        new(PesoAreaEnemErrorCodes.ResolucaoObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.peso_area_enem.resolucao_obrigatoria",
+                "Resolução é obrigatória")),
+
+        new(PesoAreaEnemErrorCodes.ResolucaoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.peso_area_enem.resolucao_tamanho",
+                "Tamanho da resolução inválido")),
+
+        new(PesoAreaEnemErrorCodes.GrupoCursoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.peso_area_enem.grupo_curso_invalido",
+                "Grupo de curso fora do domínio de grupos de área do ENEM")),
+
+        new(PesoAreaEnemErrorCodes.ParJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.peso_area_enem.par_ja_existe",
+                "Já existe uma linha de pesos ativa para esta resolução e grupo de curso")),
+
+        new(PesoAreaEnemErrorCodes.PesoNegativo,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.peso_area_enem.peso_negativo",
+                "Peso de área não pode ser negativo")),
+
+        new(PesoAreaEnemErrorCodes.CorteRedacaoNegativo,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.peso_area_enem.corte_redacao_negativo",
+                "Corte de redação não pode ser negativo")),
+
+        new(PesoAreaEnemErrorCodes.BaseLegalObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.peso_area_enem.base_legal_obrigatoria",
+                "Base legal é obrigatória")),
+
+        new(PesoAreaEnemErrorCodes.BaseLegalTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.peso_area_enem.base_legal_tamanho",
+                "Tamanho da base legal inválido")),
+
+        new(PesoAreaEnemErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.peso_area_enem.nao_encontrado",
+                "Linha de pesos do ENEM não encontrada")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/PesoAreaEnemLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/PesoAreaEnemLinksBuilder.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="PesoAreaEnemDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<PesoAreaEnemDto>, PesoAreaEnemLinksBuilder>().")]
+internal sealed class PesoAreaEnemLinksBuilder : IResourceLinksBuilder<PesoAreaEnemDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public PesoAreaEnemLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(PesoAreaEnemDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "PesosAreaEnem";
+
+        string self = ResolverPath(
+            httpContext, nameof(PesosAreaEnemController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(PesosAreaEnemController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Program.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddDomainErrorMapper();
 builder.Services.AddSingleton<IResourceLinksBuilder<CampusDto>, CampusLinksBuilder>();
 builder.Services.AddSingleton<IResourceLinksBuilder<LocalOfertaDto>, LocalOfertaLinksBuilder>();
 builder.Services.AddSingleton<IResourceLinksBuilder<ReferenciaReservaDemograficaDto>, ReferenciaReservaDemograficaLinksBuilder>();
+builder.Services.AddSingleton<IResourceLinksBuilder<PesoAreaEnemDto>, PesoAreaEnemLinksBuilder>();
 
 // Idempotency-Key (ADR-0027) + criptografia para entries at-rest. Filter global
 // se ativa apenas em endpoints com [RequiresIdempotencyKey] — os controllers

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommand.cs
@@ -15,5 +15,5 @@ public sealed record AtualizarPesoAreaEnemCommand(
     decimal PesoCienciasHumanas,
     decimal PesoLinguagens,
     decimal PesoMatematica,
-    decimal? CorteRedacao,
-    string BaseLegal) : ICommand<Result>;
+    string BaseLegal,
+    decimal? CorteRedacao = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommand.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
 
+using System.Text.Json.Serialization;
+
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
 using Unifesspa.UniPlus.Kernel.Results;
 
@@ -9,18 +11,20 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// são imutáveis (CA-04b) — não constam no payload.
 /// </summary>
 /// <remarks>
-/// PUT é substituição completa: o <c>CorteRedacao</c> é obrigatório (como os cinco
-/// pesos), não opcional. Diferente do <c>Criar</c> — que assume 400 quando omitido —
-/// aqui já existe um valor configurado; aceitar omissão faria o corte cair
-/// silenciosamente para 400, sobrescrevendo o valor atual. O cliente sempre reenvia
-/// o corte vigente.
+/// PUT é substituição completa: os cinco pesos e o <c>CorteRedacao</c> são
+/// obrigatórios, não opcionais. Como são <c>decimal</c> não-anuláveis, são marcados
+/// <c>[JsonRequired]</c> — sem isso o System.Text.Json constrói o record com
+/// <c>0m</c> quando o campo é omitido, e o validator aceita 0, sobrescrevendo
+/// silenciosamente o valor configurado (ex.: um corte 450 vira 0 ao editar só a
+/// base legal). Com <c>[JsonRequired]</c> a omissão vira 400 na desserialização. O
+/// cliente sempre reenvia o estado completo da linha.
 /// </remarks>
 public sealed record AtualizarPesoAreaEnemCommand(
     Guid Id,
-    decimal PesoRedacao,
-    decimal PesoCienciasNatureza,
-    decimal PesoCienciasHumanas,
-    decimal PesoLinguagens,
-    decimal PesoMatematica,
-    decimal CorteRedacao,
+    [property: JsonRequired] decimal PesoRedacao,
+    [property: JsonRequired] decimal PesoCienciasNatureza,
+    [property: JsonRequired] decimal PesoCienciasHumanas,
+    [property: JsonRequired] decimal PesoLinguagens,
+    [property: JsonRequired] decimal PesoMatematica,
+    [property: JsonRequired] decimal CorteRedacao,
     string BaseLegal) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommand.cs
@@ -8,6 +8,13 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// pesos. A chave de negócio (<c>Resolucao</c> + <c>GrupoCurso</c>) e o <c>Id</c>
 /// são imutáveis (CA-04b) — não constam no payload.
 /// </summary>
+/// <remarks>
+/// PUT é substituição completa: o <c>CorteRedacao</c> é obrigatório (como os cinco
+/// pesos), não opcional. Diferente do <c>Criar</c> — que assume 400 quando omitido —
+/// aqui já existe um valor configurado; aceitar omissão faria o corte cair
+/// silenciosamente para 400, sobrescrevendo o valor atual. O cliente sempre reenvia
+/// o corte vigente.
+/// </remarks>
 public sealed record AtualizarPesoAreaEnemCommand(
     Guid Id,
     decimal PesoRedacao,
@@ -15,5 +22,5 @@ public sealed record AtualizarPesoAreaEnemCommand(
     decimal PesoCienciasHumanas,
     decimal PesoLinguagens,
     decimal PesoMatematica,
-    string BaseLegal,
-    decimal? CorteRedacao = null) : ICommand<Result>;
+    decimal CorteRedacao,
+    string BaseLegal) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommand.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza os cinco pesos, o corte de redação e a base legal de uma linha de
+/// pesos. A chave de negócio (<c>Resolucao</c> + <c>GrupoCurso</c>) e o <c>Id</c>
+/// são imutáveis (CA-04b) — não constam no payload.
+/// </summary>
+public sealed record AtualizarPesoAreaEnemCommand(
+    Guid Id,
+    decimal PesoRedacao,
+    decimal PesoCienciasNatureza,
+    decimal PesoCienciasHumanas,
+    decimal PesoLinguagens,
+    decimal PesoMatematica,
+    decimal? CorteRedacao,
+    string BaseLegal) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandHandler.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarPesoAreaEnemCommand"/>. Edita apenas pesos,
+/// corte e base legal — a chave de negócio (resolução + grupo) e o <c>Id</c> são
+/// imutáveis (CA-04b), logo não há colisão de unicidade possível e nenhuma
+/// checagem de corrida é necessária.
+/// </summary>
+public static class AtualizarPesoAreaEnemCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarPesoAreaEnemCommand command,
+        IPesoAreaEnemRepository repository,
+        IUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        PesoAreaEnem? peso = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (peso is null)
+        {
+            return Result.Failure(new DomainError(
+                PesoAreaEnemErrorCodes.NaoEncontrado,
+                "Linha de pesos do ENEM não encontrada."));
+        }
+
+        Result atualizarResult = peso.Atualizar(
+            command.PesoRedacao,
+            command.PesoCienciasNatureza,
+            command.PesoCienciasHumanas,
+            command.PesoLinguagens,
+            command.PesoMatematica,
+            command.CorteRedacao,
+            command.BaseLegal);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandValidator.cs
@@ -19,8 +19,7 @@ public sealed class AtualizarPesoAreaEnemCommandValidator
         RuleFor(x => x.PesoMatematica).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de matemática deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
 
         RuleFor(x => x.CorteRedacao)
-            .InclusiveBetween(0m, PesoAreaEnem.CorteRedacaoMaximo).WithMessage($"Corte de redação deve estar entre 0 e {PesoAreaEnem.CorteRedacaoMaximo}.")
-            .When(x => x.CorteRedacao.HasValue);
+            .InclusiveBetween(0m, PesoAreaEnem.CorteRedacaoMaximo).WithMessage($"Corte de redação deve estar entre 0 e {PesoAreaEnem.CorteRedacaoMaximo}.");
 
         RuleFor(x => x.BaseLegal)
             .NotEmpty().WithMessage("Base legal é obrigatória.")

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandValidator.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
 
 using FluentValidation;
 
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
 public sealed class AtualizarPesoAreaEnemCommandValidator
     : AbstractValidator<AtualizarPesoAreaEnemCommand>
 {
@@ -10,14 +12,14 @@ public sealed class AtualizarPesoAreaEnemCommandValidator
         RuleFor(x => x.Id)
             .NotEmpty().WithMessage("Id da linha de pesos do ENEM é obrigatório.");
 
-        RuleFor(x => x.PesoRedacao).GreaterThanOrEqualTo(0).WithMessage("O peso de redação não pode ser negativo.");
-        RuleFor(x => x.PesoCienciasNatureza).GreaterThanOrEqualTo(0).WithMessage("O peso de ciências da natureza não pode ser negativo.");
-        RuleFor(x => x.PesoCienciasHumanas).GreaterThanOrEqualTo(0).WithMessage("O peso de ciências humanas não pode ser negativo.");
-        RuleFor(x => x.PesoLinguagens).GreaterThanOrEqualTo(0).WithMessage("O peso de linguagens e códigos não pode ser negativo.");
-        RuleFor(x => x.PesoMatematica).GreaterThanOrEqualTo(0).WithMessage("O peso de matemática não pode ser negativo.");
+        RuleFor(x => x.PesoRedacao).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de redação deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
+        RuleFor(x => x.PesoCienciasNatureza).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de ciências da natureza deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
+        RuleFor(x => x.PesoCienciasHumanas).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de ciências humanas deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
+        RuleFor(x => x.PesoLinguagens).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de linguagens e códigos deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
+        RuleFor(x => x.PesoMatematica).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de matemática deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
 
         RuleFor(x => x.CorteRedacao)
-            .GreaterThanOrEqualTo(0m).WithMessage("Corte de redação não pode ser negativo.")
+            .InclusiveBetween(0m, PesoAreaEnem.CorteRedacaoMaximo).WithMessage($"Corte de redação deve estar entre 0 e {PesoAreaEnem.CorteRedacaoMaximo}.")
             .When(x => x.CorteRedacao.HasValue);
 
         RuleFor(x => x.BaseLegal)

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandValidator.cs
@@ -16,8 +16,8 @@ public sealed class AtualizarPesoAreaEnemCommandValidator
         RuleFor(x => x.PesoLinguagens).GreaterThanOrEqualTo(0).WithMessage("O peso de linguagens e códigos não pode ser negativo.");
         RuleFor(x => x.PesoMatematica).GreaterThanOrEqualTo(0).WithMessage("O peso de matemática não pode ser negativo.");
 
-        RuleFor(x => x.CorteRedacao!.Value)
-            .GreaterThanOrEqualTo(0).WithMessage("Corte de redação não pode ser negativo.")
+        RuleFor(x => x.CorteRedacao)
+            .GreaterThanOrEqualTo(0m).WithMessage("Corte de redação não pode ser negativo.")
             .When(x => x.CorteRedacao.HasValue);
 
         RuleFor(x => x.BaseLegal)

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/AtualizarPesoAreaEnemCommandValidator.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+using FluentValidation;
+
+public sealed class AtualizarPesoAreaEnemCommandValidator
+    : AbstractValidator<AtualizarPesoAreaEnemCommand>
+{
+    public AtualizarPesoAreaEnemCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id da linha de pesos do ENEM é obrigatório.");
+
+        RuleFor(x => x.PesoRedacao).GreaterThanOrEqualTo(0).WithMessage("O peso de redação não pode ser negativo.");
+        RuleFor(x => x.PesoCienciasNatureza).GreaterThanOrEqualTo(0).WithMessage("O peso de ciências da natureza não pode ser negativo.");
+        RuleFor(x => x.PesoCienciasHumanas).GreaterThanOrEqualTo(0).WithMessage("O peso de ciências humanas não pode ser negativo.");
+        RuleFor(x => x.PesoLinguagens).GreaterThanOrEqualTo(0).WithMessage("O peso de linguagens e códigos não pode ser negativo.");
+        RuleFor(x => x.PesoMatematica).GreaterThanOrEqualTo(0).WithMessage("O peso de matemática não pode ser negativo.");
+
+        RuleFor(x => x.CorteRedacao!.Value)
+            .GreaterThanOrEqualTo(0).WithMessage("Corte de redação não pode ser negativo.")
+            .When(x => x.CorteRedacao.HasValue);
+
+        RuleFor(x => x.BaseLegal)
+            .NotEmpty().WithMessage("Base legal é obrigatória.")
+            .MaximumLength(500).WithMessage("Base legal deve ter no máximo 500 caracteres.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommand.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria uma linha de pesos do ENEM por grupo de área: a resolução, o grupo de
+/// área, os cinco pesos das áreas de conhecimento, o corte de redação (assume
+/// 400 quando omitido) e a base legal. Os atores de auditoria (<c>created_by</c>)
+/// são carimbados server-side via <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarPesoAreaEnemCommand(
+    string Resolucao,
+    string GrupoCurso,
+    decimal PesoRedacao,
+    decimal PesoCienciasNatureza,
+    decimal PesoCienciasHumanas,
+    decimal PesoLinguagens,
+    decimal PesoMatematica,
+    decimal? CorteRedacao,
+    string BaseLegal) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommand.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
 
+using System.Text.Json.Serialization;
+
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
 using Unifesspa.UniPlus.Kernel.Results;
 
@@ -9,13 +11,19 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// 400 quando omitido) e a base legal. Os atores de auditoria (<c>created_by</c>)
 /// são carimbados server-side via <c>IUserContext</c>, não no payload.
 /// </summary>
+/// <remarks>
+/// Os cinco pesos são <c>[JsonRequired]</c>: como são <c>decimal</c> não-anuláveis,
+/// omiti-los no JSON faria o System.Text.Json construir o record com <c>0m</c> — um
+/// peso válido — em vez de rejeitar o campo ausente. O <c>CorteRedacao</c> é o único
+/// genuinamente opcional (assume 400 quando omitido).
+/// </remarks>
 public sealed record CriarPesoAreaEnemCommand(
     string Resolucao,
     string GrupoCurso,
-    decimal PesoRedacao,
-    decimal PesoCienciasNatureza,
-    decimal PesoCienciasHumanas,
-    decimal PesoLinguagens,
-    decimal PesoMatematica,
+    [property: JsonRequired] decimal PesoRedacao,
+    [property: JsonRequired] decimal PesoCienciasNatureza,
+    [property: JsonRequired] decimal PesoCienciasHumanas,
+    [property: JsonRequired] decimal PesoLinguagens,
+    [property: JsonRequired] decimal PesoMatematica,
     string BaseLegal,
     decimal? CorteRedacao = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommand.cs
@@ -17,5 +17,5 @@ public sealed record CriarPesoAreaEnemCommand(
     decimal PesoCienciasHumanas,
     decimal PesoLinguagens,
     decimal PesoMatematica,
-    decimal? CorteRedacao,
-    string BaseLegal) : ICommand<Result<Guid>>;
+    string BaseLegal,
+    decimal? CorteRedacao = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommandHandler.cs
@@ -1,0 +1,71 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarPesoAreaEnemCommand"/> (convention-based Wolverine):
+/// confere a unicidade do par (resolução, grupo de área) entre linhas vivas, cria
+/// o agregado, persiste e commita.
+/// </summary>
+public static class CriarPesoAreaEnemCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarPesoAreaEnemCommand command,
+        IPesoAreaEnemRepository repository,
+        IUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.ParExisteEntreVivosAsync(command.Resolucao, command.GrupoCurso, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(ParJaExisteErro(command.Resolucao, command.GrupoCurso));
+        }
+
+        Result<PesoAreaEnem> pesoResult = PesoAreaEnem.Criar(
+            command.Resolucao,
+            command.GrupoCurso,
+            command.PesoRedacao,
+            command.PesoCienciasNatureza,
+            command.PesoCienciasHumanas,
+            command.PesoLinguagens,
+            command.PesoMatematica,
+            command.CorteRedacao,
+            command.BaseLegal);
+
+        if (pesoResult.IsFailure)
+        {
+            return Result<Guid>.Failure(pesoResult.Error!);
+        }
+
+        PesoAreaEnem peso = pesoResult.Value!;
+        await repository.AdicionarAsync(peso, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsParConflict(constraint))
+        {
+            // Corrida entre ParExisteEntreVivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo ParJaExiste do
+            // caminho não-race — 409 consistente, em vez de deixar o DbUpdateException
+            // virar 500 no middleware global. O filtro do `when` garante que outras
+            // exceções propagam intactas.
+            return Result<Guid>.Failure(ParJaExisteErro(command.Resolucao, command.GrupoCurso));
+        }
+
+        return Result<Guid>.Success(peso.Id);
+    }
+
+    private static DomainError ParJaExisteErro(string resolucao, string grupoCurso) =>
+        new(PesoAreaEnemErrorCodes.ParJaExiste,
+            $"Já existe uma linha de pesos viva para a resolução '{resolucao}' e o grupo '{grupoCurso}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommandValidator.cs
@@ -2,6 +2,7 @@ namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
 
 using FluentValidation;
 
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
 
 public sealed class CriarPesoAreaEnemCommandValidator
@@ -17,14 +18,14 @@ public sealed class CriarPesoAreaEnemCommandValidator
             .Must(GrupoCurso.EhValido)
             .WithMessage($"Grupo de curso deve ser um de: {string.Join(", ", GrupoCurso.Valores)}.");
 
-        RuleFor(x => x.PesoRedacao).GreaterThanOrEqualTo(0).WithMessage("O peso de redação não pode ser negativo.");
-        RuleFor(x => x.PesoCienciasNatureza).GreaterThanOrEqualTo(0).WithMessage("O peso de ciências da natureza não pode ser negativo.");
-        RuleFor(x => x.PesoCienciasHumanas).GreaterThanOrEqualTo(0).WithMessage("O peso de ciências humanas não pode ser negativo.");
-        RuleFor(x => x.PesoLinguagens).GreaterThanOrEqualTo(0).WithMessage("O peso de linguagens e códigos não pode ser negativo.");
-        RuleFor(x => x.PesoMatematica).GreaterThanOrEqualTo(0).WithMessage("O peso de matemática não pode ser negativo.");
+        RuleFor(x => x.PesoRedacao).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de redação deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
+        RuleFor(x => x.PesoCienciasNatureza).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de ciências da natureza deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
+        RuleFor(x => x.PesoCienciasHumanas).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de ciências humanas deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
+        RuleFor(x => x.PesoLinguagens).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de linguagens e códigos deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
+        RuleFor(x => x.PesoMatematica).InclusiveBetween(0m, PesoAreaEnem.PesoMaximo).WithMessage($"O peso de matemática deve estar entre 0 e {PesoAreaEnem.PesoMaximo}.");
 
         RuleFor(x => x.CorteRedacao)
-            .GreaterThanOrEqualTo(0m).WithMessage("Corte de redação não pode ser negativo.")
+            .InclusiveBetween(0m, PesoAreaEnem.CorteRedacaoMaximo).WithMessage($"Corte de redação deve estar entre 0 e {PesoAreaEnem.CorteRedacaoMaximo}.")
             .When(x => x.CorteRedacao.HasValue);
 
         RuleFor(x => x.BaseLegal)

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommandValidator.cs
@@ -23,8 +23,8 @@ public sealed class CriarPesoAreaEnemCommandValidator
         RuleFor(x => x.PesoLinguagens).GreaterThanOrEqualTo(0).WithMessage("O peso de linguagens e códigos não pode ser negativo.");
         RuleFor(x => x.PesoMatematica).GreaterThanOrEqualTo(0).WithMessage("O peso de matemática não pode ser negativo.");
 
-        RuleFor(x => x.CorteRedacao!.Value)
-            .GreaterThanOrEqualTo(0).WithMessage("Corte de redação não pode ser negativo.")
+        RuleFor(x => x.CorteRedacao)
+            .GreaterThanOrEqualTo(0m).WithMessage("Corte de redação não pode ser negativo.")
             .When(x => x.CorteRedacao.HasValue);
 
         RuleFor(x => x.BaseLegal)

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/CriarPesoAreaEnemCommandValidator.cs
@@ -1,0 +1,34 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+public sealed class CriarPesoAreaEnemCommandValidator
+    : AbstractValidator<CriarPesoAreaEnemCommand>
+{
+    public CriarPesoAreaEnemCommandValidator()
+    {
+        RuleFor(x => x.Resolucao)
+            .NotEmpty().WithMessage("Resolução é obrigatória.")
+            .MaximumLength(40).WithMessage("Resolução deve ter no máximo 40 caracteres.");
+
+        RuleFor(x => x.GrupoCurso)
+            .Must(GrupoCurso.EhValido)
+            .WithMessage($"Grupo de curso deve ser um de: {string.Join(", ", GrupoCurso.Valores)}.");
+
+        RuleFor(x => x.PesoRedacao).GreaterThanOrEqualTo(0).WithMessage("O peso de redação não pode ser negativo.");
+        RuleFor(x => x.PesoCienciasNatureza).GreaterThanOrEqualTo(0).WithMessage("O peso de ciências da natureza não pode ser negativo.");
+        RuleFor(x => x.PesoCienciasHumanas).GreaterThanOrEqualTo(0).WithMessage("O peso de ciências humanas não pode ser negativo.");
+        RuleFor(x => x.PesoLinguagens).GreaterThanOrEqualTo(0).WithMessage("O peso de linguagens e códigos não pode ser negativo.");
+        RuleFor(x => x.PesoMatematica).GreaterThanOrEqualTo(0).WithMessage("O peso de matemática não pode ser negativo.");
+
+        RuleFor(x => x.CorteRedacao!.Value)
+            .GreaterThanOrEqualTo(0).WithMessage("Corte de redação não pode ser negativo.")
+            .When(x => x.CorteRedacao.HasValue);
+
+        RuleFor(x => x.BaseLegal)
+            .NotEmpty().WithMessage("Base legal é obrigatória.")
+            .MaximumLength(500).WithMessage("Base legal deve ter no máximo 500 caracteres.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/RemoverPesoAreaEnemCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/RemoverPesoAreaEnemCommand.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed record RemoverPesoAreaEnemCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/RemoverPesoAreaEnemCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/RemoverPesoAreaEnemCommandHandler.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverPesoAreaEnemCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c>. Nenhuma FK aponta para este cadastro: a ligação
+/// do curso é por valor sobre o vocabulário de grupos e o congelamento em outro
+/// banco (ADR-0061) é cópia desacoplada — por isso a remoção nunca é bloqueada (CA-05).
+/// </summary>
+public static class RemoverPesoAreaEnemCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverPesoAreaEnemCommand command,
+        IPesoAreaEnemRepository repository,
+        IUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        PesoAreaEnem? peso = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (peso is null)
+        {
+            return Result.Failure(new DomainError(
+                PesoAreaEnemErrorCodes.NaoEncontrado,
+                "Linha de pesos do ENEM não encontrada."));
+        }
+
+        repository.Remover(peso);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/PesosAreaEnem/UniqueConstraintViolation.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do par
+/// (resolução, grupo de curso) — <c>ix_peso_area_enem_resolucao_grupo_vivo</c> —
+/// para o <c>DomainError</c> apropriado. Acessa <c>SqlState</c> e
+/// <c>ConstraintName</c> por reflection no inner exception — o shape é estável na
+/// API pública do <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção
+/// por <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch —
+/// Application referencia apenas Domain + SharedKernel + abstrações).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão do <c>UniqueConstraintViolation</c> da Referência de reserva
+/// demográfica (#593). A tradução cross-cutting de 23505 → 409 via
+/// <c>GlobalExceptionMiddleware</c> permanece como follow-up separado (#504);
+/// este helper cobre o caso específico da unicidade do par (CA-02).
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string ParConstraint = "ix_peso_area_enem_resolucao_grupo_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o
+    /// caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único parcial
+    /// que garante uma única linha viva por par (resolução, grupo de curso).
+    /// </summary>
+    public static bool IsParConflict(string? constraint) =>
+        string.Equals(constraint, ParConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/PesoAreaEnemDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/PesoAreaEnemDto.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>PesoAreaEnem</c>. Suporta HATEOAS Level 1 via
+/// <c>_links</c> (ADR-0029). O grupo de área é exposto como <c>string</c> (valor
+/// do value object <c>GrupoCurso</c>); os pesos e o corte como <c>decimal</c>.
+/// </summary>
+public sealed record PesoAreaEnemDto(
+    Guid Id,
+    string Resolucao,
+    string GrupoCurso,
+    decimal PesoRedacao,
+    decimal PesoCienciasNatureza,
+    decimal PesoCienciasHumanas,
+    decimal PesoLinguagens,
+    decimal PesoMatematica,
+    decimal CorteRedacao,
+    string BaseLegal,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/PesoAreaEnemMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/PesoAreaEnemMapping.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+public static class PesoAreaEnemMapping
+{
+    public static PesoAreaEnemDto ToDto(this PesoAreaEnem peso)
+    {
+        ArgumentNullException.ThrowIfNull(peso);
+        return new PesoAreaEnemDto(
+            peso.Id,
+            peso.Resolucao,
+            peso.GrupoCurso.Valor,
+            peso.PesoRedacao,
+            peso.PesoCienciasNatureza,
+            peso.PesoCienciasHumanas,
+            peso.PesoLinguagens,
+            peso.PesoMatematica,
+            peso.CorteRedacao,
+            peso.BaseLegal,
+            peso.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ListarPesosAreaEnemQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ListarPesosAreaEnemQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista linhas de pesos do ENEM vivas paginadas por cursor bidirecional
+/// (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e valida
+/// limit/direction antes de despachar.
+/// </summary>
+public sealed record ListarPesosAreaEnemQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarPesosAreaEnemResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ListarPesosAreaEnemQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ListarPesosAreaEnemQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarPesosAreaEnemQueryHandler
+{
+    public static async Task<ListarPesosAreaEnemResult> Handle(
+        ListarPesosAreaEnemQuery query,
+        IPesoAreaEnemRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<PesoAreaEnem> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        PesoAreaEnemDto[] items = [.. itens.Select(p => p.ToDto())];
+        return new ListarPesosAreaEnemResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ListarPesosAreaEnemResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ListarPesosAreaEnemResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarPesosAreaEnemQuery"/>: lote de linhas de pesos
+/// projetadas + âncoras opcionais para o controller construir os cursores
+/// prev/next (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarPesosAreaEnemResult(
+    IReadOnlyList<PesoAreaEnemDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ObterPesoAreaEnemPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ObterPesoAreaEnemPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterPesoAreaEnemPorIdQuery(Guid Id) : IQuery<PesoAreaEnemDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ObterPesoAreaEnemPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/PesosAreaEnem/ObterPesoAreaEnemPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.PesosAreaEnem;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterPesoAreaEnemPorIdQueryHandler
+{
+    public static async Task<PesoAreaEnemDto?> Handle(
+        ObterPesoAreaEnemPorIdQuery query,
+        IPesoAreaEnemRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        PesoAreaEnem? peso = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return peso?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IPesoAreaEnemReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IPesoAreaEnemReader.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>PesoAreaEnem</c> (ADR-0056). Expõe o estado vivo dos
+/// pesos do ENEM por grupo de área para consumo por outros bounded contexts
+/// (ex.: a frente de classificação do Módulo Seleção, que resolve o grupo de área
+/// de cada curso contra a resolução escolhida) sem acesso direto ao banco de
+/// Configuração (ADR-0054).
+/// </summary>
+public interface IPesoAreaEnemReader
+{
+    /// <summary>
+    /// Lista todas as linhas de pesos vivas (não soft-deleted), ordenadas por
+    /// <c>Resolucao</c> e <c>GrupoCurso</c> ascendentes para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<PesoAreaEnemView>> ListarVivasAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém uma linha de pesos pelo <paramref name="id"/>, ou
+    /// <see langword="null"/> se inexistente / soft-deleted.
+    /// </summary>
+    Task<PesoAreaEnemView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/PesoAreaEnemView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/PesoAreaEnemView.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>PesoAreaEnem</c> para consumo cross-módulo via
+/// <see cref="IPesoAreaEnemReader"/> (ADR-0056). Expõe a linha viva (resolução +
+/// grupo de área + os cinco pesos + corte de redação + base legal) que o Módulo
+/// Seleção lê ao montar a classificação de um processo, antes de congelar por
+/// valor no bloco de classificação do snapshot de publicação (ADR-0061).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="Resolucao">Resolução do INEP (parte 1 da chave de negócio, ex.: "Res. 805/2024").</param>
+/// <param name="GrupoCurso">Grupo de área do ENEM (parte 2 da chave de negócio).</param>
+/// <param name="PesoRedacao">Peso da Redação.</param>
+/// <param name="PesoCienciasNatureza">Peso de Ciências da Natureza.</param>
+/// <param name="PesoCienciasHumanas">Peso de Ciências Humanas.</param>
+/// <param name="PesoLinguagens">Peso de Linguagens e Códigos.</param>
+/// <param name="PesoMatematica">Peso de Matemática.</param>
+/// <param name="CorteRedacao">Nota mínima de redação (corte) que pode eliminar o candidato.</param>
+/// <param name="BaseLegal">Dispositivo legal que fundamenta a linha de pesos.</param>
+public sealed record PesoAreaEnemView(
+    Guid Id,
+    string Resolucao,
+    string GrupoCurso,
+    decimal PesoRedacao,
+    decimal PesoCienciasNatureza,
+    decimal PesoCienciasHumanas,
+    decimal PesoLinguagens,
+    decimal PesoMatematica,
+    decimal CorteRedacao,
+    string BaseLegal);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/PesoAreaEnem.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/PesoAreaEnem.cs
@@ -147,7 +147,7 @@ public sealed class PesoAreaEnem : SoftDeletableEntity, IAuditableEntity
         decimal pesoCienciasHumanas,
         decimal pesoLinguagens,
         decimal pesoMatematica,
-        decimal? corteRedacao,
+        decimal corteRedacao,
         string baseLegal)
     {
         ArgumentNullException.ThrowIfNull(baseLegal);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/PesoAreaEnem.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/PesoAreaEnem.cs
@@ -35,11 +35,24 @@ public sealed class PesoAreaEnem : SoftDeletableEntity, IAuditableEntity
     /// <summary>Escala persistida dos pesos (<c>numeric(4,2)</c>).</summary>
     private const int EscalaPeso = 2;
 
-    /// <summary>Escala persistida do corte de redação (<c>numeric(6,3)</c>).</summary>
+    /// <summary>Escala persistida do corte de redação (<c>numeric(7,3)</c>).</summary>
     private const int EscalaCorte = 3;
 
     /// <summary>Corte de redação padrão (Res. 805/2024, Anexo I) assumido quando omitido.</summary>
     public const decimal CorteRedacaoPadrao = 400m;
+
+    /// <summary>
+    /// Teto de cada peso de área — limite da precisão persistida (<c>numeric(4,2)</c>).
+    /// Um valor acima disso estouraria a coluna; o guard transforma o overflow num
+    /// erro de domínio (422) em vez de 500.
+    /// </summary>
+    public const decimal PesoMaximo = 99.99m;
+
+    /// <summary>
+    /// Nota máxima da redação do ENEM (escala 0–1000) — teto do corte de redação.
+    /// Acima disso o corte não tem sentido e estouraria a coluna persistida.
+    /// </summary>
+    public const decimal CorteRedacaoMaximo = 1000m;
 
     public string Resolucao { get; private set; } = string.Empty;
     public GrupoCurso GrupoCurso { get; private set; } = null!;
@@ -202,6 +215,13 @@ public sealed class PesoAreaEnem : SoftDeletableEntity, IAuditableEntity
                 "Corte de redação não pode ser negativo."));
         }
 
+        if (corte > CorteRedacaoMaximo)
+        {
+            return Result<decimal>.Failure(new DomainError(
+                PesoAreaEnemErrorCodes.CorteRedacaoExcedeMaximo,
+                $"Corte de redação não pode exceder {CorteRedacaoMaximo} (nota máxima da redação do ENEM)."));
+        }
+
         if (string.IsNullOrWhiteSpace(baseLegal))
         {
             return Result<decimal>.Failure(new DomainError(
@@ -220,11 +240,16 @@ public sealed class PesoAreaEnem : SoftDeletableEntity, IAuditableEntity
     }
 
     private static DomainError? ValidarPeso(decimal valor, string area) =>
-        valor < 0
-            ? new DomainError(
+        valor switch
+        {
+            < 0 => new DomainError(
                 PesoAreaEnemErrorCodes.PesoNegativo,
-                $"O peso de {area} não pode ser negativo.")
-            : null;
+                $"O peso de {area} não pode ser negativo."),
+            _ when valor > PesoMaximo => new DomainError(
+                PesoAreaEnemErrorCodes.PesoExcedeMaximo,
+                $"O peso de {area} não pode exceder {PesoMaximo}."),
+            _ => null,
+        };
 
     private static decimal Arredondar(decimal valor, int escala) =>
         Math.Round(valor, escala, MidpointRounding.ToEven);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/PesoAreaEnem.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/PesoAreaEnem.cs
@@ -1,0 +1,231 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Pesos do ENEM por grupo de área (UNI-REQ-0066, módulo Configuração) —
+/// materializa o Anexo I da Resolução INEP/ENEM 805/2024: para cada grupo de
+/// área (<see cref="GrupoCurso"/>), os pesos das cinco áreas de conhecimento
+/// (Redação, Ciências da Natureza, Ciências Humanas, Linguagens e Códigos,
+/// Matemática) e a nota mínima de redação (corte) que pode eliminar o candidato.
+/// </summary>
+/// <remarks>
+/// <para>Versionável por <c>Resolucao</c>: cada resolução do INEP gera quatro
+/// linhas (uma por grupo). A chave de negócio é o par
+/// (<c>Resolucao</c>, <c>GrupoCurso</c>), único entre linhas vivas — validado
+/// pelo handler e reforçado por índice único parcial de banco
+/// (<c>WHERE is_deleted = false</c>). O par e o <c>Id</c> são imutáveis na
+/// atualização (CA-04b).</para>
+/// <para>Dado institucional de referência, sem PII (LGPD inaplicável). Nenhuma
+/// FK aponta para este cadastro: a ligação <c>curso.grupo_area_enem</c> é por
+/// valor sobre o vocabulário de grupos, e o congelamento no bloco de
+/// classificação do snapshot (módulo Selecao, ADR-0061) é cópia por valor — por
+/// isso a remoção lógica nunca é bloqueada por referência.</para>
+/// </remarks>
+public sealed class PesoAreaEnem : SoftDeletableEntity, IAuditableEntity
+{
+    private const int ResolucaoMinLength = 1;
+    private const int ResolucaoMaxLength = 40;
+    private const int BaseLegalMaxLength = 500;
+
+    /// <summary>Escala persistida dos pesos (<c>numeric(4,2)</c>).</summary>
+    private const int EscalaPeso = 2;
+
+    /// <summary>Escala persistida do corte de redação (<c>numeric(6,3)</c>).</summary>
+    private const int EscalaCorte = 3;
+
+    /// <summary>Corte de redação padrão (Res. 805/2024, Anexo I) assumido quando omitido.</summary>
+    public const decimal CorteRedacaoPadrao = 400m;
+
+    public string Resolucao { get; private set; } = string.Empty;
+    public GrupoCurso GrupoCurso { get; private set; } = null!;
+    public decimal PesoRedacao { get; private set; }
+    public decimal PesoCienciasNatureza { get; private set; }
+    public decimal PesoCienciasHumanas { get; private set; }
+    public decimal PesoLinguagens { get; private set; }
+    public decimal PesoMatematica { get; private set; }
+    public decimal CorteRedacao { get; private set; }
+    public string BaseLegal { get; private set; } = string.Empty;
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private PesoAreaEnem()
+    {
+    }
+
+    /// <summary>
+    /// Cria uma nova linha de pesos do ENEM. Valida a resolução, o grupo de área
+    /// (domínio fechado), a não-negatividade dos cinco pesos e do corte de
+    /// redação (que assume <see cref="CorteRedacaoPadrao"/> quando omitido) e a
+    /// base legal. A unicidade do par (<paramref name="resolucao"/>,
+    /// <paramref name="grupoCurso"/>) entre linhas vivas é responsabilidade do handler.
+    /// </summary>
+    public static Result<PesoAreaEnem> Criar(
+        string resolucao,
+        string grupoCurso,
+        decimal pesoRedacao,
+        decimal pesoCienciasNatureza,
+        decimal pesoCienciasHumanas,
+        decimal pesoLinguagens,
+        decimal pesoMatematica,
+        decimal? corteRedacao,
+        string baseLegal)
+    {
+        ArgumentNullException.ThrowIfNull(resolucao);
+        ArgumentNullException.ThrowIfNull(grupoCurso);
+        ArgumentNullException.ThrowIfNull(baseLegal);
+
+        if (string.IsNullOrWhiteSpace(resolucao))
+        {
+            return Result<PesoAreaEnem>.Failure(new DomainError(
+                PesoAreaEnemErrorCodes.ResolucaoObrigatoria,
+                "Resolução é obrigatória."));
+        }
+
+        if (resolucao.Trim().Length is < ResolucaoMinLength or > ResolucaoMaxLength)
+        {
+            return Result<PesoAreaEnem>.Failure(new DomainError(
+                PesoAreaEnemErrorCodes.ResolucaoTamanho,
+                $"Resolução deve ter entre {ResolucaoMinLength} e {ResolucaoMaxLength} caracteres."));
+        }
+
+        Result<GrupoCurso> grupo = GrupoCurso.Criar(grupoCurso);
+        if (grupo.IsFailure)
+        {
+            return Result<PesoAreaEnem>.Failure(new DomainError(
+                PesoAreaEnemErrorCodes.GrupoCursoInvalido, grupo.Error!.Message));
+        }
+
+        Result<decimal> pesosCorte = ValidarPesosCorteEBaseLegal(
+            pesoRedacao, pesoCienciasNatureza, pesoCienciasHumanas, pesoLinguagens, pesoMatematica,
+            corteRedacao, baseLegal);
+        if (pesosCorte.IsFailure)
+        {
+            return Result<PesoAreaEnem>.Failure(pesosCorte.Error!);
+        }
+
+        var peso = new PesoAreaEnem
+        {
+            Resolucao = resolucao.Trim(),
+            GrupoCurso = grupo.Value!,
+        };
+        peso.AplicarPesos(
+            pesoRedacao, pesoCienciasNatureza, pesoCienciasHumanas, pesoLinguagens, pesoMatematica,
+            pesosCorte.Value, baseLegal);
+
+        return Result<PesoAreaEnem>.Success(peso);
+    }
+
+    /// <summary>
+    /// Atualiza os cinco pesos, o corte de redação e a base legal. Nunca altera o
+    /// <c>Id</c>, a <c>Resolucao</c> nem o <c>GrupoCurso</c> (chave de negócio
+    /// imutável — CA-04b). Revalida a não-negatividade dos pesos e do corte e a
+    /// presença da base legal.
+    /// </summary>
+    public Result Atualizar(
+        decimal pesoRedacao,
+        decimal pesoCienciasNatureza,
+        decimal pesoCienciasHumanas,
+        decimal pesoLinguagens,
+        decimal pesoMatematica,
+        decimal? corteRedacao,
+        string baseLegal)
+    {
+        ArgumentNullException.ThrowIfNull(baseLegal);
+
+        Result<decimal> pesosCorte = ValidarPesosCorteEBaseLegal(
+            pesoRedacao, pesoCienciasNatureza, pesoCienciasHumanas, pesoLinguagens, pesoMatematica,
+            corteRedacao, baseLegal);
+        if (pesosCorte.IsFailure)
+        {
+            return Result.Failure(pesosCorte.Error!);
+        }
+
+        AplicarPesos(
+            pesoRedacao, pesoCienciasNatureza, pesoCienciasHumanas, pesoLinguagens, pesoMatematica,
+            pesosCorte.Value, baseLegal);
+
+        return Result.Success();
+    }
+
+    private void AplicarPesos(
+        decimal pesoRedacao,
+        decimal pesoCienciasNatureza,
+        decimal pesoCienciasHumanas,
+        decimal pesoLinguagens,
+        decimal pesoMatematica,
+        decimal corteRedacao,
+        string baseLegal)
+    {
+        PesoRedacao = Arredondar(pesoRedacao, EscalaPeso);
+        PesoCienciasNatureza = Arredondar(pesoCienciasNatureza, EscalaPeso);
+        PesoCienciasHumanas = Arredondar(pesoCienciasHumanas, EscalaPeso);
+        PesoLinguagens = Arredondar(pesoLinguagens, EscalaPeso);
+        PesoMatematica = Arredondar(pesoMatematica, EscalaPeso);
+        CorteRedacao = Arredondar(corteRedacao, EscalaCorte);
+        BaseLegal = baseLegal.Trim();
+    }
+
+    // Valida os cinco pesos (não-negativos), resolve e valida o corte de redação
+    // (padrão 400 quando omitido; não-negativo) e a base legal. Devolve o corte resolvido.
+    private static Result<decimal> ValidarPesosCorteEBaseLegal(
+        decimal pesoRedacao,
+        decimal pesoCienciasNatureza,
+        decimal pesoCienciasHumanas,
+        decimal pesoLinguagens,
+        decimal pesoMatematica,
+        decimal? corteRedacao,
+        string baseLegal)
+    {
+        DomainError? pesoInvalido =
+            ValidarPeso(pesoRedacao, "redação")
+            ?? ValidarPeso(pesoCienciasNatureza, "ciências da natureza")
+            ?? ValidarPeso(pesoCienciasHumanas, "ciências humanas")
+            ?? ValidarPeso(pesoLinguagens, "linguagens e códigos")
+            ?? ValidarPeso(pesoMatematica, "matemática");
+        if (pesoInvalido is not null)
+        {
+            return Result<decimal>.Failure(pesoInvalido);
+        }
+
+        decimal corte = corteRedacao ?? CorteRedacaoPadrao;
+        if (corte < 0)
+        {
+            return Result<decimal>.Failure(new DomainError(
+                PesoAreaEnemErrorCodes.CorteRedacaoNegativo,
+                "Corte de redação não pode ser negativo."));
+        }
+
+        if (string.IsNullOrWhiteSpace(baseLegal))
+        {
+            return Result<decimal>.Failure(new DomainError(
+                PesoAreaEnemErrorCodes.BaseLegalObrigatoria,
+                "Base legal é obrigatória."));
+        }
+
+        if (baseLegal.Trim().Length > BaseLegalMaxLength)
+        {
+            return Result<decimal>.Failure(new DomainError(
+                PesoAreaEnemErrorCodes.BaseLegalTamanho,
+                $"Base legal deve ter no máximo {BaseLegalMaxLength} caracteres."));
+        }
+
+        return Result<decimal>.Success(corte);
+    }
+
+    private static DomainError? ValidarPeso(decimal valor, string area) =>
+        valor < 0
+            ? new DomainError(
+                PesoAreaEnemErrorCodes.PesoNegativo,
+                $"O peso de {area} não pode ser negativo.")
+            : null;
+
+    private static decimal Arredondar(decimal valor, int escala) =>
+        Math.Round(valor, escala, MidpointRounding.ToEven);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/PesoAreaEnemErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/PesoAreaEnemErrorCodes.cs
@@ -7,7 +7,9 @@ public static class PesoAreaEnemErrorCodes
     public const string GrupoCursoInvalido = "PesoAreaEnem.GrupoCursoInvalido";
     public const string ParJaExiste = "PesoAreaEnem.ParJaExiste";
     public const string PesoNegativo = "PesoAreaEnem.PesoNegativo";
+    public const string PesoExcedeMaximo = "PesoAreaEnem.PesoExcedeMaximo";
     public const string CorteRedacaoNegativo = "PesoAreaEnem.CorteRedacaoNegativo";
+    public const string CorteRedacaoExcedeMaximo = "PesoAreaEnem.CorteRedacaoExcedeMaximo";
     public const string BaseLegalObrigatoria = "PesoAreaEnem.BaseLegalObrigatoria";
     public const string BaseLegalTamanho = "PesoAreaEnem.BaseLegalTamanho";
     public const string NaoEncontrado = "PesoAreaEnem.NaoEncontrado";

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/PesoAreaEnemErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/PesoAreaEnemErrorCodes.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+public static class PesoAreaEnemErrorCodes
+{
+    public const string ResolucaoObrigatoria = "PesoAreaEnem.ResolucaoObrigatoria";
+    public const string ResolucaoTamanho = "PesoAreaEnem.ResolucaoTamanho";
+    public const string GrupoCursoInvalido = "PesoAreaEnem.GrupoCursoInvalido";
+    public const string ParJaExiste = "PesoAreaEnem.ParJaExiste";
+    public const string PesoNegativo = "PesoAreaEnem.PesoNegativo";
+    public const string CorteRedacaoNegativo = "PesoAreaEnem.CorteRedacaoNegativo";
+    public const string BaseLegalObrigatoria = "PesoAreaEnem.BaseLegalObrigatoria";
+    public const string BaseLegalTamanho = "PesoAreaEnem.BaseLegalTamanho";
+    public const string NaoEncontrado = "PesoAreaEnem.NaoEncontrado";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IPesoAreaEnemRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IPesoAreaEnemRepository.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="PesoAreaEnem"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros
+/// soft-deleted via query filter por convenção.
+/// </summary>
+public interface IPesoAreaEnemRepository
+{
+    /// <summary>Carrega a linha de pesos rastreada pelo contexto, para mutação.</summary>
+    Task<PesoAreaEnem?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega a linha de pesos para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<PesoAreaEnem?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista linhas de pesos vivas paginadas por cursor keyset bidirecional
+    /// (ADR-0026 + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve
+    /// as âncoras de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<PesoAreaEnem> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(PesoAreaEnem peso, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca a linha de pesos para remoção; o <c>SoftDeleteInterceptor</c> converte
+    /// em soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(PesoAreaEnem peso);
+
+    /// <summary>
+    /// Verifica se existe linha viva para o par (resolução, grupo de curso),
+    /// excluindo opcionalmente um <paramref name="excluirId"/>.
+    /// </summary>
+    Task<bool> ParExisteEntreVivosAsync(
+        string resolucao,
+        string grupoCurso,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/GrupoCurso.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/GrupoCurso.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Grupo de área do ENEM (Resolução INEP/ENEM 805/2024, Anexo I) — texto de
+/// domínio <b>fechado</b> de quatro valores canônicos. É vocabulário de
+/// referência (com acento e espaço), não um enumerado compilado: a lista vem da
+/// resolução, e o pareamento <c>curso.grupo_area_enem ↔ peso_area_enem.grupo_curso</c>
+/// é por valor sobre esse vocabulário compartilhado (sem FK). Persistido como
+/// <c>varchar</c>.
+/// </summary>
+public sealed record GrupoCurso
+{
+    /// <summary>Grupo de área "Tecnológica".</summary>
+    public const string Tecnologica = "Tecnológica";
+
+    /// <summary>Grupo de área "Humanística I".</summary>
+    public const string HumanisticaI = "Humanística I";
+
+    /// <summary>Grupo de área "Humanística II".</summary>
+    public const string HumanisticaII = "Humanística II";
+
+    /// <summary>Grupo de área "Saúde e Biológicas".</summary>
+    public const string SaudeEBiologicas = "Saúde e Biológicas";
+
+    /// <summary>Conjunto canônico dos quatro grupos de área da Res. 805/2024.</summary>
+    public static readonly IReadOnlySet<string> Valores =
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            Tecnologica,
+            HumanisticaI,
+            HumanisticaII,
+            SaudeEBiologicas,
+        };
+
+    public string Valor { get; }
+
+    private GrupoCurso(string valor) => Valor = valor;
+
+    /// <summary>
+    /// Cria um <see cref="GrupoCurso"/> validando o valor contra o conjunto
+    /// canônico. Valor fora do domínio (ou nulo/em branco) retorna falha de
+    /// domínio. O valor é normalizado por <c>Trim</c> antes da comparação.
+    /// </summary>
+    public static Result<GrupoCurso> Criar(string valor)
+    {
+        if (!EhValido(valor))
+        {
+            return Result<GrupoCurso>.Failure(new DomainError(
+                "GrupoCurso.ForaDoDominio",
+                $"Grupo de curso deve ser um de: {string.Join(", ", Valores)}."));
+        }
+
+        return Result<GrupoCurso>.Success(new GrupoCurso(valor.Trim()));
+    }
+
+    /// <summary>Indica se <paramref name="valor"/> pertence ao domínio fechado, sem alocar.</summary>
+    public static bool EhValido(string valor) =>
+        !string.IsNullOrWhiteSpace(valor) && Valores.Contains(valor.Trim());
+
+    public override string ToString() => Valor;
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -35,9 +35,11 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<ICampusRepository, CampusRepository>();
         services.AddScoped<ILocalOfertaRepository, LocalOfertaRepository>();
         services.AddScoped<IReferenciaReservaDemograficaRepository, ReferenciaReservaDemograficaRepository>();
+        services.AddScoped<IPesoAreaEnemRepository, PesoAreaEnemRepository>();
 
-        // Reader cross-módulo (ADR-0056) da Referência de reserva demográfica.
+        // Readers cross-módulo (ADR-0056).
         services.AddScoped<IReferenciaReservaDemograficaReader, ReferenciaReservaDemograficaReader>();
+        services.AddScoped<IPesoAreaEnemReader, PesoAreaEnemReader>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -28,6 +28,8 @@ public sealed class ConfiguracaoDbContext : DbContext, IUnitOfWork
 
     public DbSet<ReferenciaReservaDemografica> ReferenciasReservaDemografica => Set<ReferenciaReservaDemografica>();
 
+    public DbSet<PesoAreaEnem> PesosAreaEnem => Set<PesoAreaEnem>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/PesoAreaEnemConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/PesoAreaEnemConfiguration.cs
@@ -66,9 +66,15 @@ internal sealed class PesoAreaEnemConfiguration
         builder.Property(p => p.PesoCienciasHumanas).HasPrecision(4, 2).IsRequired();
         builder.Property(p => p.PesoLinguagens).HasPrecision(4, 2).IsRequired();
         builder.Property(p => p.PesoMatematica).HasPrecision(4, 2).IsRequired();
+        // DEFAULT 400 no banco (Anexo I) só para inserts crus que omitem a coluna.
+        // ValueGeneratedNever força o EF a SEMPRE enviar o valor da propriedade,
+        // inclusive 0m (corte "sem eliminação"): sem isso, HasDefaultValue marca a
+        // coluna como store-generated e o EF omite o valor quando ele é o default do
+        // CLR (0m), fazendo o banco gravar 400 e sobrescrever silenciosamente o corte.
         builder.Property(p => p.CorteRedacao)
             .HasPrecision(7, 3)
             .HasDefaultValue(PesoAreaEnem.CorteRedacaoPadrao)
+            .ValueGeneratedNever()
             .IsRequired();
 
         builder.Property(p => p.BaseLegal).HasMaxLength(BaseLegalMaxLength).IsRequired();

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/PesoAreaEnemConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/PesoAreaEnemConfiguration.cs
@@ -36,7 +36,10 @@ internal sealed class PesoAreaEnemConfiguration
                 t.HasCheckConstraint("ck_peso_area_enem_peso_ciencias_humanas", "peso_ciencias_humanas >= 0");
                 t.HasCheckConstraint("ck_peso_area_enem_peso_linguagens", "peso_linguagens >= 0");
                 t.HasCheckConstraint("ck_peso_area_enem_peso_matematica", "peso_matematica >= 0");
-                t.HasCheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0");
+
+                // Corte de redação na faixa válida da nota do ENEM (0–1000). O teto
+                // também impede o overflow da coluna numeric(7,3) por insert fora do app.
+                t.HasCheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0 AND corte_redacao <= 1000");
             });
 
         builder.HasKey(p => p.Id);
@@ -53,16 +56,18 @@ internal sealed class PesoAreaEnemConfiguration
             .HasMaxLength(GrupoCursoMaxLength)
             .IsRequired();
 
-        // Cinco pesos numeric(4,2) e corte de redação numeric(6,3) — com DEFAULT 400
-        // no banco (Anexo I) para inserts fora do fluxo da aplicação; a factory do
-        // agregado já resolve o padrão quando o corte é omitido no command.
+        // Cinco pesos numeric(4,2) e corte de redação numeric(7,3) — escala 3 com 4
+        // dígitos inteiros para acomodar a nota máxima da redação do ENEM (1000),
+        // que não cabe em numeric(6,3). DEFAULT 400 no banco (Anexo I) para inserts
+        // fora do fluxo da aplicação; a factory do agregado já resolve o padrão
+        // quando o corte é omitido no command.
         builder.Property(p => p.PesoRedacao).HasPrecision(4, 2).IsRequired();
         builder.Property(p => p.PesoCienciasNatureza).HasPrecision(4, 2).IsRequired();
         builder.Property(p => p.PesoCienciasHumanas).HasPrecision(4, 2).IsRequired();
         builder.Property(p => p.PesoLinguagens).HasPrecision(4, 2).IsRequired();
         builder.Property(p => p.PesoMatematica).HasPrecision(4, 2).IsRequired();
         builder.Property(p => p.CorteRedacao)
-            .HasPrecision(6, 3)
+            .HasPrecision(7, 3)
             .HasDefaultValue(PesoAreaEnem.CorteRedacaoPadrao)
             .IsRequired();
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/PesoAreaEnemConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/PesoAreaEnemConfiguration.cs
@@ -1,0 +1,82 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class PesoAreaEnemConfiguration
+    : IEntityTypeConfiguration<PesoAreaEnem>
+{
+    private const int ResolucaoMaxLength = 40;
+    private const int GrupoCursoMaxLength = 30;
+    private const int BaseLegalMaxLength = 500;
+
+    public void Configure(EntityTypeBuilder<PesoAreaEnem> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            "peso_area_enem",
+            t =>
+            {
+                // Domínio fechado do grupo de área (Res. 805/2024, Anexo I).
+                t.HasCheckConstraint(
+                    "ck_peso_area_enem_grupo_curso",
+                    "grupo_curso IN ('Tecnológica', 'Humanística I', 'Humanística II', 'Saúde e Biológicas')");
+
+                // Não-negatividade dos cinco pesos e do corte de redação.
+                t.HasCheckConstraint("ck_peso_area_enem_peso_redacao", "peso_redacao >= 0");
+                t.HasCheckConstraint("ck_peso_area_enem_peso_ciencias_natureza", "peso_ciencias_natureza >= 0");
+                t.HasCheckConstraint("ck_peso_area_enem_peso_ciencias_humanas", "peso_ciencias_humanas >= 0");
+                t.HasCheckConstraint("ck_peso_area_enem_peso_linguagens", "peso_linguagens >= 0");
+                t.HasCheckConstraint("ck_peso_area_enem_peso_matematica", "peso_matematica >= 0");
+                t.HasCheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0");
+            });
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.Resolucao)
+            .HasMaxLength(ResolucaoMaxLength)
+            .IsRequired();
+
+        // GrupoCurso é value object — persistido por valor como varchar via
+        // GrupoCursoValueConverter (reidratação fail-fast). O nome de coluna
+        // snake_case vem da convenção global.
+        builder.Property(p => p.GrupoCurso)
+            .HasConversion<GrupoCursoValueConverter>()
+            .HasMaxLength(GrupoCursoMaxLength)
+            .IsRequired();
+
+        // Cinco pesos numeric(4,2) e corte de redação numeric(6,3) — com DEFAULT 400
+        // no banco (Anexo I) para inserts fora do fluxo da aplicação; a factory do
+        // agregado já resolve o padrão quando o corte é omitido no command.
+        builder.Property(p => p.PesoRedacao).HasPrecision(4, 2).IsRequired();
+        builder.Property(p => p.PesoCienciasNatureza).HasPrecision(4, 2).IsRequired();
+        builder.Property(p => p.PesoCienciasHumanas).HasPrecision(4, 2).IsRequired();
+        builder.Property(p => p.PesoLinguagens).HasPrecision(4, 2).IsRequired();
+        builder.Property(p => p.PesoMatematica).HasPrecision(4, 2).IsRequired();
+        builder.Property(p => p.CorteRedacao)
+            .HasPrecision(6, 3)
+            .HasDefaultValue(PesoAreaEnem.CorteRedacaoPadrao)
+            .IsRequired();
+
+        builder.Property(p => p.BaseLegal).HasMaxLength(BaseLegalMaxLength).IsRequired();
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(p => p.CreatedBy).HasMaxLength(255);
+        builder.Property(p => p.UpdatedBy).HasMaxLength(255);
+
+        // Unicidade do par (resolução, grupo de curso) entre linhas vivas (índice
+        // parcial) — uma linha por par; soft-delete libera o slot para recriação.
+        builder.HasIndex(p => new { p.Resolucao, p.GrupoCurso })
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_peso_area_enem_resolucao_grupo_vivo");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/GrupoCursoValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/GrupoCursoValueConverter.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+// Mapeia GrupoCurso ↔ string (varchar). O comprimento da coluna é definido na
+// própria propriedade via HasMaxLength no IEntityTypeConfiguration. A reidratação
+// falha explicitamente (com contexto) caso a coluna seja corrompida fora do fluxo
+// da aplicação, em vez do NullReferenceException tardio de `GrupoCurso.Criar(v).Value!`.
+// O fail-fast é inlinado porque o helper compartilhado ValueObjectMaterialization é
+// internal ao assembly Infrastructure.Core (este converter mora no módulo, pois
+// GrupoCurso é vocabulário específico de Configuração).
+public sealed class GrupoCursoValueConverter : ValueConverter<GrupoCurso, string>
+{
+    public GrupoCursoValueConverter()
+        : base(
+            grupo => grupo.Valor,
+            valor => Reidratar(valor))
+    {
+    }
+
+    private static GrupoCurso Reidratar(string valor)
+    {
+        Result<GrupoCurso> resultado = GrupoCurso.Criar(valor);
+        if (resultado.IsFailure || resultado.Value is null)
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(GrupoCurso)}: " +
+                $"{resultado.Error?.Code ?? "Desconhecido"}. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return resultado.Value;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.Designer.cs
@@ -239,7 +239,6 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                         .HasColumnName("base_legal");
 
                     b.Property<decimal>("CorteRedacao")
-                        .ValueGeneratedOnAdd()
                         .HasPrecision(7, 3)
                         .HasColumnType("numeric(7,3)")
                         .HasDefaultValue(400m)

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.Designer.cs
@@ -240,8 +240,8 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 
                     b.Property<decimal>("CorteRedacao")
                         .ValueGeneratedOnAdd()
-                        .HasPrecision(6, 3)
-                        .HasColumnType("numeric(6,3)")
+                        .HasPrecision(7, 3)
+                        .HasColumnType("numeric(7,3)")
                         .HasDefaultValue(400m)
                         .HasColumnName("corte_redacao");
 
@@ -322,7 +322,7 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 
                     b.ToTable("peso_area_enem", null, t =>
                         {
-                            t.HasCheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0");
+                            t.HasCheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0 AND corte_redacao <= 1000");
 
                             t.HasCheckConstraint("ck_peso_area_enem_grupo_curso", "grupo_curso IN ('Tecnológica', 'Humanística I', 'Humanística II', 'Saúde e Biológicas')");
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624114749_AdicionaPesoAreaEnem")]
+    partial class AdicionaPesoAreaEnem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionaPesoAreaEnem : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "peso_area_enem",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    resolucao = table.Column<string>(type: "character varying(40)", maxLength: 40, nullable: false),
+                    grupo_curso = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    peso_redacao = table.Column<decimal>(type: "numeric(4,2)", precision: 4, scale: 2, nullable: false),
+                    peso_ciencias_natureza = table.Column<decimal>(type: "numeric(4,2)", precision: 4, scale: 2, nullable: false),
+                    peso_ciencias_humanas = table.Column<decimal>(type: "numeric(4,2)", precision: 4, scale: 2, nullable: false),
+                    peso_linguagens = table.Column<decimal>(type: "numeric(4,2)", precision: 4, scale: 2, nullable: false),
+                    peso_matematica = table.Column<decimal>(type: "numeric(4,2)", precision: 4, scale: 2, nullable: false),
+                    corte_redacao = table.Column<decimal>(type: "numeric(6,3)", precision: 6, scale: 3, nullable: false, defaultValue: 400m),
+                    base_legal = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_peso_area_enem", x => x.id);
+                    table.CheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0");
+                    table.CheckConstraint("ck_peso_area_enem_grupo_curso", "grupo_curso IN ('Tecnológica', 'Humanística I', 'Humanística II', 'Saúde e Biológicas')");
+                    table.CheckConstraint("ck_peso_area_enem_peso_ciencias_humanas", "peso_ciencias_humanas >= 0");
+                    table.CheckConstraint("ck_peso_area_enem_peso_ciencias_natureza", "peso_ciencias_natureza >= 0");
+                    table.CheckConstraint("ck_peso_area_enem_peso_linguagens", "peso_linguagens >= 0");
+                    table.CheckConstraint("ck_peso_area_enem_peso_matematica", "peso_matematica >= 0");
+                    table.CheckConstraint("ck_peso_area_enem_peso_redacao", "peso_redacao >= 0");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_peso_area_enem_resolucao_grupo_vivo",
+                table: "peso_area_enem",
+                columns: new[] { "resolucao", "grupo_curso" },
+                unique: true,
+                filter: "is_deleted = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "peso_area_enem");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260624114749_AdicionaPesoAreaEnem.cs
@@ -23,7 +23,7 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                     peso_ciencias_humanas = table.Column<decimal>(type: "numeric(4,2)", precision: 4, scale: 2, nullable: false),
                     peso_linguagens = table.Column<decimal>(type: "numeric(4,2)", precision: 4, scale: 2, nullable: false),
                     peso_matematica = table.Column<decimal>(type: "numeric(4,2)", precision: 4, scale: 2, nullable: false),
-                    corte_redacao = table.Column<decimal>(type: "numeric(6,3)", precision: 6, scale: 3, nullable: false, defaultValue: 400m),
+                    corte_redacao = table.Column<decimal>(type: "numeric(7,3)", precision: 7, scale: 3, nullable: false, defaultValue: 400m),
                     base_legal = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
                     created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
                     updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
@@ -36,7 +36,7 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                 constraints: table =>
                 {
                     table.PrimaryKey("pk_peso_area_enem", x => x.id);
-                    table.CheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0");
+                    table.CheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0 AND corte_redacao <= 1000");
                     table.CheckConstraint("ck_peso_area_enem_grupo_curso", "grupo_curso IN ('Tecnológica', 'Humanística I', 'Humanística II', 'Saúde e Biológicas')");
                     table.CheckConstraint("ck_peso_area_enem_peso_ciencias_humanas", "peso_ciencias_humanas >= 0");
                     table.CheckConstraint("ck_peso_area_enem_peso_ciencias_natureza", "peso_ciencias_natureza >= 0");

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/ConfiguracaoDbContextModelSnapshot.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/ConfiguracaoDbContextModelSnapshot.cs
@@ -237,8 +237,8 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 
                     b.Property<decimal>("CorteRedacao")
                         .ValueGeneratedOnAdd()
-                        .HasPrecision(6, 3)
-                        .HasColumnType("numeric(6,3)")
+                        .HasPrecision(7, 3)
+                        .HasColumnType("numeric(7,3)")
                         .HasDefaultValue(400m)
                         .HasColumnName("corte_redacao");
 
@@ -319,7 +319,7 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 
                     b.ToTable("peso_area_enem", null, t =>
                         {
-                            t.HasCheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0");
+                            t.HasCheckConstraint("ck_peso_area_enem_corte_redacao", "corte_redacao >= 0 AND corte_redacao <= 1000");
 
                             t.HasCheckConstraint("ck_peso_area_enem_grupo_curso", "grupo_curso IN ('Tecnológica', 'Humanística I', 'Humanística II', 'Saúde e Biológicas')");
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/ConfiguracaoDbContextModelSnapshot.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/ConfiguracaoDbContextModelSnapshot.cs
@@ -236,7 +236,6 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                         .HasColumnName("base_legal");
 
                     b.Property<decimal>("CorteRedacao")
-                        .ValueGeneratedOnAdd()
                         .HasPrecision(7, 3)
                         .HasColumnType("numeric(7,3)")
                         .HasDefaultValue(400m)

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/PesoAreaEnemRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/PesoAreaEnemRepository.cs
@@ -1,0 +1,88 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class PesoAreaEnemRepository : IPesoAreaEnemRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public PesoAreaEnemRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<PesoAreaEnem?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.PesosAreaEnem
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+    }
+
+    public Task<PesoAreaEnem?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.PesosAreaEnem
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<PesoAreaEnem> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<PesoAreaEnem> page = await CursorKeyset
+            .ApplyAsync(_dbContext.PesosAreaEnem.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(PesoAreaEnem peso, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(peso);
+        await _dbContext.PesosAreaEnem.AddAsync(peso, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(PesoAreaEnem peso)
+    {
+        ArgumentNullException.ThrowIfNull(peso);
+        _dbContext.PesosAreaEnem.Remove(peso);
+    }
+
+    public Task<bool> ParExisteEntreVivosAsync(
+        string resolucao,
+        string grupoCurso,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        // Um grupo fora do domínio nunca tem linha viva — evita query desnecessária
+        // e garante que a comparação use o valor canônico normalizado (Trim).
+        Result<GrupoCurso> grupoResult = GrupoCurso.Criar(grupoCurso);
+        if (grupoResult.IsFailure)
+        {
+            return Task.FromResult(false);
+        }
+
+        // Espelha a normalização do agregado (Trim) para casar com o valor persistido.
+        string resolucaoNorm = resolucao.Trim();
+        GrupoCurso grupo = grupoResult.Value!;
+
+        return _dbContext.PesosAreaEnem
+            .AsNoTracking()
+            .Where(p => excluirId == null || p.Id != excluirId)
+            .AnyAsync(p => p.Resolucao == resolucaoNorm && p.GrupoCurso == grupo, cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/PesoAreaEnemReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/PesoAreaEnemReader.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="IPesoAreaEnemReader"/> (ADR-0056): leitura direta
+/// do banco de Configuração (<c>AsNoTracking</c>, query filter de soft-delete por
+/// convenção). Sem cache — o cadastro é de baixo volume e baixa frequência de
+/// leitura viva; o congelamento por valor no consumidor (ADR-0061) dispensa
+/// releitura quente.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class PesoAreaEnemReader : IPesoAreaEnemReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public PesoAreaEnemReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<PesoAreaEnemView>> ListarVivasAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<PesoAreaEnem> entidades = await _dbContext.PesosAreaEnem
+            .AsNoTracking()
+            .OrderBy(p => p.Resolucao)
+            .ThenBy(p => p.GrupoCurso)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<PesoAreaEnemView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        PesoAreaEnem? entidade = await _dbContext.PesosAreaEnem
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static PesoAreaEnemView ParaView(PesoAreaEnem p) =>
+        new(
+            p.Id,
+            p.Resolucao,
+            p.GrupoCurso.Valor,
+            p.PesoRedacao,
+            p.PesoCienciasNatureza,
+            p.PesoCienciasHumanas,
+            p.PesoLinguagens,
+            p.PesoMatematica,
+            p.CorteRedacao,
+            p.BaseLegal);
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarPesoAreaEnemCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarPesoAreaEnemCommandHandlerTests.cs
@@ -22,8 +22,8 @@ public sealed class AtualizarPesoAreaEnemCommandHandlerTests
     private static PesoAreaEnem Existente() =>
         PesoAreaEnem.Criar("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, BaseLegal).Value!;
 
-    private static AtualizarPesoAreaEnemCommand Comando(Guid id, decimal mt = 3.00m, decimal? corte = 450.000m) =>
-        new(id, 2.00m, 1.50m, 1.50m, 1.50m, mt, BaseLegal, corte);
+    private static AtualizarPesoAreaEnemCommand Comando(Guid id, decimal mt = 3.00m, decimal corte = 450.000m) =>
+        new(id, 2.00m, 1.50m, 1.50m, 1.50m, mt, corte, BaseLegal);
 
     [Fact(DisplayName = "Linha inexistente retorna NaoEncontrado")]
     public async Task Handle_NaoEncontrado_RetornaErro()

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarPesoAreaEnemCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarPesoAreaEnemCommandHandlerTests.cs
@@ -1,0 +1,72 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarPesoAreaEnemCommandHandlerTests
+{
+    private const string BaseLegal = "Res. 805/2024 Anexo I";
+
+    private readonly IPesoAreaEnemRepository _repository = Substitute.For<IPesoAreaEnemRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private static PesoAreaEnem Existente() =>
+        PesoAreaEnem.Criar("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, BaseLegal).Value!;
+
+    private static AtualizarPesoAreaEnemCommand Comando(Guid id, decimal mt = 3.00m, decimal? corte = 450.000m) =>
+        new(id, 2.00m, 1.50m, 1.50m, 1.50m, mt, corte, BaseLegal);
+
+    [Fact(DisplayName = "Linha inexistente retorna NaoEncontrado")]
+    public async Task Handle_NaoEncontrado_RetornaErro()
+    {
+        Guid id = Guid.NewGuid();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns((PesoAreaEnem?)null);
+
+        Result resultado = await AtualizarPesoAreaEnemCommandHandler.Handle(
+            Comando(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.NaoEncontrado);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Edição válida persiste e preserva a chave de negócio (CA-04b)")]
+    public async Task Handle_DadosValidos_PreservaChave()
+    {
+        PesoAreaEnem existente = Existente();
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarPesoAreaEnemCommandHandler.Handle(
+            Comando(existente.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.Resolucao.Should().Be("Res. 805/2024");
+        existente.GrupoCurso.Valor.Should().Be(GrupoCurso.Tecnologica);
+        existente.PesoMatematica.Should().Be(3.00m);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Peso negativo na edição retorna erro e não persiste")]
+    public async Task Handle_PesoNegativo_RetornaErroSemPersistir()
+    {
+        PesoAreaEnem existente = Existente();
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarPesoAreaEnemCommandHandler.Handle(
+            Comando(existente.Id, mt: -1.00m), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.PesoNegativo);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarPesoAreaEnemCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarPesoAreaEnemCommandHandlerTests.cs
@@ -23,7 +23,7 @@ public sealed class AtualizarPesoAreaEnemCommandHandlerTests
         PesoAreaEnem.Criar("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, BaseLegal).Value!;
 
     private static AtualizarPesoAreaEnemCommand Comando(Guid id, decimal mt = 3.00m, decimal? corte = 450.000m) =>
-        new(id, 2.00m, 1.50m, 1.50m, 1.50m, mt, corte, BaseLegal);
+        new(id, 2.00m, 1.50m, 1.50m, 1.50m, mt, BaseLegal, corte);
 
     [Fact(DisplayName = "Linha inexistente retorna NaoEncontrado")]
     public async Task Handle_NaoEncontrado_RetornaErro()

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarPesoAreaEnemCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarPesoAreaEnemCommandHandlerTests.cs
@@ -18,7 +18,7 @@ public sealed class CriarPesoAreaEnemCommandHandlerTests
     private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
 
     private static CriarPesoAreaEnemCommand ComandoValido() =>
-        new("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, "Res. 805/2024 Anexo I");
+        new("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, "Res. 805/2024 Anexo I", 400m);
 
     [Fact(DisplayName = "Cria a linha de pesos, persiste e retorna o Id")]
     public async Task Handle_ParLivre_CriaEPersiste()

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarPesoAreaEnemCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarPesoAreaEnemCommandHandlerTests.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarPesoAreaEnemCommandHandlerTests
+{
+    private readonly IPesoAreaEnemRepository _repository = Substitute.For<IPesoAreaEnemRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    private static CriarPesoAreaEnemCommand ComandoValido() =>
+        new("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, "Res. 805/2024 Anexo I");
+
+    [Fact(DisplayName = "Cria a linha de pesos, persiste e retorna o Id")]
+    public async Task Handle_ParLivre_CriaEPersiste()
+    {
+        _repository.ParExisteEntreVivosAsync("Res. 805/2024", GrupoCurso.Tecnologica, null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarPesoAreaEnemCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<PesoAreaEnem>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Par (resolução, grupo) já existente entre vivos retorna conflito (ParJaExiste)")]
+    public async Task Handle_ParDuplicado_RetornaConflito()
+    {
+        _repository.ParExisteEntreVivosAsync("Res. 805/2024", GrupoCurso.Tecnologica, null, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarPesoAreaEnemCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.ParJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<PesoAreaEnem>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Peso negativo propaga o erro de domínio sem persistir")]
+    public async Task Handle_PesoNegativo_RetornaErroSemPersistir()
+    {
+        _repository.ParExisteEntreVivosAsync(Arg.Any<string>(), Arg.Any<string>(), null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        CriarPesoAreaEnemCommand comando = ComandoValido() with { PesoMatematica = -1.00m };
+
+        Result<Guid> resultado = await CriarPesoAreaEnemCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.PesoNegativo);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/PesoAreaEnemCommandJsonRequiredTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/PesoAreaEnemCommandJsonRequiredTests.cs
@@ -1,0 +1,105 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+
+/// <summary>
+/// Garante que os campos numéricos obrigatórios dos commands rejeitam a omissão no
+/// JSON (via <c>[JsonRequired]</c>), em vez de o System.Text.Json construir o record
+/// com <c>0m</c> — um valor que o validator aceitaria e que sobrescreveria
+/// silenciosamente o estado da linha numa atualização (#729).
+/// </summary>
+public sealed class PesoAreaEnemCommandJsonRequiredTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+    };
+
+    [Fact(DisplayName = "Atualizar: omitir corteRedacao no JSON é rejeitado (não vira 0 silencioso)")]
+    public void Atualizar_SemCorte_LancaJsonException()
+    {
+        const string json = """
+        {
+          "id": "0199e3a0-0000-7000-8000-000000000000",
+          "pesoRedacao": 1.5, "pesoCienciasNatureza": 1.0, "pesoCienciasHumanas": 1.0,
+          "pesoLinguagens": 1.0, "pesoMatematica": 2.0, "baseLegal": "Res. 805/2024 Anexo I"
+        }
+        """;
+
+        Action act = () => JsonSerializer.Deserialize<AtualizarPesoAreaEnemCommand>(json, Options);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact(DisplayName = "Atualizar: omitir um peso no JSON é rejeitado")]
+    public void Atualizar_SemPeso_LancaJsonException()
+    {
+        const string json = """
+        {
+          "id": "0199e3a0-0000-7000-8000-000000000000",
+          "pesoRedacao": 1.5, "pesoCienciasNatureza": 1.0, "pesoCienciasHumanas": 1.0,
+          "pesoLinguagens": 1.0, "corteRedacao": 450.0, "baseLegal": "Res. 805/2024 Anexo I"
+        }
+        """;
+
+        Action act = () => JsonSerializer.Deserialize<AtualizarPesoAreaEnemCommand>(json, Options);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact(DisplayName = "Atualizar: JSON completo desserializa")]
+    public void Atualizar_Completo_Desserializa()
+    {
+        const string json = """
+        {
+          "id": "0199e3a0-0000-7000-8000-000000000000",
+          "pesoRedacao": 1.5, "pesoCienciasNatureza": 1.0, "pesoCienciasHumanas": 1.0,
+          "pesoLinguagens": 1.0, "pesoMatematica": 2.0, "corteRedacao": 450.0,
+          "baseLegal": "Res. 805/2024 Anexo I"
+        }
+        """;
+
+        AtualizarPesoAreaEnemCommand? cmd = JsonSerializer.Deserialize<AtualizarPesoAreaEnemCommand>(json, Options);
+
+        cmd.Should().NotBeNull();
+        cmd!.CorteRedacao.Should().Be(450.0m);
+    }
+
+    [Fact(DisplayName = "Criar: omitir corteRedacao desserializa com null (mantém opcional/default 400)")]
+    public void Criar_SemCorte_DesserializaComNull()
+    {
+        const string json = """
+        {
+          "resolucao": "Res. 805/2024", "grupoCurso": "Tecnológica",
+          "pesoRedacao": 1.5, "pesoCienciasNatureza": 1.0, "pesoCienciasHumanas": 1.0,
+          "pesoLinguagens": 1.0, "pesoMatematica": 2.0, "baseLegal": "Res. 805/2024 Anexo I"
+        }
+        """;
+
+        CriarPesoAreaEnemCommand? cmd = JsonSerializer.Deserialize<CriarPesoAreaEnemCommand>(json, Options);
+
+        cmd.Should().NotBeNull();
+        cmd!.CorteRedacao.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Criar: omitir um peso no JSON é rejeitado")]
+    public void Criar_SemPeso_LancaJsonException()
+    {
+        const string json = """
+        {
+          "resolucao": "Res. 805/2024", "grupoCurso": "Tecnológica",
+          "pesoCienciasNatureza": 1.0, "pesoCienciasHumanas": 1.0,
+          "pesoLinguagens": 1.0, "pesoMatematica": 2.0, "baseLegal": "Res. 805/2024 Anexo I"
+        }
+        """;
+
+        Action act = () => JsonSerializer.Deserialize<CriarPesoAreaEnemCommand>(json, Options);
+
+        act.Should().Throw<JsonException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverPesoAreaEnemCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverPesoAreaEnemCommandHandlerTests.cs
@@ -1,0 +1,50 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverPesoAreaEnemCommandHandlerTests
+{
+    private readonly IPesoAreaEnemRepository _repository = Substitute.For<IPesoAreaEnemRepository>();
+    private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
+
+    [Fact(DisplayName = "Linha inexistente retorna NaoEncontrado")]
+    public async Task Handle_NaoEncontrado_RetornaErro()
+    {
+        Guid id = Guid.NewGuid();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>())
+            .Returns((PesoAreaEnem?)null);
+
+        Result resultado = await RemoverPesoAreaEnemCommandHandler.Handle(
+            new RemoverPesoAreaEnemCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.NaoEncontrado);
+        _repository.DidNotReceive().Remover(Arg.Any<PesoAreaEnem>());
+    }
+
+    [Fact(DisplayName = "Sem FK de entrada: remoção é soft-delete e nunca é bloqueada (CA-05)")]
+    public async Task Handle_Existente_RemoveESoftDelete()
+    {
+        PesoAreaEnem existente = PesoAreaEnem
+            .Criar("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, "Res. 805/2024 Anexo I")
+            .Value!;
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await RemoverPesoAreaEnemCommandHandler.Handle(
+            new RemoverPesoAreaEnemCommand(existente.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(existente);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/PesoAreaEnemValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/PesoAreaEnemValidatorTests.cs
@@ -84,6 +84,30 @@ public sealed class PesoAreaEnemValidatorTests
         resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarPesoAreaEnemCommand.CorteRedacao));
     }
 
+    [Fact(DisplayName = "Corte de redação acima do máximo (>1000) é rejeitado")]
+    public void CorteAcimaDoMaximo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { CorteRedacao = 1000.001m });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarPesoAreaEnemCommand.CorteRedacao));
+    }
+
+    [Fact(DisplayName = "Corte de redação no máximo (1000) é aceito")]
+    public void CorteNoMaximo_Passa()
+    {
+        _validator.Validate(Base() with { CorteRedacao = 1000m }).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Peso acima do teto persistível é rejeitado")]
+    public void PesoAcimaDoMaximo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { PesoMatematica = 100m });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarPesoAreaEnemCommand.PesoMatematica));
+    }
+
     [Fact(DisplayName = "Peso zero é aceito")]
     public void PesoZero_Aceita()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/PesoAreaEnemValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/PesoAreaEnemValidatorTests.cs
@@ -17,7 +17,7 @@ public sealed class PesoAreaEnemValidatorTests
     private readonly CriarPesoAreaEnemCommandValidator _validator = new();
 
     private static CriarPesoAreaEnemCommand Base() =>
-        new("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, "Res. 805/2024 Anexo I");
+        new("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, "Res. 805/2024 Anexo I", 400m);
 
     [Fact(DisplayName = "Comando válido passa no validator")]
     public void Valido_Passa()

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/PesoAreaEnemValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/PesoAreaEnemValidatorTests.cs
@@ -1,0 +1,101 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.PesosAreaEnem;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+/// <summary>
+/// O validator antecipa a obrigatoriedade da resolução, o domínio fechado do
+/// grupo de área, a não-negatividade dos cinco pesos e do corte de redação e a
+/// presença da base legal, mantendo a fronteira simétrica com o domínio (#594).
+/// </summary>
+public sealed class PesoAreaEnemValidatorTests
+{
+    private readonly CriarPesoAreaEnemCommandValidator _validator = new();
+
+    private static CriarPesoAreaEnemCommand Base() =>
+        new("Res. 805/2024", GrupoCurso.Tecnologica, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, "Res. 805/2024 Anexo I");
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Corte de redação omitido (null) passa no validator")]
+    public void CorteOmitido_Passa()
+    {
+        _validator.Validate(Base() with { CorteRedacao = null }).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Resolução ausente ou em branco é rejeitada")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolucaoVazia_Rejeita(string resolucao)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Resolucao = resolucao });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarPesoAreaEnemCommand.Resolucao));
+    }
+
+    [Theory(DisplayName = "Grupo fora do domínio é rejeitado")]
+    [InlineData("Engenharias")]
+    [InlineData("Humanística III")]
+    [InlineData("")]
+    public void GrupoInvalido_Rejeita(string grupo)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { GrupoCurso = grupo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarPesoAreaEnemCommand.GrupoCurso));
+    }
+
+    [Theory(DisplayName = "Peso negativo é rejeitado pelo validator (um por área)")]
+    [InlineData(-1.0, 1, 1, 1, 1, nameof(CriarPesoAreaEnemCommand.PesoRedacao))]
+    [InlineData(1, -1.0, 1, 1, 1, nameof(CriarPesoAreaEnemCommand.PesoCienciasNatureza))]
+    [InlineData(1, 1, -1.0, 1, 1, nameof(CriarPesoAreaEnemCommand.PesoCienciasHumanas))]
+    [InlineData(1, 1, 1, -1.0, 1, nameof(CriarPesoAreaEnemCommand.PesoLinguagens))]
+    [InlineData(1, 1, 1, 1, -1.0, nameof(CriarPesoAreaEnemCommand.PesoMatematica))]
+    public void PesoNegativo_Rejeita(decimal redacao, decimal cn, decimal ch, decimal lc, decimal mt, string propriedade)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with
+        {
+            PesoRedacao = redacao,
+            PesoCienciasNatureza = cn,
+            PesoCienciasHumanas = ch,
+            PesoLinguagens = lc,
+            PesoMatematica = mt,
+        });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == propriedade);
+    }
+
+    [Fact(DisplayName = "Corte de redação negativo é rejeitado")]
+    public void CorteNegativo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { CorteRedacao = -1.000m });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarPesoAreaEnemCommand.CorteRedacao));
+    }
+
+    [Fact(DisplayName = "Peso zero é aceito")]
+    public void PesoZero_Aceita()
+    {
+        _validator.Validate(Base() with { PesoCienciasHumanas = 0m }).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Base legal ausente é rejeitada")]
+    public void BaseLegalVazia_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { BaseLegal = "  " });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarPesoAreaEnemCommand.BaseLegal));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/PesoAreaEnemTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/PesoAreaEnemTests.cs
@@ -1,0 +1,176 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class PesoAreaEnemTests
+{
+    private const string Resolucao = "Res. 805/2024";
+    private const string Grupo = GrupoCurso.Tecnologica;
+    private const string BaseLegal = "Res. 805/2024 Anexo I";
+
+    private static Result<PesoAreaEnem> Criar(
+        string resolucao = Resolucao,
+        string grupo = Grupo,
+        decimal redacao = 1.50m,
+        decimal cn = 1.00m,
+        decimal ch = 1.00m,
+        decimal lc = 1.00m,
+        decimal mt = 2.00m,
+        decimal? corte = 400m,
+        string baseLegal = BaseLegal) =>
+        PesoAreaEnem.Criar(resolucao, grupo, redacao, cn, ch, lc, mt, corte, baseLegal);
+
+    [Fact(DisplayName = "Criar com dados válidos preenche os pesos e fica ativa com Guid v7")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        PesoAreaEnem peso = Criar().Value!;
+
+        peso.Id.Should().NotBe(Guid.Empty);
+        peso.Resolucao.Should().Be(Resolucao);
+        peso.GrupoCurso.Valor.Should().Be(Grupo);
+        peso.PesoRedacao.Should().Be(1.50m);
+        peso.PesoCienciasNatureza.Should().Be(1.00m);
+        peso.PesoCienciasHumanas.Should().Be(1.00m);
+        peso.PesoLinguagens.Should().Be(1.00m);
+        peso.PesoMatematica.Should().Be(2.00m);
+        peso.CorteRedacao.Should().Be(400m);
+        peso.BaseLegal.Should().Be(BaseLegal);
+        peso.IsDeleted.Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "Criar com resolução ausente ou em branco falha")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemResolucao_Falha(string resolucao)
+    {
+        Result<PesoAreaEnem> resultado = Criar(resolucao: resolucao);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.ResolucaoObrigatoria);
+    }
+
+    [Theory(DisplayName = "Criar com grupo fora do domínio falha")]
+    [InlineData("Engenharias")]
+    [InlineData("Humanística III")]
+    public void Criar_GrupoInvalido_Falha(string grupo)
+    {
+        Result<PesoAreaEnem> resultado = Criar(grupo: grupo);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.GrupoCursoInvalido);
+    }
+
+    [Theory(DisplayName = "Criar com peso negativo em qualquer das cinco áreas falha")]
+    [InlineData(-1.00, 1, 1, 1, 1)]
+    [InlineData(1, -1.00, 1, 1, 1)]
+    [InlineData(1, 1, -1.00, 1, 1)]
+    [InlineData(1, 1, 1, -1.00, 1)]
+    [InlineData(1, 1, 1, 1, -1.00)]
+    public void Criar_PesoNegativo_Falha(decimal redacao, decimal cn, decimal ch, decimal lc, decimal mt)
+    {
+        Result<PesoAreaEnem> resultado = Criar(redacao: redacao, cn: cn, ch: ch, lc: lc, mt: mt);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.PesoNegativo);
+    }
+
+    [Fact(DisplayName = "Criar com peso zero é aceito")]
+    public void Criar_PesoZero_Aceita()
+    {
+        Result<PesoAreaEnem> resultado = Criar(ch: 0.00m);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.PesoCienciasHumanas.Should().Be(0.00m);
+    }
+
+    [Fact(DisplayName = "Criar sem informar o corte de redação assume o padrão 400")]
+    public void Criar_SemCorte_AssumePadrao400()
+    {
+        PesoAreaEnem peso = Criar(corte: null).Value!;
+
+        peso.CorteRedacao.Should().Be(400m);
+    }
+
+    [Fact(DisplayName = "Criar com corte de redação informado persiste o valor")]
+    public void Criar_ComCorteInformado_Persiste()
+    {
+        PesoAreaEnem peso = Criar(corte: 500.000m).Value!;
+
+        peso.CorteRedacao.Should().Be(500.000m);
+    }
+
+    [Fact(DisplayName = "Criar com corte de redação negativo falha")]
+    public void Criar_CorteNegativo_Falha()
+    {
+        Result<PesoAreaEnem> resultado = Criar(corte: -10.000m);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.CorteRedacaoNegativo);
+    }
+
+    [Theory(DisplayName = "Criar sem base legal falha")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemBaseLegal_Falha(string baseLegal)
+    {
+        Result<PesoAreaEnem> resultado = Criar(baseLegal: baseLegal);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.BaseLegalObrigatoria);
+    }
+
+    [Fact(DisplayName = "Atualizar aplica novos pesos e preserva Id, resolução e grupo (CA-04b)")]
+    public void Atualizar_DadosValidos_PreservaChaveEId()
+    {
+        PesoAreaEnem peso = Criar().Value!;
+        Guid idOriginal = peso.Id;
+
+        Result resultado = peso.Atualizar(2.00m, 1.50m, 1.50m, 1.50m, 3.00m, 450.000m, "Res. 805/2024 Anexo I (revisado)");
+
+        resultado.IsSuccess.Should().BeTrue();
+        peso.Id.Should().Be(idOriginal);
+        peso.Resolucao.Should().Be(Resolucao);
+        peso.GrupoCurso.Valor.Should().Be(Grupo);
+        peso.PesoRedacao.Should().Be(2.00m);
+        peso.CorteRedacao.Should().Be(450.000m);
+    }
+
+    [Fact(DisplayName = "Atualizar com peso negativo falha e mantém a linha inalterada")]
+    public void Atualizar_PesoNegativo_Falha()
+    {
+        PesoAreaEnem peso = Criar().Value!;
+
+        Result resultado = peso.Atualizar(1.50m, 1.00m, 1.00m, 1.00m, -1.00m, 400m, BaseLegal);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.PesoNegativo);
+        peso.PesoMatematica.Should().Be(2.00m);
+    }
+
+    [Fact(DisplayName = "Atualizar com corte negativo falha")]
+    public void Atualizar_CorteNegativo_Falha()
+    {
+        PesoAreaEnem peso = Criar().Value!;
+
+        Result resultado = peso.Atualizar(1.50m, 1.00m, 1.00m, 1.00m, 2.00m, -1.000m, BaseLegal);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.CorteRedacaoNegativo);
+    }
+
+    [Fact(DisplayName = "Atualizar esvaziando a base legal falha")]
+    public void Atualizar_BaseLegalVazia_Falha()
+    {
+        PesoAreaEnem peso = Criar().Value!;
+
+        Result resultado = peso.Atualizar(1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, "   ");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.BaseLegalObrigatoria);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/PesoAreaEnemTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/PesoAreaEnemTests.cs
@@ -113,6 +113,56 @@ public sealed class PesoAreaEnemTests
         resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.CorteRedacaoNegativo);
     }
 
+    [Fact(DisplayName = "Criar com corte de redação no máximo (1000) é aceito")]
+    public void Criar_CorteNoMaximo_Aceita()
+    {
+        PesoAreaEnem peso = Criar(corte: PesoAreaEnem.CorteRedacaoMaximo).Value!;
+
+        peso.CorteRedacao.Should().Be(1000m);
+    }
+
+    [Fact(DisplayName = "Criar com corte de redação acima do máximo (>1000) falha em vez de estourar a coluna")]
+    public void Criar_CorteAcimaDoMaximo_Falha()
+    {
+        Result<PesoAreaEnem> resultado = Criar(corte: 1000.001m);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.CorteRedacaoExcedeMaximo);
+    }
+
+    [Theory(DisplayName = "Criar com peso acima do teto persistível falha em vez de estourar numeric(4,2)")]
+    [InlineData(100.00, 1, 1, 1, 1)]
+    [InlineData(1, 1, 1, 1, 100.00)]
+    public void Criar_PesoAcimaDoMaximo_Falha(decimal redacao, decimal cn, decimal ch, decimal lc, decimal mt)
+    {
+        Result<PesoAreaEnem> resultado = Criar(redacao: redacao, cn: cn, ch: ch, lc: lc, mt: mt);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.PesoExcedeMaximo);
+    }
+
+    [Fact(DisplayName = "Atualizar com corte acima do máximo falha")]
+    public void Atualizar_CorteAcimaDoMaximo_Falha()
+    {
+        PesoAreaEnem peso = Criar().Value!;
+
+        Result resultado = peso.Atualizar(1.50m, 1.00m, 1.00m, 1.00m, 2.00m, 1000.001m, BaseLegal);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.CorteRedacaoExcedeMaximo);
+    }
+
+    [Fact(DisplayName = "Atualizar com peso acima do máximo falha")]
+    public void Atualizar_PesoAcimaDoMaximo_Falha()
+    {
+        PesoAreaEnem peso = Criar().Value!;
+
+        Result resultado = peso.Atualizar(100.00m, 1.00m, 1.00m, 1.00m, 2.00m, 400m, BaseLegal);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(PesoAreaEnemErrorCodes.PesoExcedeMaximo);
+    }
+
     [Theory(DisplayName = "Criar sem base legal falha")]
     [InlineData("")]
     [InlineData("   ")]

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/ValueObjects/GrupoCursoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/ValueObjects/GrupoCursoTests.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class GrupoCursoTests
+{
+    [Theory(DisplayName = "Criar aceita os quatro grupos canônicos da Res. 805")]
+    [InlineData(GrupoCurso.Tecnologica)]
+    [InlineData(GrupoCurso.HumanisticaI)]
+    [InlineData(GrupoCurso.HumanisticaII)]
+    [InlineData(GrupoCurso.SaudeEBiologicas)]
+    public void Criar_GrupoCanonico_Aceita(string valor)
+    {
+        Result<GrupoCurso> resultado = GrupoCurso.Criar(valor);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Valor.Should().Be(valor);
+    }
+
+    [Fact(DisplayName = "Criar normaliza espaços nas bordas (Trim)")]
+    public void Criar_ComEspacos_Normaliza()
+    {
+        Result<GrupoCurso> resultado = GrupoCurso.Criar("  Tecnológica  ");
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Valor.Should().Be(GrupoCurso.Tecnologica);
+    }
+
+    [Theory(DisplayName = "Criar rejeita grupo fora do domínio")]
+    [InlineData("Engenharias")]
+    [InlineData("Linguística")]
+    [InlineData("Humanística III")]
+    [InlineData("tecnológica")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_GrupoForaDoDominio_Falha(string valor)
+    {
+        Result<GrupoCurso> resultado = GrupoCurso.Criar(valor);
+
+        resultado.IsFailure.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "EhValido reflete a pertinência ao domínio fechado")]
+    [InlineData(GrupoCurso.Tecnologica, true)]
+    [InlineData(GrupoCurso.SaudeEBiologicas, true)]
+    [InlineData("Engenharias", false)]
+    [InlineData("", false)]
+    public void EhValido_ReflectePertinencia(string valor, bool esperado)
+    {
+        GrupoCurso.EhValido(valor).Should().Be(esperado);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/PesosAreaEnem/PesoAreaEnemEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/PesosAreaEnem/PesoAreaEnemEndpointTests.cs
@@ -1,0 +1,184 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.PesosAreaEnem;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>PesoAreaEnem</c> (UNI-REQ-0066):
+/// routing, vendor media type, HATEOAS, autenticação/autorização, idempotência,
+/// domínio fechado do grupo (CA-03) e corte padrão 400 (CA-04) com Wolverine
+/// rodando contra Postgres efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class PesoAreaEnemEndpointTests
+{
+    private const string VendorMime = "application/vnd.uniplus.peso-area-enem.v1+json";
+    private const string ColecaoPath = "/api/pesos-area-enem";
+    private const string AdminPath = "/api/admin/pesos-area-enem";
+    private const string BaseLegal = "Res. 805/2024 Anexo I";
+
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public PesoAreaEnemEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET coleção retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri(ColecaoPath, UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be(VendorMime);
+    }
+
+    [Fact(DisplayName = "GET por id retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{ColecaoPath}/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST admin sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminPath, UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST admin autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminPath, UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(CorpoValido(ResolucaoUnica()));
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "POST admin cria (201) e o GET subsequente retorna os pesos + _links")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, AdminPath, CorpoValido(ResolucaoUnica()));
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(new Uri($"{ColecaoPath}/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("grupoCurso").GetString().Should().Be(GrupoCurso.Tecnologica);
+        root.GetProperty("pesoRedacao").GetDecimal().Should().Be(1.50m);
+        root.GetProperty("corteRedacao").GetDecimal().Should().Be(400m);
+        root.GetProperty("baseLegal").GetString().Should().Be(BaseLegal);
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "CA-04: POST admin sem corte de redação assume o padrão 400")]
+    public async Task Criar_SemCorte_AssumePadrao400()
+    {
+        var body = new
+        {
+            resolucao = ResolucaoUnica(),
+            grupoCurso = GrupoCurso.Tecnologica,
+            pesoRedacao = 1.50m,
+            pesoCienciasNatureza = 1.00m,
+            pesoCienciasHumanas = 1.00m,
+            pesoLinguagens = 1.00m,
+            pesoMatematica = 2.00m,
+            baseLegal = BaseLegal,
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, AdminPath, body);
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+
+        HttpResponseMessage obter = await client.GetAsync(new Uri($"{ColecaoPath}/{id}", UriKind.Relative));
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("corteRedacao").GetDecimal().Should().Be(400m);
+    }
+
+    [Fact(DisplayName = "CA-03: POST admin com grupo fora do domínio retorna 422")]
+    public async Task Criar_GrupoInvalido_Retorna422()
+    {
+        var body = new
+        {
+            resolucao = ResolucaoUnica(),
+            grupoCurso = "Engenharias",
+            pesoRedacao = 1.50m,
+            pesoCienciasNatureza = 1.00m,
+            pesoCienciasHumanas = 1.00m,
+            pesoLinguagens = 1.00m,
+            pesoMatematica = 2.00m,
+            corteRedacao = 400m,
+            baseLegal = BaseLegal,
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, AdminPath, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    private static object CorpoValido(string resolucao) => new
+    {
+        resolucao,
+        grupoCurso = GrupoCurso.Tecnologica,
+        pesoRedacao = 1.50m,
+        pesoCienciasNatureza = 1.00m,
+        pesoCienciasHumanas = 1.00m,
+        pesoLinguagens = 1.00m,
+        pesoMatematica = 2.00m,
+        corteRedacao = 400m,
+        baseLegal = BaseLegal,
+    };
+
+    // Resolução de até 40 chars, única por teste para não colidir na UNIQUE parcial do par.
+    private static string ResolucaoUnica() => $"Res. {Guid.NewGuid().ToString("N")[..12]}";
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, string path, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(path, UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/PesosAreaEnem/PesoAreaEnemPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/PesosAreaEnem/PesoAreaEnemPersistenceTests.cs
@@ -1,0 +1,224 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.PesosAreaEnem;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta dos Pesos do ENEM por grupo de área contra Postgres
+/// real (UNI-REQ-0066): persistência dos pesos, UNIQUE parcial do par
+/// (resolução, grupo), liberação do slot por soft-delete, CHECKs de domínio/não-
+/// negatividade, DEFAULT 400 do corte e leitura cross-módulo (CA-01, CA-04, CA-05).
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class PesoAreaEnemPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+    private const string BaseLegal = "Res. 805/2024 Anexo I";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public PesoAreaEnemPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01: criar persiste os pesos e fica visível pelo leitor cross-módulo")]
+    public async Task Insert_PersisteEFicaVisivelPeloReader()
+    {
+        string resolucao = ResolucaoUnica();
+        PesoAreaEnem peso = Nova(resolucao);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.PesosAreaEnem.Add(peso);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        PesoAreaEnem persistida = await readCtx.PesosAreaEnem.SingleAsync(p => p.Id == peso.Id);
+
+        persistida.Resolucao.Should().Be(resolucao);
+        persistida.GrupoCurso.Valor.Should().Be(GrupoCurso.Tecnologica);
+        persistida.PesoRedacao.Should().Be(1.50m);
+        persistida.PesoMatematica.Should().Be(2.00m);
+        persistida.CorteRedacao.Should().Be(400m);
+        persistida.CreatedBy.Should().Be(AdminA);
+        persistida.IsDeleted.Should().BeFalse();
+
+        var reader = new PesoAreaEnemReader(readCtx);
+        PesoAreaEnemView? view = await reader.ObterPorIdAsync(peso.Id);
+        view.Should().NotBeNull();
+        view!.Resolucao.Should().Be(resolucao);
+        view.GrupoCurso.Should().Be(GrupoCurso.Tecnologica);
+        view.PesoRedacao.Should().Be(1.50m);
+    }
+
+    [Fact(DisplayName = "CA-02: UNIQUE parcial (resolução, grupo) rejeita segundo par vivo idêntico")]
+    public async Task UniquePartial_Par_RejeitaDuplicataAtiva()
+    {
+        string resolucao = ResolucaoUnica();
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.PesosAreaEnem.Add(Nova(resolucao));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.PesosAreaEnem.Add(Nova(resolucao));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        // Trava as constantes que o handler usa para traduzir a corrida concorrente
+        // (UniqueConstraintViolation.GetViolatedConstraint/IsParConflict) em
+        // ParJaExiste/409: SqlState 23505 + nome do índice único parcial.
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_peso_area_enem_resolucao_grupo_vivo");
+    }
+
+    [Fact(DisplayName = "Mesma resolução em grupo distinto é aceita (par distinto)")]
+    public async Task ParDistinto_MesmaResolucaoOutroGrupo_Aceita()
+    {
+        string resolucao = ResolucaoUnica();
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.PesosAreaEnem.Add(Nova(resolucao, GrupoCurso.Tecnologica));
+        ctx.PesosAreaEnem.Add(Nova(resolucao, GrupoCurso.HumanisticaI));
+
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o par (resolução, grupo) é distinto");
+    }
+
+    [Fact(DisplayName = "CA-05: soft-delete preserva a trilha e liberta o slot da UNIQUE parcial do par")]
+    public async Task SoftDelete_PreservaTrilhaELibertaSlot()
+    {
+        string resolucao = ResolucaoUnica();
+        PesoAreaEnem peso = Nova(resolucao);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.PesosAreaEnem.Add(peso);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            PesoAreaEnem tracked = await ctx.PesosAreaEnem.SingleAsync(p => p.Id == peso.Id);
+            ctx.PesosAreaEnem.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            PesoAreaEnem excluida = await ctx.PesosAreaEnem
+                .IgnoreQueryFilters().SingleAsync(p => p.Id == peso.Id);
+            excluida.IsDeleted.Should().BeTrue();
+            excluida.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.PesosAreaEnem.Add(Nova(resolucao));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do par foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita peso negativo via SQL cru")]
+    public async Task Check_RejeitaPesoNegativoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO peso_area_enem (id, resolucao, grupo_curso, peso_redacao, peso_ciencias_natureza, peso_ciencias_humanas, peso_linguagens, peso_matematica, corte_redacao, base_legal, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {ResolucaoUnica()}, {GrupoCurso.Tecnologica}, {-1.0m}, {1.0m}, {1.0m}, {1.0m}, {2.0m}, {400.0m}, {BaseLegal}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK peso_redacao >= 0 impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita grupo fora do domínio via SQL cru")]
+    public async Task Check_RejeitaGrupoForaDoDominioViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO peso_area_enem (id, resolucao, grupo_curso, peso_redacao, peso_ciencias_natureza, peso_ciencias_humanas, peso_linguagens, peso_matematica, corte_redacao, base_legal, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {ResolucaoUnica()}, {"Engenharias"}, {1.5m}, {1.0m}, {1.0m}, {1.0m}, {2.0m}, {400.0m}, {BaseLegal}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de domínio de grupo_curso impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CA-04: DEFAULT 400 do banco aplica quando o corte é omitido no INSERT cru")]
+    public async Task Default_CorteRedacao_AplicaQuandoOmitido()
+    {
+        Guid id = Guid.CreateVersion7();
+        string resolucao = ResolucaoUnica();
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            await ctx.Database.ExecuteSqlAsync(
+                $"INSERT INTO peso_area_enem (id, resolucao, grupo_curso, peso_redacao, peso_ciencias_natureza, peso_ciencias_humanas, peso_linguagens, peso_matematica, base_legal, created_at, is_deleted) VALUES ({id}, {resolucao}, {GrupoCurso.Tecnologica}, {1.5m}, {1.0m}, {1.0m}, {1.0m}, {2.0m}, {BaseLegal}, {DateTimeOffset.UtcNow}, {false})");
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        PesoAreaEnem persistida = await readCtx.PesosAreaEnem.SingleAsync(p => p.Id == id);
+        persistida.CorteRedacao.Should().Be(400m);
+    }
+
+    [Fact(DisplayName = "Reader.ListarVivasAsync ordena por resolução e exclui soft-deleted")]
+    public async Task ListarVivas_OrdenaPorResolucaoEExcluiSoftDeleted()
+    {
+        // Prefixo único por execução: o banco é compartilhado na collection, então
+        // filtramos o resultado às linhas deste teste para asserções determinísticas.
+        string prefixo = $"Res. {Guid.NewGuid().ToString("N")[..12]}";
+        string resA = $"{prefixo}-a";
+        string resB = $"{prefixo}-b";
+        string resExcluida = $"{prefixo}-d";
+
+        // Insere fora de ordem (B antes de A) para provar a ordenação do reader.
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.PesosAreaEnem.Add(Nova(resB));
+            ctx.PesosAreaEnem.Add(Nova(resA));
+            ctx.PesosAreaEnem.Add(Nova(resExcluida));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            PesoAreaEnem aExcluir = await ctx.PesosAreaEnem.SingleAsync(p => p.Resolucao == resExcluida);
+            ctx.PesosAreaEnem.Remove(aExcluir);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new PesoAreaEnemReader(readCtx);
+        IReadOnlyList<PesoAreaEnemView> todas = await reader.ListarVivasAsync();
+
+        string[] meus = [.. todas
+            .Select(v => v.Resolucao)
+            .Where(r => r.StartsWith(prefixo, StringComparison.Ordinal))];
+
+        // O reader ordena por Resolucao ascendente e exclui o soft-deleted:
+        // exatamente [resA, resB], nessa ordem (inserimos B antes de A).
+        meus.Should().Equal([resA, resB]);
+    }
+
+    private static PesoAreaEnem Nova(string resolucao, string grupo = GrupoCurso.Tecnologica, decimal? corte = 400m) =>
+        PesoAreaEnem.Criar(resolucao, grupo, 1.50m, 1.00m, 1.00m, 1.00m, 2.00m, corte, BaseLegal).Value!;
+
+    private static string ResolucaoUnica() => $"Res. {Guid.NewGuid().ToString("N")[..12]}";
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/PesosAreaEnem/PesoAreaEnemPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/PesosAreaEnem/PesoAreaEnemPersistenceTests.cs
@@ -195,6 +195,23 @@ public sealed class PesoAreaEnemPersistenceTests
         persistida.CorteRedacao.Should().Be(1000m);
     }
 
+    [Fact(DisplayName = "Corte de redação 0 explícito via EF persiste 0 — o DEFAULT 400 do banco não sobrescreve")]
+    public async Task CorteRedacaoZero_ViaEf_NaoEhSobrescritoPeloDefault()
+    {
+        string resolucao = ResolucaoUnica();
+        PesoAreaEnem peso = Nova(resolucao, corte: 0m);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.PesosAreaEnem.Add(peso);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        PesoAreaEnem persistida = await readCtx.PesosAreaEnem.SingleAsync(p => p.Id == peso.Id);
+        persistida.CorteRedacao.Should().Be(0m);
+    }
+
     [Fact(DisplayName = "CHECK de banco rejeita corte de redação acima de 1000 via SQL cru")]
     public async Task Check_RejeitaCorteAcimaDoMaximoViaSqlCru()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/PesosAreaEnem/PesoAreaEnemPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/PesosAreaEnem/PesoAreaEnemPersistenceTests.cs
@@ -178,6 +178,35 @@ public sealed class PesoAreaEnemPersistenceTests
         persistida.CorteRedacao.Should().Be(400m);
     }
 
+    [Fact(DisplayName = "Corte de redação no máximo (1000) persiste — numeric(7,3) acomoda a nota máxima do ENEM")]
+    public async Task CorteRedacaoMaximo_Persiste()
+    {
+        string resolucao = ResolucaoUnica();
+        PesoAreaEnem peso = Nova(resolucao, corte: PesoAreaEnem.CorteRedacaoMaximo);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.PesosAreaEnem.Add(peso);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        PesoAreaEnem persistida = await readCtx.PesosAreaEnem.SingleAsync(p => p.Id == peso.Id);
+        persistida.CorteRedacao.Should().Be(1000m);
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita corte de redação acima de 1000 via SQL cru")]
+    public async Task Check_RejeitaCorteAcimaDoMaximoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO peso_area_enem (id, resolucao, grupo_curso, peso_redacao, peso_ciencias_natureza, peso_ciencias_humanas, peso_linguagens, peso_matematica, corte_redacao, base_legal, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {ResolucaoUnica()}, {GrupoCurso.Tecnologica}, {1.5m}, {1.0m}, {1.0m}, {1.0m}, {2.0m}, {1000.001m}, {BaseLegal}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK corte_redacao <= 1000 impede o INSERT direto");
+    }
+
     [Fact(DisplayName = "Reader.ListarVivasAsync ordena por resolução e exclui soft-deleted")]
     public async Task ListarVivas_OrdenaPorResolucaoEExcluiSoftDeleted()
     {


### PR DESCRIPTION
## Resumo

- Entrega o cadastro administrativo de **Pesos do ENEM por grupo de área** (`PesoAreaEnem`), materializando o Anexo I da Resolução INEP/ENEM 805/2024 no banco de **Configuração**.
- CRUD completo (criar / atualizar / remover por soft-delete), versionável por resolução, com chave de negócio única no par `(resolucao, grupo_curso)` e read-side cross-módulo (`IPesoAreaEnemReader`) para consumo vivo pelo Módulo Seleção (ADR-0056).
- Cobre as regras do domínio fechado de 4 grupos (Tecnológica, Humanística I, Humanística II, Saúde e Biológicas), não-negatividade dos cinco pesos, corte de redação com padrão 400 e base legal obrigatória.

## Mudanças

### Novos arquivos
- **Domínio:** entidade `PesoAreaEnem` (sealed, factory, Guid v7 — ADR-0032) + value object de domínio fechado `GrupoCurso`.
- **Application:** commands/handlers `Criar`/`Atualizar`/`Remover` (Wolverine, `Result`/cascading messages — ADR-0005), validators FluentValidation e porta `IPesoAreaEnemReader` + DTO `PesoAreaEnemView`.
- **Infrastructure:** mapeamento EF Core + migration no banco de Configuração — índice único parcial (`WHERE is_deleted = false`) sobre `(resolucao, grupo_curso)`, `CHECK` de domínio do grupo, `CHECK` de não-negatividade dos pesos/corte, `corte_redacao DEFAULT 400`, `base_legal NOT NULL`.
- **API:** endpoints REST de CRUD.
- **Testes:** unidade (`GrupoCursoTests`, `PesoAreaEnemTests`) + integração (`PesoAreaEnemPersistenceTests`, `PesoAreaEnemEndpointTests`), cobrindo o mapa de testes da story (CA-01 a CA-05).

### Modificados
- Registro de DI / `OnModelCreating` do contexto de Configuração para a nova entidade e leitor.

## Testes

- [x] Testes unitários passando
- [x] Testes de integração passando (se aplicável)
- [ ] Testes E2E passando (não aplicável a esta story)

> **Evidência (run local 2026-06-24):** `dotnet build UniPlus.slnx` → 0 avisos, 0 erros. `dotnet test UniPlus.slnx` → exit 0, suíte completa verde (Configuracao unidade + integração inclusos). O único teste `Ignorado` é pré-existente e alheio a esta story (`LocalOfertaPersistenceTests`, à espera de `oferta_curso`/UNI-REQ-0010).

## Checklist

- [x] Build sem erros e sem warnings
- [x] Código segue Clean Architecture e SOLID
- [x] Sem exposição de PII (CPF, renda, dados sensíveis) — cadastro institucional, sem dados pessoais (CA-07: LGPD inaplicável)
- [x] Strings user-facing em pt-BR
- [x] Soft delete utilizado (sem DELETE físico)
- [ ] Documentação atualizada (se aplicável)

Closes #594