### PR TITLE
feat(configuracao): adiciona cadastros de atendimento especializado

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -642,6 +642,486 @@
         }
       }
     },
+    "/api/configuracao/condicoes-atendimento": {
+      "get": {
+        "tags": [
+          "CondicoesAtendimento"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CondicaoAtendimentoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CondicaoAtendimentoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CondicaoAtendimentoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/condicoes-atendimento/{id}": {
+      "get": {
+        "tags": [
+          "CondicoesAtendimento"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CondicaoAtendimentoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CondicaoAtendimentoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CondicaoAtendimentoDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/condicoes-atendimento": {
+      "post": {
+        "tags": [
+          "CondicoesAtendimento"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCondicaoAtendimentoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCondicaoAtendimentoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCondicaoAtendimentoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/condicoes-atendimento/{id}": {
+      "put": {
+        "tags": [
+          "CondicoesAtendimento"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarCondicaoAtendimentoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarCondicaoAtendimentoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarCondicaoAtendimentoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "CondicoesAtendimento"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configuracao/locais-oferta": {
       "get": {
         "tags": [
@@ -1562,6 +2042,476 @@
         }
       }
     },
+    "/api/configuracao/recursos-acessibilidade": {
+      "get": {
+        "tags": [
+          "RecursosAcessibilidade"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RecursoAcessibilidadeDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RecursoAcessibilidadeDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RecursoAcessibilidadeDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/recursos-acessibilidade/{id}": {
+      "get": {
+        "tags": [
+          "RecursosAcessibilidade"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecursoAcessibilidadeDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecursoAcessibilidadeDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecursoAcessibilidadeDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/recursos-acessibilidade": {
+      "post": {
+        "tags": [
+          "RecursosAcessibilidade"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarRecursoAcessibilidadeCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarRecursoAcessibilidadeCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarRecursoAcessibilidadeCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/recursos-acessibilidade/{id}": {
+      "put": {
+        "tags": [
+          "RecursosAcessibilidade"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarRecursoAcessibilidadeCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarRecursoAcessibilidadeCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarRecursoAcessibilidadeCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "RecursosAcessibilidade"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configuracao/referencias-reserva-demografica": {
       "get": {
         "tags": [
@@ -1983,6 +2933,476 @@
       "delete": {
         "tags": [
           "ReferenciasReservaDemografica"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/tipos-deficiencia": {
+      "get": {
+        "tags": [
+          "TiposDeficiencia"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoDeficienciaDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoDeficienciaDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoDeficienciaDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/tipos-deficiencia/{id}": {
+      "get": {
+        "tags": [
+          "TiposDeficiencia"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoDeficienciaDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoDeficienciaDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoDeficienciaDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/tipos-deficiencia": {
+      "post": {
+        "tags": [
+          "TiposDeficiencia"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoDeficienciaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoDeficienciaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoDeficienciaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/tipos-deficiencia/{id}": {
+      "put": {
+        "tags": [
+          "TiposDeficiencia"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoDeficienciaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoDeficienciaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoDeficienciaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "TiposDeficiencia"
         ],
         "parameters": [
           {
@@ -2555,6 +3975,32 @@
           }
         }
       },
+      "AtualizarCondicaoAtendimentoCommand": {
+        "required": [
+          "id",
+          "codigo",
+          "nome"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "AtualizarLocalOfertaCommand": {
         "required": [
           "id",
@@ -2679,6 +4125,28 @@
           }
         }
       },
+      "AtualizarRecursoAcessibilidadeCommand": {
+        "required": [
+          "id",
+          "nome"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "AtualizarReferenciaReservaDemograficaCommand": {
         "required": [
           "id",
@@ -2723,6 +4191,28 @@
           },
           "baseLegal": {
             "type": "string"
+          }
+        }
+      },
+      "AtualizarTipoDeficienciaCommand": {
+        "required": [
+          "id",
+          "nome"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -2933,6 +4423,47 @@
           }
         }
       },
+      "CondicaoAtendimentoDto": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "descricao",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "CriarCampusCommand": {
         "required": [
           "sigla",
@@ -2971,6 +4502,27 @@
             ]
           },
           "codigoEmec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "CriarCondicaoAtendimentoCommand": {
+        "required": [
+          "codigo",
+          "nome"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
             "type": [
               "null",
               "string"
@@ -3100,6 +4652,23 @@
           }
         }
       },
+      "CriarRecursoAcessibilidadeCommand": {
+        "required": [
+          "nome"
+        ],
+        "type": "object",
+        "properties": {
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "CriarReferenciaReservaDemograficaCommand": {
         "required": [
           "censoReferencia",
@@ -3139,6 +4708,23 @@
           },
           "baseLegal": {
             "type": "string"
+          }
+        }
+      },
+      "CriarTipoDeficienciaCommand": {
+        "required": [
+          "nome"
+        ],
+        "type": "object",
+        "properties": {
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -3562,6 +5148,43 @@
           }
         }
       },
+      "RecursoAcessibilidadeDto": {
+        "required": [
+          "id",
+          "nome",
+          "descricao",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "ReferenciaReservaDemograficaDto": {
         "required": [
           "id",
@@ -3607,6 +5230,43 @@
           },
           "baseLegal": {
             "type": "string"
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TipoDeficienciaDto": {
+        "required": [
+          "id",
+          "nome",
+          "descricao",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "criadoEm": {
             "type": "string",
@@ -3776,13 +5436,22 @@
       "name": "Campi"
     },
     {
+      "name": "CondicoesAtendimento"
+    },
+    {
       "name": "LocaisOferta"
     },
     {
       "name": "PesosAreaEnem"
     },
     {
+      "name": "RecursosAcessibilidade"
+    },
+    {
       "name": "ReferenciasReservaDemografica"
+    },
+    {
+      "name": "TiposDeficiencia"
     },
     {
       "name": "TiposDocumento"

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
@@ -51,6 +51,9 @@ public static class ConfiguracaoModuleRegistration
         services.AddSingleton<IResourceLinksBuilder<ReferenciaReservaDemograficaDto>, ReferenciaReservaDemograficaLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<PesoAreaEnemDto>, PesoAreaEnemLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<TipoDocumentoDto>, TipoDocumentoLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<CondicaoAtendimentoDto>, CondicaoAtendimentoLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<RecursoAcessibilidadeDto>, RecursoAcessibilidadeLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<TipoDeficienciaDto>, TipoDeficienciaLinksBuilder>();
 
         // Idempotency-Key (ADR-0027) sobre o DbContext do módulo.
         services.AddIdempotency<ConfiguracaoDbContext, ConfiguracaoApiAssemblyMarker>(configuration);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CondicoesAtendimentoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CondicoesAtendimentoController.cs
@@ -1,0 +1,187 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.CondicoesAtendimento;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/condicoes-atendimento</c>,
+/// <c>GET /api/configuracao/condicoes-atendimento/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/configuracao/admin/condicoes-atendimento</c>) restritos
+/// a <c>plataforma-admin</c> (UNI-REQ-0012).
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class CondicoesAtendimentoController : ControllerBase
+{
+    private const string ResourceTag = "condicoes-atendimento";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<CondicaoAtendimentoDto> _linksBuilder;
+
+    public CondicoesAtendimentoController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<CondicaoAtendimentoDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista as condições de atendimento especializado ativas, paginadas por cursor
+    /// opaco bidirecional (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>;
+    /// cada item carrega seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("condicoes-atendimento")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "condicao-atendimento", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<CondicaoAtendimentoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarCondicoesAtendimentoResult resultado = await _queryBus
+            .Send(new ListarCondicoesAtendimentoQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        CondicaoAtendimentoDto[] comLinks =
+            [.. resultado.Items.Select(c => c with { Links = _linksBuilder.Build(c) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém uma condição pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("condicoes-atendimento/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "condicao-atendimento", Versions = [1])]
+    [ProducesResponseType(typeof(CondicaoAtendimentoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        CondicaoAtendimentoDto? condicao = await _queryBus
+            .Send(new ObterCondicaoAtendimentoPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (condicao is null)
+        {
+            return NotFound();
+        }
+
+        CondicaoAtendimentoDto comLinks = condicao with { Links = _linksBuilder.Build(condicao) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria uma nova condição. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/condicoes-atendimento")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarCondicaoAtendimentoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza uma condição existente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/condicoes-atendimento/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarCondicaoAtendimentoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) uma condição. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/condicoes-atendimento/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverCondicaoAtendimentoCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/RecursosAcessibilidadeController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/RecursosAcessibilidadeController.cs
@@ -1,0 +1,186 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.RecursosAcessibilidade;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/recursos-acessibilidade</c>,
+/// <c>GET /api/configuracao/recursos-acessibilidade/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/configuracao/admin/recursos-acessibilidade</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ-0012).
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class RecursosAcessibilidadeController : ControllerBase
+{
+    private const string ResourceTag = "recursos-acessibilidade";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<RecursoAcessibilidadeDto> _linksBuilder;
+
+    public RecursosAcessibilidadeController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<RecursoAcessibilidadeDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista os recursos de acessibilidade ativos, paginados por cursor opaco
+    /// bidirecional (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada
+    /// item carrega seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("recursos-acessibilidade")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "recurso-acessibilidade", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<RecursoAcessibilidadeDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarRecursosAcessibilidadeResult resultado = await _queryBus
+            .Send(new ListarRecursosAcessibilidadeQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        RecursoAcessibilidadeDto[] comLinks =
+            [.. resultado.Items.Select(r => r with { Links = _linksBuilder.Build(r) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém um recurso de acessibilidade pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("recursos-acessibilidade/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "recurso-acessibilidade", Versions = [1])]
+    [ProducesResponseType(typeof(RecursoAcessibilidadeDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        RecursoAcessibilidadeDto? recurso = await _queryBus
+            .Send(new ObterRecursoAcessibilidadePorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (recurso is null)
+        {
+            return NotFound();
+        }
+
+        RecursoAcessibilidadeDto comLinks = recurso with { Links = _linksBuilder.Build(recurso) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria um novo recurso de acessibilidade. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/recursos-acessibilidade")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarRecursoAcessibilidadeCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza um recurso de acessibilidade existente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/recursos-acessibilidade/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarRecursoAcessibilidadeCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) um recurso de acessibilidade. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/recursos-acessibilidade/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverRecursoAcessibilidadeCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposDeficienciaController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposDeficienciaController.cs
@@ -1,0 +1,186 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDeficiencia;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/tipos-deficiencia</c>,
+/// <c>GET /api/configuracao/tipos-deficiencia/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/configuracao/admin/tipos-deficiencia</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ-0012).
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class TiposDeficienciaController : ControllerBase
+{
+    private const string ResourceTag = "tipos-deficiencia";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<TipoDeficienciaDto> _linksBuilder;
+
+    public TiposDeficienciaController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<TipoDeficienciaDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista os tipos de deficiência ativos, paginados por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("tipos-deficiencia")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "tipo-deficiencia", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<TipoDeficienciaDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarTiposDeficienciaResult resultado = await _queryBus
+            .Send(new ListarTiposDeficienciaQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        TipoDeficienciaDto[] comLinks =
+            [.. resultado.Items.Select(t => t with { Links = _linksBuilder.Build(t) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém um tipo de deficiência pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("tipos-deficiencia/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "tipo-deficiencia", Versions = [1])]
+    [ProducesResponseType(typeof(TipoDeficienciaDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        TipoDeficienciaDto? tipo = await _queryBus
+            .Send(new ObterTipoDeficienciaPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (tipo is null)
+        {
+            return NotFound();
+        }
+
+        TipoDeficienciaDto comLinks = tipo with { Links = _linksBuilder.Build(tipo) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria um novo tipo de deficiência. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/tipos-deficiencia")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarTipoDeficienciaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza um tipo de deficiência existente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/tipos-deficiencia/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarTipoDeficienciaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) um tipo de deficiência. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/tipos-deficiencia/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverTipoDeficienciaCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -400,5 +400,122 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status404NotFound,
                 "uniplus.configuracao.tipo_documento.nao_encontrado",
                 "Tipo de documento não encontrado")),
+
+        // ── Condição de atendimento especializado (UNI-REQ-0012) ──────────
+        new(CondicaoAtendimentoErrorCodes.CodigoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.condicao_atendimento.codigo_obrigatorio",
+                "Código da condição de atendimento é obrigatório")),
+
+        new(CondicaoAtendimentoErrorCodes.CodigoFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.condicao_atendimento.codigo_formato_invalido",
+                "Código da condição de atendimento em formato inválido")),
+
+        new(CondicaoAtendimentoErrorCodes.CodigoJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.condicao_atendimento.codigo_ja_existe",
+                "Já existe uma condição de atendimento ativa com este código")),
+
+        new(CondicaoAtendimentoErrorCodes.CodigoProtegidoNaoEditavel,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.condicao_atendimento.codigo_protegido_nao_editavel",
+                "O código da condição reservada não pode ser alterado")),
+
+        new(CondicaoAtendimentoErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.condicao_atendimento.nome_obrigatorio",
+                "Nome da condição de atendimento é obrigatório")),
+
+        new(CondicaoAtendimentoErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.condicao_atendimento.nome_tamanho",
+                "Tamanho do nome da condição de atendimento inválido")),
+
+        new(CondicaoAtendimentoErrorCodes.DescricaoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.condicao_atendimento.descricao_tamanho",
+                "Tamanho da descrição da condição de atendimento inválido")),
+
+        new(CondicaoAtendimentoErrorCodes.NaoEncontrada,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.condicao_atendimento.nao_encontrada",
+                "Condição de atendimento não encontrada")),
+
+        new(CondicaoAtendimentoErrorCodes.RemocaoBloqueadaCodigoProtegido,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.condicao_atendimento.remocao_bloqueada_codigo_protegido",
+                "A condição reservada não pode ser removida")),
+
+        // ── Recurso de acessibilidade (UNI-REQ-0012) ──────────────────────
+        new(RecursoAcessibilidadeErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.recurso_acessibilidade.nome_obrigatorio",
+                "Nome do recurso de acessibilidade é obrigatório")),
+
+        new(RecursoAcessibilidadeErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.recurso_acessibilidade.nome_tamanho",
+                "Tamanho do nome do recurso de acessibilidade inválido")),
+
+        new(RecursoAcessibilidadeErrorCodes.NomeJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.recurso_acessibilidade.nome_ja_existe",
+                "Já existe um recurso de acessibilidade ativo com este nome")),
+
+        new(RecursoAcessibilidadeErrorCodes.DescricaoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.recurso_acessibilidade.descricao_tamanho",
+                "Tamanho da descrição do recurso de acessibilidade inválido")),
+
+        new(RecursoAcessibilidadeErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.recurso_acessibilidade.nao_encontrado",
+                "Recurso de acessibilidade não encontrado")),
+
+        // ── Tipo de deficiência (UNI-REQ-0012) ────────────────────────────
+        new(TipoDeficienciaErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_deficiencia.nome_obrigatorio",
+                "Nome do tipo de deficiência é obrigatório")),
+
+        new(TipoDeficienciaErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_deficiencia.nome_tamanho",
+                "Tamanho do nome do tipo de deficiência inválido")),
+
+        new(TipoDeficienciaErrorCodes.NomeJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.tipo_deficiencia.nome_ja_existe",
+                "Já existe um tipo de deficiência ativo com este nome")),
+
+        new(TipoDeficienciaErrorCodes.DescricaoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_deficiencia.descricao_tamanho",
+                "Tamanho da descrição do tipo de deficiência inválido")),
+
+        new(TipoDeficienciaErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.tipo_deficiencia.nao_encontrado",
+                "Tipo de deficiência não encontrado")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CondicaoAtendimentoLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CondicaoAtendimentoLinksBuilder.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="CondicaoAtendimentoDto"/>. Relações em V1: <c>self</c> e
+/// <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<CondicaoAtendimentoDto>, CondicaoAtendimentoLinksBuilder>().")]
+internal sealed class CondicaoAtendimentoLinksBuilder : IResourceLinksBuilder<CondicaoAtendimentoDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CondicaoAtendimentoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(CondicaoAtendimentoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "CondicoesAtendimento";
+
+        string self = ResolverPath(
+            httpContext, nameof(CondicoesAtendimentoController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(CondicoesAtendimentoController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/RecursoAcessibilidadeLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/RecursoAcessibilidadeLinksBuilder.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="RecursoAcessibilidadeDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<RecursoAcessibilidadeDto>, RecursoAcessibilidadeLinksBuilder>().")]
+internal sealed class RecursoAcessibilidadeLinksBuilder : IResourceLinksBuilder<RecursoAcessibilidadeDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public RecursoAcessibilidadeLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(RecursoAcessibilidadeDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "RecursosAcessibilidade";
+
+        string self = ResolverPath(
+            httpContext, nameof(RecursosAcessibilidadeController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(RecursosAcessibilidadeController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/TipoDeficienciaLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/TipoDeficienciaLinksBuilder.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="TipoDeficienciaDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<TipoDeficienciaDto>, TipoDeficienciaLinksBuilder>().")]
+internal sealed class TipoDeficienciaLinksBuilder : IResourceLinksBuilder<TipoDeficienciaDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public TipoDeficienciaLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(TipoDeficienciaDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "TiposDeficiencia";
+
+        string self = ResolverPath(
+            httpContext, nameof(TiposDeficienciaController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(TiposDeficienciaController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/AtualizarCondicaoAtendimentoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/AtualizarCondicaoAtendimentoCommand.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza uma condição de atendimento especializado existente. O <c>Codigo</c> é
+/// editável (com nova checagem de unicidade entre vivas), exceto quando o código
+/// atual é o reservado <c>PCD</c> — que não pode ser renomeado. O <c>Id</c> é
+/// imutável. O ator (<c>updated_by</c>) é carimbado server-side via
+/// <c>IUserContext</c>.
+/// </summary>
+public sealed record AtualizarCondicaoAtendimentoCommand(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string? Descricao = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/AtualizarCondicaoAtendimentoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/AtualizarCondicaoAtendimentoCommandHandler.cs
@@ -1,0 +1,75 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarCondicaoAtendimentoCommand"/>. Como o código é
+/// editável, confere a unicidade entre condições vivas quando ele muda (ignorando
+/// o próprio registro) e protege a corrida traduzindo a violação do índice único
+/// parcial em <c>CodigoJaExiste</c>. O bloqueio de renomeação do código reservado
+/// <c>PCD</c> é aplicado pelo agregado em <c>Atualizar</c>
+/// (<c>CodigoProtegidoNaoEditavel</c>).
+/// </summary>
+public static class AtualizarCondicaoAtendimentoCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarCondicaoAtendimentoCommand command,
+        ICondicaoAtendimentoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        CondicaoAtendimentoEspecializado? condicao = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (condicao is null)
+        {
+            return Result.Failure(new DomainError(
+                CondicaoAtendimentoErrorCodes.NaoEncontrada,
+                "Condição de atendimento especializado não encontrada."));
+        }
+
+        // Código é case-sensitive (Ordinal), normalizado por Trim no agregado — só
+        // checa colisão quando o código efetivamente muda.
+        if (!string.Equals(command.Codigo.Trim(), condicao.Codigo.Valor, StringComparison.Ordinal)
+            && await repository.CodigoExisteEntreVivosAsync(command.Codigo, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        Result atualizarResult = condicao.Atualizar(
+            command.Codigo,
+            command.Nome,
+            command.Descricao);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCodigoConflict(constraint))
+        {
+            // Corrida entre a checagem de unicidade e o UPDATE: o índice único parcial
+            // dispara 23505 e viramos o mesmo CodigoJaExiste do caminho não-race.
+            return Result.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        return Result.Success();
+    }
+
+    private static DomainError CodigoJaExisteErro(string codigo) =>
+        new(CondicaoAtendimentoErrorCodes.CodigoJaExiste,
+            $"Já existe uma condição de atendimento especializado viva com o código '{codigo}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/AtualizarCondicaoAtendimentoCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/AtualizarCondicaoAtendimentoCommandValidator.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+public sealed class AtualizarCondicaoAtendimentoCommandValidator
+    : AbstractValidator<AtualizarCondicaoAtendimentoCommand>
+{
+    public AtualizarCondicaoAtendimentoCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id da condição de atendimento especializado é obrigatório.");
+
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código da condição de atendimento especializado é obrigatório.")
+            .Must(CodigoCondicao.EhValido)
+            .WithMessage("Código da condição deve iniciar com letra maiúscula e conter apenas letras "
+                + "maiúsculas, dígitos e sublinhado, com 2 a 50 caracteres (ex.: PCD, DISLEXIA, LACTANTE).");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome da condição de atendimento especializado é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome da condição deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(1000).WithMessage("Descrição da condição deve ter no máximo 1000 caracteres.")
+            .When(x => x.Descricao is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/CriarCondicaoAtendimentoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/CriarCondicaoAtendimentoCommand.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria uma condição de atendimento especializado: código (chave natural, formato
+/// fechado UPPER_SNAKE), nome (rótulo legível) e descrição opcional. O ator de
+/// auditoria (<c>created_by</c>) é carimbado server-side via <c>IUserContext</c>,
+/// não no payload.
+/// </summary>
+public sealed record CriarCondicaoAtendimentoCommand(
+    string Codigo,
+    string Nome,
+    string? Descricao = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/CriarCondicaoAtendimentoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/CriarCondicaoAtendimentoCommandHandler.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarCondicaoAtendimentoCommand"/> (convention-based
+/// Wolverine): confere a unicidade do código entre condições vivas, cria o
+/// agregado, persiste e commita. Protege a corrida check-then-act traduzindo a
+/// violação do índice único parcial em <c>CodigoJaExiste</c>.
+/// </summary>
+public static class CriarCondicaoAtendimentoCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarCondicaoAtendimentoCommand command,
+        ICondicaoAtendimentoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.CodigoExisteEntreVivosAsync(command.Codigo, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        Result<CondicaoAtendimentoEspecializado> condicaoResult = CondicaoAtendimentoEspecializado.Criar(
+            command.Codigo,
+            command.Nome,
+            command.Descricao);
+
+        if (condicaoResult.IsFailure)
+        {
+            return Result<Guid>.Failure(condicaoResult.Error!);
+        }
+
+        CondicaoAtendimentoEspecializado condicao = condicaoResult.Value!;
+        await repository.AdicionarAsync(condicao, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCodigoConflict(constraint))
+        {
+            // Corrida entre CodigoExisteEntreVivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo CodigoJaExiste do
+            // caminho não-race — 409 consistente, em vez de deixar o DbUpdateException
+            // virar 500 no middleware global. O filtro do `when` garante que outras
+            // exceções propagam intactas.
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        return Result<Guid>.Success(condicao.Id);
+    }
+
+    private static DomainError CodigoJaExisteErro(string codigo) =>
+        new(CondicaoAtendimentoErrorCodes.CodigoJaExiste,
+            $"Já existe uma condição de atendimento especializado viva com o código '{codigo}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/CriarCondicaoAtendimentoCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/CriarCondicaoAtendimentoCommandValidator.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+public sealed class CriarCondicaoAtendimentoCommandValidator
+    : AbstractValidator<CriarCondicaoAtendimentoCommand>
+{
+    public CriarCondicaoAtendimentoCommandValidator()
+    {
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código da condição de atendimento especializado é obrigatório.")
+            .Must(CodigoCondicao.EhValido)
+            .WithMessage("Código da condição deve iniciar com letra maiúscula e conter apenas letras "
+                + "maiúsculas, dígitos e sublinhado, com 2 a 50 caracteres (ex.: PCD, DISLEXIA, LACTANTE).");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome da condição de atendimento especializado é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome da condição deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(1000).WithMessage("Descrição da condição deve ter no máximo 1000 caracteres.")
+            .When(x => x.Descricao is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/RemoverCondicaoAtendimentoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/RemoverCondicaoAtendimentoCommand.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Remove (soft-delete) uma condição de atendimento especializado pelo seu <c>Id</c>.</summary>
+public sealed record RemoverCondicaoAtendimentoCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/RemoverCondicaoAtendimentoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/RemoverCondicaoAtendimentoCommandHandler.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverCondicaoAtendimentoCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c>. A remoção é bloqueada apenas para o código
+/// reservado <see cref="CodigoCondicao.Pcd"/> (<c>RemocaoBloqueadaCodigoProtegido</c>);
+/// nunca é bloqueada por consumo de Seleção — o consumo cross-módulo é snapshot-copy
+/// desacoplado (ADR-0061).
+/// </summary>
+public static class RemoverCondicaoAtendimentoCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverCondicaoAtendimentoCommand command,
+        ICondicaoAtendimentoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        CondicaoAtendimentoEspecializado? condicao = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (condicao is null)
+        {
+            return Result.Failure(new DomainError(
+                CondicaoAtendimentoErrorCodes.NaoEncontrada,
+                "Condição de atendimento especializado não encontrada."));
+        }
+
+        if (condicao.Codigo.EhProtegido)
+        {
+            return Result.Failure(new DomainError(
+                CondicaoAtendimentoErrorCodes.RemocaoBloqueadaCodigoProtegido,
+                $"A condição reservada '{CodigoCondicao.Pcd}' não pode ser removida."));
+        }
+
+        repository.Remover(condicao);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CondicoesAtendimento/UniqueConstraintViolation.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do código vivo da
+/// condição de atendimento especializado —
+/// <c>ix_condicao_atendimento_especializado_codigo_vivo</c> — para o
+/// <c>DomainError</c> apropriado. Acessa <c>SqlState</c> e <c>ConstraintName</c>
+/// por reflection no inner exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção por
+/// <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch —
+/// Application referencia apenas Domain + SharedKernel + abstrações).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão do <c>UniqueConstraintViolation</c> do cadastro de Tipos de
+/// documento (#591). A tradução cross-cutting de 23505 → 409 via
+/// <c>GlobalExceptionMiddleware</c> permanece como follow-up separado (#504); este
+/// helper cobre o caso específico da unicidade do código (inclusive a corrida na
+/// atualização, pois o código é editável).
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string CodigoConstraint = "ix_condicao_atendimento_especializado_codigo_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o
+    /// caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único parcial
+    /// que garante uma única condição viva por código.
+    /// </summary>
+    public static bool IsCodigoConflict(string? constraint) =>
+        string.Equals(constraint, CodigoConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/AtualizarRecursoAcessibilidadeCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/AtualizarRecursoAcessibilidadeCommand.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza um recurso de acessibilidade existente. O <c>Nome</c> é editável, com
+/// nova checagem de unicidade entre vivos; a descrição também pode ser editada. O
+/// <c>Id</c> é imutável. O ator (<c>updated_by</c>) é carimbado server-side via
+/// <c>IUserContext</c>.
+/// </summary>
+public sealed record AtualizarRecursoAcessibilidadeCommand(
+    Guid Id,
+    string Nome,
+    string? Descricao = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/AtualizarRecursoAcessibilidadeCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/AtualizarRecursoAcessibilidadeCommandHandler.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarRecursoAcessibilidadeCommand"/>. Como o nome é
+/// editável, confere a unicidade entre recursos vivos quando ele muda (ignorando o
+/// próprio registro) e protege a corrida traduzindo a violação do índice único
+/// parcial em <c>NomeJaExiste</c>.
+/// </summary>
+public static class AtualizarRecursoAcessibilidadeCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarRecursoAcessibilidadeCommand command,
+        IRecursoAcessibilidadeRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        RecursoAcessibilidade? recurso = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (recurso is null)
+        {
+            return Result.Failure(new DomainError(
+                RecursoAcessibilidadeErrorCodes.NaoEncontrado,
+                "Recurso de acessibilidade não encontrado."));
+        }
+
+        // Nome é case-sensitive (Ordinal), normalizado por Trim no agregado — só
+        // checa colisão quando o nome efetivamente muda.
+        if (!string.Equals(command.Nome.Trim(), recurso.Nome, StringComparison.Ordinal)
+            && await repository.NomeExisteEntreVivosAsync(command.Nome, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(NomeJaExisteErro(command.Nome));
+        }
+
+        Result atualizarResult = recurso.Atualizar(command.Nome, command.Descricao);
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsNomeConflict(constraint))
+        {
+            // Corrida entre a checagem de unicidade e o UPDATE: o índice único parcial
+            // dispara 23505 e viramos o mesmo NomeJaExiste do caminho não-race.
+            return Result.Failure(NomeJaExisteErro(command.Nome));
+        }
+
+        return Result.Success();
+    }
+
+    private static DomainError NomeJaExisteErro(string nome) =>
+        new(RecursoAcessibilidadeErrorCodes.NomeJaExiste,
+            $"Já existe um recurso de acessibilidade vivo com o nome '{nome}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/AtualizarRecursoAcessibilidadeCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/AtualizarRecursoAcessibilidadeCommandValidator.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+using FluentValidation;
+
+public sealed class AtualizarRecursoAcessibilidadeCommandValidator
+    : AbstractValidator<AtualizarRecursoAcessibilidadeCommand>
+{
+    public AtualizarRecursoAcessibilidadeCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id do recurso de acessibilidade é obrigatório.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do recurso de acessibilidade é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do recurso de acessibilidade deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(1000).WithMessage("Descrição do recurso de acessibilidade deve ter no máximo 1000 caracteres.")
+            .When(x => x.Descricao is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/CriarRecursoAcessibilidadeCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/CriarRecursoAcessibilidadeCommand.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria um recurso de acessibilidade: nome (chave natural) e descrição opcional.
+/// O ator de auditoria (<c>created_by</c>) é carimbado server-side via
+/// <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarRecursoAcessibilidadeCommand(
+    string Nome,
+    string? Descricao = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/CriarRecursoAcessibilidadeCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/CriarRecursoAcessibilidadeCommandHandler.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarRecursoAcessibilidadeCommand"/> (convention-based
+/// Wolverine): confere a unicidade do nome entre recursos vivos, cria o agregado,
+/// persiste e commita. Protege a corrida check-then-act traduzindo a violação do
+/// índice único parcial em <c>NomeJaExiste</c>.
+/// </summary>
+public static class CriarRecursoAcessibilidadeCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarRecursoAcessibilidadeCommand command,
+        IRecursoAcessibilidadeRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.NomeExisteEntreVivosAsync(command.Nome, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(NomeJaExisteErro(command.Nome));
+        }
+
+        Result<RecursoAcessibilidade> recursoResult = RecursoAcessibilidade.Criar(
+            command.Nome,
+            command.Descricao);
+
+        if (recursoResult.IsFailure)
+        {
+            return Result<Guid>.Failure(recursoResult.Error!);
+        }
+
+        RecursoAcessibilidade recurso = recursoResult.Value!;
+        await repository.AdicionarAsync(recurso, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsNomeConflict(constraint))
+        {
+            // Corrida entre NomeExisteEntreVivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo NomeJaExiste do
+            // caminho não-race — 409 consistente, em vez de deixar o DbUpdateException
+            // virar 500 no middleware global. O filtro do `when` garante que outras
+            // exceções propagam intactas.
+            return Result<Guid>.Failure(NomeJaExisteErro(command.Nome));
+        }
+
+        return Result<Guid>.Success(recurso.Id);
+    }
+
+    private static DomainError NomeJaExisteErro(string nome) =>
+        new(RecursoAcessibilidadeErrorCodes.NomeJaExiste,
+            $"Já existe um recurso de acessibilidade vivo com o nome '{nome}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/CriarRecursoAcessibilidadeCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/CriarRecursoAcessibilidadeCommandValidator.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+using FluentValidation;
+
+public sealed class CriarRecursoAcessibilidadeCommandValidator
+    : AbstractValidator<CriarRecursoAcessibilidadeCommand>
+{
+    public CriarRecursoAcessibilidadeCommandValidator()
+    {
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do recurso de acessibilidade é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do recurso de acessibilidade deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(1000).WithMessage("Descrição do recurso de acessibilidade deve ter no máximo 1000 caracteres.")
+            .When(x => x.Descricao is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/RemoverRecursoAcessibilidadeCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/RemoverRecursoAcessibilidadeCommand.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Remove (soft-delete) um recurso de acessibilidade pelo seu <c>Id</c>.</summary>
+public sealed record RemoverRecursoAcessibilidadeCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/RemoverRecursoAcessibilidadeCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/RemoverRecursoAcessibilidadeCommandHandler.cs
@@ -1,0 +1,43 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverRecursoAcessibilidadeCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c>. A remoção <b>nunca</b> é bloqueada: o consumo
+/// cross-módulo é snapshot-copy desacoplado (ADR-0061) — remover um recurso
+/// referenciado por valor numa configuração de Seleção apenas deixa o rótulo já
+/// congelado intacto, sem alvo vivo.
+/// </summary>
+public static class RemoverRecursoAcessibilidadeCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverRecursoAcessibilidadeCommand command,
+        IRecursoAcessibilidadeRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        RecursoAcessibilidade? recurso = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (recurso is null)
+        {
+            return Result.Failure(new DomainError(
+                RecursoAcessibilidadeErrorCodes.NaoEncontrado,
+                "Recurso de acessibilidade não encontrado."));
+        }
+
+        repository.Remover(recurso);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/RecursosAcessibilidade/UniqueConstraintViolation.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do nome vivo do
+/// recurso de acessibilidade — <c>ix_recurso_acessibilidade_nome_vivo</c> — para o
+/// <c>DomainError</c> apropriado. Acessa <c>SqlState</c> e <c>ConstraintName</c>
+/// por reflection no inner exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção por
+/// <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch —
+/// Application referencia apenas Domain + SharedKernel + abstrações).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão do <c>UniqueConstraintViolation</c> do cadastro de Tipos de
+/// documento (#591). A tradução cross-cutting de 23505 → 409 via
+/// <c>GlobalExceptionMiddleware</c> permanece como follow-up separado (#504); este
+/// helper cobre o caso específico da unicidade do nome, inclusive a corrida na
+/// atualização (o nome é editável).
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string NomeConstraint = "ix_recurso_acessibilidade_nome_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o
+    /// caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único parcial
+    /// que garante um único recurso vivo por nome.
+    /// </summary>
+    public static bool IsNomeConflict(string? constraint) =>
+        string.Equals(constraint, NomeConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/AtualizarTipoDeficienciaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/AtualizarTipoDeficienciaCommand.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza um tipo de deficiência existente. O <c>Nome</c> é editável, com nova
+/// checagem de unicidade entre vivos; a descrição também pode ser editada. O
+/// <c>Id</c> é imutável. O ator (<c>updated_by</c>) é carimbado server-side via
+/// <c>IUserContext</c>.
+/// </summary>
+public sealed record AtualizarTipoDeficienciaCommand(
+    Guid Id,
+    string Nome,
+    string? Descricao = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/AtualizarTipoDeficienciaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/AtualizarTipoDeficienciaCommandHandler.cs
@@ -1,0 +1,68 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarTipoDeficienciaCommand"/>. Como o nome é
+/// editável, confere a unicidade entre tipos vivos quando ele muda (ignorando o
+/// próprio registro) e protege a corrida traduzindo a violação do índice único
+/// parcial em <c>NomeJaExiste</c>.
+/// </summary>
+public static class AtualizarTipoDeficienciaCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarTipoDeficienciaCommand command,
+        ITipoDeficienciaRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        TipoDeficiencia? tipo = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (tipo is null)
+        {
+            return Result.Failure(new DomainError(
+                TipoDeficienciaErrorCodes.NaoEncontrado,
+                "Tipo de deficiência não encontrado."));
+        }
+
+        // Nome é case-sensitive (Ordinal), normalizado por Trim no agregado — só
+        // checa colisão quando o nome efetivamente muda.
+        if (!string.Equals(command.Nome.Trim(), tipo.Nome, StringComparison.Ordinal)
+            && await repository.NomeExisteEntreVivosAsync(command.Nome, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(NomeJaExisteErro(command.Nome));
+        }
+
+        Result atualizarResult = tipo.Atualizar(command.Nome, command.Descricao);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsNomeConflict(constraint))
+        {
+            // Corrida entre a checagem de unicidade e o UPDATE: o índice único parcial
+            // dispara 23505 e viramos o mesmo NomeJaExiste do caminho não-race.
+            return Result.Failure(NomeJaExisteErro(command.Nome));
+        }
+
+        return Result.Success();
+    }
+
+    private static DomainError NomeJaExisteErro(string nome) =>
+        new(TipoDeficienciaErrorCodes.NomeJaExiste,
+            $"Já existe um tipo de deficiência vivo com o nome '{nome}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/AtualizarTipoDeficienciaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/AtualizarTipoDeficienciaCommandValidator.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+using FluentValidation;
+
+public sealed class AtualizarTipoDeficienciaCommandValidator
+    : AbstractValidator<AtualizarTipoDeficienciaCommand>
+{
+    public AtualizarTipoDeficienciaCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id do tipo de deficiência é obrigatório.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do tipo de deficiência é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do tipo de deficiência deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(1000).WithMessage("Descrição do tipo de deficiência deve ter no máximo 1000 caracteres.")
+            .When(x => x.Descricao is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/CriarTipoDeficienciaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/CriarTipoDeficienciaCommand.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria um tipo de deficiência: nome (chave natural, único entre vivos) e
+/// descrição opcional. O ator de auditoria (<c>created_by</c>) é carimbado
+/// server-side via <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarTipoDeficienciaCommand(
+    string Nome,
+    string? Descricao = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/CriarTipoDeficienciaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/CriarTipoDeficienciaCommandHandler.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarTipoDeficienciaCommand"/> (convention-based
+/// Wolverine): confere a unicidade do nome entre tipos vivos, cria o agregado,
+/// persiste e commita. Protege a corrida check-then-act traduzindo a violação do
+/// índice único parcial em <c>NomeJaExiste</c>.
+/// </summary>
+public static class CriarTipoDeficienciaCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarTipoDeficienciaCommand command,
+        ITipoDeficienciaRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.NomeExisteEntreVivosAsync(command.Nome, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(NomeJaExisteErro(command.Nome));
+        }
+
+        Result<TipoDeficiencia> tipoResult = TipoDeficiencia.Criar(command.Nome, command.Descricao);
+
+        if (tipoResult.IsFailure)
+        {
+            return Result<Guid>.Failure(tipoResult.Error!);
+        }
+
+        TipoDeficiencia tipo = tipoResult.Value!;
+        await repository.AdicionarAsync(tipo, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsNomeConflict(constraint))
+        {
+            // Corrida entre NomeExisteEntreVivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo NomeJaExiste do
+            // caminho não-race — 409 consistente, em vez de deixar o DbUpdateException
+            // virar 500 no middleware global. O filtro do `when` garante que outras
+            // exceções propagam intactas.
+            return Result<Guid>.Failure(NomeJaExisteErro(command.Nome));
+        }
+
+        return Result<Guid>.Success(tipo.Id);
+    }
+
+    private static DomainError NomeJaExisteErro(string nome) =>
+        new(TipoDeficienciaErrorCodes.NomeJaExiste,
+            $"Já existe um tipo de deficiência vivo com o nome '{nome}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/CriarTipoDeficienciaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/CriarTipoDeficienciaCommandValidator.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+using FluentValidation;
+
+public sealed class CriarTipoDeficienciaCommandValidator
+    : AbstractValidator<CriarTipoDeficienciaCommand>
+{
+    public CriarTipoDeficienciaCommandValidator()
+    {
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do tipo de deficiência é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do tipo de deficiência deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(1000).WithMessage("Descrição do tipo de deficiência deve ter no máximo 1000 caracteres.")
+            .When(x => x.Descricao is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/RemoverTipoDeficienciaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/RemoverTipoDeficienciaCommand.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Remove (soft-delete) um tipo de deficiência pelo seu <c>Id</c>.</summary>
+public sealed record RemoverTipoDeficienciaCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/RemoverTipoDeficienciaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/RemoverTipoDeficienciaCommandHandler.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverTipoDeficienciaCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c>. A remoção <b>nunca</b> é bloqueada: o consumo
+/// cross-módulo é snapshot-copy desacoplado (ADR-0061), então remover um tipo de
+/// deficiência não afeta rótulos já congelados em outros contextos.
+/// </summary>
+public static class RemoverTipoDeficienciaCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverTipoDeficienciaCommand command,
+        ITipoDeficienciaRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        TipoDeficiencia? tipo = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (tipo is null)
+        {
+            return Result.Failure(new DomainError(
+                TipoDeficienciaErrorCodes.NaoEncontrado,
+                "Tipo de deficiência não encontrado."));
+        }
+
+        repository.Remover(tipo);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposDeficiencia/UniqueConstraintViolation.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do nome vivo do tipo
+/// de deficiência — <c>ix_tipo_deficiencia_nome_vivo</c> — para o
+/// <c>DomainError</c> apropriado. Acessa <c>SqlState</c> e <c>ConstraintName</c>
+/// por reflection no inner exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção por
+/// <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch —
+/// Application referencia apenas Domain + SharedKernel + abstrações).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão do <c>UniqueConstraintViolation</c> do cadastro de Tipo de
+/// documento (#591). A tradução cross-cutting de 23505 → 409 via
+/// <c>GlobalExceptionMiddleware</c> permanece como follow-up separado (#504); este
+/// helper cobre o caso específico da unicidade do nome, inclusive a corrida na
+/// atualização (o nome é editável).
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string NomeConstraint = "ix_tipo_deficiencia_nome_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o
+    /// caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único parcial
+    /// que garante um único tipo vivo por nome.
+    /// </summary>
+    public static bool IsNomeConflict(string? constraint) =>
+        string.Equals(constraint, NomeConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CondicaoAtendimentoDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CondicaoAtendimentoDto.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>CondicaoAtendimentoEspecializado</c>. Suporta
+/// HATEOAS Level 1 via <c>_links</c> (ADR-0029). O código é exposto como
+/// <c>string</c> (token canônico UPPER_SNAKE).
+/// </summary>
+public sealed record CondicaoAtendimentoDto(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string? Descricao,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/RecursoAcessibilidadeDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/RecursoAcessibilidadeDto.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>RecursoAcessibilidade</c>. Suporta HATEOAS Level 1
+/// via <c>_links</c> (ADR-0029).
+/// </summary>
+public sealed record RecursoAcessibilidadeDto(
+    Guid Id,
+    string Nome,
+    string? Descricao,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/TipoDeficienciaDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/TipoDeficienciaDto.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>TipoDeficiencia</c>. Suporta HATEOAS Level 1 via
+/// <c>_links</c> (ADR-0029).
+/// </summary>
+public sealed record TipoDeficienciaDto(
+    Guid Id,
+    string Nome,
+    string? Descricao,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CondicaoAtendimentoMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CondicaoAtendimentoMapping.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+public static class CondicaoAtendimentoMapping
+{
+    public static CondicaoAtendimentoDto ToDto(this CondicaoAtendimentoEspecializado condicao)
+    {
+        ArgumentNullException.ThrowIfNull(condicao);
+        return new CondicaoAtendimentoDto(
+            condicao.Id,
+            condicao.Codigo.Valor,
+            condicao.Nome,
+            condicao.Descricao,
+            condicao.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/RecursoAcessibilidadeMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/RecursoAcessibilidadeMapping.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+public static class RecursoAcessibilidadeMapping
+{
+    public static RecursoAcessibilidadeDto ToDto(this RecursoAcessibilidade recurso)
+    {
+        ArgumentNullException.ThrowIfNull(recurso);
+        return new RecursoAcessibilidadeDto(
+            recurso.Id,
+            recurso.Nome,
+            recurso.Descricao,
+            recurso.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/TipoDeficienciaMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/TipoDeficienciaMapping.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+public static class TipoDeficienciaMapping
+{
+    public static TipoDeficienciaDto ToDto(this TipoDeficiencia tipo)
+    {
+        ArgumentNullException.ThrowIfNull(tipo);
+        return new TipoDeficienciaDto(
+            tipo.Id,
+            tipo.Nome,
+            tipo.Descricao,
+            tipo.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ListarCondicoesAtendimentoQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ListarCondicoesAtendimentoQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista condições de atendimento especializado vivas paginadas por cursor
+/// bidirecional (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e
+/// valida limit/direction antes de despachar.
+/// </summary>
+public sealed record ListarCondicoesAtendimentoQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarCondicoesAtendimentoResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ListarCondicoesAtendimentoQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ListarCondicoesAtendimentoQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarCondicoesAtendimentoQueryHandler
+{
+    public static async Task<ListarCondicoesAtendimentoResult> Handle(
+        ListarCondicoesAtendimentoQuery query,
+        ICondicaoAtendimentoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<CondicaoAtendimentoEspecializado> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        CondicaoAtendimentoDto[] items = [.. itens.Select(c => c.ToDto())];
+        return new ListarCondicoesAtendimentoResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ListarCondicoesAtendimentoResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ListarCondicoesAtendimentoResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarCondicoesAtendimentoQuery"/>: lote de condições
+/// projetadas + âncoras opcionais para o controller construir os cursores
+/// prev/next (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarCondicoesAtendimentoResult(
+    IReadOnlyList<CondicaoAtendimentoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ObterCondicaoAtendimentoPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ObterCondicaoAtendimentoPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterCondicaoAtendimentoPorIdQuery(Guid Id) : IQuery<CondicaoAtendimentoDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ObterCondicaoAtendimentoPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CondicoesAtendimento/ObterCondicaoAtendimentoPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CondicoesAtendimento;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterCondicaoAtendimentoPorIdQueryHandler
+{
+    public static async Task<CondicaoAtendimentoDto?> Handle(
+        ObterCondicaoAtendimentoPorIdQuery query,
+        ICondicaoAtendimentoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        CondicaoAtendimentoEspecializado? condicao = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return condicao?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ListarRecursosAcessibilidadeQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ListarRecursosAcessibilidadeQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista recursos de acessibilidade vivos paginados por cursor bidirecional
+/// (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e valida
+/// limit/direction antes de despachar.
+/// </summary>
+public sealed record ListarRecursosAcessibilidadeQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarRecursosAcessibilidadeResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ListarRecursosAcessibilidadeQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ListarRecursosAcessibilidadeQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarRecursosAcessibilidadeQueryHandler
+{
+    public static async Task<ListarRecursosAcessibilidadeResult> Handle(
+        ListarRecursosAcessibilidadeQuery query,
+        IRecursoAcessibilidadeRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<RecursoAcessibilidade> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        RecursoAcessibilidadeDto[] items = [.. itens.Select(r => r.ToDto())];
+        return new ListarRecursosAcessibilidadeResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ListarRecursosAcessibilidadeResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ListarRecursosAcessibilidadeResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarRecursosAcessibilidadeQuery"/>: lote de recursos
+/// de acessibilidade projetados + âncoras opcionais para o controller construir os
+/// cursores prev/next (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarRecursosAcessibilidadeResult(
+    IReadOnlyList<RecursoAcessibilidadeDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ObterRecursoAcessibilidadePorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ObterRecursoAcessibilidadePorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterRecursoAcessibilidadePorIdQuery(Guid Id) : IQuery<RecursoAcessibilidadeDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ObterRecursoAcessibilidadePorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/RecursosAcessibilidade/ObterRecursoAcessibilidadePorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.RecursosAcessibilidade;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterRecursoAcessibilidadePorIdQueryHandler
+{
+    public static async Task<RecursoAcessibilidadeDto?> Handle(
+        ObterRecursoAcessibilidadePorIdQuery query,
+        IRecursoAcessibilidadeRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        RecursoAcessibilidade? recurso = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return recurso?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ListarTiposDeficienciaQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ListarTiposDeficienciaQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista tipos de deficiência vivos paginados por cursor bidirecional
+/// (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e valida
+/// limit/direction antes de despachar.
+/// </summary>
+public sealed record ListarTiposDeficienciaQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarTiposDeficienciaResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ListarTiposDeficienciaQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ListarTiposDeficienciaQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarTiposDeficienciaQueryHandler
+{
+    public static async Task<ListarTiposDeficienciaResult> Handle(
+        ListarTiposDeficienciaQuery query,
+        ITipoDeficienciaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<TipoDeficiencia> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        TipoDeficienciaDto[] items = [.. itens.Select(t => t.ToDto())];
+        return new ListarTiposDeficienciaResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ListarTiposDeficienciaResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ListarTiposDeficienciaResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarTiposDeficienciaQuery"/>: lote de tipos de
+/// deficiência projetados + âncoras opcionais para o controller construir os
+/// cursores prev/next (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarTiposDeficienciaResult(
+    IReadOnlyList<TipoDeficienciaDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ObterTipoDeficienciaPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ObterTipoDeficienciaPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterTipoDeficienciaPorIdQuery(Guid Id) : IQuery<TipoDeficienciaDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ObterTipoDeficienciaPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposDeficiencia/ObterTipoDeficienciaPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposDeficiencia;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterTipoDeficienciaPorIdQueryHandler
+{
+    public static async Task<TipoDeficienciaDto?> Handle(
+        ObterTipoDeficienciaPorIdQuery query,
+        ITipoDeficienciaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        TipoDeficiencia? tipo = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return tipo?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/CondicaoAtendimentoView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/CondicaoAtendimentoView.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>CondicaoAtendimentoEspecializado</c> para consumo
+/// cross-módulo via <see cref="ICondicaoAtendimentoReader"/> (ADR-0056). Expõe a
+/// condição viva (código + nome) que o Módulo Seleção lê ao montar as opções de
+/// atendimento especializado de um edital, antes de congelar por valor a
+/// identidade na solicitação (snapshot-copy, ADR-0061).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="Codigo">Código classificatório, chave natural da condição (ex.: "PCD").</param>
+/// <param name="Nome">Rótulo legível da condição.</param>
+public sealed record CondicaoAtendimentoView(
+    Guid Id,
+    string Codigo,
+    string Nome);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ICondicaoAtendimentoReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ICondicaoAtendimentoReader.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>CondicaoAtendimentoEspecializado</c> (ADR-0056).
+/// Expõe o estado vivo do cadastro de condições de atendimento especializado para
+/// consumo por outros bounded contexts (ex.: a configuração de atendimento
+/// especializado do Módulo Seleção, que referencia a condição ao montar as opções
+/// de um edital) sem acesso direto ao banco de Configuração (ADR-0054).
+/// </summary>
+public interface ICondicaoAtendimentoReader
+{
+    /// <summary>
+    /// Lista todas as condições vivas (não soft-deleted), ordenadas por
+    /// <c>Codigo</c> ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<CondicaoAtendimentoView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém uma condição pelo <paramref name="id"/>, ou <see langword="null"/> se
+    /// inexistente / soft-deleted.
+    /// </summary>
+    Task<CondicaoAtendimentoView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IRecursoAcessibilidadeReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IRecursoAcessibilidadeReader.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>RecursoAcessibilidade</c> (ADR-0056). Expõe o estado
+/// vivo do cadastro de recursos de acessibilidade para consumo por outros bounded
+/// contexts (ex.: a configuração de atendimento especializado do Módulo Seleção,
+/// que referencia o recurso ao montar um edital) sem acesso direto ao banco de
+/// Configuração (ADR-0054).
+/// </summary>
+public interface IRecursoAcessibilidadeReader
+{
+    /// <summary>
+    /// Lista todos os recursos de acessibilidade vivos (não soft-deleted),
+    /// ordenados por <c>Nome</c> ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<RecursoAcessibilidadeView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém um recurso de acessibilidade pelo <paramref name="id"/>, ou
+    /// <see langword="null"/> se inexistente / soft-deleted.
+    /// </summary>
+    Task<RecursoAcessibilidadeView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ITipoDeficienciaReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ITipoDeficienciaReader.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>TipoDeficiencia</c> (ADR-0056). Expõe o estado vivo do
+/// cadastro classificatório de tipos de deficiência para consumo por outros bounded
+/// contexts (ex.: a solicitação de atendimento especializado do Módulo Seleção) sem
+/// acesso direto ao banco de Configuração (ADR-0054).
+/// </summary>
+public interface ITipoDeficienciaReader
+{
+    /// <summary>
+    /// Lista todos os tipos de deficiência vivos (não soft-deleted), ordenados por
+    /// <c>Nome</c> ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<TipoDeficienciaView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém um tipo de deficiência pelo <paramref name="id"/>, ou
+    /// <see langword="null"/> se inexistente / soft-deleted.
+    /// </summary>
+    Task<TipoDeficienciaView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/RecursoAcessibilidadeView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/RecursoAcessibilidadeView.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>RecursoAcessibilidade</c> para consumo cross-módulo via
+/// <see cref="IRecursoAcessibilidadeReader"/> (ADR-0056). Expõe o recurso vivo
+/// (id + nome) que o Módulo Seleção lê ao montar a configuração de atendimento
+/// especializado de um edital, antes de congelar por valor a identidade no edital
+/// (snapshot-copy, ADR-0061).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="Nome">Rótulo legível do recurso, chave natural (ex.: "Ledor").</param>
+public sealed record RecursoAcessibilidadeView(
+    Guid Id,
+    string Nome);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/TipoDeficienciaView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/TipoDeficienciaView.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>TipoDeficiencia</c> para consumo cross-módulo via
+/// <see cref="ITipoDeficienciaReader"/> (ADR-0056). Expõe o tipo vivo (id + nome)
+/// que outros bounded contexts leem antes de congelar por valor a identidade
+/// (snapshot-copy, ADR-0061).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="Nome">Rótulo legível do tipo de deficiência (chave natural).</param>
+public sealed record TipoDeficienciaView(
+    Guid Id,
+    string Nome);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CondicaoAtendimentoEspecializado.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CondicaoAtendimentoEspecializado.cs
@@ -1,0 +1,148 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Condição que habilita atendimento especializado — cadastro institucional
+/// (UNI-REQ-0012, módulo Configuração): diz <i>qual é a condição</i> que ampara
+/// um pedido de atendimento especializado (ex.: PCD, dislexia, lactante), nunca o
+/// recurso concedido nem a solicitação de um candidato (essas vivem no Módulo
+/// Seleção). Dado institucional sem PII (LGPD inaplicável).
+/// </summary>
+/// <remarks>
+/// <para>O <see cref="Codigo"/> (value object <see cref="CodigoCondicao"/>) é a
+/// chave natural, único entre condições vivas (índice único parcial
+/// <c>WHERE is_deleted = false</c>) — e <b>editável</b>, pois o consumo
+/// cross-módulo é por snapshot-copy desacoplado (ADR-0061): editar o código vivo
+/// não altera o rótulo já congelado numa solicitação de Seleção. A unicidade é
+/// checada pelo handler (com proteção de corrida via índice).</para>
+/// <para>O código reservado <see cref="CodigoCondicao.Pcd"/> não pode ser
+/// renomeado (este agregado bloqueia em <see cref="Atualizar"/>) nem removido (o
+/// handler de remoção bloqueia) — a ADR-0067 o referencia literalmente.</para>
+/// <para>A remoção é sempre soft-delete e nunca bloqueada por consumo de Seleção
+/// (snapshot-copy desacoplado).</para>
+/// </remarks>
+public sealed class CondicaoAtendimentoEspecializado : SoftDeletableEntity, IAuditableEntity
+{
+    private const int NomeMinLength = 2;
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+
+    public CodigoCondicao Codigo { get; private set; } = null!;
+    public string Nome { get; private set; } = string.Empty;
+    public string? Descricao { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private CondicaoAtendimentoEspecializado()
+    {
+    }
+
+    /// <summary>
+    /// Cria uma nova condição de atendimento especializado. Valida o código (via
+    /// <see cref="CodigoCondicao.Criar"/>), o nome (obrigatório, tamanho) e a
+    /// descrição (tamanho). A unicidade do <paramref name="codigo"/> entre
+    /// condições vivas é responsabilidade do handler.
+    /// </summary>
+    public static Result<CondicaoAtendimentoEspecializado> Criar(
+        string codigo,
+        string nome,
+        string? descricao)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+        ArgumentNullException.ThrowIfNull(nome);
+
+        Result<CodigoCondicao> validacao = ValidarCampos(codigo, nome, descricao);
+        if (validacao.IsFailure)
+        {
+            return Result<CondicaoAtendimentoEspecializado>.Failure(validacao.Error!);
+        }
+
+        var condicao = new CondicaoAtendimentoEspecializado();
+        condicao.AplicarCampos(validacao.Value!, nome, descricao);
+
+        return Result<CondicaoAtendimentoEspecializado>.Success(condicao);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos da condição. O <c>Codigo</c> é editável e sua
+    /// unicidade (quando alterado) é responsabilidade do handler — <b>exceto</b>
+    /// quando o código atual é <see cref="CodigoCondicao.Pcd"/>: a condição
+    /// reservada não pode ser renomeada (retorna
+    /// <c>CodigoProtegidoNaoEditavel</c>). Revalida formato/tamanho.
+    /// </summary>
+    public Result Atualizar(string codigo, string nome, string? descricao)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+        ArgumentNullException.ThrowIfNull(nome);
+
+        Result<CodigoCondicao> validacao = ValidarCampos(codigo, nome, descricao);
+        if (validacao.IsFailure)
+        {
+            return Result.Failure(validacao.Error!);
+        }
+
+        CodigoCondicao novoCodigo = validacao.Value!;
+
+        // O código reservado PCD não pode ser renomeado (ADR-0067). Editar o nome
+        // ou a descrição mantendo o código PCD continua permitido.
+        if (Codigo.EhProtegido && !novoCodigo.EhProtegido)
+        {
+            return Result.Failure(new DomainError(
+                CondicaoAtendimentoErrorCodes.CodigoProtegidoNaoEditavel,
+                $"A condição reservada '{CodigoCondicao.Pcd}' não pode ter o código alterado."));
+        }
+
+        AplicarCampos(novoCodigo, nome, descricao);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(CodigoCondicao codigo, string nome, string? descricao)
+    {
+        Codigo = codigo;
+        Nome = nome.Trim();
+        Descricao = NormalizarOpcional(descricao);
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result<CodigoCondicao> ValidarCampos(string codigo, string nome, string? descricao)
+    {
+        Result<CodigoCondicao> codigoResult = CodigoCondicao.Criar(codigo);
+        if (codigoResult.IsFailure)
+        {
+            return Result<CodigoCondicao>.Failure(codigoResult.Error!);
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result<CodigoCondicao>.Failure(new DomainError(
+                CondicaoAtendimentoErrorCodes.NomeObrigatorio,
+                "Nome da condição de atendimento especializado é obrigatório."));
+        }
+
+        if (nome.Trim().Length is < NomeMinLength or > NomeMaxLength)
+        {
+            return Result<CodigoCondicao>.Failure(new DomainError(
+                CondicaoAtendimentoErrorCodes.NomeTamanho,
+                $"Nome da condição deve ter entre {NomeMinLength} e {NomeMaxLength} caracteres."));
+        }
+
+        if (descricao is not null && descricao.Trim().Length > DescricaoMaxLength)
+        {
+            return Result<CodigoCondicao>.Failure(new DomainError(
+                CondicaoAtendimentoErrorCodes.DescricaoTamanho,
+                $"Descrição da condição deve ter no máximo {DescricaoMaxLength} caracteres."));
+        }
+
+        return Result<CodigoCondicao>.Success(codigoResult.Value!);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/RecursoAcessibilidade.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/RecursoAcessibilidade.cs
@@ -1,0 +1,117 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Recurso de acessibilidade — cadastro institucional do <b>apoio concreto</b>
+/// oferecido no atendimento especializado (UNI-REQ-0012, módulo Configuração):
+/// nomeia o recurso disponibilizado ao candidato (ledor, tempo adicional, prova
+/// ampliada, intérprete de Libras, sala reservada…), nunca uma regra material
+/// sobre quando ou a quem se aplica — essas regras vivem na exigência/solicitação
+/// de atendimento do edital (banco de Seleção).
+/// </summary>
+/// <remarks>
+/// <para>O <c>Nome</c> é a chave natural, único entre recursos vivos (índice único
+/// parcial <c>WHERE is_deleted = false</c>) — e <b>editável</b>, pois o consumo
+/// cross-módulo é por snapshot-copy desacoplado (ADR-0061): editar o nome vivo não
+/// altera o rótulo já congelado numa exigência de Seleção. A unicidade é checada
+/// pelo handler (com proteção de corrida via índice).</para>
+/// <para>Dado institucional sem PII (LGPD inaplicável). A remoção é sempre
+/// soft-delete e nunca bloqueada por referência.</para>
+/// </remarks>
+public sealed class RecursoAcessibilidade : SoftDeletableEntity, IAuditableEntity
+{
+    private const int NomeMinLength = 2;
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+
+    public string Nome { get; private set; } = string.Empty;
+    public string? Descricao { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private RecursoAcessibilidade()
+    {
+    }
+
+    /// <summary>
+    /// Cria um novo RecursoAcessibilidade. Valida formato/tamanho local. A
+    /// unicidade de <paramref name="nome"/> entre recursos vivos é
+    /// responsabilidade do handler.
+    /// </summary>
+    public static Result<RecursoAcessibilidade> Criar(string nome, string? descricao)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+
+        Result validacao = ValidarCampos(nome, descricao);
+        if (validacao.IsFailure)
+        {
+            return Result<RecursoAcessibilidade>.Failure(validacao.Error!);
+        }
+
+        var recurso = new RecursoAcessibilidade();
+        recurso.AplicarCampos(nome, descricao);
+
+        return Result<RecursoAcessibilidade>.Success(recurso);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos do RecursoAcessibilidade. O <c>Nome</c> é editável;
+    /// sua unicidade (quando alterado) é responsabilidade do handler. Revalida
+    /// formato/tamanho.
+    /// </summary>
+    public Result Atualizar(string nome, string? descricao)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+
+        Result validacao = ValidarCampos(nome, descricao);
+        if (validacao.IsFailure)
+        {
+            return validacao;
+        }
+
+        AplicarCampos(nome, descricao);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(string nome, string? descricao)
+    {
+        Nome = nome.Trim();
+        Descricao = NormalizarOpcional(descricao);
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result ValidarCampos(string nome, string? descricao)
+    {
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                RecursoAcessibilidadeErrorCodes.NomeObrigatorio,
+                "Nome do recurso de acessibilidade é obrigatório."));
+        }
+
+        if (nome.Trim().Length is < NomeMinLength or > NomeMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                RecursoAcessibilidadeErrorCodes.NomeTamanho,
+                $"Nome do recurso de acessibilidade deve ter entre {NomeMinLength} e {NomeMaxLength} caracteres."));
+        }
+
+        if (descricao is not null && descricao.Trim().Length > DescricaoMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                RecursoAcessibilidadeErrorCodes.DescricaoTamanho,
+                $"Descrição do recurso de acessibilidade deve ter no máximo {DescricaoMaxLength} caracteres."));
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/TipoDeficiencia.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/TipoDeficiencia.cs
@@ -1,0 +1,115 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Tipo de deficiência — cadastro institucional do tipo de deficiência reconhecido
+/// (UNI-REQ-0012, módulo Configuração): Visual, Auditiva, TEA, Física, Intelectual…
+/// É um cadastro classificatório simples (apenas nome + descrição opcional); a
+/// solicitação concreta de atendimento especializado e os recursos de
+/// acessibilidade são entidades distintas (vocabulário INEP/Edital ENEM 52/2025).
+/// </summary>
+/// <remarks>
+/// <para>O <c>Nome</c> é a chave natural, único entre tipos vivos (índice único
+/// parcial <c>WHERE is_deleted = false</c>) — e <b>editável</b>: a unicidade
+/// (quando o nome muda) é checada pelo handler, com proteção de corrida pelo índice
+/// (a violação 23505 é traduzida em <c>NomeJaExiste</c>).</para>
+/// <para>Dado institucional sem PII (LGPD inaplicável). A remoção é sempre
+/// soft-delete e nunca bloqueada por referência.</para>
+/// </remarks>
+public sealed class TipoDeficiencia : SoftDeletableEntity, IAuditableEntity
+{
+    private const int NomeMinLength = 2;
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+
+    public string Nome { get; private set; } = string.Empty;
+    public string? Descricao { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private TipoDeficiencia()
+    {
+    }
+
+    /// <summary>
+    /// Cria um novo TipoDeficiencia. Valida obrigatoriedade/tamanho do nome e o
+    /// tamanho da descrição. A unicidade de <paramref name="nome"/> entre tipos
+    /// vivos é responsabilidade do handler.
+    /// </summary>
+    public static Result<TipoDeficiencia> Criar(string nome, string? descricao)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+
+        Result validacao = ValidarCampos(nome, descricao);
+        if (validacao.IsFailure)
+        {
+            return Result<TipoDeficiencia>.Failure(validacao.Error!);
+        }
+
+        var tipo = new TipoDeficiencia();
+        tipo.AplicarCampos(nome, descricao);
+
+        return Result<TipoDeficiencia>.Success(tipo);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos do TipoDeficiencia. O <c>Nome</c> é editável; sua
+    /// unicidade (quando alterado) é responsabilidade do handler. Revalida
+    /// obrigatoriedade/tamanho do nome e o tamanho da descrição.
+    /// </summary>
+    public Result Atualizar(string nome, string? descricao)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+
+        Result validacao = ValidarCampos(nome, descricao);
+        if (validacao.IsFailure)
+        {
+            return validacao;
+        }
+
+        AplicarCampos(nome, descricao);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(string nome, string? descricao)
+    {
+        Nome = nome.Trim();
+        Descricao = NormalizarOpcional(descricao);
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result ValidarCampos(string nome, string? descricao)
+    {
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result.Failure(new DomainError(
+                TipoDeficienciaErrorCodes.NomeObrigatorio,
+                "Nome do tipo de deficiência é obrigatório."));
+        }
+
+        if (nome.Trim().Length is < NomeMinLength or > NomeMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                TipoDeficienciaErrorCodes.NomeTamanho,
+                $"Nome do tipo de deficiência deve ter entre {NomeMinLength} e {NomeMaxLength} caracteres."));
+        }
+
+        if (descricao is not null && descricao.Trim().Length > DescricaoMaxLength)
+        {
+            return Result.Failure(new DomainError(
+                TipoDeficienciaErrorCodes.DescricaoTamanho,
+                $"Descrição do tipo de deficiência deve ter no máximo {DescricaoMaxLength} caracteres."));
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CondicaoAtendimentoErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CondicaoAtendimentoErrorCodes.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+// Mapeamentos esperados para HTTP (a serem registrados em
+// ConfiguracaoDomainErrorRegistration — fora desta entrega):
+//   CodigoJaExiste                  → 409 Conflict
+//   RemocaoBloqueadaCodigoProtegido → 409 Conflict
+//   NaoEncontrada                   → 404 Not Found
+//   CodigoProtegidoNaoEditavel      → 422 Unprocessable Entity
+//   CodigoObrigatorio               → 422 Unprocessable Entity
+//   CodigoFormatoInvalido           → 422 Unprocessable Entity
+//   NomeObrigatorio                 → 422 Unprocessable Entity
+//   NomeTamanho                     → 422 Unprocessable Entity
+//   DescricaoTamanho                → 422 Unprocessable Entity
+public static class CondicaoAtendimentoErrorCodes
+{
+    public const string CodigoObrigatorio = "CondicaoAtendimento.CodigoObrigatorio";
+    public const string CodigoFormatoInvalido = "CondicaoAtendimento.CodigoFormatoInvalido";
+    public const string CodigoJaExiste = "CondicaoAtendimento.CodigoJaExiste";
+    public const string CodigoProtegidoNaoEditavel = "CondicaoAtendimento.CodigoProtegidoNaoEditavel";
+    public const string NomeObrigatorio = "CondicaoAtendimento.NomeObrigatorio";
+    public const string NomeTamanho = "CondicaoAtendimento.NomeTamanho";
+    public const string DescricaoTamanho = "CondicaoAtendimento.DescricaoTamanho";
+    public const string NaoEncontrada = "CondicaoAtendimento.NaoEncontrada";
+    public const string RemocaoBloqueadaCodigoProtegido = "CondicaoAtendimento.RemocaoBloqueadaCodigoProtegido";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/RecursoAcessibilidadeErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/RecursoAcessibilidadeErrorCodes.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+/// <summary>
+/// Códigos de erro de domínio do cadastro <c>RecursoAcessibilidade</c>. Mapeamento
+/// esperado para HTTP (registrado em <c>ConfiguracaoDomainErrorRegistration</c>):
+/// <list type="bullet">
+///   <item><c>NomeJaExiste</c> → 409 Conflict.</item>
+///   <item><c>NomeObrigatorio</c>, <c>NomeTamanho</c>, <c>DescricaoTamanho</c> → 422 Unprocessable Entity.</item>
+///   <item><c>NaoEncontrado</c> → 404 Not Found.</item>
+/// </list>
+/// </summary>
+public static class RecursoAcessibilidadeErrorCodes
+{
+    public const string NomeObrigatorio = "RecursoAcessibilidade.NomeObrigatorio";
+    public const string NomeTamanho = "RecursoAcessibilidade.NomeTamanho";
+    public const string NomeJaExiste = "RecursoAcessibilidade.NomeJaExiste";
+    public const string DescricaoTamanho = "RecursoAcessibilidade.DescricaoTamanho";
+    public const string NaoEncontrado = "RecursoAcessibilidade.NaoEncontrado";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/TipoDeficienciaErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/TipoDeficienciaErrorCodes.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+// Mapeamentos esperados em ConfiguracaoDomainErrorRegistration (UNI-REQ-0012):
+//   NomeJaExiste      → 409 Conflict
+//   NomeObrigatorio   → 422 UnprocessableEntity
+//   NomeTamanho       → 422 UnprocessableEntity
+//   DescricaoTamanho  → 422 UnprocessableEntity
+//   NaoEncontrado     → 404 NotFound
+public static class TipoDeficienciaErrorCodes
+{
+    public const string NomeObrigatorio = "TipoDeficiencia.NomeObrigatorio";
+    public const string NomeTamanho = "TipoDeficiencia.NomeTamanho";
+    public const string NomeJaExiste = "TipoDeficiencia.NomeJaExiste";
+    public const string DescricaoTamanho = "TipoDeficiencia.DescricaoTamanho";
+    public const string NaoEncontrado = "TipoDeficiencia.NaoEncontrado";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICondicaoAtendimentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICondicaoAtendimentoRepository.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="CondicaoAtendimentoEspecializado"/>
+/// (ADR-0054: banco isolado <c>uniplus_configuracao</c>). Todas as leituras
+/// excluem registros soft-deleted via query filter por convenção.
+/// </summary>
+public interface ICondicaoAtendimentoRepository
+{
+    /// <summary>Carrega a condição rastreada pelo contexto, para mutação.</summary>
+    Task<CondicaoAtendimentoEspecializado?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega a condição para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<CondicaoAtendimentoEspecializado?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista condições vivas paginadas por cursor keyset bidirecional (ADR-0026 +
+    /// ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras de
+    /// <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<CondicaoAtendimentoEspecializado> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(CondicaoAtendimentoEspecializado condicao, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca a condição para remoção; o <c>SoftDeleteInterceptor</c> converte em
+    /// soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(CondicaoAtendimentoEspecializado condicao);
+
+    /// <summary>
+    /// Verifica se existe condição viva com o <paramref name="codigo"/>
+    /// (case-sensitive, sobre o valor normalizado por <c>Trim</c>), excluindo
+    /// opcionalmente um <paramref name="excluirId"/> (para a checagem na atualização).
+    /// </summary>
+    Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IRecursoAcessibilidadeRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IRecursoAcessibilidadeRepository.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="RecursoAcessibilidade"/> (ADR-0054: banco
+/// isolado <c>uniplus_configuracao</c>). Todas as leituras excluem registros
+/// soft-deleted via query filter por convenção.
+/// </summary>
+public interface IRecursoAcessibilidadeRepository
+{
+    /// <summary>Carrega o recurso de acessibilidade rastreado pelo contexto, para mutação.</summary>
+    Task<RecursoAcessibilidade?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega o recurso de acessibilidade para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<RecursoAcessibilidade?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista recursos de acessibilidade vivos paginados por cursor keyset
+    /// bidirecional (ADR-0026 + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032)
+    /// e devolve as âncoras de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<RecursoAcessibilidade> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(RecursoAcessibilidade recurso, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca o recurso de acessibilidade para remoção; o <c>SoftDeleteInterceptor</c>
+    /// converte em soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(RecursoAcessibilidade recurso);
+
+    /// <summary>
+    /// Verifica se existe recurso de acessibilidade vivo com o <paramref name="nome"/>
+    /// (case-sensitive, sobre o valor normalizado por <c>Trim</c>), excluindo
+    /// opcionalmente um <paramref name="excluirId"/> (para a checagem na atualização).
+    /// </summary>
+    Task<bool> NomeExisteEntreVivosAsync(
+        string nome,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITipoDeficienciaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITipoDeficienciaRepository.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="TipoDeficiencia"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros
+/// soft-deleted via query filter por convenção.
+/// </summary>
+public interface ITipoDeficienciaRepository
+{
+    /// <summary>Carrega o tipo de deficiência rastreado pelo contexto, para mutação.</summary>
+    Task<TipoDeficiencia?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega o tipo de deficiência para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<TipoDeficiencia?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista tipos de deficiência vivos paginados por cursor keyset bidirecional
+    /// (ADR-0026 + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve
+    /// as âncoras de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<TipoDeficiencia> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(TipoDeficiencia tipo, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca o tipo de deficiência para remoção; o <c>SoftDeleteInterceptor</c>
+    /// converte em soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(TipoDeficiencia tipo);
+
+    /// <summary>
+    /// Verifica se existe tipo de deficiência vivo com o <paramref name="nome"/>
+    /// (case-sensitive, sobre o valor normalizado por <c>Trim</c>), excluindo
+    /// opcionalmente um <paramref name="excluirId"/> (para a checagem na atualização).
+    /// </summary>
+    Task<bool> NomeExisteEntreVivosAsync(
+        string nome,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoCondicao.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoCondicao.cs
@@ -1,0 +1,78 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+using System.Text.RegularExpressions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Código da condição que habilita atendimento especializado (UNI-REQ-0012,
+/// módulo Configuração) — chave natural classificatória (ex.: <c>PCD</c>,
+/// <c>DISLEXIA</c>, <c>LACTANTE</c>). Value object com formato fechado:
+/// <c>^[A-Z][A-Z0-9_]{1,49}$</c> — inicia com letra maiúscula, segue com letras
+/// maiúsculas, dígitos e sublinhado, total de 2 a 50 caracteres. Persistido como
+/// <c>varchar</c> via conversor de valor (fail-fast na reidratação).
+/// </summary>
+/// <remarks>
+/// O código <see cref="Pcd"/> é <b>reservado</b>: a condição cujo código é
+/// <c>PCD</c> não pode ser renomeada nem removida (a ADR-0067 a referencia
+/// literalmente). A proteção é exposta por <see cref="EhProtegido"/> e aplicada
+/// pelo agregado/handlers, não pelo banco.
+/// </remarks>
+public sealed partial record CodigoCondicao
+{
+    private const int TamanhoMinimo = 2;
+    private const int TamanhoMaximo = 50;
+
+    /// <summary>Código reservado da condição de pessoa com deficiência (ADR-0067).</summary>
+    public const string Pcd = "PCD";
+
+    public string Valor { get; }
+
+    private CodigoCondicao(string valor) => Valor = valor;
+
+    /// <summary>
+    /// Indica se este é o código reservado <see cref="Pcd"/> — comparação
+    /// case-sensitive (<see cref="StringComparison.Ordinal"/>), alinhada ao
+    /// formato canônico do value object (maiúsculas).
+    /// </summary>
+    public bool EhProtegido => string.Equals(Valor, Pcd, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Cria um <see cref="CodigoCondicao"/> validando o formato fechado. Valor
+    /// nulo/em branco retorna <c>CodigoObrigatorio</c>; fora do formato retorna
+    /// <c>CodigoFormatoInvalido</c>. O valor é normalizado por <c>Trim</c> antes
+    /// da validação.
+    /// </summary>
+    public static Result<CodigoCondicao> Criar(string valor)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return Result<CodigoCondicao>.Failure(new DomainError(
+                CondicaoAtendimentoErrorCodes.CodigoObrigatorio,
+                "Código da condição de atendimento especializado é obrigatório."));
+        }
+
+        string normalizado = valor.Trim();
+
+        if (!FormatoValido().IsMatch(normalizado))
+        {
+            return Result<CodigoCondicao>.Failure(new DomainError(
+                CondicaoAtendimentoErrorCodes.CodigoFormatoInvalido,
+                "Código da condição deve iniciar com letra maiúscula e conter apenas letras "
+                + $"maiúsculas, dígitos e sublinhado, com {TamanhoMinimo} a {TamanhoMaximo} "
+                + "caracteres (ex.: PCD, DISLEXIA, LACTANTE)."));
+        }
+
+        return Result<CodigoCondicao>.Success(new CodigoCondicao(normalizado));
+    }
+
+    /// <summary>Indica se <paramref name="valor"/> respeita o formato fechado, sem alocar value object.</summary>
+    public static bool EhValido(string valor) =>
+        !string.IsNullOrWhiteSpace(valor) && FormatoValido().IsMatch(valor.Trim());
+
+    public override string ToString() => Valor;
+
+    [GeneratedRegex("^[A-Z][A-Z0-9_]{1,49}$", RegexOptions.CultureInvariant)]
+    private static partial Regex FormatoValido();
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -38,11 +38,17 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<IReferenciaReservaDemograficaRepository, ReferenciaReservaDemograficaRepository>();
         services.AddScoped<IPesoAreaEnemRepository, PesoAreaEnemRepository>();
         services.AddScoped<ITipoDocumentoRepository, TipoDocumentoRepository>();
+        services.AddScoped<ICondicaoAtendimentoRepository, CondicaoAtendimentoRepository>();
+        services.AddScoped<IRecursoAcessibilidadeRepository, RecursoAcessibilidadeRepository>();
+        services.AddScoped<ITipoDeficienciaRepository, TipoDeficienciaRepository>();
 
         // Readers cross-módulo (ADR-0056).
         services.AddScoped<IReferenciaReservaDemograficaReader, ReferenciaReservaDemograficaReader>();
         services.AddScoped<IPesoAreaEnemReader, PesoAreaEnemReader>();
         services.AddScoped<ITipoDocumentoReader, TipoDocumentoReader>();
+        services.AddScoped<ICondicaoAtendimentoReader, CondicaoAtendimentoReader>();
+        services.AddScoped<IRecursoAcessibilidadeReader, RecursoAcessibilidadeReader>();
+        services.AddScoped<ITipoDeficienciaReader, TipoDeficienciaReader>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -39,6 +39,12 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
 
     public DbSet<TipoDocumento> TiposDocumento => Set<TipoDocumento>();
 
+    public DbSet<CondicaoAtendimentoEspecializado> CondicoesAtendimento => Set<CondicaoAtendimentoEspecializado>();
+
+    public DbSet<RecursoAcessibilidade> RecursosAcessibilidade => Set<RecursoAcessibilidade>();
+
+    public DbSet<TipoDeficiencia> TiposDeficiencia => Set<TipoDeficiencia>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CondicaoAtendimentoEspecializadoConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CondicaoAtendimentoEspecializadoConfiguration.cs
@@ -1,0 +1,60 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class CondicaoAtendimentoEspecializadoConfiguration
+    : IEntityTypeConfiguration<CondicaoAtendimentoEspecializado>
+{
+    private const int CodigoMaxLength = 50;
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+
+    public void Configure(EntityTypeBuilder<CondicaoAtendimentoEspecializado> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            "condicao_atendimento_especializado",
+            t =>
+            {
+                // Formato fechado do código (UPPER_SNAKE iniciando por letra) — defesa
+                // em profundidade do invariante de domínio (CodigoCondicao) contra
+                // inserts crus. Case-sensitive, alinhado ao value object.
+                t.HasCheckConstraint(
+                    "ck_condicao_atendimento_especializado_codigo_formato",
+                    "codigo ~ '^[A-Z][A-Z0-9_]{1,49}$'");
+            });
+
+        builder.HasKey(c => c.Id);
+
+        // Codigo é value object — persistido por valor como varchar via
+        // CodigoCondicaoValueConverter (reidratação fail-fast). O nome de coluna
+        // snake_case vem da convenção global; o CHECK acima restringe o formato.
+        builder.Property(c => c.Codigo)
+            .HasConversion<CodigoCondicaoValueConverter>()
+            .HasMaxLength(CodigoMaxLength)
+            .IsRequired();
+
+        builder.Property(c => c.Nome).HasMaxLength(NomeMaxLength).IsRequired();
+        builder.Property(c => c.Descricao).HasMaxLength(DescricaoMaxLength);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(c => c.CreatedBy).HasMaxLength(255);
+        builder.Property(c => c.UpdatedBy).HasMaxLength(255);
+
+        // Unicidade do código entre condições vivas (índice parcial) — uma condição
+        // viva por código; soft-delete libera o slot para recriação.
+        builder.HasIndex(c => c.Codigo)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_condicao_atendimento_especializado_codigo_vivo");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/RecursoAcessibilidadeConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/RecursoAcessibilidadeConfiguration.cs
@@ -1,0 +1,40 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class RecursoAcessibilidadeConfiguration
+    : IEntityTypeConfiguration<RecursoAcessibilidade>
+{
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+
+    public void Configure(EntityTypeBuilder<RecursoAcessibilidade> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("recurso_acessibilidade");
+
+        builder.HasKey(r => r.Id);
+
+        builder.Property(r => r.Nome).HasMaxLength(NomeMaxLength).IsRequired();
+        builder.Property(r => r.Descricao).HasMaxLength(DescricaoMaxLength);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(r => r.CreatedBy).HasMaxLength(255);
+        builder.Property(r => r.UpdatedBy).HasMaxLength(255);
+
+        // Unicidade do nome entre recursos vivos (índice parcial) — um recurso vivo
+        // por nome; soft-delete libera o slot para recriação.
+        builder.HasIndex(r => r.Nome)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_recurso_acessibilidade_nome_vivo");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/TipoDeficienciaConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/TipoDeficienciaConfiguration.cs
@@ -1,0 +1,40 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class TipoDeficienciaConfiguration
+    : IEntityTypeConfiguration<TipoDeficiencia>
+{
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+
+    public void Configure(EntityTypeBuilder<TipoDeficiencia> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("tipo_deficiencia");
+
+        builder.HasKey(t => t.Id);
+
+        builder.Property(t => t.Nome).HasMaxLength(NomeMaxLength).IsRequired();
+        builder.Property(t => t.Descricao).HasMaxLength(DescricaoMaxLength);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(t => t.CreatedBy).HasMaxLength(255);
+        builder.Property(t => t.UpdatedBy).HasMaxLength(255);
+
+        // Unicidade do nome entre tipos vivos (índice parcial) — um tipo vivo por
+        // nome; soft-delete libera o slot para recriação.
+        builder.HasIndex(t => t.Nome)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_tipo_deficiencia_nome_vivo");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CodigoCondicaoValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CodigoCondicaoValueConverter.cs
@@ -1,0 +1,38 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+// Mapeia CodigoCondicao ↔ string (varchar). O comprimento da coluna é definido na
+// própria propriedade via HasMaxLength no IEntityTypeConfiguration. A reidratação
+// falha explicitamente (com contexto) caso a coluna seja corrompida fora do fluxo
+// da aplicação, em vez do NullReferenceException tardio de
+// `CodigoCondicao.Criar(v).Value!`. O fail-fast é inlinado porque o helper
+// compartilhado ValueObjectMaterialization é internal ao assembly
+// Infrastructure.Core (este converter mora no módulo, pois CodigoCondicao é
+// vocabulário específico de Configuração).
+public sealed class CodigoCondicaoValueConverter : ValueConverter<CodigoCondicao, string>
+{
+    public CodigoCondicaoValueConverter()
+        : base(
+            codigo => codigo.Valor,
+            valor => Reidratar(valor))
+    {
+    }
+
+    private static CodigoCondicao Reidratar(string valor)
+    {
+        Result<CodigoCondicao> resultado = CodigoCondicao.Criar(valor);
+        if (resultado.IsFailure || resultado.Value is null)
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(CodigoCondicao)}: " +
+                $"{resultado.Error?.Code ?? "Desconhecido"}. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return resultado.Value;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260630235122_AddCadastrosAtendimentoEspecializado.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260630235122_AddCadastrosAtendimentoEspecializado.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630235122_AddCadastrosAtendimentoEspecializado")]
+    partial class AddCadastrosAtendimentoEspecializado
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260630235122_AddCadastrosAtendimentoEspecializado.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260630235122_AddCadastrosAtendimentoEspecializado.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCadastrosAtendimentoEspecializado : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "condicao_atendimento_especializado",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    descricao = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_condicao_atendimento_especializado", x => x.id);
+                    table.CheckConstraint("ck_condicao_atendimento_especializado_codigo_formato", "codigo ~ '^[A-Z][A-Z0-9_]{1,49}$'");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "recurso_acessibilidade",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    descricao = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_recurso_acessibilidade", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "tipo_deficiencia",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    descricao = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_tipo_deficiencia", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_condicao_atendimento_especializado_codigo_vivo",
+                schema: "configuracao",
+                table: "condicao_atendimento_especializado",
+                column: "codigo",
+                unique: true,
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_recurso_acessibilidade_nome_vivo",
+                schema: "configuracao",
+                table: "recurso_acessibilidade",
+                column: "nome",
+                unique: true,
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tipo_deficiencia_nome_vivo",
+                schema: "configuracao",
+                table: "tipo_deficiencia",
+                column: "nome",
+                unique: true,
+                filter: "is_deleted = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "condicao_atendimento_especializado",
+                schema: "configuracao");
+
+            migrationBuilder.DropTable(
+                name: "recurso_acessibilidade",
+                schema: "configuracao");
+
+            migrationBuilder.DropTable(
+                name: "tipo_deficiencia",
+                schema: "configuracao");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CondicaoAtendimentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CondicaoAtendimentoRepository.cs
@@ -1,0 +1,88 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class CondicaoAtendimentoRepository : ICondicaoAtendimentoRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public CondicaoAtendimentoRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<CondicaoAtendimentoEspecializado?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.CondicoesAtendimento
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+    }
+
+    public Task<CondicaoAtendimentoEspecializado?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.CondicoesAtendimento
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<CondicaoAtendimentoEspecializado> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<CondicaoAtendimentoEspecializado> page = await CursorKeyset
+            .ApplyAsync(_dbContext.CondicoesAtendimento.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(CondicaoAtendimentoEspecializado condicao, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(condicao);
+        await _dbContext.CondicoesAtendimento.AddAsync(condicao, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(CondicaoAtendimentoEspecializado condicao)
+    {
+        ArgumentNullException.ThrowIfNull(condicao);
+        _dbContext.CondicoesAtendimento.Remove(condicao);
+    }
+
+    public Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        // Um código fora do formato nunca tem condição viva — evita query
+        // desnecessária e garante que a comparação use o valor canônico normalizado
+        // (Trim). Case-sensitive (default do Postgres) — alinhado ao índice único.
+        Result<CodigoCondicao> codigoResult = CodigoCondicao.Criar(codigo);
+        if (codigoResult.IsFailure)
+        {
+            return Task.FromResult(false);
+        }
+
+        CodigoCondicao codigoVo = codigoResult.Value!;
+
+        return _dbContext.CondicoesAtendimento
+            .AsNoTracking()
+            .Where(c => excluirId == null || c.Id != excluirId)
+            .AnyAsync(c => c.Codigo == codigoVo, cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/RecursoAcessibilidadeRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/RecursoAcessibilidadeRepository.cs
@@ -1,0 +1,79 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class RecursoAcessibilidadeRepository : IRecursoAcessibilidadeRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public RecursoAcessibilidadeRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<RecursoAcessibilidade?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.RecursosAcessibilidade
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+    }
+
+    public Task<RecursoAcessibilidade?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.RecursosAcessibilidade
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<RecursoAcessibilidade> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<RecursoAcessibilidade> page = await CursorKeyset
+            .ApplyAsync(_dbContext.RecursosAcessibilidade.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(RecursoAcessibilidade recurso, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recurso);
+        await _dbContext.RecursosAcessibilidade.AddAsync(recurso, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(RecursoAcessibilidade recurso)
+    {
+        ArgumentNullException.ThrowIfNull(recurso);
+        _dbContext.RecursosAcessibilidade.Remove(recurso);
+    }
+
+    public Task<bool> NomeExisteEntreVivosAsync(
+        string nome,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+
+        // Espelha a normalização do agregado (Trim) para casar com o valor persistido.
+        // Comparação case-sensitive (default do Postgres) — alinhada ao índice único.
+        string nomeNorm = nome.Trim();
+
+        return _dbContext.RecursosAcessibilidade
+            .AsNoTracking()
+            .Where(r => excluirId == null || r.Id != excluirId)
+            .AnyAsync(r => r.Nome == nomeNorm, cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TipoDeficienciaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TipoDeficienciaRepository.cs
@@ -1,0 +1,79 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class TipoDeficienciaRepository : ITipoDeficienciaRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public TipoDeficienciaRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<TipoDeficiencia?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.TiposDeficiencia
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+    }
+
+    public Task<TipoDeficiencia?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.TiposDeficiencia
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<TipoDeficiencia> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<TipoDeficiencia> page = await CursorKeyset
+            .ApplyAsync(_dbContext.TiposDeficiencia.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(TipoDeficiencia tipo, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(tipo);
+        await _dbContext.TiposDeficiencia.AddAsync(tipo, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(TipoDeficiencia tipo)
+    {
+        ArgumentNullException.ThrowIfNull(tipo);
+        _dbContext.TiposDeficiencia.Remove(tipo);
+    }
+
+    public Task<bool> NomeExisteEntreVivosAsync(
+        string nome,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(nome);
+
+        // Espelha a normalização do agregado (Trim) para casar com o valor persistido.
+        // Comparação case-sensitive (default do Postgres) — alinhada ao índice único.
+        string nomeNorm = nome.Trim();
+
+        return _dbContext.TiposDeficiencia
+            .AsNoTracking()
+            .Where(t => excluirId == null || t.Id != excluirId)
+            .AnyAsync(t => t.Nome == nomeNorm, cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/CondicaoAtendimentoReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/CondicaoAtendimentoReader.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="ICondicaoAtendimentoReader"/> (ADR-0056): leitura
+/// direta do banco de Configuração (<c>AsNoTracking</c>, query filter de
+/// soft-delete por convenção). Sem cache — o cadastro é de baixo volume e baixa
+/// frequência de leitura viva; o congelamento por valor no consumidor (ADR-0061)
+/// dispensa releitura quente (mesmo padrão do <c>TipoDocumentoReader</c>).
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class CondicaoAtendimentoReader : ICondicaoAtendimentoReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public CondicaoAtendimentoReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<CondicaoAtendimentoView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<CondicaoAtendimentoEspecializado> entidades = await _dbContext.CondicoesAtendimento
+            .AsNoTracking()
+            .OrderBy(c => c.Codigo)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<CondicaoAtendimentoView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        CondicaoAtendimentoEspecializado? entidade = await _dbContext.CondicoesAtendimento
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static CondicaoAtendimentoView ParaView(CondicaoAtendimentoEspecializado c) =>
+        new(
+            c.Id,
+            c.Codigo.Valor,
+            c.Nome);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/RecursoAcessibilidadeReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/RecursoAcessibilidadeReader.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="IRecursoAcessibilidadeReader"/> (ADR-0056): leitura
+/// direta do banco de Configuração (<c>AsNoTracking</c>, query filter de soft-delete
+/// por convenção). Sem cache — o cadastro é de baixo volume e baixa frequência de
+/// leitura viva; o congelamento por valor no consumidor (ADR-0061) dispensa
+/// releitura quente (mesmo padrão do <c>TipoDocumentoReader</c>).
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class RecursoAcessibilidadeReader : IRecursoAcessibilidadeReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public RecursoAcessibilidadeReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<RecursoAcessibilidadeView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<RecursoAcessibilidade> entidades = await _dbContext.RecursosAcessibilidade
+            .AsNoTracking()
+            .OrderBy(r => r.Nome)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<RecursoAcessibilidadeView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        RecursoAcessibilidade? entidade = await _dbContext.RecursosAcessibilidade
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static RecursoAcessibilidadeView ParaView(RecursoAcessibilidade r) =>
+        new(r.Id, r.Nome);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/TipoDeficienciaReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/TipoDeficienciaReader.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="ITipoDeficienciaReader"/> (ADR-0056): leitura direta
+/// do banco de Configuração (<c>AsNoTracking</c>, query filter de soft-delete por
+/// convenção). Sem cache — o cadastro é de baixo volume e baixa frequência de
+/// leitura viva; o congelamento por valor no consumidor (ADR-0061) dispensa
+/// releitura quente (mesmo padrão do <c>TipoDocumentoReader</c>).
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class TipoDeficienciaReader : ITipoDeficienciaReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public TipoDeficienciaReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<TipoDeficienciaView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<TipoDeficiencia> entidades = await _dbContext.TiposDeficiencia
+            .AsNoTracking()
+            .OrderBy(t => t.Nome)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<TipoDeficienciaView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        TipoDeficiencia? entidade = await _dbContext.TiposDeficiencia
+            .AsNoTracking()
+            .FirstOrDefaultAsync(t => t.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static TipoDeficienciaView ParaView(TipoDeficiencia t) =>
+        new(t.Id, t.Nome);
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarCondicaoAtendimentoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarCondicaoAtendimentoCommandHandlerTests.cs
@@ -1,0 +1,100 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarCondicaoAtendimentoCommandHandlerTests
+{
+    private readonly ICondicaoAtendimentoRepository _repository = Substitute.For<ICondicaoAtendimentoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CondicaoAtendimentoEspecializado Existente(string codigo = "LACTANTE") =>
+        CondicaoAtendimentoEspecializado.Criar(codigo, "Lactante", null).Value!;
+
+    private static AtualizarCondicaoAtendimentoCommand Comando(Guid id, string codigo = "LACTANTE") =>
+        new(id, codigo, "Lactante", "Atendimento ampliado");
+
+    [Fact(DisplayName = "Condição inexistente retorna NaoEncontrada (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrada()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((CondicaoAtendimentoEspecializado?)null);
+
+        Result resultado = await AtualizarCondicaoAtendimentoCommandHandler.Handle(
+            Comando(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.NaoEncontrada);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um código que colide com outra condição viva retorna conflito (409)")]
+    public async Task Handle_CodigoColidente_RetornaConflito()
+    {
+        CondicaoAtendimentoEspecializado existente = Existente("LACTANTE");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.CodigoExisteEntreVivosAsync("DISLEXIA", existente.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result resultado = await AtualizarCondicaoAtendimentoCommandHandler.Handle(
+            Comando(existente.Id, codigo: "DISLEXIA"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoJaExiste);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um código distinto e livre é aceito e persiste")]
+    public async Task Handle_CodigoDistintoLivre_Aceita()
+    {
+        CondicaoAtendimentoEspecializado existente = Existente("LACTANTE");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.CodigoExisteEntreVivosAsync("DISLEXIA", existente.Id, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result resultado = await AtualizarCondicaoAtendimentoCommandHandler.Handle(
+            Comando(existente.Id, codigo: "DISLEXIA"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.Codigo.Valor.Should().Be("DISLEXIA");
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar sem mudar o código não consulta a unicidade")]
+    public async Task Handle_CodigoInalterado_NaoChecaUnicidade()
+    {
+        CondicaoAtendimentoEspecializado existente = Existente("LACTANTE");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarCondicaoAtendimentoCommandHandler.Handle(
+            Comando(existente.Id, codigo: "LACTANTE"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _repository.DidNotReceive()
+            .CodigoExisteEntreVivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Renomear o código reservado PCD é bloqueado (CodigoProtegidoNaoEditavel) sem persistir")]
+    public async Task Handle_RenomearPcd_Bloqueia()
+    {
+        CondicaoAtendimentoEspecializado pcd = Existente(CodigoCondicao.Pcd);
+        _repository.ObterPorIdAsync(pcd.Id, Arg.Any<CancellationToken>()).Returns(pcd);
+        _repository.CodigoExisteEntreVivosAsync("LACTANTE", pcd.Id, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result resultado = await AtualizarCondicaoAtendimentoCommandHandler.Handle(
+            new AtualizarCondicaoAtendimentoCommand(pcd.Id, "LACTANTE", "Lactante", null),
+            _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoProtegidoNaoEditavel);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarRecursoAcessibilidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarRecursoAcessibilidadeCommandHandlerTests.cs
@@ -1,0 +1,84 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarRecursoAcessibilidadeCommandHandlerTests
+{
+    private readonly IRecursoAcessibilidadeRepository _repository = Substitute.For<IRecursoAcessibilidadeRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static RecursoAcessibilidade Existente(string nome = "Ledor") =>
+        RecursoAcessibilidade.Criar(nome, null).Value!;
+
+    private static AtualizarRecursoAcessibilidadeCommand Comando(Guid id, string nome = "Ledor") =>
+        new(id, nome, "Descrição atualizada");
+
+    [Fact(DisplayName = "Recurso inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((RecursoAcessibilidade?)null);
+
+        Result resultado = await AtualizarRecursoAcessibilidadeCommandHandler.Handle(
+            Comando(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RecursoAcessibilidadeErrorCodes.NaoEncontrado);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um nome que colide com outro recurso vivo retorna conflito (409)")]
+    public async Task Handle_NomeColidente_RetornaConflito()
+    {
+        RecursoAcessibilidade existente = Existente("Ledor");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        // O novo nome "Tempo adicional" já pertence a outro recurso vivo.
+        _repository.NomeExisteEntreVivosAsync("Tempo adicional", existente.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result resultado = await AtualizarRecursoAcessibilidadeCommandHandler.Handle(
+            Comando(existente.Id, nome: "Tempo adicional"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RecursoAcessibilidadeErrorCodes.NomeJaExiste);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um nome distinto e livre é aceito e persiste")]
+    public async Task Handle_NomeDistintoLivre_Aceita()
+    {
+        RecursoAcessibilidade existente = Existente("Ledor");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.NomeExisteEntreVivosAsync("Prova ampliada", existente.Id, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result resultado = await AtualizarRecursoAcessibilidadeCommandHandler.Handle(
+            Comando(existente.Id, nome: "Prova ampliada"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.Nome.Should().Be("Prova ampliada");
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar sem mudar o nome não consulta a unicidade")]
+    public async Task Handle_NomeInalterado_NaoChecaUnicidade()
+    {
+        RecursoAcessibilidade existente = Existente("Ledor");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarRecursoAcessibilidadeCommandHandler.Handle(
+            Comando(existente.Id, nome: "Ledor"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _repository.DidNotReceive()
+            .NomeExisteEntreVivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarTipoDeficienciaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarTipoDeficienciaCommandHandlerTests.cs
@@ -1,0 +1,84 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarTipoDeficienciaCommandHandlerTests
+{
+    private readonly ITipoDeficienciaRepository _repository = Substitute.For<ITipoDeficienciaRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static TipoDeficiencia TipoExistente(string nome = "Visual") =>
+        TipoDeficiencia.Criar(nome, null).Value!;
+
+    private static AtualizarTipoDeficienciaCommand Comando(Guid id, string nome = "Visual") =>
+        new(id, nome, "Deficiência relacionada à visão");
+
+    [Fact(DisplayName = "Tipo inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((TipoDeficiencia?)null);
+
+        Result resultado = await AtualizarTipoDeficienciaCommandHandler.Handle(
+            Comando(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.NaoEncontrado);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um nome que colide com outro tipo vivo retorna conflito (409)")]
+    public async Task Handle_NomeColidente_RetornaConflito()
+    {
+        TipoDeficiencia existente = TipoExistente("Visual");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        // O novo nome "Auditiva" já pertence a outro tipo vivo.
+        _repository.NomeExisteEntreVivosAsync("Auditiva", existente.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result resultado = await AtualizarTipoDeficienciaCommandHandler.Handle(
+            Comando(existente.Id, nome: "Auditiva"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.NomeJaExiste);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um nome distinto e livre é aceito e persiste")]
+    public async Task Handle_NomeDistintoLivre_Aceita()
+    {
+        TipoDeficiencia existente = TipoExistente("Visual");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.NomeExisteEntreVivosAsync("Auditiva", existente.Id, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result resultado = await AtualizarTipoDeficienciaCommandHandler.Handle(
+            Comando(existente.Id, nome: "Auditiva"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.Nome.Should().Be("Auditiva");
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar sem mudar o nome não consulta a unicidade")]
+    public async Task Handle_NomeInalterado_NaoChecaUnicidade()
+    {
+        TipoDeficiencia existente = TipoExistente("Visual");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarTipoDeficienciaCommandHandler.Handle(
+            Comando(existente.Id, nome: "Visual"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _repository.DidNotReceive()
+            .NomeExisteEntreVivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCondicaoAtendimentoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCondicaoAtendimentoCommandHandlerTests.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarCondicaoAtendimentoCommandHandlerTests
+{
+    private readonly ICondicaoAtendimentoRepository _repository = Substitute.For<ICondicaoAtendimentoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CriarCondicaoAtendimentoCommand ComandoValido() =>
+        new("DISLEXIA", "Dislexia", "Transtorno específico de aprendizagem");
+
+    [Fact(DisplayName = "Código livre cria a condição, persiste e retorna o Id")]
+    public async Task Handle_CodigoLivre_CriaEPersiste()
+    {
+        _repository.CodigoExisteEntreVivosAsync("DISLEXIA", null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarCondicaoAtendimentoCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<CondicaoAtendimentoEspecializado>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Código já existente entre vivos retorna conflito (CodigoJaExiste) sem persistir")]
+    public async Task Handle_CodigoDuplicado_RetornaConflito()
+    {
+        _repository.CodigoExisteEntreVivosAsync("DISLEXIA", null, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarCondicaoAtendimentoCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<CondicaoAtendimentoEspecializado>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Código fora do formato propaga o erro de domínio sem persistir")]
+    public async Task Handle_CodigoFormatoInvalido_RetornaErroSemPersistir()
+    {
+        _repository.CodigoExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        CriarCondicaoAtendimentoCommand comando = ComandoValido() with { Codigo = "dislexia" };
+
+        Result<Guid> resultado = await CriarCondicaoAtendimentoCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoFormatoInvalido);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarRecursoAcessibilidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarRecursoAcessibilidadeCommandHandlerTests.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarRecursoAcessibilidadeCommandHandlerTests
+{
+    private readonly IRecursoAcessibilidadeRepository _repository = Substitute.For<IRecursoAcessibilidadeRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CriarRecursoAcessibilidadeCommand ComandoValido() =>
+        new("Ledor", "Profissional que lê a prova ao candidato");
+
+    [Fact(DisplayName = "Nome livre cria o recurso, persiste e retorna o Id")]
+    public async Task Handle_NomeLivre_CriaEPersiste()
+    {
+        _repository.NomeExisteEntreVivosAsync("Ledor", null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarRecursoAcessibilidadeCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<RecursoAcessibilidade>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Nome já existente entre vivos retorna conflito (NomeJaExiste) sem persistir")]
+    public async Task Handle_NomeDuplicado_RetornaConflito()
+    {
+        _repository.NomeExisteEntreVivosAsync("Ledor", null, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarRecursoAcessibilidadeCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RecursoAcessibilidadeErrorCodes.NomeJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<RecursoAcessibilidade>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Nome inválido (abaixo do mínimo) propaga o erro de domínio sem persistir")]
+    public async Task Handle_NomeInvalido_RetornaErroSemPersistir()
+    {
+        _repository.NomeExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        CriarRecursoAcessibilidadeCommand comando = ComandoValido() with { Nome = "A" };
+
+        Result<Guid> resultado = await CriarRecursoAcessibilidadeCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RecursoAcessibilidadeErrorCodes.NomeTamanho);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarTipoDeficienciaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarTipoDeficienciaCommandHandlerTests.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarTipoDeficienciaCommandHandlerTests
+{
+    private readonly ITipoDeficienciaRepository _repository = Substitute.For<ITipoDeficienciaRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CriarTipoDeficienciaCommand ComandoValido() =>
+        new("Visual", "Deficiência relacionada à visão");
+
+    [Fact(DisplayName = "Nome livre cria o tipo, persiste e retorna o Id")]
+    public async Task Handle_NomeLivre_CriaEPersiste()
+    {
+        _repository.NomeExisteEntreVivosAsync("Visual", null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarTipoDeficienciaCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<TipoDeficiencia>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Nome já existente entre vivos retorna conflito (NomeJaExiste) sem persistir")]
+    public async Task Handle_NomeDuplicado_RetornaConflito()
+    {
+        _repository.NomeExisteEntreVivosAsync("Visual", null, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarTipoDeficienciaCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.NomeJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<TipoDeficiencia>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Nome inválido propaga o erro de domínio sem persistir")]
+    public async Task Handle_NomeInvalido_RetornaErroSemPersistir()
+    {
+        _repository.NomeExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        CriarTipoDeficienciaCommand comando = ComandoValido() with { Nome = "A" };
+
+        Result<Guid> resultado = await CriarTipoDeficienciaCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.NomeTamanho);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCondicaoAtendimentoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCondicaoAtendimentoCommandHandlerTests.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverCondicaoAtendimentoCommandHandlerTests
+{
+    private readonly ICondicaoAtendimentoRepository _repository = Substitute.For<ICondicaoAtendimentoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CondicaoAtendimentoEspecializado Condicao(string codigo = "DISLEXIA") =>
+        CondicaoAtendimentoEspecializado.Criar(codigo, "Dislexia", null).Value!;
+
+    [Fact(DisplayName = "Remover uma condição não reservada faz soft-delete (Remover + Salvar)")]
+    public async Task Handle_CondicaoExistente_FazSoftDelete()
+    {
+        CondicaoAtendimentoEspecializado condicao = Condicao();
+        _repository.ObterPorIdAsync(condicao.Id, Arg.Any<CancellationToken>()).Returns(condicao);
+
+        Result resultado = await RemoverCondicaoAtendimentoCommandHandler.Handle(
+            new RemoverCondicaoAtendimentoCommand(condicao.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(condicao);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Remover o código reservado PCD é bloqueado (RemocaoBloqueadaCodigoProtegido) sem persistir")]
+    public async Task Handle_Pcd_Bloqueia()
+    {
+        CondicaoAtendimentoEspecializado pcd = Condicao(CodigoCondicao.Pcd);
+        _repository.ObterPorIdAsync(pcd.Id, Arg.Any<CancellationToken>()).Returns(pcd);
+
+        Result resultado = await RemoverCondicaoAtendimentoCommandHandler.Handle(
+            new RemoverCondicaoAtendimentoCommand(pcd.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.RemocaoBloqueadaCodigoProtegido);
+        _repository.DidNotReceive().Remover(Arg.Any<CondicaoAtendimentoEspecializado>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Remover uma condição inexistente retorna NaoEncontrada (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrada()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((CondicaoAtendimentoEspecializado?)null);
+
+        Result resultado = await RemoverCondicaoAtendimentoCommandHandler.Handle(
+            new RemoverCondicaoAtendimentoCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.NaoEncontrada);
+        _repository.DidNotReceive().Remover(Arg.Any<CondicaoAtendimentoEspecializado>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverRecursoAcessibilidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverRecursoAcessibilidadeCommandHandlerTests.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverRecursoAcessibilidadeCommandHandlerTests
+{
+    private readonly IRecursoAcessibilidadeRepository _repository = Substitute.For<IRecursoAcessibilidadeRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static RecursoAcessibilidade Recurso() =>
+        RecursoAcessibilidade.Criar("Ledor", null).Value!;
+
+    [Fact(DisplayName = "Remover um recurso existente faz soft-delete (Remover + Salvar) sem bloqueio")]
+    public async Task Handle_RecursoExistente_FazSoftDelete()
+    {
+        RecursoAcessibilidade recurso = Recurso();
+        _repository.ObterPorIdAsync(recurso.Id, Arg.Any<CancellationToken>()).Returns(recurso);
+
+        Result resultado = await RemoverRecursoAcessibilidadeCommandHandler.Handle(
+            new RemoverRecursoAcessibilidadeCommand(recurso.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(recurso);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Remover um recurso inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((RecursoAcessibilidade?)null);
+
+        Result resultado = await RemoverRecursoAcessibilidadeCommandHandler.Handle(
+            new RemoverRecursoAcessibilidadeCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RecursoAcessibilidadeErrorCodes.NaoEncontrado);
+        _repository.DidNotReceive().Remover(Arg.Any<RecursoAcessibilidade>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverTipoDeficienciaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverTipoDeficienciaCommandHandlerTests.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverTipoDeficienciaCommandHandlerTests
+{
+    private readonly ITipoDeficienciaRepository _repository = Substitute.For<ITipoDeficienciaRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static TipoDeficiencia Tipo() =>
+        TipoDeficiencia.Criar("Física", null).Value!;
+
+    [Fact(DisplayName = "Remover um tipo existente faz soft-delete (Remover + Salvar) sem bloqueio")]
+    public async Task Handle_TipoExistente_FazSoftDelete()
+    {
+        TipoDeficiencia tipo = Tipo();
+        _repository.ObterPorIdAsync(tipo.Id, Arg.Any<CancellationToken>()).Returns(tipo);
+
+        Result resultado = await RemoverTipoDeficienciaCommandHandler.Handle(
+            new RemoverTipoDeficienciaCommand(tipo.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(tipo);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Remover um tipo inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((TipoDeficiencia?)null);
+
+        Result resultado = await RemoverTipoDeficienciaCommandHandler.Handle(
+            new RemoverTipoDeficienciaCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.NaoEncontrado);
+        _repository.DidNotReceive().Remover(Arg.Any<TipoDeficiencia>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CondicaoAtendimentoValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CondicaoAtendimentoValidatorTests.cs
@@ -1,0 +1,82 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+
+/// <summary>
+/// O validator antecipa a obrigatoriedade de código e nome, o formato fechado do
+/// código (UPPER_SNAKE) e os limites de tamanho, mantendo a fronteira simétrica
+/// com o domínio (#590).
+/// </summary>
+public sealed class CondicaoAtendimentoValidatorTests
+{
+    private readonly CriarCondicaoAtendimentoCommandValidator _validator = new();
+
+    private static CriarCondicaoAtendimentoCommand Base() =>
+        new("DISLEXIA", "Dislexia", "Transtorno específico de aprendizagem");
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Comando sem descrição passa no validator")]
+    public void SemDescricao_Passa()
+    {
+        _validator.Validate(Base() with { Descricao = null }).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Código ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CodigoVazio_Rejeita(string codigo)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Codigo = codigo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCondicaoAtendimentoCommand.Codigo));
+    }
+
+    [Theory(DisplayName = "Código fora do formato fechado é rejeitado (minúsculas, dígito inicial, hífen)")]
+    [InlineData("dislexia")]
+    [InlineData("1PCD")]
+    [InlineData("PCD-A")]
+    public void CodigoFormatoInvalido_Rejeita(string codigo)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Codigo = codigo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCondicaoAtendimentoCommand.Codigo));
+    }
+
+    [Fact(DisplayName = "Nome ausente é rejeitado")]
+    public void NomeVazio_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Nome = "  " });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCondicaoAtendimentoCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Nome acima de 200 caracteres é rejeitado")]
+    public void NomeLongo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Nome = new string('N', 201) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCondicaoAtendimentoCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Descrição acima de 1000 caracteres é rejeitada")]
+    public void DescricaoLonga_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Descricao = new string('D', 1001) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCondicaoAtendimentoCommand.Descricao));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/RecursoAcessibilidadeValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/RecursoAcessibilidadeValidatorTests.cs
@@ -1,0 +1,60 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.RecursosAcessibilidade;
+
+/// <summary>
+/// O validator antecipa a obrigatoriedade do nome e os limites de tamanho de nome
+/// e descrição, mantendo a fronteira simétrica com o domínio (#590).
+/// </summary>
+public sealed class RecursoAcessibilidadeValidatorTests
+{
+    private readonly CriarRecursoAcessibilidadeCommandValidator _validator = new();
+
+    private static CriarRecursoAcessibilidadeCommand Base() =>
+        new("Ledor", "Profissional que lê a prova ao candidato");
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Comando sem descrição passa no validator")]
+    public void SemDescricao_Passa()
+    {
+        _validator.Validate(Base() with { Descricao = null }).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Nome ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NomeVazio_Rejeita(string nome)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Nome = nome });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarRecursoAcessibilidadeCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Nome acima de 200 caracteres é rejeitado")]
+    public void NomeLongo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Nome = new string('A', 201) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarRecursoAcessibilidadeCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Descrição acima de 1000 caracteres é rejeitada")]
+    public void DescricaoLonga_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Descricao = new string('D', 1001) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarRecursoAcessibilidadeCommand.Descricao));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/TipoDeficienciaValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/TipoDeficienciaValidatorTests.cs
@@ -1,0 +1,60 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposDeficiencia;
+
+/// <summary>
+/// O validator antecipa a obrigatoriedade do nome e os limites de tamanho de nome e
+/// descrição, mantendo a fronteira simétrica com o domínio (UNI-REQ-0012).
+/// </summary>
+public sealed class TipoDeficienciaValidatorTests
+{
+    private readonly CriarTipoDeficienciaCommandValidator _validator = new();
+
+    private static CriarTipoDeficienciaCommand Base() =>
+        new("Visual", "Deficiência relacionada à visão");
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Comando sem descrição passa no validator")]
+    public void SemDescricao_Passa()
+    {
+        _validator.Validate(Base() with { Descricao = null }).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Nome ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NomeVazio_Rejeita(string nome)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Nome = nome });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoDeficienciaCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Nome acima do tamanho máximo é rejeitado")]
+    public void NomeLongo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Nome = new string('A', 201) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoDeficienciaCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Descrição acima do tamanho máximo é rejeitada")]
+    public void DescricaoLonga_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Descricao = new string('A', 1001) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoDeficienciaCommand.Descricao));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CondicaoAtendimentoEspecializadoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CondicaoAtendimentoEspecializadoTests.cs
@@ -1,0 +1,146 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CondicaoAtendimentoEspecializadoTests
+{
+    private const string Codigo = "DISLEXIA";
+    private const string Nome = "Dislexia";
+
+    private static Result<CondicaoAtendimentoEspecializado> Criar(
+        string codigo = Codigo,
+        string nome = Nome,
+        string? descricao = null) =>
+        CondicaoAtendimentoEspecializado.Criar(codigo, nome, descricao);
+
+    [Fact(DisplayName = "Criar com dados válidos preenche os campos e fica ativa com Guid v7")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        CondicaoAtendimentoEspecializado condicao = Criar(descricao: "Transtorno específico de aprendizagem").Value!;
+
+        condicao.Id.Should().NotBe(Guid.Empty);
+        condicao.Codigo.Valor.Should().Be(Codigo);
+        condicao.Nome.Should().Be(Nome);
+        condicao.Descricao.Should().Be("Transtorno específico de aprendizagem");
+        condicao.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar sem descrição é aceito")]
+    public void Criar_SemDescricao_Aceita()
+    {
+        CondicaoAtendimentoEspecializado condicao = Criar(descricao: null).Value!;
+
+        condicao.Descricao.Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Código ausente ou em branco é rejeitado (CodigoObrigatorio)")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemCodigo_Falha(string codigo)
+    {
+        Result<CondicaoAtendimentoEspecializado> resultado = Criar(codigo: codigo);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoObrigatorio);
+    }
+
+    [Theory(DisplayName = "Código fora do formato fechado é rejeitado (CodigoFormatoInvalido)")]
+    [InlineData("dislexia")]      // minúsculas
+    [InlineData("1PCD")]          // começa com dígito
+    [InlineData("_PCD")]          // começa com sublinhado
+    [InlineData("P")]             // curto demais (< 2)
+    [InlineData("PCD-A")]         // hífen não permitido
+    [InlineData("PCD A")]         // espaço não permitido
+    public void Criar_CodigoFormatoInvalido_Falha(string codigo)
+    {
+        Result<CondicaoAtendimentoEspecializado> resultado = Criar(codigo: codigo);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoFormatoInvalido);
+    }
+
+    [Fact(DisplayName = "Código acima de 50 caracteres é rejeitado (CodigoFormatoInvalido)")]
+    public void Criar_CodigoLongo_Falha()
+    {
+        Result<CondicaoAtendimentoEspecializado> resultado = Criar(codigo: "A" + new string('B', 50));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoFormatoInvalido);
+    }
+
+    [Theory(DisplayName = "Nome ausente ou em branco é rejeitado (NomeObrigatorio)")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemNome_Falha(string nome)
+    {
+        Result<CondicaoAtendimentoEspecializado> resultado = Criar(nome: nome);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.NomeObrigatorio);
+    }
+
+    [Theory(DisplayName = "Nome com 1 caractere ou acima de 200 é rejeitado (NomeTamanho)")]
+    [InlineData("A")]
+    [InlineData("longo")]
+    public void Criar_NomeTamanhoInvalido_Falha(string variante)
+    {
+        string nome = variante == "longo" ? new string('N', 201) : variante;
+
+        Result<CondicaoAtendimentoEspecializado> resultado = Criar(nome: nome);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.NomeTamanho);
+    }
+
+    [Fact(DisplayName = "Descrição acima de 1000 caracteres é rejeitada (DescricaoTamanho)")]
+    public void Criar_DescricaoLonga_Falha()
+    {
+        Result<CondicaoAtendimentoEspecializado> resultado = Criar(descricao: new string('D', 1001));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.DescricaoTamanho);
+    }
+
+    [Fact(DisplayName = "Atualizar troca os atributos editáveis, inclusive o código (não reservado)")]
+    public void Atualizar_AlteraAtributos_InclusiveCodigo()
+    {
+        CondicaoAtendimentoEspecializado condicao = Criar(codigo: "LACTANTE", nome: "Lactante").Value!;
+        Guid idOriginal = condicao.Id;
+
+        Result resultado = condicao.Atualizar("LACTANTE_GESTANTE", "Lactante ou gestante", "Atendimento ampliado");
+
+        resultado.IsSuccess.Should().BeTrue();
+        condicao.Codigo.Valor.Should().Be("LACTANTE_GESTANTE");
+        condicao.Nome.Should().Be("Lactante ou gestante");
+        condicao.Id.Should().Be(idOriginal, "o Id é imutável mesmo com o código editável");
+    }
+
+    [Fact(DisplayName = "Atualizar bloqueia renomear o código reservado PCD (CodigoProtegidoNaoEditavel)")]
+    public void Atualizar_RenomearPcd_Bloqueia()
+    {
+        CondicaoAtendimentoEspecializado pcd = Criar(codigo: CodigoCondicao.Pcd, nome: "Pessoa com deficiência").Value!;
+
+        Result resultado = pcd.Atualizar("OUTRA_CONDICAO", "Outra condição", null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoProtegidoNaoEditavel);
+        pcd.Codigo.Valor.Should().Be(CodigoCondicao.Pcd, "o código reservado permanece intacto");
+    }
+
+    [Fact(DisplayName = "Atualizar o nome/descrição mantendo o código PCD é permitido")]
+    public void Atualizar_PcdMantendoCodigo_Aceita()
+    {
+        CondicaoAtendimentoEspecializado pcd = Criar(codigo: CodigoCondicao.Pcd, nome: "Pessoa com deficiência").Value!;
+
+        Result resultado = pcd.Atualizar(CodigoCondicao.Pcd, "Pessoa com deficiência (PcD)", "Conforme LBI");
+
+        resultado.IsSuccess.Should().BeTrue();
+        pcd.Nome.Should().Be("Pessoa com deficiência (PcD)");
+        pcd.Codigo.Valor.Should().Be(CodigoCondicao.Pcd);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/RecursoAcessibilidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/RecursoAcessibilidadeTests.cs
@@ -1,0 +1,88 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RecursoAcessibilidadeTests
+{
+    private const string Nome = "Ledor";
+
+    private static Result<RecursoAcessibilidade> Criar(
+        string nome = Nome,
+        string? descricao = null) =>
+        RecursoAcessibilidade.Criar(nome, descricao);
+
+    [Fact(DisplayName = "Criar com dados válidos preenche os campos e fica ativo com Guid v7")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        RecursoAcessibilidade recurso = Criar(descricao: "Profissional que lê a prova ao candidato").Value!;
+
+        recurso.Id.Should().NotBe(Guid.Empty);
+        recurso.Nome.Should().Be(Nome);
+        recurso.Descricao.Should().Be("Profissional que lê a prova ao candidato");
+        recurso.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar sem descrição é aceito e mantém o campo nulo")]
+    public void Criar_SemDescricao_Aceita()
+    {
+        RecursoAcessibilidade recurso = Criar(descricao: null).Value!;
+
+        recurso.Descricao.Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Nome ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemNome_Falha(string nome)
+    {
+        Result<RecursoAcessibilidade> resultado = Criar(nome: nome);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RecursoAcessibilidadeErrorCodes.NomeObrigatorio);
+    }
+
+    [Fact(DisplayName = "Nome abaixo do tamanho mínimo (2) é rejeitado")]
+    public void Criar_NomeCurto_Falha()
+    {
+        Result<RecursoAcessibilidade> resultado = Criar(nome: "A");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RecursoAcessibilidadeErrorCodes.NomeTamanho);
+    }
+
+    [Fact(DisplayName = "Nome acima do tamanho máximo (200) é rejeitado")]
+    public void Criar_NomeLongo_Falha()
+    {
+        Result<RecursoAcessibilidade> resultado = Criar(nome: new string('A', 201));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RecursoAcessibilidadeErrorCodes.NomeTamanho);
+    }
+
+    [Fact(DisplayName = "Descrição acima do tamanho máximo (1000) é rejeitada")]
+    public void Criar_DescricaoLonga_Falha()
+    {
+        Result<RecursoAcessibilidade> resultado = Criar(descricao: new string('D', 1001));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RecursoAcessibilidadeErrorCodes.DescricaoTamanho);
+    }
+
+    [Fact(DisplayName = "Atualizar troca os atributos editáveis, inclusive o nome, preservando o Id")]
+    public void Atualizar_AlteraAtributos_PreservaId()
+    {
+        RecursoAcessibilidade recurso = Criar(nome: "Ledor").Value!;
+        Guid idOriginal = recurso.Id;
+
+        Result resultado = recurso.Atualizar("Tempo adicional", "Acréscimo de tempo para realização da prova");
+
+        resultado.IsSuccess.Should().BeTrue();
+        recurso.Nome.Should().Be("Tempo adicional");
+        recurso.Descricao.Should().Be("Acréscimo de tempo para realização da prova");
+        recurso.Id.Should().Be(idOriginal, "o Id é imutável mesmo com o nome editável");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TipoDeficienciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TipoDeficienciaTests.cs
@@ -1,0 +1,100 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class TipoDeficienciaTests
+{
+    private const string Nome = "Visual";
+
+    private static Result<TipoDeficiencia> Criar(
+        string nome = Nome,
+        string? descricao = null) =>
+        TipoDeficiencia.Criar(nome, descricao);
+
+    [Fact(DisplayName = "Criar com dados válidos preenche os campos e fica ativo com Guid v7")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        TipoDeficiencia tipo = Criar(descricao: "Deficiência relacionada à visão").Value!;
+
+        tipo.Id.Should().NotBe(Guid.Empty);
+        tipo.Nome.Should().Be(Nome);
+        tipo.Descricao.Should().Be("Deficiência relacionada à visão");
+        tipo.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar sem descrição (opcional) é aceito")]
+    public void Criar_SemDescricao_Aceita()
+    {
+        TipoDeficiencia tipo = Criar(descricao: null).Value!;
+
+        tipo.Descricao.Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Nome ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemNome_Falha(string nome)
+    {
+        Result<TipoDeficiencia> resultado = Criar(nome: nome);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.NomeObrigatorio);
+    }
+
+    [Fact(DisplayName = "Nome abaixo do tamanho mínimo é rejeitado")]
+    public void Criar_NomeCurto_Falha()
+    {
+        Result<TipoDeficiencia> resultado = Criar(nome: "A");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.NomeTamanho);
+    }
+
+    [Fact(DisplayName = "Nome acima do tamanho máximo é rejeitado")]
+    public void Criar_NomeLongo_Falha()
+    {
+        Result<TipoDeficiencia> resultado = Criar(nome: new string('A', 201));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.NomeTamanho);
+    }
+
+    [Fact(DisplayName = "Descrição acima do tamanho máximo é rejeitada")]
+    public void Criar_DescricaoLonga_Falha()
+    {
+        Result<TipoDeficiencia> resultado = Criar(descricao: new string('A', 1001));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.DescricaoTamanho);
+    }
+
+    [Fact(DisplayName = "Atualizar troca os atributos editáveis e preserva o Id imutável")]
+    public void Atualizar_AlteraAtributos_PreservaId()
+    {
+        TipoDeficiencia tipo = Criar(nome: "Visual").Value!;
+        Guid idOriginal = tipo.Id;
+
+        Result resultado = tipo.Atualizar("Auditiva", "Deficiência relacionada à audição");
+
+        resultado.IsSuccess.Should().BeTrue();
+        tipo.Nome.Should().Be("Auditiva");
+        tipo.Descricao.Should().Be("Deficiência relacionada à audição");
+        tipo.Id.Should().Be(idOriginal, "o Id é imutável mesmo com o nome editável");
+    }
+
+    [Fact(DisplayName = "Atualizar com nome inválido falha e não altera o estado")]
+    public void Atualizar_NomeInvalido_Falha()
+    {
+        TipoDeficiencia tipo = Criar(nome: "Visual").Value!;
+
+        Result resultado = tipo.Atualizar("A", null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoDeficienciaErrorCodes.NomeTamanho);
+        tipo.Nome.Should().Be("Visual");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/ValueObjects/CodigoCondicaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/ValueObjects/CodigoCondicaoTests.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CodigoCondicaoTests
+{
+    [Theory(DisplayName = "Códigos no formato fechado são aceitos e normalizados por Trim")]
+    [InlineData("PCD")]
+    [InlineData("DISLEXIA")]
+    [InlineData("LACTANTE")]
+    [InlineData("TEA_NIVEL_2")]
+    [InlineData("AB")]
+    public void Criar_FormatoValido_Aceita(string valor)
+    {
+        Result<CodigoCondicao> resultado = CodigoCondicao.Criar($"  {valor}  ");
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Valor.Should().Be(valor);
+    }
+
+    [Theory(DisplayName = "Códigos ausentes ou em branco retornam CodigoObrigatorio")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_EmBranco_Falha(string valor)
+    {
+        Result<CodigoCondicao> resultado = CodigoCondicao.Criar(valor);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoObrigatorio);
+    }
+
+    [Theory(DisplayName = "Códigos fora do formato retornam CodigoFormatoInvalido")]
+    [InlineData("pcd")]
+    [InlineData("1PCD")]
+    [InlineData("_PCD")]
+    [InlineData("P")]
+    [InlineData("PCD-A")]
+    [InlineData("PÇD")]
+    public void Criar_FormatoInvalido_Falha(string valor)
+    {
+        Result<CodigoCondicao> resultado = CodigoCondicao.Criar(valor);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.CodigoFormatoInvalido);
+    }
+
+    [Fact(DisplayName = "EhProtegido é verdadeiro apenas para o código reservado PCD")]
+    public void EhProtegido_SomenteParaPcd()
+    {
+        CodigoCondicao.Criar(CodigoCondicao.Pcd).Value!.EhProtegido.Should().BeTrue();
+        CodigoCondicao.Criar("DISLEXIA").Value!.EhProtegido.Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "EhValido reflete o formato fechado sem alocar value object")]
+    [InlineData("PCD", true)]
+    [InlineData("pcd", false)]
+    [InlineData("", false)]
+    [InlineData("A", false)]
+    public void EhValido_RefleteFormato(string valor, bool esperado)
+    {
+        CodigoCondicao.EhValido(valor).Should().Be(esperado);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CondicoesAtendimento/CondicaoAtendimentoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CondicoesAtendimento/CondicaoAtendimentoEndpointTests.cs
@@ -1,0 +1,190 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.CondicoesAtendimento;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>CondicaoAtendimentoEspecializado</c>
+/// (UNI-REQ-0012): routing, vendor media type, HATEOAS, autenticação/autorização,
+/// idempotência, formato fechado do código (422), unicidade do código (409) e
+/// bloqueio de remoção do código reservado PCD (409) — com Wolverine contra
+/// Postgres efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class CondicaoAtendimentoEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public CondicaoAtendimentoEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/condicoes-atendimento retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/condicoes-atendimento", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.condicao-atendimento.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/condicoes-atendimento/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/condicoes-atendimento/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/configuracao/admin/condicoes-atendimento sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/condicoes-atendimento", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        var body = new { codigo = CodigoUnico(), nome = "Sem permissão" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/condicoes-atendimento", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a policy [Authorize(Roles = \"plataforma-admin\")] nega um principal autenticado sem o role");
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/condicoes-atendimento", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST cria (201) e o GET subsequente retorna os campos + HATEOAS")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        string codigo = CodigoUnico();
+        var body = new
+        {
+            codigo,
+            nome = "Dislexia",
+            descricao = "Transtorno específico de aprendizagem",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/condicoes-atendimento/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("codigo").GetString().Should().Be(codigo);
+        root.GetProperty("nome").GetString().Should().Be("Dislexia");
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "POST com código fora do formato fechado retorna 422")]
+    public async Task Criar_CodigoFormatoInvalido_Retorna422()
+    {
+        var body = new { codigo = "dislexia", nome = "Formato inválido" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com código já existente entre vivos retorna 409")]
+    public async Task Criar_CodigoDuplicado_Retorna409()
+    {
+        string codigo = CodigoUnico();
+        var body = new { codigo, nome = "Primeira" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage primeiro = await EnviarPostAdmin(client, body);
+        primeiro.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage segundo = await EnviarPostAdmin(client, new { codigo, nome = "Segunda" });
+        segundo.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact(DisplayName = "DELETE do código reservado PCD é bloqueado (409)")]
+    public async Task Remover_Pcd_Retorna409()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // Cria a condição reservada PCD (assume que não há seed prévio neste fixture).
+        HttpResponseMessage criar = await EnviarPostAdmin(client, new { codigo = "PCD", nome = "Pessoa com deficiência" });
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+
+        using HttpRequestMessage request = new(
+            HttpMethod.Delete, new Uri($"/api/configuracao/admin/condicoes-atendimento/{id}", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict,
+            "a condição reservada PCD não pode ser removida (ADR-0067)");
+    }
+
+    private static string CodigoUnico() => $"COND_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/condicoes-atendimento", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CondicoesAtendimento/CondicaoAtendimentoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CondicoesAtendimento/CondicaoAtendimentoPersistenceTests.cs
@@ -1,0 +1,213 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.CondicoesAtendimento;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CondicoesAtendimento;
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Integração ponta-a-ponta da CondicaoAtendimentoEspecializado contra Postgres
+/// real (UNI-REQ-0012): persistência, UNIQUE parcial do código vivo, liberação do
+/// slot por soft-delete, CHECK de formato do código, bloqueio de remoção do código
+/// reservado PCD (via handler) e leitura cross-módulo ordenada.
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class CondicaoAtendimentoPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public CondicaoAtendimentoPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Criar persiste os campos e fica visível pelo leitor cross-módulo")]
+    public async Task Insert_PersisteEFicaVisivelPeloReader()
+    {
+        string codigo = CodigoUnico();
+        CondicaoAtendimentoEspecializado condicao = Nova(codigo);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CondicoesAtendimento.Add(condicao);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        CondicaoAtendimentoEspecializado persistida = await readCtx.CondicoesAtendimento.SingleAsync(c => c.Id == condicao.Id);
+
+        persistida.Codigo.Valor.Should().Be(codigo);
+        persistida.Nome.Should().Be("Dislexia");
+        persistida.CreatedBy.Should().Be(AdminA);
+        persistida.IsDeleted.Should().BeFalse();
+
+        var reader = new CondicaoAtendimentoReader(readCtx);
+        CondicaoAtendimentoView? view = await reader.ObterPorIdAsync(condicao.Id);
+        view.Should().NotBeNull();
+        view!.Codigo.Should().Be(codigo);
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial do código rejeita segunda condição viva com mesmo código")]
+    public async Task UniquePartial_Codigo_RejeitaDuplicataAtiva()
+    {
+        string codigo = CodigoUnico();
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CondicoesAtendimento.Add(Nova(codigo));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.CondicoesAtendimento.Add(Nova(codigo));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        // Trava as constantes que o handler usa para traduzir a corrida concorrente
+        // (UniqueConstraintViolation.GetViolatedConstraint/IsCodigoConflict) em
+        // CodigoJaExiste/409: SqlState 23505 + nome do índice único parcial.
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_condicao_atendimento_especializado_codigo_vivo");
+    }
+
+    [Fact(DisplayName = "Código distinto é aceito")]
+    public async Task CodigoDistinto_Aceita()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.CondicoesAtendimento.Add(Nova(CodigoUnico()));
+        ctx.CondicoesAtendimento.Add(Nova(CodigoUnico()));
+
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().NotThrowAsync("os códigos são distintos");
+    }
+
+    [Fact(DisplayName = "Soft-delete preserva a trilha e libera o slot da UNIQUE parcial do código")]
+    public async Task SoftDelete_PreservaTrilhaELibertaSlot()
+    {
+        string codigo = CodigoUnico();
+        CondicaoAtendimentoEspecializado condicao = Nova(codigo);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CondicoesAtendimento.Add(condicao);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            CondicaoAtendimentoEspecializado tracked = await ctx.CondicoesAtendimento.SingleAsync(c => c.Id == condicao.Id);
+            ctx.CondicoesAtendimento.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            CondicaoAtendimentoEspecializado excluida = await ctx.CondicoesAtendimento
+                .IgnoreQueryFilters().SingleAsync(c => c.Id == condicao.Id);
+            excluida.IsDeleted.Should().BeTrue();
+            excluida.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.CondicoesAtendimento.Add(Nova(codigo));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do código foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita código fora do formato fechado via SQL cru")]
+    public async Task Check_RejeitaCodigoForaDoFormatoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.condicao_atendimento_especializado (id, codigo, nome, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"pcd"}, {"X"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de formato do código (UPPER_SNAKE iniciando por letra) impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "Remover o código reservado PCD via handler é bloqueado e não exclui o registro")]
+    public async Task Remover_Pcd_ViaHandler_Bloqueia()
+    {
+        CondicaoAtendimentoEspecializado pcd = Nova(CodigoCondicao.Pcd, nome: "Pessoa com deficiência");
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CondicoesAtendimento.Add(pcd);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext handlerCtx = _fixture.CreateDbContext(AdminB))
+        {
+            var repository = new CondicaoAtendimentoRepository(handlerCtx);
+            Result resultado = await RemoverCondicaoAtendimentoCommandHandler.Handle(
+                new RemoverCondicaoAtendimentoCommand(pcd.Id), repository, handlerCtx, CancellationToken.None);
+
+            resultado.IsFailure.Should().BeTrue();
+            resultado.Error!.Code.Should().Be(CondicaoAtendimentoErrorCodes.RemocaoBloqueadaCodigoProtegido);
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        bool aindaVivo = await readCtx.CondicoesAtendimento.AnyAsync(c => c.Id == pcd.Id);
+        aindaVivo.Should().BeTrue("a condição reservada PCD não pode ser removida");
+    }
+
+    [Fact(DisplayName = "Reader.ListarVivosAsync ordena por código e exclui soft-deleted")]
+    public async Task ListarVivos_OrdenaPorCodigoEExcluiSoftDeleted()
+    {
+        string prefixo = $"COND_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+        string codA = $"{prefixo}_A";
+        string codB = $"{prefixo}_B";
+        string codExcluido = $"{prefixo}_D";
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CondicoesAtendimento.Add(Nova(codB));
+            ctx.CondicoesAtendimento.Add(Nova(codA));
+            ctx.CondicoesAtendimento.Add(Nova(codExcluido));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            CodigoCondicao codigoExcluidoVo = CodigoCondicao.Criar(codExcluido).Value!;
+            CondicaoAtendimentoEspecializado aExcluir = await ctx.CondicoesAtendimento.SingleAsync(c => c.Codigo == codigoExcluidoVo);
+            ctx.CondicoesAtendimento.Remove(aExcluir);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new CondicaoAtendimentoReader(readCtx);
+        IReadOnlyList<CondicaoAtendimentoView> todos = await reader.ListarVivosAsync();
+
+        string[] meus = [.. todos
+            .Select(v => v.Codigo)
+            .Where(c => c.StartsWith(prefixo, StringComparison.Ordinal))];
+
+        meus.Should().Equal([codA, codB]);
+    }
+
+    private static CondicaoAtendimentoEspecializado Nova(string codigo, string nome = "Dislexia") =>
+        CondicaoAtendimentoEspecializado.Criar(codigo, nome, null).Value!;
+
+    private static string CodigoUnico() => $"COND_{Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/RecursosAcessibilidade/RecursoAcessibilidadeEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/RecursosAcessibilidade/RecursoAcessibilidadeEndpointTests.cs
@@ -1,0 +1,155 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.RecursosAcessibilidade;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>RecursoAcessibilidade</c>
+/// (UNI-REQ-0012): routing, vendor media type, HATEOAS, autenticação/autorização,
+/// idempotência e unicidade do nome (409) — com Wolverine contra Postgres efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class RecursoAcessibilidadeEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public RecursoAcessibilidadeEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/recursos-acessibilidade retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/recursos-acessibilidade", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.recurso-acessibilidade.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/recursos-acessibilidade/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/recursos-acessibilidade/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/configuracao/admin/recursos-acessibilidade sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/recursos-acessibilidade", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        var body = new { nome = NomeUnico(), descricao = "Sem permissão" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/recursos-acessibilidade", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a policy [Authorize(Roles = \"plataforma-admin\")] nega um principal autenticado sem o role");
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/recursos-acessibilidade", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST cria (201) e o GET subsequente retorna os campos + HATEOAS")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        string nome = NomeUnico();
+        var body = new
+        {
+            nome,
+            descricao = "Profissional que lê a prova ao candidato",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/recursos-acessibilidade/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("nome").GetString().Should().Be(nome);
+        root.GetProperty("descricao").GetString().Should().Be("Profissional que lê a prova ao candidato");
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "POST com nome já existente entre vivos retorna 409")]
+    public async Task Criar_NomeDuplicado_Retorna409()
+    {
+        string nome = NomeUnico();
+        var body = new { nome, descricao = "Primeiro" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage primeiro = await EnviarPostAdmin(client, body);
+        primeiro.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage segundo = await EnviarPostAdmin(client, new { nome, descricao = "Segundo" });
+        segundo.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    private static string NomeUnico() => $"Recurso {Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/recursos-acessibilidade", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/RecursosAcessibilidade/RecursoAcessibilidadePersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/RecursosAcessibilidade/RecursoAcessibilidadePersistenceTests.cs
@@ -1,0 +1,168 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.RecursosAcessibilidade;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta do RecursoAcessibilidade contra Postgres real
+/// (UNI-REQ-0012): persistência, UNIQUE parcial do nome vivo, liberação do slot por
+/// soft-delete e leitura cross-módulo ordenada por nome.
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class RecursoAcessibilidadePersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public RecursoAcessibilidadePersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Criar persiste os campos e fica visível pelo leitor cross-módulo")]
+    public async Task Insert_PersisteEFicaVisivelPeloReader()
+    {
+        string nome = NomeUnico();
+        RecursoAcessibilidade recurso = Novo(nome);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.RecursosAcessibilidade.Add(recurso);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        RecursoAcessibilidade persistido = await readCtx.RecursosAcessibilidade.SingleAsync(r => r.Id == recurso.Id);
+
+        persistido.Nome.Should().Be(nome);
+        persistido.CreatedBy.Should().Be(AdminA);
+        persistido.IsDeleted.Should().BeFalse();
+
+        var reader = new RecursoAcessibilidadeReader(readCtx);
+        RecursoAcessibilidadeView? view = await reader.ObterPorIdAsync(recurso.Id);
+        view.Should().NotBeNull();
+        view!.Nome.Should().Be(nome);
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial do nome rejeita segundo recurso vivo com mesmo nome")]
+    public async Task UniquePartial_Nome_RejeitaDuplicataAtiva()
+    {
+        string nome = NomeUnico();
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.RecursosAcessibilidade.Add(Novo(nome));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.RecursosAcessibilidade.Add(Novo(nome));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        // Trava as constantes que o handler usa para traduzir a corrida concorrente
+        // (UniqueConstraintViolation.GetViolatedConstraint/IsNomeConflict) em
+        // NomeJaExiste/409: SqlState 23505 + nome do índice único parcial.
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_recurso_acessibilidade_nome_vivo");
+    }
+
+    [Fact(DisplayName = "Nome distinto é aceito")]
+    public async Task NomeDistinto_Aceita()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.RecursosAcessibilidade.Add(Novo(NomeUnico()));
+        ctx.RecursosAcessibilidade.Add(Novo(NomeUnico()));
+
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().NotThrowAsync("os nomes são distintos");
+    }
+
+    [Fact(DisplayName = "Soft-delete preserva a trilha e libera o slot da UNIQUE parcial do nome")]
+    public async Task SoftDelete_PreservaTrilhaELibertaSlot()
+    {
+        string nome = NomeUnico();
+        RecursoAcessibilidade recurso = Novo(nome);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.RecursosAcessibilidade.Add(recurso);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            RecursoAcessibilidade tracked = await ctx.RecursosAcessibilidade.SingleAsync(r => r.Id == recurso.Id);
+            ctx.RecursosAcessibilidade.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            RecursoAcessibilidade excluido = await ctx.RecursosAcessibilidade
+                .IgnoreQueryFilters().SingleAsync(r => r.Id == recurso.Id);
+            excluido.IsDeleted.Should().BeTrue();
+            excluido.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.RecursosAcessibilidade.Add(Novo(nome));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do nome foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "Reader.ListarVivosAsync ordena por nome e exclui soft-deleted")]
+    public async Task ListarVivos_OrdenaPorNomeEExcluiSoftDeleted()
+    {
+        string prefixo = $"REC_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+        string nomeA = $"{prefixo}_A";
+        string nomeB = $"{prefixo}_B";
+        string nomeExcluido = $"{prefixo}_D";
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.RecursosAcessibilidade.Add(Novo(nomeB));
+            ctx.RecursosAcessibilidade.Add(Novo(nomeA));
+            ctx.RecursosAcessibilidade.Add(Novo(nomeExcluido));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            RecursoAcessibilidade aExcluir = await ctx.RecursosAcessibilidade.SingleAsync(r => r.Nome == nomeExcluido);
+            ctx.RecursosAcessibilidade.Remove(aExcluir);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new RecursoAcessibilidadeReader(readCtx);
+        IReadOnlyList<RecursoAcessibilidadeView> todos = await reader.ListarVivosAsync();
+
+        string[] meus = [.. todos
+            .Select(v => v.Nome)
+            .Where(n => n.StartsWith(prefixo, StringComparison.Ordinal))];
+
+        meus.Should().Equal([nomeA, nomeB]);
+    }
+
+    private static RecursoAcessibilidade Novo(string nome) =>
+        RecursoAcessibilidade.Criar(nome, "Recurso de acessibilidade").Value!;
+
+    private static string NomeUnico() => $"Recurso {Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposDeficiencia/TipoDeficienciaEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposDeficiencia/TipoDeficienciaEndpointTests.cs
@@ -1,0 +1,167 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.TiposDeficiencia;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>TipoDeficiencia</c>
+/// (UNI-REQ-0012): routing, vendor media type, HATEOAS, autenticação/autorização,
+/// idempotência, tamanho do nome (422) e unicidade do nome (409) — com Wolverine
+/// contra Postgres efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class TipoDeficienciaEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public TipoDeficienciaEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/tipos-deficiencia retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/tipos-deficiencia", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.tipo-deficiencia.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/tipos-deficiencia/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/tipos-deficiencia/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/configuracao/admin/tipos-deficiencia sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-deficiencia", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        var body = new { nome = NomeUnico() };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-deficiencia", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a policy [Authorize(Roles = \"plataforma-admin\")] nega um principal autenticado sem o role");
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-deficiencia", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST cria (201) e o GET subsequente retorna nome/descrição + HATEOAS")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        string nome = NomeUnico();
+        var body = new
+        {
+            nome,
+            descricao = "Deficiência relacionada à visão",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/tipos-deficiencia/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("nome").GetString().Should().Be(nome);
+        root.GetProperty("descricao").GetString().Should().Be("Deficiência relacionada à visão");
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "POST com nome abaixo do tamanho mínimo retorna 422")]
+    public async Task Criar_NomeCurto_Retorna422()
+    {
+        var body = new { nome = "A" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com nome já existente entre vivos retorna 409")]
+    public async Task Criar_NomeDuplicado_Retorna409()
+    {
+        string nome = NomeUnico();
+        var body = new { nome, descricao = "Primeiro" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage primeiro = await EnviarPostAdmin(client, body);
+        primeiro.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage segundo = await EnviarPostAdmin(client, new { nome, descricao = "Segundo" });
+        segundo.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    private static string NomeUnico() => $"Deficiência {Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-deficiencia", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposDeficiencia/TipoDeficienciaPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposDeficiencia/TipoDeficienciaPersistenceTests.cs
@@ -1,0 +1,168 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.TiposDeficiencia;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta do TipoDeficiencia contra Postgres real (UNI-REQ-0012):
+/// persistência, UNIQUE parcial do nome vivo, liberação do slot por soft-delete e
+/// leitura cross-módulo ordenada por nome.
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class TipoDeficienciaPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public TipoDeficienciaPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Criar persiste os campos e fica visível pelo leitor cross-módulo")]
+    public async Task Insert_PersisteEFicaVisivelPeloReader()
+    {
+        string nome = NomeUnico();
+        TipoDeficiencia tipo = Novo(nome);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposDeficiencia.Add(tipo);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        TipoDeficiencia persistido = await readCtx.TiposDeficiencia.SingleAsync(t => t.Id == tipo.Id);
+
+        persistido.Nome.Should().Be(nome);
+        persistido.CreatedBy.Should().Be(AdminA);
+        persistido.IsDeleted.Should().BeFalse();
+
+        var reader = new TipoDeficienciaReader(readCtx);
+        TipoDeficienciaView? view = await reader.ObterPorIdAsync(tipo.Id);
+        view.Should().NotBeNull();
+        view!.Nome.Should().Be(nome);
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial do nome rejeita segundo tipo vivo com mesmo nome")]
+    public async Task UniquePartial_Nome_RejeitaDuplicataAtiva()
+    {
+        string nome = NomeUnico();
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposDeficiencia.Add(Novo(nome));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.TiposDeficiencia.Add(Novo(nome));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        // Trava as constantes que o handler usa para traduzir a corrida concorrente
+        // (UniqueConstraintViolation.GetViolatedConstraint/IsNomeConflict) em
+        // NomeJaExiste/409: SqlState 23505 + nome do índice único parcial.
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_tipo_deficiencia_nome_vivo");
+    }
+
+    [Fact(DisplayName = "Nome distinto é aceito")]
+    public async Task NomeDistinto_Aceita()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.TiposDeficiencia.Add(Novo(NomeUnico()));
+        ctx.TiposDeficiencia.Add(Novo(NomeUnico()));
+
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().NotThrowAsync("os nomes são distintos");
+    }
+
+    [Fact(DisplayName = "Soft-delete preserva a trilha e libera o slot da UNIQUE parcial do nome")]
+    public async Task SoftDelete_PreservaTrilhaELibertaSlot()
+    {
+        string nome = NomeUnico();
+        TipoDeficiencia tipo = Novo(nome);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposDeficiencia.Add(tipo);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            TipoDeficiencia tracked = await ctx.TiposDeficiencia.SingleAsync(t => t.Id == tipo.Id);
+            ctx.TiposDeficiencia.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            TipoDeficiencia excluido = await ctx.TiposDeficiencia
+                .IgnoreQueryFilters().SingleAsync(t => t.Id == tipo.Id);
+            excluido.IsDeleted.Should().BeTrue();
+            excluido.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.TiposDeficiencia.Add(Novo(nome));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do nome foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "Reader.ListarVivosAsync ordena por nome e exclui soft-deleted")]
+    public async Task ListarVivos_OrdenaPorNomeEExcluiSoftDeleted()
+    {
+        string prefixo = $"DEF_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+        string nomeA = $"{prefixo}_A";
+        string nomeB = $"{prefixo}_B";
+        string nomeExcluido = $"{prefixo}_D";
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposDeficiencia.Add(Novo(nomeB));
+            ctx.TiposDeficiencia.Add(Novo(nomeA));
+            ctx.TiposDeficiencia.Add(Novo(nomeExcluido));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            TipoDeficiencia aExcluir = await ctx.TiposDeficiencia.SingleAsync(t => t.Nome == nomeExcluido);
+            ctx.TiposDeficiencia.Remove(aExcluir);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new TipoDeficienciaReader(readCtx);
+        IReadOnlyList<TipoDeficienciaView> todos = await reader.ListarVivosAsync();
+
+        string[] meus = [.. todos
+            .Select(v => v.Nome)
+            .Where(n => n.StartsWith(prefixo, StringComparison.Ordinal))];
+
+        meus.Should().Equal([nomeA, nomeB]);
+    }
+
+    private static TipoDeficiencia Novo(string nome) =>
+        TipoDeficiencia.Criar(nome, null).Value!;
+
+    private static string NomeUnico() => $"DEF_{Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
+}


### PR DESCRIPTION
## Contexto

Entrega os **três cadastros institucionais de referência** que alimentam a oferta de atendimento especializado dos processos seletivos (UNI-REQ-0012, story #590) — vocabulário canônico INEP/Edital ENEM. Cada um é um agregado independente com CRUD admin, leitor cross-módulo (ADR-0056), HATEOAS Level 1 (ADR-0029), cursor bidirecional (ADR-0089), soft-delete + auditoria — espelhando o padrão dos cadastros já na `main`.

## Os três cadastros (independentes entre si)

| Cadastro | Chave natural | Particularidade |
|---|---|---|
| **`CondicaoAtendimentoEspecializado`** | `Codigo` (VO, formato `^[A-Z][A-Z0-9_]{1,49}$`) + `Nome` | Código **PCD** reservado: não pode ser renomeado (guarda no agregado) nem removido (guarda no handler) — a trava de oferta da **ADR-0067** o referencia literalmente |
| **`RecursoAcessibilidade`** | `Nome` (único entre vivos) | Ledor, Tempo adicional, Prova ampliada, Intérprete de Libras… |
| **`TipoDeficiencia`** | `Nome` (único entre vivos) | Visual, Auditiva, TEA, Física, Intelectual… |

Os três são **independentes** (sem FK entre eles). O aninhamento *tipo de deficiência ↔ condição PCD* é regra de **consumo** do Módulo Seleção (ADR-0067), fora deste cadastro. Consumo cross-módulo por snapshot-copy desacoplado (ADR-0061): remoção sempre soft-delete e **nunca bloqueada** por oferta congelada — exceto a proteção do código PCD.

## Decisões de design (consistentes com o módulo)

- Unicidade por **índice único parcial** `WHERE is_deleted=false`; corrida `23505` → **409** via `UniqueConstraintViolation`.
- `CodigoCondicao` é value object com regex via `[GeneratedRegex]`, persistido por value converter (reidratação fail-fast); CHECK do regex no banco.
- Proteção PCD em **dois níveis**: o agregado bloqueia renomear (`CodigoProtegidoNaoEditavel`/422) e o handler bloqueia remover (`RemocaoBloqueadaCodigoProtegido`/409).
- Comparações case-sensitive (Ordinal) alinhadas ao banco; readers read-side sem cache.
- Materializa **LBI (Lei 13.146/2015, art. 30)**, **Lei 13.872/2019** (lactante) e **Lei 10.048/2000** (prioridade).

## Critérios de aceite

- **CA-01** três itens independentes com Guid v7 ✓ · **CA-02** unicidade por identificador (criação e edição) ✓ · **CA-03** regex do código / nome obrigatório ✓ · **CA-04** soft-delete + não-bloqueio por snapshot-copy + **bloqueio do PCD** ✓
- **CA-05 (a11y)** frontend · **CA-06 (LGPD)** inaplicável (rótulos institucionais, sem PII).

## Testes

Suíte completa do módulo verde, sem warnings: **Domain 162 · Application 143 · Integração 121** (1 skip pré-existente da #731). Inclui índice único via SQL cru, CHECK do regex, soft-delete liberando slot, bloqueio de remoção/renomeação do PCD e leitura cross-módulo. Migration forward-only (3 tabelas) e baseline OpenAPI regenerado (12 novos endpoints).

## Revisão prévia

Diff de produção revisado com Codex (Fase 9): **zero achados** (P1/P2/P3 nenhum), com a suíte inteira reexecutada (1653 testes, 0 warnings) e a regra PCD confirmada nos dois níveis.

Closes #590
Refs #584