### PR TITLE
feat(selecao): upload direto do documento do edital via URL pre-assinada

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -162,6 +162,171 @@
         }
       }
     },
+    "/api/selecao/processos-seletivos/{processoSeletivoId}/documentos-edital": {
+      "post": {
+        "tags": [
+          "DocumentosEdital"
+        ],
+        "parameters": [
+          {
+            "name": "processoSeletivoId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/IniciarUploadDocumentoEditalDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IniciarUploadDocumentoEditalDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IniciarUploadDocumentoEditalDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/selecao/processos-seletivos/{processoSeletivoId}/documentos-edital/{documentoEditalId}/confirmacao": {
+      "post": {
+        "tags": [
+          "DocumentosEdital"
+        ],
+        "parameters": [
+          {
+            "name": "processoSeletivoId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "documentoEditalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentoEditalDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentoEditalDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentoEditalDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
     "/api/selecao/obrigatoriedades-legais": {
       "get": {
         "tags": [
@@ -2245,6 +2410,45 @@
           }
         }
       },
+      "DocumentoEditalDto": {
+        "required": [
+          "id",
+          "processoSeletivoId",
+          "status",
+          "tamanhoBytes",
+          "hashSha256",
+          "confirmadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "processoSeletivoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "tamanhoBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int64"
+          },
+          "hashSha256": {
+            "type": "string"
+          },
+          "confirmadoEm": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
       "EtapaProcessoDto": {
         "required": [
           "id",
@@ -2350,6 +2554,28 @@
       "IFormFile": {
         "type": "string",
         "format": "binary"
+      },
+      "IniciarUploadDocumentoEditalDto": {
+        "required": [
+          "documentoEditalId",
+          "urlUpload",
+          "expiraEm"
+        ],
+        "type": "object",
+        "properties": {
+          "documentoEditalId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "urlUpload": {
+            "type": "string",
+            "format": "uri"
+          },
+          "expiraEm": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
       },
       "ItemConformidadeDto": {
         "required": [
@@ -3206,6 +3432,9 @@
     },
     {
       "name": "_smoke"
+    },
+    {
+      "name": "DocumentosEdital"
     },
     {
       "name": "ObrigatoriedadeLegal"

--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -2559,6 +2559,7 @@
         "required": [
           "documentoEditalId",
           "urlUpload",
+          "contentTypeExigido",
           "expiraEm"
         ],
         "type": "object",
@@ -2570,6 +2571,9 @@
           "urlUpload": {
             "type": "string",
             "format": "uri"
+          },
+          "contentTypeExigido": {
+            "type": "string"
           },
           "expiraEm": {
             "type": "string",

--- a/docker/docker-compose.override.example.yml
+++ b/docker/docker-compose.override.example.yml
@@ -60,6 +60,11 @@ services:
       Storage__Endpoint: "minio:9000"
       Storage__AccessKey: "${MINIO_ROOT_USER}"
       Storage__SecretKey: "${MINIO_ROOT_PASSWORD}"
+      # URLs pre-assinadas devolvidas a clientes externos (browser, Postman)
+      # precisam de um endpoint alcançável de fora da rede Docker — minio:9000
+      # só resolve dentro dela. Porta 9000 já é publicada no host (ver serviço
+      # minio), então localhost funciona para quem roda o frontend fora do Docker.
+      Storage__PublicEndpoint: "localhost:9000"
       # Realm `unifesspa` — o mesmo em que os frontends `*-web` autenticam. Para smoke
       # via password grant, o override docker-compose.smoke.yml realinha para dev-local.
       Auth__Authority: "http://keycloak:8080/realms/unifesspa"

--- a/infra/helm/uniplus/values.yaml
+++ b/infra/helm/uniplus/values.yaml
@@ -41,9 +41,15 @@ secrets:
   ingressoDbConnection: ""       # ConnectionStrings__IngressoDb
   redisConnection: ""            # Redis__ConnectionString
   kafkaBootstrapServers: ""      # Kafka__BootstrapServers
-  storageEndpoint: ""            # Storage__Endpoint
+  storageEndpoint: ""            # Storage__Endpoint (cluster-local, ex.: minio.uniplus.svc.cluster.local:9000)
   storageAccessKey: ""           # Storage__AccessKey
   storageSecretKey: ""           # Storage__SecretKey
+  # Endpoint alcançável de fora do cluster (browser), usado só para assinar
+  # URLs pre-assinadas devolvidas a clientes externos (upload/download direto
+  # — ver Story #759 T3). Sem preencher, a API cai para storageEndpoint e as
+  # URLs devolvidas ao cliente ficam com um host só o pod resolve.
+  storagePublicEndpoint: ""      # Storage__PublicEndpoint
+  storagePublicUseSsl: ""        # Storage__PublicUseSSL ("true"/"false" — opcional, cai para o mesmo de Storage__UseSSL)
   authAuthority: ""              # Auth__Authority
   # Criptografia de PII (LGPD): AddUniPlusEncryption valida no startup
   # (ValidateOnStart) — SEM estas chaves o host crasha no boot antes de servir.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/DocumentosEditalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/DocumentosEditalController.cs
@@ -1,0 +1,80 @@
+namespace Unifesspa.UniPlus.Selecao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Kernel.Results;
+using Application.Commands.DocumentosEdital;
+using Application.DTOs;
+
+/// <summary>
+/// Upload direto do documento (PDF) do Edital via URL pre-assinada do MinIO
+/// (Story #759, T3 #784) — o arquivo nunca trafega pela API. Fluxo em 3
+/// passos: iniciar (aqui) → PUT direto ao MinIO (fora da API) → confirmar
+/// (aqui). O <c>hash_edital</c> do snapshot de publicação (T4 #785) é lido do
+/// registro confirmado.
+/// </summary>
+[ApiController]
+[Route("api/selecao/processos-seletivos/{processoSeletivoId:guid}/documentos-edital")]
+// Mesma justificativa de ProcessoSeletivoController: fluxo administrativo de
+// publicação, sem fallback policy — restrito a plataforma-admin.
+[Authorize(Roles = "plataforma-admin")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public; sem isso o MVC ignora a classe e nenhum endpoint é registrado.")]
+public sealed class DocumentosEditalController : ControllerBase
+{
+    private readonly ICommandBus _commandBus;
+    private readonly IDomainErrorMapper _mapper;
+
+    public DocumentosEditalController(ICommandBus commandBus, IDomainErrorMapper mapper)
+    {
+        _commandBus = commandBus;
+        _mapper = mapper;
+    }
+
+    /// <summary>
+    /// Passo 1: cria o registro pendente vinculado ao processo e devolve a
+    /// URL pre-assinada de PUT (TTL curto) + o id do documento.
+    /// </summary>
+    [HttpPost]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(IniciarUploadDocumentoEditalDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> IniciarUpload(Guid processoSeletivoId, CancellationToken cancellationToken)
+    {
+        Result<IniciarUploadDocumentoEditalDto> resultado = await _commandBus.Send(
+            new IniciarUploadDocumentoEditalCommand(processoSeletivoId), cancellationToken);
+        if (resultado.IsSuccess)
+            return StatusCode(StatusCodes.Status201Created, resultado.Value);
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Passo 3: lê o objeto do MinIO, valida content-type/tamanho/assinatura
+    /// de arquivo, calcula o sha256 server-side e finaliza o documento como
+    /// imutável.
+    /// </summary>
+    [HttpPost("{documentoEditalId:guid}/confirmacao")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(DocumentoEditalDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> ConfirmarUpload(
+        Guid processoSeletivoId, Guid documentoEditalId, CancellationToken cancellationToken)
+    {
+        Result<DocumentoEditalDto> resultado = await _commandBus.Send(
+            new ConfirmarUploadDocumentoEditalCommand(processoSeletivoId, documentoEditalId), cancellationToken);
+        if (resultado.IsSuccess)
+            return Ok(resultado.Value);
+        return resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/DocumentosEditalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/DocumentosEditalController.cs
@@ -44,7 +44,10 @@ public sealed class DocumentosEditalController : ControllerBase
     /// URL pre-assinada de PUT (TTL curto) + o id do documento.
     /// </summary>
     [HttpPost]
-    [RequiresIdempotencyKey]
+    // TTL alinhado ao da URL pre-assinada devolvida (não ao teto default de
+    // 24h, ADR-0027) — sem isso, um replay depois da URL expirar devolveria
+    // uma URL inutilizável ao cliente. Ver XML doc de TtlUploadSegundos.
+    [RequiresIdempotencyKey(TtlSeconds = IniciarUploadDocumentoEditalCommandHandler.TtlUploadSegundos)]
     [ProducesResponseType(typeof(IniciarUploadDocumentoEditalDto), StatusCodes.Status201Created)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -132,6 +132,16 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("RegraEliminacao.MinimoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_eliminacao.minimo_obrigatorio", "Minimo é obrigatório para a regra ELIM-CORTE-REDACAO")),
         new("ProcessoSeletivo.EtapaRefEliminacaoInexistente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.etapa_ref_eliminacao_inexistente", "A regra de eliminação referencia uma etapa que não existe neste processo")),
         new("ProcessoSeletivo.EliminacaoEnemForaDeProcessoEnem", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.eliminacao_enem_fora_de_processo_enem", "A regra de eliminação só se aplica a processo baseado em ENEM (SiSU/PSVR)")),
+        // Documento do Edital — upload direto via URL pre-assinada (Story #759, T3
+        // #784). ObjetoNaoEncontrado/TamanhoExcedido/ContentTypeInvalido/AssinaturaInvalida
+        // são recusas de validação da confirmação (422); NaoEncontrado é 404
+        // (registro inexistente ou de outro processo).
+        new("DocumentoEdital.NaoEncontrado", new DomainErrorMapping(StatusCodes.Status404NotFound, "uniplus.selecao.documento_edital.nao_encontrado", "Documento do Edital não encontrado")),
+        new("DocumentoEdital.StatusInvalidoParaConfirmacao", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_edital.status_invalido_para_confirmacao", "Somente um documento pendente pode ser confirmado")),
+        new("DocumentoEdital.ObjetoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_edital.objeto_nao_encontrado", "Objeto ainda não enviado ao storage ou expirado")),
+        new("DocumentoEdital.TamanhoExcedido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_edital.tamanho_excedido", "Documento excede o tamanho máximo permitido")),
+        new("DocumentoEdital.ContentTypeInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_edital.content_type_invalido", "Documento do Edital deve ser do tipo application/pdf")),
+        new("DocumentoEdital.AssinaturaInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_edital.assinatura_invalida", "Conteúdo do arquivo não corresponde a um PDF válido")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/IDocumentoEditalStorage.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/IDocumentoEditalStorage.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Abstractions;
+
+/// <summary>
+/// Port de storage de objeto para o documento do Edital (Story #759, T3
+/// #784). Não expõe conceitos de vendor (bucket, cliente MinIO) — só
+/// operações por <c>objectKey</c>, resolvido pela implementação em
+/// <c>Selecao.Infrastructure</c> (que é quem conhece o bucket via
+/// <c>StorageOptions</c> e envolve o <c>IStorageService</c> compartilhado de
+/// <c>Infrastructure.Core</c>). Application não referencia
+/// <c>Infrastructure.Core</c> diretamente (ADR-0042 — Application depende
+/// só de Domain/SharedKernel; a fitness test R3 do módulo protege a
+/// direção de dependência).
+/// </summary>
+public interface IDocumentoEditalStorage
+{
+    /// <summary>Gera a URL pre-assinada de PUT para upload direto do cliente.</summary>
+    Task<string> GerarUrlUploadAsync(string objectKey, TimeSpan expiracao, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Metadados do objeto (tamanho + content-type) sem baixar o conteúdo.
+    /// Retorna <see langword="null"/> quando o objeto ainda não foi enviado.
+    /// </summary>
+    Task<InfoObjetoArmazenado?> ObterInfoAsync(string objectKey, CancellationToken cancellationToken = default);
+
+    /// <summary>Abre o conteúdo do objeto para leitura (hash + validação de assinatura).</summary>
+    Task<Stream> AbrirLeituraAsync(string objectKey, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Metadados de um objeto de storage, sem o conteúdo.</summary>
+public sealed record InfoObjetoArmazenado(long TamanhoBytes, string ContentType);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/IDocumentoEditalStorage.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/IDocumentoEditalStorage.cs
@@ -22,8 +22,13 @@ public interface IDocumentoEditalStorage
     /// </summary>
     Task<InfoObjetoArmazenado?> ObterInfoAsync(string objectKey, CancellationToken cancellationToken = default);
 
-    /// <summary>Abre o conteúdo do objeto para leitura (hash + validação de assinatura).</summary>
-    Task<Stream> AbrirLeituraAsync(string objectKey, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Abre o conteúdo do objeto para leitura (hash + validação de assinatura),
+    /// nunca lendo mais que <paramref name="limiteBytes"/> — o limite é
+    /// imposto pelo storage (Range request), não depois de já ter
+    /// bufferizado o objeto inteiro em memória.
+    /// </summary>
+    Task<Stream> AbrirLeituraAsync(string objectKey, long limiteBytes, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Grava o conteúdo já validado numa chave que nunca foi (nem será) alvo

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/IDocumentoEditalStorage.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/IDocumentoEditalStorage.cs
@@ -24,6 +24,14 @@ public interface IDocumentoEditalStorage
 
     /// <summary>Abre o conteúdo do objeto para leitura (hash + validação de assinatura).</summary>
     Task<Stream> AbrirLeituraAsync(string objectKey, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Grava o conteúdo já validado numa chave que nunca foi (nem será) alvo
+    /// de uma URL pre-assinada de PUT — a cópia que torna o documento
+    /// confirmado imutável de fato, mesmo que a URL de upload original ainda
+    /// não tenha expirado (ver <see cref="Unifesspa.UniPlus.Selecao.Domain.Entities.DocumentoEdital.ObjectKeyConfirmado"/>).
+    /// </summary>
+    Task SalvarConteudoSeladoAsync(string objectKey, byte[] conteudo, CancellationToken cancellationToken = default);
 }
 
 /// <summary>Metadados de um objeto de storage, sem o conteúdo.</summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommand.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.DocumentosEdital;
+
+using DTOs;
+using Kernel.Results;
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+
+/// <summary>
+/// Passo 3 do fluxo de upload direto do documento do Edital (Story #759, T3
+/// #784): lê o objeto do MinIO, valida content-type/tamanho/assinatura,
+/// calcula o sha256 server-side e finaliza o registro como imutável.
+/// </summary>
+public sealed record ConfirmarUploadDocumentoEditalCommand(
+    Guid ProcessoSeletivoId,
+    Guid DocumentoEditalId) : ICommand<Result<DocumentoEditalDto>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
@@ -46,9 +46,13 @@ public static class ConfirmarUploadDocumentoEditalCommandHandler
                 "O objeto ainda não foi enviado ao storage ou expirou antes da confirmação."));
         }
 
-        // Corta aqui, antes de baixar: o stat (HEAD) não traz o conteúdo, então
-        // barrar pelo tamanho reportado evita carregar um objeto arbitrariamente
-        // grande inteiro em memória só para descobrir que ele será recusado.
+        // Atalho: o stat (HEAD) não traz o conteúdo, então barrar cedo pelo
+        // tamanho já reportado evita abrir o stream no caso comum de um
+        // envio já obviamente grande demais. Não é a proteção definitiva —
+        // ObjectKey segue sobrescrevível até o TTL expirar (ver
+        // ObjectKeyConfirmado), então o tamanho pode mudar entre este stat e
+        // a leitura abaixo; quem garante o limite de fato é a leitura
+        // limitada, não este atalho.
         if (info.TamanhoBytes > DocumentoEdital.TamanhoMaximoBytes)
         {
             return Result<DocumentoEditalDto>.Failure(new DomainError(
@@ -56,14 +60,32 @@ public static class ConfirmarUploadDocumentoEditalCommandHandler
                 $"O documento excede o tamanho máximo permitido de {DocumentoEdital.TamanhoMaximoBytes / (1024 * 1024)} MB."));
         }
 
-        byte[] conteudo;
+        // Lê no máximo TamanhoMaximoBytes+1 — nunca mais que isso, não importa
+        // o quanto o objeto real cresça entre o stat acima e esta leitura.
+        // Sem o limite, um objeto substituído por algo muito maior depois do
+        // stat faria o CopyToAsync bufferizar o arquivo inteiro em memória
+        // antes de ValidarConteudo rejeitar pelo tamanho.
+        byte[] bufferLimitado = new byte[DocumentoEdital.TamanhoMaximoBytes + 1];
+        int totalLido = 0;
         Stream stream = await storage.AbrirLeituraAsync(documento.ObjectKey, cancellationToken).ConfigureAwait(false);
         await using (stream.ConfigureAwait(false))
         {
-            using MemoryStream buffer = new();
-            await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
-            conteudo = buffer.ToArray();
+            int lidos;
+            while (totalLido < bufferLimitado.Length &&
+                   (lidos = await stream.ReadAsync(bufferLimitado.AsMemory(totalLido), cancellationToken).ConfigureAwait(false)) > 0)
+            {
+                totalLido += lidos;
+            }
         }
+
+        if (totalLido > DocumentoEdital.TamanhoMaximoBytes)
+        {
+            return Result<DocumentoEditalDto>.Failure(new DomainError(
+                "DocumentoEdital.TamanhoExcedido",
+                $"O documento excede o tamanho máximo permitido de {DocumentoEdital.TamanhoMaximoBytes / (1024 * 1024)} MB."));
+        }
+
+        byte[] conteudo = bufferLimitado[..totalLido];
 
         Result validacao = DocumentoEdital.ValidarConteudo(conteudo.LongLength, info.ContentType, conteudo);
         if (validacao.IsFailure)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
@@ -60,32 +60,29 @@ public static class ConfirmarUploadDocumentoEditalCommandHandler
                 $"O documento excede o tamanho máximo permitido de {DocumentoEdital.TamanhoMaximoBytes / (1024 * 1024)} MB."));
         }
 
-        // Lê no máximo TamanhoMaximoBytes+1 — nunca mais que isso, não importa
-        // o quanto o objeto real cresça entre o stat acima e esta leitura.
-        // Sem o limite, um objeto substituído por algo muito maior depois do
-        // stat faria o CopyToAsync bufferizar o arquivo inteiro em memória
+        // AbrirLeituraAsync nunca traz mais que TamanhoMaximoBytes+1 — o
+        // limite é imposto pelo storage via Range request (byte 0 a
+        // limiteBytes-1), não depois de já ter bufferizado o objeto inteiro
+        // em memória. Sem isso, um objeto substituído por algo muito maior
+        // depois do stat acima faria a leitura bufferizar o arquivo inteiro
         // antes de ValidarConteudo rejeitar pelo tamanho.
-        byte[] bufferLimitado = new byte[DocumentoEdital.TamanhoMaximoBytes + 1];
-        int totalLido = 0;
-        Stream stream = await storage.AbrirLeituraAsync(documento.ObjectKey, cancellationToken).ConfigureAwait(false);
+        byte[] conteudo;
+        Stream stream = await storage
+            .AbrirLeituraAsync(documento.ObjectKey, DocumentoEdital.TamanhoMaximoBytes + 1, cancellationToken)
+            .ConfigureAwait(false);
         await using (stream.ConfigureAwait(false))
         {
-            int lidos;
-            while (totalLido < bufferLimitado.Length &&
-                   (lidos = await stream.ReadAsync(bufferLimitado.AsMemory(totalLido), cancellationToken).ConfigureAwait(false)) > 0)
-            {
-                totalLido += lidos;
-            }
+            using MemoryStream buffer = new();
+            await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            conteudo = buffer.ToArray();
         }
 
-        if (totalLido > DocumentoEdital.TamanhoMaximoBytes)
+        if (conteudo.LongLength > DocumentoEdital.TamanhoMaximoBytes)
         {
             return Result<DocumentoEditalDto>.Failure(new DomainError(
                 "DocumentoEdital.TamanhoExcedido",
                 $"O documento excede o tamanho máximo permitido de {DocumentoEdital.TamanhoMaximoBytes / (1024 * 1024)} MB."));
         }
-
-        byte[] conteudo = bufferLimitado[..totalLido];
 
         Result validacao = DocumentoEdital.ValidarConteudo(conteudo.LongLength, info.ContentType, conteudo);
         if (validacao.IsFailure)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
@@ -60,21 +60,32 @@ public static class ConfirmarUploadDocumentoEditalCommandHandler
                 $"O documento excede o tamanho máximo permitido de {DocumentoEdital.TamanhoMaximoBytes / (1024 * 1024)} MB."));
         }
 
-        // AbrirLeituraAsync nunca traz mais que TamanhoMaximoBytes+1 — o
-        // limite é imposto pelo storage via Range request (byte 0 a
-        // limiteBytes-1), não depois de já ter bufferizado o objeto inteiro
-        // em memória. Sem isso, um objeto substituído por algo muito maior
-        // depois do stat acima faria a leitura bufferizar o arquivo inteiro
-        // antes de ValidarConteudo rejeitar pelo tamanho.
+        // Objeto de 0 bytes: um Range GET (byte 0 a N) não é satisfazível
+        // sobre um objeto vazio (o servidor recusa com 416) — não há o que
+        // ler, e o resultado já é conhecido (ValidarConteudo recusa conteúdo
+        // vazio por assinatura ausente), então nem tenta a leitura.
         byte[] conteudo;
-        Stream stream = await storage
-            .AbrirLeituraAsync(documento.ObjectKey, DocumentoEdital.TamanhoMaximoBytes + 1, cancellationToken)
-            .ConfigureAwait(false);
-        await using (stream.ConfigureAwait(false))
+        if (info.TamanhoBytes == 0)
         {
-            using MemoryStream buffer = new();
-            await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
-            conteudo = buffer.ToArray();
+            conteudo = [];
+        }
+        else
+        {
+            // AbrirLeituraAsync nunca traz mais que TamanhoMaximoBytes+1 — o
+            // limite é imposto pelo storage via Range request (byte 0 a
+            // limiteBytes-1), não depois de já ter bufferizado o objeto inteiro
+            // em memória. Sem isso, um objeto substituído por algo muito maior
+            // depois do stat acima faria a leitura bufferizar o arquivo inteiro
+            // antes de ValidarConteudo rejeitar pelo tamanho.
+            Stream stream = await storage
+                .AbrirLeituraAsync(documento.ObjectKey, DocumentoEdital.TamanhoMaximoBytes + 1, cancellationToken)
+                .ConfigureAwait(false);
+            await using (stream.ConfigureAwait(false))
+            {
+                using MemoryStream buffer = new();
+                await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+                conteudo = buffer.ToArray();
+            }
         }
 
         if (conteudo.LongLength > DocumentoEdital.TamanhoMaximoBytes)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
@@ -73,6 +73,22 @@ public static class ConfirmarUploadDocumentoEditalCommandHandler
 
         string hashSha256 = Convert.ToHexStringLower(SHA256.HashData(conteudo));
 
+        // Reivindica a confirmação só agora — depois de validar o conteúdo,
+        // nunca antes: reivindicar cedo demais travaria o registro como
+        // Confirmado para sempre se a validação recusasse em seguida. Duas
+        // confirmações concorrentes do mesmo documento (Idempotency-Keys
+        // diferentes) nunca ganham as duas — só a vencedora chega a escrever
+        // a cópia selada, evitando hash/objeto de origens diferentes.
+        bool reivindicou = await documentoEditalRepository
+            .TentarReivindicarConfirmacaoAsync(documento.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (!reivindicou)
+        {
+            return Result<DocumentoEditalDto>.Failure(new DomainError(
+                "DocumentoEdital.StatusInvalidoParaConfirmacao",
+                "Somente um documento pendente pode ser confirmado."));
+        }
+
         Result confirmacao = documento.Confirmar(conteudo.LongLength, hashSha256, clock);
         if (confirmacao.IsFailure)
         {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
@@ -1,0 +1,93 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.DocumentosEdital;
+
+using System.Security.Cryptography;
+
+using Abstractions;
+using DTOs;
+using Domain.Entities;
+using Domain.Interfaces;
+using Kernel.Results;
+
+/// <summary>
+/// Handler convention-based de <see cref="ConfirmarUploadDocumentoEditalCommand"/>.
+/// </summary>
+public static class ConfirmarUploadDocumentoEditalCommandHandler
+{
+    public static async Task<Result<DocumentoEditalDto>> Handle(
+        ConfirmarUploadDocumentoEditalCommand command,
+        IDocumentoEditalRepository documentoEditalRepository,
+        IDocumentoEditalStorage storage,
+        ISelecaoUnitOfWork unitOfWork,
+        TimeProvider clock,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(documentoEditalRepository);
+        ArgumentNullException.ThrowIfNull(storage);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        DocumentoEdital? documento = await documentoEditalRepository
+            .ObterPorIdAsync(command.DocumentoEditalId, cancellationToken)
+            .ConfigureAwait(false);
+        if (documento is null || documento.ProcessoSeletivoId != command.ProcessoSeletivoId)
+        {
+            return Result<DocumentoEditalDto>.Failure(new DomainError(
+                "DocumentoEdital.NaoEncontrado", "Documento do Edital não encontrado."));
+        }
+
+        InfoObjetoArmazenado? info = await storage
+            .ObterInfoAsync(documento.ObjectKey, cancellationToken)
+            .ConfigureAwait(false);
+        if (info is null)
+        {
+            return Result<DocumentoEditalDto>.Failure(new DomainError(
+                "DocumentoEdital.ObjetoNaoEncontrado",
+                "O objeto ainda não foi enviado ao storage ou expirou antes da confirmação."));
+        }
+
+        // Corta aqui, antes de baixar: o stat (HEAD) não traz o conteúdo, então
+        // barrar pelo tamanho reportado evita carregar um objeto arbitrariamente
+        // grande inteiro em memória só para descobrir que ele será recusado.
+        if (info.TamanhoBytes > DocumentoEdital.TamanhoMaximoBytes)
+        {
+            return Result<DocumentoEditalDto>.Failure(new DomainError(
+                "DocumentoEdital.TamanhoExcedido",
+                $"O documento excede o tamanho máximo permitido de {DocumentoEdital.TamanhoMaximoBytes / (1024 * 1024)} MB."));
+        }
+
+        byte[] conteudo;
+        Stream stream = await storage.AbrirLeituraAsync(documento.ObjectKey, cancellationToken).ConfigureAwait(false);
+        await using (stream.ConfigureAwait(false))
+        {
+            using MemoryStream buffer = new();
+            await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            conteudo = buffer.ToArray();
+        }
+
+        Result validacao = DocumentoEdital.ValidarConteudo(conteudo.LongLength, info.ContentType, conteudo);
+        if (validacao.IsFailure)
+        {
+            return Result<DocumentoEditalDto>.Failure(validacao.Error!);
+        }
+
+        string hashSha256 = Convert.ToHexStringLower(SHA256.HashData(conteudo));
+
+        Result confirmacao = documento.Confirmar(conteudo.LongLength, hashSha256, clock);
+        if (confirmacao.IsFailure)
+        {
+            return Result<DocumentoEditalDto>.Failure(confirmacao.Error!);
+        }
+
+        documentoEditalRepository.Atualizar(documento);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<DocumentoEditalDto>.Success(new DocumentoEditalDto(
+            documento.Id,
+            documento.ProcessoSeletivoId,
+            documento.Status.ToString(),
+            documento.TamanhoBytes!.Value,
+            documento.HashSha256!,
+            documento.ConfirmadoEm!.Value));
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/ConfirmarUploadDocumentoEditalCommandHandler.cs
@@ -79,6 +79,12 @@ public static class ConfirmarUploadDocumentoEditalCommandHandler
             return Result<DocumentoEditalDto>.Failure(confirmacao.Error!);
         }
 
+        // A cópia selada é o que torna o documento confirmado imutável de
+        // fato: ObjectKey (o alvo da URL de upload original) segue
+        // sobrescrevível até o TTL expirar, mas ObjectKeyConfirmado nunca foi
+        // exposto por nenhuma URL pre-assinada — só o handler grava nele.
+        await storage.SalvarConteudoSeladoAsync(documento.ObjectKeyConfirmado!, conteudo, cancellationToken).ConfigureAwait(false);
+
         documentoEditalRepository.Atualizar(documento);
         await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommand.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.DocumentosEdital;
+
+using DTOs;
+using Kernel.Results;
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+
+/// <summary>
+/// Passo 1 do fluxo de upload direto do documento do Edital (Story #759, T3
+/// #784): cria o registro pendente vinculado ao processo e devolve a URL
+/// pre-assinada de PUT — o arquivo não trafega pela API.
+/// </summary>
+public sealed record IniciarUploadDocumentoEditalCommand(
+    Guid ProcessoSeletivoId) : ICommand<Result<IniciarUploadDocumentoEditalDto>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommandHandler.cs
@@ -43,12 +43,17 @@ public static class IniciarUploadDocumentoEditalCommandHandler
 
         DocumentoEdital documento = DocumentoEdital.IniciarPendente(processo.Id, clock, TtlUpload);
 
-        await documentoEditalRepository.AdicionarAsync(documento, cancellationToken).ConfigureAwait(false);
-        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
-
+        // ObjectKey já está determinada (deriva do Id gerado em memória) — dá
+        // para gerar a URL antes de persistir. Se o MinIO falhar aqui, nada é
+        // commitado: sem isso, uma falha depois do SaveChanges deixaria uma
+        // linha pendente órfã e, sob retry com a mesma Idempotency-Key, o
+        // filtro trataria a exceção como pré-conclusão e criaria outra.
         string urlUpload = await storage
             .GerarUrlUploadAsync(documento.ObjectKey, TtlUpload, cancellationToken)
             .ConfigureAwait(false);
+
+        await documentoEditalRepository.AdicionarAsync(documento, cancellationToken).ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
 
         return Result<IniciarUploadDocumentoEditalDto>.Success(
             new IniciarUploadDocumentoEditalDto(documento.Id, new Uri(urlUpload, UriKind.Absolute), documento.ExpiraEm));

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommandHandler.cs
@@ -56,6 +56,10 @@ public static class IniciarUploadDocumentoEditalCommandHandler
         await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
 
         return Result<IniciarUploadDocumentoEditalDto>.Success(
-            new IniciarUploadDocumentoEditalDto(documento.Id, new Uri(urlUpload, UriKind.Absolute), documento.ExpiraEm));
+            new IniciarUploadDocumentoEditalDto(
+                documento.Id,
+                new Uri(urlUpload, UriKind.Absolute),
+                DocumentoEdital.ContentTypeEsperado,
+                documento.ExpiraEm));
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommandHandler.cs
@@ -13,8 +13,20 @@ using Kernel.Results;
 /// </summary>
 public static class IniciarUploadDocumentoEditalCommandHandler
 {
-    /// <summary>TTL da URL pre-assinada de upload — curto por design (ADR-0027-adjacent: janela mínima de exposição).</summary>
-    public static readonly TimeSpan TtlUpload = TimeSpan.FromMinutes(15);
+    /// <summary>
+    /// TTL da URL pre-assinada de upload, em segundos — curto por design
+    /// (janela mínima de exposição). <c>const int</c> (não <see cref="TimeSpan"/>)
+    /// porque também é consumido como argumento de atributo em
+    /// <see cref="Unifesspa.UniPlus.Infrastructure.Core.Idempotency.RequiresIdempotencyKeyAttribute.TtlSeconds"/>
+    /// no controller — o cache de idempotência (teto de 24h por padrão,
+    /// ADR-0027) precisa expirar no mesmo prazo desta URL, senão um replay
+    /// devolve uma URL já expirada e o cliente fica sem como reobter uma
+    /// válida sem criar outro registro pendente com nova Idempotency-Key.
+    /// </summary>
+    public const int TtlUploadSegundos = 900;
+
+    /// <summary>TTL da URL pre-assinada de upload como <see cref="TimeSpan"/> — ver <see cref="TtlUploadSegundos"/>.</summary>
+    public static readonly TimeSpan TtlUpload = TimeSpan.FromSeconds(TtlUploadSegundos);
 
     public static async Task<Result<IniciarUploadDocumentoEditalDto>> Handle(
         IniciarUploadDocumentoEditalCommand command,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/DocumentosEdital/IniciarUploadDocumentoEditalCommandHandler.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.DocumentosEdital;
+
+using Abstractions;
+using DTOs;
+using Domain.Entities;
+using Domain.Interfaces;
+using Kernel.Results;
+
+/// <summary>
+/// Handler convention-based de <see cref="IniciarUploadDocumentoEditalCommand"/>:
+/// valida que o processo existe, cria o registro pendente e devolve a URL
+/// pre-assinada de PUT (TTL curto — <see cref="TtlUpload"/>).
+/// </summary>
+public static class IniciarUploadDocumentoEditalCommandHandler
+{
+    /// <summary>TTL da URL pre-assinada de upload — curto por design (ADR-0027-adjacent: janela mínima de exposição).</summary>
+    public static readonly TimeSpan TtlUpload = TimeSpan.FromMinutes(15);
+
+    public static async Task<Result<IniciarUploadDocumentoEditalDto>> Handle(
+        IniciarUploadDocumentoEditalCommand command,
+        IProcessoSeletivoRepository processoSeletivoRepository,
+        IDocumentoEditalRepository documentoEditalRepository,
+        IDocumentoEditalStorage storage,
+        ISelecaoUnitOfWork unitOfWork,
+        TimeProvider clock,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(processoSeletivoRepository);
+        ArgumentNullException.ThrowIfNull(documentoEditalRepository);
+        ArgumentNullException.ThrowIfNull(storage);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        ProcessoSeletivo? processo = await processoSeletivoRepository
+            .ObterPorIdAsync(command.ProcessoSeletivoId, cancellationToken)
+            .ConfigureAwait(false);
+        if (processo is null)
+        {
+            return Result<IniciarUploadDocumentoEditalDto>.Failure(new DomainError(
+                "ProcessoSeletivo.NaoEncontrado", "Processo Seletivo não encontrado."));
+        }
+
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processo.Id, clock, TtlUpload);
+
+        await documentoEditalRepository.AdicionarAsync(documento, cancellationToken).ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        string urlUpload = await storage
+            .GerarUrlUploadAsync(documento.ObjectKey, TtlUpload, cancellationToken)
+            .ConfigureAwait(false);
+
+        return Result<IniciarUploadDocumentoEditalDto>.Success(
+            new IniciarUploadDocumentoEditalDto(documento.Id, new Uri(urlUpload, UriKind.Absolute), documento.ExpiraEm));
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoEditalDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoEditalDto.cs
@@ -1,9 +1,18 @@
 namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
 
-/// <summary>Resposta do passo 1 (iniciar upload) — Story #759, T3 #784.</summary>
+/// <summary>
+/// Resposta do passo 1 (iniciar upload) — Story #759, T3 #784.
+/// <paramref name="ContentTypeExigido"/> é o valor exato do header
+/// <c>Content-Type</c> que o PUT direto ao <see cref="UrlUpload"/> precisa
+/// enviar — a assinatura SigV4 da URL o inclui como header assinado, então
+/// qualquer variação (ex.: <c>application/pdf; charset=utf-8</c>) faz o
+/// MinIO rejeitar com SignatureDoesNotMatch antes de chegar à validação de
+/// negócio.
+/// </summary>
 public sealed record IniciarUploadDocumentoEditalDto(
     Guid DocumentoEditalId,
     Uri UrlUpload,
+    string ContentTypeExigido,
     DateTimeOffset ExpiraEm);
 
 /// <summary>Resposta do passo 3 (confirmar upload) — Story #759, T3 #784.</summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoEditalDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoEditalDto.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+/// <summary>Resposta do passo 1 (iniciar upload) — Story #759, T3 #784.</summary>
+public sealed record IniciarUploadDocumentoEditalDto(
+    Guid DocumentoEditalId,
+    Uri UrlUpload,
+    DateTimeOffset ExpiraEm);
+
+/// <summary>Resposta do passo 3 (confirmar upload) — Story #759, T3 #784.</summary>
+public sealed record DocumentoEditalDto(
+    Guid Id,
+    Guid ProcessoSeletivoId,
+    string Status,
+    long TamanhoBytes,
+    string HashSha256,
+    DateTimeOffset ConfirmadoEm);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoEdital.cs
@@ -33,6 +33,18 @@ public sealed class DocumentoEdital : EntityBase
     public string? HashSha256 { get; private set; }
     public DateTimeOffset? ConfirmadoEm { get; private set; }
 
+    /// <summary>
+    /// Object key selado, gravado apenas na confirmação — <see langword="null"/>
+    /// enquanto pendente. Nunca é alvo de nenhuma URL pre-assinada de PUT
+    /// (essas só apontam para <see cref="ObjectKey"/>): a cópia do conteúdo
+    /// já validado para esta chave, feita pelo handler no mesmo passo em que
+    /// chama <see cref="Confirmar"/>, é o que torna o documento confirmado
+    /// realmente imutável — sem isso, o titular da URL de <see cref="ObjectKey"/>
+    /// poderia sobrescrever o conteúdo até o TTL expirar, mesmo depois do
+    /// registro já marcado como confirmado.
+    /// </summary>
+    public string? ObjectKeyConfirmado { get; private set; }
+
     private DocumentoEdital() { }
 
     /// <summary>
@@ -65,10 +77,13 @@ public sealed class DocumentoEdital : EntityBase
     }
 
     /// <summary>
-    /// Finaliza o documento como confirmado e imutável (passo 3 do fluxo).
-    /// Só é permitido a partir de <see cref="StatusDocumentoEdital.Pendente"/>
-    /// — a validação do conteúdo (<see cref="ValidarConteudo"/>) já deve ter
-    /// passado antes desta chamada.
+    /// Finaliza o documento como confirmado e imutável (passo 3 do fluxo) e
+    /// determina a <see cref="ObjectKeyConfirmado"/> selada. Só é permitido a
+    /// partir de <see cref="StatusDocumentoEdital.Pendente"/> — a validação
+    /// do conteúdo (<see cref="ValidarConteudo"/>) já deve ter passado antes
+    /// desta chamada. O caller (handler) ainda precisa copiar o conteúdo já
+    /// validado para <see cref="ObjectKeyConfirmado"/> no storage — este
+    /// método só decide o estado e o nome da chave selada, sem I/O.
     /// </summary>
     public Result Confirmar(long tamanhoBytes, string hashSha256, TimeProvider clock)
     {
@@ -86,6 +101,7 @@ public sealed class DocumentoEdital : EntityBase
         HashSha256 = hashSha256;
         Status = StatusDocumentoEdital.Confirmado;
         ConfirmadoEm = clock.GetUtcNow();
+        ObjectKeyConfirmado = $"selecao/documentos-edital/{ProcessoSeletivoId:D}/{Id:D}/confirmado.pdf";
         return Result.Success();
     }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoEdital.cs
@@ -22,7 +22,16 @@ public sealed class DocumentoEdital : EntityBase
     /// critério de aceite pedindo configurabilidade.</summary>
     public const long TamanhoMaximoBytes = 20 * 1024 * 1024;
 
-    private const string ContentTypeEsperado = "application/pdf";
+    /// <summary>
+    /// Content-Type exigido tanto na validação de <see cref="ValidarConteudo"/>
+    /// quanto como header assinado na URL pre-assinada de PUT (o SDK MinIO
+    /// inclui o header assinado na query da assinatura SigV4 — um PUT que não
+    /// enviar exatamente este valor falha com SignatureDoesNotMatch antes de
+    /// chegar à validação de negócio). Público para o handler devolver o
+    /// valor exato ao cliente junto da URL, em vez de exigir conhecimento
+    /// fora de banda do contrato.
+    /// </summary>
+    public const string ContentTypeEsperado = "application/pdf";
     private static readonly byte[] AssinaturaPdf = "%PDF-"u8.ToArray();
 
     public Guid ProcessoSeletivoId { get; private set; }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoEdital.cs
@@ -1,0 +1,124 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using Enums;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Documento (PDF) do Edital de um <see cref="ProcessoSeletivo"/> (Story
+/// #759, T3 #784) — armazenado no MinIO via upload direto do cliente (URL
+/// pre-assinada de PUT); a API nunca recebe os bytes. Vinculado ao processo
+/// por <see cref="ProcessoSeletivoId"/>, mas não é entidade filha do
+/// agregado: tem ciclo de vida e repositório próprios, pois nasce
+/// <see cref="StatusDocumentoEdital.Pendente"/> (URL gerada) e só se torna
+/// dado de negócio real ao ser <see cref="StatusDocumentoEdital.Confirmado"/>
+/// (conteúdo lido do MinIO, validado e hasheado server-side). Um documento
+/// confirmado é imutável — um novo envio sempre cria um novo registro com
+/// nova <see cref="ObjectKey"/>, nunca sobrescreve.
+/// </summary>
+public sealed class DocumentoEdital : EntityBase
+{
+    /// <summary>Tamanho máximo aceito para o PDF do Edital. Valor fixo — sem
+    /// critério de aceite pedindo configurabilidade.</summary>
+    public const long TamanhoMaximoBytes = 20 * 1024 * 1024;
+
+    private const string ContentTypeEsperado = "application/pdf";
+    private static readonly byte[] AssinaturaPdf = "%PDF-"u8.ToArray();
+
+    public Guid ProcessoSeletivoId { get; private set; }
+    public string ObjectKey { get; private set; } = string.Empty;
+    public StatusDocumentoEdital Status { get; private set; }
+    public DateTimeOffset ExpiraEm { get; private set; }
+    public long? TamanhoBytes { get; private set; }
+    public string? HashSha256 { get; private set; }
+    public DateTimeOffset? ConfirmadoEm { get; private set; }
+
+    private DocumentoEdital() { }
+
+    /// <summary>
+    /// Cria o registro pendente que acompanha a URL pre-assinada de upload
+    /// devolvida ao cliente (passo 1 do fluxo). A <see cref="ObjectKey"/> é
+    /// composta aqui a partir do próprio <see cref="EntityBase.Id"/> gerado
+    /// (Guid v7) — a entidade é dona da própria convenção de path, o caller
+    /// não decide o layout do storage. Qual bucket físico guarda o objeto é
+    /// decisão de configuração de infraestrutura (<c>StorageOptions</c>),
+    /// fora do alcance do domínio — por isso não é um campo aqui.
+    /// <paramref name="ttl"/> é o mesmo prazo assinado na URL — usado aqui só
+    /// para registrar quando o pendente se torna elegível a limpeza futura,
+    /// não para revalidar a assinatura (isso é responsabilidade do MinIO).
+    /// </summary>
+    public static DocumentoEdital IniciarPendente(
+        Guid processoSeletivoId,
+        TimeProvider clock,
+        TimeSpan ttl)
+    {
+        ArgumentNullException.ThrowIfNull(clock);
+
+        DocumentoEdital documento = new()
+        {
+            ProcessoSeletivoId = processoSeletivoId,
+            Status = StatusDocumentoEdital.Pendente,
+            ExpiraEm = clock.GetUtcNow().Add(ttl),
+        };
+        documento.ObjectKey = $"selecao/documentos-edital/{processoSeletivoId:D}/{documento.Id:D}.pdf";
+        return documento;
+    }
+
+    /// <summary>
+    /// Finaliza o documento como confirmado e imutável (passo 3 do fluxo).
+    /// Só é permitido a partir de <see cref="StatusDocumentoEdital.Pendente"/>
+    /// — a validação do conteúdo (<see cref="ValidarConteudo"/>) já deve ter
+    /// passado antes desta chamada.
+    /// </summary>
+    public Result Confirmar(long tamanhoBytes, string hashSha256, TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentException.ThrowIfNullOrWhiteSpace(hashSha256);
+
+        if (Status != StatusDocumentoEdital.Pendente)
+        {
+            return Result.Failure(new DomainError(
+                "DocumentoEdital.StatusInvalidoParaConfirmacao",
+                "Somente um documento pendente pode ser confirmado."));
+        }
+
+        TamanhoBytes = tamanhoBytes;
+        HashSha256 = hashSha256;
+        Status = StatusDocumentoEdital.Confirmado;
+        ConfirmadoEm = clock.GetUtcNow();
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Valida o conteúdo lido do MinIO na confirmação: content-type
+    /// declarado pelo objeto, tamanho máximo e assinatura de arquivo (magic
+    /// bytes <c>%PDF-</c>). Regra de negócio pura — sem I/O; o handler já
+    /// buscou <paramref name="tamanhoBytes"/>/<paramref name="contentType"/>
+    /// via stat e os primeiros bytes via download antes de chamar aqui.
+    /// </summary>
+    public static Result ValidarConteudo(long tamanhoBytes, string contentType, ReadOnlySpan<byte> conteudo)
+    {
+        if (tamanhoBytes > TamanhoMaximoBytes)
+        {
+            return Result.Failure(new DomainError(
+                "DocumentoEdital.TamanhoExcedido",
+                $"O documento excede o tamanho máximo permitido de {TamanhoMaximoBytes / (1024 * 1024)} MB."));
+        }
+
+        if (!string.Equals(contentType, ContentTypeEsperado, StringComparison.OrdinalIgnoreCase))
+        {
+            return Result.Failure(new DomainError(
+                "DocumentoEdital.ContentTypeInvalido",
+                "O documento do Edital deve ser do tipo application/pdf."));
+        }
+
+        if (conteudo.Length < AssinaturaPdf.Length || !conteudo[..AssinaturaPdf.Length].SequenceEqual(AssinaturaPdf))
+        {
+            return Result.Failure(new DomainError(
+                "DocumentoEdital.AssinaturaInvalida",
+                "O conteúdo do arquivo não corresponde a um PDF válido."));
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/StatusDocumentoEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/StatusDocumentoEdital.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Ciclo de vida do <see cref="Entities.DocumentoEdital"/> (Story #759, T3
+/// #784): nasce <see cref="Pendente"/> ao gerar a URL pre-assinada de upload
+/// e transita para <see cref="Confirmado"/> quando o conteúdo é validado e
+/// hasheado server-side. Não há caminho de volta — um documento confirmado é
+/// imutável; um novo envio sempre gera um novo registro.
+/// </summary>
+public enum StatusDocumentoEdital
+{
+    Pendente = 0,
+    Confirmado = 1
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IDocumentoEditalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IDocumentoEditalRepository.cs
@@ -11,4 +11,16 @@ using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
 /// </summary>
 public interface IDocumentoEditalRepository : IRepository<DocumentoEdital>
 {
+    /// <summary>
+    /// Reivindica atomicamente a confirmação do documento — <c>UPDATE ...
+    /// WHERE id = @id AND status = Pendente</c> condicional, sem passar pelo
+    /// change tracker. Duas confirmações concorrentes do mesmo documento
+    /// (Idempotency-Keys diferentes) nunca ganham as duas: a perdedora
+    /// bloqueia no lock de linha do Postgres e, ao destravar, sua condição
+    /// não bate mais (a vencedora já avançou o status), então afeta zero
+    /// linhas. Só depois de reivindicar com sucesso o handler lê/valida o
+    /// conteúdo e grava a cópia selada — nenhuma confirmação perdedora chega
+    /// a escrever no storage.
+    /// </summary>
+    Task<bool> TentarReivindicarConfirmacaoAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IDocumentoEditalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IDocumentoEditalRepository.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+using Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+/// <summary>
+/// Repositório de <see cref="DocumentoEdital"/> — independente de
+/// <see cref="IProcessoSeletivoRepository"/> porque o documento não é
+/// entidade filha do agregado <see cref="ProcessoSeletivo"/> (ver comentário
+/// da entidade).
+/// </summary>
+public interface IDocumentoEditalRepository : IRepository<DocumentoEdital>
+{
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -50,8 +50,15 @@ public static class SelecaoInfrastructureRegistration
 
         services.AddScoped<IProcessoSeletivoRepository, ProcessoSeletivoRepository>();
         services.AddScoped<IObrigatoriedadeLegalRepository, ObrigatoriedadeLegalRepository>();
+        services.AddScoped<IDocumentoEditalRepository, DocumentoEditalRepository>();
         services.AddScoped<IRegraCatalogoReader, RegraCatalogoReader>();
         services.AddScoped<IGovBrAuthService, GovBrAuthService>();
+
+        // Storage de documento do Edital (Story #759, T3 #784) — envolve o
+        // IStorageService compartilhado (registrado uma vez no host via
+        // AddUniPlusStorage). Não registra AddUniPlusStorage aqui: é
+        // cross-cutting compartilhado entre módulos, já ligado no host.
+        services.AddScoped<IDocumentoEditalStorage, DocumentoEditalStorageService>();
 
         return services;
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/ExternalServices/DocumentoEditalStorageService.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/ExternalServices/DocumentoEditalStorageService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Storage;
 using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
 
 /// <summary>
 /// Implementação de <see cref="IDocumentoEditalStorage"/> (Story #759, T3
@@ -15,8 +16,6 @@ using Unifesspa.UniPlus.Selecao.Application.Abstractions;
 /// </summary>
 public sealed class DocumentoEditalStorageService : IDocumentoEditalStorage
 {
-    private const string ContentTypePdf = "application/pdf";
-
     private readonly IStorageService _storageService;
     private readonly string _bucket;
 
@@ -31,7 +30,7 @@ public sealed class DocumentoEditalStorageService : IDocumentoEditalStorage
     }
 
     public Task<string> GerarUrlUploadAsync(string objectKey, TimeSpan expiracao, CancellationToken cancellationToken = default) =>
-        _storageService.GerarUrlUploadTemporariaAsync(_bucket, objectKey, expiracao, ContentTypePdf, cancellationToken);
+        _storageService.GerarUrlUploadTemporariaAsync(_bucket, objectKey, expiracao, DocumentoEdital.ContentTypeEsperado, cancellationToken);
 
     public async Task<InfoObjetoArmazenado?> ObterInfoAsync(string objectKey, CancellationToken cancellationToken = default)
     {
@@ -50,6 +49,6 @@ public sealed class DocumentoEditalStorageService : IDocumentoEditalStorage
         ArgumentNullException.ThrowIfNull(conteudo);
 
         using MemoryStream stream = new(conteudo);
-        await _storageService.UploadAsync(_bucket, objectKey, stream, ContentTypePdf, cancellationToken).ConfigureAwait(false);
+        await _storageService.UploadAsync(_bucket, objectKey, stream, DocumentoEdital.ContentTypeEsperado, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/ExternalServices/DocumentoEditalStorageService.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/ExternalServices/DocumentoEditalStorageService.cs
@@ -44,4 +44,12 @@ public sealed class DocumentoEditalStorageService : IDocumentoEditalStorage
 
     public Task<Stream> AbrirLeituraAsync(string objectKey, CancellationToken cancellationToken = default) =>
         _storageService.DownloadAsync(_bucket, objectKey, cancellationToken);
+
+    public async Task SalvarConteudoSeladoAsync(string objectKey, byte[] conteudo, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(conteudo);
+
+        using MemoryStream stream = new(conteudo);
+        await _storageService.UploadAsync(_bucket, objectKey, stream, ContentTypePdf, cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/ExternalServices/DocumentoEditalStorageService.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/ExternalServices/DocumentoEditalStorageService.cs
@@ -42,8 +42,8 @@ public sealed class DocumentoEditalStorageService : IDocumentoEditalStorage
         return metadados is null ? null : new InfoObjetoArmazenado(metadados.TamanhoBytes, metadados.ContentType);
     }
 
-    public Task<Stream> AbrirLeituraAsync(string objectKey, CancellationToken cancellationToken = default) =>
-        _storageService.DownloadAsync(_bucket, objectKey, cancellationToken);
+    public Task<Stream> AbrirLeituraAsync(string objectKey, long limiteBytes, CancellationToken cancellationToken = default) =>
+        _storageService.DownloadLimitadoAsync(_bucket, objectKey, limiteBytes, cancellationToken);
 
     public async Task SalvarConteudoSeladoAsync(string objectKey, byte[] conteudo, CancellationToken cancellationToken = default)
     {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/ExternalServices/DocumentoEditalStorageService.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/ExternalServices/DocumentoEditalStorageService.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.ExternalServices;
+
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Storage;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+
+/// <summary>
+/// Implementação de <see cref="IDocumentoEditalStorage"/> (Story #759, T3
+/// #784) que envolve o <see cref="IStorageService"/> compartilhado de
+/// <c>Infrastructure.Core</c>, resolvendo o bucket via
+/// <see cref="StorageOptions.BucketName"/> — a única peça deste fluxo que
+/// conhece o vendor MinIO/S3, mantendo o port em <c>Application.Abstractions</c>
+/// livre de conceitos de infraestrutura.
+/// </summary>
+public sealed class DocumentoEditalStorageService : IDocumentoEditalStorage
+{
+    private const string ContentTypePdf = "application/pdf";
+
+    private readonly IStorageService _storageService;
+    private readonly string _bucket;
+
+    public DocumentoEditalStorageService(IStorageService storageService, IOptions<StorageOptions> options)
+    {
+        ArgumentNullException.ThrowIfNull(storageService);
+        ArgumentNullException.ThrowIfNull(options);
+
+        _storageService = storageService;
+        _bucket = options.Value.BucketName
+            ?? throw new InvalidOperationException("Storage:BucketName não configurado — obrigatório para o upload de documentos do Edital.");
+    }
+
+    public Task<string> GerarUrlUploadAsync(string objectKey, TimeSpan expiracao, CancellationToken cancellationToken = default) =>
+        _storageService.GerarUrlUploadTemporariaAsync(_bucket, objectKey, expiracao, ContentTypePdf, cancellationToken);
+
+    public async Task<InfoObjetoArmazenado?> ObterInfoAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        ObjetoMetadados? metadados = await _storageService
+            .ObterMetadadosAsync(_bucket, objectKey, cancellationToken)
+            .ConfigureAwait(false);
+
+        return metadados is null ? null : new InfoObjetoArmazenado(metadados.TamanhoBytes, metadados.ContentType);
+    }
+
+    public Task<Stream> AbrirLeituraAsync(string objectKey, CancellationToken cancellationToken = default) =>
+        _storageService.DownloadAsync(_bucket, objectKey, cancellationToken);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoEditalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoEditalConfiguration.cs
@@ -17,6 +17,7 @@ public sealed class DocumentoEditalConfiguration : IEntityTypeConfiguration<Docu
         builder.Property(d => d.Id).ValueGeneratedNever();
 
         builder.Property(d => d.ObjectKey).HasMaxLength(500).IsRequired();
+        builder.Property(d => d.ObjectKeyConfirmado).HasMaxLength(500);
         builder.Property(d => d.Status).HasConversion<int>().IsRequired();
         builder.Property(d => d.HashSha256).HasMaxLength(64);
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoEditalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoEditalConfiguration.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Domain.Entities;
+
+public sealed class DocumentoEditalConfiguration : IEntityTypeConfiguration<DocumentoEdital>
+{
+    public void Configure(EntityTypeBuilder<DocumentoEdital> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("documentos_edital");
+        builder.HasKey(d => d.Id);
+        // Guid v7 gerado no domínio (EntityBase) — mesma convenção de ProcessoSeletivoConfiguration.
+        builder.Property(d => d.Id).ValueGeneratedNever();
+
+        builder.Property(d => d.ObjectKey).HasMaxLength(500).IsRequired();
+        builder.Property(d => d.Status).HasConversion<int>().IsRequired();
+        builder.Property(d => d.HashSha256).HasMaxLength(64);
+
+        // Vínculo por FK ao processo (não é entidade filha do agregado — sem
+        // navegação inversa em ProcessoSeletivo, ver comentário da entidade).
+        builder.HasOne<ProcessoSeletivo>()
+            .WithMany()
+            .HasForeignKey(d => d.ProcessoSeletivoId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(d => d.ProcessoSeletivoId);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260707213004_AddDocumentoEdital.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260707213004_AddDocumentoEdital.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260707213004_AddDocumentoEdital")]
+    partial class AddDocumentoEdital
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260707213004_AddDocumentoEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260707213004_AddDocumentoEdital.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentoEdital : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "documentos_edital",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    processo_seletivo_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    object_key = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    status = table.Column<int>(type: "integer", nullable: false),
+                    expira_em = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    tamanho_bytes = table.Column<long>(type: "bigint", nullable: true),
+                    hash_sha256 = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    confirmado_em = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_documentos_edital", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_documentos_edital_processos_seletivos_processo_seletivo_id",
+                        column: x => x.processo_seletivo_id,
+                        principalSchema: "selecao",
+                        principalTable: "processos_seletivos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_documentos_edital_processo_seletivo_id",
+                schema: "selecao",
+                table: "documentos_edital",
+                column: "processo_seletivo_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "documentos_edital",
+                schema: "selecao");
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260707215432_AddDocumentoEdital.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260707215432_AddDocumentoEdital.Designer.cs
@@ -12,7 +12,7 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    [Migration("20260707213004_AddDocumentoEdital")]
+    [Migration("20260707215432_AddDocumentoEdital")]
     partial class AddDocumentoEdital
     {
         /// <inheritdoc />
@@ -285,6 +285,11 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("character varying(500)")
                         .HasColumnName("object_key");
+
+                    b.Property<string>("ObjectKeyConfirmado")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)")
+                        .HasColumnName("object_key_confirmado");
 
                     b.Property<Guid>("ProcessoSeletivoId")
                         .HasColumnType("uuid")

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260707215432_AddDocumentoEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260707215432_AddDocumentoEdital.cs
@@ -24,6 +24,7 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
                     tamanho_bytes = table.Column<long>(type: "bigint", nullable: true),
                     hash_sha256 = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
                     confirmado_em = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    object_key_confirmado = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
                     created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
                     updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
                 },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/SelecaoDbContextModelSnapshot.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/SelecaoDbContextModelSnapshot.cs
@@ -283,6 +283,11 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
                         .HasColumnType("character varying(500)")
                         .HasColumnName("object_key");
 
+                    b.Property<string>("ObjectKeyConfirmado")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)")
+                        .HasColumnName("object_key_confirmado");
+
                     b.Property<Guid>("ProcessoSeletivoId")
                         .HasColumnType("uuid")
                         .HasColumnName("processo_seletivo_id");

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/DocumentoEditalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/DocumentoEditalRepository.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
 using Microsoft.EntityFrameworkCore;
 
 using Domain.Entities;
+using Domain.Enums;
 using Domain.Interfaces;
 
 public sealed class DocumentoEditalRepository : IDocumentoEditalRepository
@@ -40,6 +41,16 @@ public sealed class DocumentoEditalRepository : IDocumentoEditalRepository
     {
         ArgumentNullException.ThrowIfNull(entity);
         _context.DocumentosEdital.Update(entity);
+    }
+
+    public async Task<bool> TentarReivindicarConfirmacaoAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        int linhasAfetadas = await _context.DocumentosEdital
+            .Where(d => d.Id == id && d.Status == StatusDocumentoEdital.Pendente)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(d => d.Status, StatusDocumentoEdital.Confirmado), cancellationToken)
+            .ConfigureAwait(false);
+
+        return linhasAfetadas == 1;
     }
 
     public void Remover(DocumentoEdital entity)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/DocumentoEditalRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/DocumentoEditalRepository.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Domain.Entities;
+using Domain.Interfaces;
+
+public sealed class DocumentoEditalRepository : IDocumentoEditalRepository
+{
+    private readonly SelecaoDbContext _context;
+
+    public DocumentoEditalRepository(SelecaoDbContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    public async Task<DocumentoEdital?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _context.DocumentosEdital
+            .FirstOrDefaultAsync(d => d.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<DocumentoEdital>> ObterTodosAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.DocumentosEdital
+            .AsNoTracking()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task AdicionarAsync(DocumentoEdital entity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        await _context.DocumentosEdital.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Atualizar(DocumentoEdital entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        _context.DocumentosEdital.Update(entity);
+    }
+
+    public void Remover(DocumentoEdital entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        // Sem soft-delete (EntityBase puro — DocumentoEdital não é ISoftDeletable):
+        // não há caso de uso hoje que remova documento (pendentes expirados são
+        // stub de limpeza futura, ver issue #784); implementado por completude do
+        // contrato IRepository<T>.
+        _context.DocumentosEdital.Remove(entity);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
@@ -81,6 +81,13 @@ public sealed class SelecaoDbContext : DbContext, ISelecaoUnitOfWork
         Set<ObrigatoriedadeLegalHistorico>();
 
     /// <summary>
+    /// Documento (PDF) do Edital, vinculado ao processo por FK — não é
+    /// entidade filha do agregado <see cref="ProcessoSeletivo"/> (Story
+    /// #759, T3 #784; ver comentário de <see cref="DocumentoEdital"/>).
+    /// </summary>
+    public DbSet<DocumentoEdital> DocumentosEdital => Set<DocumentoEdital>();
+
+    /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do agregado
     /// para permitir gravação adjacente no outbox; entries cifradas at-rest
     /// via <c>IUniPlusEncryptionService</c>.

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
@@ -91,7 +91,8 @@ public static class StorageServiceCollectionExtensions
                 return sp.GetRequiredService<IMinioClient>();
             }
 
-            return BuildClient(opts, opts.PublicEndpoint ?? opts.Endpoint, opts.PublicUseSSL ?? opts.UseSSL);
+            string endpointResolvido = string.IsNullOrWhiteSpace(opts.PublicEndpoint) ? opts.Endpoint : opts.PublicEndpoint;
+            return BuildClient(opts, endpointResolvido, opts.PublicUseSSL ?? opts.UseSSL);
         });
 
         // IHttpClientFactory — usado por MinioStorageService.DownloadLimitadoAsync

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
@@ -77,18 +77,21 @@ public static class StorageServiceCollectionExtensions
         // devolvidas a clientes externos (browser fora da rede Docker/cluster).
         // A assinatura SigV4 inclui o header Host — reescrever a URL depois de
         // assinada com o endpoint interno invalidaria a assinatura, então este
-        // cliente assina do zero com PublicEndpoint. Sem PublicEndpoint
-        // configurado, reusa a MESMA instância do cliente interno (nenhum
-        // custo extra; comportamento idêntico ao anterior).
+        // cliente assina do zero com PublicEndpoint/PublicUseSSL. Reusa a
+        // MESMA instância do cliente interno só quando host E esquema batem
+        // (endpoint igual mas esquema diferente é um caso real: HTTP dentro
+        // do cluster, HTTPS no mesmo hostname exposto por fora via ingress).
         services.AddKeyedSingleton<IMinioClient>(StoragePublicClientKey, (sp, _) =>
         {
             StorageOptions opts = sp.GetRequiredService<IOptions<StorageOptions>>().Value;
-            if (string.IsNullOrWhiteSpace(opts.PublicEndpoint) || opts.PublicEndpoint == opts.Endpoint)
+            bool endpointIgual = string.IsNullOrWhiteSpace(opts.PublicEndpoint) || opts.PublicEndpoint == opts.Endpoint;
+            bool sslIgual = opts.PublicUseSSL is null || opts.PublicUseSSL == opts.UseSSL;
+            if (endpointIgual && sslIgual)
             {
                 return sp.GetRequiredService<IMinioClient>();
             }
 
-            return BuildClient(opts, opts.PublicEndpoint, opts.PublicUseSSL ?? opts.UseSSL);
+            return BuildClient(opts, opts.PublicEndpoint ?? opts.Endpoint, opts.PublicUseSSL ?? opts.UseSSL);
         });
 
         // IHttpClientFactory — usado por MinioStorageService.DownloadLimitadoAsync

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
@@ -82,6 +82,10 @@ public static class StorageServiceCollectionExtensions
             return client.Build();
         });
 
+        // IHttpClientFactory — usado por MinioStorageService.DownloadLimitadoAsync
+        // para o GET com Range via URL pre-assinada (a API de alto nível do SDK
+        // MinIO não suporta range parcial). AddHttpClient() é idempotente.
+        services.AddHttpClient();
         services.AddScoped<IStorageService, MinioStorageService>();
 
         return services;

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 
+using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -68,18 +70,25 @@ public static class StorageServiceCollectionExtensions
         services.AddSingleton<IMinioClient>(sp =>
         {
             StorageOptions opts = sp.GetRequiredService<IOptions<StorageOptions>>().Value;
+            return BuildClient(opts, opts.Endpoint, opts.UseSSL);
+        });
 
-            IMinioClient client = new MinioClient()
-                .WithEndpoint(opts.Endpoint)
-                .WithCredentials(opts.AccessKey, opts.SecretKey)
-                .WithSSL(opts.UseSSL);
-
-            if (!string.IsNullOrWhiteSpace(opts.Region))
+        // Cliente separado, keyed, usado só para ASSINAR URLs pre-assinadas
+        // devolvidas a clientes externos (browser fora da rede Docker/cluster).
+        // A assinatura SigV4 inclui o header Host — reescrever a URL depois de
+        // assinada com o endpoint interno invalidaria a assinatura, então este
+        // cliente assina do zero com PublicEndpoint. Sem PublicEndpoint
+        // configurado, reusa a MESMA instância do cliente interno (nenhum
+        // custo extra; comportamento idêntico ao anterior).
+        services.AddKeyedSingleton<IMinioClient>(StoragePublicClientKey, (sp, _) =>
+        {
+            StorageOptions opts = sp.GetRequiredService<IOptions<StorageOptions>>().Value;
+            if (string.IsNullOrWhiteSpace(opts.PublicEndpoint) || opts.PublicEndpoint == opts.Endpoint)
             {
-                client = client.WithRegion(opts.Region);
+                return sp.GetRequiredService<IMinioClient>();
             }
 
-            return client.Build();
+            return BuildClient(opts, opts.PublicEndpoint, opts.PublicUseSSL ?? opts.UseSSL);
         });
 
         // IHttpClientFactory — usado por MinioStorageService.DownloadLimitadoAsync
@@ -89,5 +98,27 @@ public static class StorageServiceCollectionExtensions
         services.AddScoped<IStorageService, MinioStorageService>();
 
         return services;
+    }
+
+    /// <summary>Chave do <see cref="IMinioClient"/> keyed usado para assinar URLs devolvidas a clientes externos.</summary>
+    public const string StoragePublicClientKey = "storage-public";
+
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "O cliente é devolvido ao caller (factory de DI), que o registra como singleton — o container é o dono do descarte, não este método.")]
+    private static IMinioClient BuildClient(StorageOptions opts, string endpoint, bool useSSL)
+    {
+        IMinioClient client = new MinioClient()
+            .WithEndpoint(endpoint)
+            .WithCredentials(opts.AccessKey, opts.SecretKey)
+            .WithSSL(useSSL);
+
+        if (!string.IsNullOrWhiteSpace(opts.Region))
+        {
+            client = client.WithRegion(opts.Region);
+        }
+
+        return client.Build();
     }
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
@@ -65,6 +65,11 @@ public static class StorageServiceCollectionExtensions
                     || (!options.Endpoint.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
                         && !options.Endpoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase)),
                 "Storage:Endpoint must be host:port without scheme — control HTTPS via Storage:UseSSL.")
+            .Validate(
+                options => string.IsNullOrWhiteSpace(options.PublicEndpoint)
+                    || (!options.PublicEndpoint.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                        && !options.PublicEndpoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase)),
+                "Storage:PublicEndpoint must be host:port without scheme — control HTTPS via Storage:PublicUseSSL.")
             .ValidateOnStart();
 
         services.AddSingleton<IMinioClient>(sp =>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -81,7 +81,8 @@ public sealed class IdempotencyFilter<TDbContext> : IAsyncResourceFilter
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(next);
 
-        if (!HasRequiresIdempotencyKey(context))
+        RequiresIdempotencyKeyAttribute? attribute = GetRequiresIdempotencyKeyAttribute(context);
+        if (attribute is null)
         {
             await next().ConfigureAwait(false);
             return;
@@ -164,7 +165,8 @@ public sealed class IdempotencyFilter<TDbContext> : IAsyncResourceFilter
         // em Processing (409), ou ter Hit com body diferente (422). Sem o
         // re-lookup, perdedor receberia 409 mesmo se o vencedor já estivesse
         // pronto para replay — quebra de contrato draft IETF §3.
-        DateTimeOffset expiresAt = _time.GetUtcNow().Add(_options.Ttl);
+        TimeSpan ttl = attribute.TtlSeconds >= 0 ? TimeSpan.FromSeconds(attribute.TtlSeconds) : _options.Ttl;
+        DateTimeOffset expiresAt = _time.GetUtcNow().Add(ttl);
         bool reserved = await _store.TryReserveAsync(
             scope, endpoint, idempotencyKey, bodyHash, expiresAt, httpContext.RequestAborted).ConfigureAwait(false);
 
@@ -310,16 +312,16 @@ public sealed class IdempotencyFilter<TDbContext> : IAsyncResourceFilter
         }
     }
 
-    private static bool HasRequiresIdempotencyKey(ResourceExecutingContext context)
+    private static RequiresIdempotencyKeyAttribute? GetRequiresIdempotencyKeyAttribute(ResourceExecutingContext context)
     {
         if (context.ActionDescriptor is not ControllerActionDescriptor descriptor)
-            return false;
+            return null;
 
         // Atributo aceita AttributeTargets.Method | Class. Method-level vence
         // (controlle granularidade fina); class-level cobre o caso "todos os
         // POSTs deste controller exigem Idempotency-Key" sem repetir o atributo.
-        return descriptor.MethodInfo.GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true) is not null
-            || descriptor.ControllerTypeInfo.GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true) is not null;
+        return descriptor.MethodInfo.GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true)
+            ?? descriptor.ControllerTypeInfo.GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true);
     }
 
     private static async Task<byte[]> ReadAndRewindBodyAsync(

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/RequiresIdempotencyKeyAttribute.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/RequiresIdempotencyKeyAttribute.cs
@@ -8,4 +8,18 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
 /// lookup/store e short-circuit em caso de replay ou body mismatch.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-public sealed class RequiresIdempotencyKeyAttribute : Attribute;
+public sealed class RequiresIdempotencyKeyAttribute : Attribute
+{
+    /// <summary>
+    /// Override opcional do TTL da entrada de cache para este endpoint, em
+    /// segundos. <c>-1</c> (default) usa <see cref="IdempotencyOptions.Ttl"/>
+    /// (teto de 24h, ADR-0027) — tipos de atributo não aceitam <c>int?</c>,
+    /// então <c>-1</c> é o sentinel de "não configurado" (nenhum TTL real é
+    /// negativo). Existe para o caso em que a resposta cacheada carrega um
+    /// artefato com validade própria mais curta que 24h (ex.: URL
+    /// pre-assinada de upload) — sem o override, um replay depois da URL
+    /// expirar devolveria uma URL inutilizável, sem meio do cliente reobter
+    /// uma válida sem gerar outro registro pendente com nova Idempotency-Key.
+    /// </summary>
+    public int TtlSeconds { get; init; } = -1;
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/IStorageService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/IStorageService.cs
@@ -6,4 +6,25 @@ public interface IStorageService
     Task<Stream> DownloadAsync(string bucket, string nomeArquivo, CancellationToken cancellationToken = default);
     Task RemoverAsync(string bucket, string nomeArquivo, CancellationToken cancellationToken = default);
     Task<string> GerarUrlTemporariaAsync(string bucket, string nomeArquivo, TimeSpan expiracao, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gera uma URL pre-assinada de <c>PUT</c> para upload direto do cliente ao bucket,
+    /// sem os bytes trafegarem pela API. <paramref name="contentType"/> entra na assinatura
+    /// (header <c>Content-Type</c>) — o cliente precisa enviar exatamente esse valor no PUT,
+    /// senão o MinIO recusa com <c>SignatureDoesNotMatch</c>. O SDK MinIO não expõe restrição
+    /// de tamanho para PUT pre-assinado simples (isso só existe em <c>PresignedPostPolicyArgs</c>,
+    /// upload via formulário); tamanho máximo é responsabilidade de validação server-side após
+    /// o upload (ver <see cref="ObterMetadadosAsync"/>).
+    /// </summary>
+    Task<string> GerarUrlUploadTemporariaAsync(string bucket, string nomeArquivo, TimeSpan expiracao, string contentType, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Obtém tamanho e content-type do objeto sem baixar o conteúdo (HEAD/stat) — permite
+    /// validar tamanho antes de um download potencialmente caro. Retorna <see langword="null"/>
+    /// quando o objeto (ou o bucket) não existe, em vez de propagar exceção de vendor.
+    /// </summary>
+    Task<ObjetoMetadados?> ObterMetadadosAsync(string bucket, string nomeArquivo, CancellationToken cancellationToken = default);
 }
+
+/// <summary>Metadados de um objeto armazenado, obtidos via stat/HEAD sem baixar o conteúdo.</summary>
+public sealed record ObjetoMetadados(long TamanhoBytes, string ContentType);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/IStorageService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/IStorageService.cs
@@ -24,6 +24,16 @@ public interface IStorageService
     /// quando o objeto (ou o bucket) não existe, em vez de propagar exceção de vendor.
     /// </summary>
     Task<ObjetoMetadados?> ObterMetadadosAsync(string bucket, string nomeArquivo, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Baixa no máximo <paramref name="limiteBytes"/> do objeto via GET com Range (byte
+    /// 0 a <paramref name="limiteBytes"/> - 1) — o MinIO nunca transmite mais que isso pela
+    /// rede, então o limite é aplicado no servidor, não depois de já ter bufferizado o
+    /// objeto inteiro em memória. Um objeto maior que o limite devolve exatamente
+    /// <paramref name="limiteBytes"/> bytes (sem indicar o tamanho real); o caller decide o
+    /// que fazer com isso (ex.: tratar como excedido).
+    /// </summary>
+    Task<Stream> DownloadLimitadoAsync(string bucket, string nomeArquivo, long limiteBytes, CancellationToken cancellationToken = default);
 }
 
 /// <summary>Metadados de um objeto armazenado, obtidos via stat/HEAD sem baixar o conteúdo.</summary>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
@@ -2,19 +2,28 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Storage;
 
 using System.Net.Http.Headers;
 
+using Microsoft.Extensions.DependencyInjection;
+
 using Minio;
 using Minio.DataModel;
 using Minio.DataModel.Args;
 using Minio.Exceptions;
 
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+
 public sealed class MinioStorageService : IStorageService
 {
     private readonly IMinioClient _minioClient;
+    private readonly IMinioClient _presignClient;
     private readonly IHttpClientFactory _httpClientFactory;
 
-    public MinioStorageService(IMinioClient minioClient, IHttpClientFactory httpClientFactory)
+    public MinioStorageService(
+        IMinioClient minioClient,
+        [FromKeyedServices(StorageServiceCollectionExtensions.StoragePublicClientKey)] IMinioClient presignClient,
+        IHttpClientFactory httpClientFactory)
     {
         _minioClient = minioClient;
+        _presignClient = presignClient;
         _httpClientFactory = httpClientFactory;
     }
 
@@ -100,7 +109,10 @@ public sealed class MinioStorageService : IStorageService
             .WithObject(nomeArquivo)
             .WithExpiry((int)expiracao.TotalSeconds);
 
-        return await _minioClient.PresignedGetObjectAsync(args).ConfigureAwait(false);
+        // _presignClient (não _minioClient): a URL vai para um cliente externo
+        // (browser fora da rede Docker/cluster) — precisa ser assinada com o
+        // endpoint público (ver Storage:PublicEndpoint em StorageOptions).
+        return await _presignClient.PresignedGetObjectAsync(args).ConfigureAwait(false);
     }
 
     public async Task<string> GerarUrlUploadTemporariaAsync(string bucket, string nomeArquivo, TimeSpan expiracao, string contentType, CancellationToken cancellationToken = default)
@@ -118,7 +130,10 @@ public sealed class MinioStorageService : IStorageService
             .WithExpiry((int)expiracao.TotalSeconds)
             .WithHeaders(new Dictionary<string, string> { ["Content-Type"] = contentType });
 
-        return await _minioClient.PresignedPutObjectAsync(args).ConfigureAwait(false);
+        // _presignClient: mesma razão de GerarUrlTemporariaAsync — o upload
+        // direto é feito pelo cliente externo, então a URL precisa ser
+        // alcançável e assinada por ele (endpoint público).
+        return await _presignClient.PresignedPutObjectAsync(args).ConfigureAwait(false);
     }
 
     public async Task<ObjetoMetadados?> ObterMetadadosAsync(string bucket, string nomeArquivo, CancellationToken cancellationToken = default)

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Storage;
 
+using System.Net;
 using System.Net.Http.Headers;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -80,6 +81,18 @@ public sealed class MinioStorageService : IStorageService
         using HttpResponseMessage response = await httpClient
             .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
             .ConfigureAwait(false);
+
+        // A ObjectKey de staging segue sobrescrevível até o TTL da URL de
+        // upload expirar — mesmo já tendo passado pelo stat com tamanho > 0,
+        // o objeto pode ter virado 0 bytes até este GET rodar. Um Range sobre
+        // objeto vazio não é satisfazível (416); trata como stream vazio em
+        // vez de deixar EnsureSuccessStatusCode() escapar como erro não
+        // tratado — ValidarConteudo já sabe recusar conteúdo vazio (422).
+        if (response.StatusCode == HttpStatusCode.RequestedRangeNotSatisfiable)
+        {
+            return new MemoryStream();
+        }
+
         response.EnsureSuccessStatusCode();
 
         MemoryStream memoryStream = new();

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Storage;
 
+using System.Net.Http.Headers;
+
 using Minio;
 using Minio.DataModel;
 using Minio.DataModel.Args;
@@ -8,10 +10,12 @@ using Minio.Exceptions;
 public sealed class MinioStorageService : IStorageService
 {
     private readonly IMinioClient _minioClient;
+    private readonly IHttpClientFactory _httpClientFactory;
 
-    public MinioStorageService(IMinioClient minioClient)
+    public MinioStorageService(IMinioClient minioClient, IHttpClientFactory httpClientFactory)
     {
         _minioClient = minioClient;
+        _httpClientFactory = httpClientFactory;
     }
 
     public async Task<string> UploadAsync(string bucket, string nomeArquivo, Stream conteudo, string contentType, CancellationToken cancellationToken = default)
@@ -40,6 +44,42 @@ public sealed class MinioStorageService : IStorageService
             .WithCallbackStream(stream => stream.CopyTo(memoryStream));
 
         await _minioClient.GetObjectAsync(args, cancellationToken).ConfigureAwait(false);
+        memoryStream.Position = 0;
+        return memoryStream;
+    }
+
+    public async Task<Stream> DownloadLimitadoAsync(string bucket, string nomeArquivo, long limiteBytes, CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limiteBytes);
+
+        // GetObjectAsync (API de alto nível, usada por DownloadAsync) valida o
+        // download como completo e lança PartialContentException quando recebe
+        // menos bytes que o Content-Length total do objeto — não aceita um
+        // Range GET deliberadamente parcial. Uma URL pre-assinada de GET com
+        // header Range via HttpClient é o caminho que o MinIO honra de fato: o
+        // servidor nunca transmite mais que o intervalo pedido.
+        PresignedGetObjectArgs presignedArgs = new PresignedGetObjectArgs()
+            .WithBucket(bucket)
+            .WithObject(nomeArquivo)
+            .WithExpiry(60);
+        string url = await _minioClient.PresignedGetObjectAsync(presignedArgs).ConfigureAwait(false);
+
+        using HttpClient httpClient = _httpClientFactory.CreateClient(nameof(MinioStorageService));
+        using HttpRequestMessage request = new(HttpMethod.Get, url);
+        request.Headers.Range = new RangeHeaderValue(0, limiteBytes - 1);
+
+        using HttpResponseMessage response = await httpClient
+            .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        MemoryStream memoryStream = new();
+        Stream responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using (responseStream.ConfigureAwait(false))
+        {
+            await responseStream.CopyToAsync(memoryStream, cancellationToken).ConfigureAwait(false);
+        }
+
         memoryStream.Position = 0;
         return memoryStream;
     }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
@@ -1,7 +1,9 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Storage;
 
 using Minio;
+using Minio.DataModel;
 using Minio.DataModel.Args;
+using Minio.Exceptions;
 
 public sealed class MinioStorageService : IStorageService
 {
@@ -59,6 +61,45 @@ public sealed class MinioStorageService : IStorageService
             .WithExpiry((int)expiracao.TotalSeconds);
 
         return await _minioClient.PresignedGetObjectAsync(args).ConfigureAwait(false);
+    }
+
+    public async Task<string> GerarUrlUploadTemporariaAsync(string bucket, string nomeArquivo, TimeSpan expiracao, string contentType, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentType);
+
+        // Diferente de GerarUrlTemporariaAsync (GET, assume bucket já existente): este é o
+        // primeiro write path que não passa por UploadAsync — o bucket pode ainda não existir
+        // quando o primeiro upload direto acontece.
+        await GarantirBucketExisteAsync(bucket, cancellationToken).ConfigureAwait(false);
+
+        PresignedPutObjectArgs args = new PresignedPutObjectArgs()
+            .WithBucket(bucket)
+            .WithObject(nomeArquivo)
+            .WithExpiry((int)expiracao.TotalSeconds)
+            .WithHeaders(new Dictionary<string, string> { ["Content-Type"] = contentType });
+
+        return await _minioClient.PresignedPutObjectAsync(args).ConfigureAwait(false);
+    }
+
+    public async Task<ObjetoMetadados?> ObterMetadadosAsync(string bucket, string nomeArquivo, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            StatObjectArgs args = new StatObjectArgs()
+                .WithBucket(bucket)
+                .WithObject(nomeArquivo);
+
+            ObjectStat stat = await _minioClient.StatObjectAsync(args, cancellationToken).ConfigureAwait(false);
+            return new ObjetoMetadados(stat.Size, stat.ContentType);
+        }
+        catch (ObjectNotFoundException)
+        {
+            return null;
+        }
+        catch (BucketNotFoundException)
+        {
+            return null;
+        }
     }
 
     private async Task GarantirBucketExisteAsync(string bucket, CancellationToken cancellationToken)

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/StorageOptions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/StorageOptions.cs
@@ -30,6 +30,21 @@ public sealed class StorageOptions
     public string? Region { get; init; }
 
     /// <summary>
+    /// Endpoint MinIO alcançável por clientes externos (browser, app fora da rede
+    /// Docker/cluster) — usado para <em>assinar</em> URLs pre-assinadas devolvidas a
+    /// esses clientes (upload/download direto). Necessário porque a assinatura SigV4
+    /// inclui o header <c>Host</c>: reescrever a URL depois de assinada com
+    /// <see cref="Endpoint"/> invalida a assinatura, então um segundo cliente MinIO
+    /// assina do zero com este endpoint. Quando <see langword="null"/>/vazio, cai para
+    /// <see cref="Endpoint"/> (comportamento anterior — correto quando o mesmo endpoint
+    /// já é alcançável de fora, ex.: dev local sem stack containerizada completa).
+    /// </summary>
+    public string? PublicEndpoint { get; init; }
+
+    /// <summary>Esquema do <see cref="PublicEndpoint"/>. Cai para <see cref="UseSSL"/> quando não informado.</summary>
+    public bool? PublicUseSSL { get; init; }
+
+    /// <summary>
     /// Bucket default por API (ex.: <c>uniplus-documentos</c>). Opcional na camada de DI —
     /// handlers que dependem dele devem validar a própria obrigatoriedade.
     /// </summary>

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
@@ -18,7 +18,7 @@ public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioCont
 {
     private const string TestBucket = "uniplus-storage-tests";
 
-    private ServiceProvider BuildProvider()
+    private ServiceProvider BuildProvider(string? publicEndpoint = null)
     {
         Dictionary<string, string?> config = new()
         {
@@ -26,6 +26,10 @@ public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioCont
             ["Storage:AccessKey"] = MinioContainerFixture.AccessKey,
             ["Storage:SecretKey"] = MinioContainerFixture.SecretKey,
         };
+        if (publicEndpoint is not null)
+        {
+            config["Storage:PublicEndpoint"] = publicEndpoint;
+        }
 
         ServiceCollection services = new();
         services.AddUniPlusStorage(
@@ -86,5 +90,24 @@ public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioCont
         // O MinIO só transmite os 5 primeiros bytes (Range request) — o
         // objeto real tem 20, mas nunca chegam a trafegar pela rede/memória.
         collector.ToArray().Should().Equal(payload[..(int)limite]);
+    }
+
+    [Fact]
+    public async Task GerarUrlUploadTemporariaAsync_ComPublicEndpointConfigurado_AssinaComOEndpointPublico()
+    {
+        const string publicEndpoint = "storage.uniplus.example.org";
+        await using ServiceProvider sp = BuildProvider(publicEndpoint);
+        using IServiceScope scope = sp.CreateScope();
+        IStorageService storage = scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        // Devolvida a um cliente externo (browser fora da rede Docker/cluster,
+        // ver Storage:PublicEndpoint) — precisa apontar (e estar assinada)
+        // para o endpoint público, nunca para o interno (só alcançável de
+        // dentro da rede Docker/cluster).
+        string url = await storage.GerarUrlUploadTemporariaAsync(
+            TestBucket, $"smoke/{Guid.NewGuid():N}.pdf", TimeSpan.FromMinutes(5), "application/pdf");
+
+        url.Should().Contain(publicEndpoint);
+        url.Should().NotContain(minio.Endpoint);
     }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
@@ -154,4 +154,23 @@ public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioCont
 
         url.Should().StartWith("https://");
     }
+
+    [Fact]
+    public async Task GerarUrlUploadTemporariaAsync_ComPublicEndpointVazioMasComSslPublicoDiferente_AssinaComOEndpointInternoEEsquemaPublico()
+    {
+        // Storage:PublicEndpoint="" (string vazia, não ausente — é o valor
+        // literal deixado em branco no values.yaml do Helm chart quando só
+        // Storage:PublicUseSSL é preenchido) não pode virar o host assinado:
+        // precisa cair para Storage:Endpoint mesmo assim, só trocando o
+        // esquema.
+        await using ServiceProvider sp = BuildProvider(publicEndpoint: string.Empty, publicUseSsl: true);
+        using IServiceScope scope = sp.CreateScope();
+        IStorageService storage = scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        string url = await storage.GerarUrlUploadTemporariaAsync(
+            TestBucket, $"smoke/{Guid.NewGuid():N}.pdf", TimeSpan.FromMinutes(5), "application/pdf");
+
+        url.Should().StartWith("https://");
+        url.Should().Contain(minio.Endpoint);
+    }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
@@ -62,4 +62,29 @@ public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioCont
 
         collector.ToArray().Should().Equal(payload);
     }
+
+    [Fact]
+    public async Task DownloadLimitado_ObjetoMaiorQueLimite_TruncaNoLimiteSemBaixarOResto()
+    {
+        await using ServiceProvider sp = BuildProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IStorageService storage = scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        string objectName = $"smoke/limitado-{Guid.NewGuid():N}.bin";
+        byte[] payload = Encoding.UTF8.GetBytes("0123456789ABCDEFGHIJ"); // 20 bytes
+        const long limite = 5;
+
+        using (MemoryStream uploadStream = new(payload))
+        {
+            await storage.UploadAsync(TestBucket, objectName, uploadStream, "application/octet-stream");
+        }
+
+        await using Stream limitado = await storage.DownloadLimitadoAsync(TestBucket, objectName, limite);
+        using MemoryStream collector = new();
+        await limitado.CopyToAsync(collector);
+
+        // O MinIO só transmite os 5 primeiros bytes (Range request) — o
+        // objeto real tem 20, mas nunca chegam a trafegar pela rede/memória.
+        collector.ToArray().Should().Equal(payload[..(int)limite]);
+    }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
@@ -93,6 +93,28 @@ public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioCont
     }
 
     [Fact]
+    public async Task DownloadLimitado_ObjetoVazio_DevolveStreamVazioSemLancar()
+    {
+        await using ServiceProvider sp = BuildProvider();
+        using IServiceScope scope = sp.CreateScope();
+        IStorageService storage = scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        string objectName = $"smoke/vazio-{Guid.NewGuid():N}.bin";
+        using (MemoryStream uploadStream = new([]))
+        {
+            await storage.UploadAsync(TestBucket, objectName, uploadStream, "application/pdf");
+        }
+
+        // Range sobre objeto vazio não é satisfazível (416 do MinIO) — o
+        // método trata isso como stream vazio, não como exceção.
+        await using Stream limitado = await storage.DownloadLimitadoAsync(TestBucket, objectName, 100);
+        using MemoryStream collector = new();
+        await limitado.CopyToAsync(collector);
+
+        collector.ToArray().Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task GerarUrlUploadTemporariaAsync_ComPublicEndpointConfigurado_AssinaComOEndpointPublico()
     {
         const string publicEndpoint = "storage.uniplus.example.org";

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Storage/StorageServiceCollectionExtensionsIntegrationTests.cs
@@ -18,7 +18,7 @@ public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioCont
 {
     private const string TestBucket = "uniplus-storage-tests";
 
-    private ServiceProvider BuildProvider(string? publicEndpoint = null)
+    private ServiceProvider BuildProvider(string? publicEndpoint = null, bool? publicUseSsl = null)
     {
         Dictionary<string, string?> config = new()
         {
@@ -29,6 +29,11 @@ public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioCont
         if (publicEndpoint is not null)
         {
             config["Storage:PublicEndpoint"] = publicEndpoint;
+        }
+
+        if (publicUseSsl is not null)
+        {
+            config["Storage:PublicUseSSL"] = publicUseSsl.Value.ToString();
         }
 
         ServiceCollection services = new();
@@ -131,5 +136,22 @@ public sealed class StorageServiceCollectionExtensionsIntegrationTests(MinioCont
 
         url.Should().Contain(publicEndpoint);
         url.Should().NotContain(minio.Endpoint);
+    }
+
+    [Fact]
+    public async Task GerarUrlUploadTemporariaAsync_ComMesmoEndpointMasSslPublicoDiferente_UsaOEsquemaPublico()
+    {
+        // Mesmo host interno/público (ex.: exposto por fora via ingress no
+        // mesmo hostname), mas esquemas diferentes (HTTP dentro do cluster,
+        // HTTPS por fora) — não pode reusar o cliente interno cegamente só
+        // porque o endpoint bate.
+        await using ServiceProvider sp = BuildProvider(publicEndpoint: minio.Endpoint, publicUseSsl: true);
+        using IServiceScope scope = sp.CreateScope();
+        IStorageService storage = scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        string url = await storage.GerarUrlUploadTemporariaAsync(
+            TestBucket, $"smoke/{Guid.NewGuid():N}.pdf", TimeSpan.FromMinutes(5), "application/pdf");
+
+        url.Should().StartWith("https://");
     }
 }

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/StorageServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/StorageServiceCollectionExtensionsTests.cs
@@ -177,6 +177,28 @@ public sealed class StorageServiceCollectionExtensionsTests
             .WithMessage("*host:port without scheme*");
     }
 
+    [Theory]
+    [InlineData("http://storage.example.org")]
+    [InlineData("https://storage.example.org")]
+    [InlineData("HTTPS://storage.example.org")]
+    public void AddUniPlusStorage_PublicEndpointComScheme_OptionsValueLancaOptionsValidationException(string publicEndpoint)
+    {
+        Dictionary<string, string?> values = new(CompleteConfig())
+        {
+            ["Storage:PublicEndpoint"] = publicEndpoint,
+        };
+
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(values), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+
+        Action acao = () => { _ = sp.GetRequiredService<IOptions<StorageOptions>>().Value; };
+
+        acao.Should().Throw<OptionsValidationException>()
+            .WithMessage("*Storage:PublicEndpoint*host:port without scheme*");
+    }
+
     [Fact]
     public void AddUniPlusStorage_BindingMapeiaTodasAsPropriedades()
     {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Idempotency/RequiresIdempotencyKeyAttributeTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Idempotency/RequiresIdempotencyKeyAttributeTests.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Idempotency;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+
+public sealed class RequiresIdempotencyKeyAttributeTests
+{
+    [Fact(DisplayName = "TtlSeconds default é o sentinel -1 (usa IdempotencyOptions.Ttl)")]
+    public void TtlSeconds_SemOverride_UsaSentinel()
+    {
+        RequiresIdempotencyKeyAttribute atributo = new();
+
+        atributo.TtlSeconds.Should().Be(-1);
+    }
+
+    [Fact(DisplayName = "TtlSeconds aceita override explícito via inicializador de objeto")]
+    public void TtlSeconds_ComOverride_PreservaValor()
+    {
+        RequiresIdempotencyKeyAttribute atributo = new() { TtlSeconds = 900 };
+
+        atributo.TtlSeconds.Should().Be(900);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
 
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
 using AwesomeAssertions;
@@ -96,6 +97,10 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
     }
 
     [Fact(DisplayName = "Handle recusa conteúdo sem assinatura PDV válida (422 AssinaturaInvalida)")]
+    [SuppressMessage(
+        "Reliability",
+        "CA2025:Object MemoryStream can be disposed of before operation completes",
+        Justification = "O stream é consumido de forma síncrona dentro do await Handle(...) — a leitura pelo handler termina antes do using declarado sair de escopo no fim do método.")]
     public async Task Handle_AssinaturaInvalida_Recusa()
     {
         (DocumentoEdital documento, Guid processoId) = NovoDocumentoPendente();
@@ -106,8 +111,9 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
         storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
             .Returns(new InfoObjetoArmazenado(conteudoFalso.Length, "application/pdf"));
+        using MemoryStream streamConteudoFalso = new(conteudoFalso);
         storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<Stream>(new MemoryStream(conteudoFalso)));
+            .Returns(Task.FromResult<Stream>(streamConteudoFalso));
 
         Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
             new ConfirmarUploadDocumentoEditalCommand(processoId, documento.Id),
@@ -116,9 +122,14 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("DocumentoEdital.AssinaturaInvalida");
         repository.DidNotReceive().Atualizar(Arg.Any<DocumentoEdital>());
+        await storage.DidNotReceive().SalvarConteudoSeladoAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>());
     }
 
     [Fact(DisplayName = "Handle com PDF válido confirma, calcula sha256 e persiste (fluxo feliz)")]
+    [SuppressMessage(
+        "Reliability",
+        "CA2025:Object MemoryStream can be disposed of before operation completes",
+        Justification = "O stream é consumido de forma síncrona dentro do await Handle(...) — a leitura pelo handler termina antes do using declarado sair de escopo no fim do método.")]
     public async Task Handle_PdfValido_ConfirmaEPersiste()
     {
         (DocumentoEdital documento, Guid processoId) = NovoDocumentoPendente();
@@ -128,8 +139,9 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
         storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
             .Returns(new InfoObjetoArmazenado(ConteudoPdfValido.Length, "application/pdf"));
+        using MemoryStream streamConteudoValido = new(ConteudoPdfValido);
         storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<Stream>(new MemoryStream(ConteudoPdfValido)));
+            .Returns(Task.FromResult<Stream>(streamConteudoValido));
         string hashEsperado = Convert.ToHexStringLower(SHA256.HashData(ConteudoPdfValido));
 
         Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
@@ -142,5 +154,10 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         resultado.Value.Status.Should().Be("Confirmado");
         repository.Received(1).Atualizar(documento);
         await unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+        // A cópia selada é o que efetivamente torna o documento imutável — a
+        // URL de upload original ainda aponta para ObjectKey, sobrescrevível
+        // até o TTL expirar (achado P1 Codex).
+        await storage.Received(1).SalvarConteudoSeladoAsync(
+            documento.ObjectKeyConfirmado!, Arg.Is<byte[]>(b => b.SequenceEqual(ConteudoPdfValido)), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
@@ -93,7 +93,7 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("DocumentoEdital.TamanhoExcedido");
-        await storage.DidNotReceive().AbrirLeituraAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await storage.DidNotReceive().AbrirLeituraAsync(Arg.Any<string>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Fact(DisplayName = "Handle recusa conteúdo sem assinatura PDV válida (422 AssinaturaInvalida)")]
@@ -112,7 +112,7 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
             .Returns(new InfoObjetoArmazenado(conteudoFalso.Length, "application/pdf"));
         using MemoryStream streamConteudoFalso = new(conteudoFalso);
-        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<long>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<Stream>(streamConteudoFalso));
 
         Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
@@ -144,7 +144,7 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
             .Returns(new InfoObjetoArmazenado(ConteudoPdfValido.Length, "application/pdf"));
         using MemoryStream streamConteudoValido = new(ConteudoPdfValido);
-        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<long>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<Stream>(streamConteudoValido));
         string hashEsperado = Convert.ToHexStringLower(SHA256.HashData(ConteudoPdfValido));
 
@@ -182,7 +182,7 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
             .Returns(new InfoObjetoArmazenado(ConteudoPdfValido.Length, "application/pdf"));
         using MemoryStream streamConteudoValido = new(ConteudoPdfValido);
-        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<long>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<Stream>(streamConteudoValido));
 
         Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
@@ -214,7 +214,7 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
             .Returns(new InfoObjetoArmazenado(10, "application/pdf"));
         byte[] conteudoReal = new byte[DocumentoEdital.TamanhoMaximoBytes + 1024];
         using MemoryStream streamReal = new(conteudoReal);
-        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<long>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<Stream>(streamReal));
 
         Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
@@ -225,4 +225,26 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         resultado.Error!.Code.Should().Be("DocumentoEdital.TamanhoExcedido");
         await repository.DidNotReceive().TentarReivindicarConfirmacaoAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact(DisplayName = "Handle recusa objeto de 0 bytes sem tentar ler (Range GET não é satisfazível sobre objeto vazio)")]
+    public async Task Handle_ObjetoVazio_RecusaSemTentarLer()
+    {
+        (DocumentoEdital documento, Guid processoId) = NovoDocumentoPendente();
+        IDocumentoEditalRepository repository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
+        storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(new InfoObjetoArmazenado(0, "application/pdf"));
+
+        Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processoId, documento.Id),
+            repository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.AssinaturaInvalida");
+        // Um Range GET (byte 0 a N) não é satisfazível sobre um objeto vazio —
+        // o servidor recusaria com 416. Não há o que ler, então nem tenta.
+        await storage.DidNotReceive().AbrirLeituraAsync(Arg.Any<string>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
@@ -1,0 +1,146 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
+
+using System.Security.Cryptography;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Application.Commands.DocumentosEdital;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
+{
+    private static readonly byte[] ConteudoPdfValido = [.. "%PDF-1.7 conteúdo qualquer"u8];
+
+    private static (DocumentoEdital Documento, Guid ProcessoSeletivoId) NovoDocumentoPendente()
+    {
+        Guid processoSeletivoId = Guid.CreateVersion7();
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processoSeletivoId, TimeProvider.System, TimeSpan.FromMinutes(15));
+        return (documento, processoSeletivoId);
+    }
+
+    [Fact(DisplayName = "Handle com documento inexistente recusa (404)")]
+    public async Task Handle_DocumentoInexistente_Recusa()
+    {
+        IDocumentoEditalRepository repository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        repository.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((DocumentoEdital?)null);
+
+        Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(Guid.CreateVersion7(), Guid.CreateVersion7()),
+            repository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.NaoEncontrado");
+    }
+
+    [Fact(DisplayName = "Handle com documento de outro processo recusa (404)")]
+    public async Task Handle_DocumentoDeOutroProcesso_Recusa()
+    {
+        (DocumentoEdital documento, _) = NovoDocumentoPendente();
+        IDocumentoEditalRepository repository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
+
+        Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(Guid.CreateVersion7(), documento.Id),
+            repository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.NaoEncontrado");
+    }
+
+    [Fact(DisplayName = "Handle com objeto ausente no storage recusa (422 ObjetoNaoEncontrado)")]
+    public async Task Handle_ObjetoAusente_Recusa()
+    {
+        (DocumentoEdital documento, Guid processoId) = NovoDocumentoPendente();
+        IDocumentoEditalRepository repository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
+        storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>()).Returns((InfoObjetoArmazenado?)null);
+
+        Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processoId, documento.Id),
+            repository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.ObjetoNaoEncontrado");
+    }
+
+    [Fact(DisplayName = "Handle recusa por tamanho sem baixar o conteúdo (422 TamanhoExcedido)")]
+    public async Task Handle_TamanhoExcedido_RecusaSemBaixarConteudo()
+    {
+        (DocumentoEdital documento, Guid processoId) = NovoDocumentoPendente();
+        IDocumentoEditalRepository repository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
+        storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(new InfoObjetoArmazenado(DocumentoEdital.TamanhoMaximoBytes + 1, "application/pdf"));
+
+        Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processoId, documento.Id),
+            repository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.TamanhoExcedido");
+        await storage.DidNotReceive().AbrirLeituraAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle recusa conteúdo sem assinatura PDV válida (422 AssinaturaInvalida)")]
+    public async Task Handle_AssinaturaInvalida_Recusa()
+    {
+        (DocumentoEdital documento, Guid processoId) = NovoDocumentoPendente();
+        byte[] conteudoFalso = [.. "não é um pdf de verdade"u8];
+        IDocumentoEditalRepository repository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
+        storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(new InfoObjetoArmazenado(conteudoFalso.Length, "application/pdf"));
+        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Stream>(new MemoryStream(conteudoFalso)));
+
+        Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processoId, documento.Id),
+            repository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.AssinaturaInvalida");
+        repository.DidNotReceive().Atualizar(Arg.Any<DocumentoEdital>());
+    }
+
+    [Fact(DisplayName = "Handle com PDF válido confirma, calcula sha256 e persiste (fluxo feliz)")]
+    public async Task Handle_PdfValido_ConfirmaEPersiste()
+    {
+        (DocumentoEdital documento, Guid processoId) = NovoDocumentoPendente();
+        IDocumentoEditalRepository repository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
+        storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(new InfoObjetoArmazenado(ConteudoPdfValido.Length, "application/pdf"));
+        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Stream>(new MemoryStream(ConteudoPdfValido)));
+        string hashEsperado = Convert.ToHexStringLower(SHA256.HashData(ConteudoPdfValido));
+
+        Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processoId, documento.Id),
+            repository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.HashSha256.Should().Be(hashEsperado);
+        resultado.Value.TamanhoBytes.Should().Be(ConteudoPdfValido.Length);
+        resultado.Value.Status.Should().Be("Confirmado");
+        repository.Received(1).Atualizar(documento);
+        await unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
@@ -194,4 +194,35 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         await storage.DidNotReceive().SalvarConteudoSeladoAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>());
         repository.DidNotReceive().Atualizar(Arg.Any<DocumentoEdital>());
     }
+
+    [Fact(DisplayName = "Handle recusa por tamanho quando o conteúdo real excede o limite mesmo com stat menor (TOCTOU)")]
+    [SuppressMessage(
+        "Reliability",
+        "CA2025:Object MemoryStream can be disposed of before operation completes",
+        Justification = "O stream é consumido de forma síncrona dentro do await Handle(...) — a leitura pelo handler termina antes do using declarado sair de escopo no fim do método.")]
+    public async Task Handle_ConteudoRealExcedeLimiteApesarDoStatMenor_Recusa()
+    {
+        (DocumentoEdital documento, Guid processoId) = NovoDocumentoPendente();
+        IDocumentoEditalRepository repository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
+        // Stat relata um tamanho pequeno — simula o objeto de staging tendo
+        // sido substituído por um maior entre o stat e a leitura (a chave
+        // original segue sobrescrevível até o TTL expirar).
+        storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(new InfoObjetoArmazenado(10, "application/pdf"));
+        byte[] conteudoReal = new byte[DocumentoEdital.TamanhoMaximoBytes + 1024];
+        using MemoryStream streamReal = new(conteudoReal);
+        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Stream>(streamReal));
+
+        Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processoId, documento.Id),
+            repository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.TamanhoExcedido");
+        await repository.DidNotReceive().TentarReivindicarConfirmacaoAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConfirmarUploadDocumentoEditalCommandHandlerTests.cs
@@ -123,6 +123,9 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         resultado.Error!.Code.Should().Be("DocumentoEdital.AssinaturaInvalida");
         repository.DidNotReceive().Atualizar(Arg.Any<DocumentoEdital>());
         await storage.DidNotReceive().SalvarConteudoSeladoAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>());
+        // Conteúdo inválido nunca chega a reivindicar a confirmação — senão o
+        // registro travaria como Confirmado sem hash caso a validação recuse.
+        await repository.DidNotReceive().TentarReivindicarConfirmacaoAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
     }
 
     [Fact(DisplayName = "Handle com PDF válido confirma, calcula sha256 e persiste (fluxo feliz)")]
@@ -137,6 +140,7 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
         ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
         repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
+        repository.TentarReivindicarConfirmacaoAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(true);
         storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
             .Returns(new InfoObjetoArmazenado(ConteudoPdfValido.Length, "application/pdf"));
         using MemoryStream streamConteudoValido = new(ConteudoPdfValido);
@@ -156,8 +160,38 @@ public sealed class ConfirmarUploadDocumentoEditalCommandHandlerTests
         await unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
         // A cópia selada é o que efetivamente torna o documento imutável — a
         // URL de upload original ainda aponta para ObjectKey, sobrescrevível
-        // até o TTL expirar (achado P1 Codex).
+        // até o TTL expirar.
         await storage.Received(1).SalvarConteudoSeladoAsync(
             documento.ObjectKeyConfirmado!, Arg.Is<byte[]>(b => b.SequenceEqual(ConteudoPdfValido)), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle recusa quando perde a reivindicação atômica sem escrever no storage")]
+    [SuppressMessage(
+        "Reliability",
+        "CA2025:Object MemoryStream can be disposed of before operation completes",
+        Justification = "O stream é consumido de forma síncrona dentro do await Handle(...) — a leitura pelo handler termina antes do using declarado sair de escopo no fim do método.")]
+    public async Task Handle_PerdeuReivindicacao_RecusaSemEscreverStorage()
+    {
+        (DocumentoEdital documento, Guid processoId) = NovoDocumentoPendente();
+        IDocumentoEditalRepository repository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        repository.ObterPorIdAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(documento);
+        // Simula outra confirmação concorrente já tendo vencido a reivindicação.
+        repository.TentarReivindicarConfirmacaoAsync(documento.Id, Arg.Any<CancellationToken>()).Returns(false);
+        storage.ObterInfoAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(new InfoObjetoArmazenado(ConteudoPdfValido.Length, "application/pdf"));
+        using MemoryStream streamConteudoValido = new(ConteudoPdfValido);
+        storage.AbrirLeituraAsync(documento.ObjectKey, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<Stream>(streamConteudoValido));
+
+        Result<DocumentoEditalDto> resultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processoId, documento.Id),
+            repository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.StatusInvalidoParaConfirmacao");
+        await storage.DidNotReceive().SalvarConteudoSeladoAsync(Arg.Any<string>(), Arg.Any<byte[]>(), Arg.Any<CancellationToken>());
+        repository.DidNotReceive().Atualizar(Arg.Any<DocumentoEdital>());
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/IniciarUploadDocumentoEditalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/IniciarUploadDocumentoEditalCommandHandlerTests.cs
@@ -1,0 +1,58 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Application.Commands.DocumentosEdital;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+public sealed class IniciarUploadDocumentoEditalCommandHandlerTests
+{
+    [Fact(DisplayName = "Handle com processo inexistente recusa sem criar documento")]
+    public async Task Handle_ProcessoInexistente_Recusa()
+    {
+        IProcessoSeletivoRepository processoRepository = Substitute.For<IProcessoSeletivoRepository>();
+        IDocumentoEditalRepository documentoRepository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        processoRepository.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns((ProcessoSeletivo?)null);
+
+        Result<IniciarUploadDocumentoEditalDto> resultado = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(Guid.CreateVersion7()),
+            processoRepository, documentoRepository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.NaoEncontrado");
+        await documentoRepository.DidNotReceive().AdicionarAsync(Arg.Any<DocumentoEdital>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Handle com processo existente cria documento pendente e devolve URL pre-assinada")]
+    public async Task Handle_ProcessoExistente_CriaPendenteEDevolveUrl()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — SiSU", TipoProcesso.SiSU);
+        IProcessoSeletivoRepository processoRepository = Substitute.For<IProcessoSeletivoRepository>();
+        IDocumentoEditalRepository documentoRepository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        processoRepository.ObterPorIdAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+        storage.GerarUrlUploadAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns("https://minio.local/uniplus-documentos/x.pdf?X-Amz-Signature=fake");
+
+        Result<IniciarUploadDocumentoEditalDto> resultado = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.UrlUpload.Should().Be(new Uri("https://minio.local/uniplus-documentos/x.pdf?X-Amz-Signature=fake"));
+        await documentoRepository.Received(1).AdicionarAsync(
+            Arg.Is<DocumentoEdital>(d => d.ProcessoSeletivoId == processo.Id && d.Status == StatusDocumentoEdital.Pendente),
+            Arg.Any<CancellationToken>());
+        await unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/IniciarUploadDocumentoEditalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/IniciarUploadDocumentoEditalCommandHandlerTests.cs
@@ -55,4 +55,28 @@ public sealed class IniciarUploadDocumentoEditalCommandHandlerTests
             Arg.Any<CancellationToken>());
         await unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
     }
+
+    [Fact(DisplayName = "Handle não persiste nada quando a geração da URL pre-assinada falha")]
+    public async Task Handle_FalhaAoGerarUrl_NaoPersisteRegistroOrfao()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — SiSU", TipoProcesso.SiSU);
+        IProcessoSeletivoRepository processoRepository = Substitute.For<IProcessoSeletivoRepository>();
+        IDocumentoEditalRepository documentoRepository = Substitute.For<IDocumentoEditalRepository>();
+        IDocumentoEditalStorage storage = Substitute.For<IDocumentoEditalStorage>();
+        ISelecaoUnitOfWork unitOfWork = Substitute.For<ISelecaoUnitOfWork>();
+        processoRepository.ObterPorIdAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+        storage.GerarUrlUploadAsync(Arg.Any<string>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns<Task<string>>(_ => throw new InvalidOperationException("MinIO indisponível (simulado)"));
+
+        Func<Task> act = () => IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, storage, unitOfWork, TimeProvider.System, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        // Sem isso, uma falha no presign depois do SaveChanges deixaria uma
+        // linha pendente órfã (sem URL nunca entregue ao cliente) e, sob
+        // retry com a mesma Idempotency-Key, criaria outra a cada tentativa.
+        await documentoRepository.DidNotReceive().AdicionarAsync(Arg.Any<DocumentoEdital>(), Arg.Any<CancellationToken>());
+        await unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/IniciarUploadDocumentoEditalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/IniciarUploadDocumentoEditalCommandHandlerTests.cs
@@ -50,6 +50,7 @@ public sealed class IniciarUploadDocumentoEditalCommandHandlerTests
 
         resultado.IsSuccess.Should().BeTrue();
         resultado.Value!.UrlUpload.Should().Be(new Uri("https://minio.local/uniplus-documentos/x.pdf?X-Amz-Signature=fake"));
+        resultado.Value!.ContentTypeExigido.Should().Be(DocumentoEdital.ContentTypeEsperado);
         await documentoRepository.Received(1).AdicionarAsync(
             Arg.Is<DocumentoEdital>(d => d.ProcessoSeletivoId == processo.Id && d.Status == StatusDocumentoEdital.Pendente),
             Arg.Any<CancellationToken>());

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoEditalTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoEditalTests.cs
@@ -1,0 +1,117 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Cobertura das invariantes de <see cref="DocumentoEdital"/> (Story #759, T3
+/// #784): ciclo de vida pendente → confirmado e validação de conteúdo
+/// (content-type, tamanho, assinatura PDF) na confirmação.
+/// </summary>
+public sealed class DocumentoEditalTests
+{
+    private static readonly Guid ProcessoSeletivoId = Guid.CreateVersion7();
+    private static readonly byte[] ConteudoPdfValido = [.. "%PDF-1.7 conteúdo qualquer"u8];
+
+    [Fact(DisplayName = "IniciarPendente cria o registro em Pendente com ExpiraEm = agora + ttl")]
+    public void IniciarPendente_CriaRegistroPendente()
+    {
+        TimeProvider clock = TimeProvider.System;
+        TimeSpan ttl = TimeSpan.FromMinutes(15);
+
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(
+            ProcessoSeletivoId, clock, ttl);
+
+        documento.ProcessoSeletivoId.Should().Be(ProcessoSeletivoId);
+        documento.Status.Should().Be(StatusDocumentoEdital.Pendente);
+        documento.ExpiraEm.Should().BeCloseTo(clock.GetUtcNow().Add(ttl), TimeSpan.FromSeconds(5));
+        documento.HashSha256.Should().BeNull();
+        documento.TamanhoBytes.Should().BeNull();
+        documento.ConfirmadoEm.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Confirmar a partir de Pendente finaliza o documento como imutável (CA)")]
+    public void Confirmar_APartirDePendente_Finaliza()
+    {
+        TimeProvider clock = TimeProvider.System;
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(
+            ProcessoSeletivoId, clock, TimeSpan.FromMinutes(15));
+
+        Result resultado = documento.Confirmar(1024, "hash-sha256-fake", clock);
+
+        resultado.IsSuccess.Should().BeTrue();
+        documento.Status.Should().Be(StatusDocumentoEdital.Confirmado);
+        documento.TamanhoBytes.Should().Be(1024);
+        documento.HashSha256.Should().Be("hash-sha256-fake");
+        documento.ConfirmadoEm.Should().BeCloseTo(clock.GetUtcNow(), TimeSpan.FromSeconds(5));
+    }
+
+    [Fact(DisplayName = "Confirmar um documento já confirmado é recusado (imutabilidade)")]
+    public void Confirmar_DocumentoJaConfirmado_Recusa()
+    {
+        TimeProvider clock = TimeProvider.System;
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(
+            ProcessoSeletivoId, clock, TimeSpan.FromMinutes(15));
+        documento.Confirmar(1024, "hash-original", clock);
+
+        Result resultado = documento.Confirmar(2048, "hash-novo", clock);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.StatusInvalidoParaConfirmacao");
+        // Confirmação recusada não deve mutar o registro já confirmado.
+        documento.TamanhoBytes.Should().Be(1024);
+        documento.HashSha256.Should().Be("hash-original");
+    }
+
+    [Fact(DisplayName = "ValidarConteudo aceita PDF dentro do limite com assinatura correta")]
+    public void ValidarConteudo_PdfValido_Aceita()
+    {
+        Result resultado = DocumentoEdital.ValidarConteudo(ConteudoPdfValido.Length, "application/pdf", ConteudoPdfValido);
+
+        resultado.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "ValidarConteudo recusa tamanho acima do limite máximo (422)")]
+    public void ValidarConteudo_TamanhoExcedido_Recusa()
+    {
+        Result resultado = DocumentoEdital.ValidarConteudo(
+            DocumentoEdital.TamanhoMaximoBytes + 1, "application/pdf", ConteudoPdfValido);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.TamanhoExcedido");
+    }
+
+    [Fact(DisplayName = "ValidarConteudo recusa content-type diferente de application/pdf (422)")]
+    public void ValidarConteudo_ContentTypeInvalido_Recusa()
+    {
+        Result resultado = DocumentoEdital.ValidarConteudo(
+            ConteudoPdfValido.Length, "image/png", ConteudoPdfValido);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.ContentTypeInvalido");
+    }
+
+    [Fact(DisplayName = "ValidarConteudo recusa assinatura (magic bytes) que não é %PDF- (422)")]
+    public void ValidarConteudo_AssinaturaInvalida_Recusa()
+    {
+        byte[] conteudoFalso = [.. "não é um pdf de verdade"u8];
+
+        Result resultado = DocumentoEdital.ValidarConteudo(
+            conteudoFalso.Length, "application/pdf", conteudoFalso);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.AssinaturaInvalida");
+    }
+
+    [Fact(DisplayName = "ValidarConteudo recusa conteúdo vazio (assinatura ausente)")]
+    public void ValidarConteudo_ConteudoVazio_Recusa()
+    {
+        Result resultado = DocumentoEdital.ValidarConteudo(0, "application/pdf", ReadOnlySpan<byte>.Empty);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoEdital.AssinaturaInvalida");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/RelogioObrigatorioTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/RelogioObrigatorioTests.cs
@@ -28,4 +28,13 @@ public sealed class RelogioObrigatorioTests
 
         act.Should().Throw<ArgumentNullException>();
     }
+
+    [Fact(DisplayName = "DocumentoEdital.IniciarPendente exige TimeProvider não-nulo")]
+    public void DocumentoEditalIniciarPendente_ClockNulo_Lanca()
+    {
+        Action act = () => DocumentoEdital.IniciarPendente(
+            Guid.CreateVersion7(), clock: null!, TimeSpan.FromMinutes(15));
+
+        act.Should().Throw<ArgumentNullException>();
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
@@ -139,7 +139,8 @@ public sealed class DocumentoEditalUploadIntegrationTests : IClassFixture<Proces
         HttpResponseMessage putSobrescrita = await http.PutAsync(iniciarResultado.Value.UrlUpload, conteudoSobrescrita);
         putSobrescrita.EnsureSuccessStatusCode();
 
-        await using Stream streamSelado = await _storage.AbrirLeituraAsync(documentoConfirmado.ObjectKeyConfirmado!, CancellationToken.None);
+        await using Stream streamSelado = await _storage.AbrirLeituraAsync(
+            documentoConfirmado.ObjectKeyConfirmado!, DocumentoEdital.TamanhoMaximoBytes + 1, CancellationToken.None);
         using MemoryStream buffer = new();
         await streamSelado.CopyToAsync(buffer, CancellationToken.None);
 

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
@@ -1,0 +1,201 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.DocumentosEdital;
+
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Microsoft.Extensions.Options;
+
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
+using Unifesspa.UniPlus.Infrastructure.Core.Storage;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Application.Commands.DocumentosEdital;
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Infrastructure.ExternalServices;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Selecao.IntegrationTests.ProcessosSeletivos;
+
+/// <summary>
+/// Integração real (Testcontainers Postgres + MinIO) do fluxo completo do
+/// upload direto do documento do Edital (Story #759, T3 #784): iniciar → PUT
+/// pre-assinado direto ao MinIO → confirmar → hash. Sem passar pelo HTTP
+/// pipeline (controllers/auth/idempotência) — exercita Application +
+/// Infrastructure reais, que é onde a integração com Postgres/MinIO importa.
+/// </summary>
+public sealed class DocumentoEditalUploadIntegrationTests : IClassFixture<ProcessoSeletivoDbFixture>, IClassFixture<MinioContainerFixture>
+{
+    private const string TestBucket = "uniplus-documentos-test";
+    private static readonly byte[] ConteudoPdfValido = [.. "%PDF-1.7 conteúdo de teste — Uni+ #784"u8];
+
+    private readonly ProcessoSeletivoDbFixture _dbFixture;
+    private readonly IDocumentoEditalStorage _storage;
+
+    public DocumentoEditalUploadIntegrationTests(ProcessoSeletivoDbFixture dbFixture, MinioContainerFixture minio)
+    {
+        ArgumentNullException.ThrowIfNull(dbFixture);
+        ArgumentNullException.ThrowIfNull(minio);
+        _dbFixture = dbFixture;
+
+        Dictionary<string, string?> config = new()
+        {
+            ["Storage:Endpoint"] = minio.Endpoint,
+            ["Storage:AccessKey"] = MinioContainerFixture.AccessKey,
+            ["Storage:SecretKey"] = MinioContainerFixture.SecretKey,
+            ["Storage:BucketName"] = TestBucket,
+        };
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(
+            new ConfigurationBuilder().AddInMemoryCollection(config).Build(),
+            new HostingEnvironment { EnvironmentName = Environments.Production });
+        ServiceProvider provider = services.BuildServiceProvider();
+        IStorageService storageService = provider.GetRequiredService<IStorageService>();
+        IOptions<StorageOptions> options = provider.GetRequiredService<IOptions<StorageOptions>>();
+        _storage = new DocumentoEditalStorageService(storageService, options);
+    }
+
+    private async Task<(SelecaoDbContext Context, ProcessoSeletivo Processo)> NovoProcessoAsync()
+    {
+        SelecaoDbContext context = _dbFixture.CreateDbContext();
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — SiSU (teste #784)", TipoProcesso.SiSU);
+        context.ProcessosSeletivos.Add(processo);
+        await context.SaveChangesAsync();
+        return (context, processo);
+    }
+
+    [Fact(DisplayName = "Fluxo completo: iniciar → PUT pre-assinado → confirmar → hash bate com sha256 local")]
+    public async Task FluxoCompleto_IniciarUploadConfirmar_HashConfere()
+    {
+        (SelecaoDbContext context, ProcessoSeletivo processo) = await NovoProcessoAsync();
+        DocumentoEditalRepository documentoRepository = new(context);
+        ProcessoSeletivoRepository processoRepository = new(context, TimeProvider.System);
+
+        Result<IniciarUploadDocumentoEditalDto> iniciarResultado = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+        iniciarResultado.IsSuccess.Should().BeTrue();
+
+        using HttpClient http = new();
+        using ByteArrayContent conteudo = new(ConteudoPdfValido);
+        conteudo.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        HttpResponseMessage putResponse = await http.PutAsync(iniciarResultado.Value!.UrlUpload, conteudo);
+        putResponse.EnsureSuccessStatusCode();
+
+        Result<DocumentoEditalDto> confirmarResultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processo.Id, iniciarResultado.Value.DocumentoEditalId),
+            documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+
+        confirmarResultado.IsSuccess.Should().BeTrue();
+        confirmarResultado.Value!.Status.Should().Be("Confirmado");
+        confirmarResultado.Value.TamanhoBytes.Should().Be(ConteudoPdfValido.Length);
+        confirmarResultado.Value.HashSha256.Should().Be(Convert.ToHexStringLower(SHA256.HashData(ConteudoPdfValido)));
+    }
+
+    [Fact(DisplayName = "Confirmar sem upload prévio recusa (422 ObjetoNaoEncontrado)")]
+    public async Task Confirmar_SemUploadPrevio_Recusa()
+    {
+        (SelecaoDbContext context, ProcessoSeletivo processo) = await NovoProcessoAsync();
+        DocumentoEditalRepository documentoRepository = new(context);
+        ProcessoSeletivoRepository processoRepository = new(context, TimeProvider.System);
+
+        Result<IniciarUploadDocumentoEditalDto> iniciarResultado = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+        iniciarResultado.IsSuccess.Should().BeTrue();
+
+        // Sem PUT ao MinIO — confirma direto, sem que o objeto exista.
+        Result<DocumentoEditalDto> confirmarResultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processo.Id, iniciarResultado.Value!.DocumentoEditalId),
+            documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+
+        confirmarResultado.IsFailure.Should().BeTrue();
+        confirmarResultado.Error!.Code.Should().Be("DocumentoEdital.ObjetoNaoEncontrado");
+    }
+
+    [Fact(DisplayName = "Confirmar objeto sem assinatura PDF válida recusa (422 AssinaturaInvalida)")]
+    public async Task Confirmar_ObjetoSemAssinaturaPdf_Recusa()
+    {
+        (SelecaoDbContext context, ProcessoSeletivo processo) = await NovoProcessoAsync();
+        DocumentoEditalRepository documentoRepository = new(context);
+        ProcessoSeletivoRepository processoRepository = new(context, TimeProvider.System);
+
+        Result<IniciarUploadDocumentoEditalDto> iniciarResultado = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+        iniciarResultado.IsSuccess.Should().BeTrue();
+
+        byte[] conteudoFalso = [.. "não é um pdf de verdade"u8];
+        using HttpClient http = new();
+        using ByteArrayContent conteudo = new(conteudoFalso);
+        conteudo.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        HttpResponseMessage putResponse = await http.PutAsync(iniciarResultado.Value!.UrlUpload, conteudo);
+        putResponse.EnsureSuccessStatusCode();
+
+        Result<DocumentoEditalDto> confirmarResultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processo.Id, iniciarResultado.Value.DocumentoEditalId),
+            documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+
+        confirmarResultado.IsFailure.Should().BeTrue();
+        confirmarResultado.Error!.Code.Should().Be("DocumentoEdital.AssinaturaInvalida");
+    }
+
+    [Fact(DisplayName = "Confirmar um documento já confirmado recusa (imutabilidade — CA)")]
+    public async Task Confirmar_DocumentoJaConfirmado_Recusa()
+    {
+        (SelecaoDbContext context, ProcessoSeletivo processo) = await NovoProcessoAsync();
+        DocumentoEditalRepository documentoRepository = new(context);
+        ProcessoSeletivoRepository processoRepository = new(context, TimeProvider.System);
+
+        Result<IniciarUploadDocumentoEditalDto> iniciarResultado = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+
+        using HttpClient http = new();
+        using ByteArrayContent conteudo = new(ConteudoPdfValido);
+        conteudo.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        HttpResponseMessage putResponse = await http.PutAsync(iniciarResultado.Value!.UrlUpload, conteudo);
+        putResponse.EnsureSuccessStatusCode();
+
+        Result<DocumentoEditalDto> primeiraConfirmacao = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processo.Id, iniciarResultado.Value.DocumentoEditalId),
+            documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+        primeiraConfirmacao.IsSuccess.Should().BeTrue();
+
+        Result<DocumentoEditalDto> segundaConfirmacao = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processo.Id, iniciarResultado.Value.DocumentoEditalId),
+            documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+
+        segundaConfirmacao.IsFailure.Should().BeTrue();
+        segundaConfirmacao.Error!.Code.Should().Be("DocumentoEdital.StatusInvalidoParaConfirmacao");
+    }
+
+    [Fact(DisplayName = "Iniciar upload duas vezes para o mesmo processo cria dois registros com object keys distintas (CA — nunca sobrescreve)")]
+    public async Task IniciarUpload_DuasVezes_CriaRegistrosDistintos()
+    {
+        (SelecaoDbContext context, ProcessoSeletivo processo) = await NovoProcessoAsync();
+        DocumentoEditalRepository documentoRepository = new(context);
+        ProcessoSeletivoRepository processoRepository = new(context, TimeProvider.System);
+
+        Result<IniciarUploadDocumentoEditalDto> primeiro = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+        Result<IniciarUploadDocumentoEditalDto> segundo = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+
+        primeiro.Value!.DocumentoEditalId.Should().NotBe(segundo.Value!.DocumentoEditalId);
+
+        DocumentoEdital? doc1 = await documentoRepository.ObterPorIdAsync(primeiro.Value.DocumentoEditalId, CancellationToken.None);
+        DocumentoEdital? doc2 = await documentoRepository.ObterPorIdAsync(segundo.Value.DocumentoEditalId, CancellationToken.None);
+        doc1!.ObjectKey.Should().NotBe(doc2!.ObjectKey);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
@@ -245,4 +245,20 @@ public sealed class DocumentoEditalUploadIntegrationTests : IClassFixture<Proces
         DocumentoEdital? doc2 = await documentoRepository.ObterPorIdAsync(segundo.Value.DocumentoEditalId, CancellationToken.None);
         doc1!.ObjectKey.Should().NotBe(doc2!.ObjectKey);
     }
+
+    [Fact(DisplayName = "TentarReivindicarConfirmacaoAsync é atômico: só a primeira chamada ganha (Postgres real)")]
+    public async Task TentarReivindicarConfirmacaoAsync_SoAPrimeiraChamadaGanha()
+    {
+        (SelecaoDbContext context, ProcessoSeletivo processo) = await NovoProcessoAsync();
+        DocumentoEditalRepository documentoRepository = new(context);
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processo.Id, TimeProvider.System, TimeSpan.FromMinutes(15));
+        context.DocumentosEdital.Add(documento);
+        await context.SaveChangesAsync();
+
+        bool primeira = await documentoRepository.TentarReivindicarConfirmacaoAsync(documento.Id, CancellationToken.None);
+        bool segunda = await documentoRepository.TentarReivindicarConfirmacaoAsync(documento.Id, CancellationToken.None);
+
+        primeira.Should().BeTrue();
+        segunda.Should().BeFalse();
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
@@ -198,6 +198,32 @@ public sealed class DocumentoEditalUploadIntegrationTests : IClassFixture<Proces
         confirmarResultado.Error!.Code.Should().Be("DocumentoEdital.AssinaturaInvalida");
     }
 
+    [Fact(DisplayName = "Confirmar objeto de 0 bytes recusa (422 AssinaturaInvalida, não 500 — Range GET não é satisfazível sobre objeto vazio)")]
+    public async Task Confirmar_ObjetoVazio_Recusa()
+    {
+        (SelecaoDbContext context, ProcessoSeletivo processo) = await NovoProcessoAsync();
+        DocumentoEditalRepository documentoRepository = new(context);
+        ProcessoSeletivoRepository processoRepository = new(context, TimeProvider.System);
+
+        Result<IniciarUploadDocumentoEditalDto> iniciarResultado = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+        iniciarResultado.IsSuccess.Should().BeTrue();
+
+        using HttpClient http = new();
+        using ByteArrayContent conteudoVazio = new([]);
+        conteudoVazio.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        HttpResponseMessage putResponse = await http.PutAsync(iniciarResultado.Value!.UrlUpload, conteudoVazio);
+        putResponse.EnsureSuccessStatusCode();
+
+        Result<DocumentoEditalDto> confirmarResultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processo.Id, iniciarResultado.Value.DocumentoEditalId),
+            documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+
+        confirmarResultado.IsFailure.Should().BeTrue();
+        confirmarResultado.Error!.Code.Should().Be("DocumentoEdital.AssinaturaInvalida");
+    }
+
     [Fact(DisplayName = "Confirmar um documento já confirmado recusa (imutabilidade — CA)")]
     public async Task Confirmar_DocumentoJaConfirmado_Recusa()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
@@ -6,6 +6,8 @@ using System.Security.Cryptography;
 
 using AwesomeAssertions;
 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -261,5 +263,32 @@ public sealed class DocumentoEditalUploadIntegrationTests : IClassFixture<Proces
 
         primeira.Should().BeTrue();
         segunda.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "TentarReivindicarConfirmacaoAsync participa da transação ambiente: reverte em rollback")]
+    public async Task TentarReivindicarConfirmacaoAsync_RevertNoRollbackDaTransacaoAmbiente()
+    {
+        (SelecaoDbContext context, ProcessoSeletivo processo) = await NovoProcessoAsync();
+        DocumentoEditalRepository documentoRepository = new(context);
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processo.Id, TimeProvider.System, TimeSpan.FromMinutes(15));
+        context.DocumentosEdital.Add(documento);
+        await context.SaveChangesAsync();
+
+        // Simula o mesmo cenário do handler sob Wolverine (ADR-0004,
+        // AutoApplyTransactions): a reivindicação roda dentro da transação
+        // ambiente do comando. Se um passo posterior falhar (ex.: o storage
+        // indisponível), o rollback dessa transação desfaz a reivindicação
+        // junto — o documento volta a Pendente e a confirmação é retentável.
+        await using (IDbContextTransaction transacao = await context.Database.BeginTransactionAsync())
+        {
+            bool reivindicou = await documentoRepository.TentarReivindicarConfirmacaoAsync(documento.Id, CancellationToken.None);
+            reivindicou.Should().BeTrue();
+            await transacao.RollbackAsync();
+        }
+
+        await using SelecaoDbContext contextoIndependente = _dbFixture.CreateDbContext();
+        DocumentoEdital documentoAposRollback = await contextoIndependente.DocumentosEdital
+            .FirstAsync(d => d.Id == documento.Id);
+        documentoAposRollback.Status.Should().Be(StatusDocumentoEdital.Pendente);
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/DocumentosEdital/DocumentoEditalUploadIntegrationTests.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.Selecao.IntegrationTests.DocumentosEdital;
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
 
@@ -38,6 +39,11 @@ public sealed class DocumentoEditalUploadIntegrationTests : IClassFixture<Proces
     private static readonly byte[] ConteudoPdfValido = [.. "%PDF-1.7 conteúdo de teste — Uni+ #784"u8];
 
     private readonly ProcessoSeletivoDbFixture _dbFixture;
+
+    [SuppressMessage(
+        "Performance",
+        "CA1859:Use concrete types when possible for improved performance",
+        Justification = "Intencional: o teste exercita o port da Application (IDocumentoEditalStorage), não o tipo concreto de Infrastructure — é o mesmo contrato que os handlers reais consomem.")]
     private readonly IDocumentoEditalStorage _storage;
 
     public DocumentoEditalUploadIntegrationTests(ProcessoSeletivoDbFixture dbFixture, MinioContainerFixture minio)
@@ -98,6 +104,47 @@ public sealed class DocumentoEditalUploadIntegrationTests : IClassFixture<Proces
         confirmarResultado.Value!.Status.Should().Be("Confirmado");
         confirmarResultado.Value.TamanhoBytes.Should().Be(ConteudoPdfValido.Length);
         confirmarResultado.Value.HashSha256.Should().Be(Convert.ToHexStringLower(SHA256.HashData(ConteudoPdfValido)));
+    }
+
+    [Fact(DisplayName = "Sobrescrever a object key original após confirmação não afeta o conteúdo selado (P1)")]
+    public async Task Confirmar_ObjectKeyOriginalSobrescritaDepois_ConteudoSeladoPermaneceIntacto()
+    {
+        (SelecaoDbContext context, ProcessoSeletivo processo) = await NovoProcessoAsync();
+        DocumentoEditalRepository documentoRepository = new(context);
+        ProcessoSeletivoRepository processoRepository = new(context, TimeProvider.System);
+
+        Result<IniciarUploadDocumentoEditalDto> iniciarResultado = await IniciarUploadDocumentoEditalCommandHandler.Handle(
+            new IniciarUploadDocumentoEditalCommand(processo.Id),
+            processoRepository, documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+
+        using HttpClient http = new();
+        using ByteArrayContent conteudoOriginal = new(ConteudoPdfValido);
+        conteudoOriginal.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        HttpResponseMessage putOriginal = await http.PutAsync(iniciarResultado.Value!.UrlUpload, conteudoOriginal);
+        putOriginal.EnsureSuccessStatusCode();
+
+        Result<DocumentoEditalDto> confirmarResultado = await ConfirmarUploadDocumentoEditalCommandHandler.Handle(
+            new ConfirmarUploadDocumentoEditalCommand(processo.Id, iniciarResultado.Value.DocumentoEditalId),
+            documentoRepository, _storage, context, TimeProvider.System, CancellationToken.None);
+        confirmarResultado.IsSuccess.Should().BeTrue();
+
+        DocumentoEdital documentoConfirmado = (await documentoRepository.ObterPorIdAsync(iniciarResultado.Value.DocumentoEditalId, CancellationToken.None))!;
+
+        // A URL de upload original ainda vale (TTL não expirou) — um titular
+        // mal-intencionado ou um retry duplicado do cliente sobrescreve a
+        // ObjectKey de staging depois da confirmação.
+        byte[] conteudoTrocado = [.. "%PDF-1.7 conteúdo trocado após a confirmação"u8];
+        using ByteArrayContent conteudoSobrescrita = new(conteudoTrocado);
+        conteudoSobrescrita.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+        HttpResponseMessage putSobrescrita = await http.PutAsync(iniciarResultado.Value.UrlUpload, conteudoSobrescrita);
+        putSobrescrita.EnsureSuccessStatusCode();
+
+        await using Stream streamSelado = await _storage.AbrirLeituraAsync(documentoConfirmado.ObjectKeyConfirmado!, CancellationToken.None);
+        using MemoryStream buffer = new();
+        await streamSelado.CopyToAsync(buffer, CancellationToken.None);
+
+        buffer.ToArray().Should().Equal(ConteudoPdfValido);
+        Convert.ToHexStringLower(SHA256.HashData(buffer.ToArray())).Should().Be(confirmarResultado.Value!.HashSha256);
     }
 
     [Fact(DisplayName = "Confirmar sem upload prévio recusa (422 ObjetoNaoEncontrado)")]

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/DocumentoEditalIdempotencyTtlSentinelTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/DocumentoEditalIdempotencyTtlSentinelTests.cs
@@ -1,0 +1,78 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Hosting;
+
+using System.Reflection;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+using Infrastructure;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Selecao.API.Controllers;
+using Unifesspa.UniPlus.Selecao.Application.Commands.DocumentosEdital;
+
+/// <summary>
+/// Sentinela contra o TTL de idempotência do endpoint de iniciar upload
+/// (achado Codex no PR #790) divergir do TTL real da URL pre-assinada de
+/// PUT. Um <c>[RequiresIdempotencyKey]</c> sem override usa o teto de 24h
+/// (ADR-0027) — como a URL expira em <see cref="IniciarUploadDocumentoEditalCommandHandler.TtlUploadSegundos"/>
+/// (15 min), um replay depois disso devolveria uma URL inutilizável. O
+/// override existe justamente para alinhar os dois; este teste trava que
+/// alguém mude uma constante sem a outra.
+/// </summary>
+public sealed class DocumentoEditalIdempotencyTtlSentinelTests : IClassFixture<SelecaoApiFactory>
+{
+    private readonly SelecaoApiFactory _factory;
+
+    public DocumentoEditalIdempotencyTtlSentinelTests(SelecaoApiFactory factory) => _factory = factory;
+
+    [Fact(DisplayName = "IniciarUpload tem TTL de idempotência igual ao TTL da URL pre-assinada")]
+    public void IniciarUpload_TtlIdempotenciaIgualAoTtlDaUrl()
+    {
+        using HttpClient _ = _factory.CreateClient();
+        EndpointDataSource dataSource = _factory.Services.GetRequiredService<EndpointDataSource>();
+
+        MethodInfo metodo = dataSource.Endpoints
+            .Select(static endpoint => endpoint.Metadata.GetMetadata<ControllerActionDescriptor>())
+            .Where(static descriptor => descriptor is not null)
+            .Cast<ControllerActionDescriptor>()
+            .Where(descriptor => descriptor.ControllerTypeInfo == typeof(DocumentosEditalController)
+                && descriptor.MethodInfo.Name == nameof(DocumentosEditalController.IniciarUpload))
+            .Select(descriptor => descriptor.MethodInfo)
+            .Should().ContainSingle(because: "o endpoint deve estar registrado pelo MVC")
+            .Subject;
+
+        RequiresIdempotencyKeyAttribute atributo = metodo
+            .GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true)!;
+
+        atributo.Should().NotBeNull();
+        atributo.TtlSeconds.Should().Be(
+            IniciarUploadDocumentoEditalCommandHandler.TtlUploadSegundos,
+            because: "um replay de idempotência depois da URL expirar devolveria uma URL inutilizável");
+    }
+
+    [Fact(DisplayName = "ConfirmarUpload usa o TTL default de idempotência (24h) — resposta não carrega artefato com expiração própria")]
+    public void ConfirmarUpload_UsaTtlDefault()
+    {
+        using HttpClient _ = _factory.CreateClient();
+        EndpointDataSource dataSource = _factory.Services.GetRequiredService<EndpointDataSource>();
+
+        MethodInfo metodo = dataSource.Endpoints
+            .Select(static endpoint => endpoint.Metadata.GetMetadata<ControllerActionDescriptor>())
+            .Where(static descriptor => descriptor is not null)
+            .Cast<ControllerActionDescriptor>()
+            .Where(descriptor => descriptor.ControllerTypeInfo == typeof(DocumentosEditalController)
+                && descriptor.MethodInfo.Name == nameof(DocumentosEditalController.ConfirmarUpload))
+            .Select(descriptor => descriptor.MethodInfo)
+            .Should().ContainSingle(because: "o endpoint deve estar registrado pelo MVC")
+            .Subject;
+
+        RequiresIdempotencyKeyAttribute atributo = metodo
+            .GetCustomAttribute<RequiresIdempotencyKeyAttribute>(inherit: true)!;
+
+        atributo.Should().NotBeNull();
+        atributo.TtlSeconds.Should().Be(-1, because: "sem override, usa IdempotencyOptions.Ttl");
+    }
+}


### PR DESCRIPTION
## Resumo

- Primeira funcionalidade de storage de documento do módulo Seleção: upload direto do cliente ao MinIO via URL pre-assinada de PUT — o arquivo nunca trafega pela API.
- Fluxo em 3 passos: iniciar (cria registro pendente + URL) → PUT direto ao MinIO → confirmar (lê, valida e hasheia server-side, finaliza como imutável, seladando uma cópia isolada de qualquer sobrescrita posterior).
- Alimenta o `hash_edital` do `SnapshotPublicacao` que a T4 (#785) vai compor.

## Mudanças

### Novos arquivos

- `Selecao.Domain/Entities/DocumentoEdital.cs` — agregado próprio (vinculado ao `ProcessoSeletivo` por FK, não por composição), ciclo de vida Pendente→Confirmado, `ValidarConteudo` como regra de negócio pura (content-type, tamanho máx. 20 MB, assinatura `%PDF-`). `ObjectKeyConfirmado` é a chave selada, gravada só na confirmação, nunca alvo de nenhuma URL pre-assinada.
- `Selecao.Domain/Enums/StatusDocumentoEdital.cs`, `Selecao.Domain/Interfaces/IDocumentoEditalRepository.cs` (inclui `TentarReivindicarConfirmacaoAsync`, reivindicação atômica).
- `Selecao.Application/Abstractions/IDocumentoEditalStorage.cs` — port próprio da Application (ver nota de arquitetura abaixo).
- `Selecao.Application/Commands/DocumentosEdital/*` — `IniciarUploadDocumentoEditalCommand`/Handler e `ConfirmarUploadDocumentoEditalCommand`/Handler.
- `Selecao.Infrastructure/ExternalServices/DocumentoEditalStorageService.cs` — implementa o port envolvendo `IStorageService`.
- `Selecao.Infrastructure/Persistence/{Configurations,Repositories}/DocumentoEdital*` + migration `AddDocumentoEdital` (tabela `documentos_edital`, schema `selecao`).
- `Selecao.API/Controllers/DocumentosEditalController.cs` — `POST .../documentos-edital` (iniciar) e `POST .../documentos-edital/{id}/confirmacao`, `plataforma-admin` + `Idempotency-Key`.
- Testes unitários (Domain + Application) e de integração (`Testcontainers` Postgres + MinIO reais, incluindo PUT/GET HTTP reais).

### Modificados

- `Infrastructure.Core/Storage/IStorageService.cs` + `MinioStorageService.cs` — métodos novos: `GerarUrlUploadTemporariaAsync` (presigned PUT), `ObterMetadadosAsync` (stat, sem baixar o conteúdo) e `DownloadLimitadoAsync` (leitura com limite real de tamanho via Range GET + `HttpClient`, imposto no servidor).
- `Infrastructure.Core/Storage/StorageOptions.cs` — `PublicEndpoint`/`PublicUseSSL` para assinar URLs devolvidas a clientes externos com um endpoint diferente do usado internamente pela API.
- `SelecaoDomainErrorRegistration.cs` — códigos `DocumentoEdital.*`.
- `SelecaoDbContext.cs`, `DependencyInjection.cs` (módulo Selecao) — DbSet + registro de repositório/storage service.
- `docker-compose.override.example.yml` — `Storage__PublicEndpoint=localhost:9000` para o frontend rodando fora da rede Docker.
- `contracts/openapi.selecao.json` — baseline regenerada.

## Notas de arquitetura

- **Port próprio em `Application.Abstractions`, não `Infrastructure.Core` direto**: `IStorageService` vive em Infrastructure.Core; nenhum `*.Application` do módulo referencia esse projeto (ADR-0042 + fitness test R3, confirmados verdes). `IDocumentoEditalStorage` fecha essa lacuna — Application só conhece object keys, a bucket física é resolvida pela implementação em Infrastructure via `StorageOptions`.
- **Documento confirmado é imutável de fato, não só por convenção**: a URL de upload original (`ObjectKey`) segue válida (e sobrescrevível) até o TTL expirar. A confirmação lê o conteúdo, valida, e copia para `ObjectKeyConfirmado` — uma chave que nenhuma URL pre-assinada jamais expôs — antes de persistir o hash. Uma sobrescrita posterior na chave original não afeta o conteúdo que o hash confirmado representa (coberto por teste de integração real).
- **Confirmações concorrentes não podem gravar hash e objeto selado de origens diferentes**: `TentarReivindicarConfirmacaoAsync` reivindica atomicamente via `ExecuteUpdateAsync` condicionado a `Status=Pendente` — o Postgres serializa por lock de linha, então só uma confirmação concorrente (Idempotency-Keys diferentes) ganha; a perdedora nunca escreve no storage. A reivindicação participa da transação ambiente do Wolverine (ADR-0004, `AutoApplyTransactions`) — uma falha posterior desfaz a reivindicação junto, mantendo a confirmação retentável (coberto por teste que abre a transação, reivindica, reverte e confirma o retorno a Pendente).
- **Limite de tamanho imposto no servidor, não só na Application**: a API de alto nível do SDK MinIO (`GetObjectAsync`) bufferiza o objeto inteiro antes de devolver o stream — insuficiente para proteger memória contra um objeto de staging trocado por um muito maior depois do stat (a chave original segue sobrescrevível até o TTL expirar). `DownloadLimitadoAsync` usa URL pre-assinada de GET + `HttpClient` com header `Range`: o MinIO nunca transmite mais bytes que o intervalo pedido.
- **Endpoint público configurável para URLs pre-assinadas**: em qualquer topologia onde a API fala com o MinIO por um endpoint interno (ex.: `minio:9000` na rede Docker), a URL devolvida a um cliente externo precisa ser assinada com um endpoint diferente, alcançável de fora — reescrever o host depois de assinada invalida a assinatura SigV4 (inclui o header `Host`). `Storage:PublicEndpoint` resolve isso com um segundo `IMinioClient` keyed; sem configuração, cai para o endpoint interno (comportamento anterior preservado).
- Limpeza de pendentes expirados **não implementada** nesta task — a issue permite deixar como follow-up; o campo `ExpiraEm` já fica gravado no registro para uma limpeza futura.

## Follow-up de deploy (fora do escopo desta PR)

`Storage:PublicEndpoint` precisa do valor real do endpoint público do MinIO em cada ambiente (HML/produção, provavelmente atrás de Traefik ou equivalente) para que o upload direto funcione fora da rede Docker/cluster — não tenho visibilidade da infra real (`uniplus-infra` é repositório à parte) para fixar esse valor aqui. Sem configurar, a feature funciona apenas dentro da rede interna (dev local com stack completa já configurado via `docker-compose.override.example.yml`).

## Testes

- [x] Testes unitários passando (Domain: 10 novos; Application: 12 novos)
- [x] Testes de integração passando (Testcontainers Postgres + MinIO reais — fluxo completo, imutabilidade pós-confirmação, reivindicação atômica + rollback transacional, objeto ausente, assinatura inválida, objeto de 0 bytes, dupla confirmação, dois uploads geram registros distintos, endpoint público na assinatura)
- [ ] Testes E2E — não aplicável (sem frontend nesta task)

## Checklist

- [x] Build sem erros e sem warnings (solution completa)
- [x] Código segue Clean Architecture e SOLID (fitness tests R1-R3 + ArchTests solution-wide verdes)
- [x] Sem exposição de PII
- [x] Strings user-facing em pt-BR
- [x] Soft delete não se aplica (documento confirmado é imutável por design; sem exclusão lógica necessária nesta task)
- [x] Documentação atualizada (baseline OpenAPI regenerada; docker-compose.override.example.yml)

Closes #784
