### PR TITLE
feat(configuracao): ativa bloqueio de remoção de LocalOferta por OfertaCurso viva

### DIFF
--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/RemoverLocalOfertaCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/LocaisOferta/RemoverLocalOfertaCommandHandler.cs
@@ -9,8 +9,7 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <summary>
 /// Handler do <see cref="RemoverLocalOfertaCommand"/>. Soft-delete via
 /// <c>SoftDeleteInterceptor</c> — bloqueia quando o local é referenciado por
-/// oferta de curso viva (UNI-REQ-0010). A entidade <c>oferta_curso</c> ainda não
-/// existe; a checagem é ponto de extensão (retorna <see langword="false"/>).
+/// oferta de curso viva (#731).
 /// </summary>
 public static class RemoverLocalOfertaCommandHandler
 {
@@ -32,9 +31,6 @@ public static class RemoverLocalOfertaCommandHandler
                 "Local de Oferta não encontrado."));
         }
 
-        // Ponto de extensão UNI-REQ-0010: oferta_curso ainda não existe no módulo,
-        // então a checagem retorna false hoje. Quando a oferta de curso chegar, o
-        // bloqueio passa a valer sem mudar este handler.
         if (await repository.ReferenciadoPorOfertaCursoVivaAsync(command.Id, cancellationToken).ConfigureAwait(false))
         {
             return Result.Failure(new DomainError(

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICursoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICursoRepository.cs
@@ -46,11 +46,10 @@ public interface ICursoRepository
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Ponto de extensão (#749): indica se o curso é referenciado por alguma
-    /// oferta de curso viva — caso em que a remoção é bloqueada. A entidade
-    /// <c>oferta_curso</c> ainda não existe no módulo, logo a implementação
-    /// retorna <see langword="false"/>. Quando a oferta de curso chegar, esta
-    /// checagem passa a consultá-la.
+    /// Indica se o curso é referenciado por alguma oferta de curso viva (#749)
+    /// — caso em que a remoção é bloqueada. Oferta soft-deletada não conta: o
+    /// curso fica livre para remoção assim que a última oferta viva que o
+    /// referencia deixa de existir.
     /// </summary>
     Task<bool> ReferenciadoPorOfertaCursoVivaAsync(Guid cursoId, CancellationToken cancellationToken);
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ILocalOfertaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ILocalOfertaRepository.cs
@@ -42,11 +42,10 @@ public interface ILocalOfertaRepository
     Task<bool> ExisteVivoComCampusResponsavelAsync(Guid campusResponsavelId, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Ponto de extensão (UNI-REQ-0010): indica se o local de oferta é
-    /// referenciado por alguma oferta de curso viva — caso em que a remoção é
-    /// bloqueada. A entidade <c>oferta_curso</c> ainda não existe no módulo, logo
-    /// a implementação retorna <see langword="false"/>. Quando a oferta de curso
-    /// chegar, esta checagem passa a consultá-la.
+    /// Indica se o local de oferta é referenciado por alguma oferta de curso
+    /// viva (#731) — caso em que a remoção é bloqueada. Oferta soft-deletada
+    /// não conta: o local fica livre para remoção assim que a última oferta
+    /// viva que o referencia deixa de existir.
     /// </summary>
     Task<bool> ReferenciadoPorOfertaCursoVivaAsync(Guid localOfertaId, CancellationToken cancellationToken);
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/LocalOfertaRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/LocalOfertaRepository.cs
@@ -68,11 +68,11 @@ public sealed class LocalOfertaRepository : ILocalOfertaRepository
 
     public Task<bool> ReferenciadoPorOfertaCursoVivaAsync(Guid localOfertaId, CancellationToken cancellationToken)
     {
-        // TODO(UNI-REQ-0010): quando a entidade oferta_curso existir no módulo,
-        // consultar aqui se há oferta de curso viva referenciando este local de
-        // oferta. Até lá, não há tabela a consultar — a checagem retorna false.
-        _ = localOfertaId;
-        _ = cancellationToken;
-        return Task.FromResult(false);
+        // EXISTS sobre ofertas vivas (#731): o query filter global de soft-delete
+        // já restringe a ofertas não removidas — o soft-delete da oferta libera o
+        // local de oferta para remoção.
+        return _dbContext.OfertasCurso
+            .AsNoTracking()
+            .AnyAsync(o => o.LocalOfertaId == localOfertaId, cancellationToken);
     }
 }

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCursoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCursoCommandHandlerTests.cs
@@ -38,7 +38,6 @@ public sealed class RemoverCursoCommandHandlerTests
     {
         Curso curso = NovoCurso();
         _repository.ObterPorIdAsync(curso.Id, Arg.Any<CancellationToken>()).Returns(curso);
-        // Ponto de extensão #749: oferta_curso ainda não existe → false.
         _repository.ReferenciadoPorOfertaCursoVivaAsync(curso.Id, Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -55,8 +54,6 @@ public sealed class RemoverCursoCommandHandlerTests
     {
         Curso curso = NovoCurso();
         _repository.ObterPorIdAsync(curso.Id, Arg.Any<CancellationToken>()).Returns(curso);
-        // Quando oferta_curso existir (#749), o repositório passa a reportar a
-        // referência viva — o handler já bloqueia sem precisar mudar.
         _repository.ReferenciadoPorOfertaCursoVivaAsync(curso.Id, Arg.Any<CancellationToken>())
             .Returns(true);
 

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverLocalOfertaCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverLocalOfertaCommandHandlerTests.cs
@@ -41,7 +41,6 @@ public sealed class RemoverLocalOfertaCommandHandlerTests
     {
         LocalOferta local = NovoLocal();
         _repository.ObterPorIdAsync(local.Id, Arg.Any<CancellationToken>()).Returns(local);
-        // Ponto de extensão UNI-REQ-0010: oferta_curso ainda não existe → false.
         _repository.ReferenciadoPorOfertaCursoVivaAsync(local.Id, Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -51,5 +50,22 @@ public sealed class RemoverLocalOfertaCommandHandlerTests
         resultado.IsSuccess.Should().BeTrue();
         _repository.Received(1).Remover(local);
         await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Local referenciado por oferta de curso viva tem a remoção bloqueada (409)")]
+    public async Task Handle_ComOfertaCursoViva_BloqueiaRemocao()
+    {
+        LocalOferta local = NovoLocal();
+        _repository.ObterPorIdAsync(local.Id, Arg.Any<CancellationToken>()).Returns(local);
+        _repository.ReferenciadoPorOfertaCursoVivaAsync(local.Id, Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result resultado = await RemoverLocalOfertaCommandHandler.Handle(
+            new RemoverLocalOfertaCommand(local.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(LocalOfertaErrorCodes.RemocaoBloqueadaPorOfertaCurso);
+        _repository.DidNotReceive().Remover(Arg.Any<LocalOferta>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/LocaisOferta/LocalOfertaPersistenceTests.cs
@@ -7,11 +7,16 @@ using AwesomeAssertions;
 using Microsoft.EntityFrameworkCore;
 
 using Unifesspa.UniPlus.Kernel.Domain.Cidades;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.LocaisOferta;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
 using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
 using Unifesspa.UniPlus.Kernel.Domain.Enderecos;
+using Unifesspa.UniPlus.Kernel.Results;
 
 [Collection(ConfiguracaoDbCollection.Name)]
 [SuppressMessage(
@@ -21,6 +26,7 @@ using Unifesspa.UniPlus.Kernel.Domain.Enderecos;
 public sealed class LocalOfertaPersistenceTests
 {
     private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
 
     private static readonly DateTimeOffset Agora = new(2026, 6, 17, 12, 0, 0, TimeSpan.Zero);
 
@@ -125,14 +131,68 @@ public sealed class LocalOfertaPersistenceTests
             .WithInnerException(typeof(Npgsql.PostgresException));
     }
 
-    [Fact(
-        Skip = "Bloqueio por oferta de curso viva depende de oferta_curso (UNI-REQ-0010), ainda inexistente no módulo. Ponto de extensão pronto: ILocalOfertaRepository.ReferenciadoPorOfertaCursoVivaAsync retorna false.",
-        DisplayName = "CA-05: remover LocalOferta referenciado por oferta de curso viva é bloqueado")]
-    public Task RemoverLocalOferta_ComOfertaCursoViva_Bloqueia()
+    [Fact(DisplayName = "CA-05: remover LocalOferta referenciado por oferta de curso viva é bloqueado; oferta removida libera (#731)")]
+    public async Task RemoverLocalOferta_ComOfertaCursoViva_Bloqueia()
     {
-        // Quando oferta_curso existir, semear um local + oferta viva referenciando-o
-        // e assertar que RemoverLocalOfertaCommandHandler retorna
-        // LocalOfertaErrorCodes.RemocaoBloqueadaPorOfertaCurso.
-        return Task.CompletedTask;
+        Curso curso = Curso.Criar(
+            CodigoUnico(), "Engenharia Civil", "Bacharelado", "Graduação", null).Value!;
+        LocalOferta local = LocalOferta.Criar(
+            TipoLocalOferta.CampusSede, null, "1504208", "Marabá", "PA",
+            ReferenciaCidadeGeo.OrigemGeoApi, Agora, null, null).Value!;
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.Cursos.Add(curso);
+            ctx.LocaisOferta.Add(local);
+            await ctx.SaveChangesAsync();
+        }
+
+        UnidadeOfertante unidade = UnidadeOfertante.Criar(
+            Guid.CreateVersion7(), "FACET", "Faculdade de Computação e Engenharia Elétrica", "Faculdade").Value!;
+        OfertaCurso oferta = OfertaCurso.Criar(
+            curso.Id, local.Id, unidade, "REGULAR", "PRESENCIAL",
+            null, null, null, null, null, null).Value!;
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.OfertasCurso.Add(oferta);
+            await ctx.SaveChangesAsync();
+        }
+
+        // Oferta viva referenciando o local → RemoverLocalOfertaCommandHandler bloqueia.
+        await using (ConfiguracaoDbContext handlerCtx = _fixture.CreateDbContext(AdminB))
+        {
+            var repository = new LocalOfertaRepository(handlerCtx);
+
+            Result resultado = await RemoverLocalOfertaCommandHandler.Handle(
+                new RemoverLocalOfertaCommand(local.Id), repository, handlerCtx, CancellationToken.None);
+
+            resultado.IsFailure.Should().BeTrue();
+            resultado.Error!.Code.Should().Be(LocalOfertaErrorCodes.RemocaoBloqueadaPorOfertaCurso);
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null))
+        {
+            (await ctx.LocaisOferta.AnyAsync(l => l.Id == local.Id)).Should().BeTrue(
+                "o local permanece vivo — a remoção foi bloqueada, não executada");
+        }
+
+        // Soft-delete da oferta: o local deixa de estar referenciado por oferta viva.
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            OfertaCurso ofertaTracked = await ctx.OfertasCurso.SingleAsync(o => o.Id == oferta.Id);
+            ctx.OfertasCurso.Remove(ofertaTracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext handlerCtx = _fixture.CreateDbContext(AdminB))
+        {
+            var repository = new LocalOfertaRepository(handlerCtx);
+
+            Result resultado = await RemoverLocalOfertaCommandHandler.Handle(
+                new RemoverLocalOfertaCommand(local.Id), repository, handlerCtx, CancellationToken.None);
+
+            resultado.IsSuccess.Should().BeTrue("oferta morta não bloqueia — o local fica livre para remoção");
+        }
     }
+
+    private static string CodigoUnico() => $"CUR_{Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
 }


### PR DESCRIPTION
Closes #731 · Refs #588 · Requisito UNI-REQ-0010 · ADRs: ADR-0066, ADR-0056

## O que este PR entrega

Amarra a última ponta solta da Story #588: **`LocalOfertaRepository.ReferenciadoPorOfertaCursoVivaAsync`** deixa de ser um ponto de extensão inerte (retornava `false`) e passa a consultar `oferta_curso` via `EXISTS` — espelhando o bloqueio já ativado para `Curso` na #749.

```csharp
public Task<bool> ReferenciadoPorOfertaCursoVivaAsync(Guid localOfertaId, CancellationToken cancellationToken)
{
    return _dbContext.OfertasCurso
        .AsNoTracking()
        .AnyAsync(o => o.LocalOfertaId == localOfertaId, cancellationToken);
}
```

O handler de remoção (`RemoverLocalOfertaCommandHandler`) já chamava o método e já retornava `LocalOfertaErrorCodes.RemocaoBloqueadaPorOfertaCurso` — **nenhuma mudança de fluxo** foi necessária ali, só a consulta real (mesmo padrão do `CursoRepository`, já em produção).

### Teste des-skipado

`RemoverLocalOferta_ComOfertaCursoViva_Bloqueia` estava com `[Fact(Skip = "...")]` desde a criação do stub. Implementado cobrindo os dois lados do BDD da issue, chamando o handler real contra Postgres (mesmo padrão de `CampusPersistenceTests.RemoverCampus_ComLocalOfertaVivo_Bloqueia`):
1. `LocalOferta` referenciado por `OfertaCurso` viva → remoção bloqueada (409), local permanece vivo.
2. `OfertaCurso` soft-deletada → remoção do `LocalOferta` passa a ser aceita.

Também adicionei o teste unitário simétrico que faltava (`Handle_ComOfertaCursoViva_BloqueiaRemocao`, mock-based) — `RemoverLocalOfertaCommandHandlerTests` tinha só 2 dos 3 casos que `RemoverCursoCommandHandlerTests` já cobre.

### Bônus (mesmo escopo, sem mudança de comportamento)

Limpei comentários em `ICursoRepository`/`RemoverCursoCommandHandlerTests` que ainda descreviam `oferta_curso` como "ainda não existe" — texto do stub original da #748, nunca atualizado quando a #749 ativou a implementação real. Notei ao corrigir o mesmo texto no lado `LocalOferta`.

## Critérios de aceite (DoD da issue)

- [x] `ReferenciadoPorOfertaCursoVivaAsync` consulta `oferta_curso` de verdade
- [x] Teste de integração des-skipado e implementado
- [x] Comentários/`TODO(UNI-REQ-0010)` removidos dos arquivos listados na issue
- [x] Build verde, sem warnings; soft-delete e auditoria preservados
- [x] Fecha a Story #588 (última das 3 tasks: #748 → #749 → #731)

## Testes

Suíte completa da solution verde localmente. Destaque: `Configuracao.IntegrationTests` foi de 213/214 (1 skip) para **214/214 — zero skips**.

## Notas de revisão

- Achado da revisão do PR#751 (#749): sinalizou esta lacuna exata como uma janela real de inconsistência em produção (LocalOferta soft-deletado silenciosamente enquanto referenciado por oferta viva). Este PR a fecha.
- `packages.lock.json` intocados — nenhuma dependência mudou.
