### PR TITLE
feat(configuracao): adiciona cadastros de fase canônica e tipo de banca

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -1122,6 +1122,466 @@
         }
       }
     },
+    "/api/configuracao/fases-canonicas": {
+      "get": {
+        "tags": [
+          "FasesCanonicas"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FaseCanonicaDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FaseCanonicaDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FaseCanonicaDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/fases-canonicas/{id}": {
+      "get": {
+        "tags": [
+          "FasesCanonicas"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaseCanonicaDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaseCanonicaDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FaseCanonicaDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/fases-canonicas": {
+      "post": {
+        "tags": [
+          "FasesCanonicas"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarFaseCanonicaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarFaseCanonicaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarFaseCanonicaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/fases-canonicas/{id}": {
+      "put": {
+        "tags": [
+          "FasesCanonicas"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarFaseCanonicaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarFaseCanonicaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarFaseCanonicaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "FasesCanonicas"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configuracao/locais-oferta": {
       "get": {
         "tags": [
@@ -3452,6 +3912,466 @@
         }
       }
     },
+    "/api/configuracao/tipos-banca": {
+      "get": {
+        "tags": [
+          "TiposBanca"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoBancaDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoBancaDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoBancaDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/tipos-banca/{id}": {
+      "get": {
+        "tags": [
+          "TiposBanca"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoBancaDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoBancaDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoBancaDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/tipos-banca": {
+      "post": {
+        "tags": [
+          "TiposBanca"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoBancaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoBancaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoBancaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/tipos-banca/{id}": {
+      "put": {
+        "tags": [
+          "TiposBanca"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoBancaCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoBancaCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoBancaCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "TiposBanca"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configuracao/tipos-deficiencia": {
       "get": {
         "tags": [
@@ -4471,6 +5391,50 @@
           }
         }
       },
+      "AtualizarFaseCanonicaCommand": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "nome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "donoTipico": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "agrupaEtapas": {
+            "type": "boolean",
+            "default": false
+          },
+          "permiteComplementacao": {
+            "type": "boolean",
+            "default": false
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "AtualizarLocalOfertaCommand": {
         "required": [
           "id",
@@ -4742,6 +5706,36 @@
           },
           "baseLegal": {
             "type": "string"
+          }
+        }
+      },
+      "AtualizarTipoBancaCommand": {
+        "required": [
+          "id"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "nome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "faseTipica": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -5081,6 +6075,49 @@
           }
         }
       },
+      "CriarFaseCanonicaCommand": {
+        "required": [
+          "codigo"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "donoTipico": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "agrupaEtapas": {
+            "type": "boolean",
+            "default": false
+          },
+          "permiteComplementacao": {
+            "type": "boolean",
+            "default": false
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "CriarLocalOfertaCommand": {
         "required": [
           "tipo",
@@ -5342,6 +6379,35 @@
           }
         }
       },
+      "CriarTipoBancaCommand": {
+        "required": [
+          "codigo"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "faseTipica": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "CriarTipoDeficienciaCommand": {
         "required": [
           "nome"
@@ -5582,6 +6648,66 @@
               "null",
               "string"
             ]
+          }
+        }
+      },
+      "FaseCanonicaDto": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "descricao",
+          "donoTipico",
+          "agrupaEtapas",
+          "permiteComplementacao",
+          "baseLegal",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "donoTipico": {
+            "type": "string"
+          },
+          "agrupaEtapas": {
+            "type": "boolean"
+          },
+          "permiteComplementacao": {
+            "type": "boolean"
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },
@@ -5978,6 +7104,54 @@
           }
         }
       },
+      "TipoBancaDto": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "faseTipica",
+          "descricao",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "faseTipica": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "TipoDeficienciaDto": {
         "required": [
           "id",
@@ -6171,6 +7345,9 @@
       "name": "CondicoesAtendimento"
     },
     {
+      "name": "FasesCanonicas"
+    },
+    {
       "name": "LocaisOferta"
     },
     {
@@ -6184,6 +7361,9 @@
     },
     {
       "name": "ReferenciasReservaDemografica"
+    },
+    {
+      "name": "TiposBanca"
     },
     {
       "name": "TiposDeficiencia"

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
@@ -55,6 +55,8 @@ public static class ConfiguracaoModuleRegistration
         services.AddSingleton<IResourceLinksBuilder<RecursoAcessibilidadeDto>, RecursoAcessibilidadeLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<TipoDeficienciaDto>, TipoDeficienciaLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<ModalidadeDto>, ModalidadeLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<FaseCanonicaDto>, FaseCanonicaLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<TipoBancaDto>, TipoBancaLinksBuilder>();
 
         // Idempotency-Key (ADR-0027) sobre o DbContext do módulo.
         services.AddIdempotency<ConfiguracaoDbContext, ConfiguracaoApiAssemblyMarker>(configuration);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/FasesCanonicasController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/FasesCanonicasController.cs
@@ -1,0 +1,185 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.FasesCanonicas;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/fases-canonicas</c>,
+/// <c>GET /api/configuracao/fases-canonicas/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/configuracao/admin/fases-canonicas</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ-0064).
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class FasesCanonicasController : ControllerBase
+{
+    private const string ResourceTag = "fases-canonicas";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<FaseCanonicaDto> _linksBuilder;
+
+    public FasesCanonicasController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<FaseCanonicaDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista as fases canônicas ativas, paginadas por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("fases-canonicas")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "fase-canonica", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<FaseCanonicaDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarFasesCanonicasResult resultado = await _queryBus
+            .Send(new ListarFasesCanonicasQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        FaseCanonicaDto[] comLinks =
+            [.. resultado.Items.Select(f => f with { Links = _linksBuilder.Build(f) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém uma fase canônica pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("fases-canonicas/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "fase-canonica", Versions = [1])]
+    [ProducesResponseType(typeof(FaseCanonicaDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        FaseCanonicaDto? fase = await _queryBus
+            .Send(new ObterFaseCanonicaPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (fase is null)
+        {
+            return NotFound();
+        }
+
+        FaseCanonicaDto comLinks = fase with { Links = _linksBuilder.Build(fase) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria uma nova fase canônica. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/fases-canonicas")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarFaseCanonicaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza uma fase canônica existente. O código é imutável. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/fases-canonicas/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarFaseCanonicaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) uma fase canônica. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/fases-canonicas/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverFaseCanonicaCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposBancaController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposBancaController.cs
@@ -1,0 +1,185 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.TiposBanca;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/tipos-banca</c>,
+/// <c>GET /api/configuracao/tipos-banca/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/configuracao/admin/tipos-banca</c>) restritos a
+/// <c>plataforma-admin</c> (UNI-REQ-0064).
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class TiposBancaController : ControllerBase
+{
+    private const string ResourceTag = "tipos-banca";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<TipoBancaDto> _linksBuilder;
+
+    public TiposBancaController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<TipoBancaDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista os tipos de banca ativos, paginados por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("tipos-banca")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "tipo-banca", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<TipoBancaDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarTiposBancaResult resultado = await _queryBus
+            .Send(new ListarTiposBancaQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        TipoBancaDto[] comLinks =
+            [.. resultado.Items.Select(b => b with { Links = _linksBuilder.Build(b) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém um tipo de banca pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("tipos-banca/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "tipo-banca", Versions = [1])]
+    [ProducesResponseType(typeof(TipoBancaDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        TipoBancaDto? banca = await _queryBus
+            .Send(new ObterTipoBancaPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (banca is null)
+        {
+            return NotFound();
+        }
+
+        TipoBancaDto comLinks = banca with { Links = _linksBuilder.Build(banca) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria um novo tipo de banca. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/tipos-banca")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarTipoBancaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza um tipo de banca existente. O código é imutável. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/tipos-banca/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarTipoBancaCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) um tipo de banca. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/tipos-banca/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverTipoBancaCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -614,5 +614,139 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status404NotFound,
                 "uniplus.configuracao.modalidade.nao_encontrada",
                 "Modalidade não encontrada")),
+
+        // ── Fase canônica (UNI-REQ-0064) ──────────────────────────────────
+        new(FaseCanonicaErrorCodes.CodigoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.codigo_obrigatorio",
+                "Código da fase canônica é obrigatório")),
+
+        new(FaseCanonicaErrorCodes.CodigoFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.codigo_formato_invalido",
+                "Código da fase canônica em formato inválido")),
+
+        new(FaseCanonicaErrorCodes.CodigoForaDoConjuntoCanonico,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.codigo_fora_do_conjunto_canonico",
+                "Código da fase fora do conjunto canônico das quatorze fases")),
+
+        new(FaseCanonicaErrorCodes.CodigoJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.fase_canonica.codigo_ja_existe",
+                "Já existe uma fase canônica ativa com este código")),
+
+        new(FaseCanonicaErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.nome_obrigatorio",
+                "Nome da fase canônica é obrigatório")),
+
+        new(FaseCanonicaErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.nome_tamanho",
+                "Tamanho do nome da fase canônica inválido")),
+
+        new(FaseCanonicaErrorCodes.DescricaoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.descricao_tamanho",
+                "Tamanho da descrição da fase canônica inválido")),
+
+        new(FaseCanonicaErrorCodes.DonoTipicoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.dono_tipico_obrigatorio",
+                "Dono típico da fase canônica é obrigatório")),
+
+        new(FaseCanonicaErrorCodes.DonoTipicoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.dono_tipico_invalido",
+                "Dono típico da fase canônica fora do domínio fechado")),
+
+        new(FaseCanonicaErrorCodes.AgrupaEtapasApenasAvaliacao,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.agrupa_etapas_apenas_avaliacao",
+                "Apenas a fase de avaliação agrupa etapas pontuadas")),
+
+        new(FaseCanonicaErrorCodes.ComplementacaoApenasFasesPermitidas,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.complementacao_apenas_fases_permitidas",
+                "Complementação documental só é permitida nas fases de homologação e recursos")),
+
+        new(FaseCanonicaErrorCodes.BaseLegalTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.fase_canonica.base_legal_tamanho",
+                "Tamanho da base legal da fase canônica inválido")),
+
+        new(FaseCanonicaErrorCodes.NaoEncontrada,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.fase_canonica.nao_encontrada",
+                "Fase canônica não encontrada")),
+
+        // ── Tipo de banca (UNI-REQ-0064) ──────────────────────────────────
+        new(TipoBancaErrorCodes.CodigoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_banca.codigo_obrigatorio",
+                "Código do tipo de banca é obrigatório")),
+
+        new(TipoBancaErrorCodes.CodigoFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_banca.codigo_formato_invalido",
+                "Código do tipo de banca em formato inválido")),
+
+        new(TipoBancaErrorCodes.CodigoForaDoConjuntoCanonico,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_banca.codigo_fora_do_conjunto_canonico",
+                "Código do tipo de banca fora do conjunto canônico das quatro bancas")),
+
+        new(TipoBancaErrorCodes.CodigoJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.tipo_banca.codigo_ja_existe",
+                "Já existe um tipo de banca ativo com este código")),
+
+        new(TipoBancaErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_banca.nome_obrigatorio",
+                "Nome do tipo de banca é obrigatório")),
+
+        new(TipoBancaErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_banca.nome_tamanho",
+                "Tamanho do nome do tipo de banca inválido")),
+
+        new(TipoBancaErrorCodes.FaseTipicaTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_banca.fase_tipica_tamanho",
+                "Tamanho da fase típica do tipo de banca inválido")),
+
+        new(TipoBancaErrorCodes.DescricaoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.tipo_banca.descricao_tamanho",
+                "Tamanho da descrição do tipo de banca inválido")),
+
+        new(TipoBancaErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.tipo_banca.nao_encontrado",
+                "Tipo de banca não encontrado")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/FaseCanonicaLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/FaseCanonicaLinksBuilder.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="FaseCanonicaDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<FaseCanonicaDto>, FaseCanonicaLinksBuilder>().")]
+internal sealed class FaseCanonicaLinksBuilder : IResourceLinksBuilder<FaseCanonicaDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public FaseCanonicaLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(FaseCanonicaDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "FasesCanonicas";
+
+        string self = ResolverPath(
+            httpContext, nameof(FasesCanonicasController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(FasesCanonicasController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/TipoBancaLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/TipoBancaLinksBuilder.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="TipoBancaDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<TipoBancaDto>, TipoBancaLinksBuilder>().")]
+internal sealed class TipoBancaLinksBuilder : IResourceLinksBuilder<TipoBancaDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public TipoBancaLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(TipoBancaDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "TiposBanca";
+
+        string self = ResolverPath(
+            httpContext, nameof(TiposBancaController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(TiposBancaController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/AtualizarFaseCanonicaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/AtualizarFaseCanonicaCommand.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza uma fase canônica existente. O <c>Codigo</c> e o <c>Id</c> são
+/// <b>imutáveis</b>: o comando <b>não</b> aceita código — o handler carrega a
+/// entidade e a atualiza sem alterá-lo. O dono típico chega como token canônico
+/// UPPER_SNAKE. O ator (<c>updated_by</c>) é carimbado server-side via
+/// <c>IUserContext</c>.
+/// </summary>
+public sealed record AtualizarFaseCanonicaCommand(
+    Guid Id,
+    string? Nome = null,
+    string? Descricao = null,
+    string? DonoTipico = null,
+    bool AgrupaEtapas = false,
+    bool PermiteComplementacao = false,
+    string? BaseLegal = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/AtualizarFaseCanonicaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/AtualizarFaseCanonicaCommandHandler.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarFaseCanonicaCommand"/>. Carrega a fase (404 se
+/// inexistente), aplica os campos editáveis (o <c>Codigo</c> é imutável, então não
+/// há checagem de unicidade nem corrida de índice) e revalida as invariantes de
+/// coerência (422) contra o código congelado. Sem integridade referencial — a fase
+/// não é referenciada por FK intra-banco.
+/// </summary>
+public static class AtualizarFaseCanonicaCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarFaseCanonicaCommand command,
+        IFaseCanonicaRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        FaseCanonica? fase = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (fase is null)
+        {
+            return Result.Failure(new DomainError(
+                FaseCanonicaErrorCodes.NaoEncontrada,
+                "Fase canônica não encontrada."));
+        }
+
+        Result atualizarResult = fase.Atualizar(
+            command.Nome,
+            command.Descricao,
+            command.DonoTipico,
+            command.AgrupaEtapas,
+            command.PermiteComplementacao,
+            command.BaseLegal);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/AtualizarFaseCanonicaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/AtualizarFaseCanonicaCommandValidator.cs
@@ -1,0 +1,40 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Antecipa (422) o domínio fechado do dono típico e os tamanhos na atualização. O
+/// <c>Codigo</c> é imutável e não é campo do comando; por isso a coerência
+/// <c>agrupa_etapas</c>/<c>permite_complementacao</c> (que depende do código) fica
+/// no agregado, revalidada contra o código congelado da fase.
+/// </summary>
+public sealed class AtualizarFaseCanonicaCommandValidator : AbstractValidator<AtualizarFaseCanonicaCommand>
+{
+    public AtualizarFaseCanonicaCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id da fase é obrigatório.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome da fase é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome da fase deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(300).WithMessage("Descrição da fase deve ter no máximo 300 caracteres.")
+            .When(x => x.Descricao is not null);
+
+        RuleFor(x => x.DonoTipico)
+            .NotEmpty().WithMessage("Dono típico da fase é obrigatório.");
+
+        RuleFor(x => x.DonoTipico)
+            .Must(DonosTipicos.EhValido)
+            .WithMessage($"Dono típico deve ser um de: {string.Join(", ", DonosTipicos.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.DonoTipico));
+
+        RuleFor(x => x.BaseLegal)
+            .MaximumLength(500).WithMessage("Base legal da fase deve ter no máximo 500 caracteres.")
+            .When(x => x.BaseLegal is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/CriarFaseCanonicaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/CriarFaseCanonicaCommand.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria uma fase canônica (UNI-REQ-0064): código (chave natural canônica imutável),
+/// nome, descrição opcional, dono típico como token canônico UPPER_SNAKE
+/// (<c>DonoTipico</c>), e os sinalizadores <c>AgrupaEtapas</c> /
+/// <c>PermiteComplementacao</c> (falsos por omissão). O ator de auditoria
+/// (<c>created_by</c>) é carimbado server-side via <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarFaseCanonicaCommand(
+    string Codigo,
+    string? Nome = null,
+    string? Descricao = null,
+    string? DonoTipico = null,
+    bool AgrupaEtapas = false,
+    bool PermiteComplementacao = false,
+    string? BaseLegal = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/CriarFaseCanonicaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/CriarFaseCanonicaCommandHandler.cs
@@ -1,0 +1,71 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarFaseCanonicaCommand"/> (convention-based Wolverine).
+/// Orquestra: unicidade do código entre vivos (409), construção do agregado
+/// (formato + pertença ao conjunto canônico + coerência, 422), persistência e
+/// commit. Protege a corrida check-then-act traduzindo a violação do índice único
+/// parcial em <c>CodigoJaExiste</c>.
+/// </summary>
+public static class CriarFaseCanonicaCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarFaseCanonicaCommand command,
+        IFaseCanonicaRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.CodigoExisteEntreVivosAsync(command.Codigo, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        Result<FaseCanonica> faseResult = FaseCanonica.Criar(
+            command.Codigo,
+            command.Nome,
+            command.Descricao,
+            command.DonoTipico,
+            command.AgrupaEtapas,
+            command.PermiteComplementacao,
+            command.BaseLegal);
+
+        if (faseResult.IsFailure)
+        {
+            return Result<Guid>.Failure(faseResult.Error!);
+        }
+
+        FaseCanonica fase = faseResult.Value!;
+
+        await repository.AdicionarAsync(fase, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCodigoConflict(constraint))
+        {
+            // Corrida entre CodigoExisteEntreVivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo CodigoJaExiste do
+            // caminho não-race — 409 consistente. O filtro do `when` garante que
+            // outras exceções propagam intactas.
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        return Result<Guid>.Success(fase.Id);
+    }
+
+    private static DomainError CodigoJaExisteErro(string codigo) =>
+        new(FaseCanonicaErrorCodes.CodigoJaExiste,
+            $"Já existe uma fase canônica viva com o código '{codigo}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/CriarFaseCanonicaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/CriarFaseCanonicaCommandValidator.cs
@@ -24,8 +24,10 @@ public sealed class CriarFaseCanonicaCommandValidator : AbstractValidator<CriarF
 
         // Pertença ao conjunto canônico — só quando o formato já é válido (evita
         // mensagem redundante). Em RuleFor separado para o When não vazar ao NotEmpty.
+        // Trim antes do Contains: espelha a normalização de FaseCanonica.Criar (via
+        // CodigoFase.Criar), que também compara o código já trimado contra o catálogo.
         RuleFor(x => x.Codigo)
-            .Must(FaseCanonicaCatalogo.EhCanonico)
+            .Must(codigo => FaseCanonicaCatalogo.EhCanonico(codigo.Trim()))
             .WithMessage($"Código da fase deve ser um dos canônicos: {string.Join(", ", FaseCanonicaCatalogo.Codigos)}.")
             .When(x => CodigoFase.EhValido(x.Codigo));
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/CriarFaseCanonicaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/CriarFaseCanonicaCommandValidator.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+/// <summary>
+/// Antecipa (422) o formato do código, a pertença ao conjunto canônico das
+/// quatorze fases, o domínio fechado do dono típico e os tamanhos. A coerência
+/// <c>agrupa_etapas</c>/<c>permite_complementacao</c> (que depende do código) fica
+/// no agregado — inclusive na atualização, onde o comando não carrega o código.
+/// </summary>
+public sealed class CriarFaseCanonicaCommandValidator : AbstractValidator<CriarFaseCanonicaCommand>
+{
+    public CriarFaseCanonicaCommandValidator()
+    {
+        // Formato do código (sempre avaliado — NotEmpty + regex).
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código da fase é obrigatório.")
+            .Must(CodigoFase.EhValido)
+            .WithMessage("Código da fase deve conter apenas letras maiúsculas e sublinhado "
+                + "(sem hífen e sem dígito), com no máximo 60 caracteres.");
+
+        // Pertença ao conjunto canônico — só quando o formato já é válido (evita
+        // mensagem redundante). Em RuleFor separado para o When não vazar ao NotEmpty.
+        RuleFor(x => x.Codigo)
+            .Must(FaseCanonicaCatalogo.EhCanonico)
+            .WithMessage($"Código da fase deve ser um dos canônicos: {string.Join(", ", FaseCanonicaCatalogo.Codigos)}.")
+            .When(x => CodigoFase.EhValido(x.Codigo));
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome da fase é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome da fase deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(300).WithMessage("Descrição da fase deve ter no máximo 300 caracteres.")
+            .When(x => x.Descricao is not null);
+
+        // Dono típico obrigatório (sempre) + domínio fechado (só quando informado).
+        RuleFor(x => x.DonoTipico)
+            .NotEmpty().WithMessage("Dono típico da fase é obrigatório.");
+
+        RuleFor(x => x.DonoTipico)
+            .Must(DonosTipicos.EhValido)
+            .WithMessage($"Dono típico deve ser um de: {string.Join(", ", DonosTipicos.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.DonoTipico));
+
+        RuleFor(x => x.BaseLegal)
+            .MaximumLength(500).WithMessage("Base legal da fase deve ter no máximo 500 caracteres.")
+            .When(x => x.BaseLegal is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/RemoverFaseCanonicaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/RemoverFaseCanonicaCommand.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Remove (soft-delete) uma fase canônica pelo seu <c>Id</c>.</summary>
+public sealed record RemoverFaseCanonicaCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/RemoverFaseCanonicaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/RemoverFaseCanonicaCommandHandler.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverFaseCanonicaCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c>. Nunca bloqueado por referência: o único consumo
+/// da fase é por snapshot-copy desacoplado no Módulo Seleção (ADR-0061), que não
+/// impede a remoção lógica; e não há FK intra-banco apontando para a fase.
+/// </summary>
+public static class RemoverFaseCanonicaCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverFaseCanonicaCommand command,
+        IFaseCanonicaRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        FaseCanonica? fase = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (fase is null)
+        {
+            return Result.Failure(new DomainError(
+                FaseCanonicaErrorCodes.NaoEncontrada,
+                "Fase canônica não encontrada."));
+        }
+
+        repository.Remover(fase);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/FasesCanonicas/UniqueConstraintViolation.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do código vivo da
+/// fase — <c>ix_fase_canonica_codigo_vivo</c> — para o <c>DomainError</c>
+/// apropriado. Acessa <c>SqlState</c> e <c>ConstraintName</c> por reflection no
+/// inner exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção por
+/// <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão do <c>UniqueConstraintViolation</c> dos demais cadastros de
+/// Configuração. O código é imutável, então só há corrida na criação.
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string CodigoConstraint = "ix_fase_canonica_codigo_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o caller
+    /// deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único parcial
+    /// que garante uma única fase viva por código.
+    /// </summary>
+    public static bool IsCodigoConflict(string? constraint) =>
+        string.Equals(constraint, CodigoConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/AtualizarTipoBancaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/AtualizarTipoBancaCommand.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza um tipo de banca existente. O <c>Codigo</c> e o <c>Id</c> são
+/// <b>imutáveis</b>: o comando <b>não</b> aceita código — o handler carrega a
+/// entidade e a atualiza sem alterá-lo. O ator (<c>updated_by</c>) é carimbado
+/// server-side via <c>IUserContext</c>.
+/// </summary>
+public sealed record AtualizarTipoBancaCommand(
+    Guid Id,
+    string? Nome = null,
+    string? FaseTipica = null,
+    string? Descricao = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/AtualizarTipoBancaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/AtualizarTipoBancaCommandHandler.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarTipoBancaCommand"/>. Carrega o tipo de banca (404
+/// se inexistente), aplica os campos editáveis (o <c>Codigo</c> é imutável, então
+/// não há checagem de unicidade nem corrida de índice) e commita. Sem integridade
+/// referencial — o tipo de banca não é referenciado por FK intra-banco.
+/// </summary>
+public static class AtualizarTipoBancaCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarTipoBancaCommand command,
+        ITipoBancaRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        TipoBanca? banca = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (banca is null)
+        {
+            return Result.Failure(new DomainError(
+                TipoBancaErrorCodes.NaoEncontrado,
+                "Tipo de banca não encontrado."));
+        }
+
+        Result atualizarResult = banca.Atualizar(
+            command.Nome,
+            command.FaseTipica,
+            command.Descricao);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/AtualizarTipoBancaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/AtualizarTipoBancaCommandValidator.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+using FluentValidation;
+
+/// <summary>
+/// Antecipa (422) os tamanhos na atualização. O <c>Codigo</c> é imutável e não é
+/// campo do comando. A fase típica é orientativa (não validada contra o cadastro de
+/// fases), apenas limitada em tamanho.
+/// </summary>
+public sealed class AtualizarTipoBancaCommandValidator : AbstractValidator<AtualizarTipoBancaCommand>
+{
+    public AtualizarTipoBancaCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id do tipo de banca é obrigatório.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do tipo de banca é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do tipo de banca deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.FaseTipica)
+            .MaximumLength(60).WithMessage("Fase típica do tipo de banca deve ter no máximo 60 caracteres.")
+            .When(x => x.FaseTipica is not null);
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(300).WithMessage("Descrição do tipo de banca deve ter no máximo 300 caracteres.")
+            .When(x => x.Descricao is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/CriarTipoBancaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/CriarTipoBancaCommand.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria um tipo de banca (UNI-REQ-0064): código (chave natural canônica imutável),
+/// nome, fase típica opcional (rótulo orientativo, não vinculante) e descrição
+/// opcional. O ator de auditoria (<c>created_by</c>) é carimbado server-side via
+/// <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarTipoBancaCommand(
+    string Codigo,
+    string? Nome = null,
+    string? FaseTipica = null,
+    string? Descricao = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/CriarTipoBancaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/CriarTipoBancaCommandHandler.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarTipoBancaCommand"/> (convention-based Wolverine).
+/// Orquestra: unicidade do código entre vivos (409), construção do agregado
+/// (formato + pertença ao conjunto canônico, 422), persistência e commit. Protege
+/// a corrida check-then-act traduzindo a violação do índice único parcial em
+/// <c>CodigoJaExiste</c>.
+/// </summary>
+public static class CriarTipoBancaCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarTipoBancaCommand command,
+        ITipoBancaRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.CodigoExisteEntreVivosAsync(command.Codigo, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        Result<TipoBanca> bancaResult = TipoBanca.Criar(
+            command.Codigo,
+            command.Nome,
+            command.FaseTipica,
+            command.Descricao);
+
+        if (bancaResult.IsFailure)
+        {
+            return Result<Guid>.Failure(bancaResult.Error!);
+        }
+
+        TipoBanca banca = bancaResult.Value!;
+
+        await repository.AdicionarAsync(banca, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCodigoConflict(constraint))
+        {
+            // Corrida entre CodigoExisteEntreVivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo CodigoJaExiste do
+            // caminho não-race — 409 consistente.
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        return Result<Guid>.Success(banca.Id);
+    }
+
+    private static DomainError CodigoJaExisteErro(string codigo) =>
+        new(TipoBancaErrorCodes.CodigoJaExiste,
+            $"Já existe um tipo de banca vivo com o código '{codigo}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/CriarTipoBancaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/CriarTipoBancaCommandValidator.cs
@@ -23,8 +23,10 @@ public sealed class CriarTipoBancaCommandValidator : AbstractValidator<CriarTipo
 
         // Pertença ao conjunto canônico — só quando o formato já é válido. Em RuleFor
         // separado para o When não vazar ao NotEmpty.
+        // Trim antes do Contains: espelha a normalização de TipoBanca.Criar (via
+        // CodigoBanca.Criar), que também compara o código já trimado contra o catálogo.
         RuleFor(x => x.Codigo)
-            .Must(TipoBancaCatalogo.EhCanonico)
+            .Must(codigo => TipoBancaCatalogo.EhCanonico(codigo.Trim()))
             .WithMessage($"Código do tipo de banca deve ser um dos canônicos: {string.Join(", ", TipoBancaCatalogo.Codigos)}.")
             .When(x => CodigoBanca.EhValido(x.Codigo));
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/CriarTipoBancaCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/CriarTipoBancaCommandValidator.cs
@@ -1,0 +1,43 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+/// <summary>
+/// Antecipa (422) o formato do código, a pertença ao conjunto canônico das quatro
+/// bancas e os tamanhos. A fase típica é orientativa (não validada contra o
+/// cadastro de fases), apenas limitada em tamanho.
+/// </summary>
+public sealed class CriarTipoBancaCommandValidator : AbstractValidator<CriarTipoBancaCommand>
+{
+    public CriarTipoBancaCommandValidator()
+    {
+        // Formato do código (sempre avaliado — NotEmpty + regex).
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código do tipo de banca é obrigatório.")
+            .Must(CodigoBanca.EhValido)
+            .WithMessage("Código do tipo de banca deve conter apenas letras maiúsculas e sublinhado "
+                + "(sem hífen e sem dígito), com no máximo 60 caracteres.");
+
+        // Pertença ao conjunto canônico — só quando o formato já é válido. Em RuleFor
+        // separado para o When não vazar ao NotEmpty.
+        RuleFor(x => x.Codigo)
+            .Must(TipoBancaCatalogo.EhCanonico)
+            .WithMessage($"Código do tipo de banca deve ser um dos canônicos: {string.Join(", ", TipoBancaCatalogo.Codigos)}.")
+            .When(x => CodigoBanca.EhValido(x.Codigo));
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do tipo de banca é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do tipo de banca deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.FaseTipica)
+            .MaximumLength(60).WithMessage("Fase típica do tipo de banca deve ter no máximo 60 caracteres.")
+            .When(x => x.FaseTipica is not null);
+
+        RuleFor(x => x.Descricao)
+            .MaximumLength(300).WithMessage("Descrição do tipo de banca deve ter no máximo 300 caracteres.")
+            .When(x => x.Descricao is not null);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/RemoverTipoBancaCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/RemoverTipoBancaCommand.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Remove (soft-delete) um tipo de banca pelo seu <c>Id</c>.</summary>
+public sealed record RemoverTipoBancaCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/RemoverTipoBancaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/RemoverTipoBancaCommandHandler.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverTipoBancaCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c>. Nunca bloqueado por referência: o único consumo do
+/// tipo de banca é por snapshot-copy desacoplado no Módulo Seleção (ADR-0061), que
+/// não impede a remoção lógica; e não há FK intra-banco apontando para ele.
+/// </summary>
+public static class RemoverTipoBancaCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverTipoBancaCommand command,
+        ITipoBancaRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        TipoBanca? banca = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (banca is null)
+        {
+            return Result.Failure(new DomainError(
+                TipoBancaErrorCodes.NaoEncontrado,
+                "Tipo de banca não encontrado."));
+        }
+
+        repository.Remover(banca);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/TiposBanca/UniqueConstraintViolation.cs
@@ -1,0 +1,57 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do código vivo do
+/// tipo de banca — <c>ix_tipo_banca_codigo_vivo</c> — para o <c>DomainError</c>
+/// apropriado. Acessa <c>SqlState</c> e <c>ConstraintName</c> por reflection no
+/// inner exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção por
+/// <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch).
+/// </summary>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string CodigoConstraint = "ix_tipo_banca_codigo_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o caller
+    /// deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único parcial
+    /// que garante um único tipo de banca vivo por código.
+    /// </summary>
+    public static bool IsCodigoConflict(string? constraint) =>
+        string.Equals(constraint, CodigoConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/FaseCanonicaDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/FaseCanonicaDto.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>FaseCanonica</c>. Suporta HATEOAS Level 1 via
+/// <c>_links</c> (ADR-0029). O <c>DonoTipico</c> é exposto como token canônico
+/// UPPER_SNAKE.
+/// </summary>
+public sealed record FaseCanonicaDto(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string? Descricao,
+    string DonoTipico,
+    bool AgrupaEtapas,
+    bool PermiteComplementacao,
+    string? BaseLegal,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/TipoBancaDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/TipoBancaDto.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>TipoBanca</c>. Suporta HATEOAS Level 1 via
+/// <c>_links</c> (ADR-0029).
+/// </summary>
+public sealed record TipoBancaDto(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string? FaseTipica,
+    string? Descricao,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/FaseCanonicaMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/FaseCanonicaMapping.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public static class FaseCanonicaMapping
+{
+    public static FaseCanonicaDto ToDto(this FaseCanonica fase)
+    {
+        ArgumentNullException.ThrowIfNull(fase);
+        return new FaseCanonicaDto(
+            fase.Id,
+            fase.Codigo.Valor,
+            fase.Nome,
+            fase.Descricao,
+            DonosTipicos.ParaTokenCanonico(fase.DonoTipico),
+            fase.AgrupaEtapas,
+            fase.PermiteComplementacao,
+            fase.BaseLegal,
+            fase.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/TipoBancaMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/TipoBancaMapping.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+public static class TipoBancaMapping
+{
+    public static TipoBancaDto ToDto(this TipoBanca banca)
+    {
+        ArgumentNullException.ThrowIfNull(banca);
+        return new TipoBancaDto(
+            banca.Id,
+            banca.Codigo.Valor,
+            banca.Nome,
+            banca.FaseTipica,
+            banca.Descricao,
+            banca.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ListarFasesCanonicasQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ListarFasesCanonicasQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FasesCanonicas;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista fases canônicas vivas paginadas por cursor bidirecional (ADR-0026 +
+/// ADR-0089). O controller decifra o cursor opaco e valida limit/direction antes
+/// de despachar.
+/// </summary>
+public sealed record ListarFasesCanonicasQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarFasesCanonicasResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ListarFasesCanonicasQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ListarFasesCanonicasQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FasesCanonicas;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarFasesCanonicasQueryHandler
+{
+    public static async Task<ListarFasesCanonicasResult> Handle(
+        ListarFasesCanonicasQuery query,
+        IFaseCanonicaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<FaseCanonica> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        FaseCanonicaDto[] items = [.. itens.Select(f => f.ToDto())];
+        return new ListarFasesCanonicasResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ListarFasesCanonicasResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ListarFasesCanonicasResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FasesCanonicas;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarFasesCanonicasQuery"/>: lote de fases projetadas +
+/// âncoras opcionais para o controller construir os cursores prev/next (ADR-0026 +
+/// ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarFasesCanonicasResult(
+    IReadOnlyList<FaseCanonicaDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ObterFaseCanonicaPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ObterFaseCanonicaPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FasesCanonicas;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterFaseCanonicaPorIdQuery(Guid Id) : IQuery<FaseCanonicaDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ObterFaseCanonicaPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FasesCanonicas/ObterFaseCanonicaPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FasesCanonicas;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterFaseCanonicaPorIdQueryHandler
+{
+    public static async Task<FaseCanonicaDto?> Handle(
+        ObterFaseCanonicaPorIdQuery query,
+        IFaseCanonicaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        FaseCanonica? fase = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return fase?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ListarTiposBancaQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ListarTiposBancaQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposBanca;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista tipos de banca vivos paginados por cursor bidirecional (ADR-0026 +
+/// ADR-0089). O controller decifra o cursor opaco e valida limit/direction antes de
+/// despachar.
+/// </summary>
+public sealed record ListarTiposBancaQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarTiposBancaResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ListarTiposBancaQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ListarTiposBancaQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposBanca;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarTiposBancaQueryHandler
+{
+    public static async Task<ListarTiposBancaResult> Handle(
+        ListarTiposBancaQuery query,
+        ITipoBancaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<TipoBanca> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        TipoBancaDto[] items = [.. itens.Select(b => b.ToDto())];
+        return new ListarTiposBancaResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ListarTiposBancaResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ListarTiposBancaResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposBanca;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarTiposBancaQuery"/>: lote de tipos de banca
+/// projetados + âncoras opcionais para o controller construir os cursores prev/next
+/// (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarTiposBancaResult(
+    IReadOnlyList<TipoBancaDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ObterTipoBancaPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ObterTipoBancaPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposBanca;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterTipoBancaPorIdQuery(Guid Id) : IQuery<TipoBancaDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ObterTipoBancaPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TiposBanca/ObterTipoBancaPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.TiposBanca;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterTipoBancaPorIdQueryHandler
+{
+    public static async Task<TipoBancaDto?> Handle(
+        ObterTipoBancaPorIdQuery query,
+        ITipoBancaRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        TipoBanca? banca = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return banca?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/FaseCanonicaSnapshot.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/FaseCanonicaSnapshot.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Snapshot mínimo de uma <c>FaseCanonica</c> que o Módulo Seleção congela por
+/// valor ao registrá-la no cronograma de um processo (snapshot-copy desacoplado,
+/// ADR-0061): guarda a identidade de origem, o código canônico e o sinalizador de
+/// complementação vigente no momento do congelamento — imune a edições posteriores
+/// no cadastro vivo de Configuração. O <c>agrupa_etapas</c> <b>não</b> é congelado:
+/// é atributo do cadastro vivo, não do snapshot.
+/// </summary>
+/// <param name="OrigemId">Id (Guid v7) da fase viva de origem, no momento do congelamento.</param>
+/// <param name="Codigo">Código canônico congelado (ex.: "HOMOLOGACAO").</param>
+/// <param name="PermiteComplementacao">Sinalizador de complementação documental congelado.</param>
+public sealed record FaseCanonicaSnapshot(
+    Guid OrigemId,
+    string Codigo,
+    bool PermiteComplementacao);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/FaseCanonicaView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/FaseCanonicaView.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>FaseCanonica</c> para consumo cross-módulo via
+/// <see cref="IFaseCanonicaReader"/> (ADR-0056). Expõe a fase viva que o Módulo
+/// Seleção lê ao montar o cronograma de um processo, antes de congelar por valor
+/// (snapshot-copy, ADR-0061). O <c>DonoTipico</c> é exposto como token textual
+/// (UPPER_SNAKE).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="Codigo">Código canônico, chave natural da fase (ex.: "AVALIACAO").</param>
+/// <param name="Nome">Rótulo de apresentação.</param>
+/// <param name="Descricao">Descrição livre opcional.</param>
+/// <param name="DonoTipico">Dono usual da fase (token; ex.: "CEPS") — orientativo, não vinculante.</param>
+/// <param name="AgrupaEtapas">Verdadeiro apenas para a fase de avaliação (agrupa Etapas pontuadas).</param>
+/// <param name="PermiteComplementacao">Se a fase admite reenvio/complementação documental.</param>
+/// <param name="BaseLegal">Base legal opcional.</param>
+public sealed record FaseCanonicaView(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string? Descricao,
+    string DonoTipico,
+    bool AgrupaEtapas,
+    bool PermiteComplementacao,
+    string? BaseLegal);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IFaseCanonicaReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IFaseCanonicaReader.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>FaseCanonica</c> (ADR-0056). Expõe o estado vivo do
+/// cadastro de fases para consumo por outros bounded contexts (ex.: o Módulo
+/// Seleção ao montar o cronograma de um processo) sem acesso direto ao banco de
+/// Configuração (ADR-0054).
+/// </summary>
+public interface IFaseCanonicaReader
+{
+    /// <summary>
+    /// Lista todas as fases vivas (não soft-deleted), ordenadas por <c>Codigo</c>
+    /// ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<FaseCanonicaView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém uma fase pelo <paramref name="id"/>, ou <see langword="null"/> se
+    /// inexistente / soft-deleted.
+    /// </summary>
+    Task<FaseCanonicaView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ITipoBancaReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ITipoBancaReader.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>TipoBanca</c> (ADR-0056). Expõe o estado vivo do
+/// cadastro de tipos de banca para consumo por outros bounded contexts (ex.: o
+/// Módulo Seleção ao configurar as bancas requeridas por fase de um processo) sem
+/// acesso direto ao banco de Configuração (ADR-0054).
+/// </summary>
+public interface ITipoBancaReader
+{
+    /// <summary>
+    /// Lista todos os tipos de banca vivos (não soft-deleted), ordenados por
+    /// <c>Codigo</c> ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<TipoBancaView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém um tipo de banca pelo <paramref name="id"/>, ou <see langword="null"/>
+    /// se inexistente / soft-deleted.
+    /// </summary>
+    Task<TipoBancaView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/TipoBancaSnapshot.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/TipoBancaSnapshot.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Snapshot mínimo de um <c>TipoBanca</c> que o Módulo Seleção congela por valor ao
+/// registrá-lo nas bancas requeridas por fase de um processo (snapshot-copy
+/// desacoplado, ADR-0061): guarda a identidade de origem e o código classificatório
+/// vigente no momento do congelamento — imune a edições posteriores no cadastro vivo
+/// de Configuração.
+/// </summary>
+/// <param name="OrigemId">Id (Guid v7) do tipo de banca vivo de origem, no momento do congelamento.</param>
+/// <param name="Codigo">Código classificatório congelado (ex.: "BANCA_ANALISE_DOCUMENTAL").</param>
+public sealed record TipoBancaSnapshot(
+    Guid OrigemId,
+    string Codigo);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/TipoBancaView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/TipoBancaView.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>TipoBanca</c> para consumo cross-módulo via
+/// <see cref="ITipoBancaReader"/> (ADR-0056). Expõe o tipo de banca vivo que o
+/// Módulo Seleção lê ao configurar as bancas requeridas por fase, antes de congelar
+/// por valor (snapshot-copy, ADR-0061).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="Codigo">Código classificatório, chave natural da banca (ex.: "BANCA_ENTREVISTA").</param>
+/// <param name="Nome">Rótulo de apresentação.</param>
+/// <param name="FaseTipica">Fase usual da banca — rótulo de texto orientativo, não vinculante; ou null.</param>
+/// <param name="Descricao">Descrição livre opcional.</param>
+public sealed record TipoBancaView(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string? FaseTipica,
+    string? Descricao);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/FaseCanonica.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/FaseCanonica.cs
@@ -1,0 +1,214 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Fase canônica (UNI-REQ-0064): nomeia, em domínio fechado, os momentos do ciclo
+/// de vida de um processo seletivo (inscrição, homologação, avaliação, recursos,
+/// resultado, matrícula…). Dado institucional de referência sem PII (LGPD
+/// inaplicável). Não é Etapa — a Etapa pontuada pertence a outro requisito; aqui o
+/// sinalizador <see cref="AgrupaEtapas"/> apenas marca qual fase as agrupa.
+/// </summary>
+/// <remarks>
+/// <para>O <see cref="Codigo"/> (value object <see cref="CodigoFase"/>) é a chave
+/// natural, único entre fases vivas (índice único parcial <c>WHERE is_deleted =
+/// false</c>) e <b>imutável</b>: o comando de atualização não o aceita — o
+/// vocabulário canônico é fixo. Além do formato, o código deve pertencer ao
+/// conjunto canônico das quatorze fases (<see cref="FaseCanonicaCatalogo"/>).</para>
+/// <para>As invariantes de coerência (<see cref="AgrupaEtapas"/> só para a fase de
+/// avaliação; <see cref="PermiteComplementacao"/> só nas fases legalmente permitidas)
+/// moram na factory <see cref="Criar"/>/<see cref="Atualizar"/>, revalidadas contra
+/// o código imutável. A remoção é sempre soft-delete; nunca bloqueada — o único
+/// consumo é por snapshot-copy desacoplado no Módulo Seleção (ADR-0061), e não há
+/// FK intra-banco apontando para esta entidade.</para>
+/// </remarks>
+public sealed class FaseCanonica : SoftDeletableEntity, IAuditableEntity
+{
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 300;
+    private const int BaseLegalMaxLength = 500;
+
+    public CodigoFase Codigo { get; private set; } = null!;
+    public string Nome { get; private set; } = null!;
+    public string? Descricao { get; private set; }
+    public DonoTipico DonoTipico { get; private set; }
+    public bool AgrupaEtapas { get; private set; }
+    public bool PermiteComplementacao { get; private set; }
+    public string? BaseLegal { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private FaseCanonica()
+    {
+    }
+
+    /// <summary>
+    /// Cria uma nova fase canônica. Valida o código (formato + pertença ao conjunto
+    /// canônico das quatorze fases), o nome, o dono típico (token UPPER_SNAKE
+    /// obrigatório) e as invariantes de coerência (agrupa etapas ⇒ avaliação;
+    /// permite complementação ⇒ fase legalmente permitida). A unicidade do código
+    /// entre vivos é responsabilidade do handler.
+    /// </summary>
+    public static Result<FaseCanonica> Criar(
+        string codigo,
+        string? nome,
+        string? descricao,
+        string? donoTipico,
+        bool agrupaEtapas,
+        bool permiteComplementacao,
+        string? baseLegal)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        Result<CodigoFase> codigoResult = CodigoFase.Criar(codigo);
+        if (codigoResult.IsFailure)
+        {
+            return Result<FaseCanonica>.Failure(codigoResult.Error!);
+        }
+
+        CodigoFase codigoVo = codigoResult.Value!;
+
+        if (!FaseCanonicaCatalogo.EhCanonico(codigoVo.Valor))
+        {
+            return Result<FaseCanonica>.Failure(new DomainError(
+                FaseCanonicaErrorCodes.CodigoForaDoConjuntoCanonico,
+                $"Código '{codigoVo.Valor}' não pertence ao conjunto canônico das quatorze fases."));
+        }
+
+        Result<CamposResolvidos> camposResult = ValidarComuns(
+            codigoVo.Valor, nome, descricao, donoTipico, agrupaEtapas, permiteComplementacao, baseLegal);
+        if (camposResult.IsFailure)
+        {
+            return Result<FaseCanonica>.Failure(camposResult.Error!);
+        }
+
+        var fase = new FaseCanonica { Codigo = codigoVo };
+        fase.AplicarCampos(camposResult.Value!);
+
+        return Result<FaseCanonica>.Success(fase);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos editáveis da fase. O <c>Codigo</c> e o <c>Id</c> são
+    /// <b>imutáveis</b> — este método não os recebe. Revalida as invariantes de
+    /// coerência contra o código congelado da fase.
+    /// </summary>
+    public Result Atualizar(
+        string? nome,
+        string? descricao,
+        string? donoTipico,
+        bool agrupaEtapas,
+        bool permiteComplementacao,
+        string? baseLegal)
+    {
+        Result<CamposResolvidos> camposResult = ValidarComuns(
+            Codigo.Valor, nome, descricao, donoTipico, agrupaEtapas, permiteComplementacao, baseLegal);
+        if (camposResult.IsFailure)
+        {
+            return Result.Failure(camposResult.Error!);
+        }
+
+        AplicarCampos(camposResult.Value!);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(CamposResolvidos campos)
+    {
+        Nome = campos.Nome;
+        Descricao = campos.Descricao;
+        DonoTipico = campos.DonoTipico;
+        AgrupaEtapas = campos.AgrupaEtapas;
+        PermiteComplementacao = campos.PermiteComplementacao;
+        BaseLegal = campos.BaseLegal;
+    }
+
+    private static Result<CamposResolvidos> ValidarComuns(
+        string codigoValor,
+        string? nome,
+        string? descricao,
+        string? donoTipicoToken,
+        bool agrupaEtapas,
+        bool permiteComplementacao,
+        string? baseLegal)
+    {
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Falha(FaseCanonicaErrorCodes.NomeObrigatorio, "Nome da fase canônica é obrigatório.");
+        }
+
+        string nomeNorm = nome.Trim();
+        if (nomeNorm.Length > NomeMaxLength)
+        {
+            return Falha(FaseCanonicaErrorCodes.NomeTamanho,
+                $"Nome da fase deve ter no máximo {NomeMaxLength} caracteres.");
+        }
+
+        if (descricao is not null && descricao.Trim().Length > DescricaoMaxLength)
+        {
+            return Falha(FaseCanonicaErrorCodes.DescricaoTamanho,
+                $"Descrição da fase deve ter no máximo {DescricaoMaxLength} caracteres.");
+        }
+
+        if (baseLegal is not null && baseLegal.Trim().Length > BaseLegalMaxLength)
+        {
+            return Falha(FaseCanonicaErrorCodes.BaseLegalTamanho,
+                $"Base legal da fase deve ter no máximo {BaseLegalMaxLength} caracteres.");
+        }
+
+        // DonoTipico — obrigatório, domínio fechado de quatro valores.
+        if (string.IsNullOrWhiteSpace(donoTipicoToken))
+        {
+            return Falha(FaseCanonicaErrorCodes.DonoTipicoObrigatorio, "Dono típico da fase é obrigatório.");
+        }
+
+        if (!DonosTipicos.TryAnalisar(donoTipicoToken, out DonoTipico dono))
+        {
+            return Falha(FaseCanonicaErrorCodes.DonoTipicoInvalido,
+                $"Dono típico deve ser um de: {string.Join(", ", DonosTipicos.TokensCanonicos)}.");
+        }
+
+        // Coerência: agrupa_etapas verdadeiro só para a fase de avaliação.
+        if (agrupaEtapas && !string.Equals(codigoValor, FaseCanonicaCatalogo.CodigoAvaliacao, StringComparison.Ordinal))
+        {
+            return Falha(FaseCanonicaErrorCodes.AgrupaEtapasApenasAvaliacao,
+                "Apenas a fase de avaliação agrupa etapas pontuadas.");
+        }
+
+        // Coerência: permite_complementacao verdadeiro só nas fases legalmente permitidas.
+        if (permiteComplementacao && !FaseCanonicaCatalogo.PermiteComplementacao(codigoValor))
+        {
+            return Falha(FaseCanonicaErrorCodes.ComplementacaoApenasFasesPermitidas,
+                "Complementação documental só é permitida nas fases de homologação e recursos.");
+        }
+
+        return Result<CamposResolvidos>.Success(new CamposResolvidos(
+            nomeNorm,
+            NormalizarOpcional(descricao),
+            dono,
+            agrupaEtapas,
+            permiteComplementacao,
+            NormalizarOpcional(baseLegal)));
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result<CamposResolvidos> Falha(string code, string mensagem) =>
+        Result<CamposResolvidos>.Failure(new DomainError(code, mensagem));
+
+    private sealed record CamposResolvidos(
+        string Nome,
+        string? Descricao,
+        DonoTipico DonoTipico,
+        bool AgrupaEtapas,
+        bool PermiteComplementacao,
+        string? BaseLegal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/TipoBanca.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/TipoBanca.cs
@@ -1,0 +1,162 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Tipo de banca (UNI-REQ-0064): cadastro classificatório das bancas que atuam na
+/// seleção (análise documental, entrevista, correção de redações, análise de
+/// recursos). Dado institucional de referência sem PII (LGPD inaplicável). A
+/// <b>composição</b> de uma banca (membros, atas, deliberações) é matéria de um
+/// incremento futuro e <b>não</b> é modelada aqui — este cadastro entrega apenas o
+/// <b>tipo</b> da banca.
+/// </summary>
+/// <remarks>
+/// <para>O <see cref="Codigo"/> (value object <see cref="CodigoBanca"/>) é a chave
+/// natural, único entre bancas vivas (índice único parcial <c>WHERE is_deleted =
+/// false</c>) e <b>imutável</b>. Além do formato, deve pertencer ao conjunto
+/// canônico das quatro bancas (<see cref="TipoBancaCatalogo"/>).</para>
+/// <para>A <see cref="FaseTipica"/> é a fase em que a banca usualmente atua — um
+/// rótulo de texto <b>orientativo e não vinculante</b>, <b>não</b> uma referência
+/// para o cadastro de fases. Pode ser nula e pode conter um valor que não
+/// corresponda a nenhuma fase cadastrada.</para>
+/// <para>A remoção é sempre soft-delete; nunca bloqueada — o único consumo é por
+/// snapshot-copy desacoplado no Módulo Seleção (ADR-0061).</para>
+/// </remarks>
+public sealed class TipoBanca : SoftDeletableEntity, IAuditableEntity
+{
+    private const int NomeMaxLength = 200;
+    private const int FaseTipicaMaxLength = 60;
+    private const int DescricaoMaxLength = 300;
+
+    public CodigoBanca Codigo { get; private set; } = null!;
+    public string Nome { get; private set; } = null!;
+    public string? FaseTipica { get; private set; }
+    public string? Descricao { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private TipoBanca()
+    {
+    }
+
+    /// <summary>
+    /// Cria um novo tipo de banca. Valida o código (formato + pertença ao conjunto
+    /// canônico das quatro bancas) e o nome. A <paramref name="faseTipica"/> é
+    /// orientativa (não validada contra o cadastro de fases). A unicidade do código
+    /// entre vivos é responsabilidade do handler.
+    /// </summary>
+    public static Result<TipoBanca> Criar(
+        string codigo,
+        string? nome,
+        string? faseTipica,
+        string? descricao)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        Result<CodigoBanca> codigoResult = CodigoBanca.Criar(codigo);
+        if (codigoResult.IsFailure)
+        {
+            return Result<TipoBanca>.Failure(codigoResult.Error!);
+        }
+
+        CodigoBanca codigoVo = codigoResult.Value!;
+
+        if (!TipoBancaCatalogo.EhCanonico(codigoVo.Valor))
+        {
+            return Result<TipoBanca>.Failure(new DomainError(
+                TipoBancaErrorCodes.CodigoForaDoConjuntoCanonico,
+                $"Código '{codigoVo.Valor}' não pertence ao conjunto canônico das quatro bancas."));
+        }
+
+        Result<CamposResolvidos> camposResult = ValidarComuns(nome, faseTipica, descricao);
+        if (camposResult.IsFailure)
+        {
+            return Result<TipoBanca>.Failure(camposResult.Error!);
+        }
+
+        var banca = new TipoBanca { Codigo = codigoVo };
+        banca.AplicarCampos(camposResult.Value!);
+
+        return Result<TipoBanca>.Success(banca);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos editáveis do tipo de banca. O <c>Codigo</c> e o
+    /// <c>Id</c> são <b>imutáveis</b> — este método não os recebe.
+    /// </summary>
+    public Result Atualizar(
+        string? nome,
+        string? faseTipica,
+        string? descricao)
+    {
+        Result<CamposResolvidos> camposResult = ValidarComuns(nome, faseTipica, descricao);
+        if (camposResult.IsFailure)
+        {
+            return Result.Failure(camposResult.Error!);
+        }
+
+        AplicarCampos(camposResult.Value!);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(CamposResolvidos campos)
+    {
+        Nome = campos.Nome;
+        FaseTipica = campos.FaseTipica;
+        Descricao = campos.Descricao;
+    }
+
+    private static Result<CamposResolvidos> ValidarComuns(
+        string? nome,
+        string? faseTipica,
+        string? descricao)
+    {
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Falha(TipoBancaErrorCodes.NomeObrigatorio, "Nome do tipo de banca é obrigatório.");
+        }
+
+        string nomeNorm = nome.Trim();
+        if (nomeNorm.Length > NomeMaxLength)
+        {
+            return Falha(TipoBancaErrorCodes.NomeTamanho,
+                $"Nome do tipo de banca deve ter no máximo {NomeMaxLength} caracteres.");
+        }
+
+        if (faseTipica is not null && faseTipica.Trim().Length > FaseTipicaMaxLength)
+        {
+            return Falha(TipoBancaErrorCodes.FaseTipicaTamanho,
+                $"Fase típica do tipo de banca deve ter no máximo {FaseTipicaMaxLength} caracteres.");
+        }
+
+        if (descricao is not null && descricao.Trim().Length > DescricaoMaxLength)
+        {
+            return Falha(TipoBancaErrorCodes.DescricaoTamanho,
+                $"Descrição do tipo de banca deve ter no máximo {DescricaoMaxLength} caracteres.");
+        }
+
+        return Result<CamposResolvidos>.Success(new CamposResolvidos(
+            nomeNorm,
+            NormalizarOpcional(faseTipica),
+            NormalizarOpcional(descricao)));
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result<CamposResolvidos> Falha(string code, string mensagem) =>
+        Result<CamposResolvidos>.Failure(new DomainError(code, mensagem));
+
+    private sealed record CamposResolvidos(
+        string Nome,
+        string? FaseTipica,
+        string? Descricao);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DonoTipico.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DonoTipico.cs
@@ -1,0 +1,26 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Dono <b>usual</b> de uma <see cref="Entities.FaseCanonica"/> (UNI-REQ-0064): a
+/// unidade que costuma conduzir a fase (CEPS, CRCA, MEC ou CONSEPE). É um rótulo
+/// orientativo em domínio fechado — <b>não</b> vincula o processo, que decide o
+/// dono real do seu próprio cronograma. Persistido como token UPPER_SNAKE
+/// (<see cref="DonosTipicos"/>).
+/// </summary>
+public enum DonoTipico
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhum = 0,
+
+    /// <summary>Centro de Processos Seletivos.</summary>
+    Ceps = 1,
+
+    /// <summary>Centro de Registro e Controle Acadêmico.</summary>
+    Crca = 2,
+
+    /// <summary>Ministério da Educação (ex.: SiSU).</summary>
+    Mec = 3,
+
+    /// <summary>Conselho Superior de Ensino, Pesquisa e Extensão.</summary>
+    Consepe = 4,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DonosTipicos.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DonosTipicos.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="DonoTipico"/> (domínio, PascalCase) e o token
+/// textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// <para>O parsing é por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>):
+/// só os quatro tokens canônicos são aceitos. Deliberadamente <b>não</b> usa
+/// <c>Enum.TryParse</c>, que aceitaria tokens numéricos e nomes PascalCase do enum
+/// — ambos fora do contrato textual da #592.</para>
+/// <para>É o vocabulário fonte do CHECK de domínio em <c>fase_canonica.dono_tipico</c>
+/// (<see cref="TokensCanonicos"/>) e do value converter de persistência.</para>
+/// </remarks>
+public static class DonosTipicos
+{
+    private static readonly Dictionary<DonoTipico, string> ParaToken = new()
+    {
+        [DonoTipico.Ceps] = "CEPS",
+        [DonoTipico.Crca] = "CRCA",
+        [DonoTipico.Mec] = "MEC",
+        [DonoTipico.Consepe] = "CONSEPE",
+    };
+
+    private static readonly Dictionary<string, DonoTipico> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os quatro tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de um dono válido.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="dono"/> é <see cref="DonoTipico.Nenhum"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(DonoTipico dono) =>
+        ParaToken.TryGetValue(dono, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(dono), dono, "Dono típico fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) ao dono correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens numéricos ou fora do
+    /// domínio (allowlist). Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out DonoTipico dono)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out DonoTipico resolvido))
+        {
+            dono = resolvido;
+            return true;
+        }
+
+        dono = DonoTipico.Nenhum;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos quatro tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/FaseCanonicaCatalogo.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/FaseCanonicaCatalogo.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Catálogo do domínio fechado das <b>quatorze fases canônicas</b> do ciclo de vida
+/// de um processo seletivo (UNI-REQ-0064) e das constantes de coerência associadas.
+/// Fonte única dos códigos aceitos na guarda de domínio (<c>FaseCanonica.Criar</c>),
+/// no validator e no CHECK de banco <c>ck_fase_canonica_codigo_canonico</c>.
+/// </summary>
+/// <remarks>
+/// Tratar o vocabulário de fases como catálogo (e não como enumerado compilado)
+/// segue a diretriz do Tech Lead: é dado institucional configurável. Os códigos
+/// aqui são o <b>domínio fechado</b> — cada <c>FaseCanonica</c> viva referencia um
+/// deles, mas seus demais atributos (nome, dono típico, sinalizadores) são editáveis.
+/// </remarks>
+public static class FaseCanonicaCatalogo
+{
+    /// <summary>Código canônico da fase de avaliação — a única que agrupa Etapas pontuadas.</summary>
+    public const string CodigoAvaliacao = "AVALIACAO";
+
+    /// <summary>
+    /// Os quatorze códigos canônicos das fases do ciclo, em ordem cronológica
+    /// aproximada. Ordem de declaração não é semântica — a unicidade é por código.
+    /// </summary>
+    public static readonly IReadOnlyList<string> Codigos =
+    [
+        "INSCRICAO",
+        "HOMOLOGACAO",
+        "ENSALAMENTO",
+        CodigoAvaliacao,
+        "CLASSIFICACAO",
+        "RESULTADO_PRELIMINAR",
+        "RECURSOS",
+        "RESULTADO_FINAL",
+        "HABILITACAO",
+        "HETEROIDENTIFICACAO",
+        "MATRICULA",
+        "HOMOLOGACAO_RESULTADO_FINAL",
+        "LISTA_ESPERA",
+        "CHAMADA",
+    ];
+
+    /// <summary>
+    /// Fases em que a legislação permite complementação/reenvio documental —
+    /// homologação e recursos. A habilitação é deliberadamente excluída (o SiSU
+    /// veda complementação nessa fase).
+    /// </summary>
+    public static readonly IReadOnlyList<string> CodigosComComplementacaoPermitida =
+    [
+        "HOMOLOGACAO",
+        "RECURSOS",
+    ];
+
+    private static readonly HashSet<string> CodigosSet = new(Codigos, StringComparer.Ordinal);
+
+    private static readonly HashSet<string> ComplementacaoSet =
+        new(CodigosComComplementacaoPermitida, StringComparer.Ordinal);
+
+    /// <summary>Indica se <paramref name="codigo"/> pertence ao conjunto canônico das quatorze fases.</summary>
+    public static bool EhCanonico(string? codigo) =>
+        codigo is not null && CodigosSet.Contains(codigo);
+
+    /// <summary>Indica se a fase <paramref name="codigo"/> admite complementação documental por lei.</summary>
+    public static bool PermiteComplementacao(string? codigo) =>
+        codigo is not null && ComplementacaoSet.Contains(codigo);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/TipoBancaCatalogo.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/TipoBancaCatalogo.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Catálogo do domínio fechado das <b>quatro bancas</b> da seleção (UNI-REQ-0064).
+/// Fonte única dos códigos aceitos na guarda de domínio (<c>TipoBanca.Criar</c>),
+/// no validator e no CHECK de banco <c>ck_tipo_banca_codigo_canonico</c>.
+/// </summary>
+public static class TipoBancaCatalogo
+{
+    /// <summary>Os quatro códigos canônicos dos tipos de banca da seleção.</summary>
+    public static readonly IReadOnlyList<string> Codigos =
+    [
+        "BANCA_ANALISE_DOCUMENTAL",
+        "BANCA_ENTREVISTA",
+        "BANCA_CORRECAO_REDACOES",
+        "BANCA_ANALISE_RECURSOS",
+    ];
+
+    private static readonly HashSet<string> CodigosSet = new(Codigos, StringComparer.Ordinal);
+
+    /// <summary>Indica se <paramref name="codigo"/> pertence ao conjunto canônico das quatro bancas.</summary>
+    public static bool EhCanonico(string? codigo) =>
+        codigo is not null && CodigosSet.Contains(codigo);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/FaseCanonicaErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/FaseCanonicaErrorCodes.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+/// <summary>
+/// Códigos de erro de domínio da <see cref="Entities.FaseCanonica"/> (UNI-REQ-0064),
+/// prefixados por <c>FaseCanonica.</c>. Mapeados para status HTTP em
+/// <c>ConfiguracaoDomainErrorRegistration</c>:
+/// <list type="bullet">
+///   <item><description><see cref="CodigoJaExiste"/> → 409 Conflict</description></item>
+///   <item><description><see cref="NaoEncontrada"/> → 404 Not Found</description></item>
+///   <item><description>demais → 422 Unprocessable Entity</description></item>
+/// </list>
+/// </summary>
+public static class FaseCanonicaErrorCodes
+{
+    public const string CodigoObrigatorio = "FaseCanonica.CodigoObrigatorio";
+    public const string CodigoFormatoInvalido = "FaseCanonica.CodigoFormatoInvalido";
+    public const string CodigoForaDoConjuntoCanonico = "FaseCanonica.CodigoForaDoConjuntoCanonico";
+    public const string CodigoJaExiste = "FaseCanonica.CodigoJaExiste";
+    public const string NomeObrigatorio = "FaseCanonica.NomeObrigatorio";
+    public const string NomeTamanho = "FaseCanonica.NomeTamanho";
+    public const string DescricaoTamanho = "FaseCanonica.DescricaoTamanho";
+    public const string DonoTipicoObrigatorio = "FaseCanonica.DonoTipicoObrigatorio";
+    public const string DonoTipicoInvalido = "FaseCanonica.DonoTipicoInvalido";
+    public const string AgrupaEtapasApenasAvaliacao = "FaseCanonica.AgrupaEtapasApenasAvaliacao";
+    public const string ComplementacaoApenasFasesPermitidas = "FaseCanonica.ComplementacaoApenasFasesPermitidas";
+    public const string BaseLegalTamanho = "FaseCanonica.BaseLegalTamanho";
+    public const string NaoEncontrada = "FaseCanonica.NaoEncontrada";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/TipoBancaErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/TipoBancaErrorCodes.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+/// <summary>
+/// Códigos de erro de domínio do <see cref="Entities.TipoBanca"/> (UNI-REQ-0064),
+/// prefixados por <c>TipoBanca.</c>. Mapeados para status HTTP em
+/// <c>ConfiguracaoDomainErrorRegistration</c>:
+/// <list type="bullet">
+///   <item><description><see cref="CodigoJaExiste"/> → 409 Conflict</description></item>
+///   <item><description><see cref="NaoEncontrado"/> → 404 Not Found</description></item>
+///   <item><description>demais → 422 Unprocessable Entity</description></item>
+/// </list>
+/// </summary>
+public static class TipoBancaErrorCodes
+{
+    public const string CodigoObrigatorio = "TipoBanca.CodigoObrigatorio";
+    public const string CodigoFormatoInvalido = "TipoBanca.CodigoFormatoInvalido";
+    public const string CodigoForaDoConjuntoCanonico = "TipoBanca.CodigoForaDoConjuntoCanonico";
+    public const string CodigoJaExiste = "TipoBanca.CodigoJaExiste";
+    public const string NomeObrigatorio = "TipoBanca.NomeObrigatorio";
+    public const string NomeTamanho = "TipoBanca.NomeTamanho";
+    public const string FaseTipicaTamanho = "TipoBanca.FaseTipicaTamanho";
+    public const string DescricaoTamanho = "TipoBanca.DescricaoTamanho";
+    public const string NaoEncontrado = "TipoBanca.NaoEncontrado";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IFaseCanonicaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IFaseCanonicaRepository.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="FaseCanonica"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros soft-deleted
+/// via query filter por convenção. Não há métodos de integridade referencial: a
+/// fase canônica não é referenciada por FK intra-banco (o consumo cross-módulo é
+/// por snapshot-copy desacoplado, ADR-0061).
+/// </summary>
+public interface IFaseCanonicaRepository
+{
+    /// <summary>Carrega a fase rastreada pelo contexto, para mutação.</summary>
+    Task<FaseCanonica?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega a fase para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<FaseCanonica?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista fases vivas paginadas por cursor keyset bidirecional (ADR-0026 +
+    /// ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras de
+    /// <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<FaseCanonica> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(FaseCanonica fase, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca a fase para remoção; o <c>SoftDeleteInterceptor</c> converte em
+    /// soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(FaseCanonica fase);
+
+    /// <summary>
+    /// Verifica se existe fase viva com o <paramref name="codigo"/> (case-sensitive,
+    /// sobre o valor normalizado por <c>Trim</c>), excluindo opcionalmente um
+    /// <paramref name="excluirId"/> (para a checagem na atualização).
+    /// </summary>
+    Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITipoBancaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITipoBancaRepository.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="TipoBanca"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros soft-deleted
+/// via query filter por convenção. Não há métodos de integridade referencial: o
+/// tipo de banca não é referenciado por FK intra-banco (o consumo cross-módulo é
+/// por snapshot-copy desacoplado, ADR-0061).
+/// </summary>
+public interface ITipoBancaRepository
+{
+    /// <summary>Carrega o tipo de banca rastreado pelo contexto, para mutação.</summary>
+    Task<TipoBanca?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega o tipo de banca para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<TipoBanca?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista tipos de banca vivos paginados por cursor keyset bidirecional (ADR-0026
+    /// + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras de
+    /// <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<TipoBanca> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(TipoBanca banca, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca o tipo de banca para remoção; o <c>SoftDeleteInterceptor</c> converte
+    /// em soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(TipoBanca banca);
+
+    /// <summary>
+    /// Verifica se existe tipo de banca vivo com o <paramref name="codigo"/>
+    /// (case-sensitive, sobre o valor normalizado por <c>Trim</c>), excluindo
+    /// opcionalmente um <paramref name="excluirId"/> (para a checagem na atualização).
+    /// </summary>
+    Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoBanca.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoBanca.cs
@@ -1,0 +1,69 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+using System.Text.RegularExpressions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Código de um <see cref="Entities.TipoBanca"/> (UNI-REQ-0064, módulo
+/// Configuração) — chave natural classificatória da banca (ex.:
+/// <c>BANCA_ANALISE_DOCUMENTAL</c>, <c>BANCA_ENTREVISTA</c>). Value object com
+/// formato fechado: <c>^[A-Z_]+$</c> — apenas letras maiúsculas e sublinhado (sem
+/// hífen e sem dígito). Persistido como <c>varchar</c> via conversor de valor
+/// (fail-fast na reidratação).
+/// </summary>
+/// <remarks>
+/// O value object valida apenas o <b>formato</b>. A pertença ao conjunto canônico
+/// fechado das quatro bancas é guarda de domínio da entidade
+/// (<c>TipoBanca.Criar</c>). O código é <b>imutável</b>: o comando de atualização
+/// não o aceita.
+/// </remarks>
+public sealed partial record CodigoBanca
+{
+    private const int TamanhoMaximo = 60;
+
+    public string Valor { get; }
+
+    private CodigoBanca(string valor) => Valor = valor;
+
+    /// <summary>
+    /// Cria um <see cref="CodigoBanca"/> validando o formato fechado. Valor
+    /// nulo/em branco retorna <c>CodigoObrigatorio</c>; fora do formato (ou acima
+    /// do tamanho máximo) retorna <c>CodigoFormatoInvalido</c>. O valor é
+    /// normalizado por <c>Trim</c> antes da validação.
+    /// </summary>
+    public static Result<CodigoBanca> Criar(string valor)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return Result<CodigoBanca>.Failure(new DomainError(
+                TipoBancaErrorCodes.CodigoObrigatorio,
+                "Código do tipo de banca é obrigatório."));
+        }
+
+        string normalizado = valor.Trim();
+
+        if (normalizado.Length > TamanhoMaximo || !FormatoValido().IsMatch(normalizado))
+        {
+            return Result<CodigoBanca>.Failure(new DomainError(
+                TipoBancaErrorCodes.CodigoFormatoInvalido,
+                "Código do tipo de banca deve conter apenas letras maiúsculas e sublinhado "
+                + $"(sem hífen e sem dígito), com no máximo {TamanhoMaximo} caracteres "
+                + "(ex.: BANCA_ENTREVISTA)."));
+        }
+
+        return Result<CodigoBanca>.Success(new CodigoBanca(normalizado));
+    }
+
+    /// <summary>Indica se <paramref name="valor"/> respeita o formato fechado, sem alocar value object.</summary>
+    public static bool EhValido(string? valor) =>
+        !string.IsNullOrWhiteSpace(valor)
+        && valor.Trim().Length <= TamanhoMaximo
+        && FormatoValido().IsMatch(valor.Trim());
+
+    public override string ToString() => Valor;
+
+    [GeneratedRegex("^[A-Z_]+$", RegexOptions.CultureInvariant)]
+    private static partial Regex FormatoValido();
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoFase.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoFase.cs
@@ -1,0 +1,70 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+using System.Text.RegularExpressions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Código de uma <see cref="Entities.FaseCanonica"/> (UNI-REQ-0064, módulo
+/// Configuração) — chave natural do vocabulário de cronograma (ex.: <c>INSCRICAO</c>,
+/// <c>AVALIACAO</c>, <c>RECURSOS</c>). Value object com formato fechado:
+/// <c>^[A-Z_]+$</c> — apenas letras maiúsculas e sublinhado (<b>sem hífen e sem
+/// dígito</b>, diferente do <c>CodigoModalidade</c>). Persistido como <c>varchar</c>
+/// via conversor de valor (fail-fast na reidratação).
+/// </summary>
+/// <remarks>
+/// O value object valida apenas o <b>formato</b>. A pertença ao conjunto canônico
+/// fechado das quatorze fases é guarda de domínio da entidade (factory
+/// <c>FaseCanonica.Criar</c>), não do value object — o mesmo código bem-formado
+/// pode ou não ser canônico. O código é <b>imutável</b>: o comando de atualização
+/// não o aceita como campo editável (vocabulário canônico fixo).
+/// </remarks>
+public sealed partial record CodigoFase
+{
+    private const int TamanhoMaximo = 60;
+
+    public string Valor { get; }
+
+    private CodigoFase(string valor) => Valor = valor;
+
+    /// <summary>
+    /// Cria um <see cref="CodigoFase"/> validando o formato fechado. Valor
+    /// nulo/em branco retorna <c>CodigoObrigatorio</c>; fora do formato (ou acima
+    /// do tamanho máximo) retorna <c>CodigoFormatoInvalido</c>. O valor é
+    /// normalizado por <c>Trim</c> antes da validação.
+    /// </summary>
+    public static Result<CodigoFase> Criar(string valor)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return Result<CodigoFase>.Failure(new DomainError(
+                FaseCanonicaErrorCodes.CodigoObrigatorio,
+                "Código da fase canônica é obrigatório."));
+        }
+
+        string normalizado = valor.Trim();
+
+        if (normalizado.Length > TamanhoMaximo || !FormatoValido().IsMatch(normalizado))
+        {
+            return Result<CodigoFase>.Failure(new DomainError(
+                FaseCanonicaErrorCodes.CodigoFormatoInvalido,
+                "Código da fase deve conter apenas letras maiúsculas e sublinhado "
+                + $"(sem hífen e sem dígito), com no máximo {TamanhoMaximo} caracteres "
+                + "(ex.: INSCRICAO, AVALIACAO, RECURSOS)."));
+        }
+
+        return Result<CodigoFase>.Success(new CodigoFase(normalizado));
+    }
+
+    /// <summary>Indica se <paramref name="valor"/> respeita o formato fechado, sem alocar value object.</summary>
+    public static bool EhValido(string? valor) =>
+        !string.IsNullOrWhiteSpace(valor)
+        && valor.Trim().Length <= TamanhoMaximo
+        && FormatoValido().IsMatch(valor.Trim());
+
+    public override string ToString() => Valor;
+
+    [GeneratedRegex("^[A-Z_]+$", RegexOptions.CultureInvariant)]
+    private static partial Regex FormatoValido();
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -42,6 +42,8 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<IRecursoAcessibilidadeRepository, RecursoAcessibilidadeRepository>();
         services.AddScoped<ITipoDeficienciaRepository, TipoDeficienciaRepository>();
         services.AddScoped<IModalidadeRepository, ModalidadeRepository>();
+        services.AddScoped<IFaseCanonicaRepository, FaseCanonicaRepository>();
+        services.AddScoped<ITipoBancaRepository, TipoBancaRepository>();
 
         // Readers cross-módulo (ADR-0056).
         services.AddScoped<IReferenciaReservaDemograficaReader, ReferenciaReservaDemograficaReader>();
@@ -51,6 +53,8 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<IRecursoAcessibilidadeReader, RecursoAcessibilidadeReader>();
         services.AddScoped<ITipoDeficienciaReader, TipoDeficienciaReader>();
         services.AddScoped<IModalidadeReader, ModalidadeReader>();
+        services.AddScoped<IFaseCanonicaReader, FaseCanonicaReader>();
+        services.AddScoped<ITipoBancaReader, TipoBancaReader>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -47,6 +47,10 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
 
     public DbSet<Modalidade> Modalidades => Set<Modalidade>();
 
+    public DbSet<FaseCanonica> FasesCanonicas => Set<FaseCanonica>();
+
+    public DbSet<TipoBanca> TiposBanca => Set<TipoBanca>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/FaseCanonicaConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/FaseCanonicaConfiguration.cs
@@ -1,0 +1,98 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class FaseCanonicaConfiguration : IEntityTypeConfiguration<FaseCanonica>
+{
+    private const int CodigoMaxLength = 60;
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 300;
+    private const int EnumTokenMaxLength = 30;
+    private const int BaseLegalMaxLength = 500;
+    private const int AuditUserMaxLength = 255;
+
+    public void Configure(EntityTypeBuilder<FaseCanonica> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("fase_canonica", ConfigurarChecks);
+
+        builder.HasKey(f => f.Id);
+
+        // Codigo é value object imutável — persistido por valor como varchar via
+        // CodigoFaseValueConverter (reidratação fail-fast). O CHECK de formato, o
+        // CHECK de conjunto canônico e o índice único parcial protegem a coluna.
+        builder.Property(f => f.Codigo)
+            .HasConversion<CodigoFaseValueConverter>()
+            .HasMaxLength(CodigoMaxLength)
+            .IsRequired();
+
+        builder.Property(f => f.Nome).HasMaxLength(NomeMaxLength).IsRequired();
+
+        builder.Property(f => f.Descricao).HasMaxLength(DescricaoMaxLength);
+
+        builder.Property(f => f.DonoTipico)
+            .HasConversion<DonoTipicoValueConverter>()
+            .HasMaxLength(EnumTokenMaxLength)
+            .IsRequired();
+
+        builder.Property(f => f.AgrupaEtapas).IsRequired().HasDefaultValue(false);
+
+        builder.Property(f => f.PermiteComplementacao).IsRequired().HasDefaultValue(false);
+
+        builder.Property(f => f.BaseLegal).HasMaxLength(BaseLegalMaxLength);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(f => f.CreatedBy).HasMaxLength(AuditUserMaxLength);
+        builder.Property(f => f.UpdatedBy).HasMaxLength(AuditUserMaxLength);
+
+        // Unicidade do código entre fases vivas (índice parcial) — uma fase viva por
+        // código; soft-delete libera o slot para recriação.
+        builder.HasIndex(f => f.Codigo)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_fase_canonica_codigo_vivo");
+    }
+
+    private static void ConfigurarChecks(TableBuilder<FaseCanonica> table)
+    {
+        // Formato fechado do código — alinhado ao value object CodigoFase.
+        table.HasCheckConstraint(
+            "ck_fase_canonica_codigo_formato",
+            "codigo ~ '^[A-Z_]+$'");
+
+        // Domínio fechado das quatorze fases canônicas (defesa em profundidade).
+        table.HasCheckConstraint(
+            "ck_fase_canonica_codigo_canonico",
+            $"codigo IN ({TokensSql(FaseCanonicaCatalogo.Codigos)})");
+
+        // Domínio fechado do dono típico (quatro valores).
+        table.HasCheckConstraint(
+            "ck_fase_canonica_dono_tipico",
+            $"dono_tipico IN ({TokensSql(DonosTipicos.TokensCanonicos)})");
+
+        // Coerência: agrupa_etapas verdadeiro apenas para a fase de avaliação.
+        table.HasCheckConstraint(
+            "ck_fase_canonica_agrupa_etapas",
+            $"agrupa_etapas = false OR codigo = '{FaseCanonicaCatalogo.CodigoAvaliacao}'");
+
+        // Coerência: permite_complementacao verdadeiro apenas nas fases legalmente permitidas.
+        table.HasCheckConstraint(
+            "ck_fase_canonica_complementacao",
+            $"permite_complementacao = false OR codigo IN ({TokensSql(FaseCanonicaCatalogo.CodigosComComplementacaoPermitida)})");
+    }
+
+    private static string TokensSql(IReadOnlyList<string> tokens) =>
+        string.Join(", ", tokens.Select(token => $"'{token}'"));
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/TipoBancaConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/TipoBancaConfiguration.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class TipoBancaConfiguration : IEntityTypeConfiguration<TipoBanca>
+{
+    private const int CodigoMaxLength = 60;
+    private const int NomeMaxLength = 200;
+    private const int FaseTipicaMaxLength = 60;
+    private const int DescricaoMaxLength = 300;
+    private const int AuditUserMaxLength = 255;
+
+    public void Configure(EntityTypeBuilder<TipoBanca> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("tipo_banca", ConfigurarChecks);
+
+        builder.HasKey(b => b.Id);
+
+        // Codigo é value object imutável — persistido por valor como varchar via
+        // CodigoBancaValueConverter (reidratação fail-fast). O CHECK de formato, o
+        // CHECK de conjunto canônico e o índice único parcial protegem a coluna.
+        builder.Property(b => b.Codigo)
+            .HasConversion<CodigoBancaValueConverter>()
+            .HasMaxLength(CodigoMaxLength)
+            .IsRequired();
+
+        builder.Property(b => b.Nome).HasMaxLength(NomeMaxLength).IsRequired();
+
+        // fase_tipica: rótulo de texto orientativo (NÃO é FK para fase_canonica).
+        builder.Property(b => b.FaseTipica).HasMaxLength(FaseTipicaMaxLength);
+
+        builder.Property(b => b.Descricao).HasMaxLength(DescricaoMaxLength);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(b => b.CreatedBy).HasMaxLength(AuditUserMaxLength);
+        builder.Property(b => b.UpdatedBy).HasMaxLength(AuditUserMaxLength);
+
+        // Unicidade do código entre tipos de banca vivos (índice parcial).
+        builder.HasIndex(b => b.Codigo)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_tipo_banca_codigo_vivo");
+    }
+
+    private static void ConfigurarChecks(TableBuilder<TipoBanca> table)
+    {
+        // Formato fechado do código — alinhado ao value object CodigoBanca.
+        table.HasCheckConstraint(
+            "ck_tipo_banca_codigo_formato",
+            "codigo ~ '^[A-Z_]+$'");
+
+        // Domínio fechado das quatro bancas canônicas (defesa em profundidade).
+        table.HasCheckConstraint(
+            "ck_tipo_banca_codigo_canonico",
+            $"codigo IN ({TokensSql(TipoBancaCatalogo.Codigos)})");
+    }
+
+    private static string TokensSql(IReadOnlyList<string> tokens) =>
+        string.Join(", ", tokens.Select(token => $"'{token}'"));
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CodigoBancaValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CodigoBancaValueConverter.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+// Mapeia CodigoBanca ↔ string (varchar). O comprimento da coluna é definido na
+// própria propriedade via HasMaxLength no IEntityTypeConfiguration. A reidratação
+// falha explicitamente (com contexto) caso a coluna seja corrompida fora do fluxo
+// da aplicação, em vez do NullReferenceException tardio de
+// `CodigoBanca.Criar(v).Value!`.
+public sealed class CodigoBancaValueConverter : ValueConverter<CodigoBanca, string>
+{
+    public CodigoBancaValueConverter()
+        : base(
+            codigo => codigo.Valor,
+            valor => Reidratar(valor))
+    {
+    }
+
+    private static CodigoBanca Reidratar(string valor)
+    {
+        Result<CodigoBanca> resultado = CodigoBanca.Criar(valor);
+        if (resultado.IsFailure || resultado.Value is null)
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(CodigoBanca)}: " +
+                $"{resultado.Error?.Code ?? "Desconhecido"}. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return resultado.Value;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CodigoFaseValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/CodigoFaseValueConverter.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+// Mapeia CodigoFase ↔ string (varchar). O comprimento da coluna é definido na
+// própria propriedade via HasMaxLength no IEntityTypeConfiguration. A reidratação
+// falha explicitamente (com contexto) caso a coluna seja corrompida fora do fluxo
+// da aplicação, em vez do NullReferenceException tardio de
+// `CodigoFase.Criar(v).Value!`.
+public sealed class CodigoFaseValueConverter : ValueConverter<CodigoFase, string>
+{
+    public CodigoFaseValueConverter()
+        : base(
+            codigo => codigo.Valor,
+            valor => Reidratar(valor))
+    {
+    }
+
+    private static CodigoFase Reidratar(string valor)
+    {
+        Result<CodigoFase> resultado = CodigoFase.Criar(valor);
+        if (resultado.IsFailure || resultado.Value is null)
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(CodigoFase)}: " +
+                $"{resultado.Error?.Code ?? "Desconhecido"}. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return resultado.Value;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/DonoTipicoValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/DonoTipicoValueConverter.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia DonoTipico ↔ string (varchar) usando o token canônico UPPER_SNAKE
+// (CEPS, CRCA, MEC, CONSEPE), não o nome PascalCase do enum. O comprimento da
+// coluna é definido na própria propriedade via HasMaxLength no
+// IEntityTypeConfiguration. A reidratação falha explicitamente (com contexto)
+// caso a coluna seja corrompida fora do fluxo da aplicação, em vez de um valor
+// de enum silenciosamente inválido.
+public sealed class DonoTipicoValueConverter : ValueConverter<DonoTipico, string>
+{
+    public DonoTipicoValueConverter()
+        : base(
+            dono => DonosTipicos.ParaTokenCanonico(dono),
+            token => Reidratar(token))
+    {
+    }
+
+    private static DonoTipico Reidratar(string token)
+    {
+        if (!DonosTipicos.TryAnalisar(token, out DonoTipico dono))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(DonoTipico)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return dono;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260701143441_AddFaseCanonicaETipoBanca.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260701143441_AddFaseCanonicaETipoBanca.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701143441_AddFaseCanonicaETipoBanca")]
+    partial class AddFaseCanonicaETipoBanca
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260701143441_AddFaseCanonicaETipoBanca.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260701143441_AddFaseCanonicaETipoBanca.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFaseCanonicaETipoBanca : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "fase_canonica",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    descricao = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+                    dono_tipico = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    agrupa_etapas = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    permite_complementacao = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    base_legal = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_fase_canonica", x => x.id);
+                    table.CheckConstraint("ck_fase_canonica_agrupa_etapas", "agrupa_etapas = false OR codigo = 'AVALIACAO'");
+                    table.CheckConstraint("ck_fase_canonica_codigo_canonico", "codigo IN ('INSCRICAO', 'HOMOLOGACAO', 'ENSALAMENTO', 'AVALIACAO', 'CLASSIFICACAO', 'RESULTADO_PRELIMINAR', 'RECURSOS', 'RESULTADO_FINAL', 'HABILITACAO', 'HETEROIDENTIFICACAO', 'MATRICULA', 'HOMOLOGACAO_RESULTADO_FINAL', 'LISTA_ESPERA', 'CHAMADA')");
+                    table.CheckConstraint("ck_fase_canonica_codigo_formato", "codigo ~ '^[A-Z_]+$'");
+                    table.CheckConstraint("ck_fase_canonica_complementacao", "permite_complementacao = false OR codigo IN ('HOMOLOGACAO', 'RECURSOS')");
+                    table.CheckConstraint("ck_fase_canonica_dono_tipico", "dono_tipico IN ('CEPS', 'CRCA', 'MEC', 'CONSEPE')");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "tipo_banca",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    fase_tipica = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: true),
+                    descricao = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_tipo_banca", x => x.id);
+                    table.CheckConstraint("ck_tipo_banca_codigo_canonico", "codigo IN ('BANCA_ANALISE_DOCUMENTAL', 'BANCA_ENTREVISTA', 'BANCA_CORRECAO_REDACOES', 'BANCA_ANALISE_RECURSOS')");
+                    table.CheckConstraint("ck_tipo_banca_codigo_formato", "codigo ~ '^[A-Z_]+$'");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_fase_canonica_codigo_vivo",
+                schema: "configuracao",
+                table: "fase_canonica",
+                column: "codigo",
+                unique: true,
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tipo_banca_codigo_vivo",
+                schema: "configuracao",
+                table: "tipo_banca",
+                column: "codigo",
+                unique: true,
+                filter: "is_deleted = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "fase_canonica",
+                schema: "configuracao");
+
+            migrationBuilder.DropTable(
+                name: "tipo_banca",
+                schema: "configuracao");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/FaseCanonicaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/FaseCanonicaRepository.cs
@@ -1,0 +1,88 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class FaseCanonicaRepository : IFaseCanonicaRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public FaseCanonicaRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<FaseCanonica?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.FasesCanonicas
+            .FirstOrDefaultAsync(f => f.Id == id, cancellationToken);
+    }
+
+    public Task<FaseCanonica?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.FasesCanonicas
+            .AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<FaseCanonica> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<FaseCanonica> page = await CursorKeyset
+            .ApplyAsync(_dbContext.FasesCanonicas.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(FaseCanonica fase, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(fase);
+        await _dbContext.FasesCanonicas.AddAsync(fase, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(FaseCanonica fase)
+    {
+        ArgumentNullException.ThrowIfNull(fase);
+        _dbContext.FasesCanonicas.Remove(fase);
+    }
+
+    public Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        // Um código fora do formato nunca tem fase viva — evita query desnecessária
+        // e garante que a comparação use o valor canônico normalizado (Trim).
+        // Case-sensitive (default do Postgres) — alinhado ao índice único.
+        Result<CodigoFase> codigoResult = CodigoFase.Criar(codigo);
+        if (codigoResult.IsFailure)
+        {
+            return Task.FromResult(false);
+        }
+
+        CodigoFase codigoVo = codigoResult.Value!;
+
+        return _dbContext.FasesCanonicas
+            .AsNoTracking()
+            .Where(f => excluirId == null || f.Id != excluirId)
+            .AnyAsync(f => f.Codigo == codigoVo, cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TipoBancaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TipoBancaRepository.cs
@@ -1,0 +1,88 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class TipoBancaRepository : ITipoBancaRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public TipoBancaRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<TipoBanca?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.TiposBanca
+            .FirstOrDefaultAsync(b => b.Id == id, cancellationToken);
+    }
+
+    public Task<TipoBanca?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.TiposBanca
+            .AsNoTracking()
+            .FirstOrDefaultAsync(b => b.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<TipoBanca> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<TipoBanca> page = await CursorKeyset
+            .ApplyAsync(_dbContext.TiposBanca.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(TipoBanca banca, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(banca);
+        await _dbContext.TiposBanca.AddAsync(banca, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(TipoBanca banca)
+    {
+        ArgumentNullException.ThrowIfNull(banca);
+        _dbContext.TiposBanca.Remove(banca);
+    }
+
+    public Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        // Um código fora do formato nunca tem tipo de banca vivo — evita query
+        // desnecessária e garante que a comparação use o valor canônico normalizado
+        // (Trim). Case-sensitive (default do Postgres) — alinhado ao índice único.
+        Result<CodigoBanca> codigoResult = CodigoBanca.Criar(codigo);
+        if (codigoResult.IsFailure)
+        {
+            return Task.FromResult(false);
+        }
+
+        CodigoBanca codigoVo = codigoResult.Value!;
+
+        return _dbContext.TiposBanca
+            .AsNoTracking()
+            .Where(b => excluirId == null || b.Id != excluirId)
+            .AnyAsync(b => b.Codigo == codigoVo, cancellationToken);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/FaseCanonicaReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/FaseCanonicaReader.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="IFaseCanonicaReader"/> (ADR-0056): leitura direta do
+/// banco de Configuração (<c>AsNoTracking</c>, query filter de soft-delete por
+/// convenção). Sem cache — o cadastro é de baixo volume e o congelamento por valor
+/// no consumidor (ADR-0061) dispensa releitura quente. Ordena por <c>Codigo</c>
+/// ascendente.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class FaseCanonicaReader : IFaseCanonicaReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public FaseCanonicaReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<FaseCanonicaView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<FaseCanonica> entidades = await _dbContext.FasesCanonicas
+            .AsNoTracking()
+            .OrderBy(f => f.Codigo)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<FaseCanonicaView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        FaseCanonica? entidade = await _dbContext.FasesCanonicas
+            .AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static FaseCanonicaView ParaView(FaseCanonica f) =>
+        new(
+            f.Id,
+            f.Codigo.Valor,
+            f.Nome,
+            f.Descricao,
+            DonosTipicos.ParaTokenCanonico(f.DonoTipico),
+            f.AgrupaEtapas,
+            f.PermiteComplementacao,
+            f.BaseLegal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/TipoBancaReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/TipoBancaReader.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="ITipoBancaReader"/> (ADR-0056): leitura direta do
+/// banco de Configuração (<c>AsNoTracking</c>, query filter de soft-delete por
+/// convenção). Sem cache — o cadastro é de baixo volume e o congelamento por valor
+/// no consumidor (ADR-0061) dispensa releitura quente. Ordena por <c>Codigo</c>
+/// ascendente.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class TipoBancaReader : ITipoBancaReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public TipoBancaReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<TipoBancaView>> ListarVivosAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<TipoBanca> entidades = await _dbContext.TiposBanca
+            .AsNoTracking()
+            .OrderBy(b => b.Codigo)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<TipoBancaView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        TipoBanca? entidade = await _dbContext.TiposBanca
+            .AsNoTracking()
+            .FirstOrDefaultAsync(b => b.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static TipoBancaView ParaView(TipoBanca b) =>
+        new(
+            b.Id,
+            b.Codigo.Valor,
+            b.Nome,
+            b.FaseTipica,
+            b.Descricao);
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarFaseCanonicaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarFaseCanonicaCommandHandlerTests.cs
@@ -1,0 +1,70 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarFaseCanonicaCommandHandlerTests
+{
+    private readonly IFaseCanonicaRepository _repository = Substitute.For<IFaseCanonicaRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static FaseCanonica Existente(string codigo = "ENSALAMENTO") =>
+        FaseCanonica.Criar(codigo, "Ensalamento", null, "CEPS", false, false, null).Value!;
+
+    [Fact(DisplayName = "Fase inexistente retorna NaoEncontrada (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrada()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((FaseCanonica?)null);
+
+        Result resultado = await AtualizarFaseCanonicaCommandHandler.Handle(
+            new AtualizarFaseCanonicaCommand(id, Nome: "x", DonoTipico: "CEPS"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FaseCanonicaErrorCodes.NaoEncontrada);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Atualização válida persiste e o código permanece imutável")]
+    public async Task Handle_Valido_PersisteCodigoImutavel()
+    {
+        FaseCanonica existente = Existente("ENSALAMENTO");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        var comando = new AtualizarFaseCanonicaCommand(
+            existente.Id, Nome: "Ensalamento (novo)", DonoTipico: "CRCA");
+
+        Result resultado = await AtualizarFaseCanonicaCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.Codigo.Valor.Should().Be("ENSALAMENTO", "o código é imutável — não há campo para alterá-lo");
+        existente.Nome.Should().Be("Ensalamento (novo)");
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Coerência revalidada contra o código congelado (agrupar etapas) retorna 422 sem persistir")]
+    public async Task Handle_CoerenciaInvalida_Retorna422()
+    {
+        FaseCanonica existente = Existente("HOMOLOGACAO");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        var comando = new AtualizarFaseCanonicaCommand(
+            existente.Id, Nome: "Homologação", DonoTipico: "CEPS", AgrupaEtapas: true);
+
+        Result resultado = await AtualizarFaseCanonicaCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FaseCanonicaErrorCodes.AgrupaEtapasApenasAvaliacao);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarTipoBancaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarTipoBancaCommandHandlerTests.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarTipoBancaCommandHandlerTests
+{
+    private readonly ITipoBancaRepository _repository = Substitute.For<ITipoBancaRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static TipoBanca Existente(string codigo = "BANCA_ANALISE_RECURSOS") =>
+        TipoBanca.Criar(codigo, "Banca de análise de recursos", null, null).Value!;
+
+    [Fact(DisplayName = "Tipo de banca inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((TipoBanca?)null);
+
+        Result resultado = await AtualizarTipoBancaCommandHandler.Handle(
+            new AtualizarTipoBancaCommand(id, Nome: "x"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoBancaErrorCodes.NaoEncontrado);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Atualização válida persiste e o código permanece imutável")]
+    public async Task Handle_Valido_PersisteCodigoImutavel()
+    {
+        TipoBanca existente = Existente("BANCA_ANALISE_RECURSOS");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        var comando = new AtualizarTipoBancaCommand(existente.Id, Nome: "Banca de recursos (novo)", FaseTipica: "Recursos");
+
+        Result resultado = await AtualizarTipoBancaCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.Codigo.Valor.Should().Be("BANCA_ANALISE_RECURSOS", "o código é imutável — não há campo para alterá-lo");
+        existente.Nome.Should().Be("Banca de recursos (novo)");
+        existente.FaseTipica.Should().Be("Recursos");
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarFaseCanonicaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarFaseCanonicaCommandHandlerTests.cs
@@ -1,0 +1,78 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarFaseCanonicaCommandHandlerTests
+{
+    private readonly IFaseCanonicaRepository _repository = Substitute.For<IFaseCanonicaRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CriarFaseCanonicaCommand Comando() =>
+        new("INSCRICAO", Nome: "Inscrição", DonoTipico: "CEPS");
+
+    [Fact(DisplayName = "Código livre cria a fase, persiste e retorna o Id")]
+    public async Task Handle_CodigoLivre_CriaEPersiste()
+    {
+        _repository.CodigoExisteEntreVivosAsync("INSCRICAO", null, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result<Guid> resultado = await CriarFaseCanonicaCommandHandler.Handle(
+            Comando(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<FaseCanonica>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Código já existente entre vivos retorna conflito (CodigoJaExiste) sem persistir")]
+    public async Task Handle_CodigoDuplicado_RetornaConflito()
+    {
+        _repository.CodigoExisteEntreVivosAsync("INSCRICAO", null, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result<Guid> resultado = await CriarFaseCanonicaCommandHandler.Handle(
+            Comando(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FaseCanonicaErrorCodes.CodigoJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<FaseCanonica>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Código fora do conjunto canônico propaga o erro sem persistir")]
+    public async Task Handle_ForaDoCanonico_RetornaErroSemPersistir()
+    {
+        _repository.CodigoExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>()).Returns(false);
+
+        var comando = new CriarFaseCanonicaCommand("ENTREVISTA_FINAL", Nome: "x", DonoTipico: "CEPS");
+
+        Result<Guid> resultado = await CriarFaseCanonicaCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FaseCanonicaErrorCodes.CodigoForaDoConjuntoCanonico);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Invariante de coerência (agrupar etapas fora da avaliação) propaga o erro sem persistir")]
+    public async Task Handle_CoerenciaInvalida_RetornaErroSemPersistir()
+    {
+        _repository.CodigoExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>()).Returns(false);
+
+        var comando = new CriarFaseCanonicaCommand("HOMOLOGACAO", Nome: "Homologação", DonoTipico: "CEPS", AgrupaEtapas: true);
+
+        Result<Guid> resultado = await CriarFaseCanonicaCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FaseCanonicaErrorCodes.AgrupaEtapasApenasAvaliacao);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarTipoBancaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarTipoBancaCommandHandlerTests.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarTipoBancaCommandHandlerTests
+{
+    private readonly ITipoBancaRepository _repository = Substitute.For<ITipoBancaRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CriarTipoBancaCommand Comando() =>
+        new("BANCA_ENTREVISTA", Nome: "Banca de entrevista");
+
+    [Fact(DisplayName = "Código livre cria a banca, persiste e retorna o Id")]
+    public async Task Handle_CodigoLivre_CriaEPersiste()
+    {
+        _repository.CodigoExisteEntreVivosAsync("BANCA_ENTREVISTA", null, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result<Guid> resultado = await CriarTipoBancaCommandHandler.Handle(
+            Comando(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<TipoBanca>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Código já existente entre vivos retorna conflito (CodigoJaExiste) sem persistir")]
+    public async Task Handle_CodigoDuplicado_RetornaConflito()
+    {
+        _repository.CodigoExisteEntreVivosAsync("BANCA_ENTREVISTA", null, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result<Guid> resultado = await CriarTipoBancaCommandHandler.Handle(
+            Comando(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoBancaErrorCodes.CodigoJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<TipoBanca>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Código fora do conjunto canônico propaga o erro sem persistir")]
+    public async Task Handle_ForaDoCanonico_RetornaErroSemPersistir()
+    {
+        _repository.CodigoExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>()).Returns(false);
+
+        var comando = new CriarTipoBancaCommand("BANCA_LOGISTICA", Nome: "x");
+
+        Result<Guid> resultado = await CriarTipoBancaCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoBancaErrorCodes.CodigoForaDoConjuntoCanonico);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverFaseCanonicaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverFaseCanonicaCommandHandlerTests.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverFaseCanonicaCommandHandlerTests
+{
+    private readonly IFaseCanonicaRepository _repository = Substitute.For<IFaseCanonicaRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static FaseCanonica Fase() =>
+        FaseCanonica.Criar("INSCRICAO", "Inscrição", null, "CEPS", false, false, null).Value!;
+
+    [Fact(DisplayName = "Fase existente faz soft-delete (Remover + Salvar), nunca bloqueada")]
+    public async Task Handle_Existente_FazSoftDelete()
+    {
+        FaseCanonica fase = Fase();
+        _repository.ObterPorIdAsync(fase.Id, Arg.Any<CancellationToken>()).Returns(fase);
+
+        Result resultado = await RemoverFaseCanonicaCommandHandler.Handle(
+            new RemoverFaseCanonicaCommand(fase.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(fase);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Fase inexistente retorna NaoEncontrada (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrada()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((FaseCanonica?)null);
+
+        Result resultado = await RemoverFaseCanonicaCommandHandler.Handle(
+            new RemoverFaseCanonicaCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FaseCanonicaErrorCodes.NaoEncontrada);
+        _repository.DidNotReceive().Remover(Arg.Any<FaseCanonica>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverTipoBancaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverTipoBancaCommandHandlerTests.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverTipoBancaCommandHandlerTests
+{
+    private readonly ITipoBancaRepository _repository = Substitute.For<ITipoBancaRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static TipoBanca Banca() =>
+        TipoBanca.Criar("BANCA_ENTREVISTA", "Banca de entrevista", null, null).Value!;
+
+    [Fact(DisplayName = "Tipo de banca existente faz soft-delete (Remover + Salvar), nunca bloqueado")]
+    public async Task Handle_Existente_FazSoftDelete()
+    {
+        TipoBanca banca = Banca();
+        _repository.ObterPorIdAsync(banca.Id, Arg.Any<CancellationToken>()).Returns(banca);
+
+        Result resultado = await RemoverTipoBancaCommandHandler.Handle(
+            new RemoverTipoBancaCommand(banca.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(banca);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Tipo de banca inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((TipoBanca?)null);
+
+        Result resultado = await RemoverTipoBancaCommandHandler.Handle(
+            new RemoverTipoBancaCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoBancaErrorCodes.NaoEncontrado);
+        _repository.DidNotReceive().Remover(Arg.Any<TipoBanca>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/FaseCanonicaValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/FaseCanonicaValidatorTests.cs
@@ -1,0 +1,97 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.FasesCanonicas;
+
+/// <summary>
+/// O validator antecipa o formato do código, a pertença ao conjunto canônico, o
+/// domínio fechado do dono típico e os tamanhos. A coerência
+/// <c>agrupa_etapas</c>/<c>permite_complementacao</c> (que depende do código) fica
+/// no agregado.
+/// </summary>
+public sealed class FaseCanonicaValidatorTests
+{
+    private readonly CriarFaseCanonicaCommandValidator _criarValidator = new();
+    private readonly AtualizarFaseCanonicaCommandValidator _atualizarValidator = new();
+
+    private static CriarFaseCanonicaCommand Base() =>
+        new("INSCRICAO", Nome: "Inscrição", DonoTipico: "CEPS");
+
+    [Fact(DisplayName = "Comando válido passa no validator de criação")]
+    public void Criar_Valido_Passa()
+    {
+        _criarValidator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Código fora do formato é rejeitado")]
+    [InlineData("inscricao")]
+    [InlineData("RESULTADO-FINAL")]
+    [InlineData("")]
+    public void Criar_CodigoInvalido_Rejeita(string codigo)
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { Codigo = codigo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarFaseCanonicaCommand.Codigo));
+    }
+
+    [Fact(DisplayName = "Código bem-formado fora do conjunto canônico é rejeitado")]
+    public void Criar_CodigoForaDoCanonico_Rejeita()
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { Codigo = "ENTREVISTA_FINAL" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarFaseCanonicaCommand.Codigo));
+    }
+
+    [Theory(DisplayName = "Dono típico fora do domínio (incl. numérico e PascalCase) é rejeitado")]
+    [InlineData("DTI")]
+    [InlineData("1")]
+    [InlineData("Ceps")]
+    public void Criar_DonoTipicoInvalido_Rejeita(string dono)
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { DonoTipico = dono });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarFaseCanonicaCommand.DonoTipico));
+    }
+
+    [Fact(DisplayName = "Nome ausente é rejeitado")]
+    public void Criar_SemNome_Rejeita()
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { Nome = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarFaseCanonicaCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Dono típico ausente é rejeitado")]
+    public void Criar_SemDonoTipico_Rejeita()
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { DonoTipico = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarFaseCanonicaCommand.DonoTipico));
+    }
+
+    [Fact(DisplayName = "Atualização com Id vazio é rejeitada")]
+    public void Atualizar_IdVazio_Rejeita()
+    {
+        ValidationResult resultado = _atualizarValidator.Validate(
+            new AtualizarFaseCanonicaCommand(Guid.Empty, Nome: "Inscrição", DonoTipico: "CEPS"));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(AtualizarFaseCanonicaCommand.Id));
+    }
+
+    [Fact(DisplayName = "Atualização válida passa no validator")]
+    public void Atualizar_Valido_Passa()
+    {
+        _atualizarValidator.Validate(
+            new AtualizarFaseCanonicaCommand(Guid.CreateVersion7(), Nome: "Inscrição", DonoTipico: "CEPS"))
+            .IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/FaseCanonicaValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/FaseCanonicaValidatorTests.cs
@@ -47,6 +47,12 @@ public sealed class FaseCanonicaValidatorTests
         resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarFaseCanonicaCommand.Codigo));
     }
 
+    [Fact(DisplayName = "Código canônico com espaços ao redor passa (validator trima como FaseCanonica.Criar)")]
+    public void Criar_CodigoCanonicoComEspacos_Passa()
+    {
+        _criarValidator.Validate(Base() with { Codigo = " INSCRICAO " }).IsValid.Should().BeTrue();
+    }
+
     [Theory(DisplayName = "Dono típico fora do domínio (incl. numérico e PascalCase) é rejeitado")]
     [InlineData("DTI")]
     [InlineData("1")]

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/TipoBancaValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/TipoBancaValidatorTests.cs
@@ -52,6 +52,12 @@ public sealed class TipoBancaValidatorTests
         resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoBancaCommand.Codigo));
     }
 
+    [Fact(DisplayName = "Código canônico com espaços ao redor passa (validator trima como TipoBanca.Criar)")]
+    public void Criar_CodigoCanonicoComEspacos_Passa()
+    {
+        _criarValidator.Validate(Base() with { Codigo = " BANCA_ENTREVISTA " }).IsValid.Should().BeTrue();
+    }
+
     [Fact(DisplayName = "Nome ausente é rejeitado")]
     public void Criar_SemNome_Rejeita()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/TipoBancaValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/TipoBancaValidatorTests.cs
@@ -1,0 +1,90 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.TiposBanca;
+
+/// <summary>
+/// O validator antecipa o formato do código, a pertença ao conjunto canônico das
+/// quatro bancas e os tamanhos. A fase típica é orientativa (não validada contra o
+/// cadastro de fases), apenas limitada em tamanho.
+/// </summary>
+public sealed class TipoBancaValidatorTests
+{
+    private readonly CriarTipoBancaCommandValidator _criarValidator = new();
+    private readonly AtualizarTipoBancaCommandValidator _atualizarValidator = new();
+
+    private static CriarTipoBancaCommand Base() =>
+        new("BANCA_ENTREVISTA", Nome: "Banca de entrevista");
+
+    [Fact(DisplayName = "Comando válido passa no validator de criação")]
+    public void Criar_Valido_Passa()
+    {
+        _criarValidator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Comando válido sem fase típica passa")]
+    public void Criar_SemFaseTipica_Passa()
+    {
+        _criarValidator.Validate(Base() with { FaseTipica = null }).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Código fora do formato é rejeitado")]
+    [InlineData("banca_entrevista")]
+    [InlineData("BANCA-ENTREVISTA")]
+    [InlineData("")]
+    public void Criar_CodigoInvalido_Rejeita(string codigo)
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { Codigo = codigo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoBancaCommand.Codigo));
+    }
+
+    [Fact(DisplayName = "Código bem-formado fora do conjunto canônico é rejeitado")]
+    public void Criar_CodigoForaDoCanonico_Rejeita()
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { Codigo = "BANCA_LOGISTICA" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoBancaCommand.Codigo));
+    }
+
+    [Fact(DisplayName = "Nome ausente é rejeitado")]
+    public void Criar_SemNome_Rejeita()
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { Nome = "" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoBancaCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Fase típica acima de 60 caracteres é rejeitada")]
+    public void Criar_FaseTipicaLonga_Rejeita()
+    {
+        ValidationResult resultado = _criarValidator.Validate(Base() with { FaseTipica = new string('a', 61) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoBancaCommand.FaseTipica));
+    }
+
+    [Fact(DisplayName = "Atualização com Id vazio é rejeitada")]
+    public void Atualizar_IdVazio_Rejeita()
+    {
+        ValidationResult resultado = _atualizarValidator.Validate(
+            new AtualizarTipoBancaCommand(Guid.Empty, Nome: "Banca de entrevista"));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(AtualizarTipoBancaCommand.Id));
+    }
+
+    [Fact(DisplayName = "Atualização válida passa no validator")]
+    public void Atualizar_Valido_Passa()
+    {
+        _atualizarValidator.Validate(
+            new AtualizarTipoBancaCommand(Guid.CreateVersion7(), Nome: "Banca de entrevista"))
+            .IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/FaseCanonicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/FaseCanonicaTests.cs
@@ -1,0 +1,244 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class FaseCanonicaTests
+{
+    private static Result<FaseCanonica> Criar(
+        string codigo = "INSCRICAO",
+        string? nome = "Inscrição",
+        string? descricao = null,
+        string? dono = "CEPS",
+        bool agrupaEtapas = false,
+        bool permiteComplementacao = false,
+        string? baseLegal = null) =>
+        FaseCanonica.Criar(codigo, nome, descricao, dono, agrupaEtapas, permiteComplementacao, baseLegal);
+
+    // ── Factory válida ─────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Fase válida preenche os campos e fica ativa com Guid v7")]
+    public void Criar_Valida_Aceita()
+    {
+        FaseCanonica f = Criar(
+            codigo: "AVALIACAO", nome: "Avaliação", dono: "CEPS", agrupaEtapas: true).Value!;
+
+        f.Id.Should().NotBe(Guid.Empty);
+        f.Codigo.Valor.Should().Be("AVALIACAO");
+        f.Nome.Should().Be("Avaliação");
+        f.DonoTipico.Should().Be(DonoTipico.Ceps);
+        f.AgrupaEtapas.Should().BeTrue();
+        f.PermiteComplementacao.Should().BeFalse();
+        f.IsDeleted.Should().BeFalse();
+    }
+
+    // ── Formato do código ──────────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Código com minúscula, hífen, dígito ou espaço é rejeitado (formato)")]
+    [InlineData("inscricao")]
+    [InlineData("RESULTADO-FINAL")]
+    [InlineData("FASE2")]
+    [InlineData("LISTA ESPERA")]
+    public void Criar_CodigoForaDoFormato_Falha(string codigo)
+    {
+        Result<FaseCanonica> r = Criar(codigo: codigo);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.CodigoFormatoInvalido);
+    }
+
+    [Theory(DisplayName = "Código ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemCodigo_Falha(string codigo)
+    {
+        Result<FaseCanonica> r = Criar(codigo: codigo);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.CodigoObrigatorio);
+    }
+
+    // ── Domínio canônico ───────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Código bem-formado fora do conjunto canônico é rejeitado")]
+    public void Criar_CodigoForaDoConjuntoCanonico_Falha()
+    {
+        Result<FaseCanonica> r = Criar(codigo: "ENTREVISTA_FINAL");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.CodigoForaDoConjuntoCanonico);
+    }
+
+    [Theory(DisplayName = "Códigos dentro do conjunto canônico são aceitos")]
+    [InlineData("HETEROIDENTIFICACAO")]
+    [InlineData("HOMOLOGACAO_RESULTADO_FINAL")]
+    [InlineData("CHAMADA")]
+    public void Criar_CodigoCanonico_Aceita(string codigo)
+    {
+        Result<FaseCanonica> r = Criar(codigo: codigo);
+
+        r.IsSuccess.Should().BeTrue();
+    }
+
+    // ── Nome ───────────────────────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Nome ausente é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemNome_Falha(string nome)
+    {
+        Result<FaseCanonica> r = Criar(nome: nome);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.NomeObrigatorio);
+    }
+
+    [Fact(DisplayName = "Nome acima de 200 caracteres é rejeitado")]
+    public void Criar_NomeLongo_Falha()
+    {
+        Result<FaseCanonica> r = Criar(nome: new string('a', 201));
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.NomeTamanho);
+    }
+
+    // ── Dono típico ────────────────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Dono típico em domínio é aceito")]
+    [InlineData("CEPS", DonoTipico.Ceps)]
+    [InlineData("CRCA", DonoTipico.Crca)]
+    [InlineData("MEC", DonoTipico.Mec)]
+    [InlineData("CONSEPE", DonoTipico.Consepe)]
+    public void Criar_DonoTipicoValido_Aceita(string token, DonoTipico esperado)
+    {
+        FaseCanonica f = Criar(codigo: "MATRICULA", nome: "Matrícula", dono: token).Value!;
+
+        f.DonoTipico.Should().Be(esperado);
+    }
+
+    [Theory(DisplayName = "Dono típico ausente é rejeitado (obrigatório)")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemDonoTipico_Falha(string dono)
+    {
+        Result<FaseCanonica> r = Criar(dono: dono);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.DonoTipicoObrigatorio);
+    }
+
+    [Theory(DisplayName = "Dono típico fora do domínio (incl. numérico e PascalCase) é rejeitado")]
+    [InlineData("DTI")]
+    [InlineData("1")]
+    [InlineData("Ceps")]
+    public void Criar_DonoTipicoInvalido_Falha(string dono)
+    {
+        Result<FaseCanonica> r = Criar(dono: dono);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.DonoTipicoInvalido);
+    }
+
+    // ── Coerência agrupa_etapas ⇒ avaliação ────────────────────────────────────
+
+    [Fact(DisplayName = "Agrupar etapas verdadeiro para a fase de avaliação é aceito")]
+    public void Criar_AgrupaEtapasAvaliacao_Aceita()
+    {
+        Result<FaseCanonica> r = Criar(codigo: "AVALIACAO", nome: "Avaliação", agrupaEtapas: true);
+
+        r.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Agrupar etapas verdadeiro para fase que não é avaliação é rejeitado")]
+    public void Criar_AgrupaEtapasForaDaAvaliacao_Falha()
+    {
+        Result<FaseCanonica> r = Criar(codigo: "HOMOLOGACAO", nome: "Homologação", agrupaEtapas: true);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.AgrupaEtapasApenasAvaliacao);
+    }
+
+    [Fact(DisplayName = "Agrupar etapas é falso por omissão")]
+    public void Criar_SemAgrupaEtapas_DefaultFalso()
+    {
+        FaseCanonica f = Criar(codigo: "HOMOLOGACAO", nome: "Homologação").Value!;
+
+        f.AgrupaEtapas.Should().BeFalse();
+    }
+
+    // ── Coerência permite_complementacao ⇒ fases permitidas ────────────────────
+
+    [Theory(DisplayName = "Permitir complementação verdadeiro em fase permitida é aceito")]
+    [InlineData("HOMOLOGACAO")]
+    [InlineData("RECURSOS")]
+    public void Criar_ComplementacaoFasePermitida_Aceita(string codigo)
+    {
+        Result<FaseCanonica> r = Criar(codigo: codigo, nome: "Fase", permiteComplementacao: true);
+
+        r.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Permitir complementação verdadeiro em fase vedada (habilitação) é rejeitado")]
+    public void Criar_ComplementacaoFaseVedada_Falha()
+    {
+        Result<FaseCanonica> r = Criar(codigo: "HABILITACAO", nome: "Habilitação", permiteComplementacao: true);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.ComplementacaoApenasFasesPermitidas);
+    }
+
+    [Fact(DisplayName = "Permitir complementação é falso por omissão")]
+    public void Criar_SemComplementacao_DefaultFalso()
+    {
+        FaseCanonica f = Criar(codigo: "HABILITACAO", nome: "Habilitação").Value!;
+
+        f.PermiteComplementacao.Should().BeFalse();
+    }
+
+    // ── Base legal ─────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Base legal acima de 500 caracteres é rejeitada")]
+    public void Criar_BaseLegalLonga_Falha()
+    {
+        Result<FaseCanonica> r = Criar(baseLegal: new string('a', 501));
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.BaseLegalTamanho);
+    }
+
+    // ── Imutabilidade / atualização ────────────────────────────────────────────
+
+    [Fact(DisplayName = "Atualizar troca atributos editáveis mantendo Codigo e Id imutáveis")]
+    public void Atualizar_MantemCodigoEId()
+    {
+        FaseCanonica f = Criar(codigo: "ENSALAMENTO", nome: "Ensalamento").Value!;
+        Guid idOriginal = f.Id;
+
+        Result r = f.Atualizar(
+            nome: "Ensalamento (novo)", descricao: "Nova descrição", donoTipico: "CRCA",
+            agrupaEtapas: false, permiteComplementacao: false, baseLegal: null);
+
+        r.IsSuccess.Should().BeTrue();
+        f.Codigo.Valor.Should().Be("ENSALAMENTO", "o código é imutável");
+        f.Id.Should().Be(idOriginal, "o Id é imutável");
+        f.Nome.Should().Be("Ensalamento (novo)");
+        f.DonoTipico.Should().Be(DonoTipico.Crca);
+    }
+
+    [Fact(DisplayName = "Atualizar revalida coerência de agrupar etapas contra o código congelado")]
+    public void Atualizar_AgrupaEtapasIncoerente_Falha()
+    {
+        FaseCanonica f = Criar(codigo: "HOMOLOGACAO", nome: "Homologação").Value!;
+
+        Result r = f.Atualizar(
+            nome: "Homologação", descricao: null, donoTipico: "CEPS",
+            agrupaEtapas: true, permiteComplementacao: false, baseLegal: null);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(FaseCanonicaErrorCodes.AgrupaEtapasApenasAvaliacao);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TipoBancaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TipoBancaTests.cs
@@ -1,0 +1,144 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class TipoBancaTests
+{
+    private static Result<TipoBanca> Criar(
+        string codigo = "BANCA_ENTREVISTA",
+        string? nome = "Banca de entrevista",
+        string? faseTipica = null,
+        string? descricao = null) =>
+        TipoBanca.Criar(codigo, nome, faseTipica, descricao);
+
+    // ── Factory válida ─────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Tipo de banca válido preenche os campos e fica ativo com Guid v7")]
+    public void Criar_Valido_Aceita()
+    {
+        TipoBanca b = Criar(codigo: "BANCA_ANALISE_DOCUMENTAL", nome: "Banca de análise documental").Value!;
+
+        b.Id.Should().NotBe(Guid.Empty);
+        b.Codigo.Valor.Should().Be("BANCA_ANALISE_DOCUMENTAL");
+        b.Nome.Should().Be("Banca de análise documental");
+        b.FaseTipica.Should().BeNull();
+        b.IsDeleted.Should().BeFalse();
+    }
+
+    // ── Formato do código ──────────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Código com minúscula, hífen ou dígito é rejeitado (formato)")]
+    [InlineData("banca_entrevista")]
+    [InlineData("BANCA-ENTREVISTA")]
+    [InlineData("BANCA2")]
+    public void Criar_CodigoForaDoFormato_Falha(string codigo)
+    {
+        Result<TipoBanca> r = Criar(codigo: codigo);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(TipoBancaErrorCodes.CodigoFormatoInvalido);
+    }
+
+    [Theory(DisplayName = "Código ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemCodigo_Falha(string codigo)
+    {
+        Result<TipoBanca> r = Criar(codigo: codigo);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(TipoBancaErrorCodes.CodigoObrigatorio);
+    }
+
+    // ── Domínio canônico ───────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Código bem-formado fora do conjunto canônico é rejeitado")]
+    public void Criar_CodigoForaDoConjuntoCanonico_Falha()
+    {
+        Result<TipoBanca> r = Criar(codigo: "BANCA_LOGISTICA");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(TipoBancaErrorCodes.CodigoForaDoConjuntoCanonico);
+    }
+
+    [Theory(DisplayName = "Códigos dentro do conjunto canônico são aceitos")]
+    [InlineData("BANCA_ANALISE_DOCUMENTAL")]
+    [InlineData("BANCA_CORRECAO_REDACOES")]
+    [InlineData("BANCA_ANALISE_RECURSOS")]
+    public void Criar_CodigoCanonico_Aceita(string codigo)
+    {
+        Result<TipoBanca> r = Criar(codigo: codigo);
+
+        r.IsSuccess.Should().BeTrue();
+    }
+
+    // ── Nome ───────────────────────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Nome ausente é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemNome_Falha(string nome)
+    {
+        Result<TipoBanca> r = Criar(nome: nome);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(TipoBancaErrorCodes.NomeObrigatorio);
+    }
+
+    [Fact(DisplayName = "Nome acima de 200 caracteres é rejeitado")]
+    public void Criar_NomeLongo_Falha()
+    {
+        Result<TipoBanca> r = Criar(nome: new string('a', 201));
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(TipoBancaErrorCodes.NomeTamanho);
+    }
+
+    // ── Fase típica (orientativa, não vinculante) ──────────────────────────────
+
+    [Fact(DisplayName = "Banca sem fase típica é aceita (fase típica nula)")]
+    public void Criar_SemFaseTipica_Aceita()
+    {
+        TipoBanca b = Criar(codigo: "BANCA_ANALISE_RECURSOS", nome: "Banca de análise de recursos", faseTipica: null).Value!;
+
+        b.FaseTipica.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Fase típica é rótulo orientativo — valor sem correspondência é aceito")]
+    public void Criar_FaseTipicaNaoVinculante_Aceita()
+    {
+        TipoBanca b = Criar(faseTipica: "Fase que não corresponde a nenhum código de fase").Value!;
+
+        b.FaseTipica.Should().Be("Fase que não corresponde a nenhum código de fase");
+    }
+
+    [Fact(DisplayName = "Fase típica acima de 60 caracteres é rejeitada")]
+    public void Criar_FaseTipicaLonga_Falha()
+    {
+        Result<TipoBanca> r = Criar(faseTipica: new string('a', 61));
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(TipoBancaErrorCodes.FaseTipicaTamanho);
+    }
+
+    // ── Imutabilidade / atualização ────────────────────────────────────────────
+
+    [Fact(DisplayName = "Atualizar troca atributos editáveis mantendo Codigo e Id imutáveis")]
+    public void Atualizar_MantemCodigoEId()
+    {
+        TipoBanca b = Criar(codigo: "BANCA_ANALISE_RECURSOS", nome: "Banca de análise de recursos").Value!;
+        Guid idOriginal = b.Id;
+
+        Result r = b.Atualizar(nome: "Banca de recursos (novo)", faseTipica: "Recursos", descricao: "desc");
+
+        r.IsSuccess.Should().BeTrue();
+        b.Codigo.Valor.Should().Be("BANCA_ANALISE_RECURSOS", "o código é imutável");
+        b.Id.Should().Be(idOriginal, "o Id é imutável");
+        b.Nome.Should().Be("Banca de recursos (novo)");
+        b.FaseTipica.Should().Be("Recursos");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FasesCanonicas/FaseCanonicaEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FasesCanonicas/FaseCanonicaEndpointTests.cs
@@ -1,0 +1,178 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.FasesCanonicas;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>FaseCanonica</c> (UNI-REQ-0064):
+/// routing, vendor media type, HATEOAS, autenticação/autorização, idempotência,
+/// domínio canônico (422), coerência de domínio (422) e unicidade do código (409) —
+/// com Wolverine contra Postgres efêmero. Cada teste que persiste usa um código
+/// canônico distinto (o conjunto é fechado, não há códigos aleatórios).
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class FaseCanonicaEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public FaseCanonicaEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/fases-canonicas retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/fases-canonicas", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.fase-canonica.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/fases-canonicas/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/fases-canonicas/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/configuracao/admin/fases-canonicas sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/fases-canonicas", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        var body = new { codigo = "MATRICULA", nome = "Matrícula", donoTipico = "CRCA" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/fases-canonicas", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/fases-canonicas", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST cria (201) e o GET subsequente retorna os campos + HATEOAS")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        var body = new
+        {
+            codigo = "CHAMADA",
+            nome = "Chamada",
+            donoTipico = "CEPS",
+            descricao = "Convocação de aprovados",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/fases-canonicas/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("codigo").GetString().Should().Be("CHAMADA");
+        root.GetProperty("nome").GetString().Should().Be("Chamada");
+        root.GetProperty("donoTipico").GetString().Should().Be("CEPS");
+        root.GetProperty("agrupaEtapas").GetBoolean().Should().BeFalse();
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "POST com código fora do conjunto canônico retorna 422")]
+    public async Task Criar_ForaDoCanonico_Retorna422()
+    {
+        var body = new { codigo = "ENTREVISTA_FINAL", nome = "x", donoTipico = "CEPS" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com agrupar etapas fora da avaliação retorna 422 (coerência de domínio)")]
+    public async Task Criar_AgrupaEtapasIncoerente_Retorna422()
+    {
+        var body = new { codigo = "HOMOLOGACAO", nome = "Homologação", donoTipico = "CEPS", agrupaEtapas = true };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com código já existente entre vivos retorna 409")]
+    public async Task Criar_CodigoDuplicado_Retorna409()
+    {
+        var body = new { codigo = "LISTA_ESPERA", nome = "Lista de espera", donoTipico = "CEPS" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage primeiro = await EnviarPostAdmin(client, body);
+        primeiro.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage segundo = await EnviarPostAdmin(client, body);
+        segundo.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/fases-canonicas", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FasesCanonicas/FaseCanonicaPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FasesCanonicas/FaseCanonicaPersistenceTests.cs
@@ -1,0 +1,210 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.FasesCanonicas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta da FaseCanonica contra Postgres real (UNI-REQ-0064):
+/// persistência, UNIQUE parcial do código vivo, liberação do slot por soft-delete,
+/// CHECKs de domínio (formato, conjunto canônico, dono típico, coerência de
+/// agrupar etapas e complementação) e leitura cross-módulo ordenada por código.
+/// Cada teste usa códigos canônicos distintos (o conjunto é fechado).
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class FaseCanonicaPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public FaseCanonicaPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Criar persiste os campos e fica visível pelo leitor cross-módulo")]
+    public async Task Insert_PersisteEFicaVisivelPeloReader()
+    {
+        FaseCanonica fase = Fase("INSCRICAO", "Inscrição", "CEPS");
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.FasesCanonicas.Add(fase);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        FaseCanonica persistida = await readCtx.FasesCanonicas.SingleAsync(f => f.Id == fase.Id);
+
+        persistida.Codigo.Valor.Should().Be("INSCRICAO");
+        persistida.DonoTipico.Should().Be(DonoTipico.Ceps);
+        persistida.CreatedBy.Should().Be(AdminA);
+        persistida.IsDeleted.Should().BeFalse();
+
+        var reader = new FaseCanonicaReader(readCtx);
+        FaseCanonicaView? view = await reader.ObterPorIdAsync(fase.Id);
+        view.Should().NotBeNull();
+        view!.Codigo.Should().Be("INSCRICAO");
+        view.DonoTipico.Should().Be("CEPS");
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial do código rejeita segunda fase viva com mesmo código")]
+    public async Task UniquePartial_Codigo_RejeitaDuplicataAtiva()
+    {
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.FasesCanonicas.Add(Fase("ENSALAMENTO", "Ensalamento", "CEPS"));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.FasesCanonicas.Add(Fase("ENSALAMENTO", "Ensalamento", "CEPS"));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_fase_canonica_codigo_vivo");
+    }
+
+    [Fact(DisplayName = "Soft-delete preserva a trilha e libera o slot da UNIQUE parcial do código")]
+    public async Task SoftDelete_LiberaSlot()
+    {
+        FaseCanonica fase = Fase("CLASSIFICACAO", "Classificação", "CEPS");
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.FasesCanonicas.Add(fase);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            FaseCanonica tracked = await ctx.FasesCanonicas.SingleAsync(f => f.Id == fase.Id);
+            ctx.FasesCanonicas.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            FaseCanonica excluida = await ctx.FasesCanonicas
+                .IgnoreQueryFilters().SingleAsync(f => f.Id == fase.Id);
+            excluida.IsDeleted.Should().BeTrue();
+            excluida.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.FasesCanonicas.Add(Fase("CLASSIFICACAO", "Classificação", "CEPS"));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do código foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita código fora do conjunto canônico via SQL cru")]
+    public async Task Check_RejeitaCodigoForaDoCanonicoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.fase_canonica (id, codigo, nome, dono_tipico, agrupa_etapas, permite_complementacao, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"FASE_INVALIDA"}, {"Fase"}, {"CEPS"}, {false}, {false}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de conjunto canônico impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita código fora do formato via SQL cru")]
+    public async Task Check_RejeitaCodigoForaDoFormatoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.fase_canonica (id, codigo, nome, dono_tipico, agrupa_etapas, permite_complementacao, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"lista-espera"}, {"Fase"}, {"CEPS"}, {false}, {false}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK codigo ~ '^[A-Z_]+$' impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita dono típico fora do domínio via SQL cru")]
+    public async Task Check_RejeitaDonoTipicoForaDoDominioViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.fase_canonica (id, codigo, nome, dono_tipico, agrupa_etapas, permite_complementacao, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"RESULTADO_PRELIMINAR"}, {"Resultado preliminar"}, {"DTI"}, {false}, {false}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de domínio de dono_tipico impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita agrupar etapas fora da avaliação via SQL cru")]
+    public async Task Check_RejeitaAgrupaEtapasForaDaAvaliacaoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.fase_canonica (id, codigo, nome, dono_tipico, agrupa_etapas, permite_complementacao, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"HABILITACAO"}, {"Habilitação"}, {"MEC"}, {true}, {false}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de coerência agrupa_etapas ⇒ avaliação impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita complementação em fase vedada via SQL cru")]
+    public async Task Check_RejeitaComplementacaoFaseVedadaViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.fase_canonica (id, codigo, nome, dono_tipico, agrupa_etapas, permite_complementacao, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"RESULTADO_FINAL"}, {"Resultado final"}, {"CEPS"}, {false}, {true}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de coerência permite_complementacao ⇒ fases permitidas impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "Reader.ListarVivosAsync ordena por código ascendente e exclui soft-deleted")]
+    public async Task ListarVivos_OrdenaPorCodigoEExcluiSoftDeleted()
+    {
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.FasesCanonicas.Add(Fase("MATRICULA", "Matrícula", "CRCA"));
+            ctx.FasesCanonicas.Add(Fase("HETEROIDENTIFICACAO", "Heteroidentificação", "CEPS"));
+            ctx.FasesCanonicas.Add(Fase("CHAMADA", "Chamada", "CEPS"));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            CodigoFase voExcluido = CodigoFase.Criar("CHAMADA").Value!;
+            FaseCanonica aExcluir = await ctx.FasesCanonicas.SingleAsync(f => f.Codigo == voExcluido);
+            ctx.FasesCanonicas.Remove(aExcluir);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new FaseCanonicaReader(readCtx);
+        IReadOnlyList<FaseCanonicaView> todos = await reader.ListarVivosAsync();
+
+        string[] codigos = [.. todos.Select(v => v.Codigo)];
+        codigos.Should().BeInAscendingOrder("o leitor ordena por código ascendente");
+        codigos.Should().Contain(["HETEROIDENTIFICACAO", "MATRICULA"]);
+        codigos.Should().NotContain("CHAMADA", "a fase soft-deleted não aparece no leitor de vivos");
+    }
+
+    private static FaseCanonica Fase(string codigo, string nome, string dono) =>
+        FaseCanonica.Criar(codigo, nome, null, dono, false, false, null).Value!;
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposBanca/TipoBancaEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposBanca/TipoBancaEndpointTests.cs
@@ -1,0 +1,164 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.TiposBanca;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>TipoBanca</c> (UNI-REQ-0064):
+/// routing, vendor media type, HATEOAS, autenticação/autorização, idempotência,
+/// domínio canônico (422) e unicidade do código (409) — com Wolverine contra
+/// Postgres efêmero. Cada teste que persiste usa um código canônico distinto.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class TipoBancaEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public TipoBancaEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/tipos-banca retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/tipos-banca", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.tipo-banca.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/tipos-banca/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/tipos-banca/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/configuracao/admin/tipos-banca sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-banca", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        var body = new { codigo = "BANCA_ENTREVISTA", nome = "Banca de entrevista" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-banca", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-banca", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST cria (201) e o GET subsequente retorna os campos + HATEOAS")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        var body = new
+        {
+            codigo = "BANCA_CORRECAO_REDACOES",
+            nome = "Banca de correção de redações",
+            faseTipica = "Avaliação",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/tipos-banca/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("codigo").GetString().Should().Be("BANCA_CORRECAO_REDACOES");
+        root.GetProperty("nome").GetString().Should().Be("Banca de correção de redações");
+        root.GetProperty("faseTipica").GetString().Should().Be("Avaliação");
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "POST com código fora do conjunto canônico retorna 422")]
+    public async Task Criar_ForaDoCanonico_Retorna422()
+    {
+        var body = new { codigo = "BANCA_LOGISTICA", nome = "x" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com código já existente entre vivos retorna 409")]
+    public async Task Criar_CodigoDuplicado_Retorna409()
+    {
+        var body = new { codigo = "BANCA_ANALISE_DOCUMENTAL", nome = "Banca de análise documental" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage primeiro = await EnviarPostAdmin(client, body);
+        primeiro.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage segundo = await EnviarPostAdmin(client, body);
+        segundo.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/tipos-banca", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposBanca/TipoBancaPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TiposBanca/TipoBancaPersistenceTests.cs
@@ -1,0 +1,170 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.TiposBanca;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta do TipoBanca contra Postgres real (UNI-REQ-0064):
+/// persistência, UNIQUE parcial do código vivo, liberação do slot por soft-delete,
+/// CHECKs de domínio (formato, conjunto canônico) e leitura cross-módulo. Cada teste
+/// usa um código canônico distinto (o conjunto é fechado — quatro bancas).
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class TipoBancaPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public TipoBancaPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Criar persiste os campos e fica visível pelo leitor cross-módulo")]
+    public async Task Insert_PersisteEFicaVisivelPeloReader()
+    {
+        TipoBanca banca = Banca("BANCA_ANALISE_DOCUMENTAL", "Banca de análise documental", "Homologação");
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposBanca.Add(banca);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        TipoBanca persistida = await readCtx.TiposBanca.SingleAsync(b => b.Id == banca.Id);
+
+        persistida.Codigo.Valor.Should().Be("BANCA_ANALISE_DOCUMENTAL");
+        persistida.FaseTipica.Should().Be("Homologação");
+        persistida.CreatedBy.Should().Be(AdminA);
+        persistida.IsDeleted.Should().BeFalse();
+
+        var reader = new TipoBancaReader(readCtx);
+        TipoBancaView? view = await reader.ObterPorIdAsync(banca.Id);
+        view.Should().NotBeNull();
+        view!.Codigo.Should().Be("BANCA_ANALISE_DOCUMENTAL");
+        view.FaseTipica.Should().Be("Homologação");
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial do código rejeita segunda banca viva com mesmo código")]
+    public async Task UniquePartial_Codigo_RejeitaDuplicataAtiva()
+    {
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposBanca.Add(Banca("BANCA_ENTREVISTA", "Banca de entrevista", null));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.TiposBanca.Add(Banca("BANCA_ENTREVISTA", "Banca de entrevista", null));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_tipo_banca_codigo_vivo");
+    }
+
+    [Fact(DisplayName = "Soft-delete preserva a trilha e libera o slot da UNIQUE parcial do código")]
+    public async Task SoftDelete_LiberaSlot()
+    {
+        TipoBanca banca = Banca("BANCA_CORRECAO_REDACOES", "Banca de correção de redações", null);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposBanca.Add(banca);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            TipoBanca tracked = await ctx.TiposBanca.SingleAsync(b => b.Id == banca.Id);
+            ctx.TiposBanca.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            TipoBanca excluida = await ctx.TiposBanca
+                .IgnoreQueryFilters().SingleAsync(b => b.Id == banca.Id);
+            excluida.IsDeleted.Should().BeTrue();
+            excluida.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.TiposBanca.Add(Banca("BANCA_CORRECAO_REDACOES", "Banca de correção de redações", null));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do código foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita código fora do conjunto canônico via SQL cru")]
+    public async Task Check_RejeitaCodigoForaDoCanonicoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.tipo_banca (id, codigo, nome, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"BANCA_LOGISTICA"}, {"Banca"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de conjunto canônico impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita código fora do formato via SQL cru")]
+    public async Task Check_RejeitaCodigoForaDoFormatoViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.tipo_banca (id, codigo, nome, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {"banca-entrevista"}, {"Banca"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK codigo ~ '^[A-Z_]+$' impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "Reader.ListarVivosAsync exclui bancas soft-deleted")]
+    public async Task ListarVivos_ExcluiSoftDeleted()
+    {
+        TipoBanca banca = Banca("BANCA_ANALISE_RECURSOS", "Banca de análise de recursos", null);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.TiposBanca.Add(banca);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            CodigoBanca vo = CodigoBanca.Criar("BANCA_ANALISE_RECURSOS").Value!;
+            TipoBanca aExcluir = await ctx.TiposBanca.SingleAsync(b => b.Codigo == vo);
+            ctx.TiposBanca.Remove(aExcluir);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new TipoBancaReader(readCtx);
+        IReadOnlyList<TipoBancaView> todos = await reader.ListarVivosAsync();
+
+        string[] codigos = [.. todos.Select(v => v.Codigo)];
+        codigos.Should().BeInAscendingOrder("o leitor ordena por código ascendente");
+        codigos.Should().NotContain("BANCA_ANALISE_RECURSOS", "a banca soft-deleted não aparece no leitor de vivos");
+    }
+
+    private static TipoBanca Banca(string codigo, string nome, string? faseTipica) =>
+        TipoBanca.Criar(codigo, nome, faseTipica, null).Value!;
+}


### PR DESCRIPTION
## Resumo

- Entrega os dois cadastros de referência do vocabulário de cronograma da plataforma (UNI-REQ-0064): `FaseCanonica` (as quatorze fases do ciclo de vida de um processo seletivo) e `TipoBanca` (os quatro tipos de banca).
- São entidades-raiz independentes, sem vínculo de cadastro entre si, cada uma implementada como vertical slice completo no módulo Configuração.
- Migration forward-only cria `fase_canonica` e `tipo_banca`; baseline OpenAPI de Configuração regenerado com os oito novos endpoints.

## Mudanças

Cada cadastro segue o padrão canônico dos demais cadastros de Configuração: entidade sealed com factory e código imutável (value object), commands/handlers/validators (Wolverine), queries paginadas por cursor, leitor read-side cross-módulo (ADR-0056) com View e Snapshot congelável por valor (ADR-0061), persistência EF no banco isolado de Configuração (ADR-0054) e endpoints REST com HATEOAS e idempotência.

**Regras de domínio:**
- `codigo` em domínio canônico fechado (guard + validator + CHECK); formato `^[A-Z_]+$` (sem hífen e sem dígito); único entre vivos (índice parcial).
- `FaseCanonica`: `dono_tipico` obrigatório em `{CEPS,CRCA,MEC,CONSEPE}`; `agrupa_etapas` verdadeiro só para `AVALIACAO`; `permite_complementacao` verdadeiro só para `HOMOLOGACAO` e `RECURSOS` (SiSU veda na habilitação). Coerência revalidada na atualização e reforçada por CHECK.
- `TipoBanca`: `fase_tipica` é rótulo de texto orientativo, não vinculante, sem FK.
- Remoção sempre soft-delete, nunca bloqueada: o único consumo é por snapshot-copy desacoplado no Módulo Seleção, sem FK intra-banco.

### Novos arquivos (79)
- `Domain`: entidades `FaseCanonica`/`TipoBanca`, value objects `CodigoFase`/`CodigoBanca`, enums, erros
- `Application`: commands/queries/validators/mappings para os dois cadastros
- `Infrastructure`: `FaseCanonicaConfiguration`/`TipoBancaConfiguration`, converters, repositórios, readers cross-módulo, migration `AddFaseCanonicaETipoBanca`
- `API`: `FasesCanonicasController`/`TiposBancaController`
- `tests`: suítes de unidade (Domain/Application) e integração (endpoint + persistência) para os dois cadastros

### Modificados (6)
- `contracts/openapi.configuracao.json` — baseline regenerado com os oito novos endpoints
- `ConfiguracaoModuleRegistration.cs` / `ConfiguracaoDomainErrorRegistration.cs` — registro dos novos controllers e mapeamento de erros
- `Configuracao.Infrastructure/DependencyInjection.cs` / `ConfiguracaoDbContext.cs` / `ConfiguracaoDbContextModelSnapshot.cs` — DbSets e wiring dos dois cadastros

## Testes

Validado localmente (rebase sobre `main` atualizado, sem workaround de CVE):

- Build (`UniPlus.slnx -warnaserror`): 48 projetos, 0 erros, 0 warnings
- `Configuracao.Domain.UnitTests`: 237/237
- `Configuracao.Application.UnitTests`: 206/206
- `Configuracao.IntegrationTests`: 173/174 (1 skip esperado — CA-05, bloqueio de remoção de `LocalOferta` por `OfertaCurso` viva, será ativado pela task #731 quando #588 existir)
- `ArchTests` (fitness, inclui baseline OpenAPI): 17/17

## Checklist

- [x] Build sem errors
- [x] Testes passando
- [x] Código revisado

Closes #592