### PR TITLE
feat(configuracao): adiciona filtro cursoId à listagem de ofertas-curso

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -2999,6 +2999,14 @@
         ],
         "parameters": [
           {
+            "name": "cursoId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
             "name": "cursor",
             "in": "query",
             "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/OfertasCursoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/OfertasCursoController.cs
@@ -52,7 +52,11 @@ public sealed class OfertasCursoController : ControllerBase
     /// <summary>
     /// Lista as ofertas de curso ativas, paginadas por cursor opaco bidirecional
     /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
-    /// seu <c>_links.self</c> (ADR-0029).
+    /// seu <c>_links.self</c> (ADR-0029). Aceita o filtro opcional (issue #755)
+    /// <c>cursoId</c>, que restringe às ofertas vivas de um curso específico — a
+    /// UI conta/pagina ofertas de um curso sob demanda sem varrer todo o acervo.
+    /// O filtro viaja como query param e combina com o cursor: o cliente
+    /// reanexa-o a cada página ao seguir o <c>cursor</c> do header <c>Link</c>.
     /// </summary>
     [HttpGet("ofertas-curso")]
     [AllowAnonymous]
@@ -64,12 +68,13 @@ public sealed class OfertasCursoController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<IActionResult> Listar(
         [FromCursor(ResourceTag)] PageRequest page,
+        [FromQuery(Name = "cursoId")] Guid? cursoId,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(page);
 
         ListarOfertasCursoResult resultado = await _queryBus
-            .Send(new ListarOfertasCursoQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .Send(new ListarOfertasCursoQuery(page.AfterId, page.Limit, page.Direction, cursoId), cancellationToken)
             .ConfigureAwait(false);
 
         OfertaCursoDto[] comLinks =

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoQuery.cs
@@ -8,7 +8,16 @@ using Unifesspa.UniPlus.Kernel.Pagination;
 /// (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e valida
 /// limit/direction antes de despachar.
 /// </summary>
+/// <param name="AfterId">Âncora da página anterior; <c>null</c> retorna a primeira janela.</param>
+/// <param name="Limit">Tamanho máximo da página a retornar.</param>
+/// <param name="Direction">Direção de navegação (<c>Next</c>/<c>Prev</c>, ADR-0089).</param>
+/// <param name="CursoId">
+/// Filtro opcional (issue #755): restringe às ofertas do curso informado;
+/// <c>null</c> = sem filtro. Combina com o cursor — o filtro é aplicado à query
+/// antes do keyset, então itens e âncoras <c>prev</c>/<c>next</c> respeitam o recorte.
+/// </param>
 public sealed record ListarOfertasCursoQuery(
     Guid? AfterId,
     int Limit,
-    PaginationDirection Direction) : IQuery<ListarOfertasCursoResult>;
+    PaginationDirection Direction,
+    Guid? CursoId) : IQuery<ListarOfertasCursoResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/OfertasCurso/ListarOfertasCursoQueryHandler.cs
@@ -16,7 +16,7 @@ public static class ListarOfertasCursoQueryHandler
         ArgumentNullException.ThrowIfNull(repository);
 
         (IReadOnlyList<OfertaCurso> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
-            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, query.CursoId, cancellationToken)
             .ConfigureAwait(false);
 
         OfertaCursoDto[] items = [.. itens.Select(o => o.ToDto())];

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IOfertaCursoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/IOfertaCursoRepository.cs
@@ -21,11 +21,15 @@ public interface IOfertaCursoRepository
     /// Lista ofertas de curso vivas paginadas por cursor keyset bidirecional
     /// (ADR-0026 + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve
     /// as âncoras de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// O filtro opcional <paramref name="cursoId"/> (issue #755) restringe às
+    /// ofertas do curso informado antes do keyset — itens e âncoras respeitam o
+    /// recorte; <c>null</c> lista todas.
     /// </summary>
     Task<(IReadOnlyList<OfertaCurso> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
         int limit,
         PaginationDirection direction,
+        Guid? cursoId,
         CancellationToken cancellationToken);
 
     Task AdicionarAsync(OfertaCurso ofertaCurso, CancellationToken cancellationToken);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/OfertaCursoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/OfertaCursoRepository.cs
@@ -38,11 +38,21 @@ public sealed class OfertaCursoRepository : IOfertaCursoRepository
         Guid? afterId,
         int limit,
         PaginationDirection direction,
+        Guid? cursoId,
         CancellationToken cancellationToken)
     {
+        IQueryable<OfertaCurso> query = _dbContext.OfertasCurso.AsNoTracking();
+
+        // Filtro opcional por curso (issue #755): aplicado ANTES do keyset para que
+        // os EXISTS de prev/next herdem o recorte. Index-backed por ix_oferta_curso_curso_id.
+        if (cursoId is { } curso)
+        {
+            query = query.Where(o => o.CursoId == curso);
+        }
+
         // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
         CursorKeysetPage<OfertaCurso> page = await CursorKeyset
-            .ApplyAsync(_dbContext.OfertasCurso.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
             .ConfigureAwait(false);
 
         return (page.Items, page.PrevAfterId, page.NextAfterId);

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoEndpointTests.cs
@@ -332,7 +332,93 @@ public sealed class OfertaCursoEndpointTests
             "o soft-delete da oferta libera o curso para remoção");
     }
 
+    [Fact(DisplayName = "GET /api/configuracao/ofertas-curso?cursoId={id} retorna só as ofertas do curso; curso sem oferta → 200 vazio")]
+    public async Task Listar_FiltraPorCursoId_RetornaSomenteDoCurso()
+    {
+        (Guid cursoA, Guid localId) = await SemearCursoELocalAsync();
+        Guid cursoB = await SemearCursoAsync("Arquitetura e Urbanismo");
+        Unidade unidade = await SemearUnidadeAsync("facomp-755-a", "FCP755A", "OFC755A");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        (await EnviarPostAdmin(client, CorpoOferta(cursoA, localId, unidade.Id)))
+            .StatusCode.Should().Be(HttpStatusCode.Created);
+        (await EnviarPostAdmin(client, CorpoOferta(cursoA, localId, unidade.Id)))
+            .StatusCode.Should().Be(HttpStatusCode.Created);
+        (await EnviarPostAdmin(client, CorpoOferta(cursoB, localId, unidade.Id)))
+            .StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Filtro por A (limit folgado): exatamente as 2 ofertas de A, nenhuma de B.
+        HttpResponseMessage respA = await client.GetAsync(
+            new Uri($"/api/configuracao/ofertas-curso?cursoId={cursoA}&limit=50", UriKind.Relative));
+        respA.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (JsonDocument doc = JsonDocument.Parse(await respA.Content.ReadAsStringAsync()))
+        {
+            JsonElement root = doc.RootElement;
+            root.ValueKind.Should().Be(JsonValueKind.Array, "a listagem devolve array JSON puro (ADR-0025)");
+            root.GetArrayLength().Should().Be(2, "o curso A tem 2 ofertas vivas");
+            foreach (JsonElement item in root.EnumerateArray())
+            {
+                item.GetProperty("cursoId").GetGuid().Should().Be(cursoA);
+            }
+        }
+
+        // Curso sem ofertas → 200 com coleção vazia (sem 404).
+        HttpResponseMessage respVazio = await client.GetAsync(
+            new Uri($"/api/configuracao/ofertas-curso?cursoId={Guid.NewGuid()}", UriKind.Relative));
+        respVazio.StatusCode.Should().Be(HttpStatusCode.OK);
+        using (JsonDocument doc = JsonDocument.Parse(await respVazio.Content.ReadAsStringAsync()))
+        {
+            doc.RootElement.GetArrayLength().Should().Be(0);
+        }
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/ofertas-curso preserva cursoId no header Link (self e next)")]
+    public async Task Listar_ComFiltroCursoId_PreservaQueryParamNoLink()
+    {
+        (Guid cursoA, Guid localId) = await SemearCursoELocalAsync();
+        Unidade unidade = await SemearUnidadeAsync("facomp-755-b", "FCP755B", "OFC755B");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        // Duas ofertas do mesmo curso → com limit=1 há próxima página (rel=next).
+        (await EnviarPostAdmin(client, CorpoOferta(cursoA, localId, unidade.Id)))
+            .StatusCode.Should().Be(HttpStatusCode.Created);
+        (await EnviarPostAdmin(client, CorpoOferta(cursoA, localId, unidade.Id)))
+            .StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/configuracao/ofertas-curso?cursoId={cursoA}&limit=1", UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        response.Headers.TryGetValues("Link", out IEnumerable<string>? links).Should().BeTrue();
+        string link = links!.Single();
+        link.Should().Contain("rel=\"next\"", "limit=1 com 2 ofertas filtradas deve emitir próxima página");
+        link.Should().Contain($"cursoId={cursoA}", "o filtro de curso deve viajar em self e next para o cliente reanexar");
+    }
+
     // ── Seeds (padrão LeituraInProcessTests: resolve DbContexts do container do host) ──
+
+    private static object CorpoOferta(Guid cursoId, Guid localOfertaId, Guid unidadeOfertanteOrigemId) => new
+    {
+        cursoId,
+        localOfertaId,
+        unidadeOfertanteOrigemId,
+        programaDeOferta = "REGULAR",
+        formatoPedagogico = "PRESENCIAL",
+    };
+
+    private async Task<Guid> SemearCursoAsync(string nome)
+    {
+        Curso curso = Curso.Criar(CodigoUnico(), nome, "Bacharelado", "Graduação", null).Value!;
+
+        await using AsyncServiceScope scope = _fixture.Factory.Services.CreateAsyncScope();
+        ConfiguracaoDbContext dbContext =
+            scope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+
+        dbContext.Cursos.Add(curso);
+        await dbContext.SaveChangesAsync(CancellationToken.None);
+
+        return curso.Id;
+    }
 
     private async Task<(Guid CursoId, Guid LocalOfertaId)> SemearCursoELocalAsync()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/OfertasCurso/OfertaCursoPersistenceTests.cs
@@ -15,6 +15,7 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
 using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
 using Unifesspa.UniPlus.Kernel.Domain.Cidades;
+using Unifesspa.UniPlus.Kernel.Pagination;
 
 /// <summary>
 /// Integração ponta-a-ponta da OfertaCurso contra Postgres real (story #588,
@@ -270,7 +271,82 @@ public sealed class OfertaCursoPersistenceTests
             .Should().BeFalse("o soft-delete da oferta libera o curso para remoção");
     }
 
+    [Fact(DisplayName = "ListarPaginadoAsync filtra por cursoId e o recorte respeita o cursor bidirecional (itens + âncoras)")]
+    public async Task ListarPaginado_FiltraPorCursoId_RespeitaCursorBidirecional()
+    {
+        // issue #755: o filtro entra no IQueryable ANTES do keyset — itens, prev e
+        // next devem ficar todos dentro do recorte do curso A, ignorando o curso B.
+        (Guid cursoA, Guid localId) = await SemearCursoELocalAsync();
+        Guid cursoB = await SemearCursoAsync();
+
+        // Intercala a criação (A, B, A, B, A) para provar que o filtro isola o curso.
+        await SemearOfertasAsync(
+            (cursoA, localId), (cursoB, localId), (cursoA, localId), (cursoB, localId), (cursoA, localId));
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var repository = new OfertaCursoRepository(readCtx);
+
+        // Ordem canônica do banco (uuid) das ofertas de A — base para fatiar as páginas.
+        // Derivada do próprio banco: evita depender da semântica de Guid.CompareTo no cliente.
+        List<Guid> ordemA = await readCtx.OfertasCurso.AsNoTracking()
+            .Where(o => o.CursoId == cursoA)
+            .OrderBy(o => o.Id)
+            .Select(o => o.Id)
+            .ToListAsync();
+        ordemA.Should().HaveCount(3);
+
+        // Página 1 (Next, limit 2): primeiras 2 de A; primeira página não tem anterior.
+        (IReadOnlyList<OfertaCurso> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId) pagina1 =
+            await repository.ListarPaginadoAsync(afterId: null, limit: 2, PaginationDirection.Next, cursoA, CancellationToken.None);
+        pagina1.Itens.Select(o => o.Id).Should().Equal(ordemA[0], ordemA[1]);
+        pagina1.Itens.Should().OnlyContain(o => o.CursoId == cursoA);
+        pagina1.AnteriorAfterId.Should().BeNull();
+        pagina1.ProximoAfterId.Should().Be(ordemA[1]);
+
+        // Página 2 (Next a partir da 2ª): a 3ª de A; sem próximo; com anterior.
+        (IReadOnlyList<OfertaCurso> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId) pagina2 =
+            await repository.ListarPaginadoAsync(ordemA[1], limit: 2, PaginationDirection.Next, cursoA, CancellationToken.None);
+        pagina2.Itens.Select(o => o.Id).Should().Equal(ordemA[2]);
+        pagina2.Itens.Should().OnlyContain(o => o.CursoId == cursoA);
+        pagina2.ProximoAfterId.Should().BeNull();
+        pagina2.AnteriorAfterId.Should().Be(ordemA[2]);
+
+        // Prev a partir da 3ª (limit 2): as 2 anteriores de A, já em ordem ascendente.
+        (IReadOnlyList<OfertaCurso> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId) anterior =
+            await repository.ListarPaginadoAsync(ordemA[2], limit: 2, PaginationDirection.Prev, cursoA, CancellationToken.None);
+        anterior.Itens.Select(o => o.Id).Should().Equal(ordemA[0], ordemA[1]);
+        anterior.Itens.Should().OnlyContain(o => o.CursoId == cursoA);
+
+        // Curso sem ofertas → recorte vazio.
+        (IReadOnlyList<OfertaCurso> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId) vazio =
+            await repository.ListarPaginadoAsync(afterId: null, limit: 50, PaginationDirection.Next, Guid.CreateVersion7(), CancellationToken.None);
+        vazio.Itens.Should().BeEmpty();
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
+
+    private async Task<Guid> SemearCursoAsync()
+    {
+        Curso curso = Curso.Criar(
+            CodigoUnico(), "Engenharia Elétrica", "Bacharelado", "Graduação", null).Value!;
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        ctx.Cursos.Add(curso);
+        await ctx.SaveChangesAsync();
+
+        return curso.Id;
+    }
+
+    private async Task SemearOfertasAsync(params (Guid CursoId, Guid LocalOfertaId)[] ofertas)
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA);
+        foreach ((Guid cursoId, Guid localOfertaId) in ofertas)
+        {
+            ctx.OfertasCurso.Add(NovaOferta(cursoId, localOfertaId, NovaUnidade()));
+        }
+
+        await ctx.SaveChangesAsync();
+    }
 
     private async Task<(Guid CursoId, Guid LocalOfertaId)> SemearCursoELocalAsync()
     {


### PR DESCRIPTION
## Contexto

`GET /api/configuracao/ofertas-curso` não oferecia forma de obter as ofertas de um curso específico sem buscar e paginar todo o acervo (sem filtro por `cursoId`, sem contagem agregada). A coluna "N ofertas vivas" da tela de Curso foi omitida por isso em uniplus-web#426, e o bloqueio de remoção de curso referenciado por oferta viva só se manifesta como 409 no ato da remoção, sem preview.

Fecha a issue #755 pela **Opção 1**: filtro `?cursoId={id}` na listagem existente.

## O que muda

- `GET /api/configuracao/ofertas-curso` aceita o query param **opcional** `cursoId` (`uuid`). Ausente → comportamento atual (sem filtro).
- O filtro é aplicado ao `IQueryable` **antes** do `CursorKeyset.ApplyAsync`, então itens e âncoras `prev`/`next` respeitam o recorte (cursor bidirecional, ADR-0089).
- Index-backed por `ix_oferta_curso_curso_id` (já existente) — **sem migration**.
- O filtro viaja como query param e combina com o cursor: o cliente reanexa-o a cada página seguindo o header `Link`, que já preserva query params não reservados.

Espelha o padrão do filtro `q`/`tipo` do módulo Unidades (#640): mesmo contrato de cursor, mesma mecânica de recorte-antes-do-keyset.

## Decisão de contrato

Mesma rota, mesmo shape de resposta (array JSON puro, ADR-0025); só filtra. GUID malformado → 400 (model binding); `Guid.Empty`/curso inexistente → 200 com coleção vazia. Sem validador custom — superfície mínima, consistente com Unidades. A contagem agregada dedicada (Opção 2 da issue) permanece como follow-up trivial caso a UI precise de um COUNT O(1) por linha.

## Testes

- **Repositório** (`OfertaCursoPersistenceTests`): filtro combinado com cursor bidirecional — ofertas de dois cursos intercaladas, navegação `next`/`prev` com `limit=2`, validando itens e âncoras dentro do recorte; curso sem ofertas → vazio.
- **Endpoint** (`OfertaCursoEndpointTests`): `?cursoId={id}` retorna só as ofertas do curso e curso sem oferta → 200 vazio; `?cursoId={id}&limit=1` preserva `cursoId` no header `Link` (self/next).

Baseline OpenAPI (`contracts/openapi.configuracao.json`) regenerada. Suíte local verde: Configuração integração 217, Application 287, Domain 389, ArchTest de sincronia OpenAPI 1.

## Critérios de aceite

- [x] Filtro implementado com paginação por cursor (ADR-0026/0089).
- [x] Contrato OpenAPI atualizado (`openapi.configuracao.json`).
- [x] Testes de integração cobrindo o novo filtro.

Closes #755