### PR TITLE
feat(configuracao): adiciona cadastro de curso

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -1122,6 +1122,486 @@
         }
       }
     },
+    "/api/configuracao/cursos": {
+      "get": {
+        "tags": [
+          "Cursos"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CursoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CursoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CursoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/cursos/{id}": {
+      "get": {
+        "tags": [
+          "Cursos"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CursoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CursoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CursoDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/cursos": {
+      "post": {
+        "tags": [
+          "Cursos"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCursoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCursoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCursoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/cursos/{id}": {
+      "put": {
+        "tags": [
+          "Cursos"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarCursoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarCursoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarCursoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "Cursos"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configuracao/fases-canonicas": {
       "get": {
         "tags": [
@@ -5391,6 +5871,40 @@
           }
         }
       },
+      "AtualizarCursoCommand": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "grau",
+          "nivelEnsino"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "grau": {
+            "type": "string"
+          },
+          "nivelEnsino": {
+            "type": "string"
+          },
+          "grupoAreaEnem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "AtualizarFaseCanonicaCommand": {
         "required": [
           "id"
@@ -6075,6 +6589,35 @@
           }
         }
       },
+      "CriarCursoCommand": {
+        "required": [
+          "codigo",
+          "nome",
+          "grau",
+          "nivelEnsino"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "grau": {
+            "type": "string"
+          },
+          "nivelEnsino": {
+            "type": "string"
+          },
+          "grupoAreaEnem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "CriarFaseCanonicaCommand": {
         "required": [
           "codigo"
@@ -6468,6 +7011,55 @@
               "null",
               "string"
             ]
+          }
+        }
+      },
+      "CursoDto": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "grau",
+          "nivelEnsino",
+          "grupoAreaEnem",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "grau": {
+            "type": "string"
+          },
+          "nivelEnsino": {
+            "type": "string"
+          },
+          "grupoAreaEnem": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },
@@ -7343,6 +7935,9 @@
     },
     {
       "name": "CondicoesAtendimento"
+    },
+    {
+      "name": "Cursos"
     },
     {
       "name": "FasesCanonicas"

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
@@ -57,6 +57,7 @@ public static class ConfiguracaoModuleRegistration
         services.AddSingleton<IResourceLinksBuilder<ModalidadeDto>, ModalidadeLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<FaseCanonicaDto>, FaseCanonicaLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<TipoBancaDto>, TipoBancaLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<CursoDto>, CursoLinksBuilder>();
 
         // Idempotency-Key (ADR-0027) sobre o DbContext do módulo.
         services.AddIdempotency<ConfiguracaoDbContext, ConfiguracaoApiAssemblyMarker>(configuration);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CursosController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CursosController.cs
@@ -1,0 +1,187 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.Cursos;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/cursos</c>,
+/// <c>GET /api/configuracao/cursos/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/configuracao/admin/cursos</c>) restritos a
+/// <c>plataforma-admin</c> (story #588, ADR-0066).
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class CursosController : ControllerBase
+{
+    private const string ResourceTag = "cursos";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<CursoDto> _linksBuilder;
+
+    public CursosController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<CursoDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista os cursos ativos, paginados por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("cursos")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "curso", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<CursoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarCursosResult resultado = await _queryBus
+            .Send(new ListarCursosQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        CursoDto[] comLinks =
+            [.. resultado.Items.Select(c => c with { Links = _linksBuilder.Build(c) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém um curso pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("cursos/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "curso", Versions = [1])]
+    [ProducesResponseType(typeof(CursoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        CursoDto? curso = await _queryBus
+            .Send(new ObterCursoPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (curso is null)
+        {
+            return NotFound();
+        }
+
+        CursoDto comLinks = curso with { Links = _linksBuilder.Build(curso) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria um novo curso. Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/cursos")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarCursoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Atualiza um curso existente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPut("admin/cursos/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarCursoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) um curso. Restrito a <c>plataforma-admin</c>. Bloqueado (409) quando referenciado por oferta de curso viva (#749).</summary>
+    [HttpDelete("admin/cursos/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverCursoCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -748,5 +748,77 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status404NotFound,
                 "uniplus.configuracao.tipo_banca.nao_encontrado",
                 "Tipo de banca não encontrado")),
+        // ── Curso (UNI-REQ-0010) ──────────────────────────────────────────
+        new(CursoErrorCodes.CodigoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.curso.codigo_obrigatorio",
+                "Código do curso é obrigatório")),
+
+        new(CursoErrorCodes.CodigoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.curso.codigo_tamanho",
+                "Tamanho do código do curso inválido")),
+
+        new(CursoErrorCodes.CodigoJaExiste,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.curso.codigo_ja_existe",
+                "Já existe um curso ativo com este código")),
+
+        new(CursoErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.curso.nome_obrigatorio",
+                "Nome do curso é obrigatório")),
+
+        new(CursoErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.curso.nome_tamanho",
+                "Tamanho do nome do curso inválido")),
+
+        new(CursoErrorCodes.GrauObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.curso.grau_obrigatorio",
+                "Grau do curso é obrigatório")),
+
+        new(CursoErrorCodes.GrauTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.curso.grau_tamanho",
+                "Tamanho do grau do curso inválido")),
+
+        new(CursoErrorCodes.NivelEnsinoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.curso.nivel_ensino_obrigatorio",
+                "Nível de ensino do curso é obrigatório")),
+
+        new(CursoErrorCodes.NivelEnsinoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.curso.nivel_ensino_tamanho",
+                "Tamanho do nível de ensino do curso inválido")),
+
+        new(CursoErrorCodes.GrupoAreaEnemInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.curso.grupo_area_enem_invalido",
+                "Grupo de área do ENEM fora do domínio fechado")),
+
+        new(CursoErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.curso.nao_encontrado",
+                "Curso não encontrado")),
+
+        new(CursoErrorCodes.RemocaoBloqueadaPorOfertaCurso,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.curso.remocao_bloqueada_por_oferta_curso",
+                "Não é possível remover um curso referenciado por uma oferta de curso ativa")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CursoLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CursoLinksBuilder.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="CursoDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<CursoDto>, CursoLinksBuilder>().")]
+internal sealed class CursoLinksBuilder : IResourceLinksBuilder<CursoDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CursoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(CursoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "Cursos";
+
+        string self = ResolverPath(
+            httpContext, nameof(CursosController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(CursosController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/AtualizarCursoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/AtualizarCursoCommand.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza um curso existente. O <c>Codigo</c> é editável (mesmo expediente do
+/// TipoDocumento), com nova checagem de unicidade entre vivos; os demais
+/// atributos (nome, grau, nível de ensino, grupo de área do ENEM) também podem
+/// ser editados. O <c>Id</c> é imutável. O ator (<c>updated_by</c>) é carimbado
+/// server-side via <c>IUserContext</c>.
+/// </summary>
+public sealed record AtualizarCursoCommand(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string Grau,
+    string NivelEnsino,
+    string? GrupoAreaEnem = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/AtualizarCursoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/AtualizarCursoCommandHandler.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarCursoCommand"/>. Como o código é editável,
+/// confere a unicidade entre cursos vivos quando ele muda (ignorando o próprio
+/// registro) e protege a corrida traduzindo a violação do índice único parcial
+/// em <c>CodigoJaExiste</c>.
+/// </summary>
+public static class AtualizarCursoCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarCursoCommand command,
+        ICursoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        Curso? curso = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (curso is null)
+        {
+            return Result.Failure(new DomainError(
+                CursoErrorCodes.NaoEncontrado,
+                "Curso não encontrado."));
+        }
+
+        // Código é case-sensitive (Ordinal), normalizado por Trim no agregado — só
+        // checa colisão quando o código efetivamente muda.
+        if (!string.Equals(command.Codigo.Trim(), curso.Codigo, StringComparison.Ordinal)
+            && await repository.CodigoExisteEntreVivosAsync(command.Codigo, command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        Result atualizarResult = curso.Atualizar(
+            command.Codigo,
+            command.Nome,
+            command.Grau,
+            command.NivelEnsino,
+            command.GrupoAreaEnem);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCodigoConflict(constraint))
+        {
+            // Corrida entre a checagem de unicidade e o UPDATE: o índice único parcial
+            // dispara 23505 e viramos o mesmo CodigoJaExiste do caminho não-race.
+            return Result.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        return Result.Success();
+    }
+
+    private static DomainError CodigoJaExisteErro(string codigo) =>
+        new(CursoErrorCodes.CodigoJaExiste,
+            $"Já existe um curso vivo com o código '{codigo}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/AtualizarCursoCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/AtualizarCursoCommandValidator.cs
@@ -1,0 +1,38 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+public sealed class AtualizarCursoCommandValidator
+    : AbstractValidator<AtualizarCursoCommand>
+{
+    public AtualizarCursoCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id do curso é obrigatório.");
+
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código do curso é obrigatório.")
+            .MaximumLength(60).WithMessage("Código do curso deve ter no máximo 60 caracteres.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do curso é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do curso deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Grau)
+            .NotEmpty().WithMessage("Grau do curso é obrigatório.")
+            .MaximumLength(60).WithMessage("Grau do curso deve ter no máximo 60 caracteres.");
+
+        RuleFor(x => x.NivelEnsino)
+            .NotEmpty().WithMessage("Nível de ensino do curso é obrigatório.")
+            .MaximumLength(60).WithMessage("Nível de ensino do curso deve ter no máximo 60 caracteres.");
+
+        // Grupo em branco equivale a "sem grupo" (o domínio normaliza para nulo);
+        // só valida o domínio fechado quando há valor efetivo.
+        RuleFor(x => x.GrupoAreaEnem)
+            .Must(v => GrupoCurso.EhValido(v!))
+            .WithMessage($"Grupo de área do ENEM deve ser um de: {string.Join(", ", GrupoCurso.Valores)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.GrupoAreaEnem));
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/CriarCursoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/CriarCursoCommand.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria um curso — matriz curricular pura: código (chave natural), nome, grau e
+/// nível de ensino (texto livre obrigatório) e grupo de área do ENEM opcional
+/// (domínio fechado de quatro grupos, Res. 805/2024). Código e-MEC, local e
+/// unidade pertencem à <c>OfertaCurso</c> (#749), não aqui. O ator de auditoria
+/// (<c>created_by</c>) é carimbado server-side via <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarCursoCommand(
+    string Codigo,
+    string Nome,
+    string Grau,
+    string NivelEnsino,
+    string? GrupoAreaEnem = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/CriarCursoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/CriarCursoCommandHandler.cs
@@ -1,0 +1,68 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarCursoCommand"/> (convention-based Wolverine):
+/// confere a unicidade do código entre cursos vivos, cria o agregado, persiste e
+/// commita. Protege a corrida check-then-act traduzindo a violação do índice
+/// único parcial em <c>CodigoJaExiste</c>.
+/// </summary>
+public static class CriarCursoCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarCursoCommand command,
+        ICursoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        if (await repository.CodigoExisteEntreVivosAsync(command.Codigo, null, cancellationToken).ConfigureAwait(false))
+        {
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        Result<Curso> cursoResult = Curso.Criar(
+            command.Codigo,
+            command.Nome,
+            command.Grau,
+            command.NivelEnsino,
+            command.GrupoAreaEnem);
+
+        if (cursoResult.IsFailure)
+        {
+            return Result<Guid>.Failure(cursoResult.Error!);
+        }
+
+        Curso curso = cursoResult.Value!;
+        await repository.AdicionarAsync(curso, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsCodigoConflict(constraint))
+        {
+            // Corrida entre CodigoExisteEntreVivosAsync e o INSERT (check-then-act): o
+            // índice único parcial dispara 23505 e viramos o mesmo CodigoJaExiste do
+            // caminho não-race — 409 consistente, em vez de deixar o DbUpdateException
+            // virar 500 no middleware global. O filtro do `when` garante que outras
+            // exceções propagam intactas.
+            return Result<Guid>.Failure(CodigoJaExisteErro(command.Codigo));
+        }
+
+        return Result<Guid>.Success(curso.Id);
+    }
+
+    private static DomainError CodigoJaExisteErro(string codigo) =>
+        new(CursoErrorCodes.CodigoJaExiste,
+            $"Já existe um curso vivo com o código '{codigo}'.");
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/CriarCursoCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/CriarCursoCommandValidator.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+public sealed class CriarCursoCommandValidator
+    : AbstractValidator<CriarCursoCommand>
+{
+    public CriarCursoCommandValidator()
+    {
+        RuleFor(x => x.Codigo)
+            .NotEmpty().WithMessage("Código do curso é obrigatório.")
+            .MaximumLength(60).WithMessage("Código do curso deve ter no máximo 60 caracteres.");
+
+        RuleFor(x => x.Nome)
+            .NotEmpty().WithMessage("Nome do curso é obrigatório.")
+            .MaximumLength(200).WithMessage("Nome do curso deve ter no máximo 200 caracteres.");
+
+        RuleFor(x => x.Grau)
+            .NotEmpty().WithMessage("Grau do curso é obrigatório.")
+            .MaximumLength(60).WithMessage("Grau do curso deve ter no máximo 60 caracteres.");
+
+        RuleFor(x => x.NivelEnsino)
+            .NotEmpty().WithMessage("Nível de ensino do curso é obrigatório.")
+            .MaximumLength(60).WithMessage("Nível de ensino do curso deve ter no máximo 60 caracteres.");
+
+        // Grupo em branco equivale a "sem grupo" (o domínio normaliza para nulo);
+        // só valida o domínio fechado quando há valor efetivo.
+        RuleFor(x => x.GrupoAreaEnem)
+            .Must(v => GrupoCurso.EhValido(v!))
+            .WithMessage($"Grupo de área do ENEM deve ser um de: {string.Join(", ", GrupoCurso.Valores)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.GrupoAreaEnem));
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/RemoverCursoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/RemoverCursoCommand.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Remove (soft-delete) um curso pelo seu <c>Id</c>.</summary>
+public sealed record RemoverCursoCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/RemoverCursoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/RemoverCursoCommandHandler.cs
@@ -1,0 +1,50 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverCursoCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c> — bloqueia quando o curso é referenciado por
+/// oferta de curso viva. A entidade <c>oferta_curso</c> ainda não existe (#749);
+/// a checagem é ponto de extensão (retorna <see langword="false"/>).
+/// </summary>
+public static class RemoverCursoCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverCursoCommand command,
+        ICursoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        Curso? curso = await repository.ObterPorIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (curso is null)
+        {
+            return Result.Failure(new DomainError(
+                CursoErrorCodes.NaoEncontrado,
+                "Curso não encontrado."));
+        }
+
+        // Ponto de extensão #749: oferta_curso ainda não existe no módulo, então a
+        // checagem retorna false hoje. Quando a oferta de curso chegar, o bloqueio
+        // passa a valer sem mudar este handler.
+        if (await repository.ReferenciadoPorOfertaCursoVivaAsync(command.Id, cancellationToken).ConfigureAwait(false))
+        {
+            return Result.Failure(new DomainError(
+                CursoErrorCodes.RemocaoBloqueadaPorOfertaCurso,
+                "Não é possível remover um Curso referenciado por oferta de curso ativa."));
+        }
+
+        repository.Remover(curso);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/UniqueConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Cursos/UniqueConstraintViolation.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+
+/// <summary>
+/// Helper para mapear violações 23505 do índice único parcial do código vivo do
+/// curso — <c>ix_curso_codigo_vivo</c> — para o <c>DomainError</c> apropriado.
+/// Acessa <c>SqlState</c> e <c>ConstraintName</c> por reflection no inner
+/// exception — o shape é estável na API pública do <c>Npgsql.PostgresException</c>.
+/// A inspeção do tipo da exceção por <see cref="System.Type.FullName"/> evita
+/// dependência direta do pacote <c>Microsoft.EntityFrameworkCore</c> na camada
+/// Application (mantém Clean Arch — Application referencia apenas Domain +
+/// SharedKernel + abstrações).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão do <c>UniqueConstraintViolation</c> do cadastro TipoDocumento
+/// (#591). A tradução cross-cutting de 23505 → 409 via
+/// <c>GlobalExceptionMiddleware</c> permanece como follow-up separado (#504);
+/// este helper cobre o caso específico da unicidade do código, inclusive a
+/// corrida na atualização (o código é editável).
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string CodigoConstraint = "ix_curso_codigo_vivo";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o
+    /// caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é o índice único parcial
+    /// que garante um único curso vivo por código.
+    /// </summary>
+    public static bool IsCodigoConflict(string? constraint) =>
+        string.Equals(constraint, CodigoConstraint, StringComparison.Ordinal);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CursoDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CursoDto.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>Curso</c>. Suporta HATEOAS Level 1 via
+/// <c>_links</c> (ADR-0029). O grupo de área do ENEM é exposto como
+/// <c>string?</c> (valor canônico da Res. 805/2024; nulo quando o curso não
+/// classifica por área).
+/// </summary>
+public sealed record CursoDto(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string Grau,
+    string NivelEnsino,
+    string? GrupoAreaEnem,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CursoMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CursoMapping.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+public static class CursoMapping
+{
+    public static CursoDto ToDto(this Curso curso)
+    {
+        ArgumentNullException.ThrowIfNull(curso);
+        return new CursoDto(
+            curso.Id,
+            curso.Codigo,
+            curso.Nome,
+            curso.Grau,
+            curso.NivelEnsino,
+            curso.GrupoAreaEnem?.Valor,
+            curso.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ListarCursosQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ListarCursosQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Cursos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista cursos vivos paginados por cursor bidirecional (ADR-0026 + ADR-0089).
+/// O controller decifra o cursor opaco e valida limit/direction antes de
+/// despachar.
+/// </summary>
+public sealed record ListarCursosQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarCursosResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ListarCursosQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ListarCursosQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Cursos;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarCursosQueryHandler
+{
+    public static async Task<ListarCursosResult> Handle(
+        ListarCursosQuery query,
+        ICursoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<Curso> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        CursoDto[] items = [.. itens.Select(c => c.ToDto())];
+        return new ListarCursosResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ListarCursosResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ListarCursosResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Cursos;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarCursosQuery"/>: lote de cursos projetados +
+/// âncoras opcionais para o controller construir os cursores prev/next
+/// (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarCursosResult(
+    IReadOnlyList<CursoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ObterCursoPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ObterCursoPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Cursos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterCursoPorIdQuery(Guid Id) : IQuery<CursoDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ObterCursoPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/Cursos/ObterCursoPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.Cursos;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterCursoPorIdQueryHandler
+{
+    public static async Task<CursoDto?> Handle(
+        ObterCursoPorIdQuery query,
+        ICursoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        Curso? curso = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return curso?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Curso.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Curso.cs
@@ -1,0 +1,206 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Curso — matriz curricular <b>pura</b> da oferta acadêmica (story #588,
+/// ADR-0066, módulo Configuração): diz <i>o que o curso é</i> ("Engenharia
+/// Civil", bacharelado, graduação), nunca <i>onde nem como é ofertado</i> —
+/// código e-MEC, local de oferta e unidade pertencem à <c>OfertaCurso</c>
+/// (task futura, #749).
+/// </summary>
+/// <remarks>
+/// <para>O <c>Codigo</c> é a chave natural, único entre cursos vivos (índice único
+/// parcial <c>WHERE is_deleted = false</c>) — e <b>editável</b> (mesmo expediente
+/// do TipoDocumento), pois o consumo cross-módulo é por snapshot-copy desacoplado
+/// (ADR-0061): editar o código vivo não altera o rótulo já congelado num edital de
+/// Seleção. A unicidade é checada pelo handler (com proteção de corrida via índice).</para>
+/// <para>O <c>GrupoAreaEnem</c> é opcional: nem todo curso classifica por área do
+/// ENEM. Quando informado, valida contra o domínio fechado de quatro grupos
+/// (<see cref="GrupoCurso"/>, Res. INEP/ENEM 805/2024) — o pareamento
+/// <c>curso.grupo_area_enem ↔ peso_area_enem.grupo_curso</c> é por valor sobre o
+/// vocabulário compartilhado, sem FK.</para>
+/// <para>Dado institucional sem PII (LGPD inaplicável). A remoção é soft-delete e
+/// só é bloqueada quando o curso é referenciado por oferta de curso viva (#749).</para>
+/// </remarks>
+public sealed class Curso : SoftDeletableEntity, IAuditableEntity
+{
+    private const int CodigoMinLength = 1;
+    private const int CodigoMaxLength = 60;
+    private const int NomeMinLength = 2;
+    private const int NomeMaxLength = 200;
+    private const int GrauMinLength = 2;
+    private const int GrauMaxLength = 60;
+    private const int NivelEnsinoMinLength = 2;
+    private const int NivelEnsinoMaxLength = 60;
+
+    public string Codigo { get; private set; } = string.Empty;
+    public string Nome { get; private set; } = string.Empty;
+    public string Grau { get; private set; } = string.Empty;
+    public string NivelEnsino { get; private set; } = string.Empty;
+    public GrupoCurso? GrupoAreaEnem { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private Curso()
+    {
+    }
+
+    /// <summary>
+    /// Cria um novo Curso. Valida formato/domínio local (incluindo o grupo de
+    /// área do ENEM contra o domínio fechado, quando informado — nulo é aceito).
+    /// A unicidade de <paramref name="codigo"/> entre cursos vivos é
+    /// responsabilidade do handler. Grau e nível de ensino são texto livre
+    /// obrigatório (ex.: Bacharelado / Graduação).
+    /// </summary>
+    public static Result<Curso> Criar(
+        string codigo,
+        string nome,
+        string grau,
+        string nivelEnsino,
+        string? grupoAreaEnem)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(grau);
+        ArgumentNullException.ThrowIfNull(nivelEnsino);
+
+        Result<GrupoCurso?> validacao = ValidarCampos(codigo, nome, grau, nivelEnsino, grupoAreaEnem);
+        if (validacao.IsFailure)
+        {
+            return Result<Curso>.Failure(validacao.Error!);
+        }
+
+        var curso = new Curso();
+        curso.AplicarCampos(codigo, nome, grau, nivelEnsino, validacao.Value);
+
+        return Result<Curso>.Success(curso);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos do Curso. O <c>Codigo</c> é editável; sua unicidade
+    /// (quando alterado) é responsabilidade do handler. Revalida formato/domínio,
+    /// incluindo o grupo de área do ENEM (nulo é aceito). O <c>Id</c> é imutável.
+    /// </summary>
+    public Result Atualizar(
+        string codigo,
+        string nome,
+        string grau,
+        string nivelEnsino,
+        string? grupoAreaEnem)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+        ArgumentNullException.ThrowIfNull(nome);
+        ArgumentNullException.ThrowIfNull(grau);
+        ArgumentNullException.ThrowIfNull(nivelEnsino);
+
+        Result<GrupoCurso?> validacao = ValidarCampos(codigo, nome, grau, nivelEnsino, grupoAreaEnem);
+        if (validacao.IsFailure)
+        {
+            return Result.Failure(validacao.Error!);
+        }
+
+        AplicarCampos(codigo, nome, grau, nivelEnsino, validacao.Value);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(
+        string codigo,
+        string nome,
+        string grau,
+        string nivelEnsino,
+        GrupoCurso? grupoAreaEnem)
+    {
+        Codigo = codigo.Trim();
+        Nome = nome.Trim();
+        Grau = grau.Trim();
+        NivelEnsino = nivelEnsino.Trim();
+        GrupoAreaEnem = grupoAreaEnem;
+    }
+
+    private static Result<GrupoCurso?> ValidarCampos(
+        string codigo,
+        string nome,
+        string grau,
+        string nivelEnsino,
+        string? grupoAreaEnem)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return Result<GrupoCurso?>.Failure(new DomainError(
+                CursoErrorCodes.CodigoObrigatorio,
+                "Código do curso é obrigatório."));
+        }
+
+        if (codigo.Trim().Length is < CodigoMinLength or > CodigoMaxLength)
+        {
+            return Result<GrupoCurso?>.Failure(new DomainError(
+                CursoErrorCodes.CodigoTamanho,
+                $"Código do curso deve ter entre {CodigoMinLength} e {CodigoMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Result<GrupoCurso?>.Failure(new DomainError(
+                CursoErrorCodes.NomeObrigatorio,
+                "Nome do curso é obrigatório."));
+        }
+
+        if (nome.Trim().Length is < NomeMinLength or > NomeMaxLength)
+        {
+            return Result<GrupoCurso?>.Failure(new DomainError(
+                CursoErrorCodes.NomeTamanho,
+                $"Nome do curso deve ter entre {NomeMinLength} e {NomeMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(grau))
+        {
+            return Result<GrupoCurso?>.Failure(new DomainError(
+                CursoErrorCodes.GrauObrigatorio,
+                "Grau do curso é obrigatório."));
+        }
+
+        if (grau.Trim().Length is < GrauMinLength or > GrauMaxLength)
+        {
+            return Result<GrupoCurso?>.Failure(new DomainError(
+                CursoErrorCodes.GrauTamanho,
+                $"Grau do curso deve ter entre {GrauMinLength} e {GrauMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(nivelEnsino))
+        {
+            return Result<GrupoCurso?>.Failure(new DomainError(
+                CursoErrorCodes.NivelEnsinoObrigatorio,
+                "Nível de ensino do curso é obrigatório."));
+        }
+
+        if (nivelEnsino.Trim().Length is < NivelEnsinoMinLength or > NivelEnsinoMaxLength)
+        {
+            return Result<GrupoCurso?>.Failure(new DomainError(
+                CursoErrorCodes.NivelEnsinoTamanho,
+                $"Nível de ensino do curso deve ter entre {NivelEnsinoMinLength} e {NivelEnsinoMaxLength} caracteres."));
+        }
+
+        if (string.IsNullOrWhiteSpace(grupoAreaEnem))
+        {
+            // Grupo de área do ENEM é opcional: nem todo curso classifica por área.
+            return Result<GrupoCurso?>.Success(null);
+        }
+
+        Result<GrupoCurso> grupo = GrupoCurso.Criar(grupoAreaEnem);
+        if (grupo.IsFailure)
+        {
+            return Result<GrupoCurso?>.Failure(new DomainError(
+                CursoErrorCodes.GrupoAreaEnemInvalido, grupo.Error!.Message));
+        }
+
+        return Result<GrupoCurso?>.Success(grupo.Value);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CursoErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CursoErrorCodes.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+public static class CursoErrorCodes
+{
+    public const string CodigoObrigatorio = "Curso.CodigoObrigatorio";
+    public const string CodigoTamanho = "Curso.CodigoTamanho";
+    public const string CodigoJaExiste = "Curso.CodigoJaExiste";
+    public const string NomeObrigatorio = "Curso.NomeObrigatorio";
+    public const string NomeTamanho = "Curso.NomeTamanho";
+    public const string GrauObrigatorio = "Curso.GrauObrigatorio";
+    public const string GrauTamanho = "Curso.GrauTamanho";
+    public const string NivelEnsinoObrigatorio = "Curso.NivelEnsinoObrigatorio";
+    public const string NivelEnsinoTamanho = "Curso.NivelEnsinoTamanho";
+    public const string GrupoAreaEnemInvalido = "Curso.GrupoAreaEnemInvalido";
+    public const string NaoEncontrado = "Curso.NaoEncontrado";
+    public const string RemocaoBloqueadaPorOfertaCurso = "Curso.RemocaoBloqueadaPorOfertaCurso";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICursoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICursoRepository.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="Curso"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros
+/// soft-deleted via query filter por convenção.
+/// </summary>
+public interface ICursoRepository
+{
+    /// <summary>Carrega o curso rastreado pelo contexto, para mutação.</summary>
+    Task<Curso?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega o curso para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<Curso?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista cursos vivos paginados por cursor keyset bidirecional
+    /// (ADR-0026 + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve
+    /// as âncoras de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<Curso> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(Curso curso, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca o curso para remoção; o <c>SoftDeleteInterceptor</c> converte em
+    /// soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(Curso curso);
+
+    /// <summary>
+    /// Verifica se existe curso vivo com o <paramref name="codigo"/>
+    /// (case-sensitive, sobre o valor normalizado por <c>Trim</c>), excluindo
+    /// opcionalmente um <paramref name="excluirId"/> (para a checagem na atualização).
+    /// </summary>
+    Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Ponto de extensão (#749): indica se o curso é referenciado por alguma
+    /// oferta de curso viva — caso em que a remoção é bloqueada. A entidade
+    /// <c>oferta_curso</c> ainda não existe no módulo, logo a implementação
+    /// retorna <see langword="false"/>. Quando a oferta de curso chegar, esta
+    /// checagem passa a consultá-la.
+    /// </summary>
+    Task<bool> ReferenciadoPorOfertaCursoVivaAsync(Guid cursoId, CancellationToken cancellationToken);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -44,6 +44,7 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<IModalidadeRepository, ModalidadeRepository>();
         services.AddScoped<IFaseCanonicaRepository, FaseCanonicaRepository>();
         services.AddScoped<ITipoBancaRepository, TipoBancaRepository>();
+        services.AddScoped<ICursoRepository, CursoRepository>();
 
         // Readers cross-módulo (ADR-0056).
         services.AddScoped<IReferenciaReservaDemograficaReader, ReferenciaReservaDemograficaReader>();

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -51,6 +51,8 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
 
     public DbSet<TipoBanca> TiposBanca => Set<TipoBanca>();
 
+    public DbSet<Curso> Cursos => Set<Curso>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CursoConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CursoConfiguration.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class CursoConfiguration
+    : IEntityTypeConfiguration<Curso>
+{
+    private const int CodigoMaxLength = 60;
+    private const int NomeMaxLength = 200;
+    private const int GrauMaxLength = 60;
+    private const int NivelEnsinoMaxLength = 60;
+    private const int GrupoAreaEnemMaxLength = 30;
+
+    public void Configure(EntityTypeBuilder<Curso> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            "curso",
+            t =>
+            {
+                // Domínio fechado do grupo de área do ENEM (Res. 805/2024, Anexo I) —
+                // espelha o CHECK de peso_area_enem, mas null-safe: a coluna é opcional
+                // (nem todo curso classifica por área do ENEM).
+                t.HasCheckConstraint(
+                    "ck_curso_grupo_area_enem",
+                    "grupo_area_enem IS NULL OR grupo_area_enem IN ('Tecnológica', 'Humanística I', 'Humanística II', 'Saúde e Biológicas')");
+            });
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Codigo).HasMaxLength(CodigoMaxLength).IsRequired();
+        builder.Property(c => c.Nome).HasMaxLength(NomeMaxLength).IsRequired();
+        builder.Property(c => c.Grau).HasMaxLength(GrauMaxLength).IsRequired();
+        builder.Property(c => c.NivelEnsino).HasMaxLength(NivelEnsinoMaxLength).IsRequired();
+
+        // GrupoAreaEnem é value object opcional — persistido por valor como varchar
+        // via GrupoCursoValueConverter (reidratação fail-fast; o converter só é
+        // aplicado a valores não-nulos). O CHECK acima restringe a coluna ao
+        // domínio fechado. O nome de coluna snake_case vem da convenção global.
+        builder.Property(c => c.GrupoAreaEnem)
+            .HasConversion<GrupoCursoValueConverter>()
+            .HasMaxLength(GrupoAreaEnemMaxLength);
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(c => c.CreatedBy).HasMaxLength(255);
+        builder.Property(c => c.UpdatedBy).HasMaxLength(255);
+
+        // Unicidade do código entre cursos vivos (índice parcial) — um curso vivo
+        // por código; soft-delete libera o slot para recriação.
+        builder.HasIndex(c => c.Codigo)
+            .IsUnique()
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_curso_codigo_vivo");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260702141644_AddCurso.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260702141644_AddCurso.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702141644_AddCurso")]
+    partial class AddCurso
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260702141644_AddCurso.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260702141644_AddCurso.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCurso : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "curso",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    grau = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    nivel_ensino = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    grupo_area_enem = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_curso", x => x.id);
+                    table.CheckConstraint("ck_curso_grupo_area_enem", "grupo_area_enem IS NULL OR grupo_area_enem IN ('Tecnológica', 'Humanística I', 'Humanística II', 'Saúde e Biológicas')");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_curso_codigo_vivo",
+                schema: "configuracao",
+                table: "curso",
+                column: "codigo",
+                unique: true,
+                filter: "is_deleted = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "curso",
+                schema: "configuracao");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CursoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CursoRepository.cs
@@ -1,0 +1,89 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class CursoRepository : ICursoRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public CursoRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<Curso?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Cursos
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+    }
+
+    public Task<Curso?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Cursos
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<Curso> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<Curso> page = await CursorKeyset
+            .ApplyAsync(_dbContext.Cursos.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(Curso curso, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(curso);
+        await _dbContext.Cursos.AddAsync(curso, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(Curso curso)
+    {
+        ArgumentNullException.ThrowIfNull(curso);
+        _dbContext.Cursos.Remove(curso);
+    }
+
+    public Task<bool> CodigoExisteEntreVivosAsync(
+        string codigo,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(codigo);
+
+        // Espelha a normalização do agregado (Trim) para casar com o valor persistido.
+        // Comparação case-sensitive (default do Postgres) — alinhada ao índice único.
+        string codigoNorm = codigo.Trim();
+
+        return _dbContext.Cursos
+            .AsNoTracking()
+            .Where(c => excluirId == null || c.Id != excluirId)
+            .AnyAsync(c => c.Codigo == codigoNorm, cancellationToken);
+    }
+
+    public Task<bool> ReferenciadoPorOfertaCursoVivaAsync(Guid cursoId, CancellationToken cancellationToken)
+    {
+        // TODO(#749): quando a entidade oferta_curso existir no módulo, consultar
+        // aqui se há oferta de curso viva referenciando este curso. Até lá, não há
+        // tabela a consultar — a checagem retorna false.
+        _ = cursoId;
+        _ = cancellationToken;
+        return Task.FromResult(false);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarCursoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarCursoCommandHandlerTests.cs
@@ -1,0 +1,98 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarCursoCommandHandlerTests
+{
+    private readonly ICursoRepository _repository = Substitute.For<ICursoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static Curso CursoExistente(string codigo = "ENG_CIVIL") =>
+        Curso.Criar(codigo, "Engenharia Civil", "Bacharelado", "Graduação", null).Value!;
+
+    private static AtualizarCursoCommand Comando(Guid id, string codigo = "ENG_CIVIL") =>
+        new(id, codigo, "Engenharia Civil", "Bacharelado", "Graduação", null);
+
+    [Fact(DisplayName = "Curso inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((Curso?)null);
+
+        Result resultado = await AtualizarCursoCommandHandler.Handle(
+            Comando(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.NaoEncontrado);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um código que colide com outro curso vivo retorna conflito (409)")]
+    public async Task Handle_CodigoColidente_RetornaConflito()
+    {
+        Curso existente = CursoExistente("ENG_CIVIL");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        // O novo código "MEDICINA" já pertence a outro curso vivo.
+        _repository.CodigoExisteEntreVivosAsync("MEDICINA", existente.Id, Arg.Any<CancellationToken>()).Returns(true);
+
+        Result resultado = await AtualizarCursoCommandHandler.Handle(
+            Comando(existente.Id, codigo: "MEDICINA"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.CodigoJaExiste);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar para um código distinto e livre é aceito e persiste")]
+    public async Task Handle_CodigoDistintoLivre_Aceita()
+    {
+        Curso existente = CursoExistente("ENG_CIVIL");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.CodigoExisteEntreVivosAsync("ENG_CIVIL_NOVO", existente.Id, Arg.Any<CancellationToken>()).Returns(false);
+
+        Result resultado = await AtualizarCursoCommandHandler.Handle(
+            Comando(existente.Id, codigo: "ENG_CIVIL_NOVO"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        existente.Codigo.Should().Be("ENG_CIVIL_NOVO");
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Editar sem mudar o código não consulta a unicidade")]
+    public async Task Handle_CodigoInalterado_NaoChecaUnicidade()
+    {
+        Curso existente = CursoExistente("ENG_CIVIL");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarCursoCommandHandler.Handle(
+            Comando(existente.Id, codigo: "ENG_CIVIL"), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _repository.DidNotReceive()
+            .CodigoExisteEntreVivosAsync(Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Grupo de área do ENEM inválido propaga o erro de domínio sem persistir")]
+    public async Task Handle_GrupoAreaEnemInvalido_RetornaErroSemPersistir()
+    {
+        Curso existente = CursoExistente("ENG_CIVIL");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarCursoCommandHandler.Handle(
+            Comando(existente.Id) with { GrupoAreaEnem = "Exatas" }, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.GrupoAreaEnemInvalido);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCursoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCursoCommandHandlerTests.cs
@@ -1,0 +1,81 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarCursoCommandHandlerTests
+{
+    private readonly ICursoRepository _repository = Substitute.For<ICursoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CriarCursoCommand ComandoValido() =>
+        new("ENG_CIVIL", "Engenharia Civil", "Bacharelado", "Graduação", GrupoCurso.Tecnologica);
+
+    [Fact(DisplayName = "Código livre cria o curso, persiste e retorna o Id")]
+    public async Task Handle_CodigoLivre_CriaEPersiste()
+    {
+        _repository.CodigoExisteEntreVivosAsync("ENG_CIVIL", null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarCursoCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<Curso>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Curso sem grupo de área do ENEM é criado normalmente")]
+    public async Task Handle_SemGrupoAreaEnem_CriaEPersiste()
+    {
+        _repository.CodigoExisteEntreVivosAsync("ENG_CIVIL", null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarCursoCommandHandler.Handle(
+            ComandoValido() with { GrupoAreaEnem = null }, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _repository.Received(1).AdicionarAsync(
+            Arg.Is<Curso>(c => c.GrupoAreaEnem == null), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Código já existente entre vivos retorna conflito (CodigoJaExiste) sem persistir")]
+    public async Task Handle_CodigoDuplicado_RetornaConflito()
+    {
+        _repository.CodigoExisteEntreVivosAsync("ENG_CIVIL", null, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarCursoCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.CodigoJaExiste);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<Curso>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Grupo de área do ENEM inválido propaga o erro de domínio sem persistir")]
+    public async Task Handle_GrupoAreaEnemInvalido_RetornaErroSemPersistir()
+    {
+        _repository.CodigoExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        CriarCursoCommand comando = ComandoValido() with { GrupoAreaEnem = "Exatas" };
+
+        Result<Guid> resultado = await CriarCursoCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.GrupoAreaEnemInvalido);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCursoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCursoCommandHandlerTests.cs
@@ -1,0 +1,71 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverCursoCommandHandlerTests
+{
+    private readonly ICursoRepository _repository = Substitute.For<ICursoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static Curso NovoCurso() =>
+        Curso.Criar("ENG_CIVIL", "Engenharia Civil", "Bacharelado", "Graduação", null).Value!;
+
+    [Fact(DisplayName = "Curso inexistente retorna NaoEncontrado (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrado()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((Curso?)null);
+
+        Result resultado = await RemoverCursoCommandHandler.Handle(
+            new RemoverCursoCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.NaoEncontrado);
+        _repository.DidNotReceive().Remover(Arg.Any<Curso>());
+    }
+
+    [Fact(DisplayName = "Curso sem oferta de curso viva é removido (soft-delete) e commita")]
+    public async Task Handle_SemOfertaCurso_Remove()
+    {
+        Curso curso = NovoCurso();
+        _repository.ObterPorIdAsync(curso.Id, Arg.Any<CancellationToken>()).Returns(curso);
+        // Ponto de extensão #749: oferta_curso ainda não existe → false.
+        _repository.ReferenciadoPorOfertaCursoVivaAsync(curso.Id, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result resultado = await RemoverCursoCommandHandler.Handle(
+            new RemoverCursoCommand(curso.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(curso);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Curso referenciado por oferta de curso viva tem a remoção bloqueada (409)")]
+    public async Task Handle_ComOfertaCursoViva_BloqueiaRemocao()
+    {
+        Curso curso = NovoCurso();
+        _repository.ObterPorIdAsync(curso.Id, Arg.Any<CancellationToken>()).Returns(curso);
+        // Quando oferta_curso existir (#749), o repositório passa a reportar a
+        // referência viva — o handler já bloqueia sem precisar mudar.
+        _repository.ReferenciadoPorOfertaCursoVivaAsync(curso.Id, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result resultado = await RemoverCursoCommandHandler.Handle(
+            new RemoverCursoCommand(curso.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.RemocaoBloqueadaPorOfertaCurso);
+        _repository.DidNotReceive().Remover(Arg.Any<Curso>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CursoValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CursoValidatorTests.cs
@@ -1,0 +1,107 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.Cursos;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+/// <summary>
+/// O validator antecipa a obrigatoriedade de código, nome, grau e nível de
+/// ensino, os comprimentos máximos e o domínio fechado do grupo de área do ENEM
+/// (opcional), mantendo a fronteira simétrica com o domínio (#748).
+/// </summary>
+public sealed class CursoValidatorTests
+{
+    private readonly CriarCursoCommandValidator _validator = new();
+
+    private static CriarCursoCommand Base() =>
+        new("ENG_CIVIL", "Engenharia Civil", "Bacharelado", "Graduação", GrupoCurso.Tecnologica);
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Comando sem grupo de área do ENEM (nulo ou em branco) passa no validator")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SemGrupoAreaEnem_Passa(string? grupoAreaEnem)
+    {
+        _validator.Validate(Base() with { GrupoAreaEnem = grupoAreaEnem })
+            .IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Código ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CodigoVazio_Rejeita(string codigo)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Codigo = codigo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCursoCommand.Codigo));
+    }
+
+    [Fact(DisplayName = "Código acima de 60 caracteres é rejeitado")]
+    public void CodigoLongo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Codigo = new string('A', 61) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCursoCommand.Codigo));
+    }
+
+    [Fact(DisplayName = "Nome ausente é rejeitado")]
+    public void NomeVazio_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Nome = "  " });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCursoCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Grau ausente é rejeitado")]
+    public void GrauVazio_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Grau = "  " });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCursoCommand.Grau));
+    }
+
+    [Fact(DisplayName = "Nível de ensino ausente é rejeitado")]
+    public void NivelEnsinoVazio_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { NivelEnsino = "  " });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCursoCommand.NivelEnsino));
+    }
+
+    [Theory(DisplayName = "Grupo de área do ENEM fora do domínio fechado é rejeitado")]
+    [InlineData("Exatas")]
+    [InlineData("Tecnologica")]
+    [InlineData("HUMANÍSTICA I")]
+    public void GrupoAreaEnemInvalido_Rejeita(string grupoAreaEnem)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { GrupoAreaEnem = grupoAreaEnem });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCursoCommand.GrupoAreaEnem));
+    }
+
+    [Theory(DisplayName = "Cada um dos quatro grupos canônicos é aceito")]
+    [InlineData(GrupoCurso.Tecnologica)]
+    [InlineData(GrupoCurso.HumanisticaI)]
+    [InlineData(GrupoCurso.HumanisticaII)]
+    [InlineData(GrupoCurso.SaudeEBiologicas)]
+    public void GrupoAreaEnemCanonico_Aceita(string grupoAreaEnem)
+    {
+        _validator.Validate(Base() with { GrupoAreaEnem = grupoAreaEnem })
+            .IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CursoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CursoTests.cs
@@ -1,0 +1,199 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CursoTests
+{
+    private const string Codigo = "ENG_CIVIL";
+    private const string Nome = "Engenharia Civil";
+    private const string Grau = "Bacharelado";
+    private const string NivelEnsino = "Graduação";
+
+    private static Result<Curso> Criar(
+        string codigo = Codigo,
+        string nome = Nome,
+        string grau = Grau,
+        string nivelEnsino = NivelEnsino,
+        string? grupoAreaEnem = null) =>
+        Curso.Criar(codigo, nome, grau, nivelEnsino, grupoAreaEnem);
+
+    [Fact(DisplayName = "Criar com dados válidos preenche os campos e fica ativo com Guid v7")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        Curso curso = Criar(grupoAreaEnem: GrupoCurso.Tecnologica).Value!;
+
+        curso.Id.Should().NotBe(Guid.Empty);
+        curso.Codigo.Should().Be(Codigo);
+        curso.Nome.Should().Be(Nome);
+        curso.Grau.Should().Be(Grau);
+        curso.NivelEnsino.Should().Be(NivelEnsino);
+        curso.GrupoAreaEnem!.Valor.Should().Be(GrupoCurso.Tecnologica);
+        curso.IsDeleted.Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "Criar sem grupo de área do ENEM (nulo ou em branco) é aceito — nem todo curso classifica por área")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemGrupoAreaEnem_Aceita(string? grupoAreaEnem)
+    {
+        Curso curso = Criar(grupoAreaEnem: grupoAreaEnem).Value!;
+
+        curso.GrupoAreaEnem.Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Grupo de área do ENEM fora do domínio fechado é rejeitado")]
+    [InlineData("Exatas")]
+    [InlineData("Tecnologica")]
+    [InlineData("HUMANÍSTICA I")]
+    public void Criar_GrupoAreaEnemInvalido_Falha(string grupoAreaEnem)
+    {
+        Result<Curso> resultado = Criar(grupoAreaEnem: grupoAreaEnem);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.GrupoAreaEnemInvalido);
+    }
+
+    [Theory(DisplayName = "Código ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemCodigo_Falha(string codigo)
+    {
+        Result<Curso> resultado = Criar(codigo: codigo);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.CodigoObrigatorio);
+    }
+
+    [Fact(DisplayName = "Código acima do tamanho máximo é rejeitado")]
+    public void Criar_CodigoLongo_Falha()
+    {
+        Result<Curso> resultado = Criar(codigo: new string('A', 61));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.CodigoTamanho);
+    }
+
+    [Theory(DisplayName = "Nome ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemNome_Falha(string nome)
+    {
+        Result<Curso> resultado = Criar(nome: nome);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.NomeObrigatorio);
+    }
+
+    [Fact(DisplayName = "Nome acima do tamanho máximo é rejeitado")]
+    public void Criar_NomeLongo_Falha()
+    {
+        Result<Curso> resultado = Criar(nome: new string('N', 201));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.NomeTamanho);
+    }
+
+    [Theory(DisplayName = "Grau ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemGrau_Falha(string grau)
+    {
+        Result<Curso> resultado = Criar(grau: grau);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.GrauObrigatorio);
+    }
+
+    [Fact(DisplayName = "Grau acima do tamanho máximo é rejeitado")]
+    public void Criar_GrauLongo_Falha()
+    {
+        Result<Curso> resultado = Criar(grau: new string('G', 61));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.GrauTamanho);
+    }
+
+    [Theory(DisplayName = "Nível de ensino ausente ou em branco é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemNivelEnsino_Falha(string nivelEnsino)
+    {
+        Result<Curso> resultado = Criar(nivelEnsino: nivelEnsino);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.NivelEnsinoObrigatorio);
+    }
+
+    [Fact(DisplayName = "Nível de ensino acima do tamanho máximo é rejeitado")]
+    public void Criar_NivelEnsinoLongo_Falha()
+    {
+        Result<Curso> resultado = Criar(nivelEnsino: new string('E', 61));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.NivelEnsinoTamanho);
+    }
+
+    [Fact(DisplayName = "Campos são normalizados por Trim na criação")]
+    public void Criar_CamposComEspacos_Normaliza()
+    {
+        Curso curso = Criar(
+            codigo: "  ENG_CIVIL  ",
+            nome: "  Engenharia Civil  ",
+            grau: "  Bacharelado  ",
+            nivelEnsino: "  Graduação  ",
+            grupoAreaEnem: $"  {GrupoCurso.Tecnologica}  ").Value!;
+
+        curso.Codigo.Should().Be("ENG_CIVIL");
+        curso.Nome.Should().Be("Engenharia Civil");
+        curso.Grau.Should().Be("Bacharelado");
+        curso.NivelEnsino.Should().Be("Graduação");
+        curso.GrupoAreaEnem!.Valor.Should().Be(GrupoCurso.Tecnologica);
+    }
+
+    [Fact(DisplayName = "Atualizar troca os atributos editáveis, inclusive o código (editável)")]
+    public void Atualizar_AlteraAtributos_InclusiveCodigo()
+    {
+        Curso curso = Criar().Value!;
+        Guid idOriginal = curso.Id;
+
+        Result resultado = curso.Atualizar(
+            "ENG_CIVIL_NOVO", "Engenharia Civil Integral", "Licenciatura", "Mestrado", GrupoCurso.SaudeEBiologicas);
+
+        resultado.IsSuccess.Should().BeTrue();
+        curso.Codigo.Should().Be("ENG_CIVIL_NOVO");
+        curso.Nome.Should().Be("Engenharia Civil Integral");
+        curso.Grau.Should().Be("Licenciatura");
+        curso.NivelEnsino.Should().Be("Mestrado");
+        curso.GrupoAreaEnem!.Valor.Should().Be(GrupoCurso.SaudeEBiologicas);
+        curso.Id.Should().Be(idOriginal, "o Id é imutável mesmo com o código editável");
+    }
+
+    [Fact(DisplayName = "Atualizar removendo o grupo de área do ENEM (nulo) é aceito")]
+    public void Atualizar_RemoveGrupoAreaEnem_Aceita()
+    {
+        Curso curso = Criar(grupoAreaEnem: GrupoCurso.HumanisticaI).Value!;
+
+        Result resultado = curso.Atualizar(Codigo, Nome, Grau, NivelEnsino, null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        curso.GrupoAreaEnem.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Atualizar com grupo de área do ENEM inválido é rejeitado sem alterar o agregado")]
+    public void Atualizar_GrupoAreaEnemInvalido_Falha()
+    {
+        Curso curso = Criar(grupoAreaEnem: GrupoCurso.HumanisticaII).Value!;
+
+        Result resultado = curso.Atualizar(Codigo, Nome, Grau, NivelEnsino, "Exatas");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CursoErrorCodes.GrupoAreaEnemInvalido);
+        curso.GrupoAreaEnem!.Valor.Should().Be(GrupoCurso.HumanisticaII, "a falha de validação não muta o agregado");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Cursos/CursoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Cursos/CursoEndpointTests.cs
@@ -1,0 +1,289 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Cursos;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>Curso</c> (story #588):
+/// routing, vendor media type, HATEOAS, autenticação/autorização, idempotência,
+/// domínio fechado do grupo de área do ENEM (422), unicidade do código (409),
+/// ciclo CRUD completo e soft-delete — com Wolverine contra Postgres efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class CursoEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public CursoEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/cursos retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/cursos", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.curso.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/cursos/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/cursos/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/configuracao/admin/cursos sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/cursos", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        var body = new { codigo = CodigoUnico(), nome = "Sem permissão", grau = "Bacharelado", nivelEnsino = "Graduação" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/cursos", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a policy [Authorize(Roles = \"plataforma-admin\")] nega um principal autenticado sem o role");
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/cursos", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST cria (201) e o GET subsequente retorna os campos + HATEOAS")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        string codigo = CodigoUnico();
+        var body = new
+        {
+            codigo,
+            nome = "Engenharia Civil",
+            grau = "Bacharelado",
+            nivelEnsino = "Graduação",
+            grupoAreaEnem = "Tecnológica",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/cursos/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("codigo").GetString().Should().Be(codigo);
+        root.GetProperty("nome").GetString().Should().Be("Engenharia Civil");
+        root.GetProperty("grau").GetString().Should().Be("Bacharelado");
+        root.GetProperty("nivelEnsino").GetString().Should().Be("Graduação");
+        root.GetProperty("grupoAreaEnem").GetString().Should().Be("Tecnológica");
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "POST sem grupo de área do ENEM cria (201) e o GET retorna grupoAreaEnem nulo")]
+    public async Task Criar_SemGrupoAreaEnem_Retorna201ComGrupoNulo()
+    {
+        var body = new { codigo = CodigoUnico(), nome = "Direito", grau = "Bacharelado", nivelEnsino = "Graduação" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/cursos/{id}", UriKind.Relative));
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+
+        doc.RootElement.GetProperty("grupoAreaEnem").ValueKind.Should().Be(JsonValueKind.Null,
+            "nem todo curso classifica por área do ENEM");
+    }
+
+    [Fact(DisplayName = "Contrato de matriz curricular pura: o recurso não expõe código e-MEC, local nem unidade")]
+    public async Task Criar_RecursoNaoExpoeCamposDeOferta()
+    {
+        var body = new { codigo = CodigoUnico(), nome = "Pedagogia", grau = "Licenciatura", nivelEnsino = "Graduação" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/cursos/{id}", UriKind.Relative));
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+
+        // A separação central da #748: o curso é matriz curricular pura; código
+        // e-MEC, local de oferta e unidade pertencem à OfertaCurso (#749).
+        string[] propriedadesDeOfertaProibidas =
+            ["codigoEmec", "localOfertaId", "unidadeId", "campusId", "turno", "vagas"];
+        foreach (string proibida in propriedadesDeOfertaProibidas)
+        {
+            doc.RootElement.TryGetProperty(proibida, out _)
+                .Should().BeFalse($"o curso é matriz curricular pura e não deve expor '{proibida}'");
+        }
+    }
+
+    [Fact(DisplayName = "POST com grupo de área do ENEM fora do domínio fechado retorna 422")]
+    public async Task Criar_GrupoAreaEnemInvalido_Retorna422()
+    {
+        var body = new
+        {
+            codigo = CodigoUnico(),
+            nome = "Grupo inválido",
+            grau = "Bacharelado",
+            nivelEnsino = "Graduação",
+            grupoAreaEnem = "Exatas",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com código já existente entre vivos retorna 409")]
+    public async Task Criar_CodigoDuplicado_Retorna409()
+    {
+        string codigo = CodigoUnico();
+        var body = new { codigo, nome = "Primeiro", grau = "Bacharelado", nivelEnsino = "Graduação" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage primeiro = await EnviarPostAdmin(client, body);
+        primeiro.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage segundo = await EnviarPostAdmin(
+            client, new { codigo, nome = "Segundo", grau = "Bacharelado", nivelEnsino = "Graduação" });
+        segundo.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact(DisplayName = "Ciclo CRUD completo: POST → PUT (204) → GET reflete edição → DELETE (204) → GET 404 (soft-delete)")]
+    public async Task CicloCrudCompleto_CriaEditaRemove()
+    {
+        string codigo = CodigoUnico();
+        var body = new { codigo, nome = "Engenharia Civil", grau = "Bacharelado", nivelEnsino = "Graduação" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+
+        // PUT: código é editável; grupo de área do ENEM passa a Tecnológica.
+        string codigoNovo = CodigoUnico();
+        var bodyPut = new
+        {
+            id,
+            codigo = codigoNovo,
+            nome = "Engenharia Civil Integral",
+            grau = "Licenciatura",
+            nivelEnsino = "Mestrado",
+            grupoAreaEnem = "Tecnológica",
+        };
+        HttpResponseMessage atualizar = await EnviarPutAdmin(client, id, bodyPut);
+        atualizar.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/cursos/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync()))
+        {
+            JsonElement root = doc.RootElement;
+            root.GetProperty("codigo").GetString().Should().Be(codigoNovo);
+            root.GetProperty("nome").GetString().Should().Be("Engenharia Civil Integral");
+            root.GetProperty("grau").GetString().Should().Be("Licenciatura");
+            root.GetProperty("nivelEnsino").GetString().Should().Be("Mestrado");
+            root.GetProperty("grupoAreaEnem").GetString().Should().Be("Tecnológica");
+        }
+
+        // DELETE: soft-delete — sem oferta de curso viva (#749), a remoção não bloqueia.
+        HttpResponseMessage remover = await EnviarDeleteAdmin(client, id);
+        remover.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage aposRemocao = await client.GetAsync(
+            new Uri($"/api/configuracao/cursos/{id}", UriKind.Relative));
+        aposRemocao.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "o soft-delete tira o curso das leituras via query filter global");
+    }
+
+    private static string CodigoUnico() => $"CUR_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri("/api/configuracao/admin/cursos", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> EnviarPutAdmin(HttpClient client, Guid id, object body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Put, new Uri($"/api/configuracao/admin/cursos/{id}", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> EnviarDeleteAdmin(HttpClient client, Guid id)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Delete, new Uri($"/api/configuracao/admin/cursos/{id}", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Cursos/CursoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Cursos/CursoPersistenceTests.cs
@@ -9,7 +9,9 @@ using Microsoft.EntityFrameworkCore;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
 using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Kernel.Pagination;
 
 /// <summary>
 /// Integração ponta-a-ponta do Curso contra Postgres real (story #588):
@@ -166,6 +168,52 @@ public sealed class CursoPersistenceTests
             $"INSERT INTO configuracao.curso (id, codigo, nome, grau, nivel_ensino, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"Bacharelado"}, {"Graduação"}, {DateTimeOffset.UtcNow}, {false})");
 
         await act.Should().NotThrowAsync("a coluna é opcional e o CHECK é null-safe");
+    }
+
+    [Fact(DisplayName = "Navegação bidirecional do cursor: prev volta exatamente à página anterior, com flags coerentes")]
+    public async Task Navegacao_Bidirecional_PrevVoltaPaginaAnterior()
+    {
+        // 5 cursos criados agora: o prefixo temporal do Guid v7 garante que o BLOCO
+        // fica no fim da tabela em ASC por Id — âncora determinística mesmo com
+        // linhas pré-existentes de outros testes da collection (sequencial, tabela
+        // estática). Dentro do mesmo milissegundo os bits aleatórios permutam a
+        // ordem interna do bloco, então os ids são ordenados como o Postgres ordena
+        // uuid (byte a byte = ordem lexicográfica do hex canônico).
+        Curso[] cursos = [Novo(CodigoUnico()), Novo(CodigoUnico()), Novo(CodigoUnico()), Novo(CodigoUnico()), Novo(CodigoUnico())];
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Cursos.AddRange(cursos);
+            await ctx.SaveChangesAsync();
+        }
+
+        Guid[] ids = [.. cursos.Select(c => c.Id).OrderBy(id => id.ToString(), StringComparer.Ordinal)];
+
+        // Página 1 (forward a partir de ids[0], limit 2): [1,2]; há anterior (ids[0]) e próximo.
+        (IReadOnlyList<Curso> p1, Guid? p1Ant, Guid? p1Prox) = await PaginarAsync(afterId: ids[0], PaginationDirection.Next);
+        p1.Select(c => c.Id).Should().Equal(ids[1], ids[2]);
+        p1Ant.Should().Be(ids[1]);
+        p1Prox.Should().Be(ids[2]);
+
+        // Página 2 (forward a partir do próximo da p1): [3,4]; última página → sem próximo.
+        (IReadOnlyList<Curso> p2, Guid? p2Ant, Guid? p2Prox) = await PaginarAsync(afterId: p1Prox, PaginationDirection.Next);
+        p2.Select(c => c.Id).Should().Equal(ids[3], ids[4]);
+        p2Ant.Should().Be(ids[3]);
+        p2Prox.Should().BeNull("ids[4] é a linha mais recente da tabela (Guid v7)");
+
+        // Backward a partir do anterior da p2: volta exatamente à página 1 em ASC.
+        (IReadOnlyList<Curso> volta, Guid? voltaAnt, Guid? voltaProx) = await PaginarAsync(afterId: p2Ant, PaginationDirection.Prev);
+        volta.Select(c => c.Id).Should().Equal(ids[1], ids[2]);
+        voltaAnt.Should().Be(ids[1], "ainda há linhas antes de ids[1] (ao menos ids[0])");
+        voltaProx.Should().Be(ids[2]);
+    }
+
+    private async Task<(IReadOnlyList<Curso> Itens, Guid? Anterior, Guid? Proximo)> PaginarAsync(
+        Guid? afterId,
+        PaginationDirection direction)
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var repository = new CursoRepository(ctx);
+        return await repository.ListarPaginadoAsync(afterId, limit: 2, direction, CancellationToken.None);
     }
 
     private static Curso Novo(

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Cursos/CursoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Cursos/CursoPersistenceTests.cs
@@ -1,0 +1,177 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Cursos;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta do Curso contra Postgres real (story #588):
+/// persistência (com e sem grupo de área do ENEM), UNIQUE parcial do código
+/// vivo, liberação do slot por soft-delete e CHECK null-safe do domínio fechado
+/// do grupo de área do ENEM.
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class CursoPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public CursoPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Criar persiste os campos (com grupo de área do ENEM) e carimba a auditoria")]
+    public async Task Insert_ComGrupoAreaEnem_Persiste()
+    {
+        string codigo = CodigoUnico();
+        Curso curso = Novo(codigo, grupoAreaEnem: GrupoCurso.Tecnologica);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Cursos.Add(curso);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        Curso persistido = await readCtx.Cursos.SingleAsync(c => c.Id == curso.Id);
+
+        persistido.Codigo.Should().Be(codigo);
+        persistido.Nome.Should().Be("Engenharia Civil");
+        persistido.Grau.Should().Be("Bacharelado");
+        persistido.NivelEnsino.Should().Be("Graduação");
+        persistido.GrupoAreaEnem!.Valor.Should().Be(GrupoCurso.Tecnologica);
+        persistido.CreatedBy.Should().Be(AdminA);
+        persistido.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar sem grupo de área do ENEM persiste a coluna nula e reidrata como nulo")]
+    public async Task Insert_SemGrupoAreaEnem_PersisteNulo()
+    {
+        Curso curso = Novo(CodigoUnico(), grupoAreaEnem: null);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Cursos.Add(curso);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        Curso persistido = await readCtx.Cursos.SingleAsync(c => c.Id == curso.Id);
+
+        persistido.GrupoAreaEnem.Should().BeNull("nem todo curso classifica por área do ENEM");
+    }
+
+    [Fact(DisplayName = "UNIQUE parcial do código rejeita segundo curso vivo com mesmo código")]
+    public async Task UniquePartial_Codigo_RejeitaDuplicataAtiva()
+    {
+        string codigo = CodigoUnico();
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Cursos.Add(Novo(codigo));
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.Cursos.Add(Novo(codigo));
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        // Trava as constantes que o handler usa para traduzir a corrida concorrente
+        // (UniqueConstraintViolation.GetViolatedConstraint/IsCodigoConflict) em
+        // CodigoJaExiste/409: SqlState 23505 + nome do índice único parcial.
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23505");
+        pg.ConstraintName.Should().Be("ix_curso_codigo_vivo");
+    }
+
+    [Fact(DisplayName = "Código distinto é aceito")]
+    public async Task CodigoDistinto_Aceita()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.Cursos.Add(Novo(CodigoUnico()));
+        ctx.Cursos.Add(Novo(CodigoUnico()));
+
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+        await act.Should().NotThrowAsync("os códigos são distintos");
+    }
+
+    [Fact(DisplayName = "Soft-delete preserva a trilha e libera o slot da UNIQUE parcial do código")]
+    public async Task SoftDelete_PreservaTrilhaELibertaSlot()
+    {
+        string codigo = CodigoUnico();
+        Curso curso = Novo(codigo);
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Cursos.Add(curso);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            Curso tracked = await ctx.Cursos.SingleAsync(c => c.Id == curso.Id);
+            ctx.Cursos.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            Curso excluido = await ctx.Cursos
+                .IgnoreQueryFilters().SingleAsync(c => c.Id == curso.Id);
+            excluido.IsDeleted.Should().BeTrue();
+            excluido.DeletedBy.Should().Be(AdminB);
+        }
+
+        await using ConfiguracaoDbContext ctx3 = _fixture.CreateDbContext(AdminA);
+        ctx3.Cursos.Add(Novo(codigo));
+
+        Func<Task> act = async () => await ctx3.SaveChangesAsync();
+        await act.Should().NotThrowAsync("o slot do código foi liberado pelo soft-delete");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita grupo de área do ENEM fora do domínio via SQL cru")]
+    public async Task Check_RejeitaGrupoForaDoDominioViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.curso (id, codigo, nome, grau, nivel_ensino, grupo_area_enem, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"Bacharelado"}, {"Graduação"}, {"Exatas"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de domínio do grupo de área do ENEM impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco aceita grupo de área do ENEM nulo via SQL cru (null-safe)")]
+    public async Task Check_AceitaGrupoNuloViaSqlCru()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        // A coluna grupo_area_enem é omitida de propósito: fica NULL e o CHECK
+        // null-safe não pode rejeitar o INSERT.
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"INSERT INTO configuracao.curso (id, codigo, nome, grau, nivel_ensino, created_at, is_deleted) VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"Bacharelado"}, {"Graduação"}, {DateTimeOffset.UtcNow}, {false})");
+
+        await act.Should().NotThrowAsync("a coluna é opcional e o CHECK é null-safe");
+    }
+
+    private static Curso Novo(
+        string codigo,
+        string? grupoAreaEnem = null) =>
+        Curso.Criar(codigo, "Engenharia Civil", "Bacharelado", "Graduação", grupoAreaEnem).Value!;
+
+    private static string CodigoUnico() => $"CUR_{Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
+}


### PR DESCRIPTION
Closes #748 · Story #588 · Requisito UNI-REQ-0010 · ADRs: ADR-0066, ADR-0032, ADR-0097

## O que este PR entrega

O cadastro **`Curso`** — a matriz curricular pura do modelo de oferta em três níveis (ADR-0066). O `Curso` descreve **o que** a Unifesspa oferta (`codigo`, `nome`, `grau`, `nivel_ensino`); código e-MEC, local e unidade ofertante são atributos da `OfertaCurso`, que chega na task irmã #749.

### Domínio

- Entidade `Curso` (sealed, `SoftDeletableEntity` + `IAuditableEntity`, factory `Criar`/`Atualizar` com `Result`).
- `grupo_area_enem` **opcional** reusa o VO `GrupoCurso` existente (domínio fechado dos 4 grupos da Res. 805/2024) — tipo idêntico ao de `PesoAreaEnem`, pareamento **por valor**, sem FK. A entidade traduz a falha do VO para `Curso.GrupoAreaEnemInvalido`.
- `codigo` é chave natural **única entre vivos** e **editável** — diferente da `Modalidade` (VO imutável), o `Curso` é referenciado por `Id` (FK), nunca por código; segue o precedente do `TipoDocumento`.
- Remoção é soft-delete. `ReferenciadoPorOfertaCursoVivaAsync` entra como **ponto de extensão inerte** (retorna `false`, mesmo expediente da #731) — o handler de remoção já consulta e bloqueia com `Curso.RemocaoBloqueadaPorOfertaCurso`; a consulta real chega com a tabela `oferta_curso` (#749).

### API

- `GET /api/configuracao/cursos` (público, paginação cursor bidirecional ADR-0089) · `GET cursos/{id}` · `POST/PUT/DELETE /api/configuracao/admin/cursos` (`plataforma-admin` + `Idempotency-Key`), HATEOAS nível 1 e vendor media type `curso`.
- Erros de domínio mapeados em `ConfiguracaoDomainErrorRegistration` (422/404/409); corrida de unicidade traduzida pelo índice `ix_curso_codigo_vivo` → 409.
- Baseline OpenAPI regenerada (`contracts/openapi.configuracao.json`, +595 linhas — apenas os paths/schemas de cursos).

### Persistência

- Migration `AddCurso` (forward-only): tabela `curso` no schema `configuracao`, índice único parcial `WHERE is_deleted = false`, CHECK null-safe de `grupo_area_enem` com os 4 valores canônicos acentuados.

## Critérios de aceite cobertos (Story #588)

- **CA-01** — criação com/sem grupo de área (unit + integração)
- **CA-02** — unicidade de código entre vivos (409) e grupo fora do domínio (422)
- **CA-05 (parcial)** — soft-delete com trilha preservada; bloqueio por oferta viva testado via stub (ativa na #749)

## Testes

- 15 casos de domínio (`CursoTests`), handlers + validators com NSubstitute, persistência e endpoints de integração com Testcontainers (ciclo CRUD completo, 409, 422, soft-delete, CHECK via SQL).
- Suíte completa da solution verde local: build 0 warnings; 160 testes de integração de Configuração (1 skip = stub #731).

## Notas de revisão

- `packages.lock.json` intocados — nenhuma dependência de pacote mudou.
- Sem reader cross-módulo para `Curso` (deliberado, Story #588): quem o Módulo Seleção lê é a `OfertaCurso` (#749).
