### PR TITLE
docs(adr): promove decisões de publicação a ADR-0100/0101/0102

### DIFF
--- a/docs/adrs/0100-canonicalizacao-hash-snapshot-publicacao.md
+++ b/docs/adrs/0100-canonicalizacao-hash-snapshot-publicacao.md
@@ -1,0 +1,107 @@
+---
+status: "accepted"
+date: "2026-07-07"
+decision-makers:
+  - "Tech Lead"
+---
+
+# ADR-0100: Contrato de canonicalização e hash do snapshot de publicação (RN08)
+
+## Contexto e enunciado do problema
+
+RN08 exige que a publicação do `ProcessoSeletivo` (Story #759) congele a configuração de negócio num `SnapshotPublicacao` append-only, com um hash reproduzível: a mesma configuração deve produzir sempre o mesmo hash, em qualquer runtime, máquina ou momento — é a evidência que sustenta a integridade jurídica do resultado perante mandado de segurança ou processo administrativo. Sem contrato de canonicalização explícito, "mesma configuração" é ambíguo: strings com codificação Unicode equivalente mas bytes diferentes, decimais representados com precisão variável, instantes serializados com ou sem fração de segundo, ou apenas a ordem de serialização de um objeto já produzem hashes distintos para conteúdo logicamente idêntico.
+
+O módulo já tem um precedente direto: `HashCanonicalComputer` / `CanonicalOptions` (`src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/HashCanonicalComputer.cs`), usado pelo hash de `ObrigatoriedadeLegal` ([ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md)) e do `rol_de_regras`. Ele já resolve ordenação recursiva de chaves (`StringComparer.Ordinal`) e serialização byte-estável via `Utf8JsonWriter` sem indentação. Ele **não** resolve normalização Unicode, decimais com escala declarada e arredondamento determinístico, formato canônico de instante, nem a persistência dos bytes canônicos como artefato de primeira classe — hoje o hash é calculado sobre um payload em memória, nunca persistido como `bytea`.
+
+O snapshot de publicação tem escopo maior que `ObrigatoriedadeLegal`: cobre mais de dez blocos de configuração (período, etapas, vagas, modalidades, ofertas, atendimento, documentos exigidos, formulário, bônus regional, desempate, remanejamento, divulgação, classificação, cronograma de fases), vários dos quais ainda não têm implementação no momento em que esta Story é executada — chegam em Stories subsequentes da Feature #40. O contrato precisa, portanto, resolver a ambiguidade de codificação/formato e, ao mesmo tempo, não travar a publicação por causa de blocos que ainda não existem no sistema.
+
+## Drivers da decisão
+
+- **Reprodutibilidade jurídica (RN08).** O mesmo conteúdo de negócio produz sempre o mesmo hash, hoje e em qualquer runtime futuro — é evidência para revisão judicial e auditoria.
+- **Não introduzir um segundo mecanismo de canonicalização.** O módulo já tem um mecanismo testado (`HashCanonicalComputer`); duplicar lógica equivalente em paralelo divide a fonte de verdade do que conta como "mesma configuração".
+- **Consultabilidade administrativa.** Suporte e auditoria consultam o snapshot via SQL; exigir decodificação de bytes para toda consulta rotineira é inaceitável.
+- **Extensibilidade sem quebrar snapshots existentes.** Blocos que a Story corrente ainda não implementa não podem impedir a publicação, e a evolução futura do formato não pode reinterpretar retroativamente snapshots já emitidos.
+
+## Opções consideradas
+
+- **A.** Reaproveitar o `HashCanonicalComputer` como está hoje (ordenação de chaves + camelCase), sem estendê-lo.
+- **B.** Estender o contrato canônico do `HashCanonicalComputer` com normalização NFC, decimais com escala declarada e arredondamento half-even, instantes RFC 3339 sem fração de segundo, e persistir os bytes canônicos (`bytea`) como base do hash, com `jsonb` derivado por parsing.
+- **C.** Adotar um formato de canonicalização de terceiros (ex.: JCS — RFC 8785) em vez de estender o mecanismo existente.
+- **D.** Persistir apenas o `jsonb` da configuração congelada e recalcular o hash a partir dele no momento da consulta, sem persistir bytes canônicos.
+
+## Resultado da decisão
+
+**Escolhida:** "B — estender o `HashCanonicalComputer`", porque resolve as três ambiguidades identificadas (Unicode, decimal, instante) reaproveitando o mecanismo de ordenação e serialização já validado pelo ADR-0058, sem introduzir um segundo mecanismo paralelo de canonicalização no módulo.
+
+### Contrato canônico (payload → bytes → hash)
+
+1. **Normalização Unicode NFC.** Toda string de negócio (nomes, descrições, textos livres) é normalizada para a forma NFC antes de entrar no payload — sequências combinantes e formas pré-compostas do mesmo texto colapsam para os mesmos bytes.
+2. **Decimais com escala declarada e arredondamento half-even.** Cada campo decimal declara sua escala (número de casas decimais) no schema do bloco; o valor é arredondado por half-even para essa escala antes de entrar no payload, e serializado como string decimal de largura fixa — nunca como `number` JSON de ponto flutuante, que reintroduziria ambiguidade de representação entre runtimes.
+3. **Instantes em UTC, RFC 3339, sem fração de segundo.** Todo instante é convertido para UTC e serializado com sufixo `Z`, granularidade de segundo — sem frações que variem por precisão de relógio ou serializador.
+4. **Omissão de campos opcionais ausentes.** Um campo opcional sem valor é omitido do payload, nunca serializado como `null` explícito — mesma convenção já aplicada por `CanonicalOptions.DefaultIgnoreCondition = WhenWritingNull`.
+5. **Ordenação lexicográfica de chaves por unidades de código UTF-16, recursiva, sem espaço insignificante.** Mesma regra do `CanonicalizeRecursive` existente — este contrato formaliza o comportamento já produzido pelo `Utf8JsonWriter` sem indentação e por `StringComparer.Ordinal` (que já compara por unidade de código UTF-16 no .NET), em vez de alterá-lo.
+6. **Bytes canônicos como base do hash.** O resultado da serialização acima — os bytes, não uma representação intermediária — é persistido em `configuracao_congelada_canonica bytea`. `hash_configuracao = sha256(configuracao_congelada_canonica)`, hex minúsculo.
+7. **`jsonb` de consulta derivado por parsing.** A coluna `configuracao_congelada jsonb` é obtida fazendo parse dos bytes canônicos — nunca o inverso. O banco não re-serializa nem reordena chaves para produzir o `jsonb`; ele só converte bytes já canônicos para um formato consultável por SQL. Se uma versão futura do motor de banco reordenar ou renormalizar o `jsonb` internamente, o hash permanece correto porque foi calculado sobre os bytes persistidos, nunca sobre o `jsonb`.
+8. **Envelope versionado.** `schema_version` (versão do conjunto de blocos do snapshot) e `algoritmo_hash` (ex.: `canonical-json/sha256@v1`) acompanham o snapshot — permitem evoluir o formato ou o algoritmo de hash sem reinterpretar snapshots antigos, que preservam o algoritmo com que foram gerados.
+9. **Campos voláteis fora, identidades de negócio estáveis dentro.** Chaves surrogate de linha, campos de auditoria (`CreatedAt/By`, `UpdatedAt/By`), soft-delete e quaisquer valores puramente derivados ficam fora do payload. Identidades de negócio estáveis — códigos, identificadores de origem referenciados por outros módulos via referência cross-módulo por snapshot-copy ([ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md)) — entram: são o que dá sentido a "duas configurações iguais" ao comparar hashes.
+10. **Blocos de dimensões ainda não construídas.** Um bloco do snapshot cuja dimensão ainda não tem implementação na Story corrente entra no payload com o valor canônico `{"status": "nao_construido"}`. Isso satisfaz o invariante "todo bloco canônico está presente" sem bloquear a publicação por causa de trabalho futuro e sem inventar um valor de negócio fictício para uma dimensão que ainda não existe.
+
+### Relação com o `HashCanonicalComputer` existente
+
+Esta ADR **estende** `HashCanonicalComputer`/`CanonicalOptions`, não introduz um mecanismo paralelo. O computer atual já cobre os itens 5 e 6 (ordenação recursiva, serialização byte-estável via `Utf8JsonWriter`) — o alvo desta ADR acrescenta os itens 1–3 (NFC, decimais, instantes) e a persistência de bytes canônicos como artefato de primeira classe (itens 6–7), hoje ausente porque o hash de `ObrigatoriedadeLegal` nunca precisou ser persistido como `bytea` — ele é recalculado a partir da entidade viva. A implementação segue precedente de canonicalização de payload polimórfico já validado pelo [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md).
+
+## Consequências
+
+### Positivas
+
+- Hash estável entre representações Unicode equivalentes, precisões decimais e formatos de instante distintos — elimina a classe de falso-positivo mais comum em comparação de hash de texto administrativo em pt-BR.
+- Blocos de dimensão ainda não implementados não bloqueiam a publicação incremental da Feature #40.
+- `jsonb` permanece consultável por SQL sem decodificar bytes, mesmo com os bytes canônicos sendo a fonte de verdade do hash.
+- Reaproveita um mecanismo já testado e usado em produção pelo módulo, em vez de duplicar lógica de canonicalização.
+
+### Negativas
+
+- Normalização NFC e arredondamento half-even são passos novos no `HashCanonicalComputer` — superfície de teste adicional em relação ao mecanismo atual.
+- Decimais serializados como string (não `number`) no payload canônico podem exigir cast explícito em consultas SQL diretas sobre o `jsonb`.
+
+### Neutras
+
+- Um snapshot com bloco `{"status": "nao_construido"}` permanece assim para sempre — quando a dimensão for implementada, apenas snapshots futuros carregam o valor real; snapshots antigos não são recalculados retroativamente, coerente com o princípio de que o passado não é mutado.
+
+## Confirmação
+
+- Teste de unidade: a mesma configuração de negócio, serializada a partir de strings em NFD e em NFC, produz o mesmo `hash_configuracao`.
+- Teste de unidade: variar apenas a representação decimal além da escala declarada do campo (ex.: `10.50` vs. `10.5`) produz o mesmo hash quando o valor lógico é igual.
+- Teste de integração: o hash calculado pela aplicação no momento da publicação é igual ao `sha256` recalculado sobre os bytes lidos de volta de `configuracao_congelada_canonica`.
+- Teste de integração: um bloco de dimensão ainda não implementada serializa como `{"status": "nao_construido"}` e não impede a transição do processo para publicado.
+
+## Prós e contras das opções
+
+### A — reaproveitar o computer como está, sem estender
+
+- Bom, porque não exige nenhum trabalho novo.
+- Ruim, porque não resolve NFC, decimais nem instantes — configurações logicamente iguais podem produzir hashes diferentes; e não atende ao requisito de bytes canônicos persistidos.
+
+### B — estender o `HashCanonicalComputer` (escolhida)
+
+- Bom, porque resolve as três ambiguidades identificadas reaproveitando um mecanismo já testado.
+- Ruim, porque endurece o contrato do tipo estático existente, que passa a ter mais responsabilidades.
+
+### C — adotar formato de canonicalização de terceiros (JCS/RFC 8785)
+
+- Bom, porque é um padrão externo, documentado e interoperável.
+- Ruim, porque JCS não resolve decimais com escala declarada por campo nem instantes sem fração de segundo — precisaria ser complementado de qualquer forma; introduz uma dependência externa sem necessidade quando o precedente interno já validado resolve o essencial.
+
+### D — apenas `jsonb`, hash recalculado na consulta
+
+- Bom, porque evita persistir uma coluna `bytea` adicional.
+- Ruim, porque motores de banco podem reordenar ou renormalizar `jsonb` internamente entre versões — recalcular o hash a partir do `jsonb` quebra a garantia de reprodutibilidade que RN08 exige.
+
+## Mais informações
+
+- [ADR-0058](0058-obrigatoriedade-legal-validacao-data-driven.md) — precedente de hash canônico data-driven sobre payload polimórfico.
+- [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md) — referência cross-módulo por snapshot-copy, base da distinção entre identidade de negócio estável e chave surrogate.
+- [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md) — `snapshot_publicacao` segue o mesmo princípio append-only.
+- `src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/HashCanonicalComputer.cs` — mecanismo estendido por esta decisão.
+- Issue #759 (Story) §3 e §8 — decisão originalmente fechada na modelagem, promovida a ADR por esta issue #783 (Task T2).
+- Regra de negócio **RN08** (congelamento por snapshot).

--- a/docs/adrs/0101-retificacao-novo-edital-novo-snapshot-motivo.md
+++ b/docs/adrs/0101-retificacao-novo-edital-novo-snapshot-motivo.md
@@ -1,0 +1,93 @@
+---
+status: "accepted"
+date: "2026-07-07"
+decision-makers:
+  - "Tech Lead"
+---
+
+# ADR-0101: Retificação de processo publicado é sempre novo Edital + novo snapshot + motivo
+
+## Contexto e enunciado do problema
+
+RN08 congela a configuração de negócio do `ProcessoSeletivo` num `SnapshotPublicacao` imutável no momento da publicação ([ADR-0100](0100-canonicalizacao-hash-snapshot-publicacao.md)). Um certame, uma vez publicado, frequentemente precisa mudar — correção de prazo, ajuste de vaga, adequação a decisão administrativa superveniente. A pergunta é como essa mudança acontece sem violar o congelamento que RN08 exige: editar diretamente o conteúdo publicado apagaria a evidência do que valeu entre a publicação original e a mudança, quebrando a reprodução histórica que os [ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md)/[ADR-0076](0076-contrato-snapshot-runtime-espelha-publicacao.md) já garantem para o snapshot vigente em cada instante.
+
+A modelagem da Story #759 já fechou esta decisão sem promovê-la a ADR: mudança em processo publicado exige **retificação** — um novo Edital de natureza `retificacao`, vinculado ao Edital anterior, com motivo obrigatório, que congela um novo snapshot. Falta o registro formal que trava essa decisão e evita reabertura de discussão a cada nova Story que tocar o ciclo de vida do processo.
+
+## Drivers da decisão
+
+- **Reprodução histórica fiel.** O snapshot que governou um ato no passado não pode ser alterado por uma mudança posterior no certame — pré-requisito já estabelecido pelo [ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md).
+- **Motivação de ato administrativo.** Toda mudança em processo seletivo já publicado é, na prática institucional, um ato formal que exige justificativa registrada — não uma edição silenciosa.
+- **Contrato sem ambiguidade.** Campos que só fazem sentido em retificação (edital retificado, motivo) não podem aparecer, opcionalmente, também em Edital de abertura — a ambiguidade abriria espaço para dado inconsistente sem que nenhuma trava o impeça.
+- **Escopo por processo.** Uma retificação é sempre interna ao mesmo `ProcessoSeletivo` — retificar cruzando processos não tem sentido de negócio e indicaria erro de referência.
+
+## Opções consideradas
+
+- **A.** Retificação é sempre um novo Edital (natureza `retificacao`) + novo `SnapshotPublicacao` + motivo obrigatório, com constraint de contrato abertura×retificação e trava contra retificação cruzando processos.
+- **B.** Edição direta do Edital publicado é permitida, com o histórico de mudanças registrado numa tabela paralela de auditoria.
+- **C.** Retificação como atualização in-place do mesmo Edital, com uma coluna de versão incrementada a cada mudança.
+
+## Resultado da decisão
+
+**Escolhida:** "A — retificação como novo Edital + novo snapshot + motivo", porque é a única opção em que o snapshot anterior permanece intocado e a mudança fica auditável como um evento discreto e motivado, sem introduzir uma segunda forma de mutação de conteúdo congelado.
+
+### Forma do contrato
+
+- `NaturezaEdital` é um enum fechado: `{Abertura, Retificacao}`.
+- Um Edital de natureza `Retificacao` carrega `EditalRetificadoId` (referência obrigatória ao Edital imediatamente anterior na cadeia) e `MotivoRetificacao` (texto obrigatório, não vazio).
+- Um Edital de natureza `Abertura` **não** carrega `EditalRetificadoId` nem `MotivoRetificacao` — ambos ausentes.
+- **Constraint de contrato abertura×retificação:** abertura sem os dois campos é o único estado válido para essa natureza; retificação exige os dois campos preenchidos simultaneamente. É contrato de tudo-ou-nada por natureza, não uma combinação livre de opcionais.
+- **Retificação não cruza processos.** `EditalRetificadoId` deve referenciar um Edital do **mesmo** `ProcessoSeletivo` — o agregado-raiz (`ProcessoSeletivo`, com seu único repositório) valida essa pertença antes de persistir, porque é ele quem carrega a coleção completa de Editais do processo.
+- **O snapshot de retificação preserva todos os blocos canônicos** do contrato definido pelo [ADR-0100](0100-canonicalizacao-hash-snapshot-publicacao.md) — não é um diff sobre o snapshot anterior, é um snapshot completo e independente — e **acrescenta** um bloco de retificação (motivo + referência ao Edital retificado) ao envelope.
+- **O snapshot anterior permanece imutável.** A retificação nunca edita o `SnapshotPublicacao` já emitido — segue o mesmo princípio append-only que rege o restante das entidades forenses do módulo ([ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md)).
+- **A cadeia de Editais e snapshots é a trilha auditável.** Cada Edital de retificação aponta para o anterior; percorrer a cadeia a partir do Edital vigente reconstrói integralmente a história de mudanças do processo, cada nó imutável. O seletor de snapshot vigente ([ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md)) já resolve, para qualquer instante, qual nó da cadeia governa — esta ADR não redefine o seletor, apenas garante que a cadeia sempre tem a forma que ele espera.
+
+## Consequências
+
+### Positivas
+
+- Nenhuma mutação silenciosa de processo publicado — toda mudança deixa rastro com motivo.
+- A cadeia de Editais/snapshots reconstrói o histórico completo sem depender de tabela de auditoria paralela.
+- Consistente com o princípio append-only já aplicado a `snapshot_publicacao` e com o seletor de snapshot vigente por instante.
+
+### Negativas
+
+- Toda mudança pós-publicação, mesmo uma correção trivial de digitação num campo congelável, exige o fluxo completo de retificação — não há atalho para correções menores. Trade-off aceito porque RN08 não distingue "mudança trivial" de "mudança substantiva": qualquer alteração em bloco congelável é, por definição, uma retificação.
+
+### Neutras
+
+- Nenhuma.
+
+## Confirmação
+
+- Teste: um Edital de abertura persistido sem `EditalRetificadoId` e sem `MotivoRetificacao` é aceito.
+- Teste: um Edital de retificação sem `MotivoRetificacao` ou sem `EditalRetificadoId` é recusado com erro de domínio.
+- Teste: um Edital de abertura que tenta carregar `EditalRetificadoId` ou `MotivoRetificacao` é recusado com erro de domínio.
+- Teste: uma retificação cujo `EditalRetificadoId` aponta para um Edital de outro `ProcessoSeletivo` é recusada com erro de domínio.
+- Teste: o snapshot de uma retificação contém todos os blocos canônicos do snapshot anterior mais o bloco de retificação; o snapshot anterior permanece byte-a-byte idêntico após a retificação.
+
+## Prós e contras das opções
+
+### A — novo Edital + novo snapshot + motivo (escolhida)
+
+- Bom, porque o snapshot anterior nunca é tocado e a mudança é auditável como evento discreto e motivado.
+- Ruim, porque toda mudança, por menor que seja, passa pelo fluxo completo de retificação.
+
+### B — edição direta + tabela de auditoria paralela
+
+- Bom, porque evita criar um novo Edital para mudanças pequenas.
+- Ruim, porque o conteúdo "publicado" deixa de ser imutável por definição — a garantia de RN08 passaria a depender inteiramente da tabela de auditoria estar sempre sincronizada, um ponto de falha que o modelo append-only elimina por construção.
+
+### C — atualização in-place com coluna de versão
+
+- Bom, porque simplifica a leitura do estado "atual" (uma linha por Edital, não uma cadeia).
+- Ruim, porque a versão anterior deixa de existir como registro completo e auditável por si mesma — reconstituir o snapshot vigente de uma versão antiga exigiria lógica adicional de reversão, em vez de apenas ler um nó imutável da cadeia.
+
+## Mais informações
+
+- [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md) — princípio append-only que `snapshot_publicacao` também segue.
+- [ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md) — seletor de snapshot vigente, que resolve qual nó da cadeia governa cada instante.
+- [ADR-0076](0076-contrato-snapshot-runtime-espelha-publicacao.md) — o runtime lê o snapshot congelado; a retificação é o que faz esse snapshot evoluir de forma auditável.
+- [ADR-0100](0100-canonicalizacao-hash-snapshot-publicacao.md) — contrato de canonicalização e hash que o snapshot de retificação também segue.
+- [ADR-0046](0046-validacao-de-regras-sem-excecao-result-failure.md) — violação do contrato abertura×retificação é `Result.Failure(DomainError)`, sem exceção.
+- Issue #759 (Story) §3 e §6 — cenários BDD do contrato abertura×retificação, promovidos a ADR por esta issue #783 (Task T2).
+- Regra de negócio **RN08** (congelamento por snapshot).

--- a/docs/adrs/0102-invariantes-coerencia-processo-guard-rails-422.md
+++ b/docs/adrs/0102-invariantes-coerencia-processo-guard-rails-422.md
@@ -1,0 +1,100 @@
+---
+status: "accepted"
+date: "2026-07-07"
+decision-makers:
+  - "Tech Lead"
+---
+
+# ADR-0102: Invariantes de coerência de processo como guard rails no banco, mapeadas a HTTP 422
+
+## Contexto e enunciado do problema
+
+A publicação e a retificação do `ProcessoSeletivo` ([ADR-0100](0100-canonicalizacao-hash-snapshot-publicacao.md), [ADR-0101](0101-retificacao-novo-edital-novo-snapshot-motivo.md)) introduzem invariantes de coerência enforçadas por constraints e índices únicos parciais no banco — por exemplo, a unicidade de `data_publicacao` entre Editais vivos publicados do mesmo processo (que dá ao seletor de snapshot vigente do [ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md) a garantia de que nunca há empate), a constraint de contrato abertura×retificação, e a trava contra mutação direta de conteúdo congelável após a publicação. Quando uma dessas travas dispara, a violação não pode surfar como um erro genérico de infraestrutura (HTTP 500) — é uma regra de negócio sendo enforçada, ainda que o ponto físico de detecção seja o banco, não uma checagem em memória antes do save.
+
+O módulo já tem uma convenção estabelecida: toda violação de regra de negócio é `DomainError`, mapeada por um par (chave `Contexto.CausaPascalCase`, `DomainErrorMapping(status, wire code, título)`) registrado em `SelecaoDomainErrorRegistration`, seguindo o mecanismo cross-module `IDomainErrorMapper`/`DomainErrorMapping` já decidido pelo [ADR-0024](0024-mapeamento-domain-error-http.md). Falta formalizar que essa mesma convenção — e o mesmo status HTTP — vale quando o ponto de detecção da violação é uma constraint de banco, e não deixar essa decisão implícita a cada nova trava que o ciclo de publicação introduzir.
+
+## Drivers da decisão
+
+- **Consistência com o mecanismo já decidido.** O [ADR-0024](0024-mapeamento-domain-error-http.md) já estabeleceu que todo `DomainError` ganha um `DomainErrorMapping` registrado — não se justifica uma segunda convenção para erros cuja origem física é uma constraint de banco.
+- **Nunca vazar exceção de infraestrutura como 500 quando a causa é regra de negócio.** Uma `DbUpdateException`/exceção de violação de constraint que representa uma regra de negócio esperada não é uma falha de infraestrutura.
+- **Previsibilidade do catálogo de erros.** O módulo Seleção já usa 422 como status dominante para violação de regra de negócio — a quase totalidade dos mapeamentos existentes em `SelecaoDomainErrorRegistration` usa `Status422UnprocessableEntity`. Introduzir 409 ou outro status para este subconjunto quebraria essa previsibilidade sem ganho correspondente.
+- **Nome canônico único e estável por causa.** Cada violação tem uma única chave e um único wire code — nunca variações do mesmo erro sob nomes distintos.
+
+## Opções consideradas
+
+- **A.** Capturar a exceção de violação de constraint no boundary de persistência (repository/Unit of Work), traduzi-la para um `DomainError` nomeado e mapeá-la via `DomainErrorMapping` registrado em `SelecaoDomainErrorRegistration` com status 422 — mesma convenção usada pelo resto do módulo.
+- **B.** Deixar a exceção de banco propagar e tratá-la genericamente no middleware de exceção como 500, com log estruturado da causa.
+- **C.** Duplicar cada invariante como validação em memória no domínio antes do save, tratando a constraint de banco apenas como defesa em profundidade silenciosa, sem mapeamento a `DomainError`.
+- **D.** Mapear violação de constraint para HTTP 409 Conflict, em vez de 422.
+
+## Resultado da decisão
+
+**Escolhida:** "A — traduzir a violação no boundary para `DomainError` nomeado, mapeado a 422 registrado em `SelecaoDomainErrorRegistration`", porque é a única opção consistente com o mecanismo cross-module do ADR-0024 e com o status dominante já em uso no módulo, sem introduzir uma segunda convenção de tratamento de erro.
+
+Esta decisão **não substitui** validação em memória no domínio antes do save (Opção C) — as duas são complementares: o domínio valida em memória tudo que puder antes de persistir; a constraint de banco é a última linha de defesa contra um gap de validação ou uma condição de corrida não coberta em memória. O que esta ADR decide é o que acontece quando a constraint dispara — seja porque a validação em memória tinha uma lacuna, seja por concorrência —, e a resposta é sempre a mesma: `DomainError` nomeado, nunca 500.
+
+### Forma do contrato
+
+- Toda violação de guard rail de banco relevante ao ciclo de publicação — unicidade de `data_publicacao` entre Editais vivos publicados do processo, constraint de contrato abertura×retificação, trava de mutação de conteúdo congelável pós-publicação — é traduzida, no boundary de persistência (repository/Unit of Work, [ADR-0042](0042-application-nao-depende-diretamente-de-dbcontext.md)), de exceção de infraestrutura para `Result.Failure(DomainError)` nomeado.
+- Todo `DomainError` segue o par já estabelecido: chave `Contexto.CausaPascalCase` (ex.: `Snapshot.VigenteAusente`) + `DomainErrorMapping(status, wire code, título)` registrado em `SelecaoDomainErrorRegistration` — mesmo arquivo e mesmo mecanismo já usado pelos demais mapeamentos do módulo.
+- **Status: 422 Unprocessable Entity** para toda esta categoria — não 409, não 500. É o status já dominante do módulo para "requisição bem formada que viola uma regra de negócio".
+- **Wire code:** `uniplus.selecao.<contexto_snake_case>.<causa_snake_case>` — mesma taxonomia usada por todo o catálogo do módulo.
+- **Resposta:** ProblemDetails RFC 9457, conforme já decidido pelo [ADR-0023](0023-wire-formato-erro-rfc-9457.md) — esta ADR não redecide o wire format; decide apenas a origem física do erro (constraint de banco) e seu destino (422 nomeado e registrado).
+
+### Caso concreto de referência
+
+`Snapshot.VigenteAusente` · wire code `uniplus.selecao.snapshot.vigente_ausente` · título "Nenhuma publicação vigente para o instante" · status **422**. É o erro do seletor de snapshot vigente ([ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md)) quando não há Edital vivo publicado com `data_publicacao` ≤ o instante consultado — nome canônico único, sem variações, distinto do erro de conformidade de edital ainda não publicado. Este caso ainda não está implementado no momento em que esta ADR é escrita; é o alvo de referência que a Task T6 da Story #759 vai consumir.
+
+## Consequências
+
+### Positivas
+
+- Nenhuma violação de invariante de coerência de processo surfa como 500 genérico.
+- O catálogo de erros do módulo permanece a fonte única e auditável, sem uma segunda convenção para erros originados no banco.
+- Consistente com o padrão já observável em ~90 mapeamentos existentes em `SelecaoDomainErrorRegistration`.
+
+### Negativas
+
+- Cada constraint nova exige uma tradução explícita no boundary de persistência — a constraint de banco não carrega, por si, o wire code ou o título; alguém precisa escrever esse mapeamento a cada invariante nova.
+
+### Neutras
+
+- A tradução no boundary depende de reconhecer a constraint física (nome do índice/constraint) que disparou — acoplamento local ao schema, aceitável porque o boundary de persistência já é a camada que conhece esse schema ([ADR-0042](0042-application-nao-depende-diretamente-de-dbcontext.md)).
+
+## Confirmação
+
+- Teste de integração: inserir dois Editais vivos publicados com a mesma `data_publicacao` no mesmo processo retorna 422 nomeado, nunca 500.
+- Teste de integração: tentar mutação direta de conteúdo congelável de um processo publicado retorna 422 nomeado.
+- Teste de unidade: o seletor de snapshot vigente sem publicação retorna exatamente `Snapshot.VigenteAusente`.
+- Fitness test de cobertura do registry ([ADR-0024](0024-mapeamento-domain-error-http.md)): todo `DomainError` novo introduzido pelo ciclo de publicação está registrado em `SelecaoDomainErrorRegistration`.
+
+## Prós e contras das opções
+
+### A — tradução no boundary para `DomainError` 422 registrado (escolhida)
+
+- Bom, porque reaproveita o mecanismo cross-module já decidido e mantém o catálogo de erros como fonte única.
+- Ruim, porque exige escrever a tradução explícita para cada constraint nova.
+
+### B — deixar propagar como 500 genérico
+
+- Bom, porque não exige nenhum código de tradução.
+- Ruim, porque expõe uma regra de negócio esperada como falha de infraestrutura — o cliente não recebe um erro acionável, e o catálogo público de erros fica incompleto.
+
+### C — validação em memória apenas, sem mapear a constraint
+
+- Bom, porque cobre o caso comum sem depender do banco.
+- Ruim, porque não cobre o gap de concorrência — a constraint dispara sem tradução e o resultado é 500, exatamente o cenário que este ADR decide evitar.
+
+### D — mapear a 409 Conflict
+
+- Bom, porque 409 é a semântica HTTP genérica para conflito de estado.
+- Ruim, porque introduziria uma segunda semântica de status para o mesmo tipo de falha de regra de negócio já tratado como 422 no restante do módulo, sem ganho correspondente.
+
+## Mais informações
+
+- [ADR-0024](0024-mapeamento-domain-error-http.md) — mecanismo cross-module `IDomainErrorMapper`/`DomainErrorMapping` que este ADR reaplica à origem "constraint de banco".
+- [ADR-0023](0023-wire-formato-erro-rfc-9457.md) — wire format RFC 9457, não redecidido aqui.
+- [ADR-0042](0042-application-nao-depende-diretamente-de-dbcontext.md) — boundary de persistência (repository/Unit of Work) onde a tradução acontece.
+- [ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md) — caso concreto de referência `Snapshot.VigenteAusente`.
+- `src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs` — registry onde os novos mapeamentos entram.
+- Issue #759 (Story) §3 e §8 — decisão originalmente fechada na modelagem, promovida a ADR por esta issue #783 (Task T2).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -128,12 +128,15 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0097](0097-topologia-de-deploy-em-tres-apis-monolito-modular.md) | Topologia de deploy em 3 APIs — módulos internos como libraries co-hospedadas | accepted | 2026-06-26 |
 | [0098](0098-politica-de-service-location-do-codegen-wolverine.md) | Política de service location do codegen Wolverine (`NotAllowed` + allow-list por tipo) | accepted | 2026-06-26 |
 | [0099](0099-geo-como-repositorio-dedicado.md) | Geo como repositório e serviço transversal dedicado | accepted | 2026-06-26 |
+| [0100](0100-canonicalizacao-hash-snapshot-publicacao.md) | Contrato de canonicalização e hash do snapshot de publicação (RN08) | accepted | 2026-07-07 |
+| [0101](0101-retificacao-novo-edital-novo-snapshot-motivo.md) | Retificação de processo publicado é sempre novo Edital + novo snapshot + motivo | accepted | 2026-07-07 |
+| [0102](0102-invariantes-coerencia-processo-guard-rails-422.md) | Invariantes de coerência de processo como guard rails no banco, mapeadas a HTTP 422 | accepted | 2026-07-07 |
 
-> **Nota de numeração:** a `0077` (identidade de `Unidade`) foi **publicada** — a sequência de `0001` a `0099` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0100+`.
+> **Nota de numeração:** a sequência de `0001` a `0102` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0103+`.
 
 ## Como adicionar um novo ADR
 
-1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0099`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
+1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0102`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
 2. Copie [`_template.md`](_template.md).
 3. Renomeie para `NNNN-titulo-em-slug.md` (slug ASCII em minúsculas, hífens como separador).
 4. Preencha frontmatter, contexto, drivers, opções, resultado da decisão (única), consequências.


### PR DESCRIPTION
## Resumo

Promove a ADR as três decisões da modelagem de publicação do `ProcessoSeletivo` (Story #759 §8) que hoje só existem no corpo da issue, sem ADR oficial. Task só de documentação — nenhum código de produção — mas destrava o desenho da T4 (#785, snapshot).

- **ADR-0100** — contrato de canonicalização e hash do `SnapshotPublicacao` (RN08): normalização NFC, decimais com escala declarada + arredondamento half-even, instantes UTC RFC 3339 sem fração de segundo, bytes canônicos persistidos (`bytea`) como base do hash, `jsonb` derivado por parsing. Estende o `HashCanonicalComputer`/`CanonicalOptions` existente (`src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/HashCanonicalComputer.cs`), citando o precedente do ADR-0058.
- **ADR-0101** — retificação de processo publicado é sempre novo Edital (natureza `retificacao`) + novo snapshot + motivo obrigatório, com constraint de contrato abertura×retificação e trava contra retificação cruzando processos.
- **ADR-0102** — invariantes de coerência de processo (constraints/índices únicos parciais no banco) mapeadas a `DomainError` → HTTP 422 via `SelecaoDomainErrorRegistration`, nunca 500 — mesma convenção do ADR-0024, aplicada à origem "constraint de banco". Cita `Snapshot.VigenteAusente` como caso concreto de referência para a T6.

Índice `docs/adrs/README.md` atualizado (0001–0102 sem lacunas; próximo número livre 0103+).

Closes `#783`

## Test plan

- [x] `bash tools/adr-lint/validate.sh` — 102 ADRs validados sem erros
- [x] `npx markdownlint-cli2 'docs/adrs/**/*.md'` — 0 erros