### PR TITLE
fix(deps): eleva Microsoft.OpenApi a 2.7.5 contra CVE-2026-49451

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,13 @@
 
     <!-- OpenAPI -->
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <!-- Usado diretamente pelos OpenAPI transformers (Infrastructure.Core/OpenApi), que o declaram
+         como PackageReference. Pin ≥2.7.5 obrigatório: Microsoft.AspNetCore.OpenApi 10.0.7 traz
+         transitivamente a 2.0.0, vulnerável a CVE-2026-49451 (HIGH — referência circular de schema
+         pode encerrar o processo no parsing OpenAPI); Trivy bloqueia. Com PackageVersion central, o
+         CPM aplica o pin transitivamente (CentralTransitive) a todos os projetos que recebem o pacote
+         via Microsoft.AspNetCore.OpenApi, elevando toda a solution a 2.7.5. -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Microsoft.OpenApi.Kiota" Version="1.31.1" />
 
     <!-- Encryption -->

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/packages.lock.json
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/packages.lock.json
@@ -353,11 +353,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -730,6 +725,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -859,6 +855,12 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/packages.lock.json
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/packages.lock.json
@@ -796,11 +796,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -1165,6 +1160,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1274,6 +1270,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/host/Unifesspa.UniPlus.Host/packages.lock.json
+++ b/src/host/Unifesspa.UniPlus.Host/packages.lock.json
@@ -353,11 +353,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -741,6 +736,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -975,6 +971,12 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
@@ -343,11 +343,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -672,6 +667,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -808,6 +804,12 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
@@ -660,11 +660,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -1003,6 +998,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1139,6 +1135,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/packages.lock.json
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/packages.lock.json
@@ -353,11 +353,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -682,6 +677,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -839,6 +835,12 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/packages.lock.json
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/packages.lock.json
@@ -660,11 +660,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -1003,6 +998,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1161,6 +1157,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
@@ -343,11 +343,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -672,6 +667,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -808,6 +804,12 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
@@ -660,11 +660,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -1003,6 +998,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1139,6 +1135,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
@@ -364,11 +364,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -693,6 +688,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -851,6 +847,12 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
@@ -681,11 +681,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -1024,6 +1019,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1160,6 +1156,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj
@@ -8,6 +8,8 @@
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <!-- Uso direto pelos OpenAPI transformers (OpenApi/*Transformer); pin ≥2.7.5 (CVE-2026-49451). -->
+    <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="Confluent.Kafka" />
     <PackageReference Include="Confluent.SchemaRegistry" />
     <PackageReference Include="Apache.Avro" />

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
@@ -95,6 +95,12 @@
           "Microsoft.EntityFrameworkCore": "10.0.9"
         }
       },
+      "Microsoft.OpenApi": {
+        "type": "Direct",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
+      },
       "Minio": {
         "type": "Direct",
         "requested": "[7.0.0, )",
@@ -597,11 +603,6 @@
         "dependencies": {
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
-      },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
       },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -729,11 +729,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -1208,6 +1203,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1502,6 +1498,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
@@ -823,11 +823,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -1306,6 +1301,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1585,6 +1581,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
@@ -795,11 +795,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -1278,6 +1273,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1557,6 +1553,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -783,11 +783,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -1266,6 +1261,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1545,6 +1541,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
@@ -380,11 +380,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -763,6 +758,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -898,6 +894,12 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
@@ -702,11 +702,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -1109,6 +1104,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1339,6 +1335,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
@@ -751,11 +751,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -1234,6 +1229,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1525,6 +1521,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
@@ -763,11 +763,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -1160,6 +1155,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1305,6 +1301,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
@@ -727,11 +727,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.VisualStudio.SolutionPersistence": {
         "type": "Transitive",
         "resolved": "1.0.52",
@@ -1196,6 +1191,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1476,6 +1472,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
@@ -823,11 +823,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -1306,6 +1301,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1585,6 +1581,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
@@ -702,11 +702,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -1109,6 +1104,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1339,6 +1335,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -823,11 +823,6 @@
           "Microsoft.IdentityModel.Logging": "8.0.1"
         }
       },
-      "Microsoft.OpenApi": {
-        "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
-      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -1306,6 +1301,7 @@
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
           "Minio": "[7.0.0, )",
           "Npgsql": "[10.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1585,6 +1581,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },
       "Minio": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Contexto

O scanner **Trivy** reporta **CVE-2026-49451 (HIGH)** em `Microsoft.OpenApi < 2.7.5`: uma **referência circular de schema pode encerrar o processo durante o parsing OpenAPI**. O pacote chegava **transitivamente** por `Microsoft.AspNetCore.OpenApi 10.0.7` (declarado no `Directory.Packages.props`), resolvendo a **2.0.0** em toda a solution. Correção proativa antes de o gate Trivy virar bloqueante (`exit-code: 1`).

Closes #744.

## O que muda

- **`Directory.Packages.props`** — adiciona `PackageVersion Microsoft.OpenApi 2.7.5` (mesma major da 2.0.0 → menor risco; a alternativa `3.x` seria major bump).
- **`Infrastructure.Core.csproj`** — `Microsoft.OpenApi` passa a `PackageReference` direto, pois é **usado diretamente** pelos transformers de OpenAPI (`OpenApi/UniPlusSchemaTransformer`, `UniPlusOperationTransformer`, `UniPlusInfoTransformer`, `CursorPaginationOperationTransformer`, `PaginationOrphanSchemaDocumentTransformer`).
- **24 `packages.lock.json`** regenerados: `Microsoft.OpenApi` resolve **2.7.5** em todos.

## Mecanismo (por que 2 arquivos-fonte bastam)

Este repo usa **Central Package Management com transitive pinning** ativo (a `main` já tem 691 entradas `CentralTransitive`). Ao declarar `PackageVersion Microsoft.OpenApi 2.7.5`, o CPM aplica o pin **transitivamente** (`CentralTransitive`) a todos os projetos que recebem o pacote via `Microsoft.AspNetCore.OpenApi` — não é preciso `PackageReference` direto em cada API. No `Infrastructure.Core` a referência é direta porque lá o pacote é **usado em código** (idiomático: declarar o que se usa). Nos lockfiles: `Infrastructure.Core` aparece como `Direct`, os demais como `CentralTransitive`, todos em `2.7.5`.

## Critérios de aceite

- [x] `Microsoft.OpenApi` resolve **≥ 2.7.5** em **todos os lockfiles** (24 — ver nota abaixo).
- [x] Build Release **sem warnings** (`TreatWarningsAsErrors`).
- [x] Suíte **completa verde**: unit + arch (~1600) e integração (todos os módulos), 0 falhas.
- [x] **Baseline OpenAPI inalterada** — `OpenApiEndpointTests` (drift/SpecRuntime) verdes **sem** regenerar `contracts/`; 2.7.5 gera spec idêntico à 2.0.0.
- [x] `restore --locked-mode` consistente.
- [ ] Trivy fs/image sem `CVE-2026-49451` — validado pelo CI (aba Security).

## Nota sobre a contagem de lockfiles

A issue cita **27** lockfiles. Após a extração do módulo **Geo** para repositório dedicado (já mergeada na `main`), a solution tem **24** lockfiles com `Microsoft.OpenApi` — os 3 do Geo (`Geo.API`, `Geo.Infrastructure`, `Geo.IntegrationTests`) não existem mais aqui. Por isso o passo original que citava `Geo.API/OpenApi` não se aplica neste PR.

> A 2.7.5 mantém as **mesmas dependências** da 2.0.0 (`System.Text.Json 8.0.5`), sem alterar contrato. Os `"2.0.0"` que ainda aparecem dentro de alguns lockfiles são apenas o *constraint* declarado por `Microsoft.AspNetCore.OpenApi`, não a versão resolvida (Trivy lê o campo `resolved`).

## Precedente

Achado análogo corrigido no `unifesspa-geo-api` PR [#13](https://github.com/unifesspa-edu-br/unifesspa-geo-api/pull/13) (`fix(geo): eleva Microsoft.OpenApi a 2.7.5 contra CVE-2026-49451`), onde o Trivy é bloqueante.

## Rollback

Reverter o PR. Mudança restrita a versão de dependência; sem impacto em dados ou contrato de negócio (baseline OpenAPI intacta).