### PR TITLE
chore(geo): provisiona banco de staging da DNE na stack completa

### DIFF
--- a/docker/docker-compose.override.example.yml
+++ b/docker/docker-compose.override.example.yml
@@ -108,6 +108,9 @@ services:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:8080
       ConnectionStrings__GeoDb: "Host=postgres;Port=5432;Database=uniplus_geo;Username=uniplus_geo_app;Password=uniplus_dev"
+      # Banco de staging da DNE (unifesspa-geo-api#12) — só passa a ter efeito
+      # quando GEO_IMAGE_TAG apontar para uma imagem que já inclua a correção.
+      ConnectionStrings__GeoStagingDb: "Host=postgres;Port=5432;Database=uniplus_geo_staging;Username=uniplus_geo_staging_app;Password=uniplus_dev"
       Redis__ConnectionString: "redis:6379"
       Kafka__BootstrapServers: "kafka:29092"
       Storage__Endpoint: "minio:9000"

--- a/docker/init-db.sql
+++ b/docker/init-db.sql
@@ -33,6 +33,15 @@ CREATE DATABASE keycloak;
 CREATE ROLE uniplus_geo_app LOGIN PASSWORD 'uniplus_dev';
 CREATE DATABASE uniplus_geo OWNER uniplus_geo_app;
 
+-- Banco de staging da DNE (unifesspa-geo-api#12): recebe os 15 dumps brutos
+-- (Correios/IBGE, gerados via Navicat) via `psql -f` sem nenhuma reescrita de
+-- schema — os dumps qualificam "public"."tbl_cep_..." explicitamente, então só
+-- um "public" NATIVO (banco próprio, não um schema secundário do uniplus_geo)
+-- os recebe de forma transparente. Role própria (não uniplus_geo_app) por
+-- menor privilégio: o app do domínio nunca precisa enxergar o dataset bruto.
+CREATE ROLE uniplus_geo_staging_app LOGIN PASSWORD 'uniplus_dev';
+CREATE DATABASE uniplus_geo_staging OWNER uniplus_geo_staging_app;
+
 -- Extensões dos databases de aplicação:
 --   uuid-ossp  — geração de UUIDs
 --   pg_trgm    — busca por similaridade (trigram matching)


### PR DESCRIPTION
## Contexto

A `unifesspa-geo-api#12` (implementada em `unifesspa-geo-api#20`) dedica um banco Postgres próprio (`uniplus_geo_staging`) para receber os dumps DNE sem reescrita de schema — os dumps qualificam `"public"."tbl_cep_..."` explicitamente, e um banco dedicado deixa o `public` nativo recebê-los sem `sed`/`search_path`.

Essa correção provisiona o banco via `docker/init-db.sql` do repo `unifesspa-geo-api`, usado na infra isolada daquele repo. A stack completa orquestrada por este repo (que também sobe o `geo-api` como container junto dos outros módulos) tem seu próprio `init-db.sql` e não ganhava o banco automaticamente.

## O que muda

- `docker/init-db.sql` — mesmo provisionamento (`CREATE ROLE uniplus_geo_staging_app` + `CREATE DATABASE uniplus_geo_staging`, sem extensões — dataset é só texto puro).
- `docker/docker-compose.override.example.yml` — connection string `ConnectionStrings__GeoStagingDb` no serviço `geo-api`.

## Nota importante

O serviço `geo-api` roda a imagem **publicada** (`GEO_IMAGE_TAG`), não código deste repo. A correção só passa a ter efeito prático na stack completa quando `GEO_IMAGE_TAG` apontar para uma tag que já inclua a `unifesspa-geo-api#20`. Até lá, esta mudança é inócua (variável de ambiente extra que o binário atual ignora) — mas deixa o terreno pronto sem trabalho adicional quando a imagem for atualizada.

## Validação

- `docker compose config -q` com os dois arquivos — sintaxe válida.
- Não há testes automatizados aplicáveis (mudança de infra local, sem código de app).

Closes #761