### PR TITLE
chore(docker): atualiza tag padrão do Geo para v1.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,25 @@ fica vazio (gov.br é opcional em dev). A imagem do `geo-api` vem do GHCR
 rode uma vez `docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml down -v --remove-orphans`
 (o `--import-realm` do Keycloak não reimporta um realm já existente).
 
+#### Manter a infra local do Geo em dia
+
+O repositório `unifesspa-geo-api` não publica tag `latest` — a versão consumida
+localmente fica fixada em `GEO_IMAGE_TAG` (`docker/.env`). Como `docker/.env` e
+`docker/docker-compose.override.yml` são **locais e gitignored**, um `git pull`
+não os atualiza. Ao notar uma nova release do Geo:
+
+1. Confira a tag mais recente na aba Releases do `unifesspa-geo-api` e atualize
+   `GEO_IMAGE_TAG` no seu `docker/.env`.
+2. Rode `diff docker/docker-compose.override.yml docker/docker-compose.override.example.yml`
+   para conferir se o template ganhou variáveis novas desde a última vez que
+   você copiou — o serviço `geo-api` costuma subir `healthy` mesmo com uma
+   variável faltando (a validação pode ficar adiada para o primeiro uso real),
+   então a ausência não aparece no health check, só ao exercitar a
+   funcionalidade correspondente.
+3. Propague sem recriar o stack inteiro:
+   `docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml pull geo-api`
+   seguido de `up -d geo-api`.
+
 | App | URL | Client OIDC |
 |---|---|---|
 | selecao | http://localhost:4200 | `selecao-web` |

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -30,8 +30,9 @@ KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=admin
 
 # Geo API — imagem publicada no GHCR pelo repo unifesspa-geo-api (extraído, ADR-0099).
-# O repo NÃO publica `latest`; fixar uma tag concreta. Tags publicadas: v1.0.0, sha-9722793.
-GEO_IMAGE_TAG=v1.0.0
+# O repo NÃO publica `latest`; fixar uma tag concreta. Tags publicadas: v1.0.0, v1.0.1, sha-ee1d3d6.
+# v1.0.1 inclui o fix do banco de staging dedicado da DNE (unifesspa-geo-api#12).
+GEO_IMAGE_TAG=v1.0.1
 
 # gov.br como Identity Provider externo do Keycloak (ADR-029)
 # Credenciais fornecidas pelo gov.br após cadastro institucional


### PR DESCRIPTION
## Resumo

- Atualiza `docker/.env.example`: `GEO_IMAGE_TAG` de `v1.0.0` para `v1.0.1` — a release atual do `unifesspa-geo-api`, que traz o fix do banco de staging dedicado da DNE (`unifesspa-geo-api#12`) e demais correções pós-extração (remoção Kafka/MinIO, soft-pin do Keycloak, CVE do `Microsoft.OpenApi`).
- Documenta no `CONTRIBUTING.md` (nova seção "Manter a infra local do Geo em dia") como acompanhar novas releases do Geo e sincronizar `docker/.env` + `docker/docker-compose.override.yml` — ambos locais/gitignored, não atualizados por `git pull`.

## Contexto e verificação e2e

Antes de abrir este PR, testei a stack completa de ponta a ponta com a imagem `v1.0.1`:

- Login real via Keycloak (realm `unifesspa`, app `configuracao-web`), sem loop de re-login.
- Resolução de CEP real (Marabá-PA) através do gateway Traefik (`GET /api/cep/...` via `:5000`), com JWT real, resposta 200 e UI preenchida corretamente.
- Disparo real do ETL da DNE (`POST /api/admin/geo/importacoes`) contra o banco de staging dedicado — país/estado/cidade completaram com upsert idempotente.
- Sem regressão: `uniplus-api`, `portal-api` e `geo-api` seguem `healthy`, `/health` respondendo 200 nas 3 APIs.

Esse teste revelou que meu próprio `docker-compose.override.yml` local (gitignored, cópia anterior à adição de `ConnectionStrings__GeoStagingDb` no template) estava sem essa variável — o container sobe `healthy` mesmo assim (a validação é adiada para o primeiro uso real), o que mascararia justamente o problema que a `v1.0.1` corrige. A nova seção do `CONTRIBUTING.md` documenta como qualquer dev evita cair nisso.

Também encontrei, ao re-testar o ETL num banco já totalmente populado, um timeout no merge de `logradouro` (característica de performance do modo Recarga, não relacionada a este PR) — reportado separadamente em `unifesspa-geo-api#22`.

## Test plan

- [x] `docker compose pull geo-api` + `up -d geo-api` com a nova tag — sobe `healthy`
- [x] Login + CEP resolvido via gateway com dados reais (Marabá-PA)
- [x] ETL disparado contra o staging dedicado — país/estado/cidade OK
- [x] `uniplus-api` e `portal-api` sem regressão (`/health` 200, containers `healthy`)

Closes #766