### PR TITLE
feat(configuracao): adiciona cadastro de tipo de documento

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -2031,6 +2031,476 @@
           }
         }
       }
+    },
+    "/api/configuracao/tipos-documento": {
+      "get": {
+        "tags": [
+          "TiposDocumento"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoDocumentoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoDocumentoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoDocumentoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/tipos-documento/{id}": {
+      "get": {
+        "tags": [
+          "TiposDocumento"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoDocumentoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoDocumentoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoDocumentoDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/tipos-documento": {
+      "post": {
+        "tags": [
+          "TiposDocumento"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoDocumentoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoDocumentoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoDocumentoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/tipos-documento/{id}": {
+      "put": {
+        "tags": [
+          "TiposDocumento"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoDocumentoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoDocumentoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoDocumentoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "TiposDocumento"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -2253,6 +2723,57 @@
           },
           "baseLegal": {
             "type": "string"
+          }
+        }
+      },
+      "AtualizarTipoDocumentoCommand": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "categoria"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "categoria": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "formatosAceitos": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tamanhoMaximoMb": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "tipoEquivalente": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -2618,6 +3139,52 @@
           },
           "baseLegal": {
             "type": "string"
+          }
+        }
+      },
+      "CriarTipoDocumentoCommand": {
+        "required": [
+          "codigo",
+          "nome",
+          "categoria"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "categoria": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "formatosAceitos": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tamanhoMaximoMb": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "tipoEquivalente": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -3056,6 +3623,75 @@
           }
         }
       },
+      "TipoDocumentoDto": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "descricao",
+          "categoria",
+          "formatosAceitos",
+          "tamanhoMaximoMb",
+          "tipoEquivalente",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "categoria": {
+            "type": "string"
+          },
+          "formatosAceitos": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tamanhoMaximoMb": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "tipoEquivalente": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "TipoLocalOferta": {
         "enum": [
           "nenhum",
@@ -3147,6 +3783,9 @@
     },
     {
       "name": "ReferenciasReservaDemografica"
+    },
+    {
+      "name": "TiposDocumento"
     }
   ]
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
@@ -50,6 +50,7 @@ public static class ConfiguracaoModuleRegistration
         services.AddSingleton<IResourceLinksBuilder<LocalOfertaDto>, LocalOfertaLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<ReferenciaReservaDemograficaDto>, ReferenciaReservaDemograficaLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<PesoAreaEnemDto>, PesoAreaEnemLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<TipoDocumentoDto>, TipoDocumentoLinksBuilder>();
 
         // Idempotency-Key (ADR-0027) sobre o DbContext do módulo.
         services.AddIdempotency<ConfiguracaoDbContext, ConfiguracaoApiAssemblyMarker>(configuration);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposDocumentoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposDocumentoController.cs
@@ -1,0 +1,186 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDocumento;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/tipos-documento</c>,
+/// <c>GET /api/configuracao/tipos-documento/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/configuracao/admin/tipos-documento</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ-0013).
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class TiposDocumentoController : ControllerBase
+{
+    private const string ResourceTag = "tipos-documento";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<TipoDocumentoDto> _linksBuilder;
+
+    public TiposDocumentoController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<TipoDocumentoDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista os tipos de documento ativos, paginados por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("tipos-documento")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "tipo-documento", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<TipoDocumentoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarTiposDocumentoResult resultado = await _queryBus
+            .Send(new ListarTiposDocumentoQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        TipoDocumentoDto[] comLinks =
+            [.. resultado.Items.Select(t => t with { Links = _linksBuilder.Build(t) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém um tipo de documento pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("tipos-documento/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "tipo-documento", Versions = [1])]
+    [ProducesResponseType(typeof(TipoDocumentoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        TipoDocumentoDto? tipo = await _queryBus
+            .Send(new ObterTipoDocumentoPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (tipo is null)
+        {
+            return NotFound();
+        }
+
+        TipoDocumentoDto comLinks = tipo with { Links = _linksBuilder.Build(tipo) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria um novo tipo de documento. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/tipos-documento")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarTipoDocumentoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza um tipo de documento existente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/tipos-documento/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarTipoDocumentoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) um tipo de documento. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/tipos-documento/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverTipoDocumentoCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -327,5 +327,78 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status404NotFound,
                 "uniplus.configuracao.peso_area_enem.nao_encontrado",
                 "Linha de pesos do ENEM não encontrada")),
+
+        // ── Tipo de documento (UNI-REQ-0013) ──────────────────────────────
+        new(TipoDocumentoErrorCodes.CodigoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.codigo_obrigatorio",
+                "Código do tipo de documento é obrigatório")),
+
+        new(TipoDocumentoErrorCodes.CodigoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.codigo_tamanho",
+                "Tamanho do código do tipo de documento inválido")),
+
+        new(TipoDocumentoErrorCodes.CodigoJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.tipo_documento.codigo_ja_existe",
+                "Já existe um tipo de documento ativo com este código")),
+
+        new(TipoDocumentoErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.nome_obrigatorio",
+                "Nome do tipo de documento é obrigatório")),
+
+        new(TipoDocumentoErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.nome_tamanho",
+                "Tamanho do nome do tipo de documento inválido")),
+
+        new(TipoDocumentoErrorCodes.DescricaoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.descricao_tamanho",
+                "Tamanho da descrição do tipo de documento inválido")),
+
+        new(TipoDocumentoErrorCodes.CategoriaInvalida,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.categoria_invalida",
+                "Categoria do tipo de documento fora do domínio fechado")),
+
+        new(TipoDocumentoErrorCodes.FormatosAceitosTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.formatos_aceitos_tamanho",
+                "Tamanho dos formatos aceitos do tipo de documento inválido")),
+
+        new(TipoDocumentoErrorCodes.TamanhoMaximoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.tamanho_maximo_invalido",
+                "Tamanho máximo em MB do tipo de documento deve ser positivo")),
+
+        new(TipoDocumentoErrorCodes.TipoEquivalenteTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.tipo_equivalente_tamanho",
+                "Tamanho do tipo equivalente inválido")),
+
+        new(TipoDocumentoErrorCodes.TipoEquivalenteIgualCodigo,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_documento.tipo_equivalente_igual_codigo",
+                "Um tipo de documento não pode ser equivalente a si mesmo")),
+
+        new(TipoDocumentoErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.tipo_documento.nao_encontrado",
+                "Tipo de documento não encontrado")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/TipoDocumentoLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/TipoDocumentoLinksBuilder.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="TipoDocumentoDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<TipoDocumentoDto>, TipoDocumentoLinksBuilder>().")]
+internal sealed class TipoDocumentoLinksBuilder : IResourceLinksBuilder<TipoDocumentoDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public TipoDocumentoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(TipoDocumentoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "TiposDocumento";
+
+        string self = ResolverPath(
+            httpContext, nameof(TiposDocumentoController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(TiposDocumentoController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/AtualizarTipoDocumentoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/AtualizarTipoDocumentoCommand.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza um tipo de documento existente. O <c>Codigo</c> é editável (diferente
+/// da Modalidade), com nova checagem de unicidade entre vivos; os demais atributos
+/// (nome, descrição, categoria, formatos, tamanho máximo, tipo equivalente) também
+/// podem ser editados. O <c>Id</c> é imutável. O ator (<c>updated_by</c>) é
+/// carimbado server-side via <c>IUserContext</c>.
+/// </summary>
+public sealed record AtualizarTipoDocumentoCommand(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string Categoria,
+    string? Descricao = null,
+    string? FormatosAceitos = null,
+    int? TamanhoMaximoMb = null,
+    string? TipoEquivalente = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/AtualizarTipoDocumentoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/AtualizarTipoDocumentoCommandHandler.cs
@@ -1,0 +1,75 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarTipoDocumentoCommand"/>. Como o código é
+/// editável, confere a unicidade entre tipos vivos quando ele muda (ignorando o
+/// próprio registro) e protege a corrida traduzindo a violação do índice único
+/// parcial em <c>CodigoJaExiste</c> (CA-02).
+/// </summary>
+public static class AtualizarTipoDocumentoCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarTipoDocumentoCommand command,
+        ITipoDocumentoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        TipoDocumento? tipo = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (tipo is null)
+        {
+            return Result.Failure(new DomainError(
+                TipoDocumentoErrorCodes.NaoEncontrado,
+                "Tipo de documento não encontrado."));
+        }
+
+        // Código é case-sensitive (Ordinal), normalizado por Trim no agregado — só
+        // checa colisão quando o código efetivamente muda.
+        if (!string.Equals(command.Codigo.Trim(), tipo.Codigo, StringComparison.Ordinal)
+            && await repository.CodigoExisteEntreVivosAsync(command.Codigo, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        Result atualizarResult = tipo.Atualizar(
+            command.Codigo,
+            command.Nome,
+            command.Descricao,
+            command.Categoria,
+            command.FormatosAceitos,
+            command.TamanhoMaximoMb,
+            command.TipoEquivalente);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCodigoConflict(constraint))
+        {
+            // Corrida entre a checagem de unicidade e o UPDATE: o índice único parcial
+            // dispara 23505 e viramos o mesmo CodigoJaExiste do caminho não-race.
+            return Result.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        return Result.Success();
+    }
+
+    private static DomainError CodigoJaExisteErro(string codigo) =>
+        new(TipoDocumentoErrorCodes.CodigoJaExiste,
+            $"Já existe um tipo de documento vivo com o código '{codigo}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/AtualizarTipoDocumentoCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/AtualizarTipoDocumentoCommandValidator.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public sealed class AtualizarTipoDocumentoCommandValidator
+    : AbstractValidator<AtualizarTipoDocumentoCommand>
+{
+    public AtualizarTipoDocumentoCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id do tipo de documento é obrigatório.");
+
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código do tipo de documento é obrigatório.")
+            .MaximumLength(60).WithMessage("Código do tipo de documento deve ter no máximo 60 caracteres.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do tipo de documento é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do tipo de documento deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Categoria)
+            .Must(CategoriaDocumentos.EhValido)
+            .WithMessage($"Categoria do tipo de documento deve ser uma de: {string.Join(", ", CategoriaDocumentos.TokensCanonicos)}.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(1000).WithMessage("Descrição do tipo de documento deve ter no máximo 1000 caracteres.")
+            .When(x => x.Descricao is not null);
+
+        RuleFor(x => x.FormatosAceitos)
+            .MaximumLength(200).WithMessage("Formatos aceitos devem ter no máximo 200 caracteres.")
+            .When(x => x.FormatosAceitos is not null);
+
+        RuleFor(x => x.TamanhoMaximoMb)
+            .GreaterThan(0).WithMessage("Tamanho máximo em MB, quando informado, deve ser positivo.")
+            .When(x => x.TamanhoMaximoMb.HasValue);
+
+        RuleFor(x => x.TipoEquivalente)
+            .MaximumLength(60).WithMessage("Tipo equivalente deve ter no máximo 60 caracteres.")
+            .When(x => x.TipoEquivalente is not null);
+
+        RuleFor(x => x)
+            .Must(NaoSerEquivalenteASiMesmo)
+            .WithMessage("Um tipo de documento não pode declarar-se equivalente a si mesmo.")
+            .When(x => !string.IsNullOrWhiteSpace(x.TipoEquivalente));
+    }
+
+    private static bool NaoSerEquivalenteASiMesmo(AtualizarTipoDocumentoCommand command) =>
+        !string.Equals(command.TipoEquivalente?.Trim(), command.Codigo?.Trim(), StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/CriarTipoDocumentoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/CriarTipoDocumentoCommand.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria um tipo de documento classificatório: código (chave natural), nome,
+/// descrição opcional, categoria (token canônico UPPER_SNAKE), formatos aceitos e
+/// tamanho máximo opcionais e tipo equivalente opcional (rótulo classificatório).
+/// O ator de auditoria (<c>created_by</c>) é carimbado server-side via
+/// <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarTipoDocumentoCommand(
+    string Codigo,
+    string Nome,
+    string Categoria,
+    string? Descricao = null,
+    string? FormatosAceitos = null,
+    int? TamanhoMaximoMb = null,
+    string? TipoEquivalente = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/CriarTipoDocumentoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/CriarTipoDocumentoCommandHandler.cs
@@ -1,0 +1,70 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarTipoDocumentoCommand"/> (convention-based
+/// Wolverine): confere a unicidade do código entre tipos vivos, cria o agregado,
+/// persiste e commita. Protege a corrida check-then-act traduzindo a violação do
+/// índice único parcial em <c>CodigoJaExiste</c> (CA-02).
+/// </summary>
+public static class CriarTipoDocumentoCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarTipoDocumentoCommand command,
+        ITipoDocumentoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.CodigoExisteEntreVivosAsync(command.Codigo, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        Result<TipoDocumento> tipoResult = TipoDocumento.Criar(
+            command.Codigo,
+            command.Nome,
+            command.Descricao,
+            command.Categoria,
+            command.FormatosAceitos,
+            command.TamanhoMaximoMb,
+            command.TipoEquivalente);
+
+        if (tipoResult.IsFailure)
+        {
+            return Result<Guid>.Failure(tipoResult.Error!);
+        }
+
+        TipoDocumento tipo = tipoResult.Value!;
+        await repository.AdicionarAsync(tipo, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCodigoConflict(constraint))
+        {
+            // Corrida entre CodigoExisteEntreVivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo CodigoJaExiste do
+            // caminho não-race — 409 consistente, em vez de deixar o DbUpdateException
+            // virar 500 no middleware global. O filtro do `when` garante que outras
+            // exceções propagam intactas.
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        return Result<Guid>.Success(tipo.Id);
+    }
+
+    private static DomainError CodigoJaExisteErro(string codigo) =>
+        new(TipoDocumentoErrorCodes.CodigoJaExiste,
+            $"Já existe um tipo de documento vivo com o código '{codigo}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/CriarTipoDocumentoCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/CriarTipoDocumentoCommandValidator.cs
@@ -1,0 +1,48 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public sealed class CriarTipoDocumentoCommandValidator
+    : AbstractValidator<CriarTipoDocumentoCommand>
+{
+    public CriarTipoDocumentoCommandValidator()
+    {
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código do tipo de documento é obrigatório.")
+            .MaximumLength(60).WithMessage("Código do tipo de documento deve ter no máximo 60 caracteres.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do tipo de documento é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do tipo de documento deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Categoria)
+            .Must(CategoriaDocumentos.EhValido)
+            .WithMessage($"Categoria do tipo de documento deve ser uma de: {string.Join(", ", CategoriaDocumentos.TokensCanonicos)}.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(1000).WithMessage("Descrição do tipo de documento deve ter no máximo 1000 caracteres.")
+            .When(x => x.Descricao is not null);
+
+        RuleFor(x => x.FormatosAceitos)
+            .MaximumLength(200).WithMessage("Formatos aceitos devem ter no máximo 200 caracteres.")
+            .When(x => x.FormatosAceitos is not null);
+
+        RuleFor(x => x.TamanhoMaximoMb)
+            .GreaterThan(0).WithMessage("Tamanho máximo em MB, quando informado, deve ser positivo.")
+            .When(x => x.TamanhoMaximoMb.HasValue);
+
+        RuleFor(x => x.TipoEquivalente)
+            .MaximumLength(60).WithMessage("Tipo equivalente deve ter no máximo 60 caracteres.")
+            .When(x => x.TipoEquivalente is not null);
+
+        RuleFor(x => x)
+            .Must(NaoSerEquivalenteASiMesmo)
+            .WithMessage("Um tipo de documento não pode declarar-se equivalente a si mesmo.")
+            .When(x => !string.IsNullOrWhiteSpace(x.TipoEquivalente));
+    }
+
+    private static bool NaoSerEquivalenteASiMesmo(CriarTipoDocumentoCommand command) =>
+        !string.Equals(command.TipoEquivalente?.Trim(), command.Codigo?.Trim(), StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/RemoverTipoDocumentoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/RemoverTipoDocumentoCommand.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Remove (soft-delete) um tipo de documento pelo seu <c>Id</c>.</summary>
+public sealed record RemoverTipoDocumentoCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/RemoverTipoDocumentoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/RemoverTipoDocumentoCommandHandler.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverTipoDocumentoCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c>. A remoção <b>nunca</b> é bloqueada: o consumo
+/// cross-módulo é snapshot-copy desacoplado (ADR-0061) e o <c>TipoEquivalente</c>
+/// de outro tipo é rótulo classificatório por código (não FK), não referência
+/// viva — remover um tipo apontado como equivalente apenas deixa o rótulo do outro
+/// apontando para um código sem alvo vivo (CA-04).
+/// </summary>
+public static class RemoverTipoDocumentoCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverTipoDocumentoCommand command,
+        ITipoDocumentoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        TipoDocumento? tipo = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (tipo is null)
+        {
+            return Result.Failure(new DomainError(
+                TipoDocumentoErrorCodes.NaoEncontrado,
+                "Tipo de documento não encontrado."));
+        }
+
+        repository.Remover(tipo);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDocumento/UniqueConstraintViolation.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do código vivo do
+/// tipo de documento — <c>ix_tipo_documento_codigo_vivo</c> — para o
+/// <c>DomainError</c> apropriado. Acessa <c>SqlState</c> e <c>ConstraintName</c>
+/// por reflection no inner exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção por
+/// <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch —
+/// Application referencia apenas Domain + SharedKernel + abstrações).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão do <c>UniqueConstraintViolation</c> dos cadastros de Pesos do ENEM
+/// (#594) e Referência de reserva demográfica (#593). A tradução cross-cutting de
+/// 23505 → 409 via <c>GlobalExceptionMiddleware</c> permanece como follow-up
+/// separado (#504); este helper cobre o caso específico da unicidade do código
+/// (CA-02), inclusive a corrida na atualização (o código é editável).
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string CodigoConstraint = "ix_tipo_documento_codigo_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o
+    /// caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único parcial
+    /// que garante um único tipo vivo por código.
+    /// </summary>
+    public static bool IsCodigoConflict(string? constraint) =>
+        string.Equals(constraint, CodigoConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/TipoDocumentoDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/TipoDocumentoDto.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>TipoDocumento</c>. Suporta HATEOAS Level 1 via
+/// <c>_links</c> (ADR-0029). A categoria é exposta como <c>string</c> (token
+/// canônico UPPER_SNAKE); o tamanho máximo como número (MB).
+/// </summary>
+public sealed record TipoDocumentoDto(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string? Descricao,
+    string Categoria,
+    string? FormatosAceitos,
+    int? TamanhoMaximoMb,
+    string? TipoEquivalente,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/TipoDocumentoMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/TipoDocumentoMapping.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public static class TipoDocumentoMapping
+{
+    public static TipoDocumentoDto ToDto(this TipoDocumento tipo)
+    {
+        ArgumentNullException.ThrowIfNull(tipo);
+        return new TipoDocumentoDto(
+            tipo.Id,
+            tipo.Codigo,
+            tipo.Nome,
+            tipo.Descricao,
+            CategoriaDocumentos.ParaTokenCanonico(tipo.Categoria),
+            tipo.FormatosAceitos,
+            tipo.TamanhoMaximoMb,
+            tipo.TipoEquivalente,
+            tipo.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ListarTiposDocumentoQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ListarTiposDocumentoQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDocumento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista tipos de documento vivos paginados por cursor bidirecional
+/// (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e valida
+/// limit/direction antes de despachar.
+/// </summary>
+public sealed record ListarTiposDocumentoQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarTiposDocumentoResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ListarTiposDocumentoQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ListarTiposDocumentoQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDocumento;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarTiposDocumentoQueryHandler
+{
+    public static async Task<ListarTiposDocumentoResult> Handle(
+        ListarTiposDocumentoQuery query,
+        ITipoDocumentoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<TipoDocumento> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        TipoDocumentoDto[] items = [.. itens.Select(t => t.ToDto())];
+        return new ListarTiposDocumentoResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ListarTiposDocumentoResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ListarTiposDocumentoResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDocumento;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarTiposDocumentoQuery"/>: lote de tipos de
+/// documento projetados + âncoras opcionais para o controller construir os
+/// cursores prev/next (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarTiposDocumentoResult(
+    IReadOnlyList<TipoDocumentoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ObterTipoDocumentoPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ObterTipoDocumentoPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDocumento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterTipoDocumentoPorIdQuery(Guid Id) : IQuery<TipoDocumentoDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ObterTipoDocumentoPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDocumento/ObterTipoDocumentoPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDocumento;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterTipoDocumentoPorIdQueryHandler
+{
+    public static async Task<TipoDocumentoDto?> Handle(
+        ObterTipoDocumentoPorIdQuery query,
+        ITipoDocumentoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        TipoDocumento? tipo = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return tipo?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ITipoDocumentoReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ITipoDocumentoReader.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>TipoDocumento</c> (ADR-0056). Expõe o estado vivo do
+/// cadastro classificatório de tipos de documento para consumo por outros bounded
+/// contexts (ex.: a configuração de exigências documentais do Módulo Seleção, que
+/// referencia o tipo ao montar a relação de exigências de um edital) sem acesso
+/// direto ao banco de Configuração (ADR-0054).
+/// </summary>
+public interface ITipoDocumentoReader
+{
+    /// <summary>
+    /// Lista todos os tipos de documento vivos (não soft-deleted), ordenados por
+    /// <c>Codigo</c> ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<TipoDocumentoView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém um tipo de documento pelo <paramref name="id"/>, ou
+    /// <see langword="null"/> se inexistente / soft-deleted.
+    /// </summary>
+    Task<TipoDocumentoView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/TipoDocumentoView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/TipoDocumentoView.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>TipoDocumento</c> para consumo cross-módulo via
+/// <see cref="ITipoDocumentoReader"/> (ADR-0056). Expõe o tipo vivo
+/// (código + nome + categoria) que o Módulo Seleção lê ao montar a relação de
+/// exigências documentais de um edital, antes de congelar por valor a identidade
+/// na exigência (snapshot-copy, ADR-0061).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="Codigo">Código classificatório, chave natural do tipo (ex.: "LAUDO_MEDICO").</param>
+/// <param name="Nome">Rótulo legível do tipo.</param>
+/// <param name="Categoria">Categoria classificatória (token canônico UPPER_SNAKE; ex.: "SAUDE").</param>
+public sealed record TipoDocumentoView(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string Categoria);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/TipoDocumento.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/TipoDocumento.cs
@@ -1,0 +1,230 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Tipo de documento — cadastro institucional <b>classificatório puro</b>
+/// (UNI-REQ-0013, módulo Configuração): diz <i>o que um documento é</i> (RG,
+/// laudo médico, autodeclaração PPI…), nunca uma regra material sobre ele
+/// (validade, assinatura, idade de emissão). Essas regras vivem na exigência
+/// documental do edital (banco de Seleção) ou na homologação (ADR-0072).
+/// </summary>
+/// <remarks>
+/// <para>O <c>Codigo</c> é a chave natural, único entre tipos vivos (índice único
+/// parcial <c>WHERE is_deleted = false</c>) — e <b>editável</b> (diferente da
+/// Modalidade), pois o consumo cross-módulo é por snapshot-copy desacoplado
+/// (ADR-0061): editar o código vivo não altera o rótulo já congelado numa
+/// exigência de Seleção. A unicidade é checada pelo handler (com proteção de
+/// corrida via índice).</para>
+/// <para>O <c>TipoEquivalente</c> é <b>rótulo classificatório</b> (RG ≡ CIN), não
+/// relacionamento material: guarda o <c>Codigo</c> de outro tipo (sem FK), e o
+/// único guarda é não ser equivalente a si mesmo. Por ser rótulo e não FK,
+/// remover um tipo apontado como equivalente por outro <b>não</b> é bloqueado
+/// (CA-04) — o rótulo do outro fica apontando para um código sem alvo vivo.</para>
+/// <para>Dado institucional sem PII (LGPD inaplicável). A remoção é sempre
+/// soft-delete e nunca bloqueada por referência.</para>
+/// </remarks>
+public sealed class TipoDocumento : SoftDeletableEntity, IAuditableEntity
+{
+    private const int CodigoMinLength = 1;
+    private const int CodigoMaxLength = 60;
+    private const int NomeMinLength = 2;
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+    private const int FormatosAceitosMaxLength = 200;
+    private const int TipoEquivalenteMaxLength = 60;
+
+    public string Codigo { get; private set; } = string.Empty;
+    public string Nome { get; private set; } = string.Empty;
+    public string? Descricao { get; private set; }
+    public CategoriaDocumento Categoria { get; private set; }
+    public string? FormatosAceitos { get; private set; }
+    public int? TamanhoMaximoMb { get; private set; }
+    public string? TipoEquivalente { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private TipoDocumento()
+    {
+    }
+
+    /// <summary>
+    /// Cria um novo TipoDocumento. Valida formato/domínio local (incluindo a
+    /// categoria contra o domínio fechado e o guard de auto-equivalência). A
+    /// unicidade de <paramref name="codigo"/> entre tipos vivos é
+    /// responsabilidade do handler. A <paramref name="categoria"/> chega como
+    /// token textual (UPPER_SNAKE) e é validada pela allowlist.
+    /// </summary>
+    public static Result<TipoDocumento> Criar(
+        string codigo,
+        string nome,
+        string? descricao,
+        string categoria,
+        string? formatosAceitos,
+        int? tamanhoMaximoMb,
+        string? tipoEquivalente)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(categoria);
+
+        Result<CategoriaDocumento> validacao = ValidarCampos(
+            codigo, nome, descricao, categoria, formatosAceitos, tamanhoMaximoMb, tipoEquivalente);
+        if (validacao.IsFailure)
+        {
+            return Result<TipoDocumento>.Failure(validacao.Error!);
+        }
+
+        var tipo = new TipoDocumento();
+        tipo.AplicarCampos(
+            codigo, nome, descricao, validacao.Value, formatosAceitos, tamanhoMaximoMb, tipoEquivalente);
+
+        return Result<TipoDocumento>.Success(tipo);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos do TipoDocumento. O <c>Codigo</c> é editável; sua
+    /// unicidade (quando alterado) é responsabilidade do handler. Revalida
+    /// formato/domínio e o guard de auto-equivalência.
+    /// </summary>
+    public Result Atualizar(
+        string codigo,
+        string nome,
+        string? descricao,
+        string categoria,
+        string? formatosAceitos,
+        int? tamanhoMaximoMb,
+        string? tipoEquivalente)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(categoria);
+
+        Result<CategoriaDocumento> validacao = ValidarCampos(
+            codigo, nome, descricao, categoria, formatosAceitos, tamanhoMaximoMb, tipoEquivalente);
+        if (validacao.IsFailure)
+        {
+            return Result.Failure(validacao.Error!);
+        }
+
+        AplicarCampos(
+            codigo, nome, descricao, validacao.Value, formatosAceitos, tamanhoMaximoMb, tipoEquivalente);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(
+        string codigo,
+        string nome,
+        string? descricao,
+        CategoriaDocumento categoria,
+        string? formatosAceitos,
+        int? tamanhoMaximoMb,
+        string? tipoEquivalente)
+    {
+        Codigo = codigo.Trim();
+        Nome = nome.Trim();
+        Descricao = NormalizarOpcional(descricao);
+        Categoria = categoria;
+        FormatosAceitos = NormalizarOpcional(formatosAceitos);
+        TamanhoMaximoMb = tamanhoMaximoMb;
+        TipoEquivalente = NormalizarOpcional(tipoEquivalente);
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result<CategoriaDocumento> ValidarCampos(
+        string codigo,
+        string nome,
+        string? descricao,
+        string categoria,
+        string? formatosAceitos,
+        int? tamanhoMaximoMb,
+        string? tipoEquivalente)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return Result<CategoriaDocumento>.Failure(new DomainError(
+                TipoDocumentoErrorCodes.CodigoObrigatorio,
+                "Código do tipo de documento é obrigatório."));
+        }
+
+        if (codigo.Trim().Length is < CodigoMinLength or > CodigoMaxLength)
+        {
+            return Result<CategoriaDocumento>.Failure(new DomainError(
+                TipoDocumentoErrorCodes.CodigoTamanho,
+                $"Código do tipo de documento deve ter entre {CodigoMinLength} e {CodigoMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result<CategoriaDocumento>.Failure(new DomainError(
+                TipoDocumentoErrorCodes.NomeObrigatorio,
+                "Nome do tipo de documento é obrigatório."));
+        }
+
+        if (nome.Trim().Length is < NomeMinLength or > NomeMaxLength)
+        {
+            return Result<CategoriaDocumento>.Failure(new DomainError(
+                TipoDocumentoErrorCodes.NomeTamanho,
+                $"Nome do tipo de documento deve ter entre {NomeMinLength} e {NomeMaxLength} caracteres."));
+        }
+
+        if (descricao is not null && descricao.Trim().Length > DescricaoMaxLength)
+        {
+            return Result<CategoriaDocumento>.Failure(new DomainError(
+                TipoDocumentoErrorCodes.DescricaoTamanho,
+                $"Descrição do tipo de documento deve ter no máximo {DescricaoMaxLength} caracteres."));
+        }
+
+        if (!CategoriaDocumentos.TryAnalisar(categoria, out CategoriaDocumento categoriaResolvida))
+        {
+            return Result<CategoriaDocumento>.Failure(new DomainError(
+                TipoDocumentoErrorCodes.CategoriaInvalida,
+                $"Categoria do tipo de documento deve ser uma de: {string.Join(", ", CategoriaDocumentos.TokensCanonicos)}."));
+        }
+
+        if (formatosAceitos is not null && formatosAceitos.Trim().Length > FormatosAceitosMaxLength)
+        {
+            return Result<CategoriaDocumento>.Failure(new DomainError(
+                TipoDocumentoErrorCodes.FormatosAceitosTamanho,
+                $"Formatos aceitos devem ter no máximo {FormatosAceitosMaxLength} caracteres."));
+        }
+
+        if (tamanhoMaximoMb is <= 0)
+        {
+            return Result<CategoriaDocumento>.Failure(new DomainError(
+                TipoDocumentoErrorCodes.TamanhoMaximoInvalido,
+                "Tamanho máximo em MB, quando informado, deve ser positivo."));
+        }
+
+        if (tipoEquivalente is not null && !string.IsNullOrWhiteSpace(tipoEquivalente))
+        {
+            string equivalenteNorm = tipoEquivalente.Trim();
+            if (equivalenteNorm.Length > TipoEquivalenteMaxLength)
+            {
+                return Result<CategoriaDocumento>.Failure(new DomainError(
+                    TipoDocumentoErrorCodes.TipoEquivalenteTamanho,
+                    $"Tipo equivalente deve ter no máximo {TipoEquivalenteMaxLength} caracteres."));
+            }
+
+            // Guard de auto-equivalência case-sensitive (Ordinal), alinhado ao CHECK
+            // `tipo_equivalente <> codigo` do banco (também case-sensitive).
+            if (string.Equals(equivalenteNorm, codigo.Trim(), StringComparison.Ordinal))
+            {
+                return Result<CategoriaDocumento>.Failure(new DomainError(
+                    TipoDocumentoErrorCodes.TipoEquivalenteIgualCodigo,
+                    "Um tipo de documento não pode declarar-se equivalente a si mesmo."));
+            }
+        }
+
+        return Result<CategoriaDocumento>.Success(categoriaResolvida);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CategoriaDocumento.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CategoriaDocumento.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Categoria classificatória de um <see cref="Entities.TipoDocumento"/>
+/// (UNI-REQ-0013). Roster fechado de sete valores — domínio fechado da #591.
+/// O nome de domínio (PascalCase) é mapeado para o token de contrato/banco
+/// UPPER_SNAKE por <c>CategoriaDocumentos</c> (ex.: <see cref="RacaEtnia"/> ↔
+/// <c>RACA_ETNIA</c>), persistido como <c>varchar</c> com CHECK de domínio.
+/// </summary>
+public enum CategoriaDocumento
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhum = 0,
+
+    /// <summary>Documentos de identificação (RG, CIN, CPF, passaporte).</summary>
+    Identificacao = 1,
+
+    /// <summary>Documentos de escolaridade (histórico, certificado, diploma).</summary>
+    Escolaridade = 2,
+
+    /// <summary>Documentos de comprovação de renda.</summary>
+    Renda = 3,
+
+    /// <summary>Documentos de raça/etnia (autodeclaração PPI, declaração de liderança).</summary>
+    RacaEtnia = 4,
+
+    /// <summary>Documentos de saúde (laudo médico).</summary>
+    Saude = 5,
+
+    /// <summary>Documentos de comprovação de residência.</summary>
+    Residencia = 6,
+
+    /// <summary>Demais documentos não enquadrados nas categorias anteriores.</summary>
+    Outros = 7,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CategoriaDocumentos.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CategoriaDocumentos.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="CategoriaDocumento"/> (domínio, PascalCase) e o
+/// token textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// <para>O parsing é por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>):
+/// só os sete tokens canônicos são aceitos. Deliberadamente <b>não</b> usa
+/// <c>Enum.TryParse</c>, que aceitaria tokens numéricos (<c>"1"</c> → primeiro
+/// valor) e nomes PascalCase do enum — ambos fora do contrato textual da #591.</para>
+/// <para>É o vocabulário fonte do CHECK de domínio em <c>tipo_documento.categoria</c>
+/// (<see cref="TokensCanonicos"/>) e do value converter de persistência.</para>
+/// </remarks>
+public static class CategoriaDocumentos
+{
+    private static readonly Dictionary<CategoriaDocumento, string> ParaToken = new()
+    {
+        [CategoriaDocumento.Identificacao] = "IDENTIFICACAO",
+        [CategoriaDocumento.Escolaridade] = "ESCOLARIDADE",
+        [CategoriaDocumento.Renda] = "RENDA",
+        [CategoriaDocumento.RacaEtnia] = "RACA_ETNIA",
+        [CategoriaDocumento.Saude] = "SAUDE",
+        [CategoriaDocumento.Residencia] = "RESIDENCIA",
+        [CategoriaDocumento.Outros] = "OUTROS",
+    };
+
+    private static readonly Dictionary<string, CategoriaDocumento> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os sete tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de uma categoria válida.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="categoria"/> é <see cref="CategoriaDocumento.Nenhum"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(CategoriaDocumento categoria) =>
+        ParaToken.TryGetValue(categoria, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(categoria), categoria, "Categoria de documento fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) à categoria correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens numéricos ou fora do
+    /// domínio (allowlist). Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out CategoriaDocumento categoria)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out CategoriaDocumento resolvida))
+        {
+            categoria = resolvida;
+            return true;
+        }
+
+        categoria = CategoriaDocumento.Nenhum;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos sete tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/TipoDocumentoErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/TipoDocumentoErrorCodes.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+public static class TipoDocumentoErrorCodes
+{
+    public const string CodigoObrigatorio = "TipoDocumento.CodigoObrigatorio";
+    public const string CodigoTamanho = "TipoDocumento.CodigoTamanho";
+    public const string CodigoJaExiste = "TipoDocumento.CodigoJaExiste";
+    public const string NomeObrigatorio = "TipoDocumento.NomeObrigatorio";
+    public const string NomeTamanho = "TipoDocumento.NomeTamanho";
+    public const string DescricaoTamanho = "TipoDocumento.DescricaoTamanho";
+    public const string CategoriaInvalida = "TipoDocumento.CategoriaInvalida";
+    public const string FormatosAceitosTamanho = "TipoDocumento.FormatosAceitosTamanho";
+    public const string TamanhoMaximoInvalido = "TipoDocumento.TamanhoMaximoInvalido";
+    public const string TipoEquivalenteTamanho = "TipoDocumento.TipoEquivalenteTamanho";
+    public const string TipoEquivalenteIgualCodigo = "TipoDocumento.TipoEquivalenteIgualCodigo";
+    public const string NaoEncontrado = "TipoDocumento.NaoEncontrado";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITipoDocumentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITipoDocumentoRepository.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="TipoDocumento"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros
+/// soft-deleted via query filter por convenção.
+/// </summary>
+public interface ITipoDocumentoRepository
+{
+    /// <summary>Carrega o tipo de documento rastreado pelo contexto, para mutação.</summary>
+    Task<TipoDocumento?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega o tipo de documento para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<TipoDocumento?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista tipos de documento vivos paginados por cursor keyset bidirecional
+    /// (ADR-0026 + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve
+    /// as âncoras de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<TipoDocumento> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(TipoDocumento tipo, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca o tipo de documento para remoção; o <c>SoftDeleteInterceptor</c>
+    /// converte em soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(TipoDocumento tipo);
+
+    /// <summary>
+    /// Verifica se existe tipo de documento vivo com o <paramref name="codigo"/>
+    /// (case-sensitive, sobre o valor normalizado por <c>Trim</c>), excluindo
+    /// opcionalmente um <paramref name="excluirId"/> (para a checagem na atualização).
+    /// </summary>
+    Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -37,10 +37,12 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<ILocalOfertaRepository, LocalOfertaRepository>();
         services.AddScoped<IReferenciaReservaDemograficaRepository, ReferenciaReservaDemograficaRepository>();
         services.AddScoped<IPesoAreaEnemRepository, PesoAreaEnemRepository>();
+        services.AddScoped<ITipoDocumentoRepository, TipoDocumentoRepository>();
 
         // Readers cross-módulo (ADR-0056).
         services.AddScoped<IReferenciaReservaDemograficaReader, ReferenciaReservaDemograficaReader>();
         services.AddScoped<IPesoAreaEnemReader, PesoAreaEnemReader>();
+        services.AddScoped<ITipoDocumentoReader, TipoDocumentoReader>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -37,6 +37,8 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
 
     public DbSet<PesoAreaEnem> PesosAreaEnem => Set<PesoAreaEnem>();
 
+    public DbSet<TipoDocumento> TiposDocumento => Set<TipoDocumento>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/TipoDocumentoConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/TipoDocumentoConfiguration.cs
@@ -1,0 +1,85 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class TipoDocumentoConfiguration
+    : IEntityTypeConfiguration<TipoDocumento>
+{
+    private const int CodigoMaxLength = 60;
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+    private const int CategoriaMaxLength = 30;
+    private const int FormatosAceitosMaxLength = 200;
+    private const int TipoEquivalenteMaxLength = 60;
+
+    public void Configure(EntityTypeBuilder<TipoDocumento> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            "tipo_documento",
+            t =>
+            {
+                // Domínio fechado da categoria (sete tokens canônicos UPPER_SNAKE da #591).
+                t.HasCheckConstraint(
+                    "ck_tipo_documento_categoria",
+                    $"categoria IN ({string.Join(", ", CategoriaDocumentos.TokensCanonicos.Select(token => $"'{token}'"))})");
+
+                // Tipo equivalente é rótulo classificatório: nunca aponta para o próprio
+                // código. Null-safe (a coluna é opcional). Case-sensitive, alinhado ao
+                // guard de domínio (StringComparison.Ordinal).
+                t.HasCheckConstraint(
+                    "ck_tipo_documento_equivalente_diferente_codigo",
+                    "tipo_equivalente IS NULL OR tipo_equivalente <> codigo");
+
+                // Tamanho máximo (quando informado) é positivo — defesa em profundidade
+                // do invariante de domínio contra inserts crus (espelha a proteção
+                // numérica de peso_area_enem). Null-safe (a coluna é opcional).
+                t.HasCheckConstraint(
+                    "ck_tipo_documento_tamanho_maximo_mb_positivo",
+                    "tamanho_maximo_mb IS NULL OR tamanho_maximo_mb > 0");
+            });
+
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Codigo).HasMaxLength(CodigoMaxLength).IsRequired();
+        builder.Property(t => t.Nome).HasMaxLength(NomeMaxLength).IsRequired();
+        builder.Property(t => t.Descricao).HasMaxLength(DescricaoMaxLength);
+
+        // Categoria é enum persistido por valor como o token canônico UPPER_SNAKE via
+        // CategoriaDocumentoValueConverter (reidratação fail-fast). O CHECK acima
+        // restringe a coluna ao domínio fechado.
+        builder.Property(t => t.Categoria)
+            .HasConversion<CategoriaDocumentoValueConverter>()
+            .HasMaxLength(CategoriaMaxLength)
+            .IsRequired();
+
+        builder.Property(t => t.FormatosAceitos).HasMaxLength(FormatosAceitosMaxLength);
+        builder.Property(t => t.TamanhoMaximoMb);
+        builder.Property(t => t.TipoEquivalente).HasMaxLength(TipoEquivalenteMaxLength);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(t => t.CreatedBy).HasMaxLength(255);
+        builder.Property(t => t.UpdatedBy).HasMaxLength(255);
+
+        // Unicidade do código entre tipos vivos (índice parcial) — um tipo vivo por
+        // código; soft-delete libera o slot para recriação.
+        builder.HasIndex(t => t.Codigo)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_tipo_documento_codigo_vivo");
+
+        // Índice de filtro por categoria na interface administrativa.
+        builder.HasIndex(t => t.Categoria)
+            .HasDatabaseName("ix_tipo_documento_categoria");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CategoriaDocumentoValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CategoriaDocumentoValueConverter.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia CategoriaDocumento ↔ string (varchar) usando o token canônico UPPER_SNAKE
+// (RACA_ETNIA…), não o nome PascalCase do enum. O comprimento da coluna é definido
+// na própria propriedade via HasMaxLength no IEntityTypeConfiguration. A reidratação
+// falha explicitamente (com contexto) caso a coluna seja corrompida fora do fluxo da
+// aplicação, em vez de um valor de enum silenciosamente inválido.
+public sealed class CategoriaDocumentoValueConverter : ValueConverter<CategoriaDocumento, string>
+{
+    public CategoriaDocumentoValueConverter()
+        : base(
+            categoria => CategoriaDocumentos.ParaTokenCanonico(categoria),
+            token => Reidratar(token))
+    {
+    }
+
+    private static CategoriaDocumento Reidratar(string token)
+    {
+        if (!CategoriaDocumentos.TryAnalisar(token, out CategoriaDocumento categoria))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(CategoriaDocumento)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return categoria;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260630224239_AddTipoDocumento.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260630224239_AddTipoDocumento.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630224239_AddTipoDocumento")]
+    partial class AddTipoDocumento
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260630224239_AddTipoDocumento.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260630224239_AddTipoDocumento.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTipoDocumento : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tipo_documento",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    descricao = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    categoria = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    formatos_aceitos = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    tamanho_maximo_mb = table.Column<int>(type: "integer", nullable: true),
+                    tipo_equivalente = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_tipo_documento", x => x.id);
+                    table.CheckConstraint("ck_tipo_documento_categoria", "categoria IN ('IDENTIFICACAO', 'ESCOLARIDADE', 'RENDA', 'RACA_ETNIA', 'SAUDE', 'RESIDENCIA', 'OUTROS')");
+                    table.CheckConstraint("ck_tipo_documento_equivalente_diferente_codigo", "tipo_equivalente IS NULL OR tipo_equivalente <> codigo");
+                    table.CheckConstraint("ck_tipo_documento_tamanho_maximo_mb_positivo", "tamanho_maximo_mb IS NULL OR tamanho_maximo_mb > 0");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tipo_documento_categoria",
+                schema: "configuracao",
+                table: "tipo_documento",
+                column: "categoria");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tipo_documento_codigo_vivo",
+                schema: "configuracao",
+                table: "tipo_documento",
+                column: "codigo",
+                unique: true,
+                filter: "is_deleted = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tipo_documento",
+                schema: "configuracao");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TipoDocumentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TipoDocumentoRepository.cs
@@ -1,0 +1,79 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class TipoDocumentoRepository : ITipoDocumentoRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public TipoDocumentoRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<TipoDocumento?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.TiposDocumento
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+    }
+
+    public Task<TipoDocumento?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.TiposDocumento
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<TipoDocumento> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<TipoDocumento> page = await CursorKeyset
+            .ApplyAsync(_dbContext.TiposDocumento.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(TipoDocumento tipo, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(tipo);
+        await _dbContext.TiposDocumento.AddAsync(tipo, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(TipoDocumento tipo)
+    {
+        ArgumentNullException.ThrowIfNull(tipo);
+        _dbContext.TiposDocumento.Remove(tipo);
+    }
+
+    public Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        // Espelha a normalização do agregado (Trim) para casar com o valor persistido.
+        // Comparação case-sensitive (default do Postgres) — alinhada ao índice único.
+        string codigoNorm = codigo.Trim();
+
+        return _dbContext.TiposDocumento
+            .AsNoTracking()
+            .Where(t => excluirId == null || t.Id != excluirId)
+            .AnyAsync(t => t.Codigo == codigoNorm, cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/TipoDocumentoReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/TipoDocumentoReader.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="ITipoDocumentoReader"/> (ADR-0056): leitura direta
+/// do banco de Configuração (<c>AsNoTracking</c>, query filter de soft-delete por
+/// convenção). Sem cache — o cadastro é de baixo volume e baixa frequência de
+/// leitura viva; o congelamento por valor no consumidor (ADR-0061) dispensa
+/// releitura quente (mesmo padrão do <c>PesoAreaEnemReader</c>).
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class TipoDocumentoReader : ITipoDocumentoReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public TipoDocumentoReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<TipoDocumentoView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<TipoDocumento> entidades = await _dbContext.TiposDocumento
+            .AsNoTracking()
+            .OrderBy(t => t.Codigo)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<TipoDocumentoView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        TipoDocumento? entidade = await _dbContext.TiposDocumento
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static TipoDocumentoView ParaView(TipoDocumento t) =>
+        new(
+            t.Id,
+            t.Codigo,
+            t.Nome,
+            CategoriaDocumentos.ParaTokenCanonico(t.Categoria));
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarTipoDocumentoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarTipoDocumentoCommandHandlerTests.cs
@@ -1,0 +1,84 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarTipoDocumentoCommandHandlerTests
+{
+    private readonly ITipoDocumentoRepository _repository = Substitute.For<ITipoDocumentoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static TipoDocumento TipoExistente(string codigo = "CIN") =>
+        TipoDocumento.Criar(codigo, "Carteira de Identidade Nacional", null, "IDENTIFICACAO", null, null, null).Value!;
+
+    private static AtualizarTipoDocumentoCommand Comando(Guid id, string codigo = "CIN") =>
+        new(id, codigo, "Carteira de Identidade Nacional", "IDENTIFICACAO", "Documento unificado", "pdf", 5, null);
+
+    [Fact(DisplayName = "Tipo inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((TipoDocumento?)null);
+
+        Result resultado = await AtualizarTipoDocumentoCommandHandler.Handle(
+            Comando(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.NaoEncontrado);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um código que colide com outro tipo vivo retorna conflito (409)")]
+    public async Task Handle_CodigoColidente_RetornaConflito()
+    {
+        TipoDocumento existente = TipoExistente("CIN");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        // O novo código "RG" já pertence a outro tipo vivo.
+        _repository.CodigoExisteEntreVivosAsync("RG", existente.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result resultado = await AtualizarTipoDocumentoCommandHandler.Handle(
+            Comando(existente.Id, codigo: "RG"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.CodigoJaExiste);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um código distinto e livre é aceito e persiste")]
+    public async Task Handle_CodigoDistintoLivre_Aceita()
+    {
+        TipoDocumento existente = TipoExistente("CIN");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.CodigoExisteEntreVivosAsync("CIN_NOVO", existente.Id, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result resultado = await AtualizarTipoDocumentoCommandHandler.Handle(
+            Comando(existente.Id, codigo: "CIN_NOVO"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.Codigo.Should().Be("CIN_NOVO");
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar sem mudar o código não consulta a unicidade")]
+    public async Task Handle_CodigoInalterado_NaoChecaUnicidade()
+    {
+        TipoDocumento existente = TipoExistente("CIN");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarTipoDocumentoCommandHandler.Handle(
+            Comando(existente.Id, codigo: "CIN"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _repository.DidNotReceive()
+            .CodigoExisteEntreVivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarTipoDocumentoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarTipoDocumentoCommandHandlerTests.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarTipoDocumentoCommandHandlerTests
+{
+    private readonly ITipoDocumentoRepository _repository = Substitute.For<ITipoDocumentoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CriarTipoDocumentoCommand ComandoValido() =>
+        new("LAUDO_MEDICO", "Laudo médico", "SAUDE", "Documento de saúde", "pdf,jpg", 10, null);
+
+    [Fact(DisplayName = "Código livre cria o tipo, persiste e retorna o Id")]
+    public async Task Handle_CodigoLivre_CriaEPersiste()
+    {
+        _repository.CodigoExisteEntreVivosAsync("LAUDO_MEDICO", null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarTipoDocumentoCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<TipoDocumento>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Código já existente entre vivos retorna conflito (CodigoJaExiste) sem persistir")]
+    public async Task Handle_CodigoDuplicado_RetornaConflito()
+    {
+        _repository.CodigoExisteEntreVivosAsync("LAUDO_MEDICO", null, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarTipoDocumentoCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.CodigoJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<TipoDocumento>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Categoria inválida propaga o erro de domínio sem persistir")]
+    public async Task Handle_CategoriaInvalida_RetornaErroSemPersistir()
+    {
+        _repository.CodigoExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        CriarTipoDocumentoCommand comando = ComandoValido() with { Categoria = "FINANCEIRO" };
+
+        Result<Guid> resultado = await CriarTipoDocumentoCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.CategoriaInvalida);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverTipoDocumentoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverTipoDocumentoCommandHandlerTests.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverTipoDocumentoCommandHandlerTests
+{
+    private readonly ITipoDocumentoRepository _repository = Substitute.For<ITipoDocumentoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static TipoDocumento Tipo() =>
+        TipoDocumento.Criar("RG", "Registro Geral", null, "IDENTIFICACAO", null, null, null).Value!;
+
+    [Fact(DisplayName = "Remover um tipo existente faz soft-delete (Remover + Salvar) sem bloqueio")]
+    public async Task Handle_TipoExistente_FazSoftDelete()
+    {
+        TipoDocumento tipo = Tipo();
+        _repository.ObterPorIdAsync(tipo.Id, Arg.Any<CancellationToken>()).Returns(tipo);
+
+        Result resultado = await RemoverTipoDocumentoCommandHandler.Handle(
+            new RemoverTipoDocumentoCommand(tipo.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(tipo);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Remover um tipo inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((TipoDocumento?)null);
+
+        Result resultado = await RemoverTipoDocumentoCommandHandler.Handle(
+            new RemoverTipoDocumentoCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.NaoEncontrado);
+        _repository.DidNotReceive().Remover(Arg.Any<TipoDocumento>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/TipoDocumentoValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/TipoDocumentoValidatorTests.cs
@@ -1,0 +1,92 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDocumento;
+
+/// <summary>
+/// O validator antecipa a obrigatoriedade de código e nome, o domínio fechado da
+/// categoria, a positividade do tamanho máximo e o guard de auto-equivalência,
+/// mantendo a fronteira simétrica com o domínio (#591).
+/// </summary>
+public sealed class TipoDocumentoValidatorTests
+{
+    private readonly CriarTipoDocumentoCommandValidator _validator = new();
+
+    private static CriarTipoDocumentoCommand Base() =>
+        new("LAUDO_MEDICO", "Laudo médico", "SAUDE", "Documento de saúde", "pdf,jpg", 10, null);
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Comando sem campos opcionais passa no validator")]
+    public void SemOpcionais_Passa()
+    {
+        _validator.Validate(Base() with { Descricao = null, FormatosAceitos = null, TamanhoMaximoMb = null, TipoEquivalente = null })
+            .IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Código ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CodigoVazio_Rejeita(string codigo)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Codigo = codigo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoDocumentoCommand.Codigo));
+    }
+
+    [Fact(DisplayName = "Nome ausente é rejeitado")]
+    public void NomeVazio_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Nome = "  " });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoDocumentoCommand.Nome));
+    }
+
+    [Theory(DisplayName = "Categoria fora do domínio fechado é rejeitada (incl. numérico e PascalCase)")]
+    [InlineData("FINANCEIRO")]
+    [InlineData("1")]
+    [InlineData("Saude")]
+    public void CategoriaInvalida_Rejeita(string categoria)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Categoria = categoria });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoDocumentoCommand.Categoria));
+    }
+
+    [Theory(DisplayName = "Tamanho máximo zero ou negativo é rejeitado")]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void TamanhoMaximoNaoPositivo_Rejeita(int mb)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { TamanhoMaximoMb = mb });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoDocumentoCommand.TamanhoMaximoMb));
+    }
+
+    [Fact(DisplayName = "Tipo equivalente igual ao próprio código é rejeitado")]
+    public void EquivalenteIgualCodigo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(
+            Base() with { Codigo = "RG", Categoria = "IDENTIFICACAO", TipoEquivalente = "RG" });
+
+        resultado.IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Tipo equivalente apontando para outro código é aceito")]
+    public void EquivalenteOutroCodigo_Aceita()
+    {
+        _validator.Validate(Base() with { Codigo = "RG", Categoria = "IDENTIFICACAO", TipoEquivalente = "CIN" })
+            .IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TipoDocumentoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TipoDocumentoTests.cs
@@ -1,0 +1,145 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class TipoDocumentoTests
+{
+    private const string Codigo = "LAUDO_MEDICO";
+    private const string Nome = "Laudo médico";
+    private const string Categoria = "SAUDE";
+
+    private static Result<TipoDocumento> Criar(
+        string codigo = Codigo,
+        string nome = Nome,
+        string? descricao = null,
+        string categoria = Categoria,
+        string? formatosAceitos = "pdf,jpg",
+        int? tamanhoMaximoMb = 10,
+        string? tipoEquivalente = null) =>
+        TipoDocumento.Criar(codigo, nome, descricao, categoria, formatosAceitos, tamanhoMaximoMb, tipoEquivalente);
+
+    [Fact(DisplayName = "Criar com dados válidos preenche os campos e fica ativo com Guid v7")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        TipoDocumento tipo = Criar(descricao: "Laudo emitido por profissional de saúde").Value!;
+
+        tipo.Id.Should().NotBe(Guid.Empty);
+        tipo.Codigo.Should().Be(Codigo);
+        tipo.Nome.Should().Be(Nome);
+        tipo.Descricao.Should().Be("Laudo emitido por profissional de saúde");
+        tipo.Categoria.Should().Be(CategoriaDocumento.Saude);
+        tipo.FormatosAceitos.Should().Be("pdf,jpg");
+        tipo.TamanhoMaximoMb.Should().Be(10);
+        tipo.TipoEquivalente.Should().BeNull();
+        tipo.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar sem campos opcionais (descrição, formatos, tamanho, equivalente) é aceito")]
+    public void Criar_SemOpcionais_Aceita()
+    {
+        TipoDocumento tipo = Criar(descricao: null, formatosAceitos: null, tamanhoMaximoMb: null, tipoEquivalente: null).Value!;
+
+        tipo.Descricao.Should().BeNull();
+        tipo.FormatosAceitos.Should().BeNull();
+        tipo.TamanhoMaximoMb.Should().BeNull();
+        tipo.TipoEquivalente.Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Código ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemCodigo_Falha(string codigo)
+    {
+        Result<TipoDocumento> resultado = Criar(codigo: codigo);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.CodigoObrigatorio);
+    }
+
+    [Fact(DisplayName = "Código acima do tamanho máximo é rejeitado")]
+    public void Criar_CodigoLongo_Falha()
+    {
+        Result<TipoDocumento> resultado = Criar(codigo: new string('A', 61));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.CodigoTamanho);
+    }
+
+    [Theory(DisplayName = "Nome ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemNome_Falha(string nome)
+    {
+        Result<TipoDocumento> resultado = Criar(nome: nome);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.NomeObrigatorio);
+    }
+
+    [Theory(DisplayName = "Categoria fora do domínio fechado é rejeitada (incl. numérico e PascalCase)")]
+    [InlineData("FINANCEIRO")]
+    [InlineData("1")]
+    [InlineData("Saude")]
+    [InlineData("")]
+    public void Criar_CategoriaInvalida_Falha(string categoria)
+    {
+        Result<TipoDocumento> resultado = Criar(categoria: categoria);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.CategoriaInvalida);
+    }
+
+    [Theory(DisplayName = "Tamanho máximo zero ou negativo é rejeitado; positivo e nulo são aceitos")]
+    [InlineData(0, false)]
+    [InlineData(-5, false)]
+    [InlineData(10, true)]
+    [InlineData(null, true)]
+    public void Criar_TamanhoMaximo_ValidaPositividade(int? mb, bool deveAceitar)
+    {
+        Result<TipoDocumento> resultado = Criar(tamanhoMaximoMb: mb);
+
+        resultado.IsSuccess.Should().Be(deveAceitar);
+        if (!deveAceitar)
+        {
+            resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.TamanhoMaximoInvalido);
+        }
+    }
+
+    [Fact(DisplayName = "Tipo equivalente igual ao próprio código é rejeitado")]
+    public void Criar_EquivalenteIgualCodigo_Falha()
+    {
+        Result<TipoDocumento> resultado = Criar(codigo: "RG", tipoEquivalente: "RG");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDocumentoErrorCodes.TipoEquivalenteIgualCodigo);
+    }
+
+    [Fact(DisplayName = "Tipo equivalente apontando para outro código é aceito como rótulo classificatório")]
+    public void Criar_EquivalenteOutroCodigo_Aceita()
+    {
+        TipoDocumento tipo = Criar(codigo: "RG", categoria: "IDENTIFICACAO", tipoEquivalente: "CIN").Value!;
+
+        tipo.TipoEquivalente.Should().Be("CIN");
+    }
+
+    [Fact(DisplayName = "Atualizar troca os atributos editáveis, inclusive o código (editável)")]
+    public void Atualizar_AlteraAtributos_InclusiveCodigo()
+    {
+        TipoDocumento tipo = Criar(codigo: "CIN", categoria: "IDENTIFICACAO").Value!;
+        Guid idOriginal = tipo.Id;
+
+        Result resultado = tipo.Atualizar(
+            "CIN_NOVO", "Carteira de Identidade Nacional", "Documento unificado", "IDENTIFICACAO", "pdf", 5, null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        tipo.Codigo.Should().Be("CIN_NOVO");
+        tipo.Nome.Should().Be("Carteira de Identidade Nacional");
+        tipo.Categoria.Should().Be(CategoriaDocumento.Identificacao);
+        tipo.Id.Should().Be(idOriginal, "o Id é imutável mesmo com o código editável");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/CategoriaDocumentosTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/CategoriaDocumentosTests.cs
@@ -1,0 +1,82 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Enums;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// O parsing da categoria é por allowlist textual explícita (#591): só os sete
+/// tokens canônicos UPPER_SNAKE são aceitos. Tokens numéricos e nomes PascalCase
+/// do enum são rejeitados — o que <c>Enum.TryParse</c> aceitaria por engano.
+/// </summary>
+public sealed class CategoriaDocumentosTests
+{
+    [Theory(DisplayName = "Os sete tokens canônicos são analisados para a categoria correta")]
+    [InlineData("IDENTIFICACAO", CategoriaDocumento.Identificacao)]
+    [InlineData("ESCOLARIDADE", CategoriaDocumento.Escolaridade)]
+    [InlineData("RENDA", CategoriaDocumento.Renda)]
+    [InlineData("RACA_ETNIA", CategoriaDocumento.RacaEtnia)]
+    [InlineData("SAUDE", CategoriaDocumento.Saude)]
+    [InlineData("RESIDENCIA", CategoriaDocumento.Residencia)]
+    [InlineData("OUTROS", CategoriaDocumento.Outros)]
+    public void TryAnalisar_TokenCanonico_Resolve(string token, CategoriaDocumento esperada)
+    {
+        CategoriaDocumentos.TryAnalisar(token, out CategoriaDocumento categoria).Should().BeTrue();
+        categoria.Should().Be(esperada);
+    }
+
+    [Fact(DisplayName = "Token com espaços é normalizado por Trim antes da resolução")]
+    public void TryAnalisar_ComEspacos_Normaliza()
+    {
+        CategoriaDocumentos.TryAnalisar("  SAUDE  ", out CategoriaDocumento categoria).Should().BeTrue();
+        categoria.Should().Be(CategoriaDocumento.Saude);
+    }
+
+    [Theory(DisplayName = "Tokens numéricos, PascalCase, fora do domínio e vazios são rejeitados")]
+    [InlineData("1")]               // numérico — Enum.TryParse aceitaria; a allowlist não
+    [InlineData("4")]
+    [InlineData("Identificacao")]   // PascalCase do enum — não é o token de contrato
+    [InlineData("Saude")]
+    [InlineData("FINANCEIRO")]      // fora do domínio fechado
+    [InlineData("identificacao")]   // case-sensitive
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryAnalisar_ForaDoDominio_Rejeita(string token)
+    {
+        CategoriaDocumentos.TryAnalisar(token, out CategoriaDocumento categoria).Should().BeFalse();
+        categoria.Should().Be(CategoriaDocumento.Nenhum);
+        CategoriaDocumentos.EhValido(token).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Token nulo é rejeitado sem lançar")]
+    public void TryAnalisar_Nulo_Rejeita()
+    {
+        CategoriaDocumentos.TryAnalisar(null, out CategoriaDocumento categoria).Should().BeFalse();
+        categoria.Should().Be(CategoriaDocumento.Nenhum);
+    }
+
+    [Theory(DisplayName = "ParaTokenCanonico é o inverso de TryAnalisar (round-trip)")]
+    [InlineData(CategoriaDocumento.Identificacao, "IDENTIFICACAO")]
+    [InlineData(CategoriaDocumento.RacaEtnia, "RACA_ETNIA")]
+    [InlineData(CategoriaDocumento.Outros, "OUTROS")]
+    public void ParaTokenCanonico_RoundTrip(CategoriaDocumento categoria, string token)
+    {
+        CategoriaDocumentos.ParaTokenCanonico(categoria).Should().Be(token);
+        CategoriaDocumentos.TryAnalisar(token, out CategoriaDocumento resolvida).Should().BeTrue();
+        resolvida.Should().Be(categoria);
+    }
+
+    [Fact(DisplayName = "ParaTokenCanonico de Nenhum (sentinela) lança — não é categoria válida")]
+    public void ParaTokenCanonico_Nenhum_Lanca()
+    {
+        Action act = () => CategoriaDocumentos.ParaTokenCanonico(CategoriaDocumento.Nenhum);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact(DisplayName = "TokensCanonicos lista exatamente os sete valores de domínio")]
+    public void TokensCanonicos_TemSeteValores()
+    {
+        CategoriaDocumentos.TokensCanonicos.Should().HaveCount(7)
+            .And.Contain(["IDENTIFICACAO", "ESCOLARIDADE", "RENDA", "RACA_ETNIA", "SAUDE", "RESIDENCIA", "OUTROS"]);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposDocumento/TipoDocumentoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposDocumento/TipoDocumentoEndpointTests.cs
@@ -1,0 +1,198 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.TiposDocumento;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>TipoDocumento</c> (UNI-REQ-0013):
+/// routing, vendor media type, HATEOAS, autenticação/autorização, idempotência,
+/// domínio fechado da categoria (422), unicidade do código (409) e contrato
+/// classificatório puro (sem regra material) — com Wolverine contra Postgres efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class TipoDocumentoEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public TipoDocumentoEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/tipos-documento retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/tipos-documento", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.tipo-documento.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/tipos-documento/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/tipos-documento/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/configuracao/admin/tipos-documento sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-documento", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        var body = new { codigo = CodigoUnico(), nome = "Sem permissão", categoria = "OUTROS" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-documento", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a policy [Authorize(Roles = \"plataforma-admin\")] nega um principal autenticado sem o role");
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-documento", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST cria (201) e o GET subsequente retorna os campos classificatórios + HATEOAS")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        string codigo = CodigoUnico();
+        var body = new
+        {
+            codigo,
+            nome = "Laudo médico",
+            categoria = "SAUDE",
+            descricao = "Documento de saúde",
+            formatosAceitos = "pdf,jpg",
+            tamanhoMaximoMb = 10,
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/tipos-documento/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("codigo").GetString().Should().Be(codigo);
+        root.GetProperty("nome").GetString().Should().Be("Laudo médico");
+        root.GetProperty("categoria").GetString().Should().Be("SAUDE");
+        root.GetProperty("tamanhoMaximoMb").GetInt32().Should().Be(10);
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "Contrato classificatório puro: o recurso não expõe nenhuma regra material (validade/assinatura/lideranças)")]
+    public async Task Criar_RecursoNaoExpoeRegraMaterial()
+    {
+        var body = new { codigo = CodigoUnico(), nome = "Comprovante de residência", categoria = "RESIDENCIA" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/tipos-documento/{id}", UriKind.Relative));
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+
+        // A separação central da #591: o tipo diz "o que um documento é", nunca uma
+        // regra material (essas vivem na exigência do edital ou na homologação).
+        string[] propriedadesMateriaisProibidas =
+            ["validade", "validadeMeses", "idadeMaximaMeses", "exigeAssinatura", "exigeAssinaturaDigital",
+             "numeroAssinaturas", "lideranças", "lideranca", "aplicabilidade", "consequenciaIndeferimento"];
+        foreach (string proibida in propriedadesMateriaisProibidas)
+        {
+            doc.RootElement.TryGetProperty(proibida, out _)
+                .Should().BeFalse($"o tipo de documento é classificatório puro e não deve expor '{proibida}'");
+        }
+    }
+
+    [Fact(DisplayName = "POST com categoria fora do domínio fechado retorna 422")]
+    public async Task Criar_CategoriaInvalida_Retorna422()
+    {
+        var body = new { codigo = CodigoUnico(), nome = "Categoria inválida", categoria = "FINANCEIRO" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com código já existente entre vivos retorna 409")]
+    public async Task Criar_CodigoDuplicado_Retorna409()
+    {
+        string codigo = CodigoUnico();
+        var body = new { codigo, nome = "Primeiro", categoria = "OUTROS" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage primeiro = await EnviarPostAdmin(client, body);
+        primeiro.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage segundo = await EnviarPostAdmin(client, new { codigo, nome = "Segundo", categoria = "OUTROS" });
+        segundo.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    private static string CodigoUnico() => $"DOC_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-documento", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposDocumento/TipoDocumentoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposDocumento/TipoDocumentoPersistenceTests.cs
@@ -1,0 +1,239 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.TiposDocumento;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta do TipoDocumento contra Postgres real (UNI-REQ-0013):
+/// persistência, UNIQUE parcial do código vivo, liberação do slot por soft-delete,
+/// CHECKs de domínio (categoria) e de auto-equivalência, não-bloqueio de remoção de
+/// um tipo apontado como equivalente, e leitura cross-módulo (CA-01, CA-02, CA-04).
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class TipoDocumentoPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public TipoDocumentoPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "CA-01: criar persiste os campos e fica visível pelo leitor cross-módulo")]
+    public async Task Insert_PersisteEFicaVisivelPeloReader()
+    {
+        string codigo = CodigoUnico();
+        TipoDocumento tipo = Novo(codigo, categoria: "SAUDE");
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposDocumento.Add(tipo);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        TipoDocumento persistido = await readCtx.TiposDocumento.SingleAsync(t => t.Id == tipo.Id);
+
+        persistido.Codigo.Should().Be(codigo);
+        persistido.Nome.Should().Be("Laudo médico");
+        persistido.Categoria.Should().Be(Domain.Enums.CategoriaDocumento.Saude);
+        persistido.CreatedBy.Should().Be(AdminA);
+        persistido.IsDeleted.Should().BeFalse();
+
+        var reader = new TipoDocumentoReader(readCtx);
+        TipoDocumentoView? view = await reader.ObterPorIdAsync(tipo.Id);
+        view.Should().NotBeNull();
+        view!.Codigo.Should().Be(codigo);
+        view.Categoria.Should().Be("SAUDE");
+    }
+
+    [Fact(DisplayName = "CA-02: UNIQUE parcial do código rejeita segundo tipo vivo com mesmo código")]
+    public async Task UniquePartial_Codigo_RejeitaDuplicataAtiva()
+    {
+        string codigo = CodigoUnico();
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposDocumento.Add(Novo(codigo));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.TiposDocumento.Add(Novo(codigo));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        // Trava as constantes que o handler usa para traduzir a corrida concorrente
+        // (UniqueConstraintViolation.GetViolatedConstraint/IsCodigoConflict) em
+        // CodigoJaExiste/409: SqlState 23505 + nome do índice único parcial.
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_tipo_documento_codigo_vivo");
+    }
+
+    [Fact(DisplayName = "Código distinto é aceito")]
+    public async Task CodigoDistinto_Aceita()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.TiposDocumento.Add(Novo(CodigoUnico()));
+        ctx.TiposDocumento.Add(Novo(CodigoUnico()));
+
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().NotThrowAsync("os códigos são distintos");
+    }
+
+    [Fact(DisplayName = "CA-04: soft-delete preserva a trilha e libera o slot da UNIQUE parcial do código")]
+    public async Task SoftDelete_PreservaTrilhaELibertaSlot()
+    {
+        string codigo = CodigoUnico();
+        TipoDocumento tipo = Novo(codigo);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposDocumento.Add(tipo);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            TipoDocumento tracked = await ctx.TiposDocumento.SingleAsync(t => t.Id == tipo.Id);
+            ctx.TiposDocumento.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            TipoDocumento excluido = await ctx.TiposDocumento
+                .IgnoreQueryFilters().SingleAsync(t => t.Id == tipo.Id);
+            excluido.IsDeleted.Should().BeTrue();
+            excluido.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.TiposDocumento.Add(Novo(codigo));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do código foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "CA-04: remover um tipo apontado como equivalente por outro vivo NÃO é bloqueado")]
+    public async Task SoftDelete_TipoApontadoComoEquivalente_NaoBloqueia()
+    {
+        string codigoCin = CodigoUnico();
+        string codigoRg = CodigoUnico();
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            // CIN existe; RG aponta CIN como equivalente (rótulo classificatório, sem FK).
+            ctx.TiposDocumento.Add(Novo(codigoCin, categoria: "IDENTIFICACAO"));
+            ctx.TiposDocumento.Add(Novo(codigoRg, categoria: "IDENTIFICACAO", tipoEquivalente: codigoCin));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            TipoDocumento cin = await ctx.TiposDocumento.SingleAsync(t => t.Codigo == codigoCin);
+            ctx.TiposDocumento.Remove(cin);
+            Func<Task> act = async () => await ctx.SaveChangesAsync();
+            await act.Should().NotThrowAsync("tipo_equivalente é rótulo, não FK — a remoção não é bloqueada");
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        TipoDocumento rg = await readCtx.TiposDocumento.SingleAsync(t => t.Codigo == codigoRg);
+        rg.TipoEquivalente.Should().Be(codigoCin, "o rótulo permanece, agora apontando para um código sem alvo vivo");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita categoria fora do domínio via SQL cru")]
+    public async Task Check_RejeitaCategoriaForaDoDominioViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.tipo_documento (id, codigo, nome, categoria, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"FINANCEIRO"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de domínio de categoria impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita tipo_equivalente igual ao código via SQL cru")]
+    public async Task Check_RejeitaEquivalenteIgualCodigoViaSqlCru()
+    {
+        string codigo = CodigoUnico();
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.tipo_documento (id, codigo, nome, categoria, tipo_equivalente, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {codigo}, {"X"}, {"OUTROS"}, {codigo}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK tipo_equivalente <> codigo impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita tamanho_maximo_mb não-positivo via SQL cru")]
+    public async Task Check_RejeitaTamanhoMaximoNaoPositivoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.tipo_documento (id, codigo, nome, categoria, tamanho_maximo_mb, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"OUTROS"}, {0}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK tamanho_maximo_mb > 0 impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "Reader.ListarVivosAsync ordena por código e exclui soft-deleted")]
+    public async Task ListarVivos_OrdenaPorCodigoEExcluiSoftDeleted()
+    {
+        string prefixo = $"DOC_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+        string codA = $"{prefixo}_A";
+        string codB = $"{prefixo}_B";
+        string codExcluido = $"{prefixo}_D";
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposDocumento.Add(Novo(codB));
+            ctx.TiposDocumento.Add(Novo(codA));
+            ctx.TiposDocumento.Add(Novo(codExcluido));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            TipoDocumento aExcluir = await ctx.TiposDocumento.SingleAsync(t => t.Codigo == codExcluido);
+            ctx.TiposDocumento.Remove(aExcluir);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new TipoDocumentoReader(readCtx);
+        IReadOnlyList<TipoDocumentoView> todos = await reader.ListarVivosAsync();
+
+        string[] meus = [.. todos
+            .Select(v => v.Codigo)
+            .Where(c => c.StartsWith(prefixo, StringComparison.Ordinal))];
+
+        meus.Should().Equal([codA, codB]);
+    }
+
+    private static TipoDocumento Novo(
+        string codigo,
+        string categoria = "SAUDE",
+        string? tipoEquivalente = null) =>
+        TipoDocumento.Criar(codigo, "Laudo médico", null, categoria, "pdf,jpg", 10, tipoEquivalente).Value!;
+
+    private static string CodigoUnico() => $"DOC_{Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
+}


### PR DESCRIPTION
## Contexto

Entrega a entidade **`TipoDocumento`** e seu CRUD administrativo no módulo de Configuração (UNI-REQ-0013, story #591). É um cadastro **classificatório puro**: diz *o que um documento é* (RG, laudo médico, autodeclaração PPI…), nunca uma regra material sobre ele — validade, assinatura e lideranças vivem na exigência documental do edital ou na homologação (ADR-0072).

Sexto cadastro do módulo (após Campus/LocalOferta #587, Reserva demográfica #593, Pesos ENEM #594) — espelha fielmente o padrão estabelecido: Clean Arch + Wolverine (`static` handler → `Result`), EF Core, FluentValidation, cursor bidirecional (ADR-0089), HATEOAS Level 1 (ADR-0029), soft-delete + auditoria.

## O que foi entregue

- **Domínio:** `TipoDocumento` (sealed + factory), enum `CategoriaDocumento` (7 valores) + helper de parsing por allowlist, `TipoDocumentoErrorCodes`, `ITipoDocumentoRepository`.
- **Aplicação:** Criar/Atualizar/Remover (command + handler + validator) · Listar (cursor) + ObterPorId · DTO + Mapping.
- **Contrato cross-módulo (ADR-0056):** `ITipoDocumentoReader` + `TipoDocumentoView` (Id, Código, Nome, Categoria) — o que a exigência documental de Seleção congela por snapshot-copy.
- **Infra:** `TipoDocumentoConfiguration` (índice único parcial + 3 CHECKs), `TipoDocumentoRepository`, `TipoDocumentoReader`, `CategoriaDocumentoValueConverter`, migration forward-only, DbSet + DI.
- **API:** `TiposDocumentoController` (GET público; POST/PUT/DELETE admin `plataforma-admin` + Idempotency-Key), HATEOAS builder, mapeamentos de erro→HTTP.

## Decisões de design

| Tema | Decisão |
|---|---|
| Categoria | enum de domínio fechado persistido como token canônico `UPPER_SNAKE` via value converter; parsing por **allowlist textual explícita**, que rejeita tokens numéricos e nomes PascalCase (`Enum.TryParse` os aceitaria por engano). |
| Código | **editável** (diferente da Modalidade #589), único entre vivos por índice parcial `WHERE is_deleted=false`; corrida check-then-act traduzida em 409 via `UniqueConstraintViolation`. Comparações case-sensitive (Ordinal) alinhadas ao banco. |
| Tipo equivalente | rótulo classificatório por código (sem FK); único guarda é `tipo_equivalente <> codigo` (CHECK null-safe). Remover um tipo apontado como equivalente **não** é bloqueado — o rótulo fica órfão (CA-04). |
| Remoção | soft-delete, **nunca bloqueada**: consumo cross-módulo é snapshot-copy desacoplado (ADR-0061). Reader read-side **sem cache**, espelhando `PesoAreaEnemReader`. |
| CHECKs de banco | domínio da categoria, auto-equivalência e **positividade de `tamanho_maximo_mb`** (defesa em profundidade, espelha `peso_area_enem`). |
| DELETE | sem `Idempotency-Key`, **seguindo o padrão dos demais cadastros do módulo** (Campus/LocalOferta/Pesos/Reserva). |

## Critérios de aceite

- **CA-01** criação válida com Guid v7 ✓ · **CA-02** unicidade de código (criação e atualização) ✓ · **CA-03** categoria fora do domínio / auto-equivalência / tamanho não-positivo rejeitados ✓ · **CA-04** soft-delete + não-bloqueio por rótulo equivalente ✓
- **CA-05 (a11y)** e **CA-06 (LGPD inaplicável)**: a11y é frontend; o cadastro não carrega PII.

## Testes

Suíte completa do módulo verde, sem warnings: **Domain 108 · Application 92 · Integração 80** (1 skip pré-existente da #731). Inclui teste de contrato confirmando que o recurso **não expõe nenhuma regra material**, testes dos 3 CHECKs via SQL cru, índice único parcial e leitura cross-módulo. Baseline OpenAPI regenerado.

## Revisão prévia

Plano e diff revisados localmente com Codex (Fase 6 e 9). Achados incorporados: allowlist textual para categoria, alinhamento Ordinal domínio↔banco, tratamento de corrida, reader sem cache, teste "sem regra material", CHECK de `tamanho_maximo_mb`.

Closes #591
Refs #584