### PR TITLE
feat(selecao): rol_de_regras — catálogo de regra tipada versionada (F1)

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -56,6 +56,17 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("OfertaAtendimento.CondicaoDuplicada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.oferta_atendimento.condicao_duplicada", "Condição de atendimento duplicada na oferta")),
         new("OfertaAtendimento.RecursoDuplicado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.oferta_atendimento.recurso_duplicado", "Recurso de acessibilidade duplicado na oferta")),
         new("OfertaAtendimento.TipoDeficienciaDuplicado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.oferta_atendimento.tipo_deficiencia_duplicado", "Tipo de deficiência duplicado na oferta")),
+        // rol_de_regras (Story #772, F1) — validação da definição de uma regra
+        // do catálogo e da referência tipada que a configuração embute.
+        new("RegraCatalogo.CodigoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_catalogo.codigo_obrigatorio", "Código da regra obrigatório")),
+        new("RegraCatalogo.VersaoObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_catalogo.versao_obrigatoria", "Versão da regra obrigatória")),
+        new("RegraCatalogo.TipoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_catalogo.tipo_obrigatorio", "Tipo da regra obrigatório")),
+        new("RegraCatalogo.EsquemaArgsInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_catalogo.esquema_args_invalido", "esquema_args deve ser um objeto JSON")),
+        new("RegraCatalogo.InvariantesInvalidas", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_catalogo.invariantes_invalidas", "invariantes deve ser um array JSON")),
+        new("RegraCatalogo.BaseLegalObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_catalogo.base_legal_obrigatoria", "Base legal da regra obrigatória")),
+        new("ReferenciaRegra.CodigoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.referencia_regra.codigo_obrigatorio", "Código da regra referenciada obrigatório")),
+        new("ReferenciaRegra.VersaoObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.referencia_regra.versao_obrigatoria", "Versão da regra referenciada obrigatória")),
+        new("ReferenciaRegra.HashInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.referencia_regra.hash_invalido", "Hash da regra referenciada inválido")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/RegraCatalogo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/RegraCatalogo.cs
@@ -1,0 +1,159 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using System.Text.Json;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Entrada da biblioteca <c>rol_de_regras</c> — uma regra TIPADA e VERSIONADA
+/// que a configuração do Processo Seletivo referencia e o snapshot de
+/// publicação congela por <c>(codigo, versao, hash)</c> (RN08). Materializa a
+/// tese "configurável, não programável": o comportamento (fórmula da nota,
+/// distribuição de vagas, bônus, desempate, …) é conteúdo versionado de uma
+/// regra, não constante do motor — lei muda → nova versão, não deploy.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Append-only, seed-governada.</strong> Não é CRUD de administrador:
+/// as regras são semeadas (governadas por código) e a versão de uma regra é
+/// <em>imutável</em> — corrigir/evoluir o comportamento é publicar uma nova
+/// versão, nunca mutar a existente. Por isso a entidade deriva de
+/// <see cref="EntityBase"/> puro (sem soft-delete) e a imutabilidade é imposta
+/// no banco por gatilho <c>BEFORE UPDATE OR DELETE</c>; a própria linhagem de
+/// versões é a trilha de auditoria (sem histórico forense adicional).
+/// </para>
+/// <para>
+/// <strong>Hash content-addressable.</strong> O <see cref="Hash"/> é o SHA-256
+/// canônico da definição COMPLETA (<c>codigo+versao+tipo+esquema_args+invariantes+base_legal</c>).
+/// Mudar qualquer campo definicional mudaria o hash; como a versão é imutável,
+/// o freeze do snapshot é reprodutível por construção.
+/// </para>
+/// <para>
+/// <strong>Fronteira.</strong> A entrada descreve a regra e o
+/// <c>esquema_args</c> (o <em>schema</em> dos argumentos que o admin preenche);
+/// os <em>args aplicados</em> são tipados na dimensão que consome a regra
+/// (<see cref="ReferenciaRegra"/> + payload próprio) e validados contra este
+/// esquema. O <em>motor</em> que executa a regra (algoritmo de distribuição,
+/// cálculo da nota) é incremento — consome a definição congelada, não é
+/// modelado aqui.
+/// </para>
+/// </remarks>
+public sealed class RegraCatalogo : EntityBase
+{
+    public string Codigo { get; private set; } = null!;
+    public string Versao { get; private set; } = null!;
+    public TipoRegra Tipo { get; private set; }
+
+    /// <summary>Schema (jsonb, objeto) dos argumentos que o admin preenche ao aplicar a regra.</summary>
+    public JsonElement EsquemaArgs { get; private set; }
+
+    /// <summary>Pré/pós-condições declaradas da regra (jsonb, array).</summary>
+    public JsonElement Invariantes { get; private set; }
+
+    public string BaseLegal { get; private set; } = null!;
+
+    /// <summary>SHA-256 canônico da definição completa (content-addressable).</summary>
+    public string Hash { get; private set; } = null!;
+
+    // Construtor de materialização do EF Core.
+    private RegraCatalogo()
+    {
+    }
+
+    private RegraCatalogo(
+        string codigo,
+        string versao,
+        TipoRegra tipo,
+        JsonElement esquemaArgs,
+        JsonElement invariantes,
+        string baseLegal)
+    {
+        Codigo = codigo;
+        Versao = versao;
+        Tipo = tipo;
+        EsquemaArgs = esquemaArgs;
+        Invariantes = invariantes;
+        BaseLegal = baseLegal;
+        Hash = ComputeHash();
+    }
+
+    /// <summary>
+    /// Factory canônica (usada pelo seeder do catálogo): valida a definição,
+    /// desanexa os payloads jsonb do <see cref="JsonDocument"/> de origem
+    /// (<see cref="JsonElement.Clone"/>, para uma entidade imutável não segurar
+    /// um documento externo) e computa o hash.
+    /// </summary>
+    public static Result<RegraCatalogo> Criar(
+        string codigo,
+        string versao,
+        TipoRegra tipo,
+        JsonElement esquemaArgs,
+        JsonElement invariantes,
+        string baseLegal)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return Result<RegraCatalogo>.Failure(new DomainError(
+                "RegraCatalogo.CodigoObrigatorio", "Código da regra é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(versao))
+        {
+            return Result<RegraCatalogo>.Failure(new DomainError(
+                "RegraCatalogo.VersaoObrigatoria", "Versão da regra é obrigatória."));
+        }
+
+        if (tipo == TipoRegra.Nenhuma)
+        {
+            return Result<RegraCatalogo>.Failure(new DomainError(
+                "RegraCatalogo.TipoObrigatorio", "Tipo da regra é obrigatório."));
+        }
+
+        if (esquemaArgs.ValueKind != JsonValueKind.Object)
+        {
+            return Result<RegraCatalogo>.Failure(new DomainError(
+                "RegraCatalogo.EsquemaArgsInvalido",
+                "esquema_args deve ser um objeto JSON (schema dos argumentos)."));
+        }
+
+        if (invariantes.ValueKind != JsonValueKind.Array)
+        {
+            return Result<RegraCatalogo>.Failure(new DomainError(
+                "RegraCatalogo.InvariantesInvalidas",
+                "invariantes deve ser um array JSON de pré/pós-condições."));
+        }
+
+        if (string.IsNullOrWhiteSpace(baseLegal))
+        {
+            return Result<RegraCatalogo>.Failure(new DomainError(
+                "RegraCatalogo.BaseLegalObrigatoria",
+                "Base legal é obrigatória (lei + artigo/§ ou decisão institucional)."));
+        }
+
+        return Result<RegraCatalogo>.Success(new RegraCatalogo(
+            codigo.Trim(),
+            versao.Trim(),
+            tipo,
+            esquemaArgs.Clone(),
+            invariantes.Clone(),
+            baseLegal.Trim()));
+    }
+
+    /// <summary>
+    /// Recomputa o hash a partir do estado atual — exposto para os testes de
+    /// determinismo/round-trip (recomputar deve bater com o <see cref="Hash"/>
+    /// materializado).
+    /// </summary>
+    public string RecomputeHash() => ComputeHash();
+
+    private string ComputeHash() => HashCanonicalComputer.ComputeRegraCatalogo(
+        Codigo,
+        Versao,
+        Tipo,
+        EsquemaArgs,
+        Invariantes,
+        BaseLegal);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/TipoRegra.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/TipoRegra.cs
@@ -1,0 +1,62 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Tipo de uma regra do <c>rol_de_regras</c> — a biblioteca de regras tipadas
+/// e versionadas que a configuração do Processo Seletivo referencia
+/// (<c>codigo</c>+<c>versao</c>+<c>hash</c>), congelando-a no snapshot de
+/// publicação (RN08). "Configurável, não programável": o comportamento
+/// (fórmula, distribuição de vagas, bônus, desempate, …) é conteúdo de uma
+/// regra versionada, não constante do motor — lei muda → nova versão, não
+/// deploy.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Os 11 tipos espelham o domínio validado do <c>rol_de_regras</c>
+/// (fonte de verdade da modelagem P-A/P-B, validada contra Postgres real).
+/// O sentinela <see cref="Nenhuma"/> garante que <c>default(TipoRegra)</c>
+/// nunca colida com um tipo real — a factory o rejeita explicitamente.
+/// </para>
+/// <para>
+/// Cada valor mapeia para um código textual canônico snake_case
+/// (<c>ToCodigo</c>) — o valor persistido na coluna <c>tipo</c> e o token que
+/// entra no hash content-addressable da regra. Renumerar o enum não muda o
+/// hash de regras existentes (o hash usa o código textual, não o ordinal).
+/// </para>
+/// </remarks>
+public enum TipoRegra
+{
+    Nenhuma = 0,
+
+    /// <summary>Fórmula da nota final (ex.: <c>FORMULA-MEDIA-PONDERADA</c>, <c>CLASSIFICACAO-IMPORTADA</c>).</summary>
+    RegraCalculo = 1,
+
+    /// <summary>Precisão da nota (ex.: <c>PRECISAO-TRUNCAR</c>, <c>PRECISAO-ARREDONDAR-CIMA</c>).</summary>
+    RegraArredondamento = 2,
+
+    /// <summary>Eliminação por cálculo (ex.: <c>ELIM-NOTA-MINIMA-ETAPA</c>, <c>ELIM-CORTE-REDACAO</c>, <c>ELIM-ZERO-EM-AREA</c>).</summary>
+    RegraEliminacao = 3,
+
+    /// <summary>Bônus sobre a nota final (ex.: <c>BONUS-MULTIPLICATIVO</c>).</summary>
+    RegraBonus = 4,
+
+    /// <summary>Critério de desempate (ex.: <c>DESEMPATE-IDOSO</c>, <c>DESEMPATE-MAIOR-NOTA-ETAPA</c>, <c>DESEMPATE-PREDICADO-FATO</c>).</summary>
+    CriterioDesempate = 5,
+
+    /// <summary>Critério de remanejamento entre modalidades (cascata / cruzado PSIQ).</summary>
+    CriterioRemanejamento = 6,
+
+    /// <summary>Ordem de alocação 1ª/2ª opção → remanejamento → lista de espera (ex.: <c>ALOCACAO-OPCOES-RN04</c>).</summary>
+    RegraOrdemAlocacao = 7,
+
+    /// <summary>Enquadramento em cota (ex.: <c>RENDA-PER-CAPITA-LEI-12711</c>).</summary>
+    RegraElegibilidade = 8,
+
+    /// <summary>Cálculo do quadro de vagas reservadas (ex.: <c>DISTRIB-VAGAS-LEI-12711</c>, <c>DISTRIB-VAGAS-INSTITUCIONAL</c>).</summary>
+    RegraDistribuicaoVagas = 9,
+
+    /// <summary>Reconciliação do estouro por arredondamento na distribuição (ex.: <c>RECONCILIACAO-VAGAS-ART11-PU</c>).</summary>
+    RegraAjusteDistribuicaoVagas = 10,
+
+    /// <summary>Prazo/janela/instâncias do recurso (P-D cronograma).</summary>
+    RegraPrazoRecurso = 11,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/TipoRegraCodigo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/TipoRegraCodigo.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento único entre <see cref="TipoRegra"/> e o código textual canônico
+/// snake_case do <c>rol_de_regras</c> (o valor persistido na coluna <c>tipo</c>
+/// e o token que entra no hash content-addressable). Fonte de verdade única do
+/// wire format — o EF converter e o computador de hash consomem estes métodos,
+/// nunca <c>enum.ToString()</c>.
+/// </summary>
+public static class TipoRegraCodigo
+{
+    public const string RegraCalculo = "regra_calculo";
+    public const string RegraArredondamento = "regra_arredondamento";
+    public const string RegraEliminacao = "regra_eliminacao";
+    public const string RegraBonus = "regra_bonus";
+    public const string CriterioDesempate = "criterio_desempate";
+    public const string CriterioRemanejamento = "criterio_remanejamento";
+    public const string RegraOrdemAlocacao = "regra_ordem_alocacao";
+    public const string RegraElegibilidade = "regra_elegibilidade";
+    public const string RegraDistribuicaoVagas = "regra_distribuicao_vagas";
+    public const string RegraAjusteDistribuicaoVagas = "regra_ajuste_distribuicao_vagas";
+    public const string RegraPrazoRecurso = "regra_prazo_recurso";
+
+    /// <summary>
+    /// Converte o tipo para o código canônico. O <c>switch</c> é exaustivo: uma
+    /// 12ª variante quebra a build (CS8509 promovido a erro por
+    /// <c>TreatWarningsAsErrors</c>) até este mapeamento absorvê-la.
+    /// </summary>
+    public static string ToCodigo(this TipoRegra tipo) => tipo switch
+    {
+        TipoRegra.RegraCalculo => RegraCalculo,
+        TipoRegra.RegraArredondamento => RegraArredondamento,
+        TipoRegra.RegraEliminacao => RegraEliminacao,
+        TipoRegra.RegraBonus => RegraBonus,
+        TipoRegra.CriterioDesempate => CriterioDesempate,
+        TipoRegra.CriterioRemanejamento => CriterioRemanejamento,
+        TipoRegra.RegraOrdemAlocacao => RegraOrdemAlocacao,
+        TipoRegra.RegraElegibilidade => RegraElegibilidade,
+        TipoRegra.RegraDistribuicaoVagas => RegraDistribuicaoVagas,
+        TipoRegra.RegraAjusteDistribuicaoVagas => RegraAjusteDistribuicaoVagas,
+        TipoRegra.RegraPrazoRecurso => RegraPrazoRecurso,
+        TipoRegra.Nenhuma => throw new ArgumentOutOfRangeException(
+            nameof(tipo), tipo, "TipoRegra.Nenhuma é sentinela e não tem código canônico."),
+        _ => throw new ArgumentOutOfRangeException(nameof(tipo), tipo, "TipoRegra desconhecido."),
+    };
+
+    /// <summary>
+    /// Converte o código canônico de volta para o tipo. Usado na
+    /// materialização EF (leitura da coluna <c>tipo</c>).
+    /// </summary>
+    public static TipoRegra FromCodigo(string codigo) => codigo switch
+    {
+        RegraCalculo => TipoRegra.RegraCalculo,
+        RegraArredondamento => TipoRegra.RegraArredondamento,
+        RegraEliminacao => TipoRegra.RegraEliminacao,
+        RegraBonus => TipoRegra.RegraBonus,
+        CriterioDesempate => TipoRegra.CriterioDesempate,
+        CriterioRemanejamento => TipoRegra.CriterioRemanejamento,
+        RegraOrdemAlocacao => TipoRegra.RegraOrdemAlocacao,
+        RegraElegibilidade => TipoRegra.RegraElegibilidade,
+        RegraDistribuicaoVagas => TipoRegra.RegraDistribuicaoVagas,
+        RegraAjusteDistribuicaoVagas => TipoRegra.RegraAjusteDistribuicaoVagas,
+        RegraPrazoRecurso => TipoRegra.RegraPrazoRecurso,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(codigo), codigo, "Código de tipo de regra desconhecido."),
+    };
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IRegraCatalogoReader.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IRegraCatalogoReader.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Leitura da biblioteca <c>rol_de_regras</c> (Story #772): resolve regras
+/// tipadas e versionadas para que as dimensões da configuração do Processo
+/// Seletivo montem sua <see cref="Unifesspa.UniPlus.Selecao.Domain.ValueObjects.ReferenciaRegra"/>
+/// (<c>codigo</c>+<c>versao</c>+<c>hash</c>). Somente leitura — o catálogo é
+/// seed-governado e append-only; não há escrita por esta via.
+/// </summary>
+public interface IRegraCatalogoReader
+{
+    /// <summary>
+    /// Resolve a regra pela sua identidade <c>(codigo, versao)</c>, ou
+    /// <see langword="null"/> se não houver aquela versão no catálogo.
+    /// </summary>
+    Task<RegraCatalogo?> ObterAsync(string codigo, string versao, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Lista as regras de um <paramref name="tipo"/> (ex.: as regras de
+    /// desempate disponíveis para o admin escolher), ordenadas por
+    /// <c>codigo</c>+<c>versao</c>.
+    /// </summary>
+    Task<IReadOnlyList<RegraCatalogo>> ListarPorTipoAsync(TipoRegra tipo, CancellationToken cancellationToken = default);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/HashCanonicalComputer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/HashCanonicalComputer.cs
@@ -134,6 +134,57 @@ public static class HashCanonicalComputer
             ["vigenciaInicio"] = vigenciaInicio.ToString("O", CultureInfo.InvariantCulture),
         };
 
+        return HashCanonicalPayload(payload);
+    }
+
+    /// <summary>
+    /// Computa o hash content-addressable de uma entrada do <c>rol_de_regras</c>
+    /// (<see cref="Entities.RegraCatalogo"/>) sobre a sua definição COMPLETA:
+    /// <c>codigo</c>+<c>versao</c>+<c>tipo</c>+<c>esquema_args</c>+<c>invariantes</c>+<c>base_legal</c>.
+    /// Mudar qualquer campo definicional muda o hash — e a versão de uma regra
+    /// é imutável (nova semântica = nova versão), o que dá a reprodutibilidade
+    /// do freeze do snapshot (RN08) por construção.
+    /// </summary>
+    /// <remarks>
+    /// Espelha o hash validado do <c>rol_de_regras</c> (Postgres real): os
+    /// campos de auditoria (<c>created_at/by</c>) e o próprio <c>hash</c> ficam
+    /// de fora; <paramref name="esquemaArgs"/> (objeto) e
+    /// <paramref name="invariantes"/> (array) entram canonicalizados
+    /// recursivamente, de modo que a ordem das chaves não altere o resultado.
+    /// </remarks>
+    public static string ComputeRegraCatalogo(
+        string codigo,
+        string versao,
+        TipoRegra tipo,
+        JsonElement esquemaArgs,
+        JsonElement invariantes,
+        string baseLegal)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(codigo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(versao);
+        ArgumentException.ThrowIfNullOrWhiteSpace(baseLegal);
+
+        JsonObject payload = new()
+        {
+            ["baseLegal"] = baseLegal,
+            ["codigo"] = codigo,
+            ["esquemaArgs"] = JsonNode.Parse(esquemaArgs.GetRawText()),
+            ["invariantes"] = JsonNode.Parse(invariantes.GetRawText()),
+            ["tipo"] = tipo.ToCodigo(),
+            ["versao"] = versao,
+        };
+
+        return HashCanonicalPayload(payload);
+    }
+
+    /// <summary>
+    /// Canonicaliza (reordena chaves recursivamente), serializa com
+    /// <see cref="Utf8JsonWriter"/> byte-stável e devolve o SHA-256 em hex
+    /// minúsculo. Fonte única do passo final de hashing — compartilhada entre
+    /// o hash de <c>ObrigatoriedadeLegal</c> e o do <c>rol_de_regras</c>.
+    /// </summary>
+    private static string HashCanonicalPayload(JsonObject payload)
+    {
         JsonNode canonical = CanonicalizeRecursive(payload);
 
         // Use Utf8JsonWriter for byte-stable output (no environment-dependent

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ReferenciaRegra.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ReferenciaRegra.cs
@@ -1,0 +1,71 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Referência imutável a uma regra do <c>rol_de_regras</c> pela sua identidade
+/// content-addressable — <c>(codigo, versao, hash)</c>. É o que cada dimensão
+/// da configuração do Processo Seletivo embute ao aplicar uma regra e o que o
+/// snapshot de publicação congela (RN08): o par <c>(codigo, versao)</c> aponta
+/// a regra na biblioteca versionada e o <c>hash</c> prova que a definição
+/// aplicada não mudou depois (lei muda → nova versão, não retroage a editais
+/// publicados — reprodutibilidade por construção).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A referência carrega apenas a <em>identidade</em> da regra. Os <em>args
+/// aplicados</em> (ex.: <c>fator=1,20</c> de um <c>BONUS-MULTIPLICATIVO</c>,
+/// <c>etapa_ref</c> de um <c>DESEMPATE-MAIOR-NOTA-ETAPA</c>) são tipados junto
+/// da dimensão que consome a regra e validados contra o <c>esquema_args</c> da
+/// versão referenciada — não moram aqui.
+/// </para>
+/// <para>
+/// O <c>hash</c> é validado quanto ao formato (SHA-256 hex minúsculo, 64
+/// chars); a existência efetiva da regra <c>(codigo, versao)</c> com aquele
+/// <c>hash</c> é responsabilidade do handler que resolve a referência contra o
+/// leitor do catálogo, não deste value object.
+/// </para>
+/// </remarks>
+public sealed record ReferenciaRegra
+{
+    private ReferenciaRegra(string codigo, string versao, string hash)
+    {
+        Codigo = codigo;
+        Versao = versao;
+        Hash = hash;
+    }
+
+    public string Codigo { get; }
+    public string Versao { get; }
+    public string Hash { get; }
+
+    /// <summary>
+    /// Cria a referência validando que <paramref name="codigo"/> e
+    /// <paramref name="versao"/> não são vazios e que <paramref name="hash"/>
+    /// tem o formato de um SHA-256 hex minúsculo (64 chars).
+    /// </summary>
+    public static Result<ReferenciaRegra> Criar(string codigo, string versao, string hash)
+    {
+        if (string.IsNullOrWhiteSpace(codigo))
+        {
+            return Result<ReferenciaRegra>.Failure(new DomainError(
+                "ReferenciaRegra.CodigoObrigatorio", "Código da regra é obrigatório."));
+        }
+
+        if (string.IsNullOrWhiteSpace(versao))
+        {
+            return Result<ReferenciaRegra>.Failure(new DomainError(
+                "ReferenciaRegra.VersaoObrigatoria", "Versão da regra é obrigatória."));
+        }
+
+        if (!HashCanonicalComputer.IsValidHashShape(hash))
+        {
+            return Result<ReferenciaRegra>.Failure(new DomainError(
+                "ReferenciaRegra.HashInvalido",
+                "Hash da regra deve ser um SHA-256 em hexadecimal minúsculo (64 caracteres)."));
+        }
+
+        return Result<ReferenciaRegra>.Success(
+            new ReferenciaRegra(codigo.Trim(), versao.Trim(), hash));
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -8,6 +8,7 @@ using Domain.Interfaces;
 using ExternalServices;
 using Persistence;
 using Persistence.Interceptors;
+using Persistence.Readers;
 using Persistence.Repositories;
 
 public static class SelecaoInfrastructureRegistration
@@ -51,6 +52,7 @@ public static class SelecaoInfrastructureRegistration
         services.AddScoped<IProcessoSeletivoRepository, ProcessoSeletivoRepository>();
         services.AddScoped<IInscricaoRepository, InscricaoRepository>();
         services.AddScoped<IObrigatoriedadeLegalRepository, ObrigatoriedadeLegalRepository>();
+        services.AddScoped<IRegraCatalogoReader, RegraCatalogoReader>();
         services.AddScoped<IGovBrAuthService, GovBrAuthService>();
 
         return services;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/RegraCatalogoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/RegraCatalogoConfiguration.cs
@@ -1,0 +1,154 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Seed;
+
+/// <summary>
+/// Configuração EF Core da entidade <see cref="RegraCatalogo"/> — a biblioteca
+/// <c>rol_de_regras</c> (Story #772).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A tabela é <strong>append-only e seed-governada</strong>: não há CRUD de
+/// administrador, a versão de uma regra é imutável e a única escrita é o seed.
+/// Por isso a entidade deriva de <c>EntityBase</c> puro (sem soft-delete) e o
+/// índice <c>UNIQUE (codigo, versao)</c> é <strong>total</strong> (não parcial)
+/// — é justamente o que habilita <c>v1</c>/<c>v2</c> coexistentes referenciáveis.
+/// O append-only é imposto por convenção (ausência de API de mutação; leitura
+/// via <c>IRegraCatalogoReader</c>) e por fitness test, na linha do ADR-0063 —
+/// não por gatilho de banco (o repositório não usa gatilhos).
+/// </para>
+/// <para>
+/// <c>esquema_args</c> (schema dos argumentos) e <c>invariantes</c> são
+/// colunas <c>jsonb</c>; o <c>hash</c> content-addressable da definição é
+/// computado no domínio (<c>HashCanonicalComputer.ComputeRegraCatalogo</c>).
+/// </para>
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class RegraCatalogoConfiguration : IEntityTypeConfiguration<RegraCatalogo>
+{
+    private const int CodigoMaxLength = 128;
+    private const int VersaoMaxLength = 16;
+    private const int TipoMaxLength = 48;
+    private const int BaseLegalMaxLength = 500;
+    private const int HashLength = 64;
+
+    public void Configure(EntityTypeBuilder<RegraCatalogo> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("rol_de_regras");
+        builder.HasKey(r => r.Id);
+
+        // Chave Guid v7 gerada no domínio (EntityBase): ValueGeneratedNever
+        // força o EF a tratar a chave como fornecida pela aplicação (convenção
+        // do repo — evita o heurístico Add-vs-Update sobre chave não-default).
+        builder.Property(r => r.Id).ValueGeneratedNever();
+
+        builder.Property(r => r.Codigo).HasMaxLength(CodigoMaxLength).IsRequired();
+        builder.Property(r => r.Versao).HasMaxLength(VersaoMaxLength).IsRequired();
+
+        builder.Property(r => r.Tipo)
+            .HasConversion(TipoConverter)
+            .HasMaxLength(TipoMaxLength)
+            .IsRequired();
+
+        builder.Property(r => r.EsquemaArgs)
+            .HasConversion(JsonElementConverter, JsonElementComparer)
+            .HasColumnType("jsonb")
+            .IsRequired();
+
+        builder.Property(r => r.Invariantes)
+            .HasConversion(JsonElementConverter, JsonElementComparer)
+            .HasColumnType("jsonb")
+            .IsRequired();
+
+        builder.Property(r => r.BaseLegal).HasMaxLength(BaseLegalMaxLength).IsRequired();
+
+        builder.Property(r => r.Hash)
+            .HasMaxLength(HashLength)
+            .IsFixedLength()
+            .IsRequired();
+
+        // UNIQUE total (codigo, versao): uma versão de regra é única e imutável;
+        // v1/v2 coexistem como linhas distintas referenciáveis pelo snapshot.
+        builder.HasIndex(r => new { r.Codigo, r.Versao })
+            .IsUnique()
+            .HasDatabaseName("ux_rol_de_regras_codigo_versao");
+
+        // Resolve a referência da configuração pelo hash content-addressable.
+        builder.HasIndex(r => r.Hash)
+            .HasDatabaseName("ix_rol_de_regras_hash");
+
+        SemearRegrasV1(builder);
+    }
+
+    /// <summary>
+    /// Seed das regras <c>v1</c> via <see cref="RelationalEntityTypeBuilderExtensions"/>
+    /// (<c>HasData</c>): o EF congela as linhas como literais na migration no
+    /// momento do scaffold — a migration é um snapshot imutável, e qualquer
+    /// mudança futura em <see cref="RegraCatalogoSeed.Itens"/> exige uma nova
+    /// migration (o EF detecta o diff), sem alterar as bases já migradas. O
+    /// <c>hash</c> é derivado da mesma lógica do domínio, então a linha semeada
+    /// é content-addressable por construção.
+    /// </summary>
+    private static void SemearRegrasV1(EntityTypeBuilder<RegraCatalogo> builder)
+    {
+        // Instante-âncora fixo do seed (HasData exige valor determinístico;
+        // as linhas não passam pelo AuditableInterceptor).
+        DateTimeOffset seedCriadoEm = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        builder.HasData(RegraCatalogoSeed.Itens.Select(item => new
+        {
+            item.Id,
+            item.Codigo,
+            item.Versao,
+            item.Tipo,
+            EsquemaArgs = Parse(item.EsquemaArgsJson),
+            Invariantes = Parse(item.InvariantesJson),
+            item.BaseLegal,
+            Hash = item.ComputarHash(),
+            CreatedAt = seedCriadoEm,
+        }));
+    }
+
+    /// <summary>Mapeia <see cref="TipoRegra"/> ↔ o código canônico snake_case (fonte única em <see cref="TipoRegraCodigo"/>).</summary>
+    private static readonly ValueConverter<TipoRegra, string> TipoConverter =
+        new(tipo => tipo.ToCodigo(), codigo => TipoRegraCodigo.FromCodigo(codigo));
+
+    /// <summary>
+    /// Serializa o payload jsonb (<c>esquema_args</c>/<c>invariantes</c>) pelo
+    /// texto bruto do <see cref="JsonElement"/> e o reidrata desanexado do
+    /// <see cref="JsonDocument"/> de origem (<see cref="JsonElement.Clone"/>).
+    /// </summary>
+    private static readonly ValueConverter<JsonElement, string> JsonElementConverter =
+        new(element => element.GetRawText(), json => Parse(json));
+
+    /// <summary>
+    /// ValueComparer por texto bruto — suficiente para o change-tracker de uma
+    /// entidade append-only (nunca mutada após o seed).
+    /// </summary>
+    private static readonly ValueComparer<JsonElement> JsonElementComparer =
+        new(
+            (a, b) => a.GetRawText() == b.GetRawText(),
+            v => v.GetRawText().GetHashCode(StringComparison.Ordinal),
+            v => Parse(v.GetRawText()));
+
+    private static JsonElement Parse(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260706224609_AddRolDeRegras.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260706224609_AddRolDeRegras.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706224609_AddRolDeRegras")]
+    partial class AddRolDeRegras
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260706224609_AddRolDeRegras.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260706224609_AddRolDeRegras.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRolDeRegras : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "rol_de_regras",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    versao = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    tipo = table.Column<string>(type: "character varying(48)", maxLength: 48, nullable: false),
+                    esquema_args = table.Column<string>(type: "jsonb", nullable: false),
+                    invariantes = table.Column<string>(type: "jsonb", nullable: false),
+                    base_legal = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    hash = table.Column<string>(type: "character(64)", fixedLength: true, maxLength: 64, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_rol_de_regras", x => x.id);
+                });
+
+            migrationBuilder.InsertData(
+                schema: "selecao",
+                table: "rol_de_regras",
+                columns: new[] { "id", "base_legal", "codigo", "created_at", "esquema_args", "hash", "invariantes", "tipo", "updated_at", "versao" },
+                values: new object[,]
+                {
+                    { new Guid("d0a00000-0000-7000-8000-000000000001"), "Proposta CEPS + #56; média ponderada NOTA=Σ(nota×peso)/Σpeso", "FORMULA-MEDIA-PONDERADA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"fonte_pesos\":[\"etapa\",\"peso_area_enem\"]}", "a6fdc29bce533ef3cf8acb6cfdd7d67a99104541f6201d227f0d1c7051229ad6", "[\"divisor = Σ(peso das etapas classificatória∪ambas)\"]", "regra_calculo", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000002"), "Portaria MEC 18/2012 art. 16 — SiSU federal (CEPS não calcula)", "CLASSIFICACAO-IMPORTADA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{}", "8e6f1f7b705c601991bf0617bbf881e39a3666c641abdfa4c1bd9ce2ecbcc85c", "[\"sem cálculo local; classificação federal por importação do listão\"]", "regra_calculo", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000003"), "Decisão CEPS/PO (gaps 1.1) — truncamento 2 casas (default)", "PRECISAO-TRUNCAR", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"casas\":\"integer\"}", "66cbb932e61982f09fdd1d60a0db8411ea02dedc19bb72d1af23004f1e18360b", "[\"trunca na N-ésima casa, sem arredondar\"]", "regra_arredondamento", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000004"), "Reprodução de editais antigos (PSE/Convênios)", "PRECISAO-ARREDONDAR-CIMA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"casas\":\"integer\"}", "efc491bf6a242a870c7bf9969048c198db88116ba39e72a44bcf1d5d5aebc4fb", "[\"arredonda p/ cima se 3ª casa ≥ 5\"]", "regra_arredondamento", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000005"), "Edital por processo (nota mínima eliminatória)", "ELIM-NOTA-MINIMA-ETAPA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"etapa\":\"text\",\"nota_minima\":\"numeric\"}", "b64f643eba9744efc20bf19221bde85c645da32262a7d2ef616f18bd7c2ed5ac", "[\"nota < mínima na etapa → elimina\"]", "regra_eliminacao", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000006"), "Res. 805/2024 Anexo I (corte de Redação = 400)", "ELIM-CORTE-REDACAO", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"minimo\":\"numeric\"}", "6a23db02c00878d5bb98a445e8dc72e209a95f2aa4a8bfd91de8fa08ee69c240", "[\"redação < mínimo → elimina\"]", "regra_eliminacao", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000007"), "Res. 805/2024 art. 5º (zero em qualquer área elimina)", "ELIM-ZERO-EM-AREA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{}", "75f4929b848138c8ed939a182e3664451ce38cd40a136adda438b62e1b6e3fb8", "[\"nota zero em qualquer área do ENEM → elimina\"]", "regra_eliminacao", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000008"), "RN05 + decisão PO Jairo (×1,20 sem teto, após pesos)", "BONUS-MULTIPLICATIVO", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"fator\":\"numeric\",\"teto\":\"numeric|null\"}", "d824fa64884e038e132f918dfd6efecf56d1df4cd4a1a1f86a78bf31718dae9b", "[\"nota_final × fator, após os pesos; teto opcional\"]", "regra_bonus", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000009"), "Lei 10.741/2003 art. 27 (Estatuto do Idoso)", "DESEMPATE-IDOSO", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"idade_minima\":\"integer\"}", "6738b1a9ca4f063f7f215cabb837e055d8abafaf0835f0b3deeed1c97f0becd4", "[\"prioriza quem satisfaz FAIXA_ETARIA ≥ idade_minima\"]", "criterio_desempate", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000010"), "Edital (ordem de desempate)", "DESEMPATE-MAIOR-NOTA-ETAPA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"etapa\":\"text\"}", "1a988e6681b2970dc6c568c7372ceaf2f6e5ec0f7061ac47f656e1366a9ecad8", "[\"ordena por maior nota da etapa indicada\"]", "criterio_desempate", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000011"), "Edital (maior idade cronológica)", "DESEMPATE-MAIOR-IDADE", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{}", "1efa26eaeffc88baf31ce9e2030c05c9976fae125e9845fe0283168050dc1237", "[\"ordena por data de nascimento (nascido mais cedo vence)\"]", "criterio_desempate", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000012"), "Edital (critério adicional via fato do candidato — ex.: professor rural)", "DESEMPATE-PREDICADO-FATO", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"fato\":\"text\",\"operador\":\"text\",\"valor\":\"any\"}", "d832d910826f25b6b50fd324f2f3cae472440c0e81e082be7c8d4fefe3de3f21", "[\"prioriza quem satisfaz predicado sobre FatoCandidato; fato deve estar no vocabulário e ser coletado\"]", "criterio_desempate", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000013"), "RN04 (processamento de 1ª/2ª opção)", "ALOCACAO-OPCOES-RN04", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"n_opcoes\":\"integer\"}", "2bb69f0e34483e635aa0903f8d3ba19a4255e8f542c5f7090ac75cecf200c988", "[\"1ª opção → 2ª opção → remanejamento → lista de espera\"]", "regra_ordem_alocacao", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000014"), "Lei 12.711/2012 art. 1º parágrafo único (red. Lei 14.723/2023) — renda familiar bruta per capita ≤ 1 SM (ensino superior); PN MEC 18/2012 art. 6º-7º — apuração da renda mensal per capita + exclusões obrigatórias", "RENDA-PER-CAPITA-LEI-12711", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"limite_sm\":\"numeric\",\"sm_referencia\":\"numeric (SM congelado na data de início das inscrições)\",\"periodo_apuracao_meses\":\"integer (ex.: 3 últimos meses)\",\"criterio_media_mensal\":\"text (média mensal dos rendimentos brutos)\",\"exclusoes_renda\":\"lista (PN 18/2012 art. 7º)\",\"composicao_nucleo_familiar\":\"quem compõe o núcleo familiar\"}", "5a1ad80627e354c03e4d6ef776a45db695a1203cea574a288dbcdf706ca58899", "[\"média mensal da renda familiar bruta (últimos N meses, após exclusões) ÷ nº de membros do núcleo ≤ limite_sm × sm_referencia\"]", "regra_elegibilidade", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000015"), "Portaria Normativa MEC nº 18/2012 art. 10 e 11 (red. PN 2.027/2023) — distribuição e arredondamento das vagas reservadas; Lei 12.711/2012 (red. Lei 14.723/2023)", "DISTRIB-VAGAS-LEI-12711", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"pr_minimo\":\"numeric (piso 0,5 — art. 10 II; teto 1,0)\",\"modo_arredondamento\":\"teto (ceil) em todas as sub-reservas EXCETO LI_Q (floor) — art. 11\",\"ordem_garantia_minima\":[\"LB_PPI\",\"LB_Q\",\"LB_PCD\",\"LB_EP\",\"LI_PPI\",\"LI_PCD\",\"LI_EP\"],\"sub_reservas\":[\"PPI\",\"Q\",\"PCD\",\"EP\"],\"entradas_por_edital\":[\"VO_base\",\"PR\",\"ReferenciaReservaDemografica\"]}", "0eb12ca67af16ab666e0db0894d795ec725422326cf7dedba2e804f496e0d807", "[\"VR=ceil(VO×PR)\",\"VRRI=ceil(VR×0,5)\",\"VRSI=VR−VRRI\",\"sub-reservas ceil EXCETO LI_Q=floor (art. 11)\",\"garantia mín-1 ordenada I-VII condicional à disponibilidade (art. 10 §2º), LI_Q fora\",\"INV-3a: LB_EP≥0 e LI_EP≥0\",\"INV-3b: AC≥0\",\"INV-3c: VR_final+RETIRADAS+AC=VO_base\"]", "regra_distribuicao_vagas", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000016"), "Res. Unifesspa 532/2021 (vagas PcD/Indígena/Quilombola); Portaria MEC 18/2012 art. 12 (reservas suplementares e outras ações afirmativas)", "DISTRIB-VAGAS-INSTITUCIONAL", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"quadro_fixo_por_modalidade\":\"objeto {codigo: quantidade} fixado por edital (NÃO art. 10)\",\"aplicacao\":\"PSIQ (IND/QUIL) e PSE Ed. Campo — quadro institucional\"}", "03b114eb3b559367b7d79f9edb1371f8164c5ede0c5f4b21809ee572c49c9451", "[\"quadro fixo por edital (não recalculado pelo art. 10)\",\"modalidades institucionais somam conforme composicao_vagas (SUPLEMENTAR_AO_TOTAL ou RETIRA_DE)\"]", "regra_distribuicao_vagas", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000017"), "Portaria MEC 18/2012 art. 11, parágrafo único (red. PN 2.027/2023) — cap nas vagas da oferta + prioridade do inciso III (LB) sobre o inciso IV (LI); art. 10 II (mínimo 50%, piso)", "RECONCILIACAO-VAGAS-ART11-PU", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"reconciliacao_federal\":\"CAP_VO + PRIORIDADE_LB (art. 11 §único, embutida em DISTRIB-VAGAS-LEI-12711)\",\"motores_nao_art10\":\"REDUZIR_DE | REDUZIR_PROPORCIONAL_EM (apenas distribuições institucionais; clamp >=0; VEDADOS à Lei 12.711)\"}", "ad2d8012ddc1f2ea4d763034899d07590c4a49901744b852dca2e70cede8b1e9", "[\"cap em VO: a reserva nunca excede as vagas da oferta (art. 11 §único I)\",\"prioridade LB>LI: na escassez a LI cede primeiro (art. 11 §único II)\",\"estouro sobre o nominal 50% (VR) e LEGAL — piso (art. 10 II), absorvido pela AC\",\"curso pequeno e determinístico por lei (capa, não bloqueia)\"]", "regra_ajuste_distribuicao_vagas", null, "v1" },
+                    { new Guid("d0a00000-0000-7000-8000-000000000018"), "Lei 9.784/1999 (processo administrativo federal); edital/processo (prazo configurável por edital); regimento CONSEPE (2ª instância)", "RECURSO-MULTI-INSTANCIA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), "{\"prazo_valor\":\"numeric\",\"prazo_unidade\":\"HORAS|DIAS|DIAS_UTEIS (sem default — dado do edital)\",\"contra_ato\":\"codigo da fase produtora recorrível (NUNCA resultado definitivo)\",\"marco_inicial\":\"a partir de quando conta (ex.: publicacao_resultado)\",\"instancias\":\"lista ordenada [{instancia,dono,prazo_valor,prazo_unidade}] — 1ª CEPS, 2ª CONSEPE\"}", "660cf3fffe22069f5a7f302a98b1e44b96d2e992680f02304935a36548f95490", "[\"interposição GATED pela janela aberta (sem recurso a qualquer momento)\",\"sem recurso ao resultado definitivo (≠ recurso de habilitação CRCA)\",\"2ª instância (CONSEPE) só após indeferimento da 1ª; CONSEPE emite parecer externo, CEPS anexa e aplica (vinculante)\",\"processo PARALISA enquanto 2ª instância pendente; avanço só após expirar o prazo\",\"append-only: parecer/retificação = novo fato, não sobrescreve o passado\"]", "regra_prazo_recurso", null, "v1" }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_rol_de_regras_hash",
+                schema: "selecao",
+                table: "rol_de_regras",
+                column: "hash");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_rol_de_regras_codigo_versao",
+                schema: "selecao",
+                table: "rol_de_regras",
+                columns: new[] { "codigo", "versao" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "rol_de_regras",
+                schema: "selecao");
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Readers/RegraCatalogoReader.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Readers/RegraCatalogoReader.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Readers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+/// <summary>
+/// Implementação de <see cref="IRegraCatalogoReader"/>: leitura direta do
+/// <c>rol_de_regras</c> (<c>AsNoTracking</c>), sem cache — o catálogo é de
+/// baixo volume (dezenas de regras), imutável por versão, e o congelamento por
+/// valor no consumidor (<see cref="Domain.ValueObjects.ReferenciaRegra"/> +
+/// snapshot, ADR-0061) dispensa releitura quente (mesmo padrão dos readers de
+/// reference data do módulo Configuração).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI na registration de Infrastructure do módulo Seleção.")]
+internal sealed class RegraCatalogoReader : IRegraCatalogoReader
+{
+    private readonly SelecaoDbContext _dbContext;
+
+    public RegraCatalogoReader(SelecaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<RegraCatalogo?> ObterAsync(
+        string codigo,
+        string versao,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.RolDeRegras
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.Codigo == codigo && r.Versao == versao, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<RegraCatalogo>> ListarPorTipoAsync(
+        TipoRegra tipo,
+        CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.RolDeRegras
+            .AsNoTracking()
+            .Where(r => r.Tipo == tipo)
+            .OrderBy(r => r.Codigo)
+            .ThenBy(r => r.Versao)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Seed/RegraCatalogoSeed.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Seed/RegraCatalogoSeed.cs
@@ -1,0 +1,189 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Seed;
+
+using System.Text.Json;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Fonte única do seed da biblioteca <c>rol_de_regras</c> (Story #772): as
+/// regras <c>v1</c> tipadas e versionadas que a configuração do Processo
+/// Seletivo referencia. Consumida tanto pela migration (que materializa as
+/// linhas) quanto pelos testes (que recomputam o hash e conferem a
+/// completude), garantindo uma única definição por regra.
+/// </summary>
+/// <remarks>
+/// <para>
+/// O conteúdo de domínio (código, tipo, <c>esquema_args</c>, invariantes e
+/// base legal) é a modelagem validada do CEPS (P-A distribuição / P-B
+/// classificação, provada contra Postgres real). Portado fielmente; as
+/// melhorias são estruturais — identificadores fixos determinísticos, hash
+/// canônico content-addressable computado no domínio e append-only por
+/// convenção (sem gatilho de banco).
+/// </para>
+/// <para>
+/// Os <see cref="Guid"/> são fixos (não <c>Guid.CreateVersion7</c>) porque
+/// seed precisa de identidade estável entre execuções; o <c>hash</c> não é
+/// literal — é derivado da definição via <see cref="Item.ComputarHash"/>,
+/// mantendo content-addressability por construção.
+/// </para>
+/// </remarks>
+public static class RegraCatalogoSeed
+{
+    /// <summary>Versão corrente de toda regra semeada nesta rodada.</summary>
+    public const string VersaoV1 = "v1";
+
+    private static Guid SeedId(int n) =>
+        Guid.Parse($"d0a00000-0000-7000-8000-{n:D12}");
+
+    /// <summary>As 18 regras <c>v1</c> do catálogo, na ordem canônica.</summary>
+    public static IReadOnlyList<RegraCatalogoSeedItem> Itens { get; } =
+    [
+        // regra_calculo — fórmula da nota final
+        new(SeedId(1), "FORMULA-MEDIA-PONDERADA", VersaoV1, TipoRegra.RegraCalculo,
+            """{"fonte_pesos":["etapa","peso_area_enem"]}""",
+            """["divisor = Σ(peso das etapas classificatória∪ambas)"]""",
+            "Proposta CEPS + #56; média ponderada NOTA=Σ(nota×peso)/Σpeso"),
+
+        new(SeedId(2), "CLASSIFICACAO-IMPORTADA", VersaoV1, TipoRegra.RegraCalculo,
+            "{}",
+            """["sem cálculo local; classificação federal por importação do listão"]""",
+            "Portaria MEC 18/2012 art. 16 — SiSU federal (CEPS não calcula)"),
+
+        // regra_arredondamento — precisão da nota
+        new(SeedId(3), "PRECISAO-TRUNCAR", VersaoV1, TipoRegra.RegraArredondamento,
+            """{"casas":"integer"}""",
+            """["trunca na N-ésima casa, sem arredondar"]""",
+            "Decisão CEPS/PO (gaps 1.1) — truncamento 2 casas (default)"),
+
+        new(SeedId(4), "PRECISAO-ARREDONDAR-CIMA", VersaoV1, TipoRegra.RegraArredondamento,
+            """{"casas":"integer"}""",
+            """["arredonda p/ cima se 3ª casa ≥ 5"]""",
+            "Reprodução de editais antigos (PSE/Convênios)"),
+
+        // regra_eliminacao — eliminação por cálculo (lista)
+        new(SeedId(5), "ELIM-NOTA-MINIMA-ETAPA", VersaoV1, TipoRegra.RegraEliminacao,
+            """{"etapa":"text","nota_minima":"numeric"}""",
+            """["nota < mínima na etapa → elimina"]""",
+            "Edital por processo (nota mínima eliminatória)"),
+
+        new(SeedId(6), "ELIM-CORTE-REDACAO", VersaoV1, TipoRegra.RegraEliminacao,
+            """{"minimo":"numeric"}""",
+            """["redação < mínimo → elimina"]""",
+            "Res. 805/2024 Anexo I (corte de Redação = 400)"),
+
+        new(SeedId(7), "ELIM-ZERO-EM-AREA", VersaoV1, TipoRegra.RegraEliminacao,
+            "{}",
+            """["nota zero em qualquer área do ENEM → elimina"]""",
+            "Res. 805/2024 art. 5º (zero em qualquer área elimina)"),
+
+        // regra_bonus — bônus sobre a nota final
+        new(SeedId(8), "BONUS-MULTIPLICATIVO", VersaoV1, TipoRegra.RegraBonus,
+            """{"fator":"numeric","teto":"numeric|null"}""",
+            """["nota_final × fator, após os pesos; teto opcional"]""",
+            "RN05 + decisão PO Jairo (×1,20 sem teto, após pesos)"),
+
+        // criterio_desempate — critérios de desempate (tipados)
+        new(SeedId(9), "DESEMPATE-IDOSO", VersaoV1, TipoRegra.CriterioDesempate,
+            """{"idade_minima":"integer"}""",
+            """["prioriza quem satisfaz FAIXA_ETARIA ≥ idade_minima"]""",
+            "Lei 10.741/2003 art. 27 (Estatuto do Idoso)"),
+
+        new(SeedId(10), "DESEMPATE-MAIOR-NOTA-ETAPA", VersaoV1, TipoRegra.CriterioDesempate,
+            """{"etapa":"text"}""",
+            """["ordena por maior nota da etapa indicada"]""",
+            "Edital (ordem de desempate)"),
+
+        new(SeedId(11), "DESEMPATE-MAIOR-IDADE", VersaoV1, TipoRegra.CriterioDesempate,
+            "{}",
+            """["ordena por data de nascimento (nascido mais cedo vence)"]""",
+            "Edital (maior idade cronológica)"),
+
+        new(SeedId(12), "DESEMPATE-PREDICADO-FATO", VersaoV1, TipoRegra.CriterioDesempate,
+            """{"fato":"text","operador":"text","valor":"any"}""",
+            """["prioriza quem satisfaz predicado sobre FatoCandidato; fato deve estar no vocabulário e ser coletado"]""",
+            "Edital (critério adicional via fato do candidato — ex.: professor rural)"),
+
+        // regra_ordem_alocacao — 1ª/2ª opção → remanejamento → lista de espera
+        new(SeedId(13), "ALOCACAO-OPCOES-RN04", VersaoV1, TipoRegra.RegraOrdemAlocacao,
+            """{"n_opcoes":"integer"}""",
+            """["1ª opção → 2ª opção → remanejamento → lista de espera"]""",
+            "RN04 (processamento de 1ª/2ª opção)"),
+
+        // regra_elegibilidade — enquadramento em cota
+        new(SeedId(14), "RENDA-PER-CAPITA-LEI-12711", VersaoV1, TipoRegra.RegraElegibilidade,
+            """
+            {"limite_sm":"numeric","sm_referencia":"numeric (SM congelado na data de início das inscrições)","periodo_apuracao_meses":"integer (ex.: 3 últimos meses)","criterio_media_mensal":"text (média mensal dos rendimentos brutos)","exclusoes_renda":"lista (PN 18/2012 art. 7º)","composicao_nucleo_familiar":"quem compõe o núcleo familiar"}
+            """,
+            """["média mensal da renda familiar bruta (últimos N meses, após exclusões) ÷ nº de membros do núcleo ≤ limite_sm × sm_referencia"]""",
+            "Lei 12.711/2012 art. 1º parágrafo único (red. Lei 14.723/2023) — renda familiar bruta per capita ≤ 1 SM (ensino superior); PN MEC 18/2012 art. 6º-7º — apuração da renda mensal per capita + exclusões obrigatórias"),
+
+        // regra_distribuicao_vagas — cálculo do quadro de vagas reservadas
+        new(SeedId(15), "DISTRIB-VAGAS-LEI-12711", VersaoV1, TipoRegra.RegraDistribuicaoVagas,
+            """
+            {"pr_minimo":"numeric (piso 0,5 — art. 10 II; teto 1,0)","modo_arredondamento":"teto (ceil) em todas as sub-reservas EXCETO LI_Q (floor) — art. 11","ordem_garantia_minima":["LB_PPI","LB_Q","LB_PCD","LB_EP","LI_PPI","LI_PCD","LI_EP"],"sub_reservas":["PPI","Q","PCD","EP"],"entradas_por_edital":["VO_base","PR","ReferenciaReservaDemografica"]}
+            """,
+            """
+            ["VR=ceil(VO×PR)","VRRI=ceil(VR×0,5)","VRSI=VR−VRRI","sub-reservas ceil EXCETO LI_Q=floor (art. 11)","garantia mín-1 ordenada I-VII condicional à disponibilidade (art. 10 §2º), LI_Q fora","INV-3a: LB_EP≥0 e LI_EP≥0","INV-3b: AC≥0","INV-3c: VR_final+RETIRADAS+AC=VO_base"]
+            """,
+            "Portaria Normativa MEC nº 18/2012 art. 10 e 11 (red. PN 2.027/2023) — distribuição e arredondamento das vagas reservadas; Lei 12.711/2012 (red. Lei 14.723/2023)"),
+
+        new(SeedId(16), "DISTRIB-VAGAS-INSTITUCIONAL", VersaoV1, TipoRegra.RegraDistribuicaoVagas,
+            """
+            {"quadro_fixo_por_modalidade":"objeto {codigo: quantidade} fixado por edital (NÃO art. 10)","aplicacao":"PSIQ (IND/QUIL) e PSE Ed. Campo — quadro institucional"}
+            """,
+            """
+            ["quadro fixo por edital (não recalculado pelo art. 10)","modalidades institucionais somam conforme composicao_vagas (SUPLEMENTAR_AO_TOTAL ou RETIRA_DE)"]
+            """,
+            "Res. Unifesspa 532/2021 (vagas PcD/Indígena/Quilombola); Portaria MEC 18/2012 art. 12 (reservas suplementares e outras ações afirmativas)"),
+
+        // regra_ajuste_distribuicao_vagas — reconciliação do estouro
+        new(SeedId(17), "RECONCILIACAO-VAGAS-ART11-PU", VersaoV1, TipoRegra.RegraAjusteDistribuicaoVagas,
+            """
+            {"reconciliacao_federal":"CAP_VO + PRIORIDADE_LB (art. 11 §único, embutida em DISTRIB-VAGAS-LEI-12711)","motores_nao_art10":"REDUZIR_DE | REDUZIR_PROPORCIONAL_EM (apenas distribuições institucionais; clamp >=0; VEDADOS à Lei 12.711)"}
+            """,
+            """
+            ["cap em VO: a reserva nunca excede as vagas da oferta (art. 11 §único I)","prioridade LB>LI: na escassez a LI cede primeiro (art. 11 §único II)","estouro sobre o nominal 50% (VR) e LEGAL — piso (art. 10 II), absorvido pela AC","curso pequeno e determinístico por lei (capa, não bloqueia)"]
+            """,
+            "Portaria MEC 18/2012 art. 11, parágrafo único (red. PN 2.027/2023) — cap nas vagas da oferta + prioridade do inciso III (LB) sobre o inciso IV (LI); art. 10 II (mínimo 50%, piso)"),
+
+        // regra_prazo_recurso — prazo/janela/instâncias do recurso
+        new(SeedId(18), "RECURSO-MULTI-INSTANCIA", VersaoV1, TipoRegra.RegraPrazoRecurso,
+            """
+            {"prazo_valor":"numeric","prazo_unidade":"HORAS|DIAS|DIAS_UTEIS (sem default — dado do edital)","contra_ato":"codigo da fase produtora recorrível (NUNCA resultado definitivo)","marco_inicial":"a partir de quando conta (ex.: publicacao_resultado)","instancias":"lista ordenada [{instancia,dono,prazo_valor,prazo_unidade}] — 1ª CEPS, 2ª CONSEPE"}
+            """,
+            """
+            ["interposição GATED pela janela aberta (sem recurso a qualquer momento)","sem recurso ao resultado definitivo (≠ recurso de habilitação CRCA)","2ª instância (CONSEPE) só após indeferimento da 1ª; CONSEPE emite parecer externo, CEPS anexa e aplica (vinculante)","processo PARALISA enquanto 2ª instância pendente; avanço só após expirar o prazo","append-only: parecer/retificação = novo fato, não sobrescreve o passado"]
+            """,
+            "Lei 9.784/1999 (processo administrativo federal); edital/processo (prazo configurável por edital); regimento CONSEPE (2ª instância)"),
+    ];
+}
+
+/// <summary>
+/// Definição serializável de uma regra do seed (fonte única), da qual o hash
+/// content-addressable é derivado pelo mesmo algoritmo do domínio.
+/// </summary>
+public sealed record RegraCatalogoSeedItem(
+    Guid Id,
+    string Codigo,
+    string Versao,
+    TipoRegra Tipo,
+    string EsquemaArgsJson,
+    string InvariantesJson,
+    string BaseLegal)
+{
+    /// <summary>Computa o hash canônico da definição (<see cref="HashCanonicalComputer.ComputeRegraCatalogo"/>).</summary>
+    public string ComputarHash() => HashCanonicalComputer.ComputeRegraCatalogo(
+        Codigo,
+        Versao,
+        Tipo,
+        ParseElemento(EsquemaArgsJson),
+        ParseElemento(InvariantesJson),
+        BaseLegal);
+
+    private static JsonElement ParseElemento(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
@@ -37,6 +37,16 @@ public sealed class SelecaoDbContext : DbContext, ISelecaoUnitOfWork
     public DbSet<OfertaAtendimentoEspecializado> OfertasAtendimentoEspecializado => Set<OfertaAtendimentoEspecializado>();
 
     /// <summary>
+    /// Biblioteca <c>rol_de_regras</c> (Story #772) — regras tipadas e
+    /// versionadas que a configuração do Processo Seletivo referencia
+    /// (<c>codigo</c>+<c>versao</c>+<c>hash</c>), congeladas no snapshot de
+    /// publicação (RN08). Seed-governada e append-only (não é CRUD de admin):
+    /// a leitura passa por <c>IRegraCatalogoReader</c> e a única escrita é o
+    /// seed da migration.
+    /// </summary>
+    public DbSet<RegraCatalogo> RolDeRegras => Set<RegraCatalogo>();
+
+    /// <summary>
     /// Catálogo data-driven de regras legais (Story #460, ADR-0058). O CRUD
     /// admin entra em #461; em V1 esta DbSet é populada via factory direta
     /// para testes e seeds.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Unifesspa.UniPlus.Selecao.Infrastructure.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Unifesspa.UniPlus.Selecao.Infrastructure.csproj
@@ -25,4 +25,10 @@
     <ProjectReference Include="..\Unifesspa.UniPlus.Selecao.Application\Unifesspa.UniPlus.Selecao.Application.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expõe internals (ex.: RegraCatalogoReader) aos testes de integração —
+         mesmo padrão de Configuracao/OrganizacaoInstitucional/Infrastructure.Core. -->
+    <InternalsVisibleTo Include="Unifesspa.UniPlus.Selecao.IntegrationTests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/RegraCatalogoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/RegraCatalogoTests.cs
@@ -1,0 +1,84 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura da factory de <see cref="RegraCatalogo"/>: validação da definição
+/// e hash content-addressable computado na criação.
+/// </summary>
+public sealed class RegraCatalogoTests
+{
+    private static JsonElement Json(string raw)
+    {
+        using JsonDocument document = JsonDocument.Parse(raw);
+        return document.RootElement.Clone();
+    }
+
+    private static Result<RegraCatalogo> CriarValida() => RegraCatalogo.Criar(
+        "BONUS-MULTIPLICATIVO", "v1", TipoRegra.RegraBonus,
+        Json("""{"fator":"numeric","teto":"numeric|null"}"""),
+        Json("""["nota_final × fator, após os pesos"]"""),
+        "RN05 + decisão PO");
+
+    [Fact(DisplayName = "Criar com definição válida computa hash content-addressable")]
+    public void Criar_Valida_ComputaHash()
+    {
+        Result<RegraCatalogo> resultado = CriarValida();
+
+        resultado.IsSuccess.Should().BeTrue();
+        RegraCatalogo regra = resultado.Value!;
+        HashCanonicalComputer.IsValidHashShape(regra.Hash).Should().BeTrue();
+        regra.RecomputeHash().Should().Be(regra.Hash, "recomputar a partir do estado deve bater com o hash gravado");
+        regra.Tipo.Should().Be(TipoRegra.RegraBonus);
+    }
+
+    [Theory(DisplayName = "Criar recusa código/versão/base legal vazios")]
+    [InlineData("", "v1", "base")]
+    [InlineData("  ", "v1", "base")]
+    [InlineData("R", "", "base")]
+    [InlineData("R", "v1", "")]
+    public void Criar_CamposObrigatoriosVazios_Falha(string codigo, string versao, string baseLegal)
+    {
+        Result<RegraCatalogo> resultado = RegraCatalogo.Criar(
+            codigo, versao, TipoRegra.RegraBonus, Json("{}"), Json("[]"), baseLegal);
+
+        resultado.IsFailure.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Criar recusa tipo Nenhuma (sentinela)")]
+    public void Criar_TipoNenhuma_Falha()
+    {
+        Result<RegraCatalogo> resultado = RegraCatalogo.Criar(
+            "R", "v1", TipoRegra.Nenhuma, Json("{}"), Json("[]"), "base");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("RegraCatalogo.TipoObrigatorio");
+    }
+
+    [Fact(DisplayName = "Criar recusa esquema_args que não é objeto JSON")]
+    public void Criar_EsquemaArgsNaoObjeto_Falha()
+    {
+        Result<RegraCatalogo> resultado = RegraCatalogo.Criar(
+            "R", "v1", TipoRegra.RegraBonus, Json("[]"), Json("[]"), "base");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("RegraCatalogo.EsquemaArgsInvalido");
+    }
+
+    [Fact(DisplayName = "Criar recusa invariantes que não é array JSON")]
+    public void Criar_InvariantesNaoArray_Falha()
+    {
+        Result<RegraCatalogo> resultado = RegraCatalogo.Criar(
+            "R", "v1", TipoRegra.RegraBonus, Json("{}"), Json("{}"), "base");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("RegraCatalogo.InvariantesInvalidas");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/HashCanonicalComputerRegraCatalogoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/HashCanonicalComputerRegraCatalogoTests.cs
@@ -1,0 +1,80 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.ValueObjects;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura do hash content-addressable do <c>rol_de_regras</c>
+/// (<see cref="HashCanonicalComputer.ComputeRegraCatalogo"/>): determinismo,
+/// independência da ordem das chaves do jsonb e sensibilidade a mudança de
+/// definição — as propriedades que sustentam a reprodutibilidade do freeze
+/// (RN08).
+/// </summary>
+public sealed class HashCanonicalComputerRegraCatalogoTests
+{
+    private static JsonElement Json(string raw)
+    {
+        using JsonDocument document = JsonDocument.Parse(raw);
+        return document.RootElement.Clone();
+    }
+
+    [Fact(DisplayName = "Hash é determinístico para a mesma definição")]
+    public void Hash_MesmaDefinicao_Deterministico()
+    {
+        string h1 = HashCanonicalComputer.ComputeRegraCatalogo(
+            "BONUS-MULTIPLICATIVO", "v1", TipoRegra.RegraBonus,
+            Json("""{"fator":"numeric","teto":"numeric|null"}"""),
+            Json("""["nota_final × fator, após os pesos"]"""),
+            "RN05");
+
+        string h2 = HashCanonicalComputer.ComputeRegraCatalogo(
+            "BONUS-MULTIPLICATIVO", "v1", TipoRegra.RegraBonus,
+            Json("""{"fator":"numeric","teto":"numeric|null"}"""),
+            Json("""["nota_final × fator, após os pesos"]"""),
+            "RN05");
+
+        h1.Should().Be(h2);
+        HashCanonicalComputer.IsValidHashShape(h1).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Hash independe da ordem das chaves do esquema_args (canonicalização)")]
+    public void Hash_OrdemDasChaves_NaoAltera()
+    {
+        string ordemA = HashCanonicalComputer.ComputeRegraCatalogo(
+            "R", "v1", TipoRegra.RegraBonus,
+            Json("""{"fator":"numeric","teto":"numeric|null"}"""),
+            Json("[]"),
+            "base");
+
+        string ordemB = HashCanonicalComputer.ComputeRegraCatalogo(
+            "R", "v1", TipoRegra.RegraBonus,
+            Json("""{"teto":"numeric|null","fator":"numeric"}"""),
+            Json("[]"),
+            "base");
+
+        ordemB.Should().Be(ordemA);
+    }
+
+    [Fact(DisplayName = "Hash muda quando qualquer campo definicional muda")]
+    public void Hash_MudancaDeDefinicao_MudaHash()
+    {
+        string baseHash = HashCanonicalComputer.ComputeRegraCatalogo(
+            "R", "v1", TipoRegra.RegraBonus, Json("""{"fator":"numeric"}"""), Json("[]"), "base-a");
+
+        HashCanonicalComputer.ComputeRegraCatalogo(
+            "R", "v2", TipoRegra.RegraBonus, Json("""{"fator":"numeric"}"""), Json("[]"), "base-a")
+            .Should().NotBe(baseHash, "mudar a versão muda o hash");
+
+        HashCanonicalComputer.ComputeRegraCatalogo(
+            "R", "v1", TipoRegra.RegraBonus, Json("""{"fator":"numeric"}"""), Json("[]"), "base-b")
+            .Should().NotBe(baseHash, "mudar a base legal muda o hash");
+
+        HashCanonicalComputer.ComputeRegraCatalogo(
+            "R", "v1", TipoRegra.RegraArredondamento, Json("""{"fator":"numeric"}"""), Json("[]"), "base-a")
+            .Should().NotBe(baseHash, "mudar o tipo muda o hash");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/RolDeRegras/RegraCatalogoDbFixture.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/RolDeRegras/RegraCatalogoDbFixture.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.RolDeRegras;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+using Testcontainers.PostgreSql;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Persistence.Interceptors;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// Fixture xUnit que provisiona um Postgres efêmero (Testcontainers) com o
+/// schema do <see cref="SelecaoDbContext"/> aplicado via <c>MigrateAsync</c> —
+/// inclui a migration <c>AddRolDeRegras</c> (Story #772) e o seed das 18
+/// regras <c>v1</c>, validando ponta-a-ponta contra Postgres real.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IAsyncLifetime + IClassFixture<T> exigem tipo público.")]
+[SuppressMessage(
+    "Reliability",
+    "CA1001:Types that own disposable fields should be disposable",
+    Justification = "Disposable resources released by IAsyncLifetime.DisposeAsync — xUnit invoca deterministicamente.")]
+public sealed class RegraCatalogoDbFixture : IAsyncLifetime
+{
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("postgres:18-alpine")
+        .WithDatabase("uniplus_rol_de_regras_tests")
+        .WithUsername("uniplus_test")
+        .WithPassword("uniplus_test")
+        .Build();
+
+    private string ConnectionString => _postgres.GetConnectionString();
+
+    public async Task InitializeAsync()
+    {
+        await _postgres.StartAsync().ConfigureAwait(false);
+
+        await using SelecaoDbContext context = CreateDbContext();
+        await context.Database.MigrateAsync().ConfigureAwait(false);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _postgres.DisposeAsync().ConfigureAwait(false);
+    }
+
+    public SelecaoDbContext CreateDbContext()
+    {
+        DbContextOptions<SelecaoDbContext> options = new DbContextOptionsBuilder<SelecaoDbContext>()
+            .UseNpgsql(ConnectionString)
+            .UseSnakeCaseNamingConvention()
+            .AddInterceptors(
+                new SoftDeleteInterceptor(TimeProvider.System, userContext: null),
+                new AuditableInterceptor(TimeProvider.System, userContext: null))
+            .Options;
+
+        return new SelecaoDbContext(options);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/RolDeRegras/RegraCatalogoSeedTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/RolDeRegras/RegraCatalogoSeedTests.cs
@@ -1,0 +1,148 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.RolDeRegras;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Readers;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Seed;
+
+/// <summary>
+/// Cobertura de integração (Postgres real via Testcontainers) da biblioteca
+/// <c>rol_de_regras</c> (Story #772): o seed das 18 regras <c>v1</c>, a
+/// content-addressability do hash sobrevivendo à normalização jsonb do
+/// Postgres, a coexistência de versões (<c>UNIQUE (codigo, versao)</c>) e o
+/// <see cref="RegraCatalogoReader"/>.
+/// </summary>
+public sealed class RegraCatalogoSeedTests : IClassFixture<RegraCatalogoDbFixture>
+{
+    private readonly RegraCatalogoDbFixture _fixture;
+
+    public RegraCatalogoSeedTests(RegraCatalogoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Seed materializa exatamente as 18 regras v1 do catálogo")]
+    public async Task Seed_MaterializaAsDezoitoRegras()
+    {
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+
+        List<RegraCatalogo> regras = await context.RolDeRegras
+            .AsNoTracking()
+            .ToListAsync(CancellationToken.None);
+
+        regras.Should().HaveCount(RegraCatalogoSeed.Itens.Count).And.HaveCount(18);
+        regras.Select(r => r.Codigo).Should().OnlyHaveUniqueItems();
+        regras.Should().OnlyContain(r => r.Versao == RegraCatalogoSeed.VersaoV1);
+        regras.Should().Contain(r => r.Codigo == "DISTRIB-VAGAS-LEI-12711" && r.Tipo == TipoRegra.RegraDistribuicaoVagas);
+        regras.Should().Contain(r => r.Codigo == "FORMULA-MEDIA-PONDERADA" && r.Tipo == TipoRegra.RegraCalculo);
+    }
+
+    [Fact(DisplayName = "Hash gravado é content-addressable: recomputar após round-trip jsonb bate")]
+    public async Task Seed_HashContentAddressable_RecomputeBate()
+    {
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+
+        List<RegraCatalogo> regras = await context.RolDeRegras
+            .AsNoTracking()
+            .ToListAsync(CancellationToken.None);
+
+        // A normalização jsonb do Postgres pode reordenar chaves/remover espaços;
+        // como o hash canoniza recursivamente, recomputar a partir do estado
+        // materializado deve reproduzir o hash gravado — content-addressability.
+        foreach (RegraCatalogo regra in regras)
+        {
+            regra.RecomputeHash().Should().Be(regra.Hash, $"a regra {regra.Codigo} deve ser content-addressable");
+        }
+
+        // E o hash gravado deve bater com o computado pela fonte única do seed.
+        foreach (RegraCatalogoSeedItem item in RegraCatalogoSeed.Itens)
+        {
+            RegraCatalogo persistida = regras.Single(r => r.Codigo == item.Codigo && r.Versao == item.Versao);
+            persistida.Hash.Should().Be(item.ComputarHash());
+        }
+    }
+
+    [Fact(DisplayName = "esquema_args/invariantes preservam o conteúdo semântico após o round-trip jsonb")]
+    public async Task Seed_PayloadJsonb_PreservaConteudo()
+    {
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+
+        RegraCatalogo bonus = await context.RolDeRegras
+            .AsNoTracking()
+            .SingleAsync(r => r.Codigo == "BONUS-MULTIPLICATIVO", CancellationToken.None);
+
+        bonus.EsquemaArgs.ValueKind.Should().Be(JsonValueKind.Object);
+        bonus.EsquemaArgs.GetProperty("fator").GetString().Should().Be("numeric");
+        bonus.Invariantes.ValueKind.Should().Be(JsonValueKind.Array);
+        bonus.Invariantes.GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [Fact(DisplayName = "v1 e v2 de um mesmo código coexistem (UNIQUE por codigo+versao)")]
+    public async Task Codigo_V1EV2_Coexistem()
+    {
+        // Este teste muta o banco compartilhado do fixture (insere uma v2). Para
+        // não vazar estado para as demais asserções de contagem do seed (que
+        // exigem exatamente as 18 v1), a v2 é removida ao final — a ordem de
+        // execução dentro da classe deixa de importar.
+        Guid v2Id;
+        await using (SelecaoDbContext writeContext = _fixture.CreateDbContext())
+        {
+            using JsonDocument esquema = JsonDocument.Parse("""{"fonte_pesos":["etapa"]}""");
+            using JsonDocument invariantes = JsonDocument.Parse("""["divisor = Σ(peso)"]""");
+
+            Result<RegraCatalogo> v2 = RegraCatalogo.Criar(
+                "FORMULA-MEDIA-PONDERADA", "v2", TipoRegra.RegraCalculo,
+                esquema.RootElement, invariantes.RootElement, "Revisão da fórmula (nova versão)");
+            v2.IsSuccess.Should().BeTrue();
+            v2Id = v2.Value!.Id;
+
+            writeContext.RolDeRegras.Add(v2.Value!);
+            await writeContext.SaveChangesAsync(CancellationToken.None);
+        }
+
+        try
+        {
+            await using SelecaoDbContext readContext = _fixture.CreateDbContext();
+            List<RegraCatalogo> versoes = await readContext.RolDeRegras
+                .AsNoTracking()
+                .Where(r => r.Codigo == "FORMULA-MEDIA-PONDERADA")
+                .OrderBy(r => r.Versao)
+                .ToListAsync(CancellationToken.None);
+
+            versoes.Select(r => r.Versao).Should().Equal("v1", "v2");
+        }
+        finally
+        {
+            await using SelecaoDbContext cleanupContext = _fixture.CreateDbContext();
+            await cleanupContext.RolDeRegras
+                .Where(r => r.Id == v2Id)
+                .ExecuteDeleteAsync(CancellationToken.None);
+        }
+    }
+
+    [Fact(DisplayName = "Reader resolve regra por (codigo, versao) e filtra por tipo")]
+    public async Task Reader_ObterEListar()
+    {
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+        RegraCatalogoReader reader = new(context);
+
+        RegraCatalogo? formula = await reader.ObterAsync("FORMULA-MEDIA-PONDERADA", "v1", CancellationToken.None);
+        formula.Should().NotBeNull();
+        formula!.Tipo.Should().Be(TipoRegra.RegraCalculo);
+
+        RegraCatalogo? inexistente = await reader.ObterAsync("FORMULA-MEDIA-PONDERADA", "v99", CancellationToken.None);
+        inexistente.Should().BeNull();
+
+        IReadOnlyList<RegraCatalogo> desempates = await reader.ListarPorTipoAsync(TipoRegra.CriterioDesempate, CancellationToken.None);
+        desempates.Should().HaveCount(4);
+        desempates.Should().OnlyContain(r => r.Tipo == TipoRegra.CriterioDesempate);
+    }
+}


### PR DESCRIPTION
## Contexto

Fatia **F1** da Story #758 (Configurar o Processo Seletivo): a biblioteca **`rol_de_regras`** — catálogo de regras **tipadas, versionadas e configuráveis** que as dimensões da configuração passam a referenciar por `(codigo, versao, hash)` em vez de guardar escalares crus, congelando-as no snapshot de publicação (RN08). É a **keystone** que destrava as fatias de vagas (F2), desempate/bônus (F3) e classificação (F4).

Ancorada na modelagem P-A (distribuição) / P-B (classificação) validada contra Postgres real — **com melhorias estruturais**, não transliteração do harness SQL.

## O que entra

- **`RegraCatalogo`** (`EntityBase`, tabela `rol_de_regras`): `codigo`, `versao`, `tipo` (`TipoRegra`, 11 tipos), `esquema_args`/`invariantes` (jsonb), `base_legal`, `hash`. **Seed-governada e append-only** — sem soft-delete e sem histórico forense; a imutabilidade por versão é a auditoria.
- **`UNIQUE (codigo, versao)` total** → habilita `v1`/`v2` coexistentes referenciáveis.
- **Hash content-addressable** da definição completa (`codigo+versao+tipo+esquema_args+invariantes+base_legal`) via `HashCanonicalComputer.ComputeRegraCatalogo`: **canonicaliza recursivamente** antes do SHA-256, então independe da ordem das chaves do jsonb — reprodutibilidade do freeze por construção (melhoria sobre o concat de texto cru do harness).
- **`ReferenciaRegra`** (VO): `(codigo, versao, hash)` que as dimensões embutem; os **args aplicados tipados** entram com cada dimensão em F2–F4.
- **`IRegraCatalogoReader`**: leitura direta `AsNoTracking`, sem cache (baixo volume + congelamento por valor no consumidor, ADR-0061).
- **Seed das 18 regras `v1`** (fórmula, arredondamento, eliminação, bônus, desempate, ordem de alocação, elegibilidade, distribuição de vagas, reconciliação, prazo de recurso) via fonte única `RegraCatalogoSeed`, materializado na migration com hash derivado da mesma lógica do domínio (sem drift).

## Fora de escopo (fiel ao modelo)

Os **motores/funções de validação** (algoritmo de distribuição floor-first, motor de classificação) são "Executar/incremento" — consomem a definição congelada, não entram aqui.

## Testes (validação local)

- **Domínio (88):** hash determinístico e independente da ordem de chaves; sensibilidade a mudança de definição; validação da factory.
- **Integração Postgres real (105):** seed materializa as 18 regras; content-addressability sobrevive à normalização jsonb do Postgres (recompute bate); coexistência `v1`/`v2`; reader resolve por `(codigo, versao)` e por tipo.
- **Selecao.ArchTests 6/6** (codes registrados no `IDomainErrorRegistration`, ADR-0024) · **Host.IntegrationTests 21/21** (DI + ServiceLocationGuard) · build 0 warnings · `restore --locked-mode` limpo.

Closes #772