### PR TITLE
feat(configuracao): adiciona cadastro de oferta de curso

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -2992,6 +2992,456 @@
         }
       }
     },
+    "/api/configuracao/ofertas-curso": {
+      "get": {
+        "tags": [
+          "OfertasCurso"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OfertaCursoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OfertaCursoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OfertaCursoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/ofertas-curso/{id}": {
+      "get": {
+        "tags": [
+          "OfertasCurso"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/OfertaCursoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OfertaCursoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OfertaCursoDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/ofertas-curso": {
+      "post": {
+        "tags": [
+          "OfertasCurso"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarOfertaCursoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarOfertaCursoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarOfertaCursoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/ofertas-curso/{id}": {
+      "put": {
+        "tags": [
+          "OfertasCurso"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarOfertaCursoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarOfertaCursoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarOfertaCursoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "OfertasCurso"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configuracao/pesos-area-enem": {
       "get": {
         "tags": [
@@ -6084,6 +6534,67 @@
           }
         }
       },
+      "AtualizarOfertaCursoCommand": {
+        "required": [
+          "id",
+          "programaDeOferta"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "programaDeOferta": {
+            "type": "string"
+          },
+          "formatoPedagogico": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "turno": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "eMecCodigo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "codigoSga": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "vagasAnuaisAutorizadas": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "atoAutorizacaoMec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "AtualizarPesoAreaEnemCommand": {
         "required": [
           "id",
@@ -6790,6 +7301,77 @@
           }
         }
       },
+      "CriarOfertaCursoCommand": {
+        "required": [
+          "cursoId",
+          "localOfertaId",
+          "unidadeOfertanteOrigemId",
+          "programaDeOferta"
+        ],
+        "type": "object",
+        "properties": {
+          "cursoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "localOfertaId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "unidadeOfertanteOrigemId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "programaDeOferta": {
+            "type": "string"
+          },
+          "formatoPedagogico": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "turno": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "eMecCodigo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "codigoSga": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "vagasAnuaisAutorizadas": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "atoAutorizacaoMec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "CriarPesoAreaEnemCommand": {
         "required": [
           "resolucao",
@@ -7468,6 +8050,99 @@
           }
         }
       },
+      "OfertaCursoDto": {
+        "required": [
+          "id",
+          "cursoId",
+          "localOfertaId",
+          "unidadeOfertante",
+          "programaDeOferta",
+          "formatoPedagogico",
+          "turno",
+          "eMecCodigo",
+          "codigoSga",
+          "vagasAnuaisAutorizadas",
+          "baseLegal",
+          "atoAutorizacaoMec",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "cursoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "localOfertaId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "unidadeOfertante": {
+            "$ref": "#/components/schemas/UnidadeOfertanteDto"
+          },
+          "programaDeOferta": {
+            "type": "string"
+          },
+          "formatoPedagogico": {
+            "type": "string"
+          },
+          "turno": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "eMecCodigo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "codigoSga": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "vagasAnuaisAutorizadas": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "atoAutorizacaoMec": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "PesoAreaEnemDto": {
         "required": [
           "id",
@@ -7862,6 +8537,30 @@
         ],
         "type": "string"
       },
+      "UnidadeOfertanteDto": {
+        "required": [
+          "origemId",
+          "sigla",
+          "nome",
+          "tipo"
+        ],
+        "type": "object",
+        "properties": {
+          "origemId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sigla": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "tipo": {
+            "type": "string"
+          }
+        }
+      },
       "UserProfileResponse": {
         "required": [
           "userId",
@@ -7947,6 +8646,9 @@
     },
     {
       "name": "Modalidades"
+    },
+    {
+      "name": "OfertasCurso"
     },
     {
       "name": "PesosAreaEnem"

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
@@ -58,6 +58,7 @@ public static class ConfiguracaoModuleRegistration
         services.AddSingleton<IResourceLinksBuilder<FaseCanonicaDto>, FaseCanonicaLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<TipoBancaDto>, TipoBancaLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<CursoDto>, CursoLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<OfertaCursoDto>, OfertaCursoLinksBuilder>();
 
         // Idempotency-Key (ADR-0027) sobre o DbContext do módulo.
         services.AddIdempotency<ConfiguracaoDbContext, ConfiguracaoApiAssemblyMarker>(configuration);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/OfertasCursoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/OfertasCursoController.cs
@@ -1,0 +1,196 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.OfertasCurso;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/ofertas-curso</c>,
+/// <c>GET /api/configuracao/ofertas-curso/{id}</c>) e endpoints admin
+/// (<c>POST/PUT/DELETE /api/configuracao/admin/ofertas-curso</c>) restritos a
+/// <c>plataforma-admin</c> (story #588, issue #749, ADR-0066).
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class OfertasCursoController : ControllerBase
+{
+    private const string ResourceTag = "ofertas-curso";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<OfertaCursoDto> _linksBuilder;
+
+    public OfertasCursoController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<OfertaCursoDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista as ofertas de curso ativas, paginadas por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029).
+    /// </summary>
+    [HttpGet("ofertas-curso")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "oferta-curso", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<OfertaCursoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarOfertasCursoResult resultado = await _queryBus
+            .Send(new ListarOfertasCursoQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        OfertaCursoDto[] comLinks =
+            [.. resultado.Items.Select(o => o with { Links = _linksBuilder.Build(o) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém uma oferta de curso pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("ofertas-curso/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "oferta-curso", Versions = [1])]
+    [ProducesResponseType(typeof(OfertaCursoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        OfertaCursoDto? oferta = await _queryBus
+            .Send(new ObterOfertaCursoPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (oferta is null)
+        {
+            return NotFound();
+        }
+
+        OfertaCursoDto comLinks = oferta with { Links = _linksBuilder.Build(oferta) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>
+    /// Cria uma nova oferta de curso, congelando a unidade ofertante por
+    /// snapshot-copy (ADR-0061). Restrito a <c>plataforma-admin</c>.
+    /// Idempotency-Key obrigatório (ADR-0027).
+    /// </summary>
+    [HttpPost("admin/ofertas-curso")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarOfertaCursoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos regulatórios editáveis de uma oferta de curso.
+    /// Curso, local e unidade ofertante são imutáveis (mudá-los é outra oferta).
+    /// Restrito a <c>plataforma-admin</c>.
+    /// </summary>
+    [HttpPut("admin/ofertas-curso/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarOfertaCursoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Id divergente",
+                Detail = "O Id na URL não corresponde ao Id no corpo da requisição.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        Result resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Remove (soft-delete) uma oferta de curso. Restrito a
+    /// <c>plataforma-admin</c>. Sem 409: a remoção não é bloqueada por snapshots
+    /// congelados em outros módulos (cópias desacopladas — ADR-0061).
+    /// </summary>
+    [HttpDelete("admin/ofertas-curso/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverOfertaCursoCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -820,5 +820,126 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status409Conflict,
                 "uniplus.configuracao.curso.remocao_bloqueada_por_oferta_curso",
                 "Não é possível remover um curso referenciado por uma oferta de curso ativa")),
+
+        // ── Oferta de curso (UNI-REQ-0010) ─────────────────────────────────
+        new(OfertaCursoErrorCodes.CursoInexistenteOuRemovido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.curso_inexistente_ou_removido",
+                "Curso informado não existe ou foi removido")),
+
+        new(OfertaCursoErrorCodes.LocalOfertaInexistenteOuRemovido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.local_oferta_inexistente_ou_removido",
+                "Local de oferta informado não existe ou foi removido")),
+
+        new(OfertaCursoErrorCodes.UnidadeOfertanteInexistente,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.unidade_ofertante_inexistente",
+                "Unidade ofertante informada não existe ou foi removida — não há identidade viva para congelar")),
+
+        new(OfertaCursoErrorCodes.UnidadeOfertanteOrigemObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.unidade_ofertante_origem_obrigatoria",
+                "Identificador de origem da unidade ofertante é obrigatório")),
+
+        new(OfertaCursoErrorCodes.UnidadeOfertanteSiglaObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.unidade_ofertante_sigla_obrigatoria",
+                "Sigla da unidade ofertante é obrigatória")),
+
+        new(OfertaCursoErrorCodes.UnidadeOfertanteSiglaTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.unidade_ofertante_sigla_tamanho",
+                "Tamanho da sigla da unidade ofertante inválido")),
+
+        new(OfertaCursoErrorCodes.UnidadeOfertanteNomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.unidade_ofertante_nome_obrigatorio",
+                "Nome da unidade ofertante é obrigatório")),
+
+        new(OfertaCursoErrorCodes.UnidadeOfertanteNomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.unidade_ofertante_nome_tamanho",
+                "Tamanho do nome da unidade ofertante inválido")),
+
+        new(OfertaCursoErrorCodes.UnidadeOfertanteTipoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.unidade_ofertante_tipo_obrigatorio",
+                "Tipo da unidade ofertante é obrigatório")),
+
+        new(OfertaCursoErrorCodes.UnidadeOfertanteTipoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.unidade_ofertante_tipo_tamanho",
+                "Tamanho do tipo da unidade ofertante inválido")),
+
+        new(OfertaCursoErrorCodes.ProgramaDeOfertaInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.programa_de_oferta_invalido",
+                "Programa de oferta fora do domínio fechado")),
+
+        new(OfertaCursoErrorCodes.FormatoPedagogicoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.formato_pedagogico_invalido",
+                "Formato pedagógico fora do domínio fechado")),
+
+        new(OfertaCursoErrorCodes.TurnoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.turno_invalido",
+                "Turno fora do domínio fechado")),
+
+        new(OfertaCursoErrorCodes.BaseLegalObrigatoriaParaProgramaNaoRegular,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.base_legal_obrigatoria_para_programa_nao_regular",
+                "Base legal é obrigatória quando o programa de oferta não é Regular")),
+
+        new(OfertaCursoErrorCodes.VagasAnuaisNegativas,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.vagas_anuais_negativas",
+                "Vagas anuais autorizadas não pode ser negativo")),
+
+        new(OfertaCursoErrorCodes.EMecCodigoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.e_mec_codigo_tamanho",
+                "Tamanho do código e-MEC inválido")),
+
+        new(OfertaCursoErrorCodes.CodigoSgaTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.codigo_sga_tamanho",
+                "Tamanho do código SGA inválido")),
+
+        new(OfertaCursoErrorCodes.BaseLegalTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.base_legal_tamanho",
+                "Tamanho da base legal da oferta de curso inválido")),
+
+        new(OfertaCursoErrorCodes.AtoAutorizacaoMecTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.oferta_curso.ato_autorizacao_mec_tamanho",
+                "Tamanho do ato de autorização MEC inválido")),
+
+        new(OfertaCursoErrorCodes.NaoEncontrada,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.oferta_curso.nao_encontrada",
+                "Oferta de curso não encontrada")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/OfertaCursoLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/OfertaCursoLinksBuilder.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="OfertaCursoDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<OfertaCursoDto>, OfertaCursoLinksBuilder>().")]
+internal sealed class OfertaCursoLinksBuilder : IResourceLinksBuilder<OfertaCursoDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public OfertaCursoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(OfertaCursoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "OfertasCurso";
+
+        string self = ResolverPath(
+            httpContext, nameof(OfertasCursoController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(OfertasCursoController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/packages.lock.json
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/packages.lock.json
@@ -91,7 +91,8 @@
         "resolved": "2.70.0",
         "contentHash": "xNv0FFCVJa5S1beUtye82WFCxKThuE1jbN8DO1x1Rj8VSIWXLBUmfSID5a1fGzsU2R/EMfwPoWclJ2RMfQuGXw==",
         "dependencies": {
-          "Grpc.Net.Common": "2.70.0"
+          "Grpc.Net.Common": "2.70.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
         }
       },
       "Grpc.Net.Common": {
@@ -120,6 +121,10 @@
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
           "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Polly.Core": "8.6.5",
           "Spectre.Console": "0.55.0"
         }
@@ -140,7 +145,8 @@
           "JasperFx": "1.28.0",
           "Microsoft.CodeAnalysis": "5.0.0",
           "Microsoft.CodeAnalysis.CSharp": "5.0.0",
-          "Microsoft.CodeAnalysis.Scripting": "5.0.0"
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
         }
       },
       "JasperFx.SourceGeneration": {
@@ -287,6 +293,11 @@
           "Microsoft.Build.Framework": "17.11.31",
           "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
           "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "Microsoft.Extensions.DependencyInjection": "9.0.0",
+          "Microsoft.Extensions.Logging": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Options": "9.0.0",
+          "Microsoft.Extensions.Primitives": "9.0.0",
           "Microsoft.VisualStudio.SolutionPersistence": "1.0.52",
           "Newtonsoft.Json": "13.0.3",
           "System.Composition": "9.0.0"
@@ -302,10 +313,311 @@
         "resolved": "10.0.9",
         "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "10.0.2",
         "contentHash": "DHXzj/FKmUDmhzw7AHbMXbNNcgO8Cb9PDbYOUDICjFAdIALy2WbC6pm+dFKiAUNtcYMucZu2iMVw1ef/sdcZFw=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Logging.Console": "10.0.0",
+          "Microsoft.Extensions.Logging.Debug": "10.0.0",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "KrN6TGFwCwqOkLLk/idW/XtDQh+8In+CL9T4M1Dx+5ScsjTq4TlVbal8q532m82UYrMr6RiQJF2HvYCN0QwVsA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "N7Gm9SjugYjmmnhwbBKC9DFqGqjfJvh6YfOJgtwh0AW0Xpok3dIVors1ik050XmUxKAgAc7nNngDIJyFb06K2g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "System.Diagnostics.EventLog": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -438,6 +750,8 @@
         "resolved": "1.16.0",
         "contentHash": "nE/Px3MUvQC8c0UG0DOP5OJE7vMtiMaPYi/6TkSS/o/O0s/oPq+8WaPYTVEPzb7lwu/QyLgknc+sFm2FjPXe2A==",
         "dependencies": {
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "1.16.0"
         }
       },
@@ -451,6 +765,7 @@
         "resolved": "1.16.0",
         "contentHash": "hZwaHAkXvUNn9+cS+vEvYBgIrIQOQRz2cIRUODZ5gxHsDsLeNCueLgZFkybopjE0jUhLut6lm5eL3LTqbW0hMg==",
         "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "OpenTelemetry.Api": "1.16.0"
         }
       },
@@ -474,6 +789,9 @@
         "resolved": "10.0.0",
         "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
         "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
           "Serilog": "4.3.0",
           "Serilog.Extensions.Logging": "10.0.0"
         }
@@ -483,6 +801,7 @@
         "resolved": "10.0.0",
         "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
         "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.0",
           "Serilog": "4.2.0"
         }
       },
@@ -499,6 +818,7 @@
         "resolved": "10.0.0",
         "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
           "Microsoft.Extensions.DependencyModel": "10.0.0",
           "Serilog": "4.3.0"
         }
@@ -593,6 +913,11 @@
           "System.Composition.Runtime": "9.0.0"
         }
       },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
+      },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
         "resolved": "8.0.1",
@@ -653,6 +978,7 @@
         "type": "Project",
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
@@ -666,7 +992,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {
@@ -778,6 +1105,7 @@
         "contentHash": "tIy1DwZ0On58uaENl3c9z8/23ztauvTXlO8vwhtJQsaiQrgoZKp5TmIgt5/piTgjxqTnaLRtmvZ9PwnjQ4gPiQ==",
         "dependencies": {
           "Confluent.Kafka": "2.14.2",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -799,7 +1127,8 @@
         "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)"
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation.DependencyInjectionExtensions": {
@@ -808,7 +1137,8 @@
         "resolved": "12.1.1",
         "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
         "dependencies": {
-          "FluentValidation": "12.1.1"
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
         }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
@@ -827,7 +1157,9 @@
         "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9"
         }
       },
       "Microsoft.EntityFrameworkCore.Design": {
@@ -842,7 +1174,10 @@
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
           "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
+          "Microsoft.Extensions.Caching.Memory": "10.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
           "Microsoft.Extensions.DependencyModel": "10.0.2",
+          "Microsoft.Extensions.Logging": "10.0.2",
           "Mono.TextTemplating": "3.0.0",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -853,7 +1188,19 @@
         "resolved": "10.0.9",
         "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
       },
       "Microsoft.OpenApi": {
@@ -869,6 +1216,8 @@
         "contentHash": "GiCD0koYBM8/VCXRkrfSzOtySEmrA2ngceJuxRO5H+/uGodiTX+XPaUHQq9/1DpaeBxWnkmrgqu52dwuZqIYgw==",
         "dependencies": {
           "CommunityToolkit.HighPerformance": "8.4.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.4",
+          "Microsoft.Extensions.Logging": "9.0.4",
           "System.IO.Hashing": "9.0.4",
           "System.Reactive": "6.0.1"
         }
@@ -887,7 +1236,10 @@
         "type": "CentralTransitive",
         "requested": "[10.0.3, )",
         "resolved": "10.0.3",
-        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w=="
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "CentralTransitive",
@@ -915,6 +1267,7 @@
         "resolved": "1.16.0",
         "contentHash": "/YfrO5MRaA156vhNanYGPX2JjOwKUrA0+Jf7ltT2eD3VkfHqXcEJY5Oxt/nWH8lqBOTc1nJpn2soBtD5Cml8Dg==",
         "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "OpenTelemetry": "1.16.0"
         }
       },
@@ -933,6 +1286,8 @@
         "resolved": "1.15.1-beta.1",
         "contentHash": "NmtYLk3HJUUkV0g2VnFLs67/PGIVbI8JXtu0g4f9bk2ZaInp211/AL2+Qcbgkb9ih/uOi8loN6E1Aw2o0YIWag==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
         }
       },
@@ -942,6 +1297,8 @@
         "resolved": "1.16.0",
         "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
@@ -971,6 +1328,7 @@
         "resolved": "2.12.14",
         "contentHash": "QiAQg40OP4Owem6/PjIbjEKq2+uIeQYeZ1TCMUnx/QvKugOPxOfC96wjlnBjWHi4Wq9pv9+fDlXGT06XkRZ6Ig==",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8",
           "System.IO.Hashing": "10.0.2"
         }
@@ -991,6 +1349,15 @@
           "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
           "NewId": "4.0.1",
           "Newtonsoft.Json": "13.0.3"
         }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/AtualizarOfertaCursoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/AtualizarOfertaCursoCommand.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza os atributos editáveis de uma oferta de curso: programa, formato
+/// pedagógico, turno, códigos (e-MEC / SGA), teto de vagas, base legal e ato de
+/// autorização. <c>CursoId</c>, <c>LocalOfertaId</c> e a unidade ofertante
+/// (snapshot-copy, ADR-0061) são <b>imutáveis</b> — mudar curso×local×unidade
+/// caracteriza outra oferta; este comando não os aceita. O guard condicional da
+/// base legal é revalidado na transição (Regular→Parfor sem base é rejeitado).
+/// O ator (<c>updated_by</c>) é carimbado server-side via <c>IUserContext</c>.
+/// </summary>
+public sealed record AtualizarOfertaCursoCommand(
+    Guid Id,
+    string ProgramaDeOferta,
+    string? FormatoPedagogico = null,
+    string? Turno = null,
+    string? EMecCodigo = null,
+    string? CodigoSga = null,
+    int? VagasAnuaisAutorizadas = null,
+    string? BaseLegal = null,
+    string? AtoAutorizacaoMec = null) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/AtualizarOfertaCursoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/AtualizarOfertaCursoCommandHandler.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="AtualizarOfertaCursoCommand"/>. Só toca os atributos
+/// regulatórios editáveis — curso, local e unidade ofertante são imutáveis
+/// (o agregado nem expõe a mutação). O guard da base legal condicional ao
+/// programa é revalidado pelo agregado na transição.
+/// </summary>
+public static class AtualizarOfertaCursoCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarOfertaCursoCommand command,
+        IOfertaCursoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        OfertaCurso? oferta = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (oferta is null)
+        {
+            return Result.Failure(new DomainError(
+                OfertaCursoErrorCodes.NaoEncontrada,
+                "Oferta de curso não encontrada."));
+        }
+
+        Result atualizarResult = oferta.Atualizar(
+            command.ProgramaDeOferta,
+            command.FormatoPedagogico,
+            command.Turno,
+            command.EMecCodigo,
+            command.CodigoSga,
+            command.VagasAnuaisAutorizadas,
+            command.BaseLegal,
+            command.AtoAutorizacaoMec);
+
+        if (atualizarResult.IsFailure)
+        {
+            return atualizarResult;
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/AtualizarOfertaCursoCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/AtualizarOfertaCursoCommandValidator.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public sealed class AtualizarOfertaCursoCommandValidator
+    : AbstractValidator<AtualizarOfertaCursoCommand>
+{
+    public AtualizarOfertaCursoCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage("Id da oferta de curso é obrigatório.");
+
+        RuleFor(x => x.ProgramaDeOferta)
+            .NotEmpty().WithMessage("Programa de oferta é obrigatório.")
+            .Must(ProgramasDeOferta.EhValido)
+            .WithMessage($"Programa de oferta deve ser um de: {string.Join(", ", ProgramasDeOferta.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.ProgramaDeOferta), ApplyConditionTo.CurrentValidator);
+
+        // Formato em branco equivale a "default PRESENCIAL" (o domínio aplica);
+        // só valida o domínio fechado quando há valor efetivo.
+        RuleFor(x => x.FormatoPedagogico)
+            .Must(FormatosPedagogicos.EhValido)
+            .WithMessage($"Formato pedagógico deve ser um de: {string.Join(", ", FormatosPedagogicos.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.FormatoPedagogico));
+
+        // Turno em branco equivale a "sem turno" (o domínio normaliza para nulo).
+        RuleFor(x => x.Turno)
+            .Must(TurnosOferta.EhValido)
+            .WithMessage($"Turno da oferta deve ser um de: {string.Join(", ", TurnosOferta.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Turno));
+
+        RuleFor(x => x.VagasAnuaisAutorizadas)
+            .GreaterThanOrEqualTo(0)
+            .WithMessage("Vagas anuais autorizadas não podem ser negativas (zero é aceito).")
+            .When(x => x.VagasAnuaisAutorizadas.HasValue);
+
+        RuleFor(x => x.EMecCodigo)
+            .MaximumLength(20).WithMessage("Código e-MEC da oferta deve ter no máximo 20 caracteres.");
+
+        RuleFor(x => x.CodigoSga)
+            .MaximumLength(30).WithMessage("Código no sistema de gestão acadêmica deve ter no máximo 30 caracteres.");
+
+        RuleFor(x => x.BaseLegal)
+            .MaximumLength(500).WithMessage("Base legal da oferta deve ter no máximo 500 caracteres.");
+
+        RuleFor(x => x.AtoAutorizacaoMec)
+            .MaximumLength(300).WithMessage("Ato de autorização MEC deve ter no máximo 300 caracteres.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/CriarOfertaCursoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/CriarOfertaCursoCommand.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria uma oferta de curso — a instância regulatória que liga um curso vivo a
+/// um local de oferta vivo e à unidade ofertante (story #588, issue #749,
+/// ADR-0066). A unidade chega como <paramref name="UnidadeOfertanteOrigemId"/>:
+/// o handler resolve a Unidade viva via <c>IUnidadeReader</c> (ADR-0056) e
+/// congela sigla/nome/tipo por snapshot-copy (ADR-0061) — o payload nunca traz
+/// o snapshot pronto. Enums como tokens UPPER_SNAKE: programa obrigatório;
+/// formato pedagógico com default PRESENCIAL quando ausente; turno opcional.
+/// A base legal é obrigatória quando o programa não é REGULAR (guard de
+/// domínio). O ator de auditoria (<c>created_by</c>) é carimbado server-side
+/// via <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarOfertaCursoCommand(
+    Guid CursoId,
+    Guid LocalOfertaId,
+    Guid UnidadeOfertanteOrigemId,
+    string ProgramaDeOferta,
+    string? FormatoPedagogico = null,
+    string? Turno = null,
+    string? EMecCodigo = null,
+    string? CodigoSga = null,
+    int? VagasAnuaisAutorizadas = null,
+    string? BaseLegal = null,
+    string? AtoAutorizacaoMec = null) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/CriarOfertaCursoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/CriarOfertaCursoCommandHandler.cs
@@ -1,0 +1,128 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+
+using Wolverine.Attributes;
+
+/// <summary>
+/// Handler do <see cref="CriarOfertaCursoCommand"/> (convention-based Wolverine):
+/// valida a existência viva do curso e do local de oferta (o filtro global de
+/// soft-delete já exclui removidos), resolve a Unidade viva via
+/// <see cref="IUnidadeReader"/> (ADR-0056) e a congela por snapshot-copy
+/// (<see cref="UnidadeOfertante"/>, ADR-0061) — sem identidade viva não há o que
+/// congelar, então unidade inexistente/removida é rejeitada. Sem chave natural
+/// única: não há checagem de unicidade nem tradução de 23505.
+/// </summary>
+public static class CriarOfertaCursoCommandHandler
+{
+    /// <summary>
+    /// <c>[NonTransactional]</c> é necessário porque este é o primeiro handler do
+    /// monólito que injeta um reader cross-módulo (<see cref="IUnidadeReader"/>,
+    /// implementado em Organização, dependente de
+    /// <c>OrganizacaoInstitucionalDbContext</c>) dentro de um handler que TAMBÉM
+    /// escreve no seu próprio módulo (via <see cref="IConfiguracaoUnitOfWork"/>,
+    /// dependente de <c>ConfiguracaoDbContext</c>). O detector de transação do
+    /// Wolverine.EntityFrameworkCore (<c>AutoApplyTransactions</c>) enumera TODAS
+    /// as dependências transitivas dos parâmetros do handler em busca de um único
+    /// <c>DbContext</c> a enrolar na transação do outbox — encontra os dois e
+    /// falha por ambiguidade (<c>InvalidOperationException</c> no boot do host).
+    /// A persistência continua correta sem o enrolamento automático: o handler já
+    /// chama <see cref="IConfiguracaoUnitOfWork.SalvarAlteracoesAsync"/>
+    /// explicitamente (mesmo padrão de todo handler de Configuração), e o módulo
+    /// não emite domain events — não há atomicidade write+evento de outbox a
+    /// perder (ADR-0004 não se aplica aqui). O reader é só leitura, sem
+    /// participação na transação de escrita.
+    /// </summary>
+    [NonTransactional]
+    public static async Task<Result<Guid>> Handle(
+        CriarOfertaCursoCommand command,
+        IOfertaCursoRepository repository,
+        ICursoRepository cursoRepository,
+        ILocalOfertaRepository localOfertaRepository,
+        IUnidadeReader unidadeReader,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(cursoRepository);
+        ArgumentNullException.ThrowIfNull(localOfertaRepository);
+        ArgumentNullException.ThrowIfNull(unidadeReader);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        // Existência viva do curso: o query filter global de soft-delete já
+        // exclui mortos — inexistente e removido caem no mesmo erro.
+        Curso? curso = await cursoRepository
+            .ObterPorIdParaLeituraAsync(command.CursoId, cancellationToken)
+            .ConfigureAwait(false);
+        if (curso is null)
+        {
+            return Result<Guid>.Failure(new DomainError(
+                OfertaCursoErrorCodes.CursoInexistenteOuRemovido,
+                "Curso inexistente ou removido — a oferta exige um curso vivo."));
+        }
+
+        LocalOferta? localOferta = await localOfertaRepository
+            .ObterPorIdParaLeituraAsync(command.LocalOfertaId, cancellationToken)
+            .ConfigureAwait(false);
+        if (localOferta is null)
+        {
+            return Result<Guid>.Failure(new DomainError(
+                OfertaCursoErrorCodes.LocalOfertaInexistenteOuRemovido,
+                "Local de oferta inexistente ou removido — a oferta exige um local vivo."));
+        }
+
+        // Snapshot-copy da unidade ofertante (ADR-0061): resolve a Unidade VIVA
+        // via reader cross-módulo (ADR-0056) e congela sigla/nome/tipo. Reader
+        // devolve null para inexistente/soft-deleted — não há identidade viva
+        // para congelar, então a criação é rejeitada.
+        UnidadeView? unidadeView = await unidadeReader
+            .ObterPorIdAsync(command.UnidadeOfertanteOrigemId, cancellationToken)
+            .ConfigureAwait(false);
+        if (unidadeView is null)
+        {
+            return Result<Guid>.Failure(new DomainError(
+                OfertaCursoErrorCodes.UnidadeOfertanteInexistente,
+                "Unidade ofertante inexistente ou removida — não há identidade viva para congelar."));
+        }
+
+        // O Tipo da UnidadeView já é a string estável do contrato (desacoplada do
+        // enum interno de Organização) — congela como veio.
+        Result<UnidadeOfertante> unidadeOfertanteResult = UnidadeOfertante.Criar(
+            unidadeView.Id, unidadeView.Sigla, unidadeView.Nome, unidadeView.Tipo);
+        if (unidadeOfertanteResult.IsFailure)
+        {
+            return Result<Guid>.Failure(unidadeOfertanteResult.Error!);
+        }
+
+        Result<OfertaCurso> ofertaResult = OfertaCurso.Criar(
+            command.CursoId,
+            command.LocalOfertaId,
+            unidadeOfertanteResult.Value!,
+            command.ProgramaDeOferta,
+            command.FormatoPedagogico,
+            command.Turno,
+            command.EMecCodigo,
+            command.CodigoSga,
+            command.VagasAnuaisAutorizadas,
+            command.BaseLegal,
+            command.AtoAutorizacaoMec);
+
+        if (ofertaResult.IsFailure)
+        {
+            return Result<Guid>.Failure(ofertaResult.Error!);
+        }
+
+        OfertaCurso oferta = ofertaResult.Value!;
+        await repository.AdicionarAsync(oferta, cancellationToken).ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<Guid>.Success(oferta.Id);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/CriarOfertaCursoCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/CriarOfertaCursoCommandValidator.cs
@@ -1,0 +1,57 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+
+using FluentValidation;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public sealed class CriarOfertaCursoCommandValidator
+    : AbstractValidator<CriarOfertaCursoCommand>
+{
+    public CriarOfertaCursoCommandValidator()
+    {
+        RuleFor(x => x.CursoId)
+            .NotEmpty().WithMessage("Id do curso é obrigatório.");
+
+        RuleFor(x => x.LocalOfertaId)
+            .NotEmpty().WithMessage("Id do local de oferta é obrigatório.");
+
+        RuleFor(x => x.UnidadeOfertanteOrigemId)
+            .NotEmpty().WithMessage("Id da unidade ofertante é obrigatório.");
+
+        RuleFor(x => x.ProgramaDeOferta)
+            .NotEmpty().WithMessage("Programa de oferta é obrigatório.")
+            .Must(ProgramasDeOferta.EhValido)
+            .WithMessage($"Programa de oferta deve ser um de: {string.Join(", ", ProgramasDeOferta.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.ProgramaDeOferta), ApplyConditionTo.CurrentValidator);
+
+        // Formato em branco equivale a "default PRESENCIAL" (o domínio aplica);
+        // só valida o domínio fechado quando há valor efetivo.
+        RuleFor(x => x.FormatoPedagogico)
+            .Must(FormatosPedagogicos.EhValido)
+            .WithMessage($"Formato pedagógico deve ser um de: {string.Join(", ", FormatosPedagogicos.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.FormatoPedagogico));
+
+        // Turno em branco equivale a "sem turno" (o domínio normaliza para nulo).
+        RuleFor(x => x.Turno)
+            .Must(TurnosOferta.EhValido)
+            .WithMessage($"Turno da oferta deve ser um de: {string.Join(", ", TurnosOferta.TokensCanonicos)}.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Turno));
+
+        RuleFor(x => x.VagasAnuaisAutorizadas)
+            .GreaterThanOrEqualTo(0)
+            .WithMessage("Vagas anuais autorizadas não podem ser negativas (zero é aceito).")
+            .When(x => x.VagasAnuaisAutorizadas.HasValue);
+
+        RuleFor(x => x.EMecCodigo)
+            .MaximumLength(20).WithMessage("Código e-MEC da oferta deve ter no máximo 20 caracteres.");
+
+        RuleFor(x => x.CodigoSga)
+            .MaximumLength(30).WithMessage("Código no sistema de gestão acadêmica deve ter no máximo 30 caracteres.");
+
+        RuleFor(x => x.BaseLegal)
+            .MaximumLength(500).WithMessage("Base legal da oferta deve ter no máximo 500 caracteres.");
+
+        RuleFor(x => x.AtoAutorizacaoMec)
+            .MaximumLength(300).WithMessage("Ato de autorização MEC deve ter no máximo 300 caracteres.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/RemoverOfertaCursoCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/RemoverOfertaCursoCommand.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>Remove (soft-delete) uma oferta de curso pelo seu <c>Id</c>.</summary>
+public sealed record RemoverOfertaCursoCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/RemoverOfertaCursoCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/OfertasCurso/RemoverOfertaCursoCommandHandler.cs
@@ -1,0 +1,43 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverOfertaCursoCommand"/>. Soft-delete simples via
+/// <c>SoftDeleteInterceptor</c> — a remoção <b>não</b> é bloqueada por snapshots
+/// externos: cópias congeladas da oferta em outros módulos (ex.: edital de
+/// Seleção, ADR-0061) são desacopladas e preservam o histórico por conta
+/// própria. Só a oferta viva sai das leituras.
+/// </summary>
+public static class RemoverOfertaCursoCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverOfertaCursoCommand command,
+        IOfertaCursoRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        OfertaCurso? oferta = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (oferta is null)
+        {
+            return Result.Failure(new DomainError(
+                OfertaCursoErrorCodes.NaoEncontrada,
+                "Oferta de curso não encontrada."));
+        }
+
+        repository.Remover(oferta);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/OfertaCursoDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/OfertaCursoDto.cs
@@ -1,0 +1,31 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>OfertaCurso</c>. A unidade ofertante é um
+/// sub-objeto aninhado (<see cref="UnidadeOfertanteDto"/>, snapshot-copy
+/// ADR-0061). Os enums são expostos como tokens UPPER_SNAKE do contrato
+/// (<c>programaDeOferta</c>/<c>formatoPedagogico</c> obrigatórios;
+/// <c>turno</c> nulo quando a oferta não declara turno). Suporta HATEOAS
+/// Level 1 via <c>_links</c> (ADR-0029).
+/// </summary>
+public sealed record OfertaCursoDto(
+    Guid Id,
+    Guid CursoId,
+    Guid LocalOfertaId,
+    UnidadeOfertanteDto UnidadeOfertante,
+    string ProgramaDeOferta,
+    string FormatoPedagogico,
+    string? Turno,
+    string? EMecCodigo,
+    string? CodigoSga,
+    int? VagasAnuaisAutorizadas,
+    string? BaseLegal,
+    string? AtoAutorizacaoMec,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/UnidadeOfertanteDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/UnidadeOfertanteDto.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Snapshot da unidade ofertante aninhado no contrato HTTP da oferta de curso
+/// (ADR-0061): <c>origemId</c> é a proveniência (Id da Unidade viva no ato da
+/// criação) e <c>sigla</c>/<c>nome</c>/<c>tipo</c> são a cópia congelada — não
+/// refletem mudanças posteriores na Unidade viva.
+/// </summary>
+public sealed record UnidadeOfertanteDto(
+    Guid OrigemId,
+    string Sigla,
+    string Nome,
+    string Tipo);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/OfertaCursoMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/OfertaCursoMapping.cs
@@ -1,0 +1,31 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public static class OfertaCursoMapping
+{
+    public static OfertaCursoDto ToDto(this OfertaCurso oferta)
+    {
+        ArgumentNullException.ThrowIfNull(oferta);
+        return new OfertaCursoDto(
+            oferta.Id,
+            oferta.CursoId,
+            oferta.LocalOfertaId,
+            new UnidadeOfertanteDto(
+                oferta.UnidadeOfertante.OrigemId,
+                oferta.UnidadeOfertante.Sigla,
+                oferta.UnidadeOfertante.Nome,
+                oferta.UnidadeOfertante.Tipo),
+            ProgramasDeOferta.ParaTokenCanonico(oferta.ProgramaDeOferta),
+            FormatosPedagogicos.ParaTokenCanonico(oferta.FormatoPedagogico),
+            oferta.Turno is { } turno ? TurnosOferta.ParaTokenCanonico(turno) : null,
+            oferta.EMecCodigo,
+            oferta.CodigoSga,
+            oferta.VagasAnuaisAutorizadas,
+            oferta.BaseLegal,
+            oferta.AtoAutorizacaoMec,
+            oferta.CreatedAt);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.OfertasCurso;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista ofertas de curso vivas paginadas por cursor bidirecional
+/// (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e valida
+/// limit/direction antes de despachar.
+/// </summary>
+public sealed record ListarOfertasCursoQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarOfertasCursoResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.OfertasCurso;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarOfertasCursoQueryHandler
+{
+    public static async Task<ListarOfertasCursoResult> Handle(
+        ListarOfertasCursoQuery query,
+        IOfertaCursoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<OfertaCurso> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        OfertaCursoDto[] items = [.. itens.Select(o => o.ToDto())];
+        return new ListarOfertasCursoResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.OfertasCurso;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarOfertasCursoQuery"/>: lote de ofertas
+/// projetadas + âncoras opcionais para o controller construir os cursores
+/// prev/next (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarOfertasCursoResult(
+    IReadOnlyList<OfertaCursoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ObterOfertaCursoPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ObterOfertaCursoPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.OfertasCurso;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterOfertaCursoPorIdQuery(Guid Id) : IQuery<OfertaCursoDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ObterOfertaCursoPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ObterOfertaCursoPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.OfertasCurso;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterOfertaCursoPorIdQueryHandler
+{
+    public static async Task<OfertaCursoDto?> Handle(
+        ObterOfertaCursoPorIdQuery query,
+        IOfertaCursoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        OfertaCurso? oferta = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return oferta?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Unifesspa.UniPlus.Configuracao.Application.csproj
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Unifesspa.UniPlus.Configuracao.Application.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="WolverineFx" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/packages.lock.json
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/packages.lock.json
@@ -18,10 +18,586 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
         }
       },
+      "WolverineFx": {
+        "type": "Direct",
+        "requested": "[5.39.5, )",
+        "resolved": "5.39.5",
+        "contentHash": "rnyz+ZConabOTi/U8N7UQAOaMc9P03hHyFrXZ6///6X0qtsHQ+VKDZtHe87AZJmY7By2w9As9puY6/jGCg5ZCA==",
+        "dependencies": {
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
+          "JasperFx.RuntimeCompiler": "4.5.0",
+          "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "FastExpressionCompiler": {
+        "type": "Transitive",
+        "resolved": "5.3.0",
+        "contentHash": "XRmGW48Gdm7B70WUtTJJUnmuc8jRDmOhhjG/a3rix/nXChnrkETaSvA0j2VrcsH4MNeYLe60LA5o5JABmbneag=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "ImTools": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "dms0JfLKC9AQbQX/EdpRjn59EjEvaCxIgv1z9YxbEQb5SiOVoo7vlIKdEySeEwUkWhN05rZnNpUpG+aw5VqPVQ=="
+      },
+      "JasperFx": {
+        "type": "Transitive",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
+        "dependencies": {
+          "FastExpressionCompiler": "5.3.0",
+          "ImTools": "4.0.0",
+          "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
+          "Polly.Core": "8.6.5",
+          "Spectre.Console": "0.55.0"
+        }
+      },
+      "JasperFx.Events": {
+        "type": "Transitive",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
+        "dependencies": {
+          "JasperFx": "1.31.0"
+        }
+      },
+      "JasperFx.RuntimeCompiler": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "SGJlU1kD8lX8A5p0hBWTPDV7dvPzoUB37IZjprWgA+L5yZZNyBElpn6UPNo7ZuXLKKwlSSt8BWTr99vxpxT3JA==",
+        "dependencies": {
+          "JasperFx": "1.28.0",
+          "Microsoft.CodeAnalysis": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "JasperFx.SourceGeneration": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "yIOaiA/OrlXQLGPjxFDubHnOU8MCzPTz465xBGRITMm4fDf7DbWKogb2SZC2jYLWEj27q3smTz1Z7lU4h1KkOQ=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bUubrBD6tRJE3V1kvRloYc6NymH3R5oFKjAS9e0ELNx6u0ZR+zjps9dDQyjgqN/rArzl7f+21KGszj3YRN7F2Q=="
+      },
+      "Microsoft.CodeAnalysis": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "X7vItpZDkGm4NS2wp4P1S07Z1e61LaBWDW5tPXE1c6z5/x9KbF2RymhAPoYg7Qoiyk7odEZ6EjBEJ47p3dBpYQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1sGloRYbG3743ut/+vuXy9/WaRQTm7mDtp71rBaVSmKpFntvo5Hcro1ubg6/3SeeLtiFYJl7V3Dk0Fo3CGlnHA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Scripting.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/KgZdm6kRTrR/O2jqXxU5GWREYhtVmqcNWczyPt8hsQkFGFK/C6CrLWfG44FCUn0aPHGDRBHYjXlGosQ/H8oXw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Scripting": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "XTulByMNxqXGCgMeODUoG2h4oK4/nLv1BcawRVcjv+UZHMpoaymtdaq3cJqlNrEvYEcbU48g5swJ3RhY1m3fBg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "sUBWvHs2HgHGA+b716dgjS7JiXGen5ntyohAurPLR1ZiZzFp3FlnVA7GrMTqVGdVJTVqiC3c4K8k1bk0gj6IPg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Nom4UuZVEZGaV6Qa+joJR/BawXZMtflvQJFKc0SaUc3LrZr/8LmRY5cn8mbvLOWIVfwWkQz+cVE6eQKu9qa65g==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "Zcoy6H9mSoGyvr7UvlGokEZrlZkcPCICPZr8mCsSt9U/N8eeCwCXwKF5bShdA66R0obxBCwP4AxomQHvVkC/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "krK19MKp0BNiR9rpBDW7PKSrTMLVlifS9am3CVc4O1Jq6GWz0o4F+sw5OSL4L3mVd56W8l6JRgghUa2KB51vOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "d2kDKnCsJvY7mBVhcjPSp9BkJk48DsaHPg5u+Oy4f8XaOqnEedRy/USyvnpHL92wpJ6DrTPy7htppUUzskbCXQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Logging.Console": "10.0.0",
+          "Microsoft.Extensions.Logging.Debug": "10.0.0",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "KrN6TGFwCwqOkLLk/idW/XtDQh+8In+CL9T4M1Dx+5ScsjTq4TlVbal8q532m82UYrMr6RiQJF2HvYCN0QwVsA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "System.Diagnostics.EventLog": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+      },
+      "NewId": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "jegBasNndmG21G3BmT51suFDCIz/sLN81j+IxmkZ4iWoaDi8LygeHiyNnYbXz5OQh9nCRJFIx1+PJrlYi1Gc9Q=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.5",
+        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+      },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
       },
       "unifesspa.uniplus.application.abstractions": {
         "type": "Project",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IOfertaCursoReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IOfertaCursoReader.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo de <c>OfertaCurso</c> (ADR-0056). Expõe o estado vivo do
+/// cadastro de ofertas para consumo por outros bounded contexts (ex.: o quadro de
+/// vagas de um edital no Módulo Seleção) sem acesso direto ao schema de
+/// Configuração (ADR-0054/0097).
+/// </summary>
+public interface IOfertaCursoReader
+{
+    /// <summary>
+    /// Lista todas as ofertas de curso vivas (não soft-deleted), ordenadas por
+    /// <c>Id</c> ascendente para determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<OfertaCursoView>> ListarVivasAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém uma oferta de curso pelo <paramref name="id"/>, ou
+    /// <see langword="null"/> se inexistente / soft-deleted.
+    /// </summary>
+    Task<OfertaCursoView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/OfertaCursoView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/OfertaCursoView.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>OfertaCurso</c> para consumo cross-módulo via
+/// <see cref="IOfertaCursoReader"/> (ADR-0056). Expõe a oferta viva que outro
+/// bounded context (ex.: o Módulo Seleção, ao montar o quadro de vagas de um
+/// edital) lê antes de congelar por valor o que precisar (snapshot-copy,
+/// ADR-0061) — este contrato não define, por si só, o que o consumidor
+/// congelará. Os enums são expostos como tokens textuais (UPPER_SNAKE); a
+/// unidade ofertante já vem achatada (é, ela mesma, um snapshot-copy — ADR-0061).
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7 — ADR-0032).</param>
+/// <param name="CursoId">Curso curricular referenciado (FK intra-schema).</param>
+/// <param name="LocalOfertaId">Local de oferta referenciado (FK intra-schema).</param>
+/// <param name="UnidadeOfertanteOrigemId">Identificador de origem da unidade ofertante congelada.</param>
+/// <param name="UnidadeOfertanteSigla">Sigla da unidade ofertante congelada.</param>
+/// <param name="UnidadeOfertanteNome">Nome da unidade ofertante congelada.</param>
+/// <param name="UnidadeOfertanteTipo">Tipo da unidade ofertante congelado.</param>
+/// <param name="ProgramaDeOferta">Programa de oferta (token; ex.: "REGULAR").</param>
+/// <param name="FormatoPedagogico">Formato pedagógico (token; ex.: "PRESENCIAL").</param>
+/// <param name="Turno">Turno (token) ou null.</param>
+/// <param name="EMecCodigo">Código e-MEC por campus-sede, ou null.</param>
+/// <param name="CodigoSga">Código no sistema de gestão acadêmica, ou null.</param>
+/// <param name="VagasAnuaisAutorizadas">Teto de vagas autorizadas no e-MEC (não são vagas de certame), ou null.</param>
+/// <param name="BaseLegal">Base legal (obrigatória quando o programa não é Regular), ou null.</param>
+/// <param name="AtoAutorizacaoMec">Ato de autorização específico da oferta, ou null.</param>
+public sealed record OfertaCursoView(
+    Guid Id,
+    Guid CursoId,
+    Guid LocalOfertaId,
+    Guid UnidadeOfertanteOrigemId,
+    string UnidadeOfertanteSigla,
+    string UnidadeOfertanteNome,
+    string UnidadeOfertanteTipo,
+    string ProgramaDeOferta,
+    string FormatoPedagogico,
+    string? Turno,
+    string? EMecCodigo,
+    string? CodigoSga,
+    int? VagasAnuaisAutorizadas,
+    string? BaseLegal,
+    string? AtoAutorizacaoMec);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/OfertaCurso.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/OfertaCurso.cs
@@ -1,0 +1,272 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Oferta de Curso — a instância <b>regulatória</b> da oferta acadêmica
+/// (story #588, issue #749, ADR-0066): liga um <see cref="Curso"/> (matriz
+/// curricular pura) a um <see cref="LocalOferta"/> e à unidade ofertante
+/// (instituto/faculdade, snapshot-copy — ADR-0061), carregando os atributos
+/// que variam por campus: código e-MEC, código no sistema de gestão acadêmica,
+/// programa, formato pedagógico, turno, teto de vagas e-MEC e base legal.
+/// O mesmo curso tem ofertas distintas por campus, com códigos e-MEC diferentes.
+/// </summary>
+/// <remarks>
+/// <para><see cref="CursoId"/>, <see cref="LocalOfertaId"/> e
+/// <see cref="UnidadeOfertante"/> são <b>imutáveis</b> pós-criação: mudar
+/// curso×local×unidade não é editar a oferta, é <i>outra</i> oferta —
+/// <see cref="Atualizar"/> não os recebe nem os altera. A unidade ofertante é
+/// snapshot-copy (ADR-0061): congelada da Unidade viva no ato da criação, sem FK.</para>
+/// <para><see cref="VagasAnuaisAutorizadas"/> é o teto autorizado no e-MEC —
+/// <b>não</b> são as vagas de um certame (essas pertencem ao edital, módulo
+/// Seleção). A <see cref="BaseLegal"/> é obrigatória quando
+/// <see cref="ProgramaDeOferta"/> ≠ <see cref="Enums.ProgramaDeOferta.Regular"/>
+/// (guard revalidado na criação E na atualização — ex.: transição
+/// Regular→Parfor sem base legal é rejeitada).</para>
+/// <para>Não há chave natural única entre ofertas vivas — a repetição
+/// curso×local×unidade é admitida (ex.: turnos ou programas distintos). A
+/// remoção é soft-delete simples e <b>não</b> é bloqueada por snapshots
+/// congelados em outros módulos (as cópias de Seleção são desacopladas —
+/// ADR-0061). Dado institucional sem PII (LGPD inaplicável).</para>
+/// </remarks>
+public sealed class OfertaCurso : SoftDeletableEntity, IAuditableEntity
+{
+    private const int EMecCodigoMaxLength = 20;
+    private const int CodigoSgaMaxLength = 30;
+    private const int BaseLegalMaxLength = 500;
+    private const int AtoAutorizacaoMecMaxLength = 300;
+
+    public Guid CursoId { get; private set; }
+    public Guid LocalOfertaId { get; private set; }
+
+    /// <summary>Snapshot-copy da unidade ofertante (ADR-0061) — imutável pós-criação.</summary>
+    public UnidadeOfertante UnidadeOfertante { get; private set; } = null!;
+
+    public ProgramaDeOferta ProgramaDeOferta { get; private set; }
+    public FormatoPedagogico FormatoPedagogico { get; private set; }
+    public TurnoOferta? Turno { get; private set; }
+
+    /// <summary>Código e-MEC da oferta por campus-sede (opcional).</summary>
+    public string? EMecCodigo { get; private set; }
+
+    /// <summary>Código no sistema de gestão acadêmica (nome vendor-neutral, opcional).</summary>
+    public string? CodigoSga { get; private set; }
+
+    /// <summary>Teto de vagas anuais autorizadas no e-MEC (≥ 0) — não são vagas de certame.</summary>
+    public int? VagasAnuaisAutorizadas { get; private set; }
+
+    /// <summary>Base legal da oferta — obrigatória quando o programa não é Regular (ADR-0066).</summary>
+    public string? BaseLegal { get; private set; }
+
+    public string? AtoAutorizacaoMec { get; private set; }
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private OfertaCurso()
+    {
+    }
+
+    /// <summary>
+    /// Cria uma nova Oferta de Curso. Os enums chegam como tokens textuais
+    /// (UPPER_SNAKE): <paramref name="programaDeOferta"/> é obrigatório;
+    /// <paramref name="formatoPedagogico"/> aplica default PRESENCIAL quando
+    /// ausente; <paramref name="turno"/> é opcional (nulo aceito). O
+    /// <paramref name="unidadeOfertante"/> já chega congelado (resolvido pelo
+    /// handler via <c>IUnidadeReader</c>). A existência viva do curso e do local
+    /// de oferta é responsabilidade do handler.
+    /// </summary>
+    public static Result<OfertaCurso> Criar(
+        Guid cursoId,
+        Guid localOfertaId,
+        UnidadeOfertante unidadeOfertante,
+        string? programaDeOferta,
+        string? formatoPedagogico,
+        string? turno,
+        string? eMecCodigo,
+        string? codigoSga,
+        int? vagasAnuaisAutorizadas,
+        string? baseLegal,
+        string? atoAutorizacaoMec)
+    {
+        ArgumentNullException.ThrowIfNull(unidadeOfertante);
+
+        Result<CamposResolvidos> camposResult = ValidarComuns(
+            programaDeOferta, formatoPedagogico, turno, eMecCodigo, codigoSga,
+            vagasAnuaisAutorizadas, baseLegal, atoAutorizacaoMec);
+        if (camposResult.IsFailure)
+        {
+            return Result<OfertaCurso>.Failure(camposResult.Error!);
+        }
+
+        var oferta = new OfertaCurso
+        {
+            CursoId = cursoId,
+            LocalOfertaId = localOfertaId,
+            UnidadeOfertante = unidadeOfertante,
+        };
+        oferta.AplicarCampos(camposResult.Value!);
+
+        return Result<OfertaCurso>.Success(oferta);
+    }
+
+    /// <summary>
+    /// Atualiza os atributos editáveis da Oferta de Curso: programa, formato
+    /// pedagógico, turno, códigos (e-MEC / SGA), teto de vagas, base legal e ato
+    /// de autorização. <c>CursoId</c>, <c>LocalOfertaId</c> e
+    /// <c>UnidadeOfertante</c> são <b>imutáveis</b> — mudar curso×local×unidade
+    /// caracteriza outra oferta, não uma edição; este método não os recebe nem os
+    /// altera. Revalida o guard condicional da base legal na transição (ex.:
+    /// Regular→Parfor sem base legal é rejeitado).
+    /// </summary>
+    public Result Atualizar(
+        string? programaDeOferta,
+        string? formatoPedagogico,
+        string? turno,
+        string? eMecCodigo,
+        string? codigoSga,
+        int? vagasAnuaisAutorizadas,
+        string? baseLegal,
+        string? atoAutorizacaoMec)
+    {
+        Result<CamposResolvidos> camposResult = ValidarComuns(
+            programaDeOferta, formatoPedagogico, turno, eMecCodigo, codigoSga,
+            vagasAnuaisAutorizadas, baseLegal, atoAutorizacaoMec);
+        if (camposResult.IsFailure)
+        {
+            return Result.Failure(camposResult.Error!);
+        }
+
+        AplicarCampos(camposResult.Value!);
+
+        return Result.Success();
+    }
+
+    private void AplicarCampos(CamposResolvidos campos)
+    {
+        ProgramaDeOferta = campos.ProgramaDeOferta;
+        FormatoPedagogico = campos.FormatoPedagogico;
+        Turno = campos.Turno;
+        EMecCodigo = campos.EMecCodigo;
+        CodigoSga = campos.CodigoSga;
+        VagasAnuaisAutorizadas = campos.VagasAnuaisAutorizadas;
+        BaseLegal = campos.BaseLegal;
+        AtoAutorizacaoMec = campos.AtoAutorizacaoMec;
+    }
+
+    private static Result<CamposResolvidos> ValidarComuns(
+        string? programaDeOfertaToken,
+        string? formatoPedagogicoToken,
+        string? turnoToken,
+        string? eMecCodigo,
+        string? codigoSga,
+        int? vagasAnuaisAutorizadas,
+        string? baseLegal,
+        string? atoAutorizacaoMec)
+    {
+        // ProgramaDeOferta — obrigatório, sem default: a ausência é inválida.
+        if (!ProgramasDeOferta.TryAnalisar(programaDeOfertaToken, out ProgramaDeOferta programa))
+        {
+            return Falha(OfertaCursoErrorCodes.ProgramaDeOfertaInvalido,
+                $"Programa de oferta deve ser um de: {string.Join(", ", ProgramasDeOferta.TokensCanonicos)}.");
+        }
+
+        // FormatoPedagogico — obrigatório, default PRESENCIAL quando ausente
+        // (mesmo expediente do default AMPLA de NaturezasLegais).
+        FormatoPedagogico formato;
+        if (string.IsNullOrWhiteSpace(formatoPedagogicoToken))
+        {
+            formato = FormatoPedagogico.Presencial;
+        }
+        else if (!FormatosPedagogicos.TryAnalisar(formatoPedagogicoToken, out formato))
+        {
+            return Falha(OfertaCursoErrorCodes.FormatoPedagogicoInvalido,
+                $"Formato pedagógico deve ser um de: {string.Join(", ", FormatosPedagogicos.TokensCanonicos)}.");
+        }
+
+        // Turno — opcional (null quando ausente); quando informado, um dos quatro tokens.
+        TurnoOferta? turno = null;
+        if (!string.IsNullOrWhiteSpace(turnoToken))
+        {
+            if (!TurnosOferta.TryAnalisar(turnoToken, out TurnoOferta turnoResolvido))
+            {
+                return Falha(OfertaCursoErrorCodes.TurnoInvalido,
+                    $"Turno da oferta deve ser um de: {string.Join(", ", TurnosOferta.TokensCanonicos)}.");
+            }
+
+            turno = turnoResolvido;
+        }
+
+        if (vagasAnuaisAutorizadas is < 0)
+        {
+            return Falha(OfertaCursoErrorCodes.VagasAnuaisNegativas,
+                "Vagas anuais autorizadas não podem ser negativas (zero é aceito).");
+        }
+
+        if (eMecCodigo is not null && eMecCodigo.Trim().Length > EMecCodigoMaxLength)
+        {
+            return Falha(OfertaCursoErrorCodes.EMecCodigoTamanho,
+                $"Código e-MEC da oferta deve ter no máximo {EMecCodigoMaxLength} caracteres.");
+        }
+
+        if (codigoSga is not null && codigoSga.Trim().Length > CodigoSgaMaxLength)
+        {
+            return Falha(OfertaCursoErrorCodes.CodigoSgaTamanho,
+                $"Código no sistema de gestão acadêmica deve ter no máximo {CodigoSgaMaxLength} caracteres.");
+        }
+
+        if (baseLegal is not null && baseLegal.Trim().Length > BaseLegalMaxLength)
+        {
+            return Falha(OfertaCursoErrorCodes.BaseLegalTamanho,
+                $"Base legal da oferta deve ter no máximo {BaseLegalMaxLength} caracteres.");
+        }
+
+        if (atoAutorizacaoMec is not null && atoAutorizacaoMec.Trim().Length > AtoAutorizacaoMecMaxLength)
+        {
+            return Falha(OfertaCursoErrorCodes.AtoAutorizacaoMecTamanho,
+                $"Ato de autorização MEC deve ter no máximo {AtoAutorizacaoMecMaxLength} caracteres.");
+        }
+
+        string? baseLegalNorm = NormalizarOpcional(baseLegal);
+
+        // Guard condicional (ADR-0066): programa fora do Regular exige base legal —
+        // revalidado também na atualização (transição Regular→Parfor sem base falha).
+        if (programa != ProgramaDeOferta.Regular && baseLegalNorm is null)
+        {
+            return Falha(OfertaCursoErrorCodes.BaseLegalObrigatoriaParaProgramaNaoRegular,
+                "Base legal é obrigatória quando o programa de oferta não é REGULAR.");
+        }
+
+        return Result<CamposResolvidos>.Success(new CamposResolvidos(
+            programa,
+            formato,
+            turno,
+            NormalizarOpcional(eMecCodigo),
+            NormalizarOpcional(codigoSga),
+            vagasAnuaisAutorizadas,
+            baseLegalNorm,
+            NormalizarOpcional(atoAutorizacaoMec)));
+    }
+
+    private static string? NormalizarOpcional(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+
+    private static Result<CamposResolvidos> Falha(string code, string mensagem) =>
+        Result<CamposResolvidos>.Failure(new DomainError(code, mensagem));
+
+    private sealed record CamposResolvidos(
+        ProgramaDeOferta ProgramaDeOferta,
+        FormatoPedagogico FormatoPedagogico,
+        TurnoOferta? Turno,
+        string? EMecCodigo,
+        string? CodigoSga,
+        int? VagasAnuaisAutorizadas,
+        string? BaseLegal,
+        string? AtoAutorizacaoMec);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/FormatoPedagogico.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/FormatoPedagogico.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Formato pedagógico de uma <see cref="Entities.OfertaCurso"/> (story #588,
+/// ADR-0066): presencial, semipresencial ou a distância (EaD). Persistido como
+/// token UPPER_SNAKE (<see cref="FormatosPedagogicos"/>). Quando o token não é
+/// informado na criação/atualização, o default conceitual é
+/// <see cref="Presencial"/> (mesmo expediente do default AMPLA de
+/// <see cref="NaturezasLegais"/>).
+/// </summary>
+public enum FormatoPedagogico
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhum = 0,
+
+    /// <summary>Oferta presencial (default conceitual quando o token está ausente).</summary>
+    Presencial = 1,
+
+    /// <summary>Oferta semipresencial (híbrida).</summary>
+    Semipresencial = 2,
+
+    /// <summary>Oferta a distância (EaD).</summary>
+    Ead = 3,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/FormatosPedagogicos.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/FormatosPedagogicos.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="FormatoPedagogico"/> (domínio, PascalCase) e o
+/// token textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// <para>O parsing é por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>):
+/// só os três tokens canônicos são aceitos — sem <c>Enum.TryParse</c> (que
+/// aceitaria tokens numéricos e nomes PascalCase, fora do contrato da #749).</para>
+/// <para>É o vocabulário fonte do CHECK de domínio em
+/// <c>oferta_curso.formato_pedagogico</c> (<see cref="TokensCanonicos"/>) e do
+/// value converter de persistência. O default quando o token está ausente
+/// (PRESENCIAL) é aplicado pela entidade, não aqui.</para>
+/// </remarks>
+public static class FormatosPedagogicos
+{
+    private static readonly Dictionary<FormatoPedagogico, string> ParaToken = new()
+    {
+        [FormatoPedagogico.Presencial] = "PRESENCIAL",
+        [FormatoPedagogico.Semipresencial] = "SEMIPRESENCIAL",
+        [FormatoPedagogico.Ead] = "EAD",
+    };
+
+    private static readonly Dictionary<string, FormatoPedagogico> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os três tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de um formato válido.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="formato"/> é <see cref="FormatoPedagogico.Nenhum"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(FormatoPedagogico formato) =>
+        ParaToken.TryGetValue(formato, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(formato), formato, "Formato pedagógico fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) ao formato correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens numéricos ou fora do
+    /// domínio (allowlist). Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out FormatoPedagogico formato)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out FormatoPedagogico resolvido))
+        {
+            formato = resolvido;
+            return true;
+        }
+
+        formato = FormatoPedagogico.Nenhum;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos três tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/ProgramaDeOferta.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/ProgramaDeOferta.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Programa (política pública ou convênio) sob o qual uma
+/// <see cref="Entities.OfertaCurso"/> é ofertada (story #588, ADR-0066):
+/// distingue, em domínio fechado, a oferta regular das ofertas vinculadas a
+/// programas especiais (Forma Pará, Parfor, Pronera, PEPETI) e a convênios.
+/// Persistido como token UPPER_SNAKE (<see cref="ProgramasDeOferta"/>).
+/// </summary>
+public enum ProgramaDeOferta
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhum = 0,
+
+    /// <summary>Oferta regular da instituição (sem programa especial).</summary>
+    Regular = 1,
+
+    /// <summary>Programa Forma Pará (interiorização estadual).</summary>
+    FormaPara = 2,
+
+    /// <summary>Plano Nacional de Formação de Professores da Educação Básica.</summary>
+    Parfor = 3,
+
+    /// <summary>Programa Nacional de Educação na Reforma Agrária.</summary>
+    Pronera = 4,
+
+    /// <summary>Programa de Estudantes-Convênio PEPETI.</summary>
+    Pepeti = 5,
+
+    /// <summary>Oferta vinculada a outro convênio institucional.</summary>
+    ConvenioOutro = 6,
+
+    /// <summary>Outro programa que não se enquadra nos anteriores.</summary>
+    Outro = 7,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/ProgramasDeOferta.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/ProgramasDeOferta.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="ProgramaDeOferta"/> (domínio, PascalCase) e o
+/// token textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// <para>O parsing é por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>):
+/// só os sete tokens canônicos são aceitos. Deliberadamente <b>não</b> usa
+/// <c>Enum.TryParse</c>, que aceitaria tokens numéricos (<c>"1"</c> → primeiro
+/// valor) e nomes PascalCase do enum — ambos fora do contrato textual da #749.</para>
+/// <para>É o vocabulário fonte do CHECK de domínio em
+/// <c>oferta_curso.programa_de_oferta</c> (<see cref="TokensCanonicos"/>) e do
+/// value converter de persistência.</para>
+/// </remarks>
+public static class ProgramasDeOferta
+{
+    private static readonly Dictionary<ProgramaDeOferta, string> ParaToken = new()
+    {
+        [ProgramaDeOferta.Regular] = "REGULAR",
+        [ProgramaDeOferta.FormaPara] = "FORMA_PARA",
+        [ProgramaDeOferta.Parfor] = "PARFOR",
+        [ProgramaDeOferta.Pronera] = "PRONERA",
+        [ProgramaDeOferta.Pepeti] = "PEPETI",
+        [ProgramaDeOferta.ConvenioOutro] = "CONVENIO_OUTRO",
+        [ProgramaDeOferta.Outro] = "OUTRO",
+    };
+
+    private static readonly Dictionary<string, ProgramaDeOferta> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os sete tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de um programa válido.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="programa"/> é <see cref="ProgramaDeOferta.Nenhum"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(ProgramaDeOferta programa) =>
+        ParaToken.TryGetValue(programa, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(programa), programa, "Programa de oferta fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) ao programa correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens numéricos ou fora do
+    /// domínio (allowlist). Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out ProgramaDeOferta programa)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out ProgramaDeOferta resolvido))
+        {
+            programa = resolvido;
+            return true;
+        }
+
+        programa = ProgramaDeOferta.Nenhum;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos sete tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/TurnoOferta.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/TurnoOferta.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Turno de funcionamento de uma <see cref="Entities.OfertaCurso"/> (story #588,
+/// ADR-0066). Atributo <b>opcional</b> da oferta (nem toda oferta declara turno —
+/// ex.: EaD); quando presente, é um dos quatro valores do domínio fechado.
+/// Persistido como token UPPER_SNAKE (<see cref="TurnosOferta"/>).
+/// </summary>
+public enum TurnoOferta
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhum = 0,
+
+    /// <summary>Turno matutino.</summary>
+    Matutino = 1,
+
+    /// <summary>Turno vespertino.</summary>
+    Vespertino = 2,
+
+    /// <summary>Turno noturno.</summary>
+    Noturno = 3,
+
+    /// <summary>Turno integral (manhã e tarde).</summary>
+    Integral = 4,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/TurnosOferta.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/TurnosOferta.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="TurnoOferta"/> (domínio, PascalCase) e o token
+/// textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// <para>O parsing é por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>):
+/// só os quatro tokens canônicos são aceitos — sem <c>Enum.TryParse</c> (que
+/// aceitaria tokens numéricos e nomes PascalCase, fora do contrato da #749).</para>
+/// <para>É o vocabulário fonte do CHECK de domínio em <c>oferta_curso.turno</c>
+/// (<see cref="TokensCanonicos"/>, coluna anulável) e do value converter de
+/// persistência. A ausência de turno (nulo) é decidida pela entidade, não aqui.</para>
+/// </remarks>
+public static class TurnosOferta
+{
+    private static readonly Dictionary<TurnoOferta, string> ParaToken = new()
+    {
+        [TurnoOferta.Matutino] = "MATUTINO",
+        [TurnoOferta.Vespertino] = "VESPERTINO",
+        [TurnoOferta.Noturno] = "NOTURNO",
+        [TurnoOferta.Integral] = "INTEGRAL",
+    };
+
+    private static readonly Dictionary<string, TurnoOferta> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os quatro tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de um turno válido.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="turno"/> é <see cref="TurnoOferta.Nenhum"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(TurnoOferta turno) =>
+        ParaToken.TryGetValue(turno, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(turno), turno, "Turno de oferta fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) ao turno correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens numéricos ou fora do
+    /// domínio (allowlist). Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out TurnoOferta turno)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out TurnoOferta resolvido))
+        {
+            turno = resolvido;
+            return true;
+        }
+
+        turno = TurnoOferta.Nenhum;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos quatro tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/OfertaCursoErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/OfertaCursoErrorCodes.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+public static class OfertaCursoErrorCodes
+{
+    // Referências obrigatórias (existência viva checada pelo handler).
+    public const string CursoInexistenteOuRemovido = "OfertaCurso.CursoInexistenteOuRemovido";
+    public const string LocalOfertaInexistenteOuRemovido = "OfertaCurso.LocalOfertaInexistenteOuRemovido";
+    public const string UnidadeOfertanteInexistente = "OfertaCurso.UnidadeOfertanteInexistente";
+
+    // Value object UnidadeOfertante (snapshot-copy, ADR-0061).
+    public const string UnidadeOfertanteOrigemObrigatoria = "OfertaCurso.UnidadeOfertanteOrigemObrigatoria";
+    public const string UnidadeOfertanteSiglaObrigatoria = "OfertaCurso.UnidadeOfertanteSiglaObrigatoria";
+    public const string UnidadeOfertanteSiglaTamanho = "OfertaCurso.UnidadeOfertanteSiglaTamanho";
+    public const string UnidadeOfertanteNomeObrigatorio = "OfertaCurso.UnidadeOfertanteNomeObrigatorio";
+    public const string UnidadeOfertanteNomeTamanho = "OfertaCurso.UnidadeOfertanteNomeTamanho";
+    public const string UnidadeOfertanteTipoObrigatorio = "OfertaCurso.UnidadeOfertanteTipoObrigatorio";
+    public const string UnidadeOfertanteTipoTamanho = "OfertaCurso.UnidadeOfertanteTipoTamanho";
+
+    // Domínios fechados dos enums (tokens UPPER_SNAKE).
+    public const string ProgramaDeOfertaInvalido = "OfertaCurso.ProgramaDeOfertaInvalido";
+    public const string FormatoPedagogicoInvalido = "OfertaCurso.FormatoPedagogicoInvalido";
+    public const string TurnoInvalido = "OfertaCurso.TurnoInvalido";
+
+    // Invariantes de coerência.
+    public const string BaseLegalObrigatoriaParaProgramaNaoRegular = "OfertaCurso.BaseLegalObrigatoriaParaProgramaNaoRegular";
+    public const string VagasAnuaisNegativas = "OfertaCurso.VagasAnuaisNegativas";
+
+    // Tamanhos dos campos textuais opcionais.
+    public const string EMecCodigoTamanho = "OfertaCurso.EMecCodigoTamanho";
+    public const string CodigoSgaTamanho = "OfertaCurso.CodigoSgaTamanho";
+    public const string BaseLegalTamanho = "OfertaCurso.BaseLegalTamanho";
+    public const string AtoAutorizacaoMecTamanho = "OfertaCurso.AtoAutorizacaoMecTamanho";
+
+    public const string NaoEncontrada = "OfertaCurso.NaoEncontrada";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IOfertaCursoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IOfertaCursoRepository.cs
@@ -1,0 +1,38 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="OfertaCurso"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros
+/// soft-deleted via query filter por convenção. Não há chave natural única —
+/// o repositório não expõe checagem de unicidade.
+/// </summary>
+public interface IOfertaCursoRepository
+{
+    /// <summary>Carrega a oferta rastreada pelo contexto, para mutação.</summary>
+    Task<OfertaCurso?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega a oferta para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<OfertaCurso?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista ofertas de curso vivas paginadas por cursor keyset bidirecional
+    /// (ADR-0026 + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve
+    /// as âncoras de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<OfertaCurso> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    Task AdicionarAsync(OfertaCurso ofertaCurso, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca a oferta para remoção; o <c>SoftDeleteInterceptor</c> converte em
+    /// soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(OfertaCurso ofertaCurso);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/UnidadeOfertante.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/UnidadeOfertante.cs
@@ -1,0 +1,112 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Snapshot-copy da unidade ofertante (instituto/faculdade) congelado na
+/// <c>OfertaCurso</c> (story #588, ADR-0061): o <see cref="OrigemId"/> aponta a
+/// Unidade viva de Organização (proveniência, sem FK cross-módulo) e
+/// <see cref="Sigla"/>/<see cref="Nome"/>/<see cref="Tipo"/> são a cópia
+/// congelada no ato da criação. Mudanças posteriores na Unidade viva
+/// <b>não</b> retropropagam — a oferta preserva o rótulo histórico.
+/// </summary>
+/// <remarks>
+/// A resolução da Unidade viva (via <c>IUnidadeReader</c>, ADR-0056) é
+/// responsabilidade do handler de criação; este value object valida apenas
+/// formato/completude do snapshot. Os tamanhos máximos espelham as colunas da
+/// entidade <c>Unidade</c> de Organização (sigla 50 / nome 250 / tipo 30).
+/// </remarks>
+public sealed record UnidadeOfertante
+{
+    public const int SiglaMaxLength = 50;
+    public const int NomeMaxLength = 250;
+    public const int TipoMaxLength = 30;
+
+    /// <summary>Id da Unidade viva de origem (proveniência do snapshot, sem FK).</summary>
+    public Guid OrigemId { get; }
+
+    /// <summary>Sigla da unidade congelada no ato da criação da oferta.</summary>
+    public string Sigla { get; }
+
+    /// <summary>Nome formal da unidade congelado no ato da criação da oferta.</summary>
+    public string Nome { get; }
+
+    /// <summary>Classificação organizacional congelada (string estável do contrato).</summary>
+    public string Tipo { get; }
+
+    private UnidadeOfertante(Guid origemId, string sigla, string nome, string tipo)
+    {
+        OrigemId = origemId;
+        Sigla = sigla;
+        Nome = nome;
+        Tipo = tipo;
+    }
+
+    /// <summary>
+    /// Cria o snapshot da unidade ofertante validando completude e tamanhos.
+    /// Retorna falha de domínio (códigos <c>OfertaCurso.UnidadeOfertante*</c>)
+    /// no primeiro problema. Os textos são normalizados por <c>Trim</c>.
+    /// </summary>
+    public static Result<UnidadeOfertante> Criar(
+        Guid origemId,
+        string? sigla,
+        string? nome,
+        string? tipo)
+    {
+        if (origemId == Guid.Empty)
+        {
+            return Falha(
+                OfertaCursoErrorCodes.UnidadeOfertanteOrigemObrigatoria,
+                "Id de origem da unidade ofertante é obrigatório.");
+        }
+
+        if (string.IsNullOrWhiteSpace(sigla))
+        {
+            return Falha(
+                OfertaCursoErrorCodes.UnidadeOfertanteSiglaObrigatoria,
+                "Sigla da unidade ofertante é obrigatória.");
+        }
+
+        if (sigla.Trim().Length > SiglaMaxLength)
+        {
+            return Falha(
+                OfertaCursoErrorCodes.UnidadeOfertanteSiglaTamanho,
+                $"Sigla da unidade ofertante deve ter no máximo {SiglaMaxLength} caracteres.");
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Falha(
+                OfertaCursoErrorCodes.UnidadeOfertanteNomeObrigatorio,
+                "Nome da unidade ofertante é obrigatório.");
+        }
+
+        if (nome.Trim().Length > NomeMaxLength)
+        {
+            return Falha(
+                OfertaCursoErrorCodes.UnidadeOfertanteNomeTamanho,
+                $"Nome da unidade ofertante deve ter no máximo {NomeMaxLength} caracteres.");
+        }
+
+        if (string.IsNullOrWhiteSpace(tipo))
+        {
+            return Falha(
+                OfertaCursoErrorCodes.UnidadeOfertanteTipoObrigatorio,
+                "Tipo da unidade ofertante é obrigatório.");
+        }
+
+        if (tipo.Trim().Length > TipoMaxLength)
+        {
+            return Falha(
+                OfertaCursoErrorCodes.UnidadeOfertanteTipoTamanho,
+                $"Tipo da unidade ofertante deve ter no máximo {TipoMaxLength} caracteres.");
+        }
+
+        return Result<UnidadeOfertante>.Success(
+            new UnidadeOfertante(origemId, sigla.Trim(), nome.Trim(), tipo.Trim()));
+    }
+
+    private static Result<UnidadeOfertante> Falha(string code, string mensagem) =>
+        Result<UnidadeOfertante>.Failure(new DomainError(code, mensagem));
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -45,6 +45,7 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<IFaseCanonicaRepository, FaseCanonicaRepository>();
         services.AddScoped<ITipoBancaRepository, TipoBancaRepository>();
         services.AddScoped<ICursoRepository, CursoRepository>();
+        services.AddScoped<IOfertaCursoRepository, OfertaCursoRepository>();
 
         // Readers cross-módulo (ADR-0056).
         services.AddScoped<IReferenciaReservaDemograficaReader, ReferenciaReservaDemograficaReader>();

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -57,6 +57,7 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<IModalidadeReader, ModalidadeReader>();
         services.AddScoped<IFaseCanonicaReader, FaseCanonicaReader>();
         services.AddScoped<ITipoBancaReader, TipoBancaReader>();
+        services.AddScoped<IOfertaCursoReader, OfertaCursoReader>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -53,6 +53,8 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
 
     public DbSet<Curso> Cursos => Set<Curso>();
 
+    public DbSet<OfertaCurso> OfertasCurso => Set<OfertaCurso>();
+
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/OfertaCursoConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/OfertaCursoConfiguration.cs
@@ -1,0 +1,138 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class OfertaCursoConfiguration : IEntityTypeConfiguration<OfertaCurso>
+{
+    private const int EnumTokenMaxLength = 30;
+    private const int EMecCodigoMaxLength = 20;
+    private const int CodigoSgaMaxLength = 30;
+    private const int BaseLegalMaxLength = 500;
+    private const int AtoAutorizacaoMecMaxLength = 300;
+    private const int AuditUserMaxLength = 255;
+
+    public void Configure(EntityTypeBuilder<OfertaCurso> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("oferta_curso", ConfigurarChecks);
+
+        builder.HasKey(o => o.Id);
+
+        builder.Property(o => o.CursoId).IsRequired();
+        builder.Property(o => o.LocalOfertaId).IsRequired();
+
+        builder.Property(o => o.ProgramaDeOferta)
+            .HasConversion<ProgramaDeOfertaValueConverter>()
+            .HasMaxLength(EnumTokenMaxLength)
+            .IsRequired();
+
+        builder.Property(o => o.FormatoPedagogico)
+            .HasConversion<FormatoPedagogicoValueConverter>()
+            .HasMaxLength(EnumTokenMaxLength)
+            .IsRequired();
+
+        // Enum nullable: o converter cobre o valor não-nulo; o EF encapsula null.
+        builder.Property(o => o.Turno)
+            .HasConversion(new TurnoOfertaValueConverter())
+            .HasMaxLength(EnumTokenMaxLength);
+
+        // Nome explícito: a convenção snake_case quebraria "EMecCodigo" de forma
+        // não óbvia — fixa e_mec_codigo como contrato de schema.
+        builder.Property(o => o.EMecCodigo)
+            .HasColumnName("e_mec_codigo")
+            .HasMaxLength(EMecCodigoMaxLength);
+
+        builder.Property(o => o.CodigoSga).HasMaxLength(CodigoSgaMaxLength);
+        builder.Property(o => o.VagasAnuaisAutorizadas);
+        builder.Property(o => o.BaseLegal).HasMaxLength(BaseLegalMaxLength);
+        builder.Property(o => o.AtoAutorizacaoMec).HasMaxLength(AtoAutorizacaoMecMaxLength);
+
+        // Snapshot-copy da unidade ofertante (ADR-0061): owned type obrigatório,
+        // table splitting em colunas unidade_oft_* — todas NOT NULL, SEM FK para
+        // Organização (a proveniência é só o origem_id).
+        builder.OwnsOne(o => o.UnidadeOfertante, unidade =>
+        {
+            unidade.Property(u => u.OrigemId)
+                .HasColumnName("unidade_oft_origem_id")
+                .IsRequired();
+            unidade.Property(u => u.Sigla)
+                .HasColumnName("unidade_oft_sigla")
+                .HasMaxLength(UnidadeOfertante.SiglaMaxLength)
+                .IsRequired();
+            unidade.Property(u => u.Nome)
+                .HasColumnName("unidade_oft_nome")
+                .HasMaxLength(UnidadeOfertante.NomeMaxLength)
+                .IsRequired();
+            unidade.Property(u => u.Tipo)
+                .HasColumnName("unidade_oft_tipo")
+                .HasMaxLength(UnidadeOfertante.TipoMaxLength)
+                .IsRequired();
+        });
+        builder.Navigation(o => o.UnidadeOfertante).IsRequired();
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(o => o.CreatedBy).HasMaxLength(AuditUserMaxLength);
+        builder.Property(o => o.UpdatedBy).HasMaxLength(AuditUserMaxLength);
+
+        // FKs intra-schema com RESTRICT: a remoção lógica de Curso/LocalOferta é
+        // barrada pelos handlers (RemocaoBloqueadaPorOfertaCurso, via
+        // ReferenciadoPorOfertaCursoVivaAsync); o RESTRICT cobre o DELETE físico
+        // residual — mesmo expediente do local_oferta → campus.
+        builder.HasOne<Curso>()
+            .WithMany()
+            .HasForeignKey(o => o.CursoId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<LocalOferta>()
+            .WithMany()
+            .HasForeignKey(o => o.LocalOfertaId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(o => o.CursoId)
+            .HasDatabaseName("ix_oferta_curso_curso_id");
+
+        builder.HasIndex(o => o.LocalOfertaId)
+            .HasDatabaseName("ix_oferta_curso_local_oferta_id");
+    }
+
+    private static void ConfigurarChecks(TableBuilder<OfertaCurso> table)
+    {
+        // Domínios fechados dos enums (defesa em profundidade contra inserts crus).
+        table.HasCheckConstraint(
+            "ck_oferta_curso_programa_de_oferta",
+            $"programa_de_oferta IN ({TokensSql(ProgramasDeOferta.TokensCanonicos)})");
+
+        table.HasCheckConstraint(
+            "ck_oferta_curso_formato_pedagogico",
+            $"formato_pedagogico IN ({TokensSql(FormatosPedagogicos.TokensCanonicos)})");
+
+        table.HasCheckConstraint(
+            "ck_oferta_curso_turno",
+            $"turno IS NULL OR turno IN ({TokensSql(TurnosOferta.TokensCanonicos)})");
+
+        // Teto e-MEC: nulo aceito; zero aceito; negativo nunca.
+        table.HasCheckConstraint(
+            "ck_oferta_curso_vagas_anuais_autorizadas",
+            "vagas_anuais_autorizadas IS NULL OR vagas_anuais_autorizadas >= 0");
+
+        // Guard condicional da base legal (ADR-0066): programa fora do Regular
+        // exige base legal — espelha no banco o guard de Criar/Atualizar.
+        table.HasCheckConstraint(
+            "ck_oferta_curso_base_legal_programa",
+            "programa_de_oferta = 'REGULAR' OR base_legal IS NOT NULL");
+    }
+
+    private static string TokensSql(IReadOnlyList<string> tokens) =>
+        string.Join(", ", tokens.Select(token => $"'{token}'"));
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/FormatoPedagogicoValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/FormatoPedagogicoValueConverter.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia FormatoPedagogico ↔ string (varchar) usando o token canônico UPPER_SNAKE
+// (PRESENCIAL…), não o nome PascalCase do enum. O comprimento da coluna é definido
+// na própria propriedade via HasMaxLength no IEntityTypeConfiguration. A
+// reidratação falha explicitamente (com contexto) caso a coluna seja corrompida
+// fora do fluxo da aplicação, em vez de um valor de enum silenciosamente inválido.
+public sealed class FormatoPedagogicoValueConverter : ValueConverter<FormatoPedagogico, string>
+{
+    public FormatoPedagogicoValueConverter()
+        : base(
+            formato => FormatosPedagogicos.ParaTokenCanonico(formato),
+            token => Reidratar(token))
+    {
+    }
+
+    private static FormatoPedagogico Reidratar(string token)
+    {
+        if (!FormatosPedagogicos.TryAnalisar(token, out FormatoPedagogico formato))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(FormatoPedagogico)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return formato;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/ProgramaDeOfertaValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/ProgramaDeOfertaValueConverter.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia ProgramaDeOferta ↔ string (varchar) usando o token canônico UPPER_SNAKE
+// (REGULAR…), não o nome PascalCase do enum. O comprimento da coluna é definido
+// na própria propriedade via HasMaxLength no IEntityTypeConfiguration. A
+// reidratação falha explicitamente (com contexto) caso a coluna seja corrompida
+// fora do fluxo da aplicação, em vez de um valor de enum silenciosamente inválido.
+public sealed class ProgramaDeOfertaValueConverter : ValueConverter<ProgramaDeOferta, string>
+{
+    public ProgramaDeOfertaValueConverter()
+        : base(
+            programa => ProgramasDeOferta.ParaTokenCanonico(programa),
+            token => Reidratar(token))
+    {
+    }
+
+    private static ProgramaDeOferta Reidratar(string token)
+    {
+        if (!ProgramasDeOferta.TryAnalisar(token, out ProgramaDeOferta programa))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(ProgramaDeOferta)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return programa;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/TurnoOfertaValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/TurnoOfertaValueConverter.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia TurnoOferta ↔ string (varchar) usando o token canônico UPPER_SNAKE
+// (MATUTINO…), não o nome PascalCase do enum. Aplicado a uma propriedade nullable
+// (TurnoOferta?) — o EF encapsula null automaticamente; este converter só vê
+// valores não-nulos. A reidratação falha explicitamente (com contexto) caso a
+// coluna seja corrompida fora do fluxo da aplicação.
+public sealed class TurnoOfertaValueConverter : ValueConverter<TurnoOferta, string>
+{
+    public TurnoOfertaValueConverter()
+        : base(
+            turno => TurnosOferta.ParaTokenCanonico(turno),
+            token => Reidratar(token))
+    {
+    }
+
+    private static TurnoOferta Reidratar(string token)
+    {
+        if (!TurnosOferta.TryAnalisar(token, out TurnoOferta turno))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(TurnoOferta)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return turno;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260702145710_AddOfertaCurso.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260702145710_AddOfertaCurso.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702145710_AddOfertaCurso")]
+    partial class AddOfertaCurso
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260702145710_AddOfertaCurso.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260702145710_AddOfertaCurso.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOfertaCurso : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "oferta_curso",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    curso_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    local_oferta_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    unidade_oft_origem_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    unidade_oft_sigla = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    unidade_oft_nome = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+                    unidade_oft_tipo = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    programa_de_oferta = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    formato_pedagogico = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: false),
+                    turno = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: true),
+                    e_mec_codigo = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    codigo_sga = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: true),
+                    vagas_anuais_autorizadas = table.Column<int>(type: "integer", nullable: true),
+                    base_legal = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    ato_autorizacao_mec = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_oferta_curso", x => x.id);
+                    table.CheckConstraint("ck_oferta_curso_base_legal_programa", "programa_de_oferta = 'REGULAR' OR base_legal IS NOT NULL");
+                    table.CheckConstraint("ck_oferta_curso_formato_pedagogico", "formato_pedagogico IN ('PRESENCIAL', 'SEMIPRESENCIAL', 'EAD')");
+                    table.CheckConstraint("ck_oferta_curso_programa_de_oferta", "programa_de_oferta IN ('REGULAR', 'FORMA_PARA', 'PARFOR', 'PRONERA', 'PEPETI', 'CONVENIO_OUTRO', 'OUTRO')");
+                    table.CheckConstraint("ck_oferta_curso_turno", "turno IS NULL OR turno IN ('MATUTINO', 'VESPERTINO', 'NOTURNO', 'INTEGRAL')");
+                    table.CheckConstraint("ck_oferta_curso_vagas_anuais_autorizadas", "vagas_anuais_autorizadas IS NULL OR vagas_anuais_autorizadas >= 0");
+                    table.ForeignKey(
+                        name: "fk_oferta_curso_curso_curso_id",
+                        column: x => x.curso_id,
+                        principalSchema: "configuracao",
+                        principalTable: "curso",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_oferta_curso_local_oferta_local_oferta_id",
+                        column: x => x.local_oferta_id,
+                        principalSchema: "configuracao",
+                        principalTable: "local_oferta",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_oferta_curso_curso_id",
+                schema: "configuracao",
+                table: "oferta_curso",
+                column: "curso_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_oferta_curso_local_oferta_id",
+                schema: "configuracao",
+                table: "oferta_curso",
+                column: "local_oferta_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "oferta_curso",
+                schema: "configuracao");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CursoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CursoRepository.cs
@@ -79,11 +79,11 @@ public sealed class CursoRepository : ICursoRepository
 
     public Task<bool> ReferenciadoPorOfertaCursoVivaAsync(Guid cursoId, CancellationToken cancellationToken)
     {
-        // TODO(#749): quando a entidade oferta_curso existir no módulo, consultar
-        // aqui se há oferta de curso viva referenciando este curso. Até lá, não há
-        // tabela a consultar — a checagem retorna false.
-        _ = cursoId;
-        _ = cancellationToken;
-        return Task.FromResult(false);
+        // EXISTS sobre ofertas vivas (#749): o query filter global de soft-delete
+        // já restringe a ofertas não removidas — o soft-delete da oferta libera o
+        // curso para remoção.
+        return _dbContext.OfertasCurso
+            .AsNoTracking()
+            .AnyAsync(o => o.CursoId == cursoId, cancellationToken);
     }
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/OfertaCursoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/OfertaCursoRepository.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class OfertaCursoRepository : IOfertaCursoRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public OfertaCursoRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<OfertaCurso?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.OfertasCurso
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
+    }
+
+    public Task<OfertaCurso?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.OfertasCurso
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<OfertaCurso> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        CursorKeysetPage<OfertaCurso> page = await CursorKeyset
+            .ApplyAsync(_dbContext.OfertasCurso.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public async Task AdicionarAsync(OfertaCurso ofertaCurso, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(ofertaCurso);
+        await _dbContext.OfertasCurso.AddAsync(ofertaCurso, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(OfertaCurso ofertaCurso)
+    {
+        ArgumentNullException.ThrowIfNull(ofertaCurso);
+        _dbContext.OfertasCurso.Remove(ofertaCurso);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/OfertaCursoReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/OfertaCursoReader.cs
@@ -1,0 +1,77 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="IOfertaCursoReader"/> (ADR-0056): leitura direta
+/// do banco de Configuração (<c>AsNoTracking</c>, query filter de soft-delete por
+/// convenção). Sem cache — mesmo padrão do <c>ModalidadeReader</c>: o consumidor
+/// congela por valor o que precisar (ADR-0061), dispensando releitura quente.
+/// Ordena por <c>Id</c> ascendente.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class OfertaCursoReader : IOfertaCursoReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public OfertaCursoReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<OfertaCursoView>> ListarVivasAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<OfertaCurso> entidades = await _dbContext.OfertasCurso
+            .AsNoTracking()
+            .OrderBy(o => o.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. entidades.Select(ParaView)];
+    }
+
+    public async Task<OfertaCursoView?> ObterPorIdAsync(
+        Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        OfertaCurso? entidade = await _dbContext.OfertasCurso
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entidade is null ? null : ParaView(entidade);
+    }
+
+    private static OfertaCursoView ParaView(OfertaCurso o)
+    {
+        UnidadeOfertante unidade = o.UnidadeOfertante;
+
+        return new OfertaCursoView(
+            o.Id,
+            o.CursoId,
+            o.LocalOfertaId,
+            unidade.OrigemId,
+            unidade.Sigla,
+            unidade.Nome,
+            unidade.Tipo,
+            ProgramasDeOferta.ParaTokenCanonico(o.ProgramaDeOferta),
+            FormatosPedagogicos.ParaTokenCanonico(o.FormatoPedagogico),
+            o.Turno is { } turno ? TurnosOferta.ParaTokenCanonico(turno) : null,
+            o.EMecCodigo,
+            o.CodigoSga,
+            o.VagasAnuaisAutorizadas,
+            o.BaseLegal,
+            o.AtoAutorizacaoMec);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/packages.lock.json
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/packages.lock.json
@@ -1123,7 +1123,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {

--- a/src/host/Unifesspa.UniPlus.Host/packages.lock.json
+++ b/src/host/Unifesspa.UniPlus.Host/packages.lock.json
@@ -91,7 +91,8 @@
         "resolved": "2.70.0",
         "contentHash": "xNv0FFCVJa5S1beUtye82WFCxKThuE1jbN8DO1x1Rj8VSIWXLBUmfSID5a1fGzsU2R/EMfwPoWclJ2RMfQuGXw==",
         "dependencies": {
-          "Grpc.Net.Common": "2.70.0"
+          "Grpc.Net.Common": "2.70.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
         }
       },
       "Grpc.Net.Common": {
@@ -120,6 +121,10 @@
           "FastExpressionCompiler": "5.3.0",
           "ImTools": "4.0.0",
           "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
           "Polly.Core": "8.6.5",
           "Spectre.Console": "0.55.0"
         }
@@ -140,7 +145,8 @@
           "JasperFx": "1.28.0",
           "Microsoft.CodeAnalysis": "5.0.0",
           "Microsoft.CodeAnalysis.CSharp": "5.0.0",
-          "Microsoft.CodeAnalysis.Scripting": "5.0.0"
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
         }
       },
       "JasperFx.SourceGeneration": {
@@ -287,6 +293,11 @@
           "Microsoft.Build.Framework": "17.11.31",
           "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
           "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "Microsoft.Extensions.DependencyInjection": "9.0.0",
+          "Microsoft.Extensions.Logging": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Options": "9.0.0",
+          "Microsoft.Extensions.Primitives": "9.0.0",
           "Microsoft.VisualStudio.SolutionPersistence": "1.0.52",
           "Newtonsoft.Json": "13.0.3",
           "System.Composition": "9.0.0"
@@ -302,10 +313,311 @@
         "resolved": "10.0.9",
         "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+      },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "10.0.2",
         "contentHash": "DHXzj/FKmUDmhzw7AHbMXbNNcgO8Cb9PDbYOUDICjFAdIALy2WbC6pm+dFKiAUNtcYMucZu2iMVw1ef/sdcZFw=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Logging.Console": "10.0.0",
+          "Microsoft.Extensions.Logging.Debug": "10.0.0",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "KrN6TGFwCwqOkLLk/idW/XtDQh+8In+CL9T4M1Dx+5ScsjTq4TlVbal8q532m82UYrMr6RiQJF2HvYCN0QwVsA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "N7Gm9SjugYjmmnhwbBKC9DFqGqjfJvh6YfOJgtwh0AW0Xpok3dIVors1ik050XmUxKAgAc7nNngDIJyFb06K2g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "System.Diagnostics.EventLog": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -438,6 +750,8 @@
         "resolved": "1.16.0",
         "contentHash": "nE/Px3MUvQC8c0UG0DOP5OJE7vMtiMaPYi/6TkSS/o/O0s/oPq+8WaPYTVEPzb7lwu/QyLgknc+sFm2FjPXe2A==",
         "dependencies": {
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "1.16.0"
         }
       },
@@ -451,6 +765,7 @@
         "resolved": "1.16.0",
         "contentHash": "hZwaHAkXvUNn9+cS+vEvYBgIrIQOQRz2cIRUODZ5gxHsDsLeNCueLgZFkybopjE0jUhLut6lm5eL3LTqbW0hMg==",
         "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
           "OpenTelemetry.Api": "1.16.0"
         }
       },
@@ -474,6 +789,9 @@
         "resolved": "10.0.0",
         "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
         "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
           "Serilog": "4.3.0",
           "Serilog.Extensions.Logging": "10.0.0"
         }
@@ -483,6 +801,7 @@
         "resolved": "10.0.0",
         "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
         "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.0",
           "Serilog": "4.2.0"
         }
       },
@@ -499,6 +818,7 @@
         "resolved": "10.0.0",
         "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
           "Microsoft.Extensions.DependencyModel": "10.0.0",
           "Serilog": "4.3.0"
         }
@@ -593,6 +913,11 @@
           "System.Composition.Runtime": "9.0.0"
         }
       },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
+      },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
         "resolved": "8.0.1",
@@ -653,6 +978,7 @@
         "type": "Project",
         "dependencies": {
           "FluentValidation": "[12.1.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
@@ -677,7 +1003,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {
@@ -894,6 +1221,7 @@
         "contentHash": "tIy1DwZ0On58uaENl3c9z8/23ztauvTXlO8vwhtJQsaiQrgoZKp5TmIgt5/piTgjxqTnaLRtmvZ9PwnjQ4gPiQ==",
         "dependencies": {
           "Confluent.Kafka": "2.14.2",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -915,7 +1243,8 @@
         "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)"
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
         }
       },
       "FluentValidation.DependencyInjectionExtensions": {
@@ -924,7 +1253,8 @@
         "resolved": "12.1.1",
         "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
         "dependencies": {
-          "FluentValidation": "12.1.1"
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
         }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
@@ -943,7 +1273,9 @@
         "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
-          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9"
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9"
         }
       },
       "Microsoft.EntityFrameworkCore.Design": {
@@ -958,7 +1290,10 @@
           "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
           "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
           "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
+          "Microsoft.Extensions.Caching.Memory": "10.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
           "Microsoft.Extensions.DependencyModel": "10.0.2",
+          "Microsoft.Extensions.Logging": "10.0.2",
           "Mono.TextTemplating": "3.0.0",
           "Newtonsoft.Json": "13.0.3"
         }
@@ -969,7 +1304,19 @@
         "resolved": "10.0.9",
         "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.9"
+          "Microsoft.EntityFrameworkCore": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.9",
+        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
       },
       "Microsoft.OpenApi": {
@@ -985,6 +1332,8 @@
         "contentHash": "GiCD0koYBM8/VCXRkrfSzOtySEmrA2ngceJuxRO5H+/uGodiTX+XPaUHQq9/1DpaeBxWnkmrgqu52dwuZqIYgw==",
         "dependencies": {
           "CommunityToolkit.HighPerformance": "8.4.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.4",
+          "Microsoft.Extensions.Logging": "9.0.4",
           "System.IO.Hashing": "9.0.4",
           "System.Reactive": "6.0.1"
         }
@@ -1003,7 +1352,10 @@
         "type": "CentralTransitive",
         "requested": "[10.0.3, )",
         "resolved": "10.0.3",
-        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w=="
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
       },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "CentralTransitive",
@@ -1031,6 +1383,7 @@
         "resolved": "1.16.0",
         "contentHash": "/YfrO5MRaA156vhNanYGPX2JjOwKUrA0+Jf7ltT2eD3VkfHqXcEJY5Oxt/nWH8lqBOTc1nJpn2soBtD5Cml8Dg==",
         "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
           "OpenTelemetry": "1.16.0"
         }
       },
@@ -1049,6 +1402,8 @@
         "resolved": "1.15.1-beta.1",
         "contentHash": "NmtYLk3HJUUkV0g2VnFLs67/PGIVbI8JXtu0g4f9bk2ZaInp211/AL2+Qcbgkb9ih/uOi8loN6E1Aw2o0YIWag==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
         }
       },
@@ -1058,6 +1413,8 @@
         "resolved": "1.16.0",
         "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
         }
       },
@@ -1087,6 +1444,7 @@
         "resolved": "2.12.14",
         "contentHash": "QiAQg40OP4Owem6/PjIbjEKq2+uIeQYeZ1TCMUnx/QvKugOPxOfC96wjlnBjWHi4Wq9pv9+fDlXGT06XkRZ6Ig==",
         "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
           "Pipelines.Sockets.Unofficial": "2.2.8",
           "System.IO.Hashing": "10.0.2"
         }
@@ -1107,6 +1465,15 @@
           "JasperFx.Events": "1.36.0",
           "JasperFx.RuntimeCompiler": "4.5.0",
           "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
           "NewId": "4.0.1",
           "Newtonsoft.Json": "13.0.3"
         }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Readers/UnidadeReader.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Readers/UnidadeReader.cs
@@ -15,11 +15,18 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
 /// cache Redis (TTL 5 min) + stampede protection via lease ~2s
 /// (ADR-0057 Pattern 4).
 /// </summary>
+/// <remarks>
+/// Pública (não <c>internal</c>) porque é injetada em handlers Wolverine de
+/// outros módulos co-hospedados (ex.: o congelamento da unidade ofertante na
+/// <c>OfertaCurso</c> de Configuração) e, sob <c>ServiceLocationPolicy.NotAllowed</c>
+/// (ADR-0098), o codegen precisa construir o tipo concreto — mesmo root fix
+/// aplicado aos cache invalidators.
+/// </remarks>
 [System.Diagnostics.CodeAnalysis.SuppressMessage(
     "Performance",
     "CA1812:Avoid uninstantiated internal classes",
     Justification = "Instanciada via DI em OrganizacaoInstitucionalInfrastructureRegistration.")]
-internal sealed partial class UnidadeReader : IUnidadeReader
+public sealed partial class UnidadeReader : IUnidadeReader
 {
     private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan LeaseTtl = TimeSpan.FromSeconds(2);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/Interceptors/SoftDeleteInterceptor.cs
@@ -75,6 +75,29 @@ public sealed class SoftDeleteInterceptor : SaveChangesInterceptor
             {
                 entry.State = EntityState.Modified;
                 entry.Entity.MarkAsDeleted(deletedBy, deletedAt);
+
+                RestoreOwnedReferences(entry);
+            }
+        }
+    }
+
+    // Owned types (OwnsOne, table splitting — ex.: OfertaCurso.UnidadeOfertante)
+    // são rastreados como entradas próprias e cascateiam para EntityState.Deleted
+    // junto do principal quando ele é removido. Sem este passo, a entrada owned
+    // permaneceria Deleted mesmo após o principal virar Modified acima, e o EF
+    // Core anularia as colunas owned no UPDATE da mesma linha (table splitting) —
+    // corrompendo um snapshot obrigatório (NOT NULL) em vez de só marcar o
+    // principal como removido. Nada no snapshot mudou: a entrada owned volta para
+    // Unchanged. Recursivo para cobrir owned-de-owned, se algum dia existir.
+    private static void RestoreOwnedReferences(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+    {
+        foreach (Microsoft.EntityFrameworkCore.ChangeTracking.ReferenceEntry reference in entry.References)
+        {
+            if (reference.TargetEntry is { State: EntityState.Deleted } target
+                && reference.Metadata.TargetEntityType.IsOwned())
+            {
+                target.State = EntityState.Unchanged;
+                RestoreOwnedReferences(target);
             }
         }
     }

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -1131,7 +1131,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarOfertaCursoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarOfertaCursoCommandHandlerTests.cs
@@ -1,0 +1,105 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class AtualizarOfertaCursoCommandHandlerTests
+{
+    private static readonly Guid CursoId = Guid.CreateVersion7();
+    private static readonly Guid LocalOfertaId = Guid.CreateVersion7();
+
+    private readonly IOfertaCursoRepository _repository = Substitute.For<IOfertaCursoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static UnidadeOfertante Unidade() =>
+        UnidadeOfertante.Criar(
+            Guid.CreateVersion7(), "FACET", "Faculdade de Computação e Engenharia Elétrica", "Faculdade").Value!;
+
+    private static OfertaCurso OfertaExistente(UnidadeOfertante? unidade = null) =>
+        OfertaCurso.Criar(
+            CursoId, LocalOfertaId, unidade ?? Unidade(), "REGULAR", "PRESENCIAL",
+            "MATUTINO", "123456", "ENG-01", 40, null, null).Value!;
+
+    private static AtualizarOfertaCursoCommand Comando(
+        Guid id,
+        string programa = "REGULAR",
+        string? baseLegal = null) =>
+        new(id, programa, FormatoPedagogico: "EAD", Turno: null,
+            EMecCodigo: "654321", CodigoSga: "ENG-02",
+            VagasAnuaisAutorizadas: 60, BaseLegal: baseLegal, AtoAutorizacaoMec: null);
+
+    [Fact(DisplayName = "Oferta inexistente retorna NaoEncontrada (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrada()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((OfertaCurso?)null);
+
+        Result resultado = await AtualizarOfertaCursoCommandHandler.Handle(
+            Comando(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.NaoEncontrada);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Atualização válida troca os atributos regulatórios e persiste")]
+    public async Task Handle_AtualizacaoValida_Persiste()
+    {
+        OfertaCurso oferta = OfertaExistente();
+        _repository.ObterPorIdAsync(oferta.Id, Arg.Any<CancellationToken>()).Returns(oferta);
+
+        Result resultado = await AtualizarOfertaCursoCommandHandler.Handle(
+            Comando(oferta.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        oferta.FormatoPedagogico.Should().Be(FormatoPedagogico.Ead);
+        oferta.Turno.Should().BeNull();
+        oferta.EMecCodigo.Should().Be("654321");
+        oferta.CodigoSga.Should().Be("ENG-02");
+        oferta.VagasAnuaisAutorizadas.Should().Be(60);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Transição Regular→Parfor sem base legal é rejeitada sem persistir (guard revalidado)")]
+    public async Task Handle_TransicaoRegularParforSemBaseLegal_RejeitaSemPersistir()
+    {
+        OfertaCurso oferta = OfertaExistente();
+        _repository.ObterPorIdAsync(oferta.Id, Arg.Any<CancellationToken>()).Returns(oferta);
+
+        Result resultado = await AtualizarOfertaCursoCommandHandler.Handle(
+            Comando(oferta.Id, programa: "PARFOR", baseLegal: null),
+            _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.BaseLegalObrigatoriaParaProgramaNaoRegular);
+        oferta.ProgramaDeOferta.Should().Be(ProgramaDeOferta.Regular, "a falha não muta o agregado");
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Atualizar preserva curso, local e unidade ofertante (imutáveis — não trafegam no comando)")]
+    public async Task Handle_Atualizacao_PreservaImutaveis()
+    {
+        UnidadeOfertante unidade = Unidade();
+        OfertaCurso oferta = OfertaExistente(unidade);
+        _repository.ObterPorIdAsync(oferta.Id, Arg.Any<CancellationToken>()).Returns(oferta);
+
+        Result resultado = await AtualizarOfertaCursoCommandHandler.Handle(
+            Comando(oferta.Id, programa: "OUTRO", baseLegal: "Resolução CONSEPE 1/2026"),
+            _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        oferta.CursoId.Should().Be(CursoId);
+        oferta.LocalOfertaId.Should().Be(LocalOfertaId);
+        oferta.UnidadeOfertante.Should().Be(unidade, "o snapshot congelado (ADR-0061) é imutável pós-criação");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarOfertaCursoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarOfertaCursoCommandHandlerTests.cs
@@ -1,0 +1,169 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Governance.Contracts;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarOfertaCursoCommandHandlerTests
+{
+    private static readonly DateTimeOffset Agora = new(2026, 7, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly IOfertaCursoRepository _repository = Substitute.For<IOfertaCursoRepository>();
+    private readonly ICursoRepository _cursoRepository = Substitute.For<ICursoRepository>();
+    private readonly ILocalOfertaRepository _localOfertaRepository = Substitute.For<ILocalOfertaRepository>();
+    private readonly IUnidadeReader _unidadeReader = Substitute.For<IUnidadeReader>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static Curso CursoVivo() =>
+        Curso.Criar("ENG_CIVIL", "Engenharia Civil", "Bacharelado", "Graduação", null).Value!;
+
+    private static LocalOferta LocalVivo() =>
+        LocalOferta.Criar(
+            TipoLocalOferta.CampusSede, null, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null).Value!;
+
+    private static UnidadeView UnidadeViva(Guid id) =>
+        new(id, "FACET", "facet", "Faculdade de Computação e Engenharia Elétrica",
+            null, "Faculdade", UnidadeAcademica: true, UnidadeSuperiorId: null);
+
+    private static CriarOfertaCursoCommand Comando(
+        Guid cursoId,
+        Guid localOfertaId,
+        Guid unidadeOrigemId,
+        string programa = "REGULAR",
+        string? baseLegal = null) =>
+        new(cursoId, localOfertaId, unidadeOrigemId, programa,
+            FormatoPedagogico: "PRESENCIAL", Turno: "MATUTINO",
+            EMecCodigo: "123456", CodigoSga: "ENG-01",
+            VagasAnuaisAutorizadas: 40, BaseLegal: baseLegal, AtoAutorizacaoMec: null);
+
+    private Task<Result<Guid>> HandleAsync(CriarOfertaCursoCommand comando) =>
+        CriarOfertaCursoCommandHandler.Handle(
+            comando, _repository, _cursoRepository, _localOfertaRepository,
+            _unidadeReader, _unitOfWork, CancellationToken.None);
+
+    [Fact(DisplayName = "Curso e local vivos + unidade viva: congela o snapshot da view, persiste e retorna o Id")]
+    public async Task Handle_ReferenciasVivas_CongelaEPersiste()
+    {
+        Curso curso = CursoVivo();
+        LocalOferta local = LocalVivo();
+        Guid unidadeId = Guid.CreateVersion7();
+        _cursoRepository.ObterPorIdParaLeituraAsync(curso.Id, Arg.Any<CancellationToken>()).Returns(curso);
+        _localOfertaRepository.ObterPorIdParaLeituraAsync(local.Id, Arg.Any<CancellationToken>()).Returns(local);
+        _unidadeReader.ObterPorIdAsync(unidadeId, Arg.Any<CancellationToken>()).Returns(UnidadeViva(unidadeId));
+
+        Result<Guid> resultado = await HandleAsync(Comando(curso.Id, local.Id, unidadeId));
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        // Snapshot-copy (ADR-0061): sigla/nome/tipo congelados exatamente como a view devolveu.
+        await _repository.Received(1).AdicionarAsync(
+            Arg.Is<OfertaCurso>(o =>
+                o.UnidadeOfertante.OrigemId == unidadeId
+                && o.UnidadeOfertante.Sigla == "FACET"
+                && o.UnidadeOfertante.Nome == "Faculdade de Computação e Engenharia Elétrica"
+                && o.UnidadeOfertante.Tipo == "Faculdade"
+                && o.CursoId == curso.Id
+                && o.LocalOfertaId == local.Id),
+            Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Curso inexistente ou removido retorna CursoInexistenteOuRemovido sem consultar o reader")]
+    public async Task Handle_CursoInexistente_RetornaErro()
+    {
+        Guid cursoId = Guid.CreateVersion7();
+        _cursoRepository.ObterPorIdParaLeituraAsync(cursoId, Arg.Any<CancellationToken>()).Returns((Curso?)null);
+
+        Result<Guid> resultado = await HandleAsync(
+            Comando(cursoId, Guid.CreateVersion7(), Guid.CreateVersion7()));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.CursoInexistenteOuRemovido);
+        await _unidadeReader.DidNotReceive().ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<OfertaCurso>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Local de oferta inexistente ou removido retorna LocalOfertaInexistenteOuRemovido sem persistir")]
+    public async Task Handle_LocalInexistente_RetornaErro()
+    {
+        Curso curso = CursoVivo();
+        Guid localId = Guid.CreateVersion7();
+        _cursoRepository.ObterPorIdParaLeituraAsync(curso.Id, Arg.Any<CancellationToken>()).Returns(curso);
+        _localOfertaRepository.ObterPorIdParaLeituraAsync(localId, Arg.Any<CancellationToken>()).Returns((LocalOferta?)null);
+
+        Result<Guid> resultado = await HandleAsync(Comando(curso.Id, localId, Guid.CreateVersion7()));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.LocalOfertaInexistenteOuRemovido);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<OfertaCurso>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Reader devolve null: UnidadeOfertanteInexistente — não há identidade viva para congelar (ADR-0061)")]
+    public async Task Handle_UnidadeInexistente_RetornaErro()
+    {
+        Curso curso = CursoVivo();
+        LocalOferta local = LocalVivo();
+        Guid unidadeId = Guid.CreateVersion7();
+        _cursoRepository.ObterPorIdParaLeituraAsync(curso.Id, Arg.Any<CancellationToken>()).Returns(curso);
+        _localOfertaRepository.ObterPorIdParaLeituraAsync(local.Id, Arg.Any<CancellationToken>()).Returns(local);
+        _unidadeReader.ObterPorIdAsync(unidadeId, Arg.Any<CancellationToken>()).Returns((UnidadeView?)null);
+
+        Result<Guid> resultado = await HandleAsync(Comando(curso.Id, local.Id, unidadeId));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.UnidadeOfertanteInexistente);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<OfertaCurso>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Programa não-REGULAR sem base legal propaga o erro de domínio sem persistir")]
+    public async Task Handle_ProgramaNaoRegularSemBaseLegal_RetornaErroSemPersistir()
+    {
+        Curso curso = CursoVivo();
+        LocalOferta local = LocalVivo();
+        Guid unidadeId = Guid.CreateVersion7();
+        _cursoRepository.ObterPorIdParaLeituraAsync(curso.Id, Arg.Any<CancellationToken>()).Returns(curso);
+        _localOfertaRepository.ObterPorIdParaLeituraAsync(local.Id, Arg.Any<CancellationToken>()).Returns(local);
+        _unidadeReader.ObterPorIdAsync(unidadeId, Arg.Any<CancellationToken>()).Returns(UnidadeViva(unidadeId));
+
+        Result<Guid> resultado = await HandleAsync(
+            Comando(curso.Id, local.Id, unidadeId, programa: "PARFOR", baseLegal: null));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.BaseLegalObrigatoriaParaProgramaNaoRegular);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Programa não-REGULAR com base legal cria normalmente")]
+    public async Task Handle_ProgramaNaoRegularComBaseLegal_Cria()
+    {
+        Curso curso = CursoVivo();
+        LocalOferta local = LocalVivo();
+        Guid unidadeId = Guid.CreateVersion7();
+        _cursoRepository.ObterPorIdParaLeituraAsync(curso.Id, Arg.Any<CancellationToken>()).Returns(curso);
+        _localOfertaRepository.ObterPorIdParaLeituraAsync(local.Id, Arg.Any<CancellationToken>()).Returns(local);
+        _unidadeReader.ObterPorIdAsync(unidadeId, Arg.Any<CancellationToken>()).Returns(UnidadeViva(unidadeId));
+
+        Result<Guid> resultado = await HandleAsync(
+            Comando(curso.Id, local.Id, unidadeId, programa: "PARFOR", baseLegal: "Decreto 6.755/2009"));
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _repository.Received(1).AdicionarAsync(
+            Arg.Is<OfertaCurso>(o =>
+                o.ProgramaDeOferta == ProgramaDeOferta.Parfor
+                && o.BaseLegal == "Decreto 6.755/2009"),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverOfertaCursoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverOfertaCursoCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverOfertaCursoCommandHandlerTests
+{
+    private readonly IOfertaCursoRepository _repository = Substitute.For<IOfertaCursoRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static OfertaCurso NovaOferta()
+    {
+        UnidadeOfertante unidade = UnidadeOfertante.Criar(
+            Guid.CreateVersion7(), "FACET", "Faculdade de Computação e Engenharia Elétrica", "Faculdade").Value!;
+
+        return OfertaCurso.Criar(
+            Guid.CreateVersion7(), Guid.CreateVersion7(), unidade, "REGULAR", null,
+            null, null, null, null, null, null).Value!;
+    }
+
+    [Fact(DisplayName = "Oferta inexistente retorna NaoEncontrada (404)")]
+    public async Task Handle_Inexistente_RetornaNaoEncontrada()
+    {
+        Guid id = Guid.CreateVersion7();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((OfertaCurso?)null);
+
+        Result resultado = await RemoverOfertaCursoCommandHandler.Handle(
+            new RemoverOfertaCursoCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.NaoEncontrada);
+        _repository.DidNotReceive().Remover(Arg.Any<OfertaCurso>());
+    }
+
+    [Fact(DisplayName = "Oferta existente é removida (soft-delete) sem bloqueio — snapshots externos são desacoplados (ADR-0061)")]
+    public async Task Handle_Existente_RemoveSemBloqueio()
+    {
+        OfertaCurso oferta = NovaOferta();
+        _repository.ObterPorIdAsync(oferta.Id, Arg.Any<CancellationToken>()).Returns(oferta);
+
+        Result resultado = await RemoverOfertaCursoCommandHandler.Handle(
+            new RemoverOfertaCursoCommand(oferta.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(oferta);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/OfertaCursoValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/OfertaCursoValidatorTests.cs
@@ -1,0 +1,235 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.OfertasCurso;
+
+/// <summary>
+/// O validator antecipa a obrigatoriedade das referências (curso, local,
+/// unidade ofertante) e do programa, os domínios fechados dos tokens (quando há
+/// valor efetivo), o teto de vagas não-negativo e os comprimentos máximos —
+/// fronteira simétrica com o domínio (#749). O guard condicional da base legal
+/// (programa ≠ REGULAR) é regra de domínio (422), não do validator.
+/// </summary>
+public sealed class OfertaCursoValidatorTests
+{
+    private readonly CriarOfertaCursoCommandValidator _validator = new();
+    private readonly AtualizarOfertaCursoCommandValidator _atualizarValidator = new();
+
+    private static CriarOfertaCursoCommand Base() =>
+        new(Guid.CreateVersion7(), Guid.CreateVersion7(), Guid.CreateVersion7(),
+            "REGULAR", "PRESENCIAL", "MATUTINO", "123456", "ENG-01", 40, null, null);
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Comando mínimo (só referências + programa) passa no validator")]
+    public void Minimo_Passa()
+    {
+        var comando = new CriarOfertaCursoCommand(
+            Guid.CreateVersion7(), Guid.CreateVersion7(), Guid.CreateVersion7(), "REGULAR");
+
+        _validator.Validate(comando).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "CursoId vazio é rejeitado")]
+    public void CursoIdVazio_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { CursoId = Guid.Empty });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarOfertaCursoCommand.CursoId));
+    }
+
+    [Fact(DisplayName = "LocalOfertaId vazio é rejeitado")]
+    public void LocalOfertaIdVazio_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { LocalOfertaId = Guid.Empty });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarOfertaCursoCommand.LocalOfertaId));
+    }
+
+    [Fact(DisplayName = "UnidadeOfertanteOrigemId vazio é rejeitado")]
+    public void UnidadeOrigemVazia_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(
+            Base() with { UnidadeOfertanteOrigemId = Guid.Empty });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(
+            e => e.PropertyName == nameof(CriarOfertaCursoCommand.UnidadeOfertanteOrigemId));
+    }
+
+    [Theory(DisplayName = "Programa ausente ou fora do domínio fechado é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Regular")]
+    [InlineData("PROUNI")]
+    [InlineData("1")]
+    public void ProgramaInvalido_Rejeita(string programa)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { ProgramaDeOferta = programa });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(
+            e => e.PropertyName == nameof(CriarOfertaCursoCommand.ProgramaDeOferta));
+    }
+
+    [Theory(DisplayName = "Cada um dos sete tokens canônicos de programa é aceito")]
+    [InlineData("REGULAR")]
+    [InlineData("FORMA_PARA")]
+    [InlineData("PARFOR")]
+    [InlineData("PRONERA")]
+    [InlineData("PEPETI")]
+    [InlineData("CONVENIO_OUTRO")]
+    [InlineData("OUTRO")]
+    public void ProgramaCanonico_Aceita(string programa)
+    {
+        // O guard da base legal para programas não-REGULAR é de domínio, não do validator.
+        _validator.Validate(Base() with { ProgramaDeOferta = programa })
+            .IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Formato pedagógico em branco passa (default PRESENCIAL é do domínio)")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SemFormato_Passa(string? formato)
+    {
+        _validator.Validate(Base() with { FormatoPedagogico = formato })
+            .IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Formato pedagógico fora do domínio fechado é rejeitado")]
+    [InlineData("Presencial")]
+    [InlineData("HIBRIDO")]
+    public void FormatoInvalido_Rejeita(string formato)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { FormatoPedagogico = formato });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(
+            e => e.PropertyName == nameof(CriarOfertaCursoCommand.FormatoPedagogico));
+    }
+
+    [Theory(DisplayName = "Turno em branco passa (nulo aceito — nem toda oferta declara turno)")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SemTurno_Passa(string? turno)
+    {
+        _validator.Validate(Base() with { Turno = turno }).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Turno fora do domínio fechado é rejeitado")]
+    [InlineData("Matutino")]
+    [InlineData("DIURNO")]
+    public void TurnoInvalido_Rejeita(string turno)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { Turno = turno });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarOfertaCursoCommand.Turno));
+    }
+
+    [Fact(DisplayName = "Vagas anuais negativas são rejeitadas")]
+    public void VagasNegativas_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(
+            Base() with { VagasAnuaisAutorizadas = -1 });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(
+            e => e.PropertyName == nameof(CriarOfertaCursoCommand.VagasAnuaisAutorizadas));
+    }
+
+    [Theory(DisplayName = "Vagas anuais zero e nulas passam — o teto e-MEC é opcional")]
+    [InlineData(0)]
+    [InlineData(null)]
+    public void VagasZeroOuNulas_Passa(int? vagas)
+    {
+        _validator.Validate(Base() with { VagasAnuaisAutorizadas = vagas })
+            .IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Código e-MEC acima de 20 caracteres é rejeitado")]
+    public void EMecCodigoLongo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(
+            Base() with { EMecCodigo = new string('1', 21) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarOfertaCursoCommand.EMecCodigo));
+    }
+
+    [Fact(DisplayName = "Código SGA acima de 30 caracteres é rejeitado")]
+    public void CodigoSgaLongo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(
+            Base() with { CodigoSga = new string('S', 31) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarOfertaCursoCommand.CodigoSga));
+    }
+
+    [Fact(DisplayName = "Base legal acima de 500 caracteres é rejeitada")]
+    public void BaseLegalLonga_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(
+            Base() with { BaseLegal = new string('B', 501) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarOfertaCursoCommand.BaseLegal));
+    }
+
+    [Fact(DisplayName = "Ato de autorização MEC acima de 300 caracteres é rejeitado")]
+    public void AtoAutorizacaoMecLongo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(
+            Base() with { AtoAutorizacaoMec = new string('A', 301) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(
+            e => e.PropertyName == nameof(CriarOfertaCursoCommand.AtoAutorizacaoMec));
+    }
+
+    // ── Atualizar — espelho do Criar sem as referências imutáveis ─────────
+
+    [Fact(DisplayName = "Atualizar: comando válido passa no validator")]
+    public void Atualizar_Valido_Passa()
+    {
+        var comando = new AtualizarOfertaCursoCommand(
+            Guid.CreateVersion7(), "REGULAR", "EAD", null, "654321", "ENG-02", 60, null, null);
+
+        _atualizarValidator.Validate(comando).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Atualizar: Id vazio é rejeitado")]
+    public void Atualizar_IdVazio_Rejeita()
+    {
+        var comando = new AtualizarOfertaCursoCommand(Guid.Empty, "REGULAR");
+
+        ValidationResult resultado = _atualizarValidator.Validate(comando);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(AtualizarOfertaCursoCommand.Id));
+    }
+
+    [Fact(DisplayName = "Atualizar: programa fora do domínio fechado é rejeitado")]
+    public void Atualizar_ProgramaInvalido_Rejeita()
+    {
+        var comando = new AtualizarOfertaCursoCommand(Guid.CreateVersion7(), "PROUNI");
+
+        ValidationResult resultado = _atualizarValidator.Validate(comando);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(
+            e => e.PropertyName == nameof(AtualizarOfertaCursoCommand.ProgramaDeOferta));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/packages.lock.json
@@ -58,15 +58,487 @@
           "System.Diagnostics.EventLog": "6.0.0"
         }
       },
+      "FastExpressionCompiler": {
+        "type": "Transitive",
+        "resolved": "5.3.0",
+        "contentHash": "XRmGW48Gdm7B70WUtTJJUnmuc8jRDmOhhjG/a3rix/nXChnrkETaSvA0j2VrcsH4MNeYLe60LA5o5JABmbneag=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "ImTools": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "dms0JfLKC9AQbQX/EdpRjn59EjEvaCxIgv1z9YxbEQb5SiOVoo7vlIKdEySeEwUkWhN05rZnNpUpG+aw5VqPVQ=="
+      },
+      "JasperFx": {
+        "type": "Transitive",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
+        "dependencies": {
+          "FastExpressionCompiler": "5.3.0",
+          "ImTools": "4.0.0",
+          "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
+          "Polly.Core": "8.6.5",
+          "Spectre.Console": "0.55.0"
+        }
+      },
+      "JasperFx.Events": {
+        "type": "Transitive",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
+        "dependencies": {
+          "JasperFx": "1.31.0"
+        }
+      },
+      "JasperFx.RuntimeCompiler": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "SGJlU1kD8lX8A5p0hBWTPDV7dvPzoUB37IZjprWgA+L5yZZNyBElpn6UPNo7ZuXLKKwlSSt8BWTr99vxpxT3JA==",
+        "dependencies": {
+          "JasperFx": "1.28.0",
+          "Microsoft.CodeAnalysis": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "JasperFx.SourceGeneration": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "yIOaiA/OrlXQLGPjxFDubHnOU8MCzPTz465xBGRITMm4fDf7DbWKogb2SZC2jYLWEj27q3smTz1Z7lU4h1KkOQ=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bUubrBD6tRJE3V1kvRloYc6NymH3R5oFKjAS9e0ELNx6u0ZR+zjps9dDQyjgqN/rArzl7f+21KGszj3YRN7F2Q=="
+      },
+      "Microsoft.CodeAnalysis": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "X7vItpZDkGm4NS2wp4P1S07Z1e61LaBWDW5tPXE1c6z5/x9KbF2RymhAPoYg7Qoiyk7odEZ6EjBEJ47p3dBpYQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1sGloRYbG3743ut/+vuXy9/WaRQTm7mDtp71rBaVSmKpFntvo5Hcro1ubg6/3SeeLtiFYJl7V3Dk0Fo3CGlnHA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Scripting.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/KgZdm6kRTrR/O2jqXxU5GWREYhtVmqcNWczyPt8hsQkFGFK/C6CrLWfG44FCUn0aPHGDRBHYjXlGosQ/H8oXw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Scripting": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "XTulByMNxqXGCgMeODUoG2h4oK4/nLv1BcawRVcjv+UZHMpoaymtdaq3cJqlNrEvYEcbU48g5swJ3RhY1m3fBg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "sUBWvHs2HgHGA+b716dgjS7JiXGen5ntyohAurPLR1ZiZzFp3FlnVA7GrMTqVGdVJTVqiC3c4K8k1bk0gj6IPg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Nom4UuZVEZGaV6Qa+joJR/BawXZMtflvQJFKc0SaUc3LrZr/8LmRY5cn8mbvLOWIVfwWkQz+cVE6eQKu9qa65g==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "18.7.0",
         "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
       },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "Zcoy6H9mSoGyvr7UvlGokEZrlZkcPCICPZr8mCsSt9U/N8eeCwCXwKF5bShdA66R0obxBCwP4AxomQHvVkC/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "krK19MKp0BNiR9rpBDW7PKSrTMLVlifS9am3CVc4O1Jq6GWz0o4F+sw5OSL4L3mVd56W8l6JRgghUa2KB51vOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "d2kDKnCsJvY7mBVhcjPSp9BkJk48DsaHPg5u+Oy4f8XaOqnEedRy/USyvnpHL92wpJ6DrTPy7htppUUzskbCXQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.7",
         "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Logging.Console": "10.0.0",
+          "Microsoft.Extensions.Logging.Debug": "10.0.0",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "KrN6TGFwCwqOkLLk/idW/XtDQh+8In+CL9T4M1Dx+5ScsjTq4TlVbal8q532m82UYrMr6RiQJF2HvYCN0QwVsA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "System.Diagnostics.EventLog": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
@@ -82,15 +554,86 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
+      "NewId": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "jegBasNndmG21G3BmT51suFDCIz/sLN81j+IxmkZ4iWoaDi8LygeHiyNnYbXz5OQh9nCRJFIx1+PJrlYi1Gc9Q=="
+      },
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.5",
+        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+      },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+        "resolved": "10.0.0",
+        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
       },
       "xunit.abstractions": {
         "type": "Transitive",
@@ -150,7 +693,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {
@@ -199,6 +743,29 @@
         "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "WolverineFx": {
+        "type": "CentralTransitive",
+        "requested": "[5.39.5, )",
+        "resolved": "5.39.5",
+        "contentHash": "rnyz+ZConabOTi/U8N7UQAOaMc9P03hHyFrXZ6///6X0qtsHQ+VKDZtHe87AZJmY7By2w9As9puY6/jGCg5ZCA==",
+        "dependencies": {
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
+          "JasperFx.RuntimeCompiler": "4.5.0",
+          "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
         }
       }
     }

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/OfertaCursoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/OfertaCursoTests.cs
@@ -1,0 +1,329 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class OfertaCursoTests
+{
+    private static readonly Guid CursoId = Guid.CreateVersion7();
+    private static readonly Guid LocalOfertaId = Guid.CreateVersion7();
+
+    private static UnidadeOfertante Unidade() =>
+        UnidadeOfertante.Criar(
+            Guid.CreateVersion7(), "FACET", "Faculdade de Computação e Engenharia Elétrica", "Faculdade").Value!;
+
+    private static Result<OfertaCurso> Criar(
+        string? programaDeOferta = "REGULAR",
+        string? formatoPedagogico = "PRESENCIAL",
+        string? turno = "MATUTINO",
+        string? eMecCodigo = "123456",
+        string? codigoSga = "ENG-01",
+        int? vagasAnuaisAutorizadas = 40,
+        string? baseLegal = null,
+        string? atoAutorizacaoMec = "Portaria MEC 123/2020",
+        UnidadeOfertante? unidade = null) =>
+        OfertaCurso.Criar(
+            CursoId, LocalOfertaId, unidade ?? Unidade(), programaDeOferta, formatoPedagogico,
+            turno, eMecCodigo, codigoSga, vagasAnuaisAutorizadas, baseLegal, atoAutorizacaoMec);
+
+    [Fact(DisplayName = "Criar com dados válidos preenche os campos e fica ativa com Guid v7")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        UnidadeOfertante unidade = Unidade();
+
+        OfertaCurso oferta = Criar(unidade: unidade).Value!;
+
+        oferta.Id.Should().NotBe(Guid.Empty);
+        oferta.CursoId.Should().Be(CursoId);
+        oferta.LocalOfertaId.Should().Be(LocalOfertaId);
+        oferta.UnidadeOfertante.Should().Be(unidade);
+        oferta.ProgramaDeOferta.Should().Be(ProgramaDeOferta.Regular);
+        oferta.FormatoPedagogico.Should().Be(FormatoPedagogico.Presencial);
+        oferta.Turno.Should().Be(TurnoOferta.Matutino);
+        oferta.EMecCodigo.Should().Be("123456");
+        oferta.CodigoSga.Should().Be("ENG-01");
+        oferta.VagasAnuaisAutorizadas.Should().Be(40);
+        oferta.BaseLegal.Should().BeNull();
+        oferta.AtoAutorizacaoMec.Should().Be("Portaria MEC 123/2020");
+        oferta.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar com unidade ofertante nula lança — o snapshot é pré-requisito do handler")]
+    public void Criar_UnidadeNula_Lanca()
+    {
+        Action act = () => OfertaCurso.Criar(
+            CursoId, LocalOfertaId, null!, "REGULAR", null, null, null, null, null, null, null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // ── Programa de oferta ────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Cada um dos sete tokens canônicos de programa é aceito (não-REGULAR exige base legal)")]
+    [InlineData("REGULAR", ProgramaDeOferta.Regular)]
+    [InlineData("FORMA_PARA", ProgramaDeOferta.FormaPara)]
+    [InlineData("PARFOR", ProgramaDeOferta.Parfor)]
+    [InlineData("PRONERA", ProgramaDeOferta.Pronera)]
+    [InlineData("PEPETI", ProgramaDeOferta.Pepeti)]
+    [InlineData("CONVENIO_OUTRO", ProgramaDeOferta.ConvenioOutro)]
+    [InlineData("OUTRO", ProgramaDeOferta.Outro)]
+    public void Criar_ProgramaCanonico_Aceita(string token, ProgramaDeOferta esperado)
+    {
+        Result<OfertaCurso> resultado = Criar(
+            programaDeOferta: token, baseLegal: "Lei 12.345/2010");
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.ProgramaDeOferta.Should().Be(esperado);
+    }
+
+    [Theory(DisplayName = "Programa ausente ou fora do domínio fechado é rejeitado (sem default)")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Regular")]
+    [InlineData("regular")]
+    [InlineData("1")]
+    [InlineData("PROUNI")]
+    public void Criar_ProgramaInvalido_Falha(string? token)
+    {
+        Result<OfertaCurso> resultado = Criar(programaDeOferta: token);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.ProgramaDeOfertaInvalido);
+    }
+
+    // ── Formato pedagógico ────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Cada um dos três tokens canônicos de formato é aceito")]
+    [InlineData("PRESENCIAL", FormatoPedagogico.Presencial)]
+    [InlineData("SEMIPRESENCIAL", FormatoPedagogico.Semipresencial)]
+    [InlineData("EAD", FormatoPedagogico.Ead)]
+    public void Criar_FormatoCanonico_Aceita(string token, FormatoPedagogico esperado)
+    {
+        Criar(formatoPedagogico: token).Value!.FormatoPedagogico.Should().Be(esperado);
+    }
+
+    [Theory(DisplayName = "Formato ausente aplica o default conceitual PRESENCIAL")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemFormato_DefaultPresencial(string? token)
+    {
+        OfertaCurso oferta = Criar(formatoPedagogico: token).Value!;
+
+        oferta.FormatoPedagogico.Should().Be(
+            FormatoPedagogico.Presencial, "o default conceitual espelha o AMPLA de NaturezasLegais");
+    }
+
+    [Theory(DisplayName = "Formato fora do domínio fechado é rejeitado")]
+    [InlineData("Presencial")]
+    [InlineData("HIBRIDO")]
+    [InlineData("2")]
+    public void Criar_FormatoInvalido_Falha(string token)
+    {
+        Result<OfertaCurso> resultado = Criar(formatoPedagogico: token);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.FormatoPedagogicoInvalido);
+    }
+
+    // ── Turno ─────────────────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Cada um dos quatro tokens canônicos de turno é aceito")]
+    [InlineData("MATUTINO", TurnoOferta.Matutino)]
+    [InlineData("VESPERTINO", TurnoOferta.Vespertino)]
+    [InlineData("NOTURNO", TurnoOferta.Noturno)]
+    [InlineData("INTEGRAL", TurnoOferta.Integral)]
+    public void Criar_TurnoCanonico_Aceita(string token, TurnoOferta esperado)
+    {
+        Criar(turno: token).Value!.Turno.Should().Be(esperado);
+    }
+
+    [Theory(DisplayName = "Turno ausente é aceito e normalizado para nulo — nem toda oferta declara turno")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemTurno_Aceita(string? token)
+    {
+        Criar(turno: token).Value!.Turno.Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Turno fora do domínio fechado é rejeitado")]
+    [InlineData("Matutino")]
+    [InlineData("DIURNO")]
+    [InlineData("3")]
+    public void Criar_TurnoInvalido_Falha(string token)
+    {
+        Result<OfertaCurso> resultado = Criar(turno: token);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.TurnoInvalido);
+    }
+
+    // ── Vagas anuais autorizadas (teto e-MEC) ─────────────────────────────
+
+    [Fact(DisplayName = "Vagas anuais negativas são rejeitadas")]
+    public void Criar_VagasNegativas_Falha()
+    {
+        Result<OfertaCurso> resultado = Criar(vagasAnuaisAutorizadas: -1);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.VagasAnuaisNegativas);
+    }
+
+    [Theory(DisplayName = "Vagas anuais zero e nulas são aceitas — o teto e-MEC é opcional")]
+    [InlineData(0)]
+    [InlineData(null)]
+    public void Criar_VagasZeroOuNulas_Aceita(int? vagas)
+    {
+        Result<OfertaCurso> resultado = Criar(vagasAnuaisAutorizadas: vagas);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.VagasAnuaisAutorizadas.Should().Be(vagas);
+    }
+
+    // ── Base legal condicional (ADR-0066) ─────────────────────────────────
+
+    [Theory(DisplayName = "Criar com programa não-REGULAR sem base legal é rejeitado")]
+    [InlineData("FORMA_PARA")]
+    [InlineData("PARFOR")]
+    [InlineData("PRONERA")]
+    [InlineData("PEPETI")]
+    [InlineData("CONVENIO_OUTRO")]
+    [InlineData("OUTRO")]
+    public void Criar_ProgramaNaoRegularSemBaseLegal_Falha(string programa)
+    {
+        Result<OfertaCurso> resultado = Criar(programaDeOferta: programa, baseLegal: null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.BaseLegalObrigatoriaParaProgramaNaoRegular);
+    }
+
+    [Fact(DisplayName = "Base legal em branco não satisfaz o guard condicional (normaliza para nulo)")]
+    public void Criar_ProgramaNaoRegularComBaseLegalEmBranco_Falha()
+    {
+        Result<OfertaCurso> resultado = Criar(programaDeOferta: "PARFOR", baseLegal: "   ");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.BaseLegalObrigatoriaParaProgramaNaoRegular);
+    }
+
+    [Fact(DisplayName = "Criar REGULAR sem base legal é aceito — o guard é condicional ao programa")]
+    public void Criar_RegularSemBaseLegal_Aceita()
+    {
+        Result<OfertaCurso> resultado = Criar(programaDeOferta: "REGULAR", baseLegal: null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.BaseLegal.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Atualizar na transição Regular→Parfor sem base legal é rejeitado sem mutar o agregado")]
+    public void Atualizar_TransicaoRegularParforSemBaseLegal_Falha()
+    {
+        OfertaCurso oferta = Criar(programaDeOferta: "REGULAR", baseLegal: null).Value!;
+
+        Result resultado = oferta.Atualizar(
+            "PARFOR", "PRESENCIAL", "MATUTINO", "123456", "ENG-01", 40, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.BaseLegalObrigatoriaParaProgramaNaoRegular);
+        oferta.ProgramaDeOferta.Should().Be(
+            ProgramaDeOferta.Regular, "a falha de validação não muta o agregado");
+    }
+
+    [Fact(DisplayName = "Atualizar na transição Regular→Parfor com base legal é aceito")]
+    public void Atualizar_TransicaoRegularParforComBaseLegal_Aceita()
+    {
+        OfertaCurso oferta = Criar(programaDeOferta: "REGULAR", baseLegal: null).Value!;
+
+        Result resultado = oferta.Atualizar(
+            "PARFOR", "SEMIPRESENCIAL", null, "654321", "PED-02", 50,
+            "Decreto 6.755/2009", "Portaria MEC 9/2009");
+
+        resultado.IsSuccess.Should().BeTrue();
+        oferta.ProgramaDeOferta.Should().Be(ProgramaDeOferta.Parfor);
+        oferta.FormatoPedagogico.Should().Be(FormatoPedagogico.Semipresencial);
+        oferta.Turno.Should().BeNull();
+        oferta.EMecCodigo.Should().Be("654321");
+        oferta.CodigoSga.Should().Be("PED-02");
+        oferta.VagasAnuaisAutorizadas.Should().Be(50);
+        oferta.BaseLegal.Should().Be("Decreto 6.755/2009");
+        oferta.AtoAutorizacaoMec.Should().Be("Portaria MEC 9/2009");
+    }
+
+    // ── Imutabilidade curso × local × unidade ─────────────────────────────
+
+    [Fact(DisplayName = "Atualizar não altera CursoId, LocalOfertaId, UnidadeOfertante nem Id (imutáveis)")]
+    public void Atualizar_PreservaCursoLocalUnidadeEId()
+    {
+        UnidadeOfertante unidade = Unidade();
+        OfertaCurso oferta = Criar(unidade: unidade).Value!;
+        Guid idOriginal = oferta.Id;
+
+        Result resultado = oferta.Atualizar(
+            "OUTRO", "EAD", "NOTURNO", null, null, null, "Resolução CONSEPE 1/2026", null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        oferta.Id.Should().Be(idOriginal);
+        oferta.CursoId.Should().Be(CursoId, "mudar o curso caracteriza outra oferta");
+        oferta.LocalOfertaId.Should().Be(LocalOfertaId, "mudar o local caracteriza outra oferta");
+        oferta.UnidadeOfertante.Should().Be(unidade, "o snapshot congelado (ADR-0061) é imutável pós-criação");
+    }
+
+    // ── Normalização e tamanhos ───────────────────────────────────────────
+
+    [Fact(DisplayName = "Campos textuais opcionais são normalizados por Trim; em branco viram nulos")]
+    public void Criar_CamposOpcionais_Normaliza()
+    {
+        OfertaCurso oferta = Criar(
+            eMecCodigo: "  123456  ",
+            codigoSga: "   ",
+            atoAutorizacaoMec: "  Portaria MEC 123/2020  ").Value!;
+
+        oferta.EMecCodigo.Should().Be("123456");
+        oferta.CodigoSga.Should().BeNull();
+        oferta.AtoAutorizacaoMec.Should().Be("Portaria MEC 123/2020");
+    }
+
+    [Fact(DisplayName = "Código e-MEC acima do tamanho máximo é rejeitado")]
+    public void Criar_EMecCodigoLongo_Falha()
+    {
+        Result<OfertaCurso> resultado = Criar(eMecCodigo: new string('1', 21));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.EMecCodigoTamanho);
+    }
+
+    [Fact(DisplayName = "Código SGA acima do tamanho máximo é rejeitado")]
+    public void Criar_CodigoSgaLongo_Falha()
+    {
+        Result<OfertaCurso> resultado = Criar(codigoSga: new string('S', 31));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.CodigoSgaTamanho);
+    }
+
+    [Fact(DisplayName = "Base legal acima do tamanho máximo é rejeitada")]
+    public void Criar_BaseLegalLonga_Falha()
+    {
+        Result<OfertaCurso> resultado = Criar(
+            programaDeOferta: "PARFOR", baseLegal: new string('B', 501));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.BaseLegalTamanho);
+    }
+
+    [Fact(DisplayName = "Ato de autorização MEC acima do tamanho máximo é rejeitado")]
+    public void Criar_AtoAutorizacaoMecLongo_Falha()
+    {
+        Result<OfertaCurso> resultado = Criar(atoAutorizacaoMec: new string('A', 301));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.AtoAutorizacaoMecTamanho);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/FormatosPedagogicosTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/FormatosPedagogicosTests.cs
@@ -1,0 +1,78 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Enums;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// O parsing do formato pedagógico é por allowlist textual explícita (#749): só
+/// os três tokens canônicos UPPER_SNAKE são aceitos. O default PRESENCIAL quando
+/// o token está ausente é regra da entidade, não deste mapeamento.
+/// </summary>
+public sealed class FormatosPedagogicosTests
+{
+    [Theory(DisplayName = "Os três tokens canônicos são analisados para o formato correto")]
+    [InlineData("PRESENCIAL", FormatoPedagogico.Presencial)]
+    [InlineData("SEMIPRESENCIAL", FormatoPedagogico.Semipresencial)]
+    [InlineData("EAD", FormatoPedagogico.Ead)]
+    public void TryAnalisar_TokenCanonico_Resolve(string token, FormatoPedagogico esperado)
+    {
+        FormatosPedagogicos.TryAnalisar(token, out FormatoPedagogico formato).Should().BeTrue();
+        formato.Should().Be(esperado);
+    }
+
+    [Fact(DisplayName = "Token com espaços é normalizado por Trim antes da resolução")]
+    public void TryAnalisar_ComEspacos_Normaliza()
+    {
+        FormatosPedagogicos.TryAnalisar("  EAD  ", out FormatoPedagogico formato).Should().BeTrue();
+        formato.Should().Be(FormatoPedagogico.Ead);
+    }
+
+    [Theory(DisplayName = "Tokens numéricos, PascalCase, fora do domínio e vazios são rejeitados")]
+    [InlineData("1")]               // numérico — Enum.TryParse aceitaria; a allowlist não
+    [InlineData("3")]
+    [InlineData("Presencial")]      // PascalCase do enum — não é o token de contrato
+    [InlineData("Ead")]
+    [InlineData("HIBRIDO")]         // fora do domínio fechado
+    [InlineData("presencial")]      // case-sensitive
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryAnalisar_ForaDoDominio_Rejeita(string token)
+    {
+        FormatosPedagogicos.TryAnalisar(token, out FormatoPedagogico formato).Should().BeFalse();
+        formato.Should().Be(FormatoPedagogico.Nenhum);
+        FormatosPedagogicos.EhValido(token).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Token nulo é rejeitado sem lançar")]
+    public void TryAnalisar_Nulo_Rejeita()
+    {
+        FormatosPedagogicos.TryAnalisar(null, out FormatoPedagogico formato).Should().BeFalse();
+        formato.Should().Be(FormatoPedagogico.Nenhum);
+    }
+
+    [Theory(DisplayName = "ParaTokenCanonico é o inverso de TryAnalisar (round-trip)")]
+    [InlineData(FormatoPedagogico.Presencial, "PRESENCIAL")]
+    [InlineData(FormatoPedagogico.Semipresencial, "SEMIPRESENCIAL")]
+    [InlineData(FormatoPedagogico.Ead, "EAD")]
+    public void ParaTokenCanonico_RoundTrip(FormatoPedagogico formato, string token)
+    {
+        FormatosPedagogicos.ParaTokenCanonico(formato).Should().Be(token);
+        FormatosPedagogicos.TryAnalisar(token, out FormatoPedagogico resolvido).Should().BeTrue();
+        resolvido.Should().Be(formato);
+    }
+
+    [Fact(DisplayName = "ParaTokenCanonico de Nenhum (sentinela) lança — não é formato válido")]
+    public void ParaTokenCanonico_Nenhum_Lanca()
+    {
+        Action act = () => FormatosPedagogicos.ParaTokenCanonico(FormatoPedagogico.Nenhum);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact(DisplayName = "TokensCanonicos lista exatamente os três valores de domínio")]
+    public void TokensCanonicos_TemTresValores()
+    {
+        FormatosPedagogicos.TokensCanonicos.Should().HaveCount(3)
+            .And.Contain(["PRESENCIAL", "SEMIPRESENCIAL", "EAD"]);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/ProgramasDeOfertaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/ProgramasDeOfertaTests.cs
@@ -1,0 +1,83 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Enums;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// O parsing do programa de oferta é por allowlist textual explícita (#749): só
+/// os sete tokens canônicos UPPER_SNAKE são aceitos. Tokens numéricos e nomes
+/// PascalCase do enum são rejeitados — o que <c>Enum.TryParse</c> aceitaria por
+/// engano.
+/// </summary>
+public sealed class ProgramasDeOfertaTests
+{
+    [Theory(DisplayName = "Os sete tokens canônicos são analisados para o programa correto")]
+    [InlineData("REGULAR", ProgramaDeOferta.Regular)]
+    [InlineData("FORMA_PARA", ProgramaDeOferta.FormaPara)]
+    [InlineData("PARFOR", ProgramaDeOferta.Parfor)]
+    [InlineData("PRONERA", ProgramaDeOferta.Pronera)]
+    [InlineData("PEPETI", ProgramaDeOferta.Pepeti)]
+    [InlineData("CONVENIO_OUTRO", ProgramaDeOferta.ConvenioOutro)]
+    [InlineData("OUTRO", ProgramaDeOferta.Outro)]
+    public void TryAnalisar_TokenCanonico_Resolve(string token, ProgramaDeOferta esperado)
+    {
+        ProgramasDeOferta.TryAnalisar(token, out ProgramaDeOferta programa).Should().BeTrue();
+        programa.Should().Be(esperado);
+    }
+
+    [Fact(DisplayName = "Token com espaços é normalizado por Trim antes da resolução")]
+    public void TryAnalisar_ComEspacos_Normaliza()
+    {
+        ProgramasDeOferta.TryAnalisar("  PARFOR  ", out ProgramaDeOferta programa).Should().BeTrue();
+        programa.Should().Be(ProgramaDeOferta.Parfor);
+    }
+
+    [Theory(DisplayName = "Tokens numéricos, PascalCase, fora do domínio e vazios são rejeitados")]
+    [InlineData("1")]           // numérico — Enum.TryParse aceitaria; a allowlist não
+    [InlineData("7")]
+    [InlineData("Regular")]     // PascalCase do enum — não é o token de contrato
+    [InlineData("Parfor")]
+    [InlineData("PROUNI")]      // fora do domínio fechado
+    [InlineData("regular")]     // case-sensitive
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryAnalisar_ForaDoDominio_Rejeita(string token)
+    {
+        ProgramasDeOferta.TryAnalisar(token, out ProgramaDeOferta programa).Should().BeFalse();
+        programa.Should().Be(ProgramaDeOferta.Nenhum);
+        ProgramasDeOferta.EhValido(token).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Token nulo é rejeitado sem lançar")]
+    public void TryAnalisar_Nulo_Rejeita()
+    {
+        ProgramasDeOferta.TryAnalisar(null, out ProgramaDeOferta programa).Should().BeFalse();
+        programa.Should().Be(ProgramaDeOferta.Nenhum);
+    }
+
+    [Theory(DisplayName = "ParaTokenCanonico é o inverso de TryAnalisar (round-trip)")]
+    [InlineData(ProgramaDeOferta.Regular, "REGULAR")]
+    [InlineData(ProgramaDeOferta.FormaPara, "FORMA_PARA")]
+    [InlineData(ProgramaDeOferta.ConvenioOutro, "CONVENIO_OUTRO")]
+    public void ParaTokenCanonico_RoundTrip(ProgramaDeOferta programa, string token)
+    {
+        ProgramasDeOferta.ParaTokenCanonico(programa).Should().Be(token);
+        ProgramasDeOferta.TryAnalisar(token, out ProgramaDeOferta resolvido).Should().BeTrue();
+        resolvido.Should().Be(programa);
+    }
+
+    [Fact(DisplayName = "ParaTokenCanonico de Nenhum (sentinela) lança — não é programa válido")]
+    public void ParaTokenCanonico_Nenhum_Lanca()
+    {
+        Action act = () => ProgramasDeOferta.ParaTokenCanonico(ProgramaDeOferta.Nenhum);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact(DisplayName = "TokensCanonicos lista exatamente os sete valores de domínio")]
+    public void TokensCanonicos_TemSeteValores()
+    {
+        ProgramasDeOferta.TokensCanonicos.Should().HaveCount(7)
+            .And.Contain(["REGULAR", "FORMA_PARA", "PARFOR", "PRONERA", "PEPETI", "CONVENIO_OUTRO", "OUTRO"]);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/TurnosOfertaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/TurnosOfertaTests.cs
@@ -1,0 +1,79 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Enums;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// O parsing do turno é por allowlist textual explícita (#749): só os quatro
+/// tokens canônicos UPPER_SNAKE são aceitos. A ausência de turno (nulo aceito)
+/// é regra da entidade, não deste mapeamento.
+/// </summary>
+public sealed class TurnosOfertaTests
+{
+    [Theory(DisplayName = "Os quatro tokens canônicos são analisados para o turno correto")]
+    [InlineData("MATUTINO", TurnoOferta.Matutino)]
+    [InlineData("VESPERTINO", TurnoOferta.Vespertino)]
+    [InlineData("NOTURNO", TurnoOferta.Noturno)]
+    [InlineData("INTEGRAL", TurnoOferta.Integral)]
+    public void TryAnalisar_TokenCanonico_Resolve(string token, TurnoOferta esperado)
+    {
+        TurnosOferta.TryAnalisar(token, out TurnoOferta turno).Should().BeTrue();
+        turno.Should().Be(esperado);
+    }
+
+    [Fact(DisplayName = "Token com espaços é normalizado por Trim antes da resolução")]
+    public void TryAnalisar_ComEspacos_Normaliza()
+    {
+        TurnosOferta.TryAnalisar("  NOTURNO  ", out TurnoOferta turno).Should().BeTrue();
+        turno.Should().Be(TurnoOferta.Noturno);
+    }
+
+    [Theory(DisplayName = "Tokens numéricos, PascalCase, fora do domínio e vazios são rejeitados")]
+    [InlineData("1")]           // numérico — Enum.TryParse aceitaria; a allowlist não
+    [InlineData("4")]
+    [InlineData("Matutino")]    // PascalCase do enum — não é o token de contrato
+    [InlineData("Integral")]
+    [InlineData("DIURNO")]      // fora do domínio fechado
+    [InlineData("matutino")]    // case-sensitive
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryAnalisar_ForaDoDominio_Rejeita(string token)
+    {
+        TurnosOferta.TryAnalisar(token, out TurnoOferta turno).Should().BeFalse();
+        turno.Should().Be(TurnoOferta.Nenhum);
+        TurnosOferta.EhValido(token).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Token nulo é rejeitado sem lançar")]
+    public void TryAnalisar_Nulo_Rejeita()
+    {
+        TurnosOferta.TryAnalisar(null, out TurnoOferta turno).Should().BeFalse();
+        turno.Should().Be(TurnoOferta.Nenhum);
+    }
+
+    [Theory(DisplayName = "ParaTokenCanonico é o inverso de TryAnalisar (round-trip)")]
+    [InlineData(TurnoOferta.Matutino, "MATUTINO")]
+    [InlineData(TurnoOferta.Vespertino, "VESPERTINO")]
+    [InlineData(TurnoOferta.Integral, "INTEGRAL")]
+    public void ParaTokenCanonico_RoundTrip(TurnoOferta turno, string token)
+    {
+        TurnosOferta.ParaTokenCanonico(turno).Should().Be(token);
+        TurnosOferta.TryAnalisar(token, out TurnoOferta resolvido).Should().BeTrue();
+        resolvido.Should().Be(turno);
+    }
+
+    [Fact(DisplayName = "ParaTokenCanonico de Nenhum (sentinela) lança — não é turno válido")]
+    public void ParaTokenCanonico_Nenhum_Lanca()
+    {
+        Action act = () => TurnosOferta.ParaTokenCanonico(TurnoOferta.Nenhum);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact(DisplayName = "TokensCanonicos lista exatamente os quatro valores de domínio")]
+    public void TokensCanonicos_TemQuatroValores()
+    {
+        TurnosOferta.TokensCanonicos.Should().HaveCount(4)
+            .And.Contain(["MATUTINO", "VESPERTINO", "NOTURNO", "INTEGRAL"]);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/ValueObjects/UnidadeOfertanteTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/ValueObjects/UnidadeOfertanteTests.cs
@@ -1,0 +1,124 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class UnidadeOfertanteTests
+{
+    private static readonly Guid OrigemId = Guid.CreateVersion7();
+
+    private static Result<UnidadeOfertante> Criar(
+        Guid? origemId = null,
+        string? sigla = "FACET",
+        string? nome = "Faculdade de Computação e Engenharia Elétrica",
+        string? tipo = "Faculdade") =>
+        UnidadeOfertante.Criar(origemId ?? OrigemId, sigla, nome, tipo);
+
+    [Fact(DisplayName = "Criar com dados válidos congela origem, sigla, nome e tipo")]
+    public void Criar_DadosValidos_Preenche()
+    {
+        UnidadeOfertante unidade = Criar().Value!;
+
+        unidade.OrigemId.Should().Be(OrigemId);
+        unidade.Sigla.Should().Be("FACET");
+        unidade.Nome.Should().Be("Faculdade de Computação e Engenharia Elétrica");
+        unidade.Tipo.Should().Be("Faculdade");
+    }
+
+    [Fact(DisplayName = "Campos são normalizados por Trim na criação")]
+    public void Criar_ComEspacos_Normaliza()
+    {
+        UnidadeOfertante unidade = Criar(
+            sigla: "  FACET  ", nome: "  Faculdade de Computação  ", tipo: "  Faculdade  ").Value!;
+
+        unidade.Sigla.Should().Be("FACET");
+        unidade.Nome.Should().Be("Faculdade de Computação");
+        unidade.Tipo.Should().Be("Faculdade");
+    }
+
+    [Fact(DisplayName = "OrigemId vazio é rejeitado — sem proveniência não há snapshot")]
+    public void Criar_OrigemVazia_Falha()
+    {
+        Result<UnidadeOfertante> resultado = Criar(origemId: Guid.Empty);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.UnidadeOfertanteOrigemObrigatoria);
+    }
+
+    [Theory(DisplayName = "Sigla ausente ou em branco é rejeitada")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemSigla_Falha(string? sigla)
+    {
+        Result<UnidadeOfertante> resultado = Criar(sigla: sigla);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.UnidadeOfertanteSiglaObrigatoria);
+    }
+
+    [Fact(DisplayName = "Sigla acima do tamanho máximo é rejeitada")]
+    public void Criar_SiglaLonga_Falha()
+    {
+        Result<UnidadeOfertante> resultado = Criar(sigla: new string('S', 51));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.UnidadeOfertanteSiglaTamanho);
+    }
+
+    [Theory(DisplayName = "Nome ausente ou em branco é rejeitado")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemNome_Falha(string? nome)
+    {
+        Result<UnidadeOfertante> resultado = Criar(nome: nome);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.UnidadeOfertanteNomeObrigatorio);
+    }
+
+    [Fact(DisplayName = "Nome acima do tamanho máximo é rejeitado")]
+    public void Criar_NomeLongo_Falha()
+    {
+        Result<UnidadeOfertante> resultado = Criar(nome: new string('N', 251));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.UnidadeOfertanteNomeTamanho);
+    }
+
+    [Theory(DisplayName = "Tipo ausente ou em branco é rejeitado")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_SemTipo_Falha(string? tipo)
+    {
+        Result<UnidadeOfertante> resultado = Criar(tipo: tipo);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.UnidadeOfertanteTipoObrigatorio);
+    }
+
+    [Fact(DisplayName = "Tipo acima do tamanho máximo é rejeitado")]
+    public void Criar_TipoLongo_Falha()
+    {
+        Result<UnidadeOfertante> resultado = Criar(tipo: new string('T', 31));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(OfertaCursoErrorCodes.UnidadeOfertanteTipoTamanho);
+    }
+
+    [Fact(DisplayName = "Igualdade estrutural de record: mesmos campos, mesmo valor")]
+    public void Igualdade_Estrutural()
+    {
+        Guid origem = Guid.CreateVersion7();
+
+        UnidadeOfertante a = UnidadeOfertante.Criar(origem, "FACET", "Faculdade de Computação", "Faculdade").Value!;
+        UnidadeOfertante b = UnidadeOfertante.Criar(origem, "FACET", "Faculdade de Computação", "Faculdade").Value!;
+
+        a.Should().Be(b);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoEndpointTests.cs
@@ -1,0 +1,423 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.OfertasCurso;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Entities;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.ValueObjects;
+using Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.Persistence;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>OfertaCurso</c> (story #588,
+/// issue #749): routing, vendor media type, HATEOAS, autenticação/autorização,
+/// idempotência, referências vivas (curso/local/unidade), <b>congelamento do
+/// snapshot da unidade ofertante com Unidade REAL semeada no schema
+/// organizacao</b> (ADR-0061, padrão LeituraInProcessTests — o monólito
+/// co-hospeda os módulos e o IUnidadeReader resolve in-process), guard da base
+/// legal condicional (422), ciclo CRUD completo e CA-05 (curso referenciado por
+/// oferta viva bloqueia a remoção do curso; remover a oferta libera).
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class OfertaCursoEndpointTests
+{
+    private static readonly DateOnly VigenciaInicio = new(2026, 1, 1);
+    private static readonly DateTimeOffset Agora = new(2026, 7, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public OfertaCursoEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/ofertas-curso retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/ofertas-curso", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.oferta-curso.v1+json");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/ofertas-curso/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/ofertas-curso/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST /api/configuracao/admin/ofertas-curso sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Post, new Uri("/api/configuracao/admin/ofertas-curso", UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Post, new Uri("/api/configuracao/admin/ofertas-curso", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(new { });
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a policy [Authorize(Roles = \"plataforma-admin\")] nega um principal autenticado sem o role");
+    }
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Post, new Uri("/api/configuracao/admin/ofertas-curso", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST cria (201) congelando o snapshot da Unidade REAL semeada; o GET expõe o sub-objeto + HATEOAS")]
+    public async Task Criar_CongelaUnidadeRealSemeada()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+        Unidade unidade = await SemearUnidadeAsync("faceel-oferta", "FACEEL", "OFC001");
+
+        var body = new
+        {
+            cursoId,
+            localOfertaId = localId,
+            unidadeOfertanteOrigemId = unidade.Id,
+            programaDeOferta = "REGULAR",
+            formatoPedagogico = "PRESENCIAL",
+            turno = "MATUTINO",
+            eMecCodigo = "123456",
+            codigoSga = "ENG-01",
+            vagasAnuaisAutorizadas = 40,
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/ofertas-curso/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("cursoId").GetGuid().Should().Be(cursoId);
+        root.GetProperty("localOfertaId").GetGuid().Should().Be(localId);
+        root.GetProperty("programaDeOferta").GetString().Should().Be("REGULAR");
+        root.GetProperty("formatoPedagogico").GetString().Should().Be("PRESENCIAL");
+        root.GetProperty("turno").GetString().Should().Be("MATUTINO");
+        root.GetProperty("eMecCodigo").GetString().Should().Be("123456");
+        root.GetProperty("codigoSga").GetString().Should().Be("ENG-01");
+        root.GetProperty("vagasAnuaisAutorizadas").GetInt32().Should().Be(40);
+
+        // Congelamento (ADR-0061): o sub-objeto reflete a Unidade viva resolvida
+        // in-process pelo IUnidadeReader no ato da criação.
+        JsonElement unidadeOfertante = root.GetProperty("unidadeOfertante");
+        unidadeOfertante.GetProperty("origemId").GetGuid().Should().Be(unidade.Id);
+        unidadeOfertante.GetProperty("sigla").GetString().Should().Be("FACEEL");
+        unidadeOfertante.GetProperty("nome").GetString().Should().Be("Unidade FACEEL");
+        unidadeOfertante.GetProperty("tipo").GetString().Should().Be(nameof(TipoUnidade.Centro));
+
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "POST com unidade ofertante inexistente retorna 422 — não há identidade viva para congelar")]
+    public async Task Criar_UnidadeInexistente_Retorna422()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+
+        var body = new
+        {
+            cursoId,
+            localOfertaId = localId,
+            unidadeOfertanteOrigemId = Guid.NewGuid(),
+            programaDeOferta = "REGULAR",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com curso inexistente retorna 422")]
+    public async Task Criar_CursoInexistente_Retorna422()
+    {
+        (_, Guid localId) = await SemearCursoELocalAsync();
+        Unidade unidade = await SemearUnidadeAsync("ilinguas-oferta", "ILINGUAS", "OFC002");
+
+        var body = new
+        {
+            cursoId = Guid.NewGuid(),
+            localOfertaId = localId,
+            unidadeOfertanteOrigemId = unidade.Id,
+            programaDeOferta = "REGULAR",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com programa não-REGULAR sem base legal retorna 422 (guard de domínio)")]
+    public async Task Criar_ProgramaNaoRegularSemBaseLegal_Retorna422()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+        Unidade unidade = await SemearUnidadeAsync("iedar-oferta", "IEDAR", "OFC003");
+
+        var body = new
+        {
+            cursoId,
+            localOfertaId = localId,
+            unidadeOfertanteOrigemId = unidade.Id,
+            programaDeOferta = "PARFOR",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "Ciclo CRUD completo: POST → PUT (204, guard revalidado) → GET reflete → DELETE (204) → GET 404")]
+    public async Task CicloCrudCompleto_CriaEditaRemove()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+        Unidade unidade = await SemearUnidadeAsync("isaude-oferta", "ISAUDE", "OFC004");
+
+        var body = new
+        {
+            cursoId,
+            localOfertaId = localId,
+            unidadeOfertanteOrigemId = unidade.Id,
+            programaDeOferta = "REGULAR",
+            turno = "MATUTINO",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+
+        // PUT Regular→Parfor sem base legal: guard revalidado na transição → 422.
+        var putSemBase = new { id, programaDeOferta = "PARFOR" };
+        HttpResponseMessage transicaoInvalida = await EnviarPutAdmin(client, id, putSemBase);
+        transicaoInvalida.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity,
+            "a transição Regular→Parfor sem base legal viola o guard condicional (ADR-0066)");
+
+        // PUT válido: Parfor com base legal, formato EAD, sem turno.
+        var putValido = new
+        {
+            id,
+            programaDeOferta = "PARFOR",
+            formatoPedagogico = "EAD",
+            eMecCodigo = "654321",
+            vagasAnuaisAutorizadas = 0,
+            baseLegal = "Decreto 6.755/2009",
+        };
+        HttpResponseMessage atualizar = await EnviarPutAdmin(client, id, putValido);
+        atualizar.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/ofertas-curso/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync()))
+        {
+            JsonElement root = doc.RootElement;
+            root.GetProperty("programaDeOferta").GetString().Should().Be("PARFOR");
+            root.GetProperty("formatoPedagogico").GetString().Should().Be("EAD");
+            root.GetProperty("turno").ValueKind.Should().Be(JsonValueKind.Null, "o PUT não enviou turno");
+            root.GetProperty("eMecCodigo").GetString().Should().Be("654321");
+            root.GetProperty("vagasAnuaisAutorizadas").GetInt32().Should().Be(0, "zero é teto válido");
+            root.GetProperty("baseLegal").GetString().Should().Be("Decreto 6.755/2009");
+            root.GetProperty("cursoId").GetGuid().Should().Be(cursoId, "curso é imutável");
+            root.GetProperty("unidadeOfertante").GetProperty("sigla").GetString()
+                .Should().Be("ISAUDE", "o snapshot congelado é imutável pós-criação");
+        }
+
+        // DELETE: soft-delete simples — sem 409 (snapshots externos são desacoplados).
+        HttpResponseMessage remover = await EnviarDeleteAdmin(client, id);
+        remover.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage aposRemocao = await client.GetAsync(
+            new Uri($"/api/configuracao/ofertas-curso/{id}", UriKind.Relative));
+        aposRemocao.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "o soft-delete tira a oferta das leituras via query filter global");
+    }
+
+    [Fact(DisplayName = "CA-05: curso com oferta viva bloqueia DELETE do curso (409); remover a oferta libera (204)")]
+    public async Task Ca05_OfertaVivaBloqueiaRemocaoDoCurso()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+        Unidade unidade = await SemearUnidadeAsync("igeo-oferta", "IGEOF", "OFC005");
+
+        var body = new
+        {
+            cursoId,
+            localOfertaId = localId,
+            unidadeOfertanteOrigemId = unidade.Id,
+            programaDeOferta = "REGULAR",
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, body);
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid ofertaId = await criar.Content.ReadFromJsonAsync<Guid>();
+
+        // Curso referenciado por oferta viva → remoção bloqueada (409).
+        using HttpRequestMessage removerCursoBloqueado = NovoDeleteAdmin(
+            $"/api/configuracao/admin/cursos/{cursoId}");
+        HttpResponseMessage bloqueado = await client.SendAsync(removerCursoBloqueado);
+        bloqueado.StatusCode.Should().Be(HttpStatusCode.Conflict,
+            "ReferenciadoPorOfertaCursoVivaAsync agora consulta oferta_curso de verdade (CA-05)");
+
+        // Remover a oferta (204) libera o curso.
+        HttpResponseMessage removerOferta = await EnviarDeleteAdmin(client, ofertaId);
+        removerOferta.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using HttpRequestMessage removerCursoLiberado = NovoDeleteAdmin(
+            $"/api/configuracao/admin/cursos/{cursoId}");
+        HttpResponseMessage liberado = await client.SendAsync(removerCursoLiberado);
+        liberado.StatusCode.Should().Be(HttpStatusCode.NoContent,
+            "o soft-delete da oferta libera o curso para remoção");
+    }
+
+    // ── Seeds (padrão LeituraInProcessTests: resolve DbContexts do container do host) ──
+
+    private async Task<(Guid CursoId, Guid LocalOfertaId)> SemearCursoELocalAsync()
+    {
+        Curso curso = Curso.Criar(
+            CodigoUnico(), "Engenharia Civil", "Bacharelado", "Graduação", null).Value!;
+        LocalOferta local = LocalOferta.Criar(
+            TipoLocalOferta.CampusSede, null, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null).Value!;
+
+        await using AsyncServiceScope scope = _fixture.Factory.Services.CreateAsyncScope();
+        ConfiguracaoDbContext dbContext =
+            scope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+
+        dbContext.Cursos.Add(curso);
+        dbContext.LocaisOferta.Add(local);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        return (curso.Id, local.Id);
+    }
+
+    private async Task<Unidade> SemearUnidadeAsync(string slug, string sigla, string codigo)
+    {
+        Unidade unidade = Unidade.Criar(
+            nome: $"Unidade {sigla}",
+            alias: null,
+            slug: Slug.From(slug).Value!,
+            sigla: sigla,
+            codigo: codigo,
+            unidadeSuperiorId: null,
+            tipo: TipoUnidade.Centro,
+            unidadeAcademica: true,
+            vigenciaInicio: VigenciaInicio,
+            vigenciaFim: null,
+            origem: OrigemUnidade.CriadoNoUniPlus).Value!;
+
+        // Semeia pelo DbContext do MÓDULO Organização resolvido do container do
+        // host — o schema `organizacao` foi criado pelas migrations no boot; o
+        // IUnidadeReader (in-process, ADR-0056) enxerga a Unidade na criação da oferta.
+        await using AsyncServiceScope scope = _fixture.Factory.Services.CreateAsyncScope();
+        OrganizacaoInstitucionalDbContext dbContext =
+            scope.ServiceProvider.GetRequiredService<OrganizacaoInstitucionalDbContext>();
+
+        dbContext.Unidades.Add(unidade);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        return unidade;
+    }
+
+    // ── Helpers HTTP ──────────────────────────────────────────────────────
+
+    private static string CodigoUnico() => $"CUR_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, object body)
+    {
+        using HttpRequestMessage request = new(
+            HttpMethod.Post, new Uri("/api/configuracao/admin/ofertas-curso", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> EnviarPutAdmin(HttpClient client, Guid id, object body)
+    {
+        using HttpRequestMessage request = new(
+            HttpMethod.Put, new Uri($"/api/configuracao/admin/ofertas-curso/{id}", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> EnviarDeleteAdmin(HttpClient client, Guid id)
+    {
+        using HttpRequestMessage request = NovoDeleteAdmin($"/api/configuracao/admin/ofertas-curso/{id}");
+        return await client.SendAsync(request);
+    }
+
+    private static HttpRequestMessage NovoDeleteAdmin(string path)
+    {
+        HttpRequestMessage request = new(HttpMethod.Delete, new Uri(path, UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        return request;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoPersistenceTests.cs
@@ -1,0 +1,311 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.OfertasCurso;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
+
+/// <summary>
+/// Integração ponta-a-ponta da OfertaCurso contra Postgres real (story #588,
+/// issue #749): persistência com owned type <c>unidade_oft_*</c> (roundtrip do
+/// snapshot ADR-0061), FKs intra-schema reais (curso/local_oferta, RESTRICT),
+/// CHECKs de domínio via SQL cru (programa/formato/turno/vagas/base legal
+/// condicional), soft-delete e o EXISTS real de
+/// <c>CursoRepository.ReferenciadoPorOfertaCursoVivaAsync</c>.
+/// </summary>
+/// <remarks>
+/// O snapshot da unidade ofertante já chega congelado no VO — a persistência não
+/// precisa de Unidade real (o schema <c>organizacao</c> nem existe nesta fixture);
+/// o congelamento com Unidade real é coberto nos endpoint tests.
+/// </remarks>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class OfertaCursoPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private static readonly DateTimeOffset Agora = new(2026, 7, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public OfertaCursoPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Criar persiste os campos, o snapshot unidade_oft_* faz roundtrip e a auditoria é carimbada")]
+    public async Task Insert_Completa_PersisteComOwnedRoundtrip()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+        UnidadeOfertante unidade = NovaUnidade();
+        OfertaCurso oferta = NovaOferta(cursoId, localId, unidade);
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.OfertasCurso.Add(oferta);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        OfertaCurso persistida = await readCtx.OfertasCurso.SingleAsync(o => o.Id == oferta.Id);
+
+        persistida.CursoId.Should().Be(cursoId);
+        persistida.LocalOfertaId.Should().Be(localId);
+        persistida.UnidadeOfertante.Should().Be(unidade, "o owned type reidrata o snapshot por igualdade estrutural");
+        persistida.ProgramaDeOferta.Should().Be(ProgramaDeOferta.Parfor);
+        persistida.FormatoPedagogico.Should().Be(FormatoPedagogico.Semipresencial);
+        persistida.Turno.Should().Be(TurnoOferta.Noturno);
+        persistida.EMecCodigo.Should().Be("123456");
+        persistida.CodigoSga.Should().Be("ENG-01");
+        persistida.VagasAnuaisAutorizadas.Should().Be(40);
+        persistida.BaseLegal.Should().Be("Decreto 6.755/2009");
+        persistida.AtoAutorizacaoMec.Should().Be("Portaria MEC 9/2009");
+        persistida.CreatedBy.Should().Be(AdminA);
+        persistida.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Turno e campos opcionais nulos persistem nulos e reidratam como nulos")]
+    public async Task Insert_OpcionaisNulos_PersisteNulos()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+        OfertaCurso oferta = OfertaCurso.Criar(
+            cursoId, localId, NovaUnidade(), "REGULAR", null,
+            null, null, null, null, null, null).Value!;
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.OfertasCurso.Add(oferta);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        OfertaCurso persistida = await readCtx.OfertasCurso.SingleAsync(o => o.Id == oferta.Id);
+
+        persistida.FormatoPedagogico.Should().Be(FormatoPedagogico.Presencial, "default conceitual quando o token está ausente");
+        persistida.Turno.Should().BeNull();
+        persistida.EMecCodigo.Should().BeNull();
+        persistida.CodigoSga.Should().BeNull();
+        persistida.VagasAnuaisAutorizadas.Should().BeNull();
+        persistida.BaseLegal.Should().BeNull();
+        persistida.AtoAutorizacaoMec.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "FK real: oferta apontando curso inexistente é rejeitada pelo banco (23503)")]
+    public async Task Fk_CursoInexistente_Rejeita()
+    {
+        (_, Guid localId) = await SemearCursoELocalAsync();
+        OfertaCurso orfa = NovaOferta(Guid.CreateVersion7(), localId, NovaUnidade());
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.OfertasCurso.Add(orfa);
+
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23503", "curso_id tem FK intra-schema real para configuracao.curso");
+    }
+
+    [Fact(DisplayName = "FK real: oferta apontando local de oferta inexistente é rejeitada pelo banco (23503)")]
+    public async Task Fk_LocalOfertaInexistente_Rejeita()
+    {
+        (Guid cursoId, _) = await SemearCursoELocalAsync();
+        OfertaCurso orfa = NovaOferta(cursoId, Guid.CreateVersion7(), NovaUnidade());
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.OfertasCurso.Add(orfa);
+
+        Func<Task> act = async () => await ctx.SaveChangesAsync();
+
+        DbUpdateException ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        Npgsql.PostgresException pg = ex.InnerException.Should().BeOfType<Npgsql.PostgresException>().Which;
+        pg.SqlState.Should().Be("23503", "local_oferta_id tem FK intra-schema real para configuracao.local_oferta");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita programa de oferta fora do domínio via SQL cru")]
+    public async Task Check_RejeitaProgramaForaDoDominioViaSqlCru()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+
+        Func<Task> act = () => InserirCruAsync(
+            cursoId, localId, programa: "PROUNI", formato: "PRESENCIAL", turno: null, vagas: null, baseLegal: "Lei X");
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK ck_oferta_curso_programa_de_oferta impede o INSERT direto");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita turno fora do domínio via SQL cru, mas aceita turno nulo (null-safe)")]
+    public async Task Check_Turno_NullSafe()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+
+        Func<Task> invalido = () => InserirCruAsync(
+            cursoId, localId, programa: "REGULAR", formato: "PRESENCIAL", turno: "DIURNO", vagas: null, baseLegal: null);
+        await invalido.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK ck_oferta_curso_turno impede token fora do domínio");
+
+        Func<Task> nulo = () => InserirCruAsync(
+            cursoId, localId, programa: "REGULAR", formato: "PRESENCIAL", turno: null, vagas: null, baseLegal: null);
+        await nulo.Should().NotThrowAsync("turno é opcional e o CHECK é null-safe");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita vagas negativas via SQL cru, mas aceita zero e nulo")]
+    public async Task Check_VagasAnuais_RejeitaNegativas()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+
+        Func<Task> negativa = () => InserirCruAsync(
+            cursoId, localId, programa: "REGULAR", formato: "PRESENCIAL", turno: null, vagas: -1, baseLegal: null);
+        await negativa.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK ck_oferta_curso_vagas_anuais_autorizadas impede teto negativo");
+
+        Func<Task> zero = () => InserirCruAsync(
+            cursoId, localId, programa: "REGULAR", formato: "PRESENCIAL", turno: null, vagas: 0, baseLegal: null);
+        await zero.Should().NotThrowAsync("zero é teto válido no e-MEC");
+    }
+
+    [Fact(DisplayName = "CHECK condicional da base legal via SQL cru: PARFOR sem base é rejeitado; REGULAR sem base passa")]
+    public async Task Check_BaseLegalCondicional()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+
+        Func<Task> parforSemBase = () => InserirCruAsync(
+            cursoId, localId, programa: "PARFOR", formato: "PRESENCIAL", turno: null, vagas: null, baseLegal: null);
+        await parforSemBase.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK ck_oferta_curso_base_legal_programa espelha o guard de domínio (ADR-0066)");
+
+        Func<Task> regularSemBase = () => InserirCruAsync(
+            cursoId, localId, programa: "REGULAR", formato: "PRESENCIAL", turno: null, vagas: null, baseLegal: null);
+        await regularSemBase.Should().NotThrowAsync("REGULAR não exige base legal");
+    }
+
+    [Fact(DisplayName = "Soft-delete preserva a trilha e tira a oferta das leituras via query filter")]
+    public async Task SoftDelete_PreservaTrilha()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+        OfertaCurso oferta = NovaOferta(cursoId, localId, NovaUnidade());
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.OfertasCurso.Add(oferta);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            OfertaCurso tracked = await ctx.OfertasCurso.SingleAsync(o => o.Id == oferta.Id);
+            ctx.OfertasCurso.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        (await readCtx.OfertasCurso.AnyAsync(o => o.Id == oferta.Id))
+            .Should().BeFalse("o soft-delete tira a oferta das leituras");
+
+        OfertaCurso excluida = await readCtx.OfertasCurso
+            .IgnoreQueryFilters().SingleAsync(o => o.Id == oferta.Id);
+        excluida.IsDeleted.Should().BeTrue();
+        excluida.DeletedBy.Should().Be(AdminB);
+    }
+
+    [Fact(DisplayName = "ReferenciadoPorOfertaCursoVivaAsync: true com oferta viva; false após soft-delete da oferta")]
+    public async Task ReferenciadoPorOfertaCursoViva_ReflecteVida()
+    {
+        (Guid cursoId, Guid localId) = await SemearCursoELocalAsync();
+        OfertaCurso oferta = NovaOferta(cursoId, localId, NovaUnidade());
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.OfertasCurso.Add(oferta);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            var cursoRepository = new CursoRepository(ctx);
+            (await cursoRepository.ReferenciadoPorOfertaCursoVivaAsync(cursoId, CancellationToken.None))
+                .Should().BeTrue("há oferta viva referenciando o curso — a remoção do curso deve bloquear (CA-05)");
+            (await cursoRepository.ReferenciadoPorOfertaCursoVivaAsync(Guid.CreateVersion7(), CancellationToken.None))
+                .Should().BeFalse("curso sem oferta não é referenciado");
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            OfertaCurso tracked = await ctx.OfertasCurso.SingleAsync(o => o.Id == oferta.Id);
+            ctx.OfertasCurso.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var repositoryAposRemocao = new CursoRepository(readCtx);
+        (await repositoryAposRemocao.ReferenciadoPorOfertaCursoVivaAsync(cursoId, CancellationToken.None))
+            .Should().BeFalse("o soft-delete da oferta libera o curso para remoção");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private async Task<(Guid CursoId, Guid LocalOfertaId)> SemearCursoELocalAsync()
+    {
+        Curso curso = Curso.Criar(
+            CodigoUnico(), "Engenharia Civil", "Bacharelado", "Graduação", null).Value!;
+        LocalOferta local = LocalOferta.Criar(
+            TipoLocalOferta.CampusSede, null, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null).Value!;
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.Cursos.Add(curso);
+        ctx.LocaisOferta.Add(local);
+        await ctx.SaveChangesAsync();
+
+        return (curso.Id, local.Id);
+    }
+
+    private static UnidadeOfertante NovaUnidade() =>
+        UnidadeOfertante.Criar(
+            Guid.CreateVersion7(), "FACET", "Faculdade de Computação e Engenharia Elétrica", "Faculdade").Value!;
+
+    private static OfertaCurso NovaOferta(Guid cursoId, Guid localId, UnidadeOfertante unidade) =>
+        OfertaCurso.Criar(
+            cursoId, localId, unidade, "PARFOR", "SEMIPRESENCIAL", "NOTURNO",
+            "123456", "ENG-01", 40, "Decreto 6.755/2009", "Portaria MEC 9/2009").Value!;
+
+    private async Task InserirCruAsync(
+        Guid cursoId,
+        Guid localId,
+        string programa,
+        string formato,
+        string? turno,
+        int? vagas,
+        string? baseLegal)
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+        await ctx.Database.ExecuteSqlAsync(
+            $"""
+            INSERT INTO configuracao.oferta_curso
+                (id, curso_id, local_oferta_id,
+                 unidade_oft_origem_id, unidade_oft_sigla, unidade_oft_nome, unidade_oft_tipo,
+                 programa_de_oferta, formato_pedagogico, turno, vagas_anuais_autorizadas, base_legal,
+                 created_at, is_deleted)
+            VALUES
+                ({Guid.CreateVersion7()}, {cursoId}, {localId},
+                 {Guid.CreateVersion7()}, {"FACET"}, {"Faculdade de Computação"}, {"Faculdade"},
+                 {programa}, {formato}, {turno}, {vagas}, {baseLegal},
+                 {DateTimeOffset.UtcNow}, {false})
+            """);
+    }
+
+    private static string CodigoUnico() => $"CUR_{Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoPersistenceTests.cs
@@ -6,11 +6,13 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Unifesspa.UniPlus.Configuracao.Contracts;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
 using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
 using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 
@@ -75,6 +77,19 @@ public sealed class OfertaCursoPersistenceTests
         persistida.AtoAutorizacaoMec.Should().Be("Portaria MEC 9/2009");
         persistida.CreatedBy.Should().Be(AdminA);
         persistida.IsDeleted.Should().BeFalse();
+
+        var reader = new OfertaCursoReader(readCtx);
+        OfertaCursoView? view = await reader.ObterPorIdAsync(oferta.Id);
+        view.Should().NotBeNull();
+        view!.CursoId.Should().Be(cursoId);
+        view.LocalOfertaId.Should().Be(localId);
+        view.UnidadeOfertanteOrigemId.Should().Be(unidade.OrigemId);
+        view.UnidadeOfertanteSigla.Should().Be(unidade.Sigla);
+        view.ProgramaDeOferta.Should().Be("PARFOR");
+        view.FormatoPedagogico.Should().Be("SEMIPRESENCIAL");
+        view.Turno.Should().Be("NOTURNO");
+
+        (await reader.ListarVivasAsync()).Should().Contain(v => v.Id == oferta.Id);
     }
 
     [Fact(DisplayName = "Turno e campos opcionais nulos persistem nulos e reidratam como nulos")]

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
@@ -1229,7 +1229,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {

--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
@@ -1201,7 +1201,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -1189,7 +1189,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
@@ -1157,7 +1157,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {

--- a/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
@@ -1119,7 +1119,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
@@ -1229,7 +1229,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -1229,7 +1229,8 @@
           "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
           "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
           "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
-          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.configuracao.contracts": {


### PR DESCRIPTION
Closes #749 · Story #588 · Requisito UNI-REQ-0010 · ADRs: ADR-0066, ADR-0061, ADR-0056, ADR-0097, ADR-0098

## O que este PR entrega

A instância regulatória do modelo de oferta em três níveis (ADR-0066): **`OfertaCurso`** liga um `Curso` vivo (#748, já na main) a um `LocalOferta` vivo e à unidade ofertante — congelada por snapshot-copy no ato de criação. Completa a Story #588.

### Congelamento server-side da unidade ofertante

`CriarOfertaCursoCommandHandler` injeta `IUnidadeReader` (Governance.Contracts), resolvido **in-process** no host co-hospedado (ADR-0097) — sem POC, sem 2ª connection string. Resolve a Unidade pelo `origemId` informado; se inexistente/removida, rejeita a criação (`UnidadeOfertanteInexistente`, 422) — não há identidade viva para congelar. A unidade ofertante é imutável após a criação.

### Modelo

- `CursoId`/`LocalOfertaId`: FK intra-schema, `RESTRICT`.
- `UnidadeOfertante`: value object `OwnsOne` (colunas `unidade_oft_*`), sem FK — snapshot-copy ADR-0061.
- `ProgramaDeOferta` (7 valores), `FormatoPedagogico` (3), `Turno` (4, nullable): par enum + helper de tokens UPPER_SNAKE, mesmo padrão de `Modalidade`, com CHECK derivado dos tokens canônicos.
- `BaseLegal` obrigatória quando `ProgramaDeOferta != Regular` — três camadas: guard de domínio (`Criar` e `Atualizar`), validator, CHECK `programa_de_oferta = 'REGULAR' OR base_legal IS NOT NULL`.
- Ativa o bloqueio de remoção de `Curso`: `ReferenciadoPorOfertaCursoVivaAsync` deixa de ser stub e passa a consultar via `EXISTS`.

### Dois problemas de integração descobertos e corrigidos

1. **Ambiguidade de transação no Wolverine.** `CriarOfertaCursoCommandHandler` é o primeiro handler do monólito a cruzar leitura de outro módulo com escrita no próprio módulo. O detector de transação do `Wolverine.EntityFrameworkCore` enumera as dependências transitivas dos parâmetros do handler em busca de um único `DbContext` a enrolar na transação do outbox — encontra `ConfiguracaoDbContext` (via a UoW) **e** `OrganizacaoInstitucionalDbContext` (via o reader), e falha por ambiguidade no boot do host. Corrigido com `[NonTransactional]` no handler (mecanismo oficial do Wolverine para este cenário) — a persistência segue correta via `IConfiguracaoUnitOfWork.SalvarAlteracoesAsync`, chamado explicitamente como em todo handler do módulo; sem domain events aqui, não há atomicidade de outbox a perder.
2. **Bug latente no `SoftDeleteInterceptor` compartilhado.** O interceptor convertia `Delete→Modified` apenas na entrada principal (`ISoftDeletable`); uma entrada de owned type (`OwnsOne`, table splitting) cascateia para `Deleted` junto do principal e permanecia nesse estado — o EF Core então anulava as colunas owned no mesmo `UPDATE`, violando o `NOT NULL`. Ficou latente porque todo owned type do projeto até aqui era opcional (ex.: `Campus.Endereco`); `OfertaCurso.UnidadeOfertante` é o primeiro **obrigatório** sobre uma entidade soft-deletable. Corrigido na raiz (`Infrastructure.Core`, compartilhado por todos os módulos), commit isolado.

### Read-side cross-módulo

`IOfertaCursoReader` + `OfertaCursoView` (Configuracao.Contracts), espelhando `IModalidadeReader`. Sem `OfertaCursoSnapshot` por ora — o snapshot é definido pelo consumidor (Seleção, story futura).

## Critérios de aceite cobertos (Story #588)

- **CA-03** — criação com curso/local/unidade vivos congela a identidade; unidade inexistente/removida rejeitada.
- **CA-04** — `BaseLegal` condicional (transição Regular→Parfor sem base rejeitada); vagas negativas rejeitadas, zero/nulo aceitos.
- **CA-05 (completo)** — remoção de Curso bloqueada por oferta viva (409); remoção de OfertaCurso não bloqueada por snapshots externos.

## Commits (4, cada um verde)

1. `refactor(organizacao): torna UnidadeReader público para consumo cross-módulo`
2. `fix(persistence): preserva colunas de owned type obrigatório no soft-delete`
3. `feat(configuracao): adiciona cadastro de oferta de curso`
4. `feat(configuracao): expõe leitura cross-módulo de oferta de curso`

## Testes

Suíte completa da solution verde localmente (build 0 warnings; todos os projetos, incl. fitness R8, `ServiceLocationGuardTests`, `Selecao.IntegrationTests` — confirma que o fix do interceptor não regride módulos com domain events/outbox). Integração de Configuração: 213/214 (1 skip = stub da #731, próxima na sequência).

## Notas de revisão

- `WolverineFx` (core) passa a ser referenciado por `Configuracao.Application` — primeira vez que um pacote Wolverine aparece nessa camada no projeto, motivado unicamente pelo `[NonTransactional]`. Avaliei alternativas (mover a resolução da unidade para o controller, políticas customizadas de chain, `IDbContextFactory`) e este foi o caminho mais cirúrgico — vale meu segundo olhar na review.
- `packages.lock.json` intocados.
