### PR TITLE
chore(keycloak): alinha imagem composta ao soft-pin 26.6.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - **Mensageria:** Apache Kafka 4.2 (KRaft)
 - **Cache:** Redis 8
 - **Storage:** MinIO (S3-compatible)
-- **Autenticação:** Keycloak 26.5 (Gov.br) — imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.x` (base `26.5.7` + JAR `cpf-matcher` embutido). Não é Keycloak vanilla. Detalhes em [`docker/keycloak/README.md`](docker/keycloak/README.md#imagem-do-keycloak)
+- **Autenticação:** Keycloak 26.6 (Gov.br) — imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4` (base `26.6.4` + JAR `cpf-matcher` embutido). Não é Keycloak vanilla. Detalhes em [`docker/keycloak/README.md`](docker/keycloak/README.md#imagem-do-keycloak)
 - **CQRS/messaging:** Wolverine 5.x ([ADR-0003](docs/adrs/0003-wolverine-como-backbone-cqrs.md)) — abstrações `ICommandBus` e `IQueryBus` em `Application.Abstractions/Messaging`. Validação e logging do pipeline aplicados como middleware Wolverine — validação via `UseFluentValidation` (pacote `WolverineFx.FluentValidation`) e logging via `WolverineLoggingMiddleware`, configurados em `Infrastructure.Core/Messaging/Middleware/MessagingMiddlewarePolicies`. Outbox transacional sobre EF Core / PostgreSQL ([ADR-0004](docs/adrs/0004-outbox-transacional-via-wolverine.md)); drenagem de domain events via cascading messages ([ADR-0005](docs/adrs/0005-cascading-messages-para-drenagem-de-domain-events.md)).
 - **Validação:** FluentValidation 12
 - **Logging:** Serilog 10

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       start_period: 30s
 
   keycloak:
-    image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2
+    image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4
     restart: unless-stopped
     command: start-dev --import-realm
     environment:

--- a/docker/keycloak/README.md
+++ b/docker/keycloak/README.md
@@ -20,17 +20,18 @@ ghcr.io/unifesspa-edu-br/uniplus-keycloak
 
 Componentes:
 
-- **Base:** `quay.io/keycloak/keycloak:26.5.7`
+- **Base:** `quay.io/keycloak/keycloak:26.6.4` (a versão do Keycloak viva em produção)
 - **JAR `cpf-matcher-*.jar`** embutido em `/opt/keycloak/providers/` — Authenticator Java SPI custom que resolve auto-link por CPF no first-broker-login do gov.br (ver [ADR-0020](../../docs/adrs/0020-identity-brokering-govbr.md))
 
 ### Tags publicadas
 
+O esquema de tag espelha a versão do Keycloak: `v<KC>-<patch-providers>` (ex.: `26.6.4-0`), descontinuando o esquema antigo `1.0.x`.
+
 | Tag | Quando usar |
 |---|---|
-| `1.0.2` | Pinning patch fixo — usado pelo `docker-compose.yml` deste repo |
-| `1.0` | Float dentro do minor `1.0.x` |
-| `1.x` | Float dentro do major `1.x.y` — recomendado para CI/Testcontainers (pega patches automaticamente) |
-| `latest` | Disponível, mas evitar em ambientes reproduzíveis (compose, CI) |
+| `26.6.4-0` | Release imutável (`<KC>-<patch-providers>`) — pinning estrito; consumida pelo Helm em HML/PROD |
+| `26.6.4` | Soft-pin: aponta para o último patch dos providers Uni+ sobre o Keycloak 26.6.4 — usada no `docker-compose.yml` (dev) e em Testcontainers (CI), absorvendo patches sem editar a tag |
+| `latest` | Móvel — evitar em ambientes reproduzíveis (compose, CI) |
 
 A imagem é **pública** — pull sem credenciais.
 
@@ -38,9 +39,9 @@ A imagem é **pública** — pull sem credenciais.
 
 | Cenário | Tag recomendada | Por quê |
 |---|---|---|
-| `docker-compose.yml` (dev local) | Patch fixo (`1.0.2`) | Reproducibilidade entre devs do time; mudança de versão é commit explícito e revisável |
-| CI / Testcontainers | Float minor (`1.x`) | Patches absorvidos automaticamente; cold start de pull em PR vale o trade-off |
-| HML / PROD (Helm) | Patch fixo | Atualização controlada via PR de chart |
+| `docker-compose.yml` (dev local) | Soft-pin (`26.6.4`) | Desenvolve contra a mesma versão de Keycloak que roda em produção; absorve patches dos providers sobre o mesmo KC sem editar o compose |
+| CI / Testcontainers | Soft-pin (`26.6.4`) | Parity teste/prod no pipeline JwtBearer — exercita a versão que será promovida a produção |
+| HML / PROD (Helm) | Patch fixo (`26.6.4-0`) | Atualização controlada via PR de chart |
 
 ### Ciclo de release
 
@@ -48,7 +49,7 @@ Push de tag `v*.*.*` no repo `unifesspa-edu-br/uniplus-keycloak-providers` dispa
 
 1. Builda o JAR via Maven 3.9 / Eclipse Temurin 21
 2. Publica o JAR no GitHub Release (artefato auditável)
-3. Builda e publica a imagem composta no GHCR com tags semver (`1.0.2`, `1.0`, `1.x`, `latest`)
+3. Builda e publica a imagem composta no GHCR com as tags `26.6.4-0` (release imutável), `26.6.4` (soft-pin) e `latest`
 
 Para devs do `uniplus-api` consumirem uma versão nova, basta atualizar a tag em `docker-compose.yml` (e Helm em HML/PROD). **Não há build manual de JAR para devs/operadores** — o consumo padrão é puxar a imagem pronta. O JAR continua publicado no Release apenas como artefato de auditoria.
 
@@ -348,7 +349,7 @@ A configuração desse flow é idempotente e vive em `scripts/setup-cpf-matcher-
 O ambiente de desenvolvimento usa um **segundo realm no mesmo Keycloak** (`govbr-mock`) como simulador do gov.br. Isso permite exercitar todo o flow do cpf-matcher localmente, sem depender do gov.br staging (que não aceita `localhost` como redirect URI).
 
 ```bash
-# 1. Sobe a stack (a imagem ghcr.io/.../uniplus-keycloak:1.0.2 já traz o JAR embutido)
+# 1. Sobe a stack (a imagem ghcr.io/.../uniplus-keycloak:26.6.4 já traz o JAR embutido)
 docker compose -f docker/docker-compose.yml up -d
 
 # 2. Setup completo do realm DEV — flow custom + LDAP sintético + mock IdP
@@ -396,7 +397,7 @@ A validação E2E contra o gov.br staging acontece no Keycloak HML institucional
 
 > ⚠️ O Keycloak HML é **realm compartilhado** com outros sistemas (`ficha_facil`, `sisplad`). Os scripts abaixo só tocam recursos especificamente vinculados ao gov.br + cpf-matcher. **Nunca rodar `setup-keycloak-dev.sh` ou `setup-govbr-mock.sh` em HML.**
 
-Pré-requisito: o Keycloak HML precisa estar rodando a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak` em **patch pinado** (ex.: `1.0.2`), conforme a política descrita no bloco "Imagem do Keycloak" deste README — HML/PROD nunca usam float (`1.x`/`latest`), para garantir reprodutibilidade e atualização controlada via PR de chart. A imagem já traz o JAR `cpf-matcher` embutido em `/opt/keycloak/providers/`. O pipeline Helm/CI institucional cuida do deploy da imagem — issue separada.
+Pré-requisito: o Keycloak HML precisa estar rodando a imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak` em **patch pinado** (ex.: `26.6.4-0`), conforme a política descrita no bloco "Imagem do Keycloak" deste README — HML/PROD nunca usam soft-pin (`26.6.4`) nem `latest`, para garantir reprodutibilidade e atualização controlada via PR de chart. A imagem já traz o JAR `cpf-matcher` embutido em `/opt/keycloak/providers/`. O pipeline Helm/CI institucional cuida do deploy da imagem — issue separada.
 
 ```bash
 # Variáveis de ambiente HML

--- a/docs/testing-e2e-auth.md
+++ b/docs/testing-e2e-auth.md
@@ -18,7 +18,7 @@ Esta suíte exercita o pipeline real `JwtBearer` da API Uni+ contra um Keycloak 
 
 ## Stack
 
-- **`KeycloakContainerFixture`** (em `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/`) — usa o Testcontainers genérico para subir a imagem composta canônica `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2` (Keycloak 26.5.7 + JAR `cpf-matcher` embutido), montar o realm sintético `realm-e2e-tests.json` em `/opt/keycloak/data/import/` e iniciar com `start-dev --import-realm`. A wait strategy aguarda o discovery `/realms/unifesspa-e2e/.well-known/openid-configuration` responder 200, garantindo que o realm está importado antes dos testes começarem.
+- **`KeycloakContainerFixture`** (em `tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/`) — usa o Testcontainers genérico para subir a imagem composta canônica `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4` (Keycloak 26.6.4 + JAR `cpf-matcher` embutido), montar o realm sintético `realm-e2e-tests.json` em `/opt/keycloak/data/import/` e iniciar com `start-dev --import-realm`. A wait strategy aguarda o discovery `/realms/unifesspa-e2e/.well-known/openid-configuration` responder 200, garantindo que o realm está importado antes dos testes começarem.
 - **`KeycloakCollection`** — `[CollectionDefinition("Keycloak")]` xUnit que serializa as classes que precisam do container e mantém o cold start pago apenas uma vez por execução.
 - **`OidcRealApiFactory`** — subclasse de `ApiFactoryBase<Program>` que sobrescreve `ConfigureTestAuthentication` como no-op, mantendo o `JwtBearer` produtivo ativo e apontando `Auth:Authority` para o container. O método foi extraído da base como ponto de extensão semântico — subclasses E2E que precisam exercitar o pipeline real ganham um override nomeado em vez de uma flag opaca.
 - **Realm sintético de teste (`docker/keycloak/realm-e2e-tests.json`)** — arquivo SEPARADO do realm canônico (`realm-export.json`), realm name `unifesspa-e2e`. Contém apenas o necessário para os 6 cenários: 4 usuários sintéticos com senha não-temporary, 2 clients confidenciais e o scope `uniplus-profile`. Esse arquivo NUNCA é montado pelo `docker-compose` nem por Helm — vive exclusivamente para o ciclo da fixture.
@@ -45,10 +45,10 @@ echo veth | sudo tee /etc/modules-load.d/veth.conf
 
 ### 2. Pré-cache da imagem (opcional, recomendado para a primeira execução)
 
-A imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2` tem ~600MB. Sem cache local, o cold start do Testcontainers pode levar 1–2 minutos só no pull. Para evitar surpresa:
+A imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4` tem ~600MB. Sem cache local, o cold start do Testcontainers pode levar 1–2 minutos só no pull. Para evitar surpresa:
 
 ```bash
-docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2
+docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4
 ```
 
 ### 3. Rodar a suíte
@@ -82,7 +82,7 @@ A imagem é pinned em **patch fixo** (`1.0.2`) para garantir parity bit-a-bit en
 | Sintoma | Causa provável | Como resolver |
 |---|---|---|
 | `failed to set up container ... endpoint with name ... already exists` | Módulo `veth` ausente no kernel 6.19+ | `sudo modprobe veth` antes de rodar a suíte |
-| Cold start > 2min na primeira execução | Pull da imagem do GHCR sem cache local | Rodar `docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2` antes |
+| Cold start > 2min na primeira execução | Pull da imagem do GHCR sem cache local | Rodar `docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4` antes |
 | Cenário de token expirado falha esporadicamente | Variação de relógio entre host e container | O delay já cobre `ClockSkew + lifespan`; se persistir, conferir se o host está com NTP sincronizado |
 | `connection refused` na wait strategy | Imagem composta não expõe `/realms/unifesspa/.well-known/openid-configuration` | Verificar se o `realm-export.json` foi montado em `/opt/keycloak/data/import/` e se o `--import-realm` está no comando |
 | Discovery health check `Unhealthy` no cenário 6 | Authority injetada na API não bate com o endpoint do container | Conferir que `OidcRealApiFactory.GetConfigurationOverrides` usa `keycloak.Authority` (URL com porta efêmera publicada) |

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/KeycloakContainerFixture.cs
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/Hosting/KeycloakContainerFixture.cs
@@ -9,19 +9,23 @@ using DotNet.Testcontainers.Containers;
 
 /// <summary>
 /// Sobe um container do Keycloak real (imagem composta canônica do projeto, com SPI <c>cpf-matcher</c>
-/// embutido) importando o <c>realm-export.json</c> versionado em <c>docker/keycloak/</c>. A fixture é
-/// compartilhada entre testes via <c>[Collection("Keycloak")]</c> — ver <see cref="KeycloakCollection"/>.
+/// embutido) importando o realm sintético <c>realm-e2e-tests.json</c> versionado em
+/// <c>docker/keycloak/</c>. A fixture é compartilhada entre testes via <c>[Collection("Keycloak")]</c>
+/// — ver <see cref="KeycloakCollection"/>.
 ///
-/// Garante que a suíte E2E exercite o pipeline real <c>JwtBearer</c> da API contra o IdP de produção,
-/// sem mocks no esquema de autenticação.
+/// Garante que a suíte E2E exercite o pipeline real <c>JwtBearer</c> da API contra a mesma imagem e
+/// versão de Keycloak que rodam em produção, sem mocks no esquema de autenticação.
 /// </summary>
 public sealed class KeycloakContainerFixture : IAsyncLifetime
 {
     /// <summary>
-    /// Imagem composta canônica do projeto. Patch fixo alinhado ao <c>docker/docker-compose.yml</c>
-    /// para garantir parity dev/CI/prod e evitar deriva silenciosa em <c>1.x</c>.
+    /// Imagem composta canônica do projeto (Keycloak + SPI <c>cpf-matcher</c>), publicada em
+    /// <c>ghcr.io/unifesspa-edu-br/uniplus-keycloak</c>. Soft-pin na versão do Keycloak vivo em
+    /// produção (tag <c>&lt;KC&gt;</c> = último patch dos providers Uni+ sobre o mesmo Keycloak):
+    /// a suíte é exercitada contra a versão que será promovida a produção. Avançar a tag quando o
+    /// Keycloak de produção subir.
     /// </summary>
-    public const string Image = "ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2";
+    public const string Image = "ghcr.io/unifesspa-edu-br/uniplus-keycloak:26.6.4";
 
     /// <summary>
     /// Nome convencional da xUnit collection que compartilha esta fixture entre classes de teste.


### PR DESCRIPTION
## O que muda

Alinha a imagem do Keycloak (testes/dev) ao novo padrão de versionamento, fixando no soft-pin **`26.6.4`** — a mesma versão de produção.

| Arquivo | Antes | Depois |
|---|---|---|
| `tests/.../Hosting/KeycloakContainerFixture.cs` | `uniplus-keycloak:1.0.2` | `uniplus-keycloak:26.6.4` |
| `docker/docker-compose.yml` | `uniplus-keycloak:1.0.2` | `uniplus-keycloak:26.6.4` |
| `docker/keycloak/README.md` | esquema `1.0.x`, base `26.5.7` | esquema `v<KC>-<patch>`, base `26.6.4`, política de pinning |
| `docs/testing-e2e-auth.md`, `CLAUDE.md` | refs `1.0.2`/`26.5.7` | `26.6.4` |

## Por quê

A tag `1.0.2` é do esquema antigo (`1.0.x` = Keycloak 26.5.7), descontinuado. A composta passou a versionar espelhando o Keycloak (`v<KC>-<patch>`); o **26.6.4** já está publicado (`unifesspa-edu-br/uniplus-keycloak-providers#16`) e rodando em prod via Helm (`unifesspa-edu-br/uniplus-infra#392`).

O Keycloak **26.6.4** corrige **8 CVEs** (incl. CVE-2026-11800 — auth bypass via JWT algorithm confusion) e o bug de migração Postgres #48438. É a mesma imagem composta (mantém o SPI `cpf-matcher`), apenas a tag muda → **parity teste/dev/prod**.

Testes sobem o Keycloak com **H2 efêmero** (sem `KC_DB`); a troca de versão é transparente para a suíte.

## Validação

- `dotnet test` (`AuthE2ETests`, Selecao.IntegrationTests): **7/7 aprovados** contra a imagem `26.6.4`.
- `dotnet format --verify-no-changes` (fixture): sem alterações.

## Fora do escopo

ADRs históricos (`0016`, `0020`, `0050`) mencionam `1.x`/`1.0.2`/`26.5.7` como registro datado da decisão/entrega — **preservados** (não reescrevem história).

Closes #739