### PR TITLE
feat(configuracao): adiciona cadastro de modalidade de concorrência

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -1582,6 +1582,476 @@
         }
       }
     },
+    "/api/configuracao/modalidades": {
+      "get": {
+        "tags": [
+          "Modalidades"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ModalidadeDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ModalidadeDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ModalidadeDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/modalidades/{id}": {
+      "get": {
+        "tags": [
+          "Modalidades"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModalidadeDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModalidadeDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModalidadeDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/modalidades": {
+      "post": {
+        "tags": [
+          "Modalidades"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarModalidadeCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarModalidadeCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarModalidadeCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/modalidades/{id}": {
+      "put": {
+        "tags": [
+          "Modalidades"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarModalidadeCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarModalidadeCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarModalidadeCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "Modalidades"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configuracao/pesos-area-enem": {
       "get": {
         "tags": [
@@ -4055,6 +4525,87 @@
           }
         }
       },
+      "AtualizarModalidadeCommand": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "naturezaLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "composicaoVagas": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "composicaoOrigem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "regraRemanejamento": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "remanejamentoDestino": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "remanejamentoPar": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "remanejamentoFallback": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criteriosCumulativos": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "acaoQuandoIndeferido": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "AtualizarPesoAreaEnemCommand": {
         "required": [
           "id",
@@ -4579,6 +5130,86 @@
           }
         }
       },
+      "CriarModalidadeCommand": {
+        "required": [
+          "codigo"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "naturezaLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "composicaoVagas": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "composicaoOrigem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "regraRemanejamento": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "remanejamentoDestino": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "remanejamentoPar": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "remanejamentoFallback": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criteriosCumulativos": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "acaoQuandoIndeferido": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "CriarPesoAreaEnemCommand": {
         "required": [
           "resolucao",
@@ -4998,6 +5629,107 @@
             ]
           },
           "codigoEmec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ModalidadeDto": {
+        "required": [
+          "id",
+          "codigo",
+          "descricao",
+          "naturezaLegal",
+          "composicaoVagas",
+          "composicaoOrigem",
+          "regraRemanejamento",
+          "remanejamentoDestino",
+          "remanejamentoPar",
+          "remanejamentoFallback",
+          "criteriosCumulativos",
+          "acaoQuandoIndeferido",
+          "baseLegal",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "naturezaLegal": {
+            "type": "string"
+          },
+          "composicaoVagas": {
+            "type": "string"
+          },
+          "composicaoOrigem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "regraRemanejamento": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "remanejamentoDestino": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "remanejamentoPar": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "remanejamentoFallback": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criteriosCumulativos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "acaoQuandoIndeferido": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "baseLegal": {
             "type": [
               "null",
               "string"
@@ -5440,6 +6172,9 @@
     },
     {
       "name": "LocaisOferta"
+    },
+    {
+      "name": "Modalidades"
     },
     {
       "name": "PesosAreaEnem"

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
@@ -54,6 +54,7 @@ public static class ConfiguracaoModuleRegistration
         services.AddSingleton<IResourceLinksBuilder<CondicaoAtendimentoDto>, CondicaoAtendimentoLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<RecursoAcessibilidadeDto>, RecursoAcessibilidadeLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<TipoDeficienciaDto>, TipoDeficienciaLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<ModalidadeDto>, ModalidadeLinksBuilder>();
 
         // Idempotency-Key (ADR-0027) sobre o DbContext do módulo.
         services.AddIdempotency<ConfiguracaoDbContext, ConfiguracaoApiAssemblyMarker>(configuration);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/ModalidadesController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/ModalidadesController.cs
@@ -1,0 +1,186 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.Modalidades;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/modalidades</c>,
+/// <c>GET /api/configuracao/modalidades/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/configuracao/admin/modalidades</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ-0011).
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class ModalidadesController : ControllerBase
+{
+    private const string ResourceTag = "modalidades";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<ModalidadeDto> _linksBuilder;
+
+    public ModalidadesController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<ModalidadeDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista as modalidades ativas, paginadas por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("modalidades")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "modalidade", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<ModalidadeDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarModalidadesResult resultado = await _queryBus
+            .Send(new ListarModalidadesQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        ModalidadeDto[] comLinks =
+            [.. resultado.Items.Select(m => m with { Links = _linksBuilder.Build(m) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém uma modalidade pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("modalidades/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "modalidade", Versions = [1])]
+    [ProducesResponseType(typeof(ModalidadeDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        ModalidadeDto? modalidade = await _queryBus
+            .Send(new ObterModalidadePorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (modalidade is null)
+        {
+            return NotFound();
+        }
+
+        ModalidadeDto comLinks = modalidade with { Links = _linksBuilder.Build(modalidade) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria uma nova modalidade. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/modalidades")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarModalidadeCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza uma modalidade existente. O código é imutável. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/modalidades/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarModalidadeCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) uma modalidade. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/modalidades/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverModalidadeCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -517,5 +517,102 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status404NotFound,
                 "uniplus.configuracao.tipo_deficiencia.nao_encontrado",
                 "Tipo de deficiência não encontrado")),
+
+        // ── Modalidade de concorrência (UNI-REQ-0011) ─────────────────────
+        new(ModalidadeErrorCodes.CodigoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.codigo_obrigatorio",
+                "Código da modalidade é obrigatório")),
+
+        new(ModalidadeErrorCodes.CodigoFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.codigo_formato_invalido",
+                "Código da modalidade em formato inválido")),
+
+        new(ModalidadeErrorCodes.CodigoJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.modalidade.codigo_ja_existe",
+                "Já existe uma modalidade ativa com este código")),
+
+        new(ModalidadeErrorCodes.DescricaoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.descricao_tamanho",
+                "Tamanho da descrição da modalidade inválido")),
+
+        new(ModalidadeErrorCodes.NaturezaInvalida,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.natureza_invalida",
+                "Natureza legal da modalidade fora do domínio fechado")),
+
+        new(ModalidadeErrorCodes.ComposicaoVagasInvalida,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.composicao_vagas_invalida",
+                "Composição de vagas da modalidade fora do domínio fechado")),
+
+        new(ModalidadeErrorCodes.RegraRemanejamentoInvalida,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.regra_remanejamento_invalida",
+                "Regra de remanejamento da modalidade fora do domínio fechado")),
+
+        new(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.natureza_remanejamento_incoerente",
+                "Regra de remanejamento incoerente com a natureza legal da modalidade")),
+
+        new(ModalidadeErrorCodes.OrigemObrigatoriaParaRetiraDe,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.origem_obrigatoria_para_retira_de",
+                "A modalidade com composição 'retira de' exige a modalidade de origem")),
+
+        new(ModalidadeErrorCodes.OrigemApenasParaRetiraDe,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.origem_apenas_para_retira_de",
+                "Somente a composição 'retira de' admite modalidade de origem")),
+
+        new(ModalidadeErrorCodes.ArgumentoRemanejamentoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.argumento_remanejamento_obrigatorio",
+                "Argumentos de remanejamento incompatíveis com a regra declarada")),
+
+        new(ModalidadeErrorCodes.AcaoIndeferimentoInvalida,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.acao_indeferimento_invalida",
+                "Ação no indeferimento fora do domínio fechado")),
+
+        new(ModalidadeErrorCodes.ReferenciaInexistenteOuInativa,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.referencia_inexistente_ou_inativa",
+                "Modalidade referenciada (origem/destino/par/fallback) inexistente ou inativa")),
+
+        new(ModalidadeErrorCodes.RemocaoBloqueadaPorReferencia,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.modalidade.remocao_bloqueada_por_referencia",
+                "Não é possível remover uma modalidade referenciada por outra modalidade ativa")),
+
+        new(ModalidadeErrorCodes.BaseLegalTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.base_legal_tamanho",
+                "Tamanho da base legal da modalidade inválido")),
+
+        new(ModalidadeErrorCodes.NaoEncontrada,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.modalidade.nao_encontrada",
+                "Modalidade não encontrada")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/ModalidadeLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/ModalidadeLinksBuilder.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="ModalidadeDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<ModalidadeDto>, ModalidadeLinksBuilder>().")]
+internal sealed class ModalidadeLinksBuilder : IResourceLinksBuilder<ModalidadeDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public ModalidadeLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(ModalidadeDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "Modalidades";
+
+        string self = ResolverPath(
+            httpContext, nameof(ModalidadesController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(ModalidadesController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/AtualizarModalidadeCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/AtualizarModalidadeCommand.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza uma modalidade de concorrência existente. O <c>Codigo</c> e o <c>Id</c>
+/// são <b>imutáveis</b> (diferente do TipoDocumento): o comando <b>não</b> aceita
+/// código — o handler carrega a entidade e a atualiza sem alterá-lo. Os enums
+/// chegam como tokens canônicos UPPER_SNAKE. O ator (<c>updated_by</c>) é carimbado
+/// server-side via <c>IUserContext</c>.
+/// </summary>
+public sealed record AtualizarModalidadeCommand(
+    Guid Id,
+    string? Descricao = null,
+    string? NaturezaLegal = null,
+    string? ComposicaoVagas = null,
+    string? ComposicaoOrigem = null,
+    string? RegraRemanejamento = null,
+    string? RemanejamentoDestino = null,
+    string? RemanejamentoPar = null,
+    string? RemanejamentoFallback = null,
+    IReadOnlyList<string>? CriteriosCumulativos = null,
+    string? AcaoQuandoIndeferido = null,
+    string? BaseLegal = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/AtualizarModalidadeCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/AtualizarModalidadeCommandHandler.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarModalidadeCommand"/>. Carrega a modalidade (404
+/// se inexistente), aplica os campos editáveis (o <c>Codigo</c> é imutável, então
+/// não há checagem de unicidade nem corrida de índice), revalida as invariantes de
+/// coerência (422) e a integridade referencial dos códigos citados (422), e commita.
+/// </summary>
+public static class AtualizarModalidadeCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarModalidadeCommand command,
+        IModalidadeRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        Modalidade? modalidade = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (modalidade is null)
+        {
+            return Result.Failure(new DomainError(
+                ModalidadeErrorCodes.NaoEncontrada,
+                "Modalidade de concorrência não encontrada."));
+        }
+
+        Result atualizarResult = modalidade.Atualizar(
+            command.Descricao,
+            command.NaturezaLegal,
+            command.ComposicaoVagas,
+            command.ComposicaoOrigem,
+            command.RegraRemanejamento,
+            command.RemanejamentoDestino,
+            command.RemanejamentoPar,
+            command.RemanejamentoFallback,
+            command.CriteriosCumulativos,
+            command.AcaoQuandoIndeferido,
+            command.BaseLegal);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        // Integridade referencial (invariante 7): todos os códigos citados após a
+        // atualização devem existir como modalidade viva.
+        IReadOnlyCollection<string> referencias = ReferenciasDeModalidade.Coletar(modalidade);
+        if (referencias.Count > 0
+            && !await repository.CodigosVivosExistemAsync(referencias, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                ModalidadeErrorCodes.ReferenciaInexistenteOuInativa,
+                "Um ou mais códigos de modalidade referenciados (origem ou remanejamento) "
+                + "não correspondem a modalidades vivas."));
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/AtualizarModalidadeCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/AtualizarModalidadeCommandValidator.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Antecipa (422) o domínio fechado dos enums e os tamanhos na atualização. O
+/// <c>Codigo</c> é imutável e não é campo do comando. A coerência e a integridade
+/// referencial ficam no agregado e no handler.
+/// </summary>
+public sealed class AtualizarModalidadeCommandValidator : AbstractValidator<AtualizarModalidadeCommand>
+{
+    public AtualizarModalidadeCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id da modalidade é obrigatório.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(300).WithMessage("Descrição da modalidade deve ter no máximo 300 caracteres.")
+            .When(x => x.Descricao is not null);
+
+        RuleFor(x => x.NaturezaLegal)
+            .Must(NaturezasLegais.EhValido)
+            .WithMessage($"Natureza legal deve ser uma de: {string.Join(", ", NaturezasLegais.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.NaturezaLegal));
+
+        RuleFor(x => x.ComposicaoVagas)
+            .Must(ComposicoesVagas.EhValido)
+            .WithMessage($"Composição de vagas deve ser uma de: {string.Join(", ", ComposicoesVagas.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.ComposicaoVagas));
+
+        RuleFor(x => x.RegraRemanejamento)
+            .Must(RegrasRemanejamento.EhValido)
+            .WithMessage($"Regra de remanejamento deve ser uma de: {string.Join(", ", RegrasRemanejamento.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.RegraRemanejamento));
+
+        RuleFor(x => x.AcaoQuandoIndeferido)
+            .Must(AcoesQuandoIndeferido.EhValido)
+            .WithMessage($"Ação quando indeferido deve ser uma de: {string.Join(", ", AcoesQuandoIndeferido.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.AcaoQuandoIndeferido));
+
+        RuleFor(x => x.ComposicaoOrigem)
+            .MaximumLength(60).WithMessage("Código de origem da composição deve ter no máximo 60 caracteres.")
+            .When(x => x.ComposicaoOrigem is not null);
+
+        RuleFor(x => x.BaseLegal)
+            .MaximumLength(500).WithMessage("Base legal da modalidade deve ter no máximo 500 caracteres.")
+            .When(x => x.BaseLegal is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/CriarModalidadeCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/CriarModalidadeCommand.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria uma modalidade de concorrência (UNI-REQ-0011): código (chave natural
+/// imutável), descrição opcional, e os campos de cota como tokens canônicos
+/// UPPER_SNAKE para os enums (<c>NaturezaLegal</c>, <c>ComposicaoVagas</c>,
+/// <c>RegraRemanejamento</c>, <c>AcaoQuandoIndeferido</c>). Quando ausentes,
+/// <c>NaturezaLegal</c> assume AMPLA e <c>ComposicaoVagas</c> assume RESIDUAL_DO_VO.
+/// O ator de auditoria (<c>created_by</c>) é carimbado server-side via
+/// <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarModalidadeCommand(
+    string Codigo,
+    string? Descricao = null,
+    string? NaturezaLegal = null,
+    string? ComposicaoVagas = null,
+    string? ComposicaoOrigem = null,
+    string? RegraRemanejamento = null,
+    string? RemanejamentoDestino = null,
+    string? RemanejamentoPar = null,
+    string? RemanejamentoFallback = null,
+    IReadOnlyList<string>? CriteriosCumulativos = null,
+    string? AcaoQuandoIndeferido = null,
+    string? BaseLegal = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/CriarModalidadeCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/CriarModalidadeCommandHandler.cs
@@ -1,0 +1,91 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarModalidadeCommand"/> (convention-based Wolverine).
+/// Orquestra: unicidade do código entre vivos (409), construção do agregado
+/// (invariantes de coerência, 422), integridade referencial dos códigos citados em
+/// composição/remanejamento (422), persistência e commit. Protege a corrida
+/// check-then-act traduzindo a violação do índice único parcial em
+/// <c>CodigoJaExiste</c>.
+/// </summary>
+public static class CriarModalidadeCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarModalidadeCommand command,
+        IModalidadeRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.CodigoExisteEntreVivosAsync(command.Codigo, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        Result<Modalidade> modalidadeResult = Modalidade.Criar(
+            command.Codigo,
+            command.Descricao,
+            command.NaturezaLegal,
+            command.ComposicaoVagas,
+            command.ComposicaoOrigem,
+            command.RegraRemanejamento,
+            command.RemanejamentoDestino,
+            command.RemanejamentoPar,
+            command.RemanejamentoFallback,
+            command.CriteriosCumulativos,
+            command.AcaoQuandoIndeferido,
+            command.BaseLegal);
+
+        if (modalidadeResult.IsFailure)
+        {
+            return Result<Guid>.Failure(modalidadeResult.Error!);
+        }
+
+        Modalidade modalidade = modalidadeResult.Value!;
+
+        // Integridade referencial (invariante 7): todos os códigos citados (origem +
+        // remanejamento) devem existir como modalidade viva.
+        IReadOnlyCollection<string> referencias = ReferenciasDeModalidade.Coletar(modalidade);
+        if (referencias.Count > 0
+            && !await repository.CodigosVivosExistemAsync(referencias, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(ReferenciaInexistenteErro());
+        }
+
+        await repository.AdicionarAsync(modalidade, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCodigoConflict(constraint))
+        {
+            // Corrida entre CodigoExisteEntreVivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo CodigoJaExiste do
+            // caminho não-race — 409 consistente. O filtro do `when` garante que
+            // outras exceções propagam intactas.
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        return Result<Guid>.Success(modalidade.Id);
+    }
+
+    private static DomainError CodigoJaExisteErro(string codigo) =>
+        new(ModalidadeErrorCodes.CodigoJaExiste,
+            $"Já existe uma modalidade viva com o código '{codigo}'.");
+
+    private static DomainError ReferenciaInexistenteErro() =>
+        new(ModalidadeErrorCodes.ReferenciaInexistenteOuInativa,
+            "Um ou mais códigos de modalidade referenciados (origem ou remanejamento) "
+            + "não correspondem a modalidades vivas.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/CriarModalidadeCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/CriarModalidadeCommandValidator.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+/// <summary>
+/// Antecipa (422) o formato do código, o domínio fechado dos enums e os tamanhos —
+/// simétrico ao domínio (#589). A coerência natureza↔remanejamento, a equivalência
+/// RetiraDe⟺origem, os args por regra e a integridade referencial ficam no agregado
+/// e no handler.
+/// </summary>
+public sealed class CriarModalidadeCommandValidator : AbstractValidator<CriarModalidadeCommand>
+{
+    public CriarModalidadeCommandValidator()
+    {
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código da modalidade é obrigatório.")
+            .Must(CodigoModalidade.EhValido)
+            .WithMessage("Código da modalidade deve conter apenas letras maiúsculas, dígitos e "
+                + "sublinhado (sem hífen), com no máximo 60 caracteres.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(300).WithMessage("Descrição da modalidade deve ter no máximo 300 caracteres.")
+            .When(x => x.Descricao is not null);
+
+        RuleFor(x => x.NaturezaLegal)
+            .Must(NaturezasLegais.EhValido)
+            .WithMessage($"Natureza legal deve ser uma de: {string.Join(", ", NaturezasLegais.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.NaturezaLegal));
+
+        RuleFor(x => x.ComposicaoVagas)
+            .Must(ComposicoesVagas.EhValido)
+            .WithMessage($"Composição de vagas deve ser uma de: {string.Join(", ", ComposicoesVagas.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.ComposicaoVagas));
+
+        RuleFor(x => x.RegraRemanejamento)
+            .Must(RegrasRemanejamento.EhValido)
+            .WithMessage($"Regra de remanejamento deve ser uma de: {string.Join(", ", RegrasRemanejamento.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.RegraRemanejamento));
+
+        RuleFor(x => x.AcaoQuandoIndeferido)
+            .Must(AcoesQuandoIndeferido.EhValido)
+            .WithMessage($"Ação quando indeferido deve ser uma de: {string.Join(", ", AcoesQuandoIndeferido.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.AcaoQuandoIndeferido));
+
+        RuleFor(x => x.ComposicaoOrigem)
+            .MaximumLength(60).WithMessage("Código de origem da composição deve ter no máximo 60 caracteres.")
+            .When(x => x.ComposicaoOrigem is not null);
+
+        RuleFor(x => x.BaseLegal)
+            .MaximumLength(500).WithMessage("Base legal da modalidade deve ter no máximo 500 caracteres.")
+            .When(x => x.BaseLegal is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/ReferenciasDeModalidade.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/ReferenciasDeModalidade.cs
@@ -1,0 +1,34 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+/// <summary>
+/// Coleta os códigos de outras modalidades que uma <see cref="Modalidade"/> cita —
+/// <c>ComposicaoOrigem</c> e os argumentos de remanejamento (destino/par/fallback)
+/// — para a checagem de integridade referencial no handler (invariante 7). Lê os
+/// valores já normalizados pelo agregado.
+/// </summary>
+internal static class ReferenciasDeModalidade
+{
+    public static IReadOnlyCollection<string> Coletar(Modalidade modalidade)
+    {
+        ArgumentNullException.ThrowIfNull(modalidade);
+
+        var referencias = new HashSet<string>(StringComparer.Ordinal);
+
+        Adicionar(referencias, modalidade.ComposicaoOrigem);
+        Adicionar(referencias, modalidade.RemanejamentoArgs.Destino);
+        Adicionar(referencias, modalidade.RemanejamentoArgs.Par);
+        Adicionar(referencias, modalidade.RemanejamentoArgs.Fallback);
+
+        return referencias;
+    }
+
+    private static void Adicionar(HashSet<string> destino, string? codigo)
+    {
+        if (!string.IsNullOrWhiteSpace(codigo))
+        {
+            destino.Add(codigo);
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/RemoverModalidadeCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/RemoverModalidadeCommand.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Remove (soft-delete) uma modalidade de concorrência pelo seu <c>Id</c>.</summary>
+public sealed record RemoverModalidadeCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/RemoverModalidadeCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/RemoverModalidadeCommandHandler.cs
@@ -1,0 +1,58 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverModalidadeCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c> — bloqueia (409) quando ESTA modalidade é
+/// referenciada por OUTRA modalidade viva como <c>composicao_origem</c> ou como
+/// destino/par/fallback em <c>remanejamento_args</c> (integridade referencial
+/// intra-banco, invariante 7). Nunca é bloqueada por snapshot-copy de Seleção
+/// (ADR-0061). A auto-referência não bloqueia a própria remoção (checagem exclui o
+/// próprio Id).
+/// </summary>
+public static class RemoverModalidadeCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverModalidadeCommand command,
+        IModalidadeRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        Modalidade? modalidade = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (modalidade is null)
+        {
+            return Result.Failure(new DomainError(
+                ModalidadeErrorCodes.NaoEncontrada,
+                "Modalidade de concorrência não encontrada."));
+        }
+
+        // Check-then-act, simétrico ao bloqueio de remoção dos demais cadastros. A
+        // serialização estrita sob concorrência é controle cross-cutting, fora desta
+        // Story. O próprio Id é excluído — auto-referência não bloqueia a remoção.
+        if (await repository
+            .EhReferenciadaPorOutraModalidadeVivaAsync(modalidade.Codigo.Valor, modalidade.Id, cancellationToken)
+            .ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                ModalidadeErrorCodes.RemocaoBloqueadaPorReferencia,
+                "Não é possível remover uma modalidade referenciada por outra modalidade viva "
+                + "(como origem de composição ou destino/par/fallback de remanejamento)."));
+        }
+
+        repository.Remover(modalidade);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/UniqueConstraintViolation.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do código vivo da
+/// modalidade — <c>ix_modalidade_codigo_vivo</c> — para o <c>DomainError</c>
+/// apropriado. Acessa <c>SqlState</c> e <c>ConstraintName</c> por reflection no
+/// inner exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção por
+/// <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão do <c>UniqueConstraintViolation</c> dos demais cadastros de
+/// Configuração. A tradução cross-cutting de 23505 → 409 via
+/// <c>GlobalExceptionMiddleware</c> permanece como follow-up separado (#504); este
+/// helper cobre o caso específico da unicidade do código, inclusive a corrida na
+/// criação (o código é imutável, então não há corrida na atualização).
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string CodigoConstraint = "ix_modalidade_codigo_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o caller
+    /// deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único parcial
+    /// que garante uma única modalidade viva por código.
+    /// </summary>
+    public static bool IsCodigoConflict(string? constraint) =>
+        string.Equals(constraint, CodigoConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/ModalidadeDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/ModalidadeDto.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>Modalidade</c> de concorrência. Suporta HATEOAS
+/// Level 1 via <c>_links</c> (ADR-0029). Os enums são expostos como tokens
+/// canônicos UPPER_SNAKE; os argumentos de remanejamento como campos planos.
+/// </summary>
+public sealed record ModalidadeDto(
+    Guid Id,
+    string Codigo,
+    string? Descricao,
+    string NaturezaLegal,
+    string ComposicaoVagas,
+    string? ComposicaoOrigem,
+    string? RegraRemanejamento,
+    string? RemanejamentoDestino,
+    string? RemanejamentoPar,
+    string? RemanejamentoFallback,
+    IReadOnlyList<string> CriteriosCumulativos,
+    string? AcaoQuandoIndeferido,
+    string? BaseLegal,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/ModalidadeMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/ModalidadeMapping.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public static class ModalidadeMapping
+{
+    public static ModalidadeDto ToDto(this Modalidade modalidade)
+    {
+        ArgumentNullException.ThrowIfNull(modalidade);
+        return new ModalidadeDto(
+            modalidade.Id,
+            modalidade.Codigo.Valor,
+            modalidade.Descricao,
+            NaturezasLegais.ParaTokenCanonico(modalidade.NaturezaLegal),
+            ComposicoesVagas.ParaTokenCanonico(modalidade.ComposicaoVagas),
+            modalidade.ComposicaoOrigem,
+            modalidade.RegraRemanejamento is { } regra
+                ? RegrasRemanejamento.ParaTokenCanonico(regra)
+                : null,
+            modalidade.RemanejamentoArgs.Destino,
+            modalidade.RemanejamentoArgs.Par,
+            modalidade.RemanejamentoArgs.Fallback,
+            modalidade.CriteriosCumulativos,
+            modalidade.AcaoQuandoIndeferido is { } acao
+                ? AcoesQuandoIndeferido.ParaTokenCanonico(acao)
+                : null,
+            modalidade.BaseLegal,
+            modalidade.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ListarModalidadesQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ListarModalidadesQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Modalidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista modalidades de concorrência vivas paginadas por cursor bidirecional
+/// (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e valida
+/// limit/direction antes de despachar.
+/// </summary>
+public sealed record ListarModalidadesQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarModalidadesResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ListarModalidadesQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ListarModalidadesQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Modalidades;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarModalidadesQueryHandler
+{
+    public static async Task<ListarModalidadesResult> Handle(
+        ListarModalidadesQuery query,
+        IModalidadeRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<Modalidade> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        ModalidadeDto[] items = [.. itens.Select(m => m.ToDto())];
+        return new ListarModalidadesResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ListarModalidadesResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ListarModalidadesResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Modalidades;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarModalidadesQuery"/>: lote de modalidades
+/// projetadas + âncoras opcionais para o controller construir os cursores
+/// prev/next (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarModalidadesResult(
+    IReadOnlyList<ModalidadeDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ObterModalidadePorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ObterModalidadePorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Modalidades;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterModalidadePorIdQuery(Guid Id) : IQuery<ModalidadeDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ObterModalidadePorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Modalidades/ObterModalidadePorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Modalidades;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterModalidadePorIdQueryHandler
+{
+    public static async Task<ModalidadeDto?> Handle(
+        ObterModalidadePorIdQuery query,
+        IModalidadeRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        Modalidade? modalidade = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return modalidade?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IModalidadeReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IModalidadeReader.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>Modalidade</c> de concorrência (ADR-0056). Expõe o
+/// estado vivo do cadastro de modalidades para consumo por outros bounded contexts
+/// (ex.: a configuração de modalidades de um edital no Módulo Seleção) sem acesso
+/// direto ao banco de Configuração (ADR-0054).
+/// </summary>
+public interface IModalidadeReader
+{
+    /// <summary>
+    /// Lista todas as modalidades vivas (não soft-deleted), ordenadas por
+    /// <c>Codigo</c> ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<ModalidadeView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém uma modalidade pelo <paramref name="id"/>, ou <see langword="null"/>
+    /// se inexistente / soft-deleted.
+    /// </summary>
+    Task<ModalidadeView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ModalidadeSnapshot.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ModalidadeSnapshot.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Snapshot mínimo de uma <c>Modalidade</c> de concorrência que o Módulo Seleção
+/// congela por valor ao vinculá-la a um edital (snapshot-copy desacoplado,
+/// ADR-0061): guarda a identidade de origem, o código classificatório e a ação de
+/// indeferimento vigente no momento do congelamento — imune a edições posteriores
+/// no cadastro vivo de Configuração.
+/// </summary>
+/// <param name="OrigemId">Id (Guid v7) da modalidade viva de origem, no momento do congelamento.</param>
+/// <param name="Codigo">Código classificatório congelado (ex.: "LB_PPI").</param>
+/// <param name="AcaoQuandoIndeferido">Ação ao indeferir (token UPPER_SNAKE) congelada, ou null.</param>
+public sealed record ModalidadeSnapshot(
+    Guid OrigemId,
+    string Codigo,
+    string? AcaoQuandoIndeferido);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ModalidadeView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ModalidadeView.cs
@@ -1,0 +1,36 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>Modalidade</c> de concorrência para consumo cross-módulo via
+/// <see cref="IModalidadeReader"/> (ADR-0056). Expõe a modalidade viva que o Módulo
+/// Seleção lê ao montar as modalidades de um edital, antes de congelar por valor a
+/// identidade (snapshot-copy, ADR-0061). Os enums são expostos como tokens textuais
+/// (UPPER_SNAKE).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="Codigo">Código classificatório, chave natural da modalidade (ex.: "LB_PPI").</param>
+/// <param name="Descricao">Descrição livre opcional.</param>
+/// <param name="NaturezaLegal">Natureza jurídica (token; ex.: "COTA_RESERVADA").</param>
+/// <param name="ComposicaoVagas">Forma de composição das vagas (token; ex.: "RETIRA_DE").</param>
+/// <param name="ComposicaoOrigem">Código da modalidade de origem (só em RETIRA_DE), ou null.</param>
+/// <param name="RegraRemanejamento">Regra de remanejamento (token) ou null.</param>
+/// <param name="RemanejamentoDestino">Código de destino único (regra DESTINO_UNICO) ou null.</param>
+/// <param name="RemanejamentoPar">Código par (regra CRUZADO) ou null.</param>
+/// <param name="RemanejamentoFallback">Código de fallback (regra CRUZADO) ou null.</param>
+/// <param name="CriteriosCumulativos">Critérios cumulativos declarados (pode ser vazio).</param>
+/// <param name="AcaoQuandoIndeferido">Ação ao indeferir (token) ou null.</param>
+/// <param name="BaseLegal">Base legal opcional.</param>
+public sealed record ModalidadeView(
+    Guid Id,
+    string Codigo,
+    string? Descricao,
+    string NaturezaLegal,
+    string ComposicaoVagas,
+    string? ComposicaoOrigem,
+    string? RegraRemanejamento,
+    string? RemanejamentoDestino,
+    string? RemanejamentoPar,
+    string? RemanejamentoFallback,
+    IReadOnlyList<string> CriteriosCumulativos,
+    string? AcaoQuandoIndeferido,
+    string? BaseLegal);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Modalidade.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Modalidade.cs
@@ -1,0 +1,377 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Modalidade de concorrência — a entidade mais rica do módulo Configuração
+/// (UNI-REQ-0011): modela o sistema de cotas da legislação brasileira de ações
+/// afirmativas (Lei 12.711/2012, atual. Lei 14.723/2023). Descreve a natureza
+/// jurídica da modalidade, como suas vagas se compõem, para onde vagas ociosas
+/// remanejam e o que fazer com o candidato quando indeferido. Dado institucional
+/// sem PII (LGPD inaplicável).
+/// </summary>
+/// <remarks>
+/// <para>O <see cref="Codigo"/> (value object <see cref="CodigoModalidade"/>) é a
+/// chave natural, único entre modalidades vivas (índice único parcial
+/// <c>WHERE is_deleted = false</c>) e <b>imutável</b>: o comando de atualização
+/// não o aceita — a cascata de remanejamento e as referências de composição
+/// apontam para modalidades por código, e renomear quebraria a integridade
+/// referencial intra-banco. A unicidade é checada pelo handler (com proteção de
+/// corrida via índice).</para>
+/// <para>As invariantes de coerência (natureza↔remanejamento, composição
+/// RetiraDe⟺origem, args por regra, ação de indeferimento) moram na factory
+/// <see cref="Criar"/>/<see cref="Atualizar"/>. A integridade referencial (todos
+/// os códigos referenciados existem vivos; bloqueio de remoção quando referenciada)
+/// exige consulta ao banco e mora no handler via repositório.</para>
+/// <para>A remoção é sempre soft-delete; nunca bloqueada por snapshot-copy de
+/// Seleção (ADR-0061), apenas por referência intra-banco viva (outra modalidade
+/// viva que a aponte como origem ou destino/par/fallback).</para>
+/// </remarks>
+public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
+{
+    private const int DescricaoMaxLength = 300;
+    private const int BaseLegalMaxLength = 500;
+    private const int CodigoReferenciaMaxLength = 60;
+
+    public CodigoModalidade Codigo { get; private set; } = null!;
+    public string? Descricao { get; private set; }
+    public NaturezaLegal NaturezaLegal { get; private set; }
+    public ComposicaoVagas ComposicaoVagas { get; private set; }
+    public string? ComposicaoOrigem { get; private set; }
+    public RegraRemanejamento? RegraRemanejamento { get; private set; }
+    public RemanejamentoArgs RemanejamentoArgs { get; private set; } = RemanejamentoArgs.Vazio;
+    public IReadOnlyList<string> CriteriosCumulativos { get; private set; } = [];
+    public AcaoQuandoIndeferido? AcaoQuandoIndeferido { get; private set; }
+    public string? BaseLegal { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private Modalidade()
+    {
+    }
+
+    /// <summary>
+    /// Cria uma nova Modalidade. Valida o código (formato) e todas as invariantes
+    /// de coerência de domínio (natureza↔remanejamento, RetiraDe⟺origem, args por
+    /// regra, ação de indeferimento). Os enums chegam como tokens textuais
+    /// (UPPER_SNAKE): <paramref name="naturezaLegal"/> e <paramref name="composicaoVagas"/>
+    /// aplicam default quando ausentes (AMPLA / RESIDUAL_DO_VO);
+    /// <paramref name="regraRemanejamento"/> e <paramref name="acaoQuandoIndeferido"/>
+    /// são opcionais. A unicidade do código e a integridade referencial dos códigos
+    /// citados são responsabilidade do handler.
+    /// </summary>
+    public static Result<Modalidade> Criar(
+        string codigo,
+        string? descricao,
+        string? naturezaLegal,
+        string? composicaoVagas,
+        string? composicaoOrigem,
+        string? regraRemanejamento,
+        string? remanejamentoDestino,
+        string? remanejamentoPar,
+        string? remanejamentoFallback,
+        IReadOnlyList<string>? criteriosCumulativos,
+        string? acaoQuandoIndeferido,
+        string? baseLegal)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        Result<CodigoModalidade> codigoResult = CodigoModalidade.Criar(codigo);
+        if (codigoResult.IsFailure)
+        {
+            return Result<Modalidade>.Failure(codigoResult.Error!);
+        }
+
+        Result<CamposResolvidos> camposResult = ValidarComuns(
+            descricao, naturezaLegal, composicaoVagas, composicaoOrigem, regraRemanejamento,
+            remanejamentoDestino, remanejamentoPar, remanejamentoFallback,
+            criteriosCumulativos, acaoQuandoIndeferido, baseLegal);
+        if (camposResult.IsFailure)
+        {
+            return Result<Modalidade>.Failure(camposResult.Error!);
+        }
+
+        var modalidade = new Modalidade { Codigo = codigoResult.Value! };
+        modalidade.AplicarCampos(camposResult.Value!);
+
+        return Result<Modalidade>.Success(modalidade);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos editáveis da Modalidade. O <c>Codigo</c> e o <c>Id</c>
+    /// são <b>imutáveis</b> — este método não os recebe nem os altera. Revalida
+    /// todas as invariantes de coerência de domínio.
+    /// </summary>
+    public Result Atualizar(
+        string? descricao,
+        string? naturezaLegal,
+        string? composicaoVagas,
+        string? composicaoOrigem,
+        string? regraRemanejamento,
+        string? remanejamentoDestino,
+        string? remanejamentoPar,
+        string? remanejamentoFallback,
+        IReadOnlyList<string>? criteriosCumulativos,
+        string? acaoQuandoIndeferido,
+        string? baseLegal)
+    {
+        Result<CamposResolvidos> camposResult = ValidarComuns(
+            descricao, naturezaLegal, composicaoVagas, composicaoOrigem, regraRemanejamento,
+            remanejamentoDestino, remanejamentoPar, remanejamentoFallback,
+            criteriosCumulativos, acaoQuandoIndeferido, baseLegal);
+        if (camposResult.IsFailure)
+        {
+            return Result.Failure(camposResult.Error!);
+        }
+
+        AplicarCampos(camposResult.Value!);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(CamposResolvidos campos)
+    {
+        Descricao = campos.Descricao;
+        NaturezaLegal = campos.NaturezaLegal;
+        ComposicaoVagas = campos.ComposicaoVagas;
+        ComposicaoOrigem = campos.ComposicaoOrigem;
+        RegraRemanejamento = campos.RegraRemanejamento;
+        RemanejamentoArgs = campos.RemanejamentoArgs;
+        CriteriosCumulativos = campos.CriteriosCumulativos;
+        AcaoQuandoIndeferido = campos.AcaoQuandoIndeferido;
+        BaseLegal = campos.BaseLegal;
+    }
+
+    private static Result<CamposResolvidos> ValidarComuns(
+        string? descricao,
+        string? naturezaLegalToken,
+        string? composicaoVagasToken,
+        string? composicaoOrigem,
+        string? regraRemanejamentoToken,
+        string? remanejamentoDestino,
+        string? remanejamentoPar,
+        string? remanejamentoFallback,
+        IReadOnlyList<string>? criteriosCumulativos,
+        string? acaoQuandoIndeferidoToken,
+        string? baseLegal)
+    {
+        if (descricao is not null && descricao.Trim().Length > DescricaoMaxLength)
+        {
+            return Falha(ModalidadeErrorCodes.DescricaoTamanho,
+                $"Descrição da modalidade deve ter no máximo {DescricaoMaxLength} caracteres.");
+        }
+
+        if (baseLegal is not null && baseLegal.Trim().Length > BaseLegalMaxLength)
+        {
+            return Falha(ModalidadeErrorCodes.BaseLegalTamanho,
+                $"Base legal da modalidade deve ter no máximo {BaseLegalMaxLength} caracteres.");
+        }
+
+        // NaturezaLegal — obrigatória, default AMPLA quando ausente.
+        NaturezaLegal natureza;
+        if (string.IsNullOrWhiteSpace(naturezaLegalToken))
+        {
+            natureza = NaturezaLegal.Ampla;
+        }
+        else if (!NaturezasLegais.TryAnalisar(naturezaLegalToken, out natureza))
+        {
+            return Falha(ModalidadeErrorCodes.NaturezaInvalida,
+                $"Natureza legal deve ser uma de: {string.Join(", ", NaturezasLegais.TokensCanonicos)}.");
+        }
+
+        // ComposicaoVagas — obrigatória, default RESIDUAL_DO_VO quando ausente.
+        ComposicaoVagas composicao;
+        if (string.IsNullOrWhiteSpace(composicaoVagasToken))
+        {
+            composicao = ComposicaoVagas.ResidualDoVo;
+        }
+        else if (!ComposicoesVagas.TryAnalisar(composicaoVagasToken, out composicao))
+        {
+            return Falha(ModalidadeErrorCodes.ComposicaoVagasInvalida,
+                $"Composição de vagas deve ser uma de: {string.Join(", ", ComposicoesVagas.TokensCanonicos)}.");
+        }
+
+        // RegraRemanejamento — opcional (null quando ausente).
+        RegraRemanejamento? regra = null;
+        if (!string.IsNullOrWhiteSpace(regraRemanejamentoToken))
+        {
+            if (!RegrasRemanejamento.TryAnalisar(regraRemanejamentoToken, out RegraRemanejamento regraResolvida))
+            {
+                return Falha(ModalidadeErrorCodes.RegraRemanejamentoInvalida,
+                    $"Regra de remanejamento deve ser uma de: {string.Join(", ", RegrasRemanejamento.TokensCanonicos)}.");
+            }
+
+            regra = regraResolvida;
+        }
+
+        // AcaoQuandoIndeferido — opcional (null quando ausente); quando informada,
+        // deve ser um dos dois tokens (invariante 6).
+        AcaoQuandoIndeferido? acao = null;
+        if (!string.IsNullOrWhiteSpace(acaoQuandoIndeferidoToken))
+        {
+            if (!AcoesQuandoIndeferido.TryAnalisar(acaoQuandoIndeferidoToken, out AcaoQuandoIndeferido acaoResolvida))
+            {
+                return Falha(ModalidadeErrorCodes.AcaoIndeferimentoInvalida,
+                    $"Ação quando indeferido deve ser uma de: {string.Join(", ", AcoesQuandoIndeferido.TokensCanonicos)}.");
+            }
+
+            acao = acaoResolvida;
+        }
+
+        string? origemNorm = NormalizarOpcional(composicaoOrigem);
+        if (origemNorm is not null && origemNorm.Length > CodigoReferenciaMaxLength)
+        {
+            return Falha(ModalidadeErrorCodes.CodigoFormatoInvalido,
+                $"Código de origem da composição deve ter no máximo {CodigoReferenciaMaxLength} caracteres.");
+        }
+
+        // Invariante 4 — equivalência exata RetiraDe ⟺ ComposicaoOrigem preenchida.
+        bool ehRetiraDe = composicao == ComposicaoVagas.RetiraDe;
+        if (ehRetiraDe && origemNorm is null)
+        {
+            return Falha(ModalidadeErrorCodes.OrigemObrigatoriaParaRetiraDe,
+                "Composição RETIRA_DE exige o código de origem (composicao_origem).");
+        }
+
+        if (!ehRetiraDe && origemNorm is not null)
+        {
+            return Falha(ModalidadeErrorCodes.OrigemApenasParaRetiraDe,
+                "Código de origem (composicao_origem) só é permitido na composição RETIRA_DE.");
+        }
+
+        // Invariante 3 — coerência natureza ↔ regra de remanejamento.
+        Result<CamposResolvidos>? coerencia = ValidarCoerenciaNaturezaRemanejamento(natureza, regra);
+        if (coerencia is not null)
+        {
+            return coerencia;
+        }
+
+        // Invariante 5 — argumentos exigidos/proibidos por regra.
+        RemanejamentoArgs args = RemanejamentoArgs.Criar(
+            remanejamentoDestino, remanejamentoPar, remanejamentoFallback);
+        Result<CamposResolvidos>? argsCheck = ValidarArgumentosPorRegra(regra, args);
+        if (argsCheck is not null)
+        {
+            return argsCheck;
+        }
+
+        IReadOnlyList<string> criterios = NormalizarCriterios(criteriosCumulativos);
+
+        return Result<CamposResolvidos>.Success(new CamposResolvidos(
+            NormalizarOpcional(descricao),
+            natureza,
+            composicao,
+            origemNorm,
+            regra,
+            args,
+            criterios,
+            acao,
+            NormalizarOpcional(baseLegal)));
+    }
+
+    private static Result<CamposResolvidos>? ValidarCoerenciaNaturezaRemanejamento(
+        NaturezaLegal natureza,
+        RegraRemanejamento? regra)
+    {
+        switch (natureza)
+        {
+            case NaturezaLegal.CotaReservada when regra != Enums.RegraRemanejamento.SegueCascata:
+                return Falha(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente,
+                    "Cota reservada exige regra de remanejamento SEGUE_CASCATA.");
+
+            case NaturezaLegal.Ampla when regra is not null:
+                return Falha(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente,
+                    "Ampla concorrência não admite regra de remanejamento.");
+
+            case NaturezaLegal.Suplementar or NaturezaLegal.OutraModalidade
+                when regra is not (Enums.RegraRemanejamento.DestinoUnico or Enums.RegraRemanejamento.Cruzado):
+                return Falha(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente,
+                    "Modalidade suplementar ou de outra natureza exige regra de remanejamento "
+                    + "DESTINO_UNICO ou CRUZADO.");
+
+            default:
+                return null;
+        }
+    }
+
+    private static Result<CamposResolvidos>? ValidarArgumentosPorRegra(
+        RegraRemanejamento? regra,
+        RemanejamentoArgs args)
+    {
+        switch (regra)
+        {
+            case Enums.RegraRemanejamento.DestinoUnico:
+                if (args.Destino is null)
+                {
+                    return Falha(ModalidadeErrorCodes.ArgumentoRemanejamentoObrigatorio,
+                        "Regra DESTINO_UNICO exige o argumento 'destino'.");
+                }
+
+                if (args.Par is not null || args.Fallback is not null)
+                {
+                    return Falha(ModalidadeErrorCodes.ArgumentoRemanejamentoObrigatorio,
+                        "Regra DESTINO_UNICO não admite os argumentos 'par' e 'fallback'.");
+                }
+
+                return null;
+
+            case Enums.RegraRemanejamento.Cruzado:
+                if (args.Par is null || args.Fallback is null)
+                {
+                    return Falha(ModalidadeErrorCodes.ArgumentoRemanejamentoObrigatorio,
+                        "Regra CRUZADO exige os argumentos 'par' e 'fallback'.");
+                }
+
+                if (args.Destino is not null)
+                {
+                    return Falha(ModalidadeErrorCodes.ArgumentoRemanejamentoObrigatorio,
+                        "Regra CRUZADO não admite o argumento 'destino'.");
+                }
+
+                return null;
+
+            // SegueCascata ou sem regra: nenhum argumento é permitido.
+            default:
+                return args.TemAlgum
+                    ? Falha(ModalidadeErrorCodes.ArgumentoRemanejamentoObrigatorio,
+                        "Nenhum argumento de remanejamento é admitido para esta regra.")
+                    : null;
+        }
+    }
+
+    private static IReadOnlyList<string> NormalizarCriterios(IReadOnlyList<string>? criterios)
+    {
+        if (criterios is null || criterios.Count == 0)
+        {
+            return [];
+        }
+
+        return [.. criterios
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .Select(c => c.Trim())];
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result<CamposResolvidos> Falha(string code, string mensagem) =>
+        Result<CamposResolvidos>.Failure(new DomainError(code, mensagem));
+
+    private sealed record CamposResolvidos(
+        string? Descricao,
+        NaturezaLegal NaturezaLegal,
+        ComposicaoVagas ComposicaoVagas,
+        string? ComposicaoOrigem,
+        RegraRemanejamento? RegraRemanejamento,
+        RemanejamentoArgs RemanejamentoArgs,
+        IReadOnlyList<string> CriteriosCumulativos,
+        AcaoQuandoIndeferido? AcaoQuandoIndeferido,
+        string? BaseLegal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/AcaoQuandoIndeferido.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/AcaoQuandoIndeferido.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Ação a aplicar ao candidato de uma <see cref="Entities.Modalidade"/> de
+/// concorrência quando o pedido de reserva é indeferido (UNI-REQ-0011): descreve,
+/// em domínio fechado, se o candidato é reclassificado na ampla concorrência ou
+/// conforme a regra específica do edital. Persistida como token UPPER_SNAKE
+/// (<see cref="AcoesQuandoIndeferido"/>). É opcional.
+/// </summary>
+public enum AcaoQuandoIndeferido
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhuma = 0,
+
+    /// <summary>Reclassifica o candidato na ampla concorrência (AC).</summary>
+    ReclassificarAc = 1,
+
+    /// <summary>Reclassifica o candidato conforme a regra específica do edital.</summary>
+    ReclassificarRegraEdital = 2,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/AcoesQuandoIndeferido.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/AcoesQuandoIndeferido.cs
@@ -1,0 +1,58 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="AcaoQuandoIndeferido"/> (domínio, PascalCase) e o
+/// token textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// <para>O parsing é por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>):
+/// só os dois tokens canônicos são aceitos. Deliberadamente <b>não</b> usa
+/// <c>Enum.TryParse</c>, que aceitaria tokens numéricos e nomes PascalCase do enum
+/// — ambos fora do contrato textual da #589.</para>
+/// <para>É o vocabulário fonte do CHECK de domínio (null-safe) em
+/// <c>modalidade.acao_quando_indeferido</c> (<see cref="TokensCanonicos"/>) e do
+/// value converter de persistência.</para>
+/// </remarks>
+public static class AcoesQuandoIndeferido
+{
+    private static readonly Dictionary<AcaoQuandoIndeferido, string> ParaToken = new()
+    {
+        [AcaoQuandoIndeferido.ReclassificarAc] = "RECLASSIFICAR_AC",
+        [AcaoQuandoIndeferido.ReclassificarRegraEdital] = "RECLASSIFICAR_REGRA_EDITAL",
+    };
+
+    private static readonly Dictionary<string, AcaoQuandoIndeferido> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os dois tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de uma ação válida.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="acao"/> é <see cref="AcaoQuandoIndeferido.Nenhuma"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(AcaoQuandoIndeferido acao) =>
+        ParaToken.TryGetValue(acao, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(acao), acao, "Ação quando indeferido fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) à ação correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens numéricos ou fora do
+    /// domínio (allowlist). Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out AcaoQuandoIndeferido acao)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out AcaoQuandoIndeferido resolvida))
+        {
+            acao = resolvida;
+            return true;
+        }
+
+        acao = AcaoQuandoIndeferido.Nenhuma;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos dois tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/ComposicaoVagas.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/ComposicaoVagas.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Forma de composição das vagas de uma <see cref="Entities.Modalidade"/> de
+/// concorrência (UNI-REQ-0011): descreve, em domínio fechado, como as vagas da
+/// modalidade se relacionam com o total do processo (residuais do VO, dentro do
+/// VR, retiradas de outra modalidade ou suplementares ao total). Persistida como
+/// token UPPER_SNAKE (<see cref="ComposicoesVagas"/>).
+/// </summary>
+public enum ComposicaoVagas
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhuma = 0,
+
+    /// <summary>Vagas residuais do Volume de Oferta (VO).</summary>
+    ResidualDoVo = 1,
+
+    /// <summary>Vagas contidas dentro das Vagas Reservadas (VR).</summary>
+    DentroDoVr = 2,
+
+    /// <summary>Vagas retiradas de outra modalidade (exige <c>ComposicaoOrigem</c>).</summary>
+    RetiraDe = 3,
+
+    /// <summary>Vagas suplementares, acrescidas ao total do processo.</summary>
+    SuplementarAoTotal = 4,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/ComposicoesVagas.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/ComposicoesVagas.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="ComposicaoVagas"/> (domínio, PascalCase) e o token
+/// textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// <para>O parsing é por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>):
+/// só os quatro tokens canônicos são aceitos. Deliberadamente <b>não</b> usa
+/// <c>Enum.TryParse</c>, que aceitaria tokens numéricos e nomes PascalCase do enum
+/// — ambos fora do contrato textual da #589.</para>
+/// <para>É o vocabulário fonte do CHECK de domínio em <c>modalidade.composicao_vagas</c>
+/// (<see cref="TokensCanonicos"/>) e do value converter de persistência.</para>
+/// </remarks>
+public static class ComposicoesVagas
+{
+    private static readonly Dictionary<ComposicaoVagas, string> ParaToken = new()
+    {
+        [ComposicaoVagas.ResidualDoVo] = "RESIDUAL_DO_VO",
+        [ComposicaoVagas.DentroDoVr] = "DENTRO_DO_VR",
+        [ComposicaoVagas.RetiraDe] = "RETIRA_DE",
+        [ComposicaoVagas.SuplementarAoTotal] = "SUPLEMENTAR_AO_TOTAL",
+    };
+
+    private static readonly Dictionary<string, ComposicaoVagas> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os quatro tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de uma composição válida.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="composicao"/> é <see cref="ComposicaoVagas.Nenhuma"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(ComposicaoVagas composicao) =>
+        ParaToken.TryGetValue(composicao, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(composicao), composicao, "Composição de vagas fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) à composição correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens numéricos ou fora do
+    /// domínio (allowlist). Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out ComposicaoVagas composicao)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out ComposicaoVagas resolvida))
+        {
+            composicao = resolvida;
+            return true;
+        }
+
+        composicao = ComposicaoVagas.Nenhuma;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos quatro tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezaLegal.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezaLegal.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Natureza jurídica de uma <see cref="Entities.Modalidade"/> de concorrência
+/// (UNI-REQ-0011): distingue, em domínio fechado, reserva de cota, ampla
+/// concorrência, modalidade suplementar e outra modalidade (Lei 12.711/2012 atual.
+/// Lei 14.723/2023). Persistida como token UPPER_SNAKE (<see cref="NaturezasLegais"/>).
+/// </summary>
+public enum NaturezaLegal
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhuma = 0,
+
+    /// <summary>Cota reservada por ação afirmativa (segue a cascata de remanejamento).</summary>
+    CotaReservada = 1,
+
+    /// <summary>Ampla concorrência — aberta a todos; não é reserva, não é remanejada como cota.</summary>
+    Ampla = 2,
+
+    /// <summary>Modalidade suplementar (ex.: PcD em ampla concorrência).</summary>
+    Suplementar = 3,
+
+    /// <summary>Outra modalidade que não se enquadra nas anteriores.</summary>
+    OutraModalidade = 4,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezasLegais.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezasLegais.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="NaturezaLegal"/> (domínio, PascalCase) e o token
+/// textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// <para>O parsing é por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>):
+/// só os quatro tokens canônicos são aceitos. Deliberadamente <b>não</b> usa
+/// <c>Enum.TryParse</c>, que aceitaria tokens numéricos (<c>"1"</c> → primeiro
+/// valor) e nomes PascalCase do enum — ambos fora do contrato textual da #589.</para>
+/// <para>É o vocabulário fonte do CHECK de domínio em <c>modalidade.natureza_legal</c>
+/// (<see cref="TokensCanonicos"/>) e do value converter de persistência.</para>
+/// </remarks>
+public static class NaturezasLegais
+{
+    private static readonly Dictionary<NaturezaLegal, string> ParaToken = new()
+    {
+        [NaturezaLegal.CotaReservada] = "COTA_RESERVADA",
+        [NaturezaLegal.Ampla] = "AMPLA",
+        [NaturezaLegal.Suplementar] = "SUPLEMENTAR",
+        [NaturezaLegal.OutraModalidade] = "OUTRA_MODALIDADE",
+    };
+
+    private static readonly Dictionary<string, NaturezaLegal> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os quatro tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de uma natureza válida.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="natureza"/> é <see cref="NaturezaLegal.Nenhuma"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(NaturezaLegal natureza) =>
+        ParaToken.TryGetValue(natureza, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(natureza), natureza, "Natureza legal fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) à natureza correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens numéricos ou fora do
+    /// domínio (allowlist). Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out NaturezaLegal natureza)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out NaturezaLegal resolvida))
+        {
+            natureza = resolvida;
+            return true;
+        }
+
+        natureza = NaturezaLegal.Nenhuma;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos quatro tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/RegraRemanejamento.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/RegraRemanejamento.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Regra de remanejamento das vagas não preenchidas de uma
+/// <see cref="Entities.Modalidade"/> de concorrência (UNI-REQ-0011): descreve, em
+/// domínio fechado, para onde vagas ociosas migram (cascata legal, destino único
+/// ou par cruzado). Persistida como token UPPER_SNAKE (<see cref="RegrasRemanejamento"/>).
+/// É opcional — modalidades de ampla concorrência não remanejam como cota.
+/// </summary>
+public enum RegraRemanejamento
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhuma = 0,
+
+    /// <summary>Segue a cascata de remanejamento legalmente estabelecida (cotas reservadas).</summary>
+    SegueCascata = 1,
+
+    /// <summary>Remaneja para um destino único informado em <c>RemanejamentoArgs.Destino</c>.</summary>
+    DestinoUnico = 2,
+
+    /// <summary>Remaneja de forma cruzada entre um par (<c>Par</c>) com fallback (<c>Fallback</c>).</summary>
+    Cruzado = 3,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/RegrasRemanejamento.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/RegrasRemanejamento.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="RegraRemanejamento"/> (domínio, PascalCase) e o
+/// token textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// <para>O parsing é por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>):
+/// só os três tokens canônicos são aceitos. Deliberadamente <b>não</b> usa
+/// <c>Enum.TryParse</c>, que aceitaria tokens numéricos e nomes PascalCase do enum
+/// — ambos fora do contrato textual da #589.</para>
+/// <para>É o vocabulário fonte do CHECK de domínio (null-safe) em
+/// <c>modalidade.regra_remanejamento</c> (<see cref="TokensCanonicos"/>) e do value
+/// converter de persistência.</para>
+/// </remarks>
+public static class RegrasRemanejamento
+{
+    private static readonly Dictionary<RegraRemanejamento, string> ParaToken = new()
+    {
+        [RegraRemanejamento.SegueCascata] = "SEGUE_CASCATA",
+        [RegraRemanejamento.DestinoUnico] = "DESTINO_UNICO",
+        [RegraRemanejamento.Cruzado] = "CRUZADO",
+    };
+
+    private static readonly Dictionary<string, RegraRemanejamento> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os três tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de uma regra válida.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="regra"/> é <see cref="RegraRemanejamento.Nenhuma"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(RegraRemanejamento regra) =>
+        ParaToken.TryGetValue(regra, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(regra), regra, "Regra de remanejamento fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) à regra correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens numéricos ou fora do
+    /// domínio (allowlist). Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out RegraRemanejamento regra)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out RegraRemanejamento resolvida))
+        {
+            regra = resolvida;
+            return true;
+        }
+
+        regra = RegraRemanejamento.Nenhuma;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos três tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/ModalidadeErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/ModalidadeErrorCodes.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+/// <summary>
+/// Códigos de erro de domínio da <see cref="Entities.Modalidade"/> de concorrência
+/// (UNI-REQ-0011), prefixados por <c>Modalidade.</c>. Mapeados para status HTTP em
+/// <c>ConfiguracaoDomainErrorRegistration</c>:
+/// <list type="bullet">
+///   <item><description><see cref="CodigoJaExiste"/> → 409 Conflict</description></item>
+///   <item><description><see cref="RemocaoBloqueadaPorReferencia"/> → 409 Conflict</description></item>
+///   <item><description><see cref="NaoEncontrada"/> → 404 Not Found</description></item>
+///   <item><description>demais → 422 Unprocessable Entity</description></item>
+/// </list>
+/// </summary>
+public static class ModalidadeErrorCodes
+{
+    public const string CodigoObrigatorio = "Modalidade.CodigoObrigatorio";
+    public const string CodigoFormatoInvalido = "Modalidade.CodigoFormatoInvalido";
+    public const string CodigoJaExiste = "Modalidade.CodigoJaExiste";
+    public const string DescricaoTamanho = "Modalidade.DescricaoTamanho";
+    public const string NaturezaInvalida = "Modalidade.NaturezaInvalida";
+    public const string ComposicaoVagasInvalida = "Modalidade.ComposicaoVagasInvalida";
+    public const string RegraRemanejamentoInvalida = "Modalidade.RegraRemanejamentoInvalida";
+    public const string NaturezaRemanejamentoIncoerente = "Modalidade.NaturezaRemanejamentoIncoerente";
+    public const string OrigemObrigatoriaParaRetiraDe = "Modalidade.OrigemObrigatoriaParaRetiraDe";
+    public const string OrigemApenasParaRetiraDe = "Modalidade.OrigemApenasParaRetiraDe";
+    public const string ArgumentoRemanejamentoObrigatorio = "Modalidade.ArgumentoRemanejamentoObrigatorio";
+    public const string AcaoIndeferimentoInvalida = "Modalidade.AcaoIndeferimentoInvalida";
+    public const string ReferenciaInexistenteOuInativa = "Modalidade.ReferenciaInexistenteOuInativa";
+    public const string RemocaoBloqueadaPorReferencia = "Modalidade.RemocaoBloqueadaPorReferencia";
+    public const string BaseLegalTamanho = "Modalidade.BaseLegalTamanho";
+    public const string NaoEncontrada = "Modalidade.NaoEncontrada";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IModalidadeRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IModalidadeRepository.cs
@@ -1,0 +1,68 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="Modalidade"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros soft-deleted
+/// via query filter por convenção.
+/// </summary>
+public interface IModalidadeRepository
+{
+    /// <summary>Carrega a modalidade rastreada pelo contexto, para mutação.</summary>
+    Task<Modalidade?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega a modalidade para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<Modalidade?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista modalidades vivas paginadas por cursor keyset bidirecional (ADR-0026 +
+    /// ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras de
+    /// <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<Modalidade> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(Modalidade modalidade, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca a modalidade para remoção; o <c>SoftDeleteInterceptor</c> converte em
+    /// soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(Modalidade modalidade);
+
+    /// <summary>
+    /// Verifica se existe modalidade viva com o <paramref name="codigo"/>
+    /// (case-sensitive, sobre o valor normalizado por <c>Trim</c>), excluindo
+    /// opcionalmente um <paramref name="excluirId"/> (para a checagem na atualização).
+    /// </summary>
+    Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Indica se <b>todos</b> os <paramref name="codigos"/> informados correspondem
+    /// a modalidades vivas — integridade referencial dos códigos citados em
+    /// <c>ComposicaoOrigem</c> e <c>RemanejamentoArgs</c>. Coleção vazia retorna
+    /// <see langword="true"/> (nada a validar).
+    /// </summary>
+    Task<bool> CodigosVivosExistemAsync(
+        IReadOnlyCollection<string> codigos,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Indica se ESTE <paramref name="codigo"/> é referenciado por <b>outra</b>
+    /// modalidade viva (excluindo <paramref name="excluirId"/>) — como
+    /// <c>composicao_origem</c> OU como destino/par/fallback em
+    /// <c>remanejamento_args</c> (consulta jsonb). Base do bloqueio de remoção.
+    /// </summary>
+    Task<bool> EhReferenciadaPorOutraModalidadeVivaAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoModalidade.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoModalidade.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+using System.Text.RegularExpressions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Código de uma <see cref="Entities.Modalidade"/> de concorrência (UNI-REQ-0011,
+/// módulo Configuração) — chave natural classificatória (ex.: <c>AC</c>,
+/// <c>LB_PPI</c>, <c>LI_Q</c>). Value object com formato fechado:
+/// <c>^[A-Z0-9_]+$</c> — apenas letras maiúsculas, dígitos e sublinhado (sem
+/// hífen). Persistido como <c>varchar</c> via conversor de valor (fail-fast na
+/// reidratação).
+/// </summary>
+/// <remarks>
+/// Diferente do <c>TipoDocumento</c>, o código da Modalidade é <b>imutável</b>: o
+/// comando de atualização não o aceita como campo editável, pois a cascata de
+/// remanejamento e as referências de composição (<c>ComposicaoOrigem</c>,
+/// <c>RemanejamentoArgs</c>) apontam para modalidades por código — renomear
+/// quebraria a integridade referencial intra-banco.
+/// </remarks>
+public sealed partial record CodigoModalidade
+{
+    private const int TamanhoMaximo = 60;
+
+    public string Valor { get; }
+
+    private CodigoModalidade(string valor) => Valor = valor;
+
+    /// <summary>
+    /// Cria um <see cref="CodigoModalidade"/> validando o formato fechado. Valor
+    /// nulo/em branco retorna <c>CodigoObrigatorio</c>; fora do formato (ou acima
+    /// do tamanho máximo) retorna <c>CodigoFormatoInvalido</c>. O valor é
+    /// normalizado por <c>Trim</c> antes da validação.
+    /// </summary>
+    public static Result<CodigoModalidade> Criar(string valor)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return Result<CodigoModalidade>.Failure(new DomainError(
+                ModalidadeErrorCodes.CodigoObrigatorio,
+                "Código da modalidade de concorrência é obrigatório."));
+        }
+
+        string normalizado = valor.Trim();
+
+        if (normalizado.Length > TamanhoMaximo || !FormatoValido().IsMatch(normalizado))
+        {
+            return Result<CodigoModalidade>.Failure(new DomainError(
+                ModalidadeErrorCodes.CodigoFormatoInvalido,
+                "Código da modalidade deve conter apenas letras maiúsculas, dígitos e sublinhado "
+                + $"(sem hífen), com no máximo {TamanhoMaximo} caracteres (ex.: AC, LB_PPI, LI_Q)."));
+        }
+
+        return Result<CodigoModalidade>.Success(new CodigoModalidade(normalizado));
+    }
+
+    /// <summary>Indica se <paramref name="valor"/> respeita o formato fechado, sem alocar value object.</summary>
+    public static bool EhValido(string? valor) =>
+        !string.IsNullOrWhiteSpace(valor)
+        && valor.Trim().Length <= TamanhoMaximo
+        && FormatoValido().IsMatch(valor.Trim());
+
+    public override string ToString() => Valor;
+
+    [GeneratedRegex("^[A-Z0-9_]+$", RegexOptions.CultureInvariant)]
+    private static partial Regex FormatoValido();
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/RemanejamentoArgs.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/RemanejamentoArgs.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Argumentos da regra de remanejamento de uma <see cref="Entities.Modalidade"/>
+/// de concorrência (UNI-REQ-0011): códigos de outras modalidades usados como
+/// destino/par/fallback conforme a <c>RegraRemanejamento</c>. Value object
+/// imutável serializado como <c>jsonb</c> na coluna <c>remanejamento_args</c>.
+/// </summary>
+/// <remarks>
+/// <para>As chaves JSON são fixadas por <see cref="JsonPropertyNameAttribute"/>
+/// (<c>destino</c>, <c>par</c>, <c>fallback</c>) — o repositório consulta esses
+/// campos por operador <c>-&gt;&gt;</c> do Postgres para detectar referências vivas
+/// ao remover uma modalidade, e a estabilidade das chaves é parte do contrato.</para>
+/// <para>Quais campos são obrigatórios/proibidos depende da regra e é validado no
+/// agregado <c>Modalidade</c> (invariante "args por regra"); este VO apenas
+/// normaliza (Trim → null) e transporta.</para>
+/// </remarks>
+public sealed record RemanejamentoArgs
+{
+    /// <summary>Código da modalidade de destino único (regra <c>DestinoUnico</c>).</summary>
+    [JsonPropertyName("destino")]
+    public string? Destino { get; init; }
+
+    /// <summary>Código da modalidade par no remanejamento cruzado (regra <c>Cruzado</c>).</summary>
+    [JsonPropertyName("par")]
+    public string? Par { get; init; }
+
+    /// <summary>Código da modalidade de fallback no remanejamento cruzado (regra <c>Cruzado</c>).</summary>
+    [JsonPropertyName("fallback")]
+    public string? Fallback { get; init; }
+
+    /// <summary>Instância canônica sem nenhum argumento (regra <c>SegueCascata</c> ou ausente).</summary>
+    public static RemanejamentoArgs Vazio { get; } = new();
+
+    /// <summary>
+    /// Cria um <see cref="RemanejamentoArgs"/> normalizando cada campo por
+    /// <c>Trim</c> (valores em branco viram <see langword="null"/>).
+    /// </summary>
+    public static RemanejamentoArgs Criar(string? destino, string? par, string? fallback) =>
+        new()
+        {
+            Destino = Normalizar(destino),
+            Par = Normalizar(par),
+            Fallback = Normalizar(fallback),
+        };
+
+    /// <summary>Indica se há ao menos um argumento preenchido.</summary>
+    [JsonIgnore]
+    public bool TemAlgum => Destino is not null || Par is not null || Fallback is not null;
+
+    private static string? Normalizar(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -41,6 +41,7 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<ICondicaoAtendimentoRepository, CondicaoAtendimentoRepository>();
         services.AddScoped<IRecursoAcessibilidadeRepository, RecursoAcessibilidadeRepository>();
         services.AddScoped<ITipoDeficienciaRepository, TipoDeficienciaRepository>();
+        services.AddScoped<IModalidadeRepository, ModalidadeRepository>();
 
         // Readers cross-módulo (ADR-0056).
         services.AddScoped<IReferenciaReservaDemograficaReader, ReferenciaReservaDemograficaReader>();
@@ -49,6 +50,7 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<ICondicaoAtendimentoReader, CondicaoAtendimentoReader>();
         services.AddScoped<IRecursoAcessibilidadeReader, RecursoAcessibilidadeReader>();
         services.AddScoped<ITipoDeficienciaReader, TipoDeficienciaReader>();
+        services.AddScoped<IModalidadeReader, ModalidadeReader>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -45,6 +45,8 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
 
     public DbSet<TipoDeficiencia> TiposDeficiencia => Set<TipoDeficiencia>();
 
+    public DbSet<Modalidade> Modalidades => Set<Modalidade>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/ModalidadeConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/ModalidadeConfiguration.cs
@@ -1,0 +1,175 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class ModalidadeConfiguration : IEntityTypeConfiguration<Modalidade>
+{
+    private const int CodigoMaxLength = 60;
+    private const int DescricaoMaxLength = 300;
+    private const int EnumTokenMaxLength = 30;
+    private const int CodigoReferenciaMaxLength = 60;
+    private const int BaseLegalMaxLength = 500;
+    private const int AuditUserMaxLength = 255;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = false,
+    };
+
+    public void Configure(EntityTypeBuilder<Modalidade> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("modalidade", ConfigurarChecks);
+
+        builder.HasKey(m => m.Id);
+
+        // Codigo é value object imutável — persistido por valor como varchar via
+        // CodigoModalidadeValueConverter (reidratação fail-fast). O CHECK de formato
+        // e o índice único parcial abaixo protegem a coluna.
+        builder.Property(m => m.Codigo)
+            .HasConversion<CodigoModalidadeValueConverter>()
+            .HasMaxLength(CodigoMaxLength)
+            .IsRequired();
+
+        builder.Property(m => m.Descricao).HasMaxLength(DescricaoMaxLength);
+
+        builder.Property(m => m.NaturezaLegal)
+            .HasConversion<NaturezaLegalValueConverter>()
+            .HasMaxLength(EnumTokenMaxLength)
+            .IsRequired();
+
+        builder.Property(m => m.ComposicaoVagas)
+            .HasConversion<ComposicaoVagasValueConverter>()
+            .HasMaxLength(EnumTokenMaxLength)
+            .IsRequired();
+
+        builder.Property(m => m.ComposicaoOrigem).HasMaxLength(CodigoReferenciaMaxLength);
+
+        // Enums nullable: o converter cobre o valor não-nulo; o EF encapsula null.
+        builder.Property(m => m.RegraRemanejamento)
+            .HasConversion(new RegraRemanejamentoValueConverter())
+            .HasMaxLength(EnumTokenMaxLength);
+
+        builder.Property(m => m.AcaoQuandoIndeferido)
+            .HasConversion(new AcaoQuandoIndeferidoValueConverter())
+            .HasMaxLength(EnumTokenMaxLength);
+
+        // remanejamento_args: value object serializado como jsonb (chaves fixadas por
+        // JsonPropertyName — destino/par/fallback). Default '{}' cobre inserts crus.
+        builder.Property(m => m.RemanejamentoArgs)
+            .HasConversion(RemanejamentoArgsConverter, RemanejamentoArgsComparer)
+            .HasColumnType("jsonb")
+            .HasDefaultValueSql("'{}'::jsonb")
+            .IsRequired();
+
+        // criterios_cumulativos: lista de strings serializada como jsonb. Default '[]'.
+        builder.Property(m => m.CriteriosCumulativos)
+            .HasConversion(CriteriosConverter, CriteriosComparer)
+            .HasColumnType("jsonb")
+            .HasDefaultValueSql("'[]'::jsonb")
+            .IsRequired();
+
+        builder.Property(m => m.BaseLegal).HasMaxLength(BaseLegalMaxLength);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(m => m.CreatedBy).HasMaxLength(AuditUserMaxLength);
+        builder.Property(m => m.UpdatedBy).HasMaxLength(AuditUserMaxLength);
+
+        // Unicidade do código entre modalidades vivas (índice parcial) — uma
+        // modalidade viva por código; soft-delete libera o slot para recriação.
+        builder.HasIndex(m => m.Codigo)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_modalidade_codigo_vivo");
+    }
+
+    private static void ConfigurarChecks(TableBuilder<Modalidade> table)
+    {
+        // Domínios fechados dos enums (defesa em profundidade contra inserts crus).
+        table.HasCheckConstraint(
+            "ck_modalidade_natureza_legal",
+            $"natureza_legal IN ({TokensSql(NaturezasLegais.TokensCanonicos)})");
+
+        table.HasCheckConstraint(
+            "ck_modalidade_composicao_vagas",
+            $"composicao_vagas IN ({TokensSql(ComposicoesVagas.TokensCanonicos)})");
+
+        table.HasCheckConstraint(
+            "ck_modalidade_regra_remanejamento",
+            $"regra_remanejamento IS NULL OR regra_remanejamento IN ({TokensSql(RegrasRemanejamento.TokensCanonicos)})");
+
+        table.HasCheckConstraint(
+            "ck_modalidade_acao_quando_indeferido",
+            $"acao_quando_indeferido IS NULL OR acao_quando_indeferido IN ({TokensSql(AcoesQuandoIndeferido.TokensCanonicos)})");
+
+        // Formato fechado do código — alinhado ao value object CodigoModalidade.
+        table.HasCheckConstraint(
+            "ck_modalidade_codigo_formato",
+            "codigo ~ '^[A-Z0-9_]+$'");
+
+        // Equivalência exata RETIRA_DE ⟺ composicao_origem preenchida (invariante 4),
+        // como igualdade de dois booleanos — null-safe (ambos os lados nunca são null).
+        table.HasCheckConstraint(
+            "ck_modalidade_retira_de_origem",
+            "(composicao_vagas = 'RETIRA_DE') = (composicao_origem IS NOT NULL)");
+    }
+
+    private static string TokensSql(IReadOnlyList<string> tokens) =>
+        string.Join(", ", tokens.Select(token => $"'{token}'"));
+
+    // ── Conversores/comparadores jsonb ────────────────────────────────────────
+
+    private static readonly ValueConverter<RemanejamentoArgs, string> RemanejamentoArgsConverter =
+        new(
+            args => JsonSerializer.Serialize(args, JsonOptions),
+            json => JsonSerializer.Deserialize<RemanejamentoArgs>(json, JsonOptions) ?? RemanejamentoArgs.Vazio);
+
+    private static readonly ValueComparer<RemanejamentoArgs> RemanejamentoArgsComparer =
+        new(
+            (a, b) => SerializeArgs(a) == SerializeArgs(b),
+            v => v == null ? 0 : SerializeArgs(v).GetHashCode(StringComparison.Ordinal),
+            v => DeserializeArgs(SerializeArgs(v)));
+
+    private static string SerializeArgs(RemanejamentoArgs? v) =>
+        v is null ? string.Empty : JsonSerializer.Serialize(v, JsonOptions);
+
+    private static RemanejamentoArgs DeserializeArgs(string json) =>
+        string.IsNullOrEmpty(json)
+            ? RemanejamentoArgs.Vazio
+            : JsonSerializer.Deserialize<RemanejamentoArgs>(json, JsonOptions) ?? RemanejamentoArgs.Vazio;
+
+    private static readonly ValueConverter<IReadOnlyList<string>, string> CriteriosConverter =
+        new(
+            criterios => JsonSerializer.Serialize(criterios, JsonOptions),
+            json => (IReadOnlyList<string>)DeserializeCriterios(json));
+
+    private static readonly ValueComparer<IReadOnlyList<string>> CriteriosComparer =
+        new(
+            (a, b) => SerializeCriterios(a) == SerializeCriterios(b),
+            v => v == null ? 0 : SerializeCriterios(v).GetHashCode(StringComparison.Ordinal),
+            v => (IReadOnlyList<string>)DeserializeCriterios(SerializeCriterios(v)));
+
+    private static string SerializeCriterios(IReadOnlyList<string>? v) =>
+        v is null ? "[]" : JsonSerializer.Serialize(v, JsonOptions);
+
+    private static List<string> DeserializeCriterios(string json) =>
+        string.IsNullOrEmpty(json)
+            ? []
+            : JsonSerializer.Deserialize<List<string>>(json, JsonOptions) ?? [];
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/AcaoQuandoIndeferidoValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/AcaoQuandoIndeferidoValueConverter.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia AcaoQuandoIndeferido ↔ string (varchar) usando o token canônico
+// UPPER_SNAKE (RECLASSIFICAR_AC…), não o nome PascalCase do enum. Aplicado a uma
+// propriedade nullable (AcaoQuandoIndeferido?) — o EF encapsula null
+// automaticamente; este converter só vê valores não-nulos. A reidratação falha
+// explicitamente (com contexto) caso a coluna seja corrompida fora do fluxo.
+public sealed class AcaoQuandoIndeferidoValueConverter : ValueConverter<AcaoQuandoIndeferido, string>
+{
+    public AcaoQuandoIndeferidoValueConverter()
+        : base(
+            acao => AcoesQuandoIndeferido.ParaTokenCanonico(acao),
+            token => Reidratar(token))
+    {
+    }
+
+    private static AcaoQuandoIndeferido Reidratar(string token)
+    {
+        if (!AcoesQuandoIndeferido.TryAnalisar(token, out AcaoQuandoIndeferido acao))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(AcaoQuandoIndeferido)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return acao;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CodigoModalidadeValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CodigoModalidadeValueConverter.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+// Mapeia CodigoModalidade ↔ string (varchar). O comprimento da coluna é definido na
+// própria propriedade via HasMaxLength no IEntityTypeConfiguration. A reidratação
+// falha explicitamente (com contexto) caso a coluna seja corrompida fora do fluxo
+// da aplicação, em vez do NullReferenceException tardio de
+// `CodigoModalidade.Criar(v).Value!`.
+public sealed class CodigoModalidadeValueConverter : ValueConverter<CodigoModalidade, string>
+{
+    public CodigoModalidadeValueConverter()
+        : base(
+            codigo => codigo.Valor,
+            valor => Reidratar(valor))
+    {
+    }
+
+    private static CodigoModalidade Reidratar(string valor)
+    {
+        Result<CodigoModalidade> resultado = CodigoModalidade.Criar(valor);
+        if (resultado.IsFailure || resultado.Value is null)
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(CodigoModalidade)}: " +
+                $"{resultado.Error?.Code ?? "Desconhecido"}. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return resultado.Value;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/ComposicaoVagasValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/ComposicaoVagasValueConverter.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia ComposicaoVagas ↔ string (varchar) usando o token canônico UPPER_SNAKE
+// (RESIDUAL_DO_VO…), não o nome PascalCase do enum. O comprimento da coluna é
+// definido na própria propriedade via HasMaxLength no IEntityTypeConfiguration. A
+// reidratação falha explicitamente (com contexto) caso a coluna seja corrompida
+// fora do fluxo da aplicação, em vez de um valor de enum silenciosamente inválido.
+public sealed class ComposicaoVagasValueConverter : ValueConverter<ComposicaoVagas, string>
+{
+    public ComposicaoVagasValueConverter()
+        : base(
+            composicao => ComposicoesVagas.ParaTokenCanonico(composicao),
+            token => Reidratar(token))
+    {
+    }
+
+    private static ComposicaoVagas Reidratar(string token)
+    {
+        if (!ComposicoesVagas.TryAnalisar(token, out ComposicaoVagas composicao))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(ComposicaoVagas)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return composicao;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/NaturezaLegalValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/NaturezaLegalValueConverter.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia NaturezaLegal ↔ string (varchar) usando o token canônico UPPER_SNAKE
+// (COTA_RESERVADA…), não o nome PascalCase do enum. O comprimento da coluna é
+// definido na própria propriedade via HasMaxLength no IEntityTypeConfiguration. A
+// reidratação falha explicitamente (com contexto) caso a coluna seja corrompida
+// fora do fluxo da aplicação, em vez de um valor de enum silenciosamente inválido.
+public sealed class NaturezaLegalValueConverter : ValueConverter<NaturezaLegal, string>
+{
+    public NaturezaLegalValueConverter()
+        : base(
+            natureza => NaturezasLegais.ParaTokenCanonico(natureza),
+            token => Reidratar(token))
+    {
+    }
+
+    private static NaturezaLegal Reidratar(string token)
+    {
+        if (!NaturezasLegais.TryAnalisar(token, out NaturezaLegal natureza))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(NaturezaLegal)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return natureza;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/RegraRemanejamentoValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/RegraRemanejamentoValueConverter.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia RegraRemanejamento ↔ string (varchar) usando o token canônico UPPER_SNAKE
+// (SEGUE_CASCATA…), não o nome PascalCase do enum. Aplicado a uma propriedade
+// nullable (RegraRemanejamento?) — o EF encapsula null automaticamente; este
+// converter só vê valores não-nulos. A reidratação falha explicitamente (com
+// contexto) caso a coluna seja corrompida fora do fluxo da aplicação.
+public sealed class RegraRemanejamentoValueConverter : ValueConverter<RegraRemanejamento, string>
+{
+    public RegraRemanejamentoValueConverter()
+        : base(
+            regra => RegrasRemanejamento.ParaTokenCanonico(regra),
+            token => Reidratar(token))
+    {
+    }
+
+    private static RegraRemanejamento Reidratar(string token)
+    {
+        if (!RegrasRemanejamento.TryAnalisar(token, out RegraRemanejamento regra))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(RegraRemanejamento)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return regra;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260701011246_AddModalidade.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260701011246_AddModalidade.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701011246_AddModalidade")]
+    partial class AddModalidade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260701011246_AddModalidade.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260701011246_AddModalidade.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddModalidade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "modalidade",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    descricao = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+                    natureza_legal = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    composicao_vagas = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    composicao_origem = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: true),
+                    regra_remanejamento = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: true),
+                    remanejamento_args = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    criterios_cumulativos = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'[]'::jsonb"),
+                    acao_quando_indeferido = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: true),
+                    base_legal = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_modalidade", x => x.id);
+                    table.CheckConstraint("ck_modalidade_acao_quando_indeferido", "acao_quando_indeferido IS NULL OR acao_quando_indeferido IN ('RECLASSIFICAR_AC', 'RECLASSIFICAR_REGRA_EDITAL')");
+                    table.CheckConstraint("ck_modalidade_codigo_formato", "codigo ~ '^[A-Z0-9_]+$'");
+                    table.CheckConstraint("ck_modalidade_composicao_vagas", "composicao_vagas IN ('RESIDUAL_DO_VO', 'DENTRO_DO_VR', 'RETIRA_DE', 'SUPLEMENTAR_AO_TOTAL')");
+                    table.CheckConstraint("ck_modalidade_natureza_legal", "natureza_legal IN ('COTA_RESERVADA', 'AMPLA', 'SUPLEMENTAR', 'OUTRA_MODALIDADE')");
+                    table.CheckConstraint("ck_modalidade_regra_remanejamento", "regra_remanejamento IS NULL OR regra_remanejamento IN ('SEGUE_CASCATA', 'DESTINO_UNICO', 'CRUZADO')");
+                    table.CheckConstraint("ck_modalidade_retira_de_origem", "(composicao_vagas = 'RETIRA_DE') = (composicao_origem IS NOT NULL)");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_modalidade_codigo_vivo",
+                schema: "configuracao",
+                table: "modalidade",
+                column: "codigo",
+                unique: true,
+                filter: "is_deleted = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "modalidade",
+                schema: "configuracao");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/ModalidadeRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/ModalidadeRepository.cs
@@ -1,0 +1,163 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class ModalidadeRepository : IModalidadeRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public ModalidadeRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<Modalidade?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Modalidades
+            .FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+    }
+
+    public Task<Modalidade?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Modalidades
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<Modalidade> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<Modalidade> page = await CursorKeyset
+            .ApplyAsync(_dbContext.Modalidades.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(Modalidade modalidade, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(modalidade);
+        await _dbContext.Modalidades.AddAsync(modalidade, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(Modalidade modalidade)
+    {
+        ArgumentNullException.ThrowIfNull(modalidade);
+        _dbContext.Modalidades.Remove(modalidade);
+    }
+
+    public Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        // Um código fora do formato nunca tem modalidade viva — evita query
+        // desnecessária e garante que a comparação use o valor canônico normalizado
+        // (Trim). Case-sensitive (default do Postgres) — alinhado ao índice único.
+        Result<CodigoModalidade> codigoResult = CodigoModalidade.Criar(codigo);
+        if (codigoResult.IsFailure)
+        {
+            return Task.FromResult(false);
+        }
+
+        CodigoModalidade codigoVo = codigoResult.Value!;
+
+        return _dbContext.Modalidades
+            .AsNoTracking()
+            .Where(m => excluirId == null || m.Id != excluirId)
+            .AnyAsync(m => m.Codigo == codigoVo, cancellationToken);
+    }
+
+    public async Task<bool> CodigosVivosExistemAsync(
+        IReadOnlyCollection<string> codigos,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(codigos);
+
+        var normalizados = codigos
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .Select(c => c.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (normalizados.Count == 0)
+        {
+            return true;
+        }
+
+        // Qualquer código fora do formato canônico não pode ter modalidade viva —
+        // logo "nem todos existem".
+        var codigosVo = new List<CodigoModalidade>(normalizados.Count);
+        foreach (string codigo in normalizados)
+        {
+            Result<CodigoModalidade> resultado = CodigoModalidade.Criar(codigo);
+            if (resultado.IsFailure)
+            {
+                return false;
+            }
+
+            codigosVo.Add(resultado.Value!);
+        }
+
+        int encontrados = await _dbContext.Modalidades
+            .AsNoTracking()
+            .Where(m => codigosVo.Contains(m.Codigo))
+            .Select(m => m.Codigo)
+            .Distinct()
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return encontrados == codigosVo.Count;
+    }
+
+    public Task<bool> EhReferenciadaPorOutraModalidadeVivaAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        string codigoNorm = codigo.Trim();
+
+        // Consulta jsonb: composicao_origem OU qualquer campo de remanejamento_args
+        // (destino/par/fallback, extraídos por ->>). SQL cru é necessário porque
+        // RemanejamentoArgs é serializado como jsonb via value converter e o EF não
+        // traduz acesso aos campos internos em LINQ. O query filter global de
+        // soft-delete é aplicado por composição sobre o FromSql.
+        FormattableString sql = $@"
+            SELECT * FROM configuracao.modalidade
+            WHERE composicao_origem = {codigoNorm}
+               OR remanejamento_args ->> 'destino' = {codigoNorm}
+               OR remanejamento_args ->> 'par' = {codigoNorm}
+               OR remanejamento_args ->> 'fallback' = {codigoNorm}";
+
+        IQueryable<Modalidade> consulta = _dbContext.Modalidades
+            .FromSqlInterpolated(sql)
+            .AsNoTracking();
+
+        if (excluirId is { } id)
+        {
+            consulta = consulta.Where(m => m.Id != id);
+        }
+
+        return consulta.AnyAsync(cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/ModalidadeReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/ModalidadeReader.cs
@@ -1,0 +1,70 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="IModalidadeReader"/> (ADR-0056): leitura direta do
+/// banco de Configuração (<c>AsNoTracking</c>, query filter de soft-delete por
+/// convenção). Sem cache — o cadastro é de baixo volume e o congelamento por valor
+/// no consumidor (ADR-0061) dispensa releitura quente (mesmo padrão do
+/// <c>TipoDocumentoReader</c>). Ordena por <c>Codigo</c> ascendente.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class ModalidadeReader : IModalidadeReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public ModalidadeReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<ModalidadeView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<Modalidade> entidades = await _dbContext.Modalidades
+            .AsNoTracking()
+            .OrderBy(m => m.Codigo)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<ModalidadeView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        Modalidade? entidade = await _dbContext.Modalidades
+            .AsNoTracking()
+            .FirstOrDefaultAsync(m => m.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static ModalidadeView ParaView(Modalidade m) =>
+        new(
+            m.Id,
+            m.Codigo.Valor,
+            m.Descricao,
+            NaturezasLegais.ParaTokenCanonico(m.NaturezaLegal),
+            ComposicoesVagas.ParaTokenCanonico(m.ComposicaoVagas),
+            m.ComposicaoOrigem,
+            m.RegraRemanejamento is { } regra ? RegrasRemanejamento.ParaTokenCanonico(regra) : null,
+            m.RemanejamentoArgs.Destino,
+            m.RemanejamentoArgs.Par,
+            m.RemanejamentoArgs.Fallback,
+            m.CriteriosCumulativos,
+            m.AcaoQuandoIndeferido is { } acao ? AcoesQuandoIndeferido.ParaTokenCanonico(acao) : null,
+            m.BaseLegal);
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarModalidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarModalidadeCommandHandlerTests.cs
@@ -1,0 +1,74 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarModalidadeCommandHandlerTests
+{
+    private readonly IModalidadeRepository _repository = Substitute.For<IModalidadeRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static Modalidade Existente(string codigo = "AC") =>
+        Modalidade.Criar(codigo, "Ampla", "AMPLA", "RESIDUAL_DO_VO", null, null, null, null, null, null, null, null)
+            .Value!;
+
+    [Fact(DisplayName = "Modalidade inexistente retorna NaoEncontrada (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrada()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((Modalidade?)null);
+
+        Result resultado = await AtualizarModalidadeCommandHandler.Handle(
+            new AtualizarModalidadeCommand(id, Descricao: "x"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.NaoEncontrada);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Atualização válida persiste e o código permanece imutável")]
+    public async Task Handle_Valido_PersisteCodigoImutavel()
+    {
+        Modalidade existente = Existente("AC");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        var comando = new AtualizarModalidadeCommand(
+            existente.Id, Descricao: "Descrição nova", NaturezaLegal: "AMPLA", ComposicaoVagas: "RESIDUAL_DO_VO");
+
+        Result resultado = await AtualizarModalidadeCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.Codigo.Valor.Should().Be("AC", "o código é imutável — não há campo para alterá-lo");
+        existente.Descricao.Should().Be("Descrição nova");
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Referência de remanejamento inexistente entre vivos retorna 422 sem persistir")]
+    public async Task Handle_ReferenciaInexistente_Retorna422()
+    {
+        Modalidade existente = Existente("SUP");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.CodigosVivosExistemAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var comando = new AtualizarModalidadeCommand(
+            existente.Id, NaturezaLegal: "SUPLEMENTAR", ComposicaoVagas: "SUPLEMENTAR_AO_TOTAL",
+            RegraRemanejamento: "DESTINO_UNICO", RemanejamentoDestino: "XPTO");
+
+        Result resultado = await AtualizarModalidadeCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.ReferenciaInexistenteOuInativa);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarModalidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarModalidadeCommandHandlerTests.cs
@@ -1,0 +1,84 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarModalidadeCommandHandlerTests
+{
+    private readonly IModalidadeRepository _repository = Substitute.For<IModalidadeRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CriarModalidadeCommand ComandoAmpla() =>
+        new("AC", Descricao: "Ampla concorrência", NaturezaLegal: "AMPLA");
+
+    [Fact(DisplayName = "Código livre cria a modalidade, persiste e retorna o Id")]
+    public async Task Handle_CodigoLivre_CriaEPersiste()
+    {
+        _repository.CodigoExisteEntreVivosAsync("AC", null, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result<Guid> resultado = await CriarModalidadeCommandHandler.Handle(
+            ComandoAmpla(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<Modalidade>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Código já existente entre vivos retorna conflito (CodigoJaExiste) sem persistir")]
+    public async Task Handle_CodigoDuplicado_RetornaConflito()
+    {
+        _repository.CodigoExisteEntreVivosAsync("AC", null, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result<Guid> resultado = await CriarModalidadeCommandHandler.Handle(
+            ComandoAmpla(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.CodigoJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<Modalidade>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Referência de composição inexistente entre vivos retorna 422 sem persistir")]
+    public async Task Handle_ReferenciaInexistente_Retorna422()
+    {
+        _repository.CodigoExisteEntreVivosAsync("LB_PPI", null, Arg.Any<CancellationToken>()).Returns(false);
+        _repository.CodigosVivosExistemAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        // RETIRA_DE exige origem; a origem "XPTO" não existe viva.
+        var comando = new CriarModalidadeCommand(
+            "LB_PPI", NaturezaLegal: "AMPLA", ComposicaoVagas: "RETIRA_DE", ComposicaoOrigem: "XPTO");
+
+        Result<Guid> resultado = await CriarModalidadeCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.ReferenciaInexistenteOuInativa);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<Modalidade>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Invariante de domínio (cota sem cascata) propaga o erro sem persistir")]
+    public async Task Handle_DominioIncoerente_RetornaErroSemPersistir()
+    {
+        _repository.CodigoExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>()).Returns(false);
+
+        var comando = new CriarModalidadeCommand(
+            "LB_PPI", NaturezaLegal: "COTA_RESERVADA", ComposicaoVagas: "DENTRO_DO_VR");
+
+        Result<Guid> resultado = await CriarModalidadeCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverModalidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverModalidadeCommandHandlerTests.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverModalidadeCommandHandlerTests
+{
+    private readonly IModalidadeRepository _repository = Substitute.For<IModalidadeRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static Modalidade Modalidade() =>
+        Domain.Entities.Modalidade.Criar("AC", null, "AMPLA", "RESIDUAL_DO_VO", null, null, null, null, null, null, null, null)
+            .Value!;
+
+    [Fact(DisplayName = "Modalidade referenciada por outra viva bloqueia a remoção (409)")]
+    public async Task Handle_Referenciada_RetornaConflito()
+    {
+        Modalidade modalidade = Modalidade();
+        _repository.ObterPorIdAsync(modalidade.Id, Arg.Any<CancellationToken>()).Returns(modalidade);
+        _repository.EhReferenciadaPorOutraModalidadeVivaAsync("AC", modalidade.Id, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result resultado = await RemoverModalidadeCommandHandler.Handle(
+            new RemoverModalidadeCommand(modalidade.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.RemocaoBloqueadaPorReferencia);
+        _repository.DidNotReceive().Remover(Arg.Any<Modalidade>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Modalidade livre de referências faz soft-delete (Remover + Salvar)")]
+    public async Task Handle_Livre_FazSoftDelete()
+    {
+        Modalidade modalidade = Modalidade();
+        _repository.ObterPorIdAsync(modalidade.Id, Arg.Any<CancellationToken>()).Returns(modalidade);
+        _repository.EhReferenciadaPorOutraModalidadeVivaAsync("AC", modalidade.Id, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result resultado = await RemoverModalidadeCommandHandler.Handle(
+            new RemoverModalidadeCommand(modalidade.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(modalidade);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Modalidade inexistente retorna NaoEncontrada (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrada()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((Modalidade?)null);
+
+        Result resultado = await RemoverModalidadeCommandHandler.Handle(
+            new RemoverModalidadeCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.NaoEncontrada);
+        _repository.DidNotReceive().Remover(Arg.Any<Modalidade>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/ModalidadeValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/ModalidadeValidatorTests.cs
@@ -1,0 +1,113 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Modalidades;
+
+/// <summary>
+/// O validator antecipa o formato do código, o domínio fechado dos enums e os
+/// tamanhos, mantendo a fronteira simétrica com o domínio (#589). A coerência e a
+/// integridade referencial ficam no agregado e no handler.
+/// </summary>
+public sealed class ModalidadeValidatorTests
+{
+    private readonly CriarModalidadeCommandValidator _criarValidator = new();
+    private readonly AtualizarModalidadeCommandValidator _atualizarValidator = new();
+
+    private static CriarModalidadeCommand Base() =>
+        new("AC", Descricao: "Ampla concorrência", NaturezaLegal: "AMPLA", ComposicaoVagas: "RESIDUAL_DO_VO");
+
+    [Fact(DisplayName = "Comando válido passa no validator de criação")]
+    public void Criar_Valido_Passa()
+    {
+        _criarValidator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Comando sem enums opcionais (defaults) passa")]
+    public void Criar_SemEnumsOpcionais_Passa()
+    {
+        _criarValidator.Validate(new CriarModalidadeCommand("AC")).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Código fora do formato é rejeitado")]
+    [InlineData("lb_ppi")]
+    [InlineData("LB-PPI")]
+    [InlineData("")]
+    public void Criar_CodigoInvalido_Rejeita(string codigo)
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { Codigo = codigo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarModalidadeCommand.Codigo));
+    }
+
+    [Theory(DisplayName = "Natureza legal fora do domínio é rejeitada (incl. numérico e PascalCase)")]
+    [InlineData("COTA")]
+    [InlineData("1")]
+    [InlineData("Ampla")]
+    public void Criar_NaturezaInvalida_Rejeita(string natureza)
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { NaturezaLegal = natureza });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarModalidadeCommand.NaturezaLegal));
+    }
+
+    [Theory(DisplayName = "Composição de vagas fora do domínio é rejeitada")]
+    [InlineData("RESIDUAL")]
+    [InlineData("2")]
+    public void Criar_ComposicaoInvalida_Rejeita(string composicao)
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { ComposicaoVagas = composicao });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarModalidadeCommand.ComposicaoVagas));
+    }
+
+    [Fact(DisplayName = "Regra de remanejamento fora do domínio é rejeitada")]
+    public void Criar_RegraInvalida_Rejeita()
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { RegraRemanejamento = "CASCATA" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarModalidadeCommand.RegraRemanejamento));
+    }
+
+    [Fact(DisplayName = "Ação quando indeferido fora do domínio é rejeitada")]
+    public void Criar_AcaoInvalida_Rejeita()
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { AcaoQuandoIndeferido = "REPROVAR" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarModalidadeCommand.AcaoQuandoIndeferido));
+    }
+
+    [Fact(DisplayName = "Descrição acima de 300 caracteres é rejeitada")]
+    public void Criar_DescricaoLonga_Rejeita()
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { Descricao = new string('a', 301) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarModalidadeCommand.Descricao));
+    }
+
+    [Fact(DisplayName = "Atualização com Id vazio é rejeitada")]
+    public void Atualizar_IdVazio_Rejeita()
+    {
+        ValidationResult resultado = _atualizarValidator.Validate(
+            new AtualizarModalidadeCommand(Guid.Empty, NaturezaLegal: "AMPLA"));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(AtualizarModalidadeCommand.Id));
+    }
+
+    [Fact(DisplayName = "Atualização válida passa no validator")]
+    public void Atualizar_Valido_Passa()
+    {
+        _atualizarValidator.Validate(
+            new AtualizarModalidadeCommand(Guid.CreateVersion7(), NaturezaLegal: "AMPLA", ComposicaoVagas: "RESIDUAL_DO_VO"))
+            .IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/ModalidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/ModalidadeTests.cs
@@ -1,0 +1,281 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class ModalidadeTests
+{
+    private static Result<Modalidade> Criar(
+        string codigo = "AC",
+        string? descricao = null,
+        string? natureza = "AMPLA",
+        string? composicao = "RESIDUAL_DO_VO",
+        string? origem = null,
+        string? regra = null,
+        string? destino = null,
+        string? par = null,
+        string? fallback = null,
+        IReadOnlyList<string>? criterios = null,
+        string? acao = null,
+        string? baseLegal = null) =>
+        Modalidade.Criar(
+            codigo, descricao, natureza, composicao, origem, regra,
+            destino, par, fallback, criterios, acao, baseLegal);
+
+    // ── Factory válida ─────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Ampla sem remanejamento preenche os campos e fica ativa com Guid v7")]
+    public void Criar_AmplaSemRemanejamento_Valida()
+    {
+        Modalidade m = Criar(
+            codigo: "AC", descricao: "Ampla concorrência", natureza: "AMPLA").Value!;
+
+        m.Id.Should().NotBe(Guid.Empty);
+        m.Codigo.Valor.Should().Be("AC");
+        m.NaturezaLegal.Should().Be(NaturezaLegal.Ampla);
+        m.ComposicaoVagas.Should().Be(ComposicaoVagas.ResidualDoVo);
+        m.RegraRemanejamento.Should().BeNull();
+        m.RemanejamentoArgs.TemAlgum.Should().BeFalse();
+        m.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Cota reservada com SEGUE_CASCATA é válida")]
+    public void Criar_CotaComCascata_Valida()
+    {
+        Modalidade m = Criar(
+            codigo: "LB_PPI", natureza: "COTA_RESERVADA", composicao: "DENTRO_DO_VR",
+            regra: "SEGUE_CASCATA").Value!;
+
+        m.NaturezaLegal.Should().Be(NaturezaLegal.CotaReservada);
+        m.RegraRemanejamento.Should().Be(RegraRemanejamento.SegueCascata);
+    }
+
+    [Fact(DisplayName = "Natureza e composição ausentes assumem defaults AMPLA / RESIDUAL_DO_VO")]
+    public void Criar_SemNaturezaComposicao_AplicaDefaults()
+    {
+        Modalidade m = Criar(natureza: null, composicao: null).Value!;
+
+        m.NaturezaLegal.Should().Be(NaturezaLegal.Ampla);
+        m.ComposicaoVagas.Should().Be(ComposicaoVagas.ResidualDoVo);
+    }
+
+    // ── Formato do código ──────────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Código com hífen, minúscula ou espaço é rejeitado (formato)")]
+    [InlineData("lb_ppi")]
+    [InlineData("LB-PPI")]
+    [InlineData("LB PPI")]
+    public void Criar_CodigoForaDoFormato_Falha(string codigo)
+    {
+        Result<Modalidade> r = Criar(codigo: codigo);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.CodigoFormatoInvalido);
+    }
+
+    [Theory(DisplayName = "Código ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemCodigo_Falha(string codigo)
+    {
+        Result<Modalidade> r = Criar(codigo: codigo);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.CodigoObrigatorio);
+    }
+
+    // ── Coerência natureza ↔ remanejamento (invariante 3) ──────────────────────
+
+    [Fact(DisplayName = "Cota reservada SEM cascata é incoerente")]
+    public void Criar_CotaSemCascata_Incoerente()
+    {
+        Result<Modalidade> r = Criar(natureza: "COTA_RESERVADA", composicao: "DENTRO_DO_VR", regra: null);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente);
+    }
+
+    [Fact(DisplayName = "Ampla COM remanejamento é incoerente")]
+    public void Criar_AmplaComRemanejamento_Incoerente()
+    {
+        Result<Modalidade> r = Criar(natureza: "AMPLA", regra: "SEGUE_CASCATA");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente);
+    }
+
+    [Fact(DisplayName = "Suplementar com SEGUE_CASCATA é incoerente (exige destino único ou cruzado)")]
+    public void Criar_SuplementarComCascata_Incoerente()
+    {
+        Result<Modalidade> r = Criar(
+            natureza: "SUPLEMENTAR", composicao: "SUPLEMENTAR_AO_TOTAL", regra: "SEGUE_CASCATA");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente);
+    }
+
+    [Fact(DisplayName = "Contraprova: Suplementar com DESTINO_UNICO + destino é coerente")]
+    public void Criar_SuplementarComDestinoUnico_Coerente()
+    {
+        Result<Modalidade> r = Criar(
+            natureza: "SUPLEMENTAR", composicao: "SUPLEMENTAR_AO_TOTAL",
+            regra: "DESTINO_UNICO", destino: "AC");
+
+        r.IsSuccess.Should().BeTrue();
+        r.Value!.RegraRemanejamento.Should().Be(RegraRemanejamento.DestinoUnico);
+    }
+
+    // ── Equivalência composição RETIRA_DE ⟺ origem (invariante 4) ──────────────
+
+    [Fact(DisplayName = "RETIRA_DE sem origem é rejeitado (origem obrigatória)")]
+    public void Criar_RetiraDeSemOrigem_Falha()
+    {
+        Result<Modalidade> r = Criar(composicao: "RETIRA_DE", origem: null);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.OrigemObrigatoriaParaRetiraDe);
+    }
+
+    [Fact(DisplayName = "Origem preenchida sem RETIRA_DE é rejeitada (origem apenas para RETIRA_DE)")]
+    public void Criar_OrigemSemRetiraDe_Falha()
+    {
+        Result<Modalidade> r = Criar(composicao: "RESIDUAL_DO_VO", origem: "AC");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.OrigemApenasParaRetiraDe);
+    }
+
+    [Fact(DisplayName = "Contraprova: RETIRA_DE com origem é aceito")]
+    public void Criar_RetiraDeComOrigem_Aceita()
+    {
+        Modalidade m = Criar(natureza: "AMPLA", composicao: "RETIRA_DE", origem: "AC").Value!;
+
+        m.ComposicaoVagas.Should().Be(ComposicaoVagas.RetiraDe);
+        m.ComposicaoOrigem.Should().Be("AC");
+    }
+
+    // ── Argumentos por regra (invariante 5) ────────────────────────────────────
+
+    [Fact(DisplayName = "DESTINO_UNICO sem destino é rejeitado")]
+    public void Criar_DestinoUnicoSemDestino_Falha()
+    {
+        Result<Modalidade> r = Criar(
+            natureza: "SUPLEMENTAR", composicao: "SUPLEMENTAR_AO_TOTAL", regra: "DESTINO_UNICO");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.ArgumentoRemanejamentoObrigatorio);
+    }
+
+    [Fact(DisplayName = "CRUZADO sem par/fallback é rejeitado")]
+    public void Criar_CruzadoSemParFallback_Falha()
+    {
+        Result<Modalidade> r = Criar(
+            natureza: "OUTRA_MODALIDADE", composicao: "SUPLEMENTAR_AO_TOTAL",
+            regra: "CRUZADO", par: "AC");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.ArgumentoRemanejamentoObrigatorio);
+    }
+
+    [Fact(DisplayName = "Contraprova: CRUZADO com par e fallback é aceito")]
+    public void Criar_CruzadoComParFallback_Aceita()
+    {
+        Modalidade m = Criar(
+            natureza: "OUTRA_MODALIDADE", composicao: "SUPLEMENTAR_AO_TOTAL",
+            regra: "CRUZADO", par: "AC", fallback: "LB_PPI").Value!;
+
+        m.RemanejamentoArgs.Par.Should().Be("AC");
+        m.RemanejamentoArgs.Fallback.Should().Be("LB_PPI");
+        m.RemanejamentoArgs.Destino.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "SEGUE_CASCATA com argumentos preenchidos é rejeitado (nenhum arg admitido)")]
+    public void Criar_CascataComArgs_Falha()
+    {
+        Result<Modalidade> r = Criar(
+            natureza: "COTA_RESERVADA", composicao: "DENTRO_DO_VR",
+            regra: "SEGUE_CASCATA", destino: "AC");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.ArgumentoRemanejamentoObrigatorio);
+    }
+
+    // ── Ação quando indeferido (invariante 6) ──────────────────────────────────
+
+    [Fact(DisplayName = "Ação quando indeferido fora do domínio é rejeitada")]
+    public void Criar_AcaoInvalida_Falha()
+    {
+        Result<Modalidade> r = Criar(acao: "REPROVAR");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.AcaoIndeferimentoInvalida);
+    }
+
+    [Fact(DisplayName = "Ação quando indeferido válida é aceita")]
+    public void Criar_AcaoValida_Aceita()
+    {
+        Modalidade m = Criar(acao: "RECLASSIFICAR_AC").Value!;
+
+        m.AcaoQuandoIndeferido.Should().Be(AcaoQuandoIndeferido.ReclassificarAc);
+    }
+
+    // ── Descrição e base legal ─────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Descrição acima de 300 caracteres é rejeitada")]
+    public void Criar_DescricaoLonga_Falha()
+    {
+        Result<Modalidade> r = Criar(descricao: new string('a', 301));
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.DescricaoTamanho);
+    }
+
+    [Fact(DisplayName = "Base legal acima de 500 caracteres é rejeitada")]
+    public void Criar_BaseLegalLonga_Falha()
+    {
+        Result<Modalidade> r = Criar(baseLegal: new string('a', 501));
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.BaseLegalTamanho);
+    }
+
+    // ── Imutabilidade do código na atualização ─────────────────────────────────
+
+    [Fact(DisplayName = "Atualizar troca atributos editáveis mantendo Codigo e Id imutáveis")]
+    public void Atualizar_MantemCodigoEId()
+    {
+        Modalidade m = Criar(codigo: "LB_PPI", natureza: "COTA_RESERVADA", regra: "SEGUE_CASCATA").Value!;
+        Guid idOriginal = m.Id;
+
+        Result r = m.Atualizar(
+            descricao: "Nova descrição", naturezaLegal: "AMPLA", composicaoVagas: "RESIDUAL_DO_VO",
+            composicaoOrigem: null, regraRemanejamento: null,
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: null);
+
+        r.IsSuccess.Should().BeTrue();
+        m.Codigo.Valor.Should().Be("LB_PPI", "o código é imutável");
+        m.Id.Should().Be(idOriginal, "o Id é imutável");
+        m.NaturezaLegal.Should().Be(NaturezaLegal.Ampla);
+        m.Descricao.Should().Be("Nova descrição");
+    }
+
+    [Fact(DisplayName = "Atualizar revalida coerência (cota sem cascata falha)")]
+    public void Atualizar_Incoerente_Falha()
+    {
+        Modalidade m = Criar(codigo: "AC", natureza: "AMPLA").Value!;
+
+        Result r = m.Atualizar(
+            descricao: null, naturezaLegal: "COTA_RESERVADA", composicaoVagas: "DENTRO_DO_VR",
+            composicaoOrigem: null, regraRemanejamento: null,
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: null);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Modalidades/ModalidadeEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Modalidades/ModalidadeEndpointTests.cs
@@ -1,0 +1,183 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Modalidades;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>Modalidade</c> (UNI-REQ-0011):
+/// routing, vendor media type, HATEOAS, autenticação/autorização, idempotência,
+/// domínio fechado dos enums (422), coerência de domínio (422) e unicidade do
+/// código (409) — com Wolverine contra Postgres efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class ModalidadeEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public ModalidadeEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/modalidades retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/modalidades", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.modalidade.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/modalidades/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/modalidades/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/configuracao/admin/modalidades sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/modalidades", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        var body = new { codigo = CodigoUnico(), naturezaLegal = "AMPLA" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/modalidades", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/modalidades", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST cria (201) e o GET subsequente retorna os campos + HATEOAS")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        string codigo = CodigoUnico();
+        var body = new
+        {
+            codigo,
+            descricao = "Cota PPI de baixa renda",
+            naturezaLegal = "COTA_RESERVADA",
+            composicaoVagas = "DENTRO_DO_VR",
+            regraRemanejamento = "SEGUE_CASCATA",
+            baseLegal = "Lei 12.711/2012",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/modalidades/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("codigo").GetString().Should().Be(codigo);
+        root.GetProperty("naturezaLegal").GetString().Should().Be("COTA_RESERVADA");
+        root.GetProperty("composicaoVagas").GetString().Should().Be("DENTRO_DO_VR");
+        root.GetProperty("regraRemanejamento").GetString().Should().Be("SEGUE_CASCATA");
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "POST com natureza fora do domínio fechado retorna 422")]
+    public async Task Criar_NaturezaInvalida_Retorna422()
+    {
+        var body = new { codigo = CodigoUnico(), naturezaLegal = "COTA" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST RETIRA_DE sem origem retorna 422 (coerência de domínio)")]
+    public async Task Criar_RetiraDeSemOrigem_Retorna422()
+    {
+        var body = new { codigo = CodigoUnico(), naturezaLegal = "AMPLA", composicaoVagas = "RETIRA_DE" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com código já existente entre vivos retorna 409")]
+    public async Task Criar_CodigoDuplicado_Retorna409()
+    {
+        string codigo = CodigoUnico();
+        var body = new { codigo, naturezaLegal = "AMPLA" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage primeiro = await EnviarPostAdmin(client, body);
+        primeiro.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage segundo = await EnviarPostAdmin(client, new { codigo, naturezaLegal = "AMPLA" });
+        segundo.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    private static string CodigoUnico() => $"MOD_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/modalidades", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Modalidades/ModalidadePersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Modalidades/ModalidadePersistenceTests.cs
@@ -1,0 +1,277 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Modalidades;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta da Modalidade contra Postgres real (UNI-REQ-0011):
+/// persistência, UNIQUE parcial do código vivo, liberação do slot por soft-delete,
+/// CHECKs de domínio (natureza, formato do código, coerência RETIRA_DE⟺origem),
+/// bloqueio de remoção quando referenciada (composicao_origem e remanejamento_args
+/// jsonb) e leitura cross-módulo ordenada por código.
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class ModalidadePersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public ModalidadePersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Criar persiste os campos e fica visível pelo leitor cross-módulo")]
+    public async Task Insert_PersisteEFicaVisivelPeloReader()
+    {
+        string codigo = CodigoUnico();
+        Modalidade modalidade = Cota(codigo);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Modalidades.Add(modalidade);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        Modalidade persistida = await readCtx.Modalidades.SingleAsync(m => m.Id == modalidade.Id);
+
+        persistida.Codigo.Valor.Should().Be(codigo);
+        persistida.NaturezaLegal.Should().Be(Domain.Enums.NaturezaLegal.CotaReservada);
+        persistida.RegraRemanejamento.Should().Be(Domain.Enums.RegraRemanejamento.SegueCascata);
+        persistida.CreatedBy.Should().Be(AdminA);
+        persistida.IsDeleted.Should().BeFalse();
+
+        var reader = new ModalidadeReader(readCtx);
+        ModalidadeView? view = await reader.ObterPorIdAsync(modalidade.Id);
+        view.Should().NotBeNull();
+        view!.Codigo.Should().Be(codigo);
+        view.NaturezaLegal.Should().Be("COTA_RESERVADA");
+        view.RegraRemanejamento.Should().Be("SEGUE_CASCATA");
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial do código rejeita segunda modalidade viva com mesmo código")]
+    public async Task UniquePartial_Codigo_RejeitaDuplicataAtiva()
+    {
+        string codigo = CodigoUnico();
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Modalidades.Add(Ampla(codigo));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.Modalidades.Add(Ampla(codigo));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        // Trava as constantes que o handler usa para traduzir a corrida concorrente
+        // (UniqueConstraintViolation) em CodigoJaExiste/409.
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_modalidade_codigo_vivo");
+    }
+
+    [Fact(DisplayName = "Soft-delete preserva a trilha e libera o slot da UNIQUE parcial do código")]
+    public async Task SoftDelete_LiberaSlot()
+    {
+        string codigo = CodigoUnico();
+        Modalidade modalidade = Ampla(codigo);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Modalidades.Add(modalidade);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            Modalidade tracked = await ctx.Modalidades.SingleAsync(m => m.Id == modalidade.Id);
+            ctx.Modalidades.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            Modalidade excluida = await ctx.Modalidades
+                .IgnoreQueryFilters().SingleAsync(m => m.Id == modalidade.Id);
+            excluida.IsDeleted.Should().BeTrue();
+            excluida.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.Modalidades.Add(Ampla(codigo));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do código foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita natureza fora do domínio via SQL cru")]
+    public async Task Check_RejeitaNaturezaForaDoDominioViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.modalidade (id, codigo, natureza_legal, composicao_vagas, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"INVALIDA"}, {"RESIDUAL_DO_VO"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de domínio de natureza_legal impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita código fora do formato via SQL cru")]
+    public async Task Check_RejeitaCodigoForaDoFormatoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.modalidade (id, codigo, natureza_legal, composicao_vagas, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"lb-ppi"}, {"AMPLA"}, {"RESIDUAL_DO_VO"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK codigo ~ '^[A-Z0-9_]+$' impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita RETIRA_DE sem origem via SQL cru")]
+    public async Task Check_RejeitaRetiraDeSemOrigemViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.modalidade (id, codigo, natureza_legal, composicao_vagas, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"AMPLA"}, {"RETIRA_DE"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK (composicao_vagas = 'RETIRA_DE') = (composicao_origem IS NOT NULL) impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita origem preenchida sem RETIRA_DE via SQL cru")]
+    public async Task Check_RejeitaOrigemSemRetiraDeViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.modalidade (id, codigo, natureza_legal, composicao_vagas, composicao_origem, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"AMPLA"}, {"RESIDUAL_DO_VO"}, {"AC"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de coerência RETIRA_DE⟺origem impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "Remoção é bloqueada por referência via composicao_origem (repo)")]
+    public async Task EhReferenciada_PorComposicaoOrigem_True()
+    {
+        string origem = CodigoUnico();
+        string dependente = CodigoUnico();
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.Modalidades.Add(Ampla(origem));
+        ctx.Modalidades.Add(RetiraDe(dependente, origem));
+        await ctx.SaveChangesAsync();
+
+        var repo = new ModalidadeRepository(ctx);
+        bool referenciada = await repo.EhReferenciadaPorOutraModalidadeVivaAsync(origem, ExcluirId(ctx, origem), default);
+
+        referenciada.Should().BeTrue("outra modalidade viva aponta este código como composicao_origem");
+    }
+
+    [Fact(DisplayName = "Remoção é bloqueada por referência via remanejamento_args jsonb (repo)")]
+    public async Task EhReferenciada_PorRemanejamentoArgs_True()
+    {
+        string destino = CodigoUnico();
+        string dependente = CodigoUnico();
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.Modalidades.Add(Ampla(destino));
+        ctx.Modalidades.Add(DestinoUnico(dependente, destino));
+        await ctx.SaveChangesAsync();
+
+        var repo = new ModalidadeRepository(ctx);
+        bool referenciada = await repo.EhReferenciadaPorOutraModalidadeVivaAsync(destino, ExcluirId(ctx, destino), default);
+
+        referenciada.Should().BeTrue("o destino consta em remanejamento_args->>'destino' de outra viva");
+    }
+
+    [Fact(DisplayName = "Código não referenciado por ninguém não bloqueia a remoção (repo)")]
+    public async Task EhReferenciada_SemReferencia_False()
+    {
+        string livre = CodigoUnico();
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.Modalidades.Add(Ampla(livre));
+        await ctx.SaveChangesAsync();
+
+        var repo = new ModalidadeRepository(ctx);
+        bool referenciada = await repo.EhReferenciadaPorOutraModalidadeVivaAsync(livre, ExcluirId(ctx, livre), default);
+
+        referenciada.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Reader.ListarVivosAsync ordena por código e exclui soft-deleted")]
+    public async Task ListarVivos_OrdenaPorCodigoEExcluiSoftDeleted()
+    {
+        string prefixo = $"MOD_{Guid.NewGuid().ToString("N")[..8].ToUpperInvariant()}";
+        string codA = $"{prefixo}_A";
+        string codB = $"{prefixo}_B";
+        string codExcluido = $"{prefixo}_D";
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Modalidades.Add(Ampla(codB));
+            ctx.Modalidades.Add(Ampla(codA));
+            ctx.Modalidades.Add(Ampla(codExcluido));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            CodigoModalidade voExcluido = CodigoModalidade.Criar(codExcluido).Value!;
+            Modalidade aExcluir = await ctx.Modalidades.SingleAsync(m => m.Codigo == voExcluido);
+            ctx.Modalidades.Remove(aExcluir);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new ModalidadeReader(readCtx);
+        IReadOnlyList<ModalidadeView> todos = await reader.ListarVivosAsync();
+
+        string[] meus = [.. todos
+            .Select(v => v.Codigo)
+            .Where(c => c.StartsWith(prefixo, StringComparison.Ordinal))];
+
+        meus.Should().Equal([codA, codB]);
+    }
+
+    private static Guid ExcluirId(ConfiguracaoDbContext ctx, string codigo)
+    {
+        CodigoModalidade vo = CodigoModalidade.Criar(codigo).Value!;
+        return ctx.Modalidades.Single(m => m.Codigo == vo).Id;
+    }
+
+    private static Modalidade Ampla(string codigo) =>
+        Modalidade.Criar(codigo, null, "AMPLA", "RESIDUAL_DO_VO", null, null, null, null, null, null, null, null).Value!;
+
+    private static Modalidade Cota(string codigo) =>
+        Modalidade.Criar(codigo, "Cota", "COTA_RESERVADA", "DENTRO_DO_VR", null, "SEGUE_CASCATA", null, null, null, null, null, null).Value!;
+
+    private static Modalidade RetiraDe(string codigo, string origem) =>
+        Modalidade.Criar(codigo, null, "AMPLA", "RETIRA_DE", origem, null, null, null, null, null, null, null).Value!;
+
+    private static Modalidade DestinoUnico(string codigo, string destino) =>
+        Modalidade.Criar(codigo, null, "SUPLEMENTAR", "SUPLEMENTAR_AO_TOTAL", null, "DESTINO_UNICO", destino, null, null, null, null, null).Value!;
+
+    private static string CodigoUnico() => $"MOD_{Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
+}


### PR DESCRIPTION
## Contexto

Entrega a entidade **`Modalidade`** e seu CRUD administrativo no módulo de Configuração (UNI-REQ-0011, story #589) — o cadastro **configurável** (não enumerado de código) que materializa a legislação de cotas (**Lei 12.711/2012** atual. **Lei 14.723/2023**, **Portaria MEC 18/2012**): ampla concorrência, as oito modalidades reservadas federais e modalidades suplementares. É a entidade mais rica do módulo — espelha o padrão dos cadastros já na `main`.

## Modelo rico

- **`Codigo`** — value object com formato fechado (`^[A-Z0-9_]+$`, sem hífen), **IMUTÁVEL** após criado (participa da ordenação byte-a-byte do hash de publicação, RN08). Diferente dos demais cadastros, o command de atualização **não aceita** o código.
- **4 enums de domínio fechado** (`NaturezaLegal`, `ComposicaoVagas`, `RegraRemanejamento`, `AcaoQuandoIndeferido`) persistidos como token UPPER_SNAKE via value converter (parsing por allowlist textual).
- **`RemanejamentoArgs`** (destino/par/fallback) e **`CriteriosCumulativos`** em **jsonb** (com ValueComparer).

## Invariantes (guard de domínio + validator + CHECK)

| Invariante | Onde |
|---|---|
| Coerência natureza↔remanejamento: cota⇒cascata; ampla⇒sem regra; suplementar/outra⇒destino único/cruzado | factory + validator |
| Equivalência exata composição `RETIRA_DE` ⟺ `composicao_origem` preenchida | factory + **CHECK** `(composicao_vagas='RETIRA_DE') = (composicao_origem IS NOT NULL)` |
| Args por regra: destino único⇒destino; cruzado⇒par+fallback | factory |
| Integridade referencial: origem/destino/par/fallback existem vivos | handler (`CodigosVivosExistem`) |
| Remoção bloqueada se referenciada por outra viva (`composicao_origem` OU `remanejamento_args` jsonb) | handler (`EhReferenciadaPorOutraModalidadeViva`, `FromSqlInterpolated`) |
| `Codigo`/`Id` imutáveis na atualização | command sem campo código |

## Decisões de design

Consistentes com o módulo: índice único parcial `WHERE is_deleted=false`, corrida `23505` → **409** via `UniqueConstraintViolation`, comparações Ordinal, 6 CHECKs de domínio (4 enums + regex + coerência), reader read-side sem cache + **`ModalidadeSnapshot`** (`OrigemId`+`Codigo`+`AcaoQuandoIndeferido`) para o congelamento em Seleção (ADR-0061).

## ⚠️ Limitação conhecida (documentada)

A integridade referencial cross-linha é **check-then-act** — não há FK para jsonb. Existe uma **janela concorrente teórica** entre remover uma modalidade e criar/atualizar outra que a referencie simultaneamente (T1 checa "não referenciada" e T2 checa "origem existe viva", ambos commitam). É **aceitável para um cadastro administrativo de baixíssima concorrência** e consistente com o padrão check-then-act do módulo; candidata a **hardening futuro** (advisory lock por código referenciado ou trigger/constraint de banco) se a operação exigir. Apontado pela revisão Codex (Fase 9) e aceito conscientemente — a spec descreve a integridade como guard de domínio + teste, não serialização.

## Critérios de aceite

- **CA-01..CA-06** cobertos: criação (ampla/cota); unicidade + regex; coerência natureza↔remanejamento; equivalência origem; args por regra; ação no indeferimento; imutabilidade do código; remoção soft-delete + bloqueio por referência viva + não-bloqueio por snapshot. CA-07 (a11y) frontend; CA-08 (LGPD) inaplicável.

## Testes

Suíte completa do módulo verde, sem warnings: **Domain 187 · Application 168 · Integração 141** (1 skip pré-existente da #731). Inclui os 6 CHECKs via SQL cru, índice único parcial, bloqueio de remoção por `composicao_origem` e por `remanejamento_args` jsonb, e leitura cross-módulo. Migration forward-only e baseline OpenAPI regenerado.

## Revisão prévia

Diff revisado com Codex (Fase 9): zero P1; o único P2 (janela concorrente check-then-act) está documentado acima como limitação conhecida. Corrigidos 4 testes de integração que consultavam o VO por `.Codigo.Valor` em LINQ (não-traduzível) — o código de produção comparava corretamente pelo VO.

Closes #589
Refs #584