### PR TITLE
feat(selecao): publica Processo Seletivo com snapshot RN08 (T4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,14 +324,10 @@ jobs:
             exit 1
           fi
 
-      # MIN_TESTS temporariamente 0 (#782): a demonstração do ADR-0005 rodava
-      # contra o agregado Edital legado, removido por inteiro. A T4 (#785)
-      # recria a demonstração sobre o slice ProcessoSeletivo — reativar o
-      # threshold quando os novos testes cascading existirem.
       - name: Sanity check — Category=OutboxCascading filter has expected coverage
         run: |
           set -euo pipefail
-          MIN_TESTS=0
+          MIN_TESTS=10
           out=$(dotnet test tests/Unifesspa.UniPlus.Selecao.IntegrationTests \
             --configuration ${{ env.BUILD_CONFIG }} \
             --no-build \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,39 +211,40 @@ Siga a ordem de implementação por camada — de dentro para fora:
 
 #### Padrão de handler
 
-> **Nota temporária (#782):** o slice `Edital` usado historicamente como referência
-> pedagógica deste padrão foi removido — era o agregado legado, pré-inversão
-> ProcessoSeletivo↔Edital. O bloco de código abaixo ilustra a FORMA do padrão
-> CQRS/Wolverine (ainda válida), mas os tipos citados (`CriarEditalCommand`,
-> `IEditalRepository` etc.) não existem mais no código. Reescrita completa com um
-> slice de referência vivo (`ProcessoSeletivo`) está planejada para a T4 (#785).
-
 Commands implementam `ICommand<TResponse>`, queries implementam `IQuery<TResponse>` — ambos definidos em `Application.Abstractions/Messaging`. Handlers seguem a convenção do Wolverine: classe `static`, método `Handle` (`Task<TResponse>` ou `(TResponse, IEnumerable<object>)` para cascading messages) e dependências resolvidas como parâmetros do método.
 
-```csharp
-// Command + handler (forma ilustrativa — ver nota acima)
-public sealed record CriarEditalCommand(...) : ICommand<Result<Guid>>;
+Slice de referência (Story #759, T4 #785): `src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommandHandler.cs`.
 
-public static class CriarEditalCommandHandler
+```csharp
+// Command + handler que muta agregado e emite domain event (cascading)
+public sealed record PublicarProcessoSeletivoCommand(
+    Guid ProcessoSeletivoId,
+    string? Numero,
+    DateOnly PeriodoInscricaoInicio,
+    DateOnly PeriodoInscricaoFim,
+    Guid DocumentoEditalId) : ICommand<Result>;
+
+public static class PublicarProcessoSeletivoCommandHandler
 {
-    public static async Task<Result<Guid>> Handle(
-        CriarEditalCommand command,
-        IEditalRepository editalRepository,
-        IUnitOfWork unitOfWork,
+    public static async Task<(Result Resposta, IEnumerable<object> Eventos)> Handle(
+        PublicarProcessoSeletivoCommand command,
+        IProcessoSeletivoRepository processoSeletivoRepository,
+        ISelecaoUnitOfWork unitOfWork,
         CancellationToken cancellationToken)
     {
-        // ... lógica de domínio + persistência
+        // ... carrega o agregado, chama ProcessoSeletivo.Publicar, persiste ...
+        return (Result.Success(), processo.DequeueDomainEvents().Cast<object>());
     }
 }
 
-// Query + handler (forma ilustrativa — ver nota acima)
-public sealed record ObterEditalQuery(Guid Id) : IQuery<EditalDto?>;
+// Query + handler (leitura pura, sem cascading)
+public sealed record ObterProcessoSeletivoQuery(Guid Id) : IQuery<ProcessoSeletivoDto?>;
 
-public static class ObterEditalQueryHandler
+public static class ObterProcessoSeletivoQueryHandler
 {
-    public static async Task<EditalDto?> Handle(
-        ObterEditalQuery query,
-        IEditalRepository editalRepository,
+    public static async Task<ProcessoSeletivoDto?> Handle(
+        ObterProcessoSeletivoQuery query,
+        IProcessoSeletivoRepository processoSeletivoRepository,
         CancellationToken cancellationToken) => /* ... */;
 }
 ```

--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -1633,6 +1633,82 @@
         "x-uniplus-idempotent": true
       }
     },
+    "/api/selecao/processos-seletivos/{id}/publicacao": {
+      "post": {
+        "tags": [
+          "ProcessoSeletivo"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicarProcessoSeletivoRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicarProcessoSeletivoRequest"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicarProcessoSeletivoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
     "/api/selecao/processos-seletivos/{id}/conformidade": {
       "get": {
         "tags": [
@@ -3199,6 +3275,35 @@
           "criadoEm": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "PublicarProcessoSeletivoRequest": {
+        "required": [
+          "numero",
+          "periodoInscricaoInicio",
+          "periodoInscricaoFim",
+          "documentoEditalId"
+        ],
+        "type": "object",
+        "properties": {
+          "numero": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "periodoInscricaoInicio": {
+            "type": "string",
+            "format": "date"
+          },
+          "periodoInscricaoFim": {
+            "type": "string",
+            "format": "date"
+          },
+          "documentoEditalId": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/docs/guia-apicurio-schema-registry.md
+++ b/docs/guia-apicurio-schema-registry.md
@@ -5,13 +5,6 @@
 > [ADR-0044](adrs/0044-roteamento-domain-events-pg-queue-kafka-opcional.md) (routing PG queue/Kafka) +
 > RUNBOOKS §15 do `uniplus-infra` (Apicurio chart deploy + recuperação de `client_secret`).
 
-> **Nota temporária (#782):** o exemplo `EditalPublicado`/`EditalPublicadoEvent`
-> usado abaixo era o único schema Avro de fato registrado no projeto até aqui — o
-> slice Edital foi removido por inteiro (agregado legado, pré-inversão
-> ProcessoSeletivo↔Edital). Hoje o projeto não tem nenhum schema Avro registrado.
-> O wiring e a arquitetura descritos abaixo continuam válidos; a reescrita com um
-> exemplo real vivo entra quando um novo evento cross-módulo precisar de Avro.
-
 ## O que é
 
 [Apicurio Schema Registry](https://www.apicur.io/registry/) é o **registro central de schemas Avro** dos eventos cross-módulo do Uni+. Em standalone roda em
@@ -39,65 +32,63 @@
        │                     │ (consumer futuro)  │
        │                     └────────────────────┘
        ▼
-┌──────────────────────────────────┐
-│ Selecao.Domain                   │
-│ Events/Schemas/EditalPublicado.avsc │
-└──────────────────────────────────┘
+┌────────────────────────────────────────┐
+│ Selecao.Domain                          │
+│ Events/Schemas/ProcessoPublicado.avsc   │
+└────────────────────────────────────────┘
 ```
 
-**Single source of truth:** o `.avsc` vive como **embedded resource** em `Selecao.Domain`. A classe `unifesspa.uniplus.selecao.events.EditalPublicado` (`Selecao.Infrastructure`) e o `SchemaRegistrationHostedService` (`Infrastructure.Core`) leem o mesmo recurso via reflection — não há cópia em outro arquivo.
+**Single source of truth:** o `.avsc` vive como **embedded resource** em `Selecao.Domain`. A classe `unifesspa.uniplus.selecao.events.ProcessoPublicado` (`Selecao.Infrastructure`) e o `SchemaRegistrationHostedService` (`Infrastructure.Core`) leem o mesmo recurso via reflection — não há cópia em outro arquivo.
 
 ## Wiring no Program.cs
 
+Slice de referência (Story #759, T4 #785): `src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoMessagingRegistration.cs` — o módulo Selecao encapsula seu próprio wiring de mensageria num método de extensão (`AddSelecaoMessaging`), consumido pelo composition root (`src/host/Unifesspa.UniPlus.Host/Program.cs`):
+
 ```csharp
-// 1) Settings + cliente único (compartilhado entre hosted service e Wolverine).
-SchemaRegistrySettings selecaoSrSettings = builder.Configuration
-    .GetSection(SchemaRegistrySettings.SectionName)
-    .Get<SchemaRegistrySettings>() ?? new SchemaRegistrySettings();
+// SelecaoMessagingRegistration.AddSelecaoMessaging — registra o Schema Registry
+// do módulo (cliente + schema Avro processo_seletivo_events-value) e devolve o
+// configurador de routing Wolverine, sem o host precisar conhecer Kafka/SR.
+Action<WolverineOptions> configurarSelecaoRouting =
+    builder.Services.AddSelecaoMessaging(builder.Configuration, builder.Environment);
 
-ISchemaRegistryClient? selecaoSrClient = null;
-if (!string.IsNullOrWhiteSpace(selecaoSrSettings.Url))
-{
-    using ILoggerFactory bootstrapLoggerFactory = LoggerFactory.Create(b => b.AddSerilog());
-    selecaoSrClient = SchemaRegistryServiceCollectionExtensions.CreateClient(
-        selecaoSrSettings,
-        bootstrapLoggerFactory);
-    builder.Services.AddSingleton(selecaoSrClient);
-}
-
-// 2) Hosted service idempotente registra subjects no Apicurio no startup.
-builder.Services.AddSchemaRegistry(builder.Configuration)
-    .AddSchema(
-        subject: "edital_events-value",
-        schemaResourceName: unifesspa.uniplus.selecao.events.EditalPublicado.SchemaResourceName,
-        resourceAssembly: typeof(EditalPublicadoEvent).Assembly);
-
-// 3) Wolverine routing: cascade EditalPublicadoEvent → EditalPublicado (Avro) → Kafka.
-builder.Host.UseWolverineOutboxCascading(builder.Configuration, "SelecaoDb",
+builder.Host.UseWolverineOutboxCascading(builder.Configuration, "UniPlusDb",
     configureRouting: opts =>
     {
-        opts.Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly);
-        opts.Discovery.IncludeAssembly(typeof(EditalPublicadoToKafkaCascadeHandler).Assembly);
+        opts.Discovery.IncludeAssembly(typeof(CriarProcessoSeletivoCommand).Assembly);
+        opts.Discovery.IncludeAssembly(typeof(ProcessoPublicadoToKafkaCascadeHandler).Assembly);
 
-        opts.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
-        opts.ListenToPostgresqlQueue("domain-events");
-
-        bool kafkaConfigured = !string.IsNullOrWhiteSpace(builder.Configuration["Kafka:BootstrapServers"]);
-        if (kafkaConfigured && selecaoSrClient is not null)
-        {
-            opts.PublishMessage<unifesspa.uniplus.selecao.events.EditalPublicado>()
-                .ToKafkaTopic("edital_events")
-                .DefaultSerializer(new SchemaRegistryAvroSerializer(selecaoSrClient));
-        }
+        // Routing do Selecao (PG queue domain-events + Kafka processo_seletivo_events).
+        configurarSelecaoRouting(opts);
     });
+```
+
+Dentro de `AddSelecaoMessaging`/`ConfigurarRouting` (`Selecao.API/SelecaoMessagingRegistration.cs`):
+
+```csharp
+services.AddSchemaRegistry(configuration)
+    .AddSchema(
+        subject: "processo_seletivo_events-value",
+        schemaResourceName: unifesspa.uniplus.selecao.events.ProcessoPublicado.SchemaResourceName,
+        resourceAssembly: typeof(ProcessoPublicadoEvent).Assembly);
+
+opts.PublishMessage<ProcessoPublicadoEvent>().ToPostgresqlQueue("domain-events");
+opts.ListenToPostgresqlQueue("domain-events");
+
+bool kafkaConfigured = !string.IsNullOrWhiteSpace(configuration["Kafka:BootstrapServers"]);
+if (kafkaConfigured && srClient is not null)
+{
+    opts.PublishMessage<unifesspa.uniplus.selecao.events.ProcessoPublicado>()
+        .ToKafkaTopic("processo_seletivo_events")
+        .DefaultSerializer(new SchemaRegistryAvroSerializer(srClient));
+}
 ```
 
 **Pontos importantes:**
 
 1. **Feature off:** `SchemaRegistry:Url` vazio → cliente não é construído, hosted service não é registrado, routing Avro é skippado. APIs sobem sem Apicurio (dev local sem o serviço).
 2. **Cliente único:** o singleton no DI é a mesma instância capturada no closure do callback Wolverine. Evita 2 caches.
-3. **Cascade:** o handler `EditalPublicadoToKafkaCascadeHandler` (em `Selecao.Infrastructure`) projeta o evento de domínio (`EditalPublicadoEvent`, intra-módulo) em `EditalPublicado` (Avro, cross-módulo). Application/Domain ficam puros — não conhecem `Apache.Avro`.
-4. **Outbox cascade:** o `EditalPublicado` (Avro) é instalado no outbox **dentro** da transação do listener da PG queue. Se o publish para Kafka falhar, o Wolverine retenta a partir do outbox (at-least-once). Consumers cross-módulo deduplicam por `EventId` (UUID v7).
+3. **Cascade:** o handler `ProcessoPublicadoToKafkaCascadeHandler` (em `Selecao.Infrastructure`) projeta o evento de domínio (`ProcessoPublicadoEvent`, intra-módulo) em `ProcessoPublicado` (Avro, cross-módulo). Application/Domain ficam puros — não conhecem `Apache.Avro`.
+4. **Outbox cascade:** o `ProcessoPublicado` (Avro) é instalado no outbox **dentro** da transação do listener da PG queue. Se o publish para Kafka falhar, o Wolverine retenta a partir do outbox (at-least-once). Consumers cross-módulo deduplicam por `EventId` (UUID v7).
 
 ## Configuração — modos de auth
 
@@ -175,7 +166,7 @@ Padrão concreto. Para acrescentar `InscricaoCriadaEvent` (módulo Selecao):
 | API trava em `StartAsync` com erro de bind | `SchemaRegistrySettingsValidator` falhou | Logs mostram a falha exata. Conferir env vars `SchemaRegistry__*` |
 | Hosted service loga `Falha ao registrar schema Avro no startup` | Apicurio offline, auth inválida, ou DNS não resolve | Logs incluem o subject; Apicurio side: `kubectl logs deploy/apicurio-registry`. Após Apicurio voltar, registro tenta novamente em runtime |
 | Producer falha com `SchemaRegistryException: Schema being registered is incompatible` | Mudança no `.avsc` quebra BACKWARD compatibility | Re-pensar evolução — campos novos devem ter default; remoção exige etapa intermediária |
-| Consumer recebe `AvroException: Unable to find type 'unifesspa...EditalPublicado'` | Namespace do `.avsc` não casa com namespace da classe C# | Apache.Avro NET resolve via `Type.GetType("&lt;ns&gt;.&lt;name&gt;")` — namespace lowercase é mandatório quando o schema usa lowercase |
+| Consumer recebe `AvroException: Unable to find type 'unifesspa...ProcessoPublicado'` | Namespace do `.avsc` não casa com namespace da classe C# | Apache.Avro NET resolve via `Type.GetType("&lt;ns&gt;.&lt;name&gt;")` — namespace lowercase é mandatório quando o schema usa lowercase |
 | Token endpoint retorna 401 | Vault não populado ou client_secret rotacionado | RUNBOOKS §15.6 do `uniplus-infra` — re-recuperar via `kcadm.sh get clients/$CID/client-secret` |
 | Wolverine envia `byte[]` JSON em vez de Avro | `selecaoSrClient` é `null` (URL vazia) ou Kafka não configurado | Conferir `SchemaRegistry__Url` + `Kafka__BootstrapServers` ambos populados |
 
@@ -192,10 +183,10 @@ curl http://localhost:8081/q/health/ready
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d --build uniplus-api
 
 # Inspeciona o schema registrado
-curl http://localhost:8081/apis/ccompat/v7/subjects/edital_events-value/versions/latest
+curl http://localhost:8081/apis/ccompat/v7/subjects/processo_seletivo_events-value/versions/latest
 
-# Publica via endpoint (cria + publica edital → cascade dispara → Avro vai para Kafka)
-curl -X POST http://localhost:5202/api/editais ...
+# Publica via endpoint (publica processo → cascade dispara → Avro vai para Kafka)
+curl -X POST http://localhost:5202/api/selecao/processos-seletivos/{id}/publicacao ...
 ```
 
 ## Referências

--- a/docs/guia-commits-e-integracao.md
+++ b/docs/guia-commits-e-integracao.md
@@ -239,9 +239,8 @@ docs/0021-cache-distribuido
 Antes de começar uma feature, leia o slice canônico mais próximo:
 
 - **Command + handler / Query + handler / domain event com cascading messages:**
-  o slice `Edital` usado historicamente como referência foi removido (#782 —
-  agregado legado, pré-inversão ProcessoSeletivo↔Edital). Reescrita com um slice
-  vivo (`ProcessoSeletivo`) está planejada para a T4 (#785).
+  slice `ProcessoSeletivo` (Story #759, T4 #785) —
+  `src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommandHandler.cs`.
 - **EntityTypeConfiguration:** `src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/`
 
 ## 10. Referências

--- a/docs/guia-wolverine-golden-path.md
+++ b/docs/guia-wolverine-golden-path.md
@@ -15,14 +15,6 @@ Guia operacional em pt-BR para criar novos commands, queries, handlers e domain 
 
 Dúvidas sobre implementação no dia a dia ficam neste guia. Dúvidas sobre contrato, escopo ou reversibilidade vão para a ADR correspondente. Mudanças de escopo (novas abstrações, adoção de features avançadas do Wolverine) exigem emenda à ADR-0003 com PR explícito.
 
-> **Nota temporária (#782):** os exemplos deste guia usam o slice `Edital` (agregado
-> legado, pré-inversão ProcessoSeletivo↔Edital) como referência pedagógica. Esse
-> slice foi removido por inteiro — os tipos citados abaixo (`PublicarEditalCommand`,
-> `EditalController`, `IEditalRepository`, `EditalPublicadoEvent` etc.) não existem
-> mais no código. A FORMA do padrão CQRS/Wolverine/cascading ilustrada continua
-> válida; a reescrita completa com um slice de referência vivo (`ProcessoSeletivo`)
-> está planejada para a T4 (#785).
-
 > **Princípio central:** habilitar o time antes de completar a arquitetura. Apenas duas abstrações (`ICommandBus`, `IQueryBus`) cruzam para `Application`. Drenagem de domain events não é abstração — é convenção de retorno do handler (cascading messages, ADR-0005). Features avançadas do Wolverine (sagas, scheduled messages, middleware custom específico) ficam fora do escopo até um caso de uso concreto pedir.
 
 ## Arquitetura resumida
@@ -59,26 +51,27 @@ Handlers e código de domínio **nunca** importam `Wolverine.*`. Usam apenas os 
 A configuração Wolverine vive no helper `UseWolverineOutboxCascading` em `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/WolverineOutboxConfiguration.cs` ([ADR-0040](adrs/0040-helper-wolverine-outbox-cascading-canonico.md)). Cada `*.API/Program.cs` consome o helper passando connection string name + um callback opcional de roteamento específico do módulo:
 
 ```csharp
-// src/selecao/Unifesspa.UniPlus.Selecao.API/Program.cs
+// src/host/Unifesspa.UniPlus.Host/Program.cs (composition root do monólito)
+Action<WolverineOptions> configurarSelecaoRouting =
+    builder.Services.AddSelecaoMessaging(builder.Configuration, builder.Environment);
+
 builder.Host.UseWolverineOutboxCascading(
     builder.Configuration,
-    connectionStringName: "SelecaoDb",
+    connectionStringName: "UniPlusDb",
     configureRouting: opts =>
     {
-        // Wolverine escaneia o entry assembly (Selecao.API) por padrão;
-        // handlers produtivos vivem em Selecao.Application — incluir
-        // explicitamente para que PublicarEditalCommandHandler (e futuros)
-        // sejam descobertos. Obrigatório por ADR-0043.
-        opts.Discovery.IncludeAssembly(typeof(PublicarEditalCommand).Assembly);
+        // Wolverine escaneia o entry assembly por padrão; handlers
+        // produtivos vivem em Selecao.Application/Infrastructure — incluir
+        // explicitamente para que PublicarProcessoSeletivoCommandHandler
+        // (e futuros) sejam descobertos. Obrigatório por ADR-0043.
+        opts.Discovery.IncludeAssembly(typeof(CriarProcessoSeletivoCommand).Assembly);
+        opts.Discovery.IncludeAssembly(typeof(ProcessoPublicadoToKafkaCascadeHandler).Assembly);
 
-        // Roteamento específico do módulo Selecao (ADR-0044).
-        opts.PublishMessage<EditalPublicadoEvent>().ToPostgresqlQueue("domain-events");
-        opts.ListenToPostgresqlQueue("domain-events");
-
-        if (!string.IsNullOrWhiteSpace(builder.Configuration["Kafka:BootstrapServers"]))
-        {
-            opts.PublishMessage<EditalPublicadoEvent>().ToKafkaTopic("edital_events");
-        }
+        // Roteamento específico do módulo Selecao (ADR-0044) — PG queue
+        // domain-events sempre; Kafka processo_seletivo_events quando
+        // configurado. O módulo é dono do próprio wiring
+        // (SelecaoMessagingRegistration); o host só compõe.
+        configurarSelecaoRouting(opts);
     });
 ```
 
@@ -183,23 +176,29 @@ Regras análogas existem em `Unifesspa.UniPlus.Ingresso.ArchTests` e na suíte s
 **Commands** representam intenções de mudança de estado. **Queries** representam leitura. Ambos são `sealed record`s, mas com convenções de retorno distintas:
 
 ```csharp
-// src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/PublicarEditalCommand.cs
-namespace Unifesspa.UniPlus.Selecao.Application.Commands.Editais;
+// src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommand.cs
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
 
-public sealed record PublicarEditalCommand(Guid EditalId) : ICommand<Result>;
+public sealed record PublicarProcessoSeletivoCommand(
+    Guid ProcessoSeletivoId,
+    string? Numero,
+    DateOnly PeriodoInscricaoInicio,
+    DateOnly PeriodoInscricaoFim,
+    Guid DocumentoEditalId) : ICommand<Result>;
 ```
 
 ```csharp
-// src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ObterEditalQuery.cs
-namespace Unifesspa.UniPlus.Selecao.Application.Queries.Editais;
+// src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQuery.cs
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ProcessosSeletivos;
 
 // Queries retornam o DTO direto (`?` quando "não encontrado" é caso normal).
-public sealed record ObterEditalQuery(Guid Id) : IQuery<EditalDto?>;
+public sealed record ObterProcessoSeletivoQuery(Guid Id) : IQuery<ProcessoSeletivoDto?>;
 ```
 
 ```csharp
-// src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ListarEditaisQuery.cs
-public sealed record ListarEditaisQuery(Guid? AfterId, int Limit) : IQuery<ListarEditaisResult>;
+// src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ListarProcessosSeletivosQuery.cs
+public sealed record ListarProcessosSeletivosQuery(Guid? AfterId, int Limit, PaginationDirection Direction)
+    : IQuery<ListarProcessosSeletivosResult>;
 ```
 
 **Convenções:**
@@ -208,7 +207,7 @@ public sealed record ListarEditaisQuery(Guid? AfterId, int Limit) : IQuery<Lista
 - Namespace: `<Module>.Application.{Commands,Queries}.<Feature>`.
 - Nome termina em `Command` (mutação) ou `Query` (leitura).
 - **Commands** retornam `Result` ou `Result<T>` — nunca `void`, nunca `Task`, nunca o tipo de domínio direto. Mantém o contrato de erro explícito ([ADR-0046](adrs/0046-validacao-de-regras-sem-excecao-result-failure.md)).
-- **Queries** retornam o **DTO de leitura direto** (`EditalDto?`, `ListarEditaisResult`) — sem `Result<T>`. Queries não falham por regra de negócio; falham por entrada inválida (`ValidationException` via middleware) ou erro técnico (mapeado pelo `GlobalExceptionMiddleware`). Essa simetria evita boilerplate de `Result.Failure` em caminhos de leitura onde "não encontrado" é resposta normal (`null` ou coleção vazia).
+- **Queries** retornam o **DTO de leitura direto** (`ProcessoSeletivoDto?`, `ListarProcessosSeletivosResult`) — sem `Result<T>`. Queries não falham por regra de negócio; falham por entrada inválida (`ValidationException` via middleware) ou erro técnico (mapeado pelo `GlobalExceptionMiddleware`). Essa simetria evita boilerplate de `Result.Failure` em caminhos de leitura onde "não encontrado" é resposta normal (`null` ou coleção vazia).
 
 ## Passo 2 — escrever o command handler que muta agregado
 
@@ -216,54 +215,58 @@ Handlers são classes `sealed class` ou `static class` convention-based. **Sem i
 
 Quando o handler **muta agregado** e o agregado emite domain events, o retorno é uma **tupla** `(Result, IEnumerable<object>)` ([ADR-0041](adrs/0041-padrao-retorno-handlers-wolverine-cascading.md)). O Wolverine reconhece o padrão, propaga a `Result` para o caller via `ICommandBus.Send<Result>` e captura o `IEnumerable<object>` como cascading messages, persistindo cada envelope no outbox dentro da `IEnvelopeTransaction` ativa — atomicidade write+evento garantida por design.
 
-Slice de referência: `src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/Editais/PublicarEditalCommandHandler.cs`.
+Slice de referência (Story #759, T4 #785): `src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommandHandler.cs`.
 
 ```csharp
-public sealed class PublicarEditalCommandHandler
+public static class PublicarProcessoSeletivoCommandHandler
 {
     public static async Task<(Result Resposta, IEnumerable<object> Eventos)> Handle(
-        PublicarEditalCommand command,
-        IEditalRepository editalRepository,
-        IUnitOfWork unitOfWork,
+        PublicarProcessoSeletivoCommand command,
+        IProcessoSeletivoRepository processoSeletivoRepository,
+        IDocumentoEditalRepository documentoEditalRepository,
+        ISnapshotPublicacaoCanonicalizer canonicalizer,
+        ISelecaoUnitOfWork unitOfWork,
+        IUserContext userContext,
+        TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
-        ArgumentNullException.ThrowIfNull(editalRepository);
-        ArgumentNullException.ThrowIfNull(unitOfWork);
+        // ... demais guards ...
 
-        Edital? edital = await editalRepository
-            .ObterPorIdAsync(command.EditalId, cancellationToken)
+        ProcessoSeletivo? processo = await processoSeletivoRepository
+            .ObterComConfiguracaoAsync(command.ProcessoSeletivoId, cancellationToken)
             .ConfigureAwait(false);
 
-        if (edital is null)
+        if (processo is null)
         {
             return (
                 Result.Failure(new DomainError(
-                    "Edital.NaoEncontrado",
-                    $"Edital '{command.EditalId}' não encontrado.")),
+                    "ProcessoSeletivo.NaoEncontrado",
+                    $"Processo Seletivo {command.ProcessoSeletivoId} não encontrado.")),
                 []);
         }
 
-        if (edital.Status == StatusEdital.Publicado)
+        // ... carrega o documento confirmado, monta DadosEdital, canonicaliza
+        // a configuração (ADR-0100) ...
+
+        Result<PublicacaoResultado> publicarResult = processo.Publicar(
+            dados, canonico.Bytes, canonico.SchemaVersion, canonico.AlgoritmoHash,
+            documento.HashSha256!, atorUsuarioSub, timeProvider);
+        if (publicarResult.IsFailure)
         {
-            return (
-                Result.Failure(new DomainError(
-                    "Edital.JaPublicado",
-                    $"Edital '{command.EditalId}' já está publicado.")),
-                []);
+            return (Result.Failure(publicarResult.Error!), []);
         }
 
-        edital.Publicar();
-        editalRepository.Atualizar(edital);
-        await unitOfWork
-            .SalvarAlteracoesAsync(cancellationToken)
+        await processoSeletivoRepository
+            .AdicionarSnapshotPublicacaoAsync(publicarResult.Value!.Snapshot, cancellationToken)
             .ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
 
-        // ADR-0005 + ADR-0041: drenagem por cascading messages.
-        // Cast<object> garante o switch case `IEnumerable<object>` em
-        // MessageContext.EnqueueCascadingAsync sem depender de covariância
-        // implícita de IDomainEvent (interface) para object.
-        return (Result.Success(), edital.DequeueDomainEvents().Cast<object>());
+        // ADR-0005 + ADR-0041: drenagem por cascading messages, DEPOIS do
+        // SaveChanges bem-sucedido. Cast<object> garante o switch case
+        // `IEnumerable<object>` em MessageContext.EnqueueCascadingAsync sem
+        // depender de covariância implícita de IDomainEvent para object.
+        return (Result.Success(), processo.DequeueDomainEvents().Cast<object>());
     }
 }
 ```
@@ -278,63 +281,63 @@ public sealed class PublicarEditalCommandHandler
 6. **Domain events são retornados explicitamente.** `entity.DequeueDomainEvents().Cast<object>()` é o helper canônico do `EntityBase` — combina snapshot atômico e clear da coleção interna ([ADR-0005](adrs/0005-cascading-messages-para-drenagem-de-domain-events.md)).
 7. **`DequeueDomainEvents()` deve vir DEPOIS de `SaveChangesAsync`.** Drenar antes do save abre janela em que o agregado fica sem eventos se houver rollback.
 
-Handlers de **query** (leitura pura) seguem assinatura `Task<TResponse>` simples sem tupla, retornando o DTO direto. Slice de referência: `src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/Editais/ObterEditalQueryHandler.cs`.
+Handlers de **query** (leitura pura) seguem assinatura `Task<TResponse>` simples sem tupla, retornando o DTO direto. Slice de referência: `src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs`.
 
 ```csharp
-public static class ObterEditalQueryHandler
+public static class ObterProcessoSeletivoQueryHandler
 {
-    public static async Task<EditalDto?> Handle(
-        ObterEditalQuery query,
-        IEditalRepository editalRepository,
+    public static async Task<ProcessoSeletivoDto?> Handle(
+        ObterProcessoSeletivoQuery query,
+        IProcessoSeletivoRepository processoSeletivoRepository,
         CancellationToken ct)
     {
-        Edital? edital = await editalRepository
+        ProcessoSeletivo? processo = await processoSeletivoRepository
             .ObterPorIdAsync(query.Id, ct)
             .ConfigureAwait(false);
 
-        if (edital is null)
+        if (processo is null)
             return null;
 
-        return new EditalDto(
-            edital.Id,
-            edital.NumeroEdital.ToString(),
+        return new ProcessoSeletivoDto(
+            processo.Id,
+            processo.Nome,
             // ... demais campos do DTO
         );
     }
 }
 ```
 
-`null` aqui não é erro — é resposta semanticamente válida para "edital não encontrado". O controller mapeia `null` para `404 NotFound` no caminho HTTP, sem precisar instanciar `Result.Failure`. Query handlers podem ser declarados como `static class` (sem instanciamento por request) quando o método `Handle` é `static`.
+`null` aqui não é erro — é resposta semanticamente válida para "processo não encontrado". O controller mapeia `null` para `404 NotFound` no caminho HTTP, sem precisar instanciar `Result.Failure`. Query handlers podem ser declarados como `static class` (sem instanciamento por request) quando o método `Handle` é `static`.
 
 ## Passo 3 — escrever o domain event handler
 
 Domain events reagem a fatos consumados. Mesmo padrão dos command handlers: classe pública (`sealed partial` quando usa `[LoggerMessage]` source generator) + método `static Handle`:
 
 ```csharp
-// src/selecao/Unifesspa.UniPlus.Selecao.Application/Events/Editais/EditalPublicadoEventHandler.cs
+// src/selecao/Unifesspa.UniPlus.Selecao.Application/Events/ProcessosSeletivos/ProcessoPublicadoEventHandler.cs
 [SuppressMessage(
     "Naming",
     "CA1711:Identifiers should not have incorrect suffix",
     Justification = "Convenção do projeto: subscritores de domain events terminam em EventHandler.")]
-public sealed partial class EditalPublicadoEventHandler
+public sealed partial class ProcessoPublicadoEventHandler
 {
     public static void Handle(
-        EditalPublicadoEvent @event,
-        ILogger<EditalPublicadoEventHandler> logger)
+        ProcessoPublicadoEvent @event,
+        ILogger<ProcessoPublicadoEventHandler> logger)
     {
         ArgumentNullException.ThrowIfNull(@event);
         ArgumentNullException.ThrowIfNull(logger);
 
-        LogEditalPublicadoRecebido(logger, @event.EditalId, @event.NumeroEdital);
+        LogProcessoPublicadoRecebido(logger, @event.ProcessoSeletivoId, @event.EditalId);
     }
 
     [LoggerMessage(
         Level = LogLevel.Information,
-        Message = "EditalPublicadoEvent recebido. EditalId={EditalId} NumeroEdital={NumeroEdital}")]
-    private static partial void LogEditalPublicadoRecebido(
+        Message = "ProcessoPublicadoEvent recebido. ProcessoSeletivoId={ProcessoSeletivoId} EditalId={EditalId}")]
+    private static partial void LogProcessoPublicadoRecebido(
         ILogger logger,
-        Guid editalId,
-        string numeroEdital);
+        Guid processoSeletivoId,
+        Guid editalId);
 }
 ```
 
@@ -351,8 +354,9 @@ Controllers MVC ([ADR-0036](adrs/0036-controllers-mvc-para-negocio-minimal-api-p
 
 ```csharp
 [ApiController]
-[Route("api/editais")]
-public sealed class EditalController(
+[Route("api/selecao/processos-seletivos")]
+[Authorize(Roles = "plataforma-admin")]
+public sealed class ProcessoSeletivoController(
     ICommandBus commandBus,
     IQueryBus queryBus,
     IDomainErrorMapper mapper) : ControllerBase
@@ -361,10 +365,15 @@ public sealed class EditalController(
     private readonly IQueryBus _queryBus = queryBus;
     private readonly IDomainErrorMapper _mapper = mapper;
 
-    [HttpPost("{id:guid}/publicar")]
-    public async Task<IActionResult> Publicar(Guid id, CancellationToken ct)
+    [HttpPost("{id:guid}/publicacao")]
+    [RequiresIdempotencyKey]
+    public async Task<IActionResult> Publicar(
+        Guid id, [FromBody] PublicarProcessoSeletivoRequest request, CancellationToken ct)
     {
-        Result resultado = await _commandBus.Send(new PublicarEditalCommand(id), ct);
+        Result resultado = await _commandBus.Send(
+            new PublicarProcessoSeletivoCommand(
+                id, request.Numero, request.PeriodoInscricaoInicio, request.PeriodoInscricaoFim, request.DocumentoEditalId),
+            ct);
         if (resultado.IsSuccess)
             return NoContent();
         return resultado.ToActionResult(_mapper);
@@ -373,8 +382,8 @@ public sealed class EditalController(
     [HttpGet("{id:guid}")]
     public async Task<IActionResult> ObterPorId(Guid id, CancellationToken ct)
     {
-        EditalDto? edital = await _queryBus.Send(new ObterEditalQuery(id), ct);
-        return edital is null ? NotFound() : Ok(edital);
+        ProcessoSeletivoDto? processo = await _queryBus.Send(new ObterProcessoSeletivoQuery(id), ct);
+        return processo is null ? NotFound() : Ok(processo);
     }
 }
 ```
@@ -385,7 +394,7 @@ public sealed class EditalController(
 - Comando falho → `resultado.ToActionResult(_mapper)` mapeia `DomainError` para `ProblemDetails` RFC 9457 ([ADR-0023](adrs/0023-wire-formato-erro-rfc-9457.md), [ADR-0024](adrs/0024-mapeamento-domain-error-http.md)).
 - **`ToActionResult` exige `IDomainErrorMapper` injetado e só é válido para failures** — chamar em `Result.Success` lança exceção. Por isso o pattern é sempre `if (IsSuccess) return ...; return resultado.ToActionResult(_mapper);`, nunca `return resultado.ToActionResult()` direto.
 
-Slice canônico real: `src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/EditalController.cs`.
+Slice canônico real: `src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs`.
 
 **Nunca** injete `IMessageBus` do Wolverine diretamente em controllers ou handlers. Sempre `ICommandBus` ou `IQueryBus` — contrato enforçado pela ArchUnitNET.
 
@@ -394,11 +403,13 @@ Slice canônico real: `src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/Edi
 Validação de comando/query usa o middleware FluentValidation do Wolverine (`UseFluentValidation`) automaticamente — basta declarar um validator em `Application` no mesmo namespace do command:
 
 ```csharp
-public sealed class PublicarEditalCommandValidator : AbstractValidator<PublicarEditalCommand>
+public sealed class PublicarProcessoSeletivoCommandValidator : AbstractValidator<PublicarProcessoSeletivoCommand>
 {
-    public PublicarEditalCommandValidator()
+    public PublicarProcessoSeletivoCommandValidator()
     {
-        RuleFor(x => x.EditalId).NotEmpty();
+        RuleFor(x => x.ProcessoSeletivoId).NotEmpty();
+        RuleFor(x => x.DocumentoEditalId).NotEmpty();
+        RuleFor(x => x.PeriodoInscricaoFim).GreaterThanOrEqualTo(x => x.PeriodoInscricaoInicio);
     }
 }
 ```
@@ -452,21 +463,25 @@ Dois cenários, alinhados a [ADR-0046](adrs/0046-validacao-de-regras-sem-excecao
 
 ```csharp
 [Fact]
-public async Task Deve_falhar_quando_edital_nao_encontrado()
+public async Task Deve_falhar_quando_processo_nao_encontrado()
 {
-    var repository = Substitute.For<IEditalRepository>();
-    repository.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
-        .Returns((Edital?)null);
-    var unitOfWork = Substitute.For<IUnitOfWork>();
+    var repository = Substitute.For<IProcessoSeletivoRepository>();
+    repository.ObterComConfiguracaoAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+        .Returns((ProcessoSeletivo?)null);
+    // ... demais dependências via Substitute.For<T>() ...
 
-    var (resposta, eventos) = await PublicarEditalCommandHandler.Handle(
-        new PublicarEditalCommand(Guid.NewGuid()),
+    var (resposta, eventos) = await PublicarProcessoSeletivoCommandHandler.Handle(
+        new PublicarProcessoSeletivoCommand(Guid.NewGuid(), null, DateOnly.MinValue, DateOnly.MaxValue, Guid.NewGuid()),
         repository,
+        documentoEditalRepository,
+        canonicalizer,
         unitOfWork,
+        userContext,
+        timeProvider,
         CancellationToken.None);
 
     resposta.IsFailure.Should().BeTrue();
-    resposta.Error!.Code.Should().Be("Edital.NaoEncontrado");
+    resposta.Error!.Code.Should().Be("ProcessoSeletivo.NaoEncontrado");
     eventos.Should().BeEmpty();
 }
 ```

--- a/src/host/Unifesspa.UniPlus.Host/Program.cs
+++ b/src/host/Unifesspa.UniPlus.Host/Program.cs
@@ -17,6 +17,7 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.API;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Application;
 using Unifesspa.UniPlus.Selecao.API;
 using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
 
 // Composition root do monólito modular. Compõe os 4 módulos internos
 // (Selecao, Ingresso, Configuracao, OrganizacaoInstitucional) num processo único,
@@ -82,6 +83,12 @@ builder.Services.AddUniPlusHealthChecks(builder.Configuration, connectionStringN
 // migrations on startup (registradas acima nos Add*Module) precedem o runtime
 // Wolverine (invariante #419). ---
 
+// Mensageria do Selecao (Kafka/Schema Registry — ADR-0051 — + routing): o módulo
+// é dono do seu wiring (SelecaoMessagingRegistration); o host registra o Schema
+// Registry e compõe o configurador de routing na instância única de Wolverine.
+Action<Wolverine.WolverineOptions> configurarSelecaoRouting =
+    builder.Services.AddSelecaoMessaging(builder.Configuration, builder.Environment);
+
 builder.Host.UseWolverineOutboxCascading(
     builder.Configuration,
     connectionStringName: "UniPlusDb",
@@ -90,6 +97,7 @@ builder.Host.UseWolverineOutboxCascading(
         opts.Discovery.IncludeAssembly(typeof(ConfiguracaoApplicationServiceRegistration).Assembly);
         opts.Discovery.IncludeAssembly(typeof(OrganizacaoInstitucionalApplicationServiceRegistration).Assembly);
         opts.Discovery.IncludeAssembly(typeof(CriarProcessoSeletivoCommand).Assembly);
+        opts.Discovery.IncludeAssembly(typeof(ProcessoPublicadoToKafkaCascadeHandler).Assembly);
 
         // Opt-ins de codegen (ADR-0098): sob ServiceLocationPolicy.NotAllowed, cada
         // módulo declara as UoW que usam service location intencionalmente (forwarding
@@ -99,6 +107,10 @@ builder.Host.UseWolverineOutboxCascading(
         SelecaoCodegenRegistration.ConfigurarCodegenWolverine(opts);
         ConfiguracaoCodegenRegistration.ConfigurarCodegenWolverine(opts);
         OrganizacaoInstitucionalCodegenRegistration.ConfigurarCodegenWolverine(opts);
+
+        // Routing do Selecao (PG queue domain-events + Kafka processo_seletivo_events) —
+        // religa a mensageria externa antes deferida no monólito.
+        configurarSelecaoRouting(opts);
     });
 builder.Services.AddWolverineMessaging();
 

--- a/src/host/Unifesspa.UniPlus.Host/packages.lock.json
+++ b/src/host/Unifesspa.UniPlus.Host/packages.lock.json
@@ -1162,6 +1162,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1186,6 +1187,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -23,8 +23,9 @@ using Application.Queries.ProcessosSeletivos;
 /// distribuição de vagas (Story #773), bônus regional e critérios de
 /// desempate (Story #774) e classificação (Story #775, 15º bloco canônico),
 /// estes por referência ao catálogo de regras tipadas versionadas
-/// (<c>rol_de_regras</c>, Story #772). O <c>Edital</c> não é criado aqui; é o
-/// documento emitido pela publicação (Story #759, fora deste escopo).
+/// (<c>rol_de_regras</c>, Story #772). O <c>Edital</c> não é criado
+/// diretamente — é o documento emitido pelo ato de publicação
+/// (<see cref="Publicar"/>, Story #759 T4 #785).
 /// </summary>
 [ApiController]
 [Route("api/selecao/processos-seletivos")]
@@ -268,6 +269,59 @@ public sealed class ProcessoSeletivoController : ControllerBase
     }
 
     /// <summary>
+    /// Publica o Edital de abertura do processo (RN08, Story #759, T4 #785):
+    /// valida a conformidade, congela um <c>SnapshotPublicacao</c> append-only
+    /// e transita o status para Publicado, tudo na mesma transação. Quando a
+    /// publicação é recusada por conformidade insuficiente (CA-03), o corpo
+    /// do 422 carrega <c>Extensions["pendencias"]</c> com o checklist.
+    /// </summary>
+    [HttpPost("{id:guid}/publicacao")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Publicar(
+        Guid id,
+        [FromBody] PublicarProcessoSeletivoRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Result resultado = await _commandBus.Send(
+            new PublicarProcessoSeletivoCommand(
+                id, request.Numero, request.PeriodoInscricaoInicio, request.PeriodoInscricaoFim, request.DocumentoEditalId),
+            cancellationToken);
+        if (resultado.IsSuccess)
+        {
+            return NoContent();
+        }
+
+        IActionResult actionResult = resultado.ToActionResult(_mapper);
+        if (!resultado.HasErrorCode("ProcessoSeletivo.ConformidadeInsuficiente")
+            || actionResult is not ObjectResult { Value: ProblemDetails problem })
+        {
+            return actionResult;
+        }
+
+        // CA-03: enriquece o 422 de conformidade insuficiente com o checklist
+        // de pendências — reconsulta ObterConformidadeProcessoSeletivoQuery
+        // (mesmo ProcessoSeletivo.AvaliarConformidade() por trás do gate de
+        // Publicar, sem duplicar a regra) para montar Extensions["pendencias"].
+        ConformidadeProcessoSeletivoDto? conformidade = await _queryBus
+            .Send(new ObterConformidadeProcessoSeletivoQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+        if (conformidade is not null)
+        {
+            problem.Extensions["pendencias"] = conformidade.Itens
+                .Where(item => !item.Ok)
+                .Select(item => item.Item)
+                .ToArray();
+        }
+
+        return actionResult;
+    }
+
+    /// <summary>
     /// Consulta a conformidade estrutural do processo (CA-07): checklist com
     /// cada item obrigatório marcado ok/pendente, sem alterar o processo.
     /// </summary>
@@ -289,6 +343,16 @@ public sealed class ProcessoSeletivoController : ControllerBase
         return Ok(conformidade);
     }
 }
+
+/// <summary>
+/// Corpo de <see cref="ProcessoSeletivoController.Publicar"/> — omite
+/// <c>ProcessoSeletivoId</c> (vem da rota).
+/// </summary>
+public sealed record PublicarProcessoSeletivoRequest(
+    string? Numero,
+    DateOnly PeriodoInscricaoInicio,
+    DateOnly PeriodoInscricaoFim,
+    Guid DocumentoEditalId);
 
 /// <summary>
 /// Corpo de <see cref="ProcessoSeletivoController.DefinirOfertaAtendimento"/>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -142,6 +142,24 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("DocumentoEdital.TamanhoExcedido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_edital.tamanho_excedido", "Documento excede o tamanho máximo permitido")),
         new("DocumentoEdital.ContentTypeInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_edital.content_type_invalido", "Documento do Edital deve ser do tipo application/pdf")),
         new("DocumentoEdital.AssinaturaInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_edital.assinatura_invalida", "Conteúdo do arquivo não corresponde a um PDF válido")),
+        // Publicação do Processo Seletivo — RN08 (Story #759, T4 #785). Todo
+        // 422: status dominante do módulo para violação de regra de negócio,
+        // inclusive quando a origem física é constraint de banco (ADR-0102).
+        new("DadosEdital.DocumentoEditalIdObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.dados_edital.documento_edital_id_obrigatorio", "Referência ao documento do Edital é obrigatória")),
+        new("DadosEdital.PeriodoInscricaoInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.dados_edital.periodo_inscricao_invalido", "O fim do período de inscrição não pode anteceder o início")),
+        new("Edital.ProcessoSeletivoIdObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.processo_seletivo_id_obrigatorio", "O Edital deve estar vinculado a um Processo Seletivo")),
+        new("Edital.DataPublicacaoDuplicada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.data_publicacao_duplicada", "Já existe um Edital publicado neste processo com a mesma data de publicação")),
+        new("Edital.AberturaJaExiste", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.abertura_ja_existe", "Este processo já tem um Edital de abertura publicado")),
+        new("Edital.ContratoNaturezaInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.contrato_natureza_invalido", "Abertura não carrega edital retificado nem motivo; retificação exige ambos")),
+        // SnapshotPublicacao.Congelar (ADR-0063): entidade forensic — guards
+        // de invariante lançam ArgumentException (defesa em profundidade
+        // contra erro de programação do caller, nunca alcançável a partir de
+        // input do usuário), não DomainError. Sem entradas de registry aqui.
+        new("ProcessoSeletivo.TransicaoInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.transicao_invalida", "Só é possível publicar um processo em rascunho")),
+        new("ProcessoSeletivo.ConformidadeInsuficiente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.conformidade_insuficiente", "Processo não conforme para publicação")),
+        new("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.mutacao_pos_publicacao_bloqueada", "Processo publicado não aceita mutação direta da configuração")),
+        new("ProcessoSeletivo.DocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_encontrado", "Documento do Edital não encontrado ou não pertence a este processo")),
+        new("ProcessoSeletivo.DocumentoNaoConfirmado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_confirmado", "Somente um documento confirmado pode ser referenciado na publicação")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoMessagingRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoMessagingRegistration.cs
@@ -1,0 +1,172 @@
+namespace Unifesspa.UniPlus.Selecao.API;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Confluent.SchemaRegistry;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Serilog;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Messaging.SchemaRegistry;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+
+using Wolverine;
+using Wolverine.Kafka;
+using Wolverine.Kafka.Serialization;
+using Wolverine.Postgresql;
+
+using ProcessoPublicadoAvro = unifesspa.uniplus.selecao.events.ProcessoPublicado;
+
+/// <summary>
+/// Wiring de mensageria do módulo Seleção (Kafka/Schema Registry — ADR-0051 — e
+/// routing Wolverine — ADR-0003/0004/0005). É setup de processo (uma instância
+/// Wolverine por host), então fica fora de <see cref="SelecaoModuleRegistration"/>:
+/// tanto o Program.cs standalone quanto o composition root do monólito modular
+/// chamam este mesmo método, garantindo paridade de comportamento.
+/// </summary>
+/// <remarks>
+/// Slice canônico do ADR-0005/ADR-0041 (Story #759, T4 #785) — reconstrói sobre
+/// <see cref="ProcessoPublicadoEvent"/> a demonstração que antes vivia sobre o
+/// agregado <c>Edital</c> legado (removido por #782).
+/// </remarks>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "Referenciado pelo composition root (host do monólito modular) fora deste assembly.")]
+public static class SelecaoMessagingRegistration
+{
+    /// <summary>
+    /// Registra o Schema Registry do módulo (cliente + schema Avro
+    /// <c>processo_seletivo_events-value</c>) e devolve o configurador de routing
+    /// Wolverine do Seleção, para o host compor no <c>configureRouting</c> de
+    /// <c>UseWolverineOutboxCascading</c> — sem o host precisar conhecer Kafka/SR.
+    /// </summary>
+    /// <returns>
+    /// Ação que aplica o routing do Seleção a um <see cref="WolverineOptions"/>:
+    /// PG queue intra-módulo <c>domain-events</c> + (quando Kafka e SR estão
+    /// configurados) tópico Kafka <c>processo_seletivo_events</c> com serializer
+    /// Avro Confluent.
+    /// </returns>
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "O ISchemaRegistryClient devolvido por RegistrarSchemaRegistry é "
+            + "registrado como singleton no DI (ownership transferido ao container, que o "
+            + "dispõe no shutdown do IHost). CA2000 não rastreia ownership via DI.")]
+    public static Action<WolverineOptions> AddSelecaoMessaging(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        ISchemaRegistryClient? srClient = RegistrarSchemaRegistry(services, configuration, environment);
+
+        services.AddSchemaRegistry(configuration)
+            .AddSchema(
+                subject: "processo_seletivo_events-value",
+                schemaResourceName: ProcessoPublicadoAvro.SchemaResourceName,
+                resourceAssembly: typeof(ProcessoPublicadoEvent).Assembly);
+
+        return opts => ConfigurarRouting(opts, configuration, srClient);
+    }
+
+    /// <summary>
+    /// Routing do Seleção: drena <see cref="ProcessoPublicadoEvent"/> pela PG queue
+    /// <c>domain-events</c> (cascading ADR-0005) e, quando Kafka + Schema Registry
+    /// estão configurados, projeta o evento Avro para o tópico
+    /// <c>processo_seletivo_events</c>.
+    /// </summary>
+    public static void ConfigurarRouting(
+        WolverineOptions opts,
+        IConfiguration configuration,
+        ISchemaRegistryClient? srClient)
+    {
+        ArgumentNullException.ThrowIfNull(opts);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        opts.PublishMessage<ProcessoPublicadoEvent>().ToPostgresqlQueue("domain-events");
+        opts.ListenToPostgresqlQueue("domain-events");
+
+        bool kafkaConfigured = !string.IsNullOrWhiteSpace(configuration["Kafka:BootstrapServers"]);
+        if (kafkaConfigured && srClient is not null)
+        {
+            // Kafka + Schema Registry: produz Avro com schema-id no envelope
+            // (Confluent wire format). Consumers cross-módulo recuperam o schema
+            // via schema-id, sem dependência do assembly Selecao.Domain.
+            opts.PublishMessage<ProcessoPublicadoAvro>()
+                .ToKafkaTopic("processo_seletivo_events")
+                .DefaultSerializer(new SchemaRegistryAvroSerializer(srClient));
+        }
+    }
+
+    /// <summary>
+    /// Cria o <see cref="ISchemaRegistryClient"/> a partir de
+    /// <c>SchemaRegistry:Url</c> (ou <see langword="null"/> quando vazio) e o
+    /// registra como singleton, aplicando a invariante ADR-0051/0053 (Kafka em
+    /// ambiente produtivo exige Schema Registry).
+    /// </summary>
+    [SuppressMessage(
+        "Reliability",
+        "CA2000:Dispose objects before losing scope",
+        Justification = "O cliente criado por CreateClient é registrado como singleton no DI "
+            + "logo em seguida (services.AddSingleton); o container assume ownership e o dispõe "
+            + "no shutdown do IHost. CA2000 não rastreia ownership via DI.")]
+    private static ISchemaRegistryClient? RegistrarSchemaRegistry(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        SchemaRegistrySettings srSettings = configuration
+            .GetSection(SchemaRegistrySettings.SectionName)
+            .Get<SchemaRegistrySettings>() ?? new SchemaRegistrySettings();
+
+        // Invariante operacional (ADR-0051/0053): Kafka habilitado exige Schema
+        // Registry em ambientes produtivos. Só Development afrouxa (cobre test
+        // factories que sobem com UseEnvironment("Development")).
+        bool kafkaEnabled = !string.IsNullOrWhiteSpace(configuration["Kafka:BootstrapServers"]);
+        bool srMissing = string.IsNullOrWhiteSpace(srSettings.Url);
+        if (kafkaEnabled && srMissing)
+        {
+            if (!environment.IsDevelopment())
+            {
+                throw new InvalidOperationException(
+                    "Configuração inválida: Kafka:BootstrapServers populado mas SchemaRegistry:Url vazio em "
+                    + $"ASPNETCORE_ENVIRONMENT={environment.EnvironmentName}. "
+                    + "ADR-0051 exige Schema Registry para todo publishing cross-módulo em ambientes produtivos. "
+                    + "Configure SchemaRegistry:Url (ou desligue Kafka apagando Kafka:BootstrapServers).");
+            }
+
+            using ILoggerFactory missingSrLoggerFactory = LoggerFactory.Create(static b => b.AddSerilog());
+            Microsoft.Extensions.Logging.ILogger missingSrLogger =
+                missingSrLoggerFactory.CreateLogger("Selecao.Messaging.Bootstrap");
+#pragma warning disable CA1848 // Bootstrap logging — fora do hot path; LoggerMessage source generator overkill aqui.
+#pragma warning disable CA2254 // Mensagem fixa após format de string interpolada — sem placeholders dinâmicos.
+            missingSrLogger.LogWarning(
+                "Kafka habilitado sem Schema Registry em ambiente {Env} — publishing Avro cross-módulo desligado. "
+                + "Esperado em test factory que isola cascading puro; sinal de bug em ambiente produtivo (ADR-0051).",
+                environment.EnvironmentName);
+#pragma warning restore CA2254
+#pragma warning restore CA1848
+        }
+
+        if (string.IsNullOrWhiteSpace(srSettings.Url))
+        {
+            return null;
+        }
+
+        using ILoggerFactory bootstrapLoggerFactory = LoggerFactory.Create(static b => b.AddSerilog());
+        ISchemaRegistryClient srClient = SchemaRegistryServiceCollectionExtensions.CreateClient(
+            srSettings,
+            bootstrapLoggerFactory,
+            services);
+        services.AddSingleton(srClient);
+        return srClient;
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj
@@ -3,9 +3,8 @@
   <!--
     Módulo interno do monólito modular: class library (não executável). Roda apenas
     dentro da API UniPlus; não carrega Program/appsettings próprios. Deploy: somente
-    Geo, Portal e UniPlus são executáveis. WolverineFx.Postgresql permanece —
-    traz o namespace base Wolverine (WolverineOptions) consumido por
-    SelecaoCodegenRegistration.
+    Geo, Portal e UniPlus são executáveis. WolverineFx.Kafka permanece — o wiring de
+    mensageria (SelecaoMessagingRegistration) é consumido pelo host.
   -->
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
@@ -13,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="WolverineFx.Postgresql" />
+    <PackageReference Include="WolverineFx.Kafka" />
   </ItemGroup>
 
   <!-- Implicit usings que o Sdk.Web adicionava e o Sdk padrão não traz. -->

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
@@ -32,6 +32,17 @@
           "Serilog.Sinks.File": "7.0.0"
         }
       },
+      "WolverineFx.Kafka": {
+        "type": "Direct",
+        "requested": "[5.39.5, )",
+        "resolved": "5.39.5",
+        "contentHash": "6QT36/IJNiAQxkbj2bEU+QI1ckOZtRbH5ppfsTpa2iQjI72hgLs8JfBKh0xzNrenGMcNMZRoBwrwaz2/dM/28A==",
+        "dependencies": {
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.14.0",
+          "Confluent.SchemaRegistry.Serdes.Json": "2.14.0",
+          "WolverineFx": "5.39.5"
+        }
+      },
       "WolverineFx.Postgresql": {
         "type": "Direct",
         "requested": "[5.39.5, )",
@@ -1058,6 +1069,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
@@ -1368,17 +1381,6 @@
         "contentHash": "GndYpol1608Mahrw4ZTbwEZO/V/qgPXzy5Q5Bkfa1iYvFiRkf9B11eSsC9SOHhtRONPVI1ZI4Q4CeppTumT+2w==",
         "dependencies": {
           "FluentValidation": "12.0.0",
-          "WolverineFx": "5.39.5"
-        }
-      },
-      "WolverineFx.Kafka": {
-        "type": "CentralTransitive",
-        "requested": "[5.39.5, )",
-        "resolved": "5.39.5",
-        "contentHash": "6QT36/IJNiAQxkbj2bEU+QI1ckOZtRbH5ppfsTpa2iQjI72hgLs8JfBKh0xzNrenGMcNMZRoBwrwaz2/dM/28A==",
-        "dependencies": {
-          "Confluent.SchemaRegistry.Serdes.Avro": "2.14.0",
-          "Confluent.SchemaRegistry.Serdes.Json": "2.14.0",
           "WolverineFx": "5.39.5"
         }
       }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/ISnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/ISnapshotPublicacaoCanonicalizer.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Abstractions;
+
+using Domain.Entities;
+using Domain.ValueObjects;
+
+/// <summary>
+/// Bytes canônicos + metadados de um snapshot de publicação, prontos para
+/// <c>ProcessoSeletivo.Publicar</c> congelar (ADR-0100). Não carrega hash —
+/// <c>SnapshotPublicacao.Congelar</c> deriva o hash dos bytes internamente
+/// (revisão de plano, evita divergência entre bytes e hash persistidos).
+/// </summary>
+#pragma warning disable CA1819 // Properties should not return arrays — bytes canônicos, sem value-equality de record aplicável.
+public sealed record SnapshotCanonico(byte[] Bytes, string SchemaVersion, string AlgoritmoHash);
+#pragma warning restore CA1819
+
+/// <summary>
+/// Porta do serializador canônico dos 17 blocos do snapshot de publicação
+/// (ADR-0100) — implementação em Infrastructure. Projeta a configuração viva
+/// do <see cref="ProcessoSeletivo"/> num payload canônico (11 blocos reais +
+/// 6 stubs <c>{"status":"nao_construido"}</c> para dimensões ainda não
+/// implementadas), serializa e devolve os bytes que
+/// <c>SnapshotPublicacao.Congelar</c> persiste como base do hash.
+/// </summary>
+public interface ISnapshotPublicacaoCanonicalizer
+{
+    SnapshotCanonico Canonicalizar(ProcessoSeletivo processo, DadosEdital dados, string hashEdital);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirBonusRegionalCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirBonusRegionalCommandHandler.cs
@@ -39,7 +39,12 @@ public static class DefinirBonusRegionalCommandHandler
 
         if (command.RegraCodigo is null)
         {
-            processo.DefinirBonusRegional(null);
+            Result removerResult = processo.DefinirBonusRegional(null);
+            if (removerResult.IsFailure)
+            {
+                return removerResult;
+            }
+
             await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
             return Result.Success();
         }
@@ -81,7 +86,12 @@ public static class DefinirBonusRegionalCommandHandler
             return Result.Failure(bonusResult.Error!);
         }
 
-        processo.DefinirBonusRegional(bonusResult.Value!);
+        Result definirResult = processo.DefinirBonusRegional(bonusResult.Value!);
+        if (definirResult.IsFailure)
+        {
+            return definirResult;
+        }
+
         await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
 
         return Result.Success();

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommand.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Kernel.Results;
+
+/// <summary>
+/// Publica o Edital de abertura do processo (RN08, Story #759, T4 #785):
+/// valida a conformidade estrutural, congela a configuração num
+/// <c>SnapshotPublicacao</c> append-only e transita o status para Publicado,
+/// tudo na mesma transação (CA-01/CA-02). O ator (<c>IUserContext.UserId</c>)
+/// nunca é input do command — vem do contexto autenticado.
+/// </summary>
+public sealed record PublicarProcessoSeletivoCommand(
+    Guid ProcessoSeletivoId,
+    string? Numero,
+    DateOnly PeriodoInscricaoInicio,
+    DateOnly PeriodoInscricaoFim,
+    Guid DocumentoEditalId) : ICommand<Result>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommandHandler.cs
@@ -1,0 +1,137 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using Abstractions;
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using Kernel.Results;
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+
+/// <summary>
+/// Handler convention-based do <see cref="PublicarProcessoSeletivoCommand"/>
+/// (RN08, Story #759 T4 #785, ADR-0005 + ADR-0041): carrega o agregado,
+/// valida o documento confirmado (T3), canonicaliza a configuração
+/// (ADR-0100) e delega a orquestração de negócio a
+/// <see cref="ProcessoSeletivo.Publicar"/>. Cascading messages — o
+/// <see cref="Domain.Events.ProcessoPublicadoEvent"/> é drenado só depois do
+/// <c>SaveChanges</c> bem-sucedido.
+/// </summary>
+public static class PublicarProcessoSeletivoCommandHandler
+{
+    public static async Task<(Result Resposta, IEnumerable<object> Eventos)> Handle(
+        PublicarProcessoSeletivoCommand command,
+        IProcessoSeletivoRepository processoSeletivoRepository,
+        IDocumentoEditalRepository documentoEditalRepository,
+        ISnapshotPublicacaoCanonicalizer canonicalizer,
+        ISelecaoUnitOfWork unitOfWork,
+        IUserContext userContext,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(processoSeletivoRepository);
+        ArgumentNullException.ThrowIfNull(documentoEditalRepository);
+        ArgumentNullException.ThrowIfNull(canonicalizer);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(userContext);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        ProcessoSeletivo? processo = await processoSeletivoRepository
+            .ObterComConfiguracaoAsync(command.ProcessoSeletivoId, cancellationToken)
+            .ConfigureAwait(false);
+        if (processo is null)
+        {
+            return (Result.Failure(new DomainError(
+                "ProcessoSeletivo.NaoEncontrado",
+                $"Processo Seletivo {command.ProcessoSeletivoId} não encontrado.")), []);
+        }
+
+        DocumentoEdital? documento = await documentoEditalRepository
+            .ObterPorIdAsync(command.DocumentoEditalId, cancellationToken)
+            .ConfigureAwait(false);
+        if (documento is null || documento.ProcessoSeletivoId != command.ProcessoSeletivoId)
+        {
+            return (Result.Failure(new DomainError(
+                "ProcessoSeletivo.DocumentoNaoEncontrado",
+                $"Documento do Edital {command.DocumentoEditalId} não encontrado ou não pertence a este processo.")), []);
+        }
+
+        if (documento.Status != Domain.Enums.StatusDocumentoEdital.Confirmado)
+        {
+            return (Result.Failure(new DomainError(
+                "ProcessoSeletivo.DocumentoNaoConfirmado",
+                "Somente um documento confirmado pode ser referenciado na publicação.")), []);
+        }
+
+        Result<DadosEdital> dadosResult = DadosEdital.Criar(
+            command.Numero,
+            command.PeriodoInscricaoInicio,
+            command.PeriodoInscricaoFim,
+            command.DocumentoEditalId);
+        if (dadosResult.IsFailure)
+        {
+            return (Result.Failure(dadosResult.Error!), []);
+        }
+
+        DadosEdital dados = dadosResult.Value!;
+
+        SnapshotCanonico canonico = canonicalizer.Canonicalizar(processo, dados, documento.HashSha256!);
+
+        string atorUsuarioSub = userContext.UserId ?? "system";
+
+        Result<PublicacaoResultado> publicarResult = processo.Publicar(
+            dados,
+            canonico.Bytes,
+            canonico.SchemaVersion,
+            canonico.AlgoritmoHash,
+            documento.HashSha256!,
+            atorUsuarioSub,
+            timeProvider);
+        if (publicarResult.IsFailure)
+        {
+            return (Result.Failure(publicarResult.Error!), []);
+        }
+
+        await processoSeletivoRepository
+            .AdicionarSnapshotPublicacaoAsync(publicarResult.Value!.Snapshot, cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint)
+        {
+            // Traduz violação de guard rail de banco (ADR-0102) — corrida de
+            // duas publicações concorrentes do mesmo processo, ou gap de
+            // validação em memória. Filtro do `when` garante que outras
+            // exceções não mapeadas propagam intactas.
+            if (UniqueConstraintViolation.IsAberturaJaExiste(constraint))
+            {
+                return (Result.Failure(new DomainError(
+                    "Edital.AberturaJaExiste",
+                    "Este processo já tem um Edital de abertura publicado.")), []);
+            }
+
+            if (UniqueConstraintViolation.IsDataPublicacaoDuplicada(constraint))
+            {
+                return (Result.Failure(new DomainError(
+                    "Edital.DataPublicacaoDuplicada",
+                    "Já existe um Edital publicado neste processo com a mesma data de publicação.")), []);
+            }
+
+            if (UniqueConstraintViolation.IsContratoNaturezaInvalido(constraint))
+            {
+                return (Result.Failure(new DomainError(
+                    "Edital.ContratoNaturezaInvalido",
+                    "Abertura não carrega edital retificado nem motivo; retificação exige ambos.")), []);
+            }
+
+            throw;
+        }
+
+        // ADR-0005 + ADR-0041: drenagem por cascading messages, DEPOIS do
+        // SaveChanges bem-sucedido — nunca antes (janela de perda em rollback).
+        return (Result.Success(), processo.DequeueDomainEvents().Cast<object>());
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/UniqueConstraintViolation.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/UniqueConstraintViolation.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+/// <summary>
+/// Helper para mapear violações de constraint de banco (índice UNIQUE
+/// parcial ou CHECK) do ciclo de publicação do Processo Seletivo para
+/// <c>DomainError</c> nomeado (RN08, Story #759 T4 #785, ADR-0102). Mesmo
+/// padrão de <c>ObrigatoriedadesLegais/UniqueConstraintViolation.cs</c>:
+/// inspeção do tipo da exceção por nome via <see cref="System.Type.FullName"/>
+/// evita dependência direta do <c>Microsoft.EntityFrameworkCore</c> package
+/// na camada Application (mantém Clean Arch).
+/// </summary>
+/// <remarks>
+/// A tradução acontece no boundary de persistência (ADR-0102 §"Forma do
+/// contrato") no sentido em que é aplicada imediatamente em torno da chamada
+/// a <c>ISelecaoUnitOfWork.SalvarAlteracoesAsync</c> — o ponto exato em que
+/// Application invoca o boundary de persistência — não dentro do
+/// repositório. Mesma convenção já usada por 7+ handlers do módulo antes
+/// desta ADR existir; não introduz uma segunda forma de tradução.
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+    private const string CheckViolationSqlState = "23514";
+
+    private const string DataPublicacaoConstraint = "ux_editais_processo_data_publicacao";
+    private const string AberturaUnicaConstraint = "ux_editais_processo_abertura_unica";
+    private const string ContratoNaturezaConstraint = "ck_editais_contrato_natureza";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> wrapping uma <c>PostgresException</c> com
+    /// <c>SqlState</c> de violação de UNIQUE (23505) ou CHECK (23514).
+    /// <see langword="null"/> caso contrário — o caller deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState && sqlState != CheckViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary><see langword="true"/> quando a constraint violada é a de unicidade de <c>data_publicacao</c> por processo (CA-08).</summary>
+    public static bool IsDataPublicacaoDuplicada(string? constraint) =>
+        string.Equals(constraint, DataPublicacaoConstraint, StringComparison.Ordinal);
+
+    /// <summary><see langword="true"/> quando a constraint violada é a de abertura única por processo (corrida de publicações concorrentes).</summary>
+    public static bool IsAberturaJaExiste(string? constraint) =>
+        string.Equals(constraint, AberturaUnicaConstraint, StringComparison.Ordinal);
+
+    /// <summary><see langword="true"/> quando a constraint violada é o CHECK do contrato abertura×retificação (ADR-0101).</summary>
+    public static bool IsContratoNaturezaInvalido(string? constraint) =>
+        string.Equals(constraint, ContratoNaturezaConstraint, StringComparison.Ordinal);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Events/ProcessosSeletivos/ProcessoPublicadoEventHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Events/ProcessosSeletivos/ProcessoPublicadoEventHandler.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Events.ProcessosSeletivos;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+
+/// <summary>
+/// Handler exemplar do <see cref="ProcessoPublicadoEvent"/> — registra o evento
+/// drenado via cascading messages (ADR-0005/ADR-0041, Story #759 T4 #785). Slice
+/// canônico de referência para subscritores de domain events do UniPlus: handler
+/// convention-based, método <c>Handle</c> público, dependências por parâmetro do
+/// método. Logging via <c>[LoggerMessage]</c> source generator (regra obrigatória
+/// do projeto — chamadas diretas a <c>logger.LogX(...)</c> são bloqueadas pelo
+/// analisador CA1848 com <c>TreatWarningsAsErrors</c>).
+/// </summary>
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção do projeto: subscritores de domain events terminam em EventHandler, conforme AC da #136.")]
+public sealed partial class ProcessoPublicadoEventHandler
+{
+    public static void Handle(
+        ProcessoPublicadoEvent @event,
+        ILogger<ProcessoPublicadoEventHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        LogProcessoPublicadoRecebido(logger, @event.ProcessoSeletivoId, @event.EditalId);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "ProcessoPublicadoEvent recebido. ProcessoSeletivoId={ProcessoSeletivoId} EditalId={EditalId}")]
+    private static partial void LogProcessoPublicadoRecebido(
+        ILogger logger,
+        Guid processoSeletivoId,
+        Guid editalId);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterConformidadeProcessoSeletivoQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterConformidadeProcessoSeletivoQueryHandler.cs
@@ -6,11 +6,16 @@ using Domain.Interfaces;
 
 /// <summary>
 /// Handler da <see cref="ObterConformidadeProcessoSeletivoQuery"/>: leitura
-/// pura (sem side effects) que avalia a presença das dimensões estruturalmente
-/// obrigatórias do agregado — não confundir com a conformidade de
+/// pura (sem side effects) que mapeia <see cref="ProcessoSeletivo.AvaliarConformidade"/>
+/// para o DTO público — não confundir com a conformidade de
 /// <c>ObrigatoriedadeLegal</c> (Story #460/#461), que avalia regras
 /// legais configuráveis contra o <c>Edital</c> legado.
 /// </summary>
+/// <remarks>
+/// O checklist em si vive em <c>ProcessoSeletivo.AvaliarConformidade()</c>
+/// (Domain) — reusado também pelo gate de <c>Publicar</c> (Story #759 CA-03),
+/// para que a leitura pública e o gate de publicação nunca divirjam.
+/// </remarks>
 public static class ObterConformidadeProcessoSeletivoQueryHandler
 {
     public static async Task<ConformidadeProcessoSeletivoDto?> Handle(
@@ -29,13 +34,8 @@ public static class ObterConformidadeProcessoSeletivoQueryHandler
             return null;
         }
 
-        ItemConformidadeDto[] itens =
-        [
-            new ItemConformidadeDto("Etapas", processo.Etapas.Count > 0),
-            new ItemConformidadeDto("Atendimento especializado", processo.OfertaAtendimento is not null),
-            new ItemConformidadeDto("Distribuição de vagas", processo.DistribuicaoVagas.Count > 0),
-            new ItemConformidadeDto("Classificação", processo.Classificacao is not null),
-        ];
+        ItemConformidadeDto[] itens = [.. processo.AvaliarConformidade()
+            .Select(static item => new ItemConformidadeDto(item.Item, item.Ok))];
 
         return new ConformidadeProcessoSeletivoDto(processo.Id, itens);
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/PublicarProcessoSeletivoCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/PublicarProcessoSeletivoCommandValidator.cs
@@ -1,0 +1,43 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+
+using FluentValidation;
+
+using Commands.ProcessosSeletivos;
+
+public sealed class PublicarProcessoSeletivoCommandValidator : AbstractValidator<PublicarProcessoSeletivoCommand>
+{
+    // Espelha a coluna varchar(60) de EditalConfiguration.Numero — sem este
+    // limite aqui, um número acima do tamanho da coluna só falharia no
+    // SaveChanges (erro de infraestrutura não tratado), nunca como 422.
+    private const int NumeroMaxLength = 60;
+
+    public PublicarProcessoSeletivoCommandValidator()
+    {
+        RuleFor(x => x.ProcessoSeletivoId)
+            .NotEmpty()
+            .WithMessage("Id do processo seletivo é obrigatório.");
+
+        RuleFor(x => x.DocumentoEditalId)
+            .NotEmpty()
+            .WithMessage("Referência ao documento do Edital é obrigatória.");
+
+        RuleFor(x => x.Numero)
+            .MaximumLength(NumeroMaxLength)
+            .WithMessage($"Número do Edital deve ter no máximo {NumeroMaxLength} caracteres.");
+
+        // DateOnly não aceita [FromBody] ausente como null (é struct não-nullable)
+        // — campo omitido do JSON body binda para default(DateOnly) = 0001-01-01.
+        // Sem esta checagem, os dois defaults passariam trivialmente na
+        // comparação GreaterThanOrEqualTo abaixo, congelando um snapshot com
+        // período de inscrição inválido.
+        RuleFor(x => x.PeriodoInscricaoInicio)
+            .NotEqual(default(DateOnly))
+            .WithMessage("Início do período de inscrição é obrigatório.");
+
+        RuleFor(x => x.PeriodoInscricaoFim)
+            .NotEqual(default(DateOnly))
+            .WithMessage("Fim do período de inscrição é obrigatório.")
+            .GreaterThanOrEqualTo(x => x.PeriodoInscricaoInicio)
+            .WithMessage("O fim do período de inscrição não pode anteceder o início.");
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
@@ -1,0 +1,68 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using Enums;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Documento emitido pelo ato de publicação/retificação do
+/// <see cref="ProcessoSeletivo"/> (RN08, Story #759) — entidade INTERNA ao
+/// agregado: sem CRUD, repositório ou controller próprios. Só é criada e
+/// anexada pela raiz, dentro de <see cref="ProcessoSeletivo.Publicar"/>
+/// (T4, #785; a retificação chega na T5, #786).
+/// </summary>
+/// <remarks>
+/// <see cref="EntityBase"/> puro (sem soft-delete) — mesmo padrão de
+/// <see cref="EtapaProcesso"/>/<see cref="CriterioDesempate"/>: entidade
+/// filha do agregado, criada e persistida exclusivamente pela raiz. Diferente
+/// delas, não é substituível por <c>Definir*</c> — um Edital publicado é
+/// append-only por natureza (ADR-0101): a única forma de "mudar" é emitir um
+/// novo Edital de retificação, nunca editar um existente.
+/// </remarks>
+public sealed class Edital : EntityBase
+{
+    public Guid ProcessoSeletivoId { get; private set; }
+    public NaturezaEdital Natureza { get; private set; }
+    public string? Numero { get; private set; }
+    public DateTimeOffset? DataPublicacao { get; private set; }
+    public Guid DocumentoEditalId { get; private set; }
+
+    /// <summary>Nulo em Edital de abertura; obrigatório em retificação (ADR-0101, T5).</summary>
+    public Guid? EditalRetificadoId { get; private set; }
+
+    /// <summary>Nulo em Edital de abertura; obrigatório em retificação (ADR-0101, T5).</summary>
+    public string? MotivoRetificacao { get; private set; }
+
+    private Edital() { }
+
+    /// <summary>
+    /// Emite o Edital de abertura — a primeira publicação do processo.
+    /// <see cref="EditalRetificadoId"/>/<see cref="MotivoRetificacao"/> ficam
+    /// sempre nulos (contrato abertura×retificação, ADR-0101); a T5 (#786)
+    /// introduz <c>EmitirRetificacao</c> para a variante que os exige.
+    /// </summary>
+    public static Result<Edital> EmitirAbertura(Guid processoSeletivoId, DadosEdital dados, TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(dados);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        if (processoSeletivoId == Guid.Empty)
+        {
+            return Result<Edital>.Failure(new DomainError(
+                "Edital.ProcessoSeletivoIdObrigatorio",
+                "O Edital deve estar vinculado a um Processo Seletivo."));
+        }
+
+        return Result<Edital>.Success(new Edital
+        {
+            ProcessoSeletivoId = processoSeletivoId,
+            Natureza = NaturezaEdital.Abertura,
+            Numero = dados.Numero,
+            DataPublicacao = clock.GetUtcNow(),
+            DocumentoEditalId = dados.DocumentoEditalId,
+            EditalRetificadoId = null,
+            MotivoRetificacao = null,
+        });
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
 
 using Enums;
+using Events;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
@@ -53,6 +54,14 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// <summary>Configuração de classificação (15º bloco canônico, Story #775) — compõe por referência a fórmula, precisão, eliminação e ordem de alocação.</summary>
     public ConfiguracaoClassificacao? Classificacao { get; private set; }
 
+    /// <summary>
+    /// Editais emitidos pelo ato de publicação/retificação (Story #759, T4
+    /// #785) — só cresce dentro de <see cref="Publicar"/> (e, na T5, de
+    /// <c>Retificar</c>); nunca exposta como <c>Definir*</c> mutável.
+    /// </summary>
+    private readonly List<Edital> _editais = [];
+    public IReadOnlyCollection<Edital> Editais => _editais.AsReadOnly();
+
     private ProcessoSeletivo() { }
 
     public static ProcessoSeletivo Criar(string nome, TipoProcesso tipo)
@@ -79,6 +88,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     public Result DefinirEtapas(IReadOnlyList<EtapaProcesso> etapas)
     {
         ArgumentNullException.ThrowIfNull(etapas);
+
+        if (MutacaoBloqueadaPosPublicacao() is { } bloqueio)
+        {
+            return Result.Failure(bloqueio);
+        }
 
         if (etapas.Count == 0)
         {
@@ -165,6 +179,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     {
         ArgumentNullException.ThrowIfNull(oferta);
 
+        if (MutacaoBloqueadaPosPublicacao() is { } bloqueio)
+        {
+            return Result.Failure(bloqueio);
+        }
+
         oferta.VincularProcesso(Id);
         OfertaAtendimento = oferta;
         return Result.Success();
@@ -181,6 +200,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     public Result DefinirDistribuicaoVagas(IReadOnlyList<ConfiguracaoDistribuicaoVagas> distribuicaoVagas)
     {
         ArgumentNullException.ThrowIfNull(distribuicaoVagas);
+
+        if (MutacaoBloqueadaPosPublicacao() is { } bloqueio)
+        {
+            return Result.Failure(bloqueio);
+        }
 
         if (distribuicaoVagas.Count == 0)
         {
@@ -214,6 +238,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// </summary>
     public Result DefinirBonusRegional(ConfiguracaoBonusRegional? bonus)
     {
+        if (MutacaoBloqueadaPosPublicacao() is { } bloqueio)
+        {
+            return Result.Failure(bloqueio);
+        }
+
         if (bonus is null)
         {
             BonusRegional = null;
@@ -236,6 +265,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     public Result DefinirCriteriosDesempate(IReadOnlyList<CriterioDesempate> criterios)
     {
         ArgumentNullException.ThrowIfNull(criterios);
+
+        if (MutacaoBloqueadaPosPublicacao() is { } bloqueio)
+        {
+            return Result.Failure(bloqueio);
+        }
 
         List<int> ordensInformadas = [.. criterios.Select(c => c.Ordem)];
         if (ordensInformadas.Distinct().Count() != ordensInformadas.Count)
@@ -285,6 +319,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     {
         ArgumentNullException.ThrowIfNull(classificacao);
 
+        if (MutacaoBloqueadaPosPublicacao() is { } bloqueio)
+        {
+            return Result.Failure(bloqueio);
+        }
+
         bool baseadoEmEnem = Tipo is TipoProcesso.SiSU or TipoProcesso.PSVR;
 
         foreach (RegraEliminacao regra in classificacao.RegrasEliminacao)
@@ -331,4 +370,125 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         _distribuicaoVagas
             .SelectMany(d => d.Modalidades)
             .Any(m => m.NaturezaLegal == NaturezaLegalModalidade.CotaReservada);
+
+    /// <summary>
+    /// Checklist de conformidade estrutural (Story #758 CA-07; reusado por
+    /// <see cref="Publicar"/>, Story #759 CA-03) — cobre as dimensões
+    /// estruturalmente OBRIGATÓRIAS do agregado: Etapas (1..*), Oferta de
+    /// atendimento especializado (1), Distribuição de vagas (1..*) e
+    /// Classificação (1). Bônus regional (0..1) e critérios de desempate
+    /// (0..*) são deliberadamente opcionais e NÃO entram — a ausência é um
+    /// estado válido (RN05: ausência de bônus = sem bônus), não uma
+    /// pendência. Única fonte de verdade do checklist: tanto
+    /// <c>ObterConformidadeProcessoSeletivoQueryHandler</c> quanto
+    /// <see cref="Publicar"/> chamam este método, nunca duplicam a lista.
+    /// </summary>
+    public IReadOnlyList<ItemConformidade> AvaliarConformidade() =>
+    [
+        new ItemConformidade("Etapas", _etapas.Count > 0),
+        new ItemConformidade("Atendimento especializado", OfertaAtendimento is not null),
+        new ItemConformidade("Distribuição de vagas", _distribuicaoVagas.Count > 0),
+        new ItemConformidade("Classificação", Classificacao is not null),
+    ];
+
+    /// <summary>
+    /// Publica o processo (RN08, Story #759 T4): valida a transição e a
+    /// conformidade estrutural, emite o <see cref="Edital"/> de abertura,
+    /// congela o <see cref="SnapshotPublicacao"/> a partir dos bytes
+    /// canônicos já produzidos pelo <c>ISnapshotPublicacaoCanonicalizer</c>
+    /// (Application — Domain não pode chamá-lo, ver ADR-0042) e transita o
+    /// status — tudo dentro deste método, atomicamente em memória; o handler
+    /// só persiste o resultado numa única transação.
+    /// </summary>
+    /// <param name="dados">Número, período de inscrição e referência ao documento confirmado.</param>
+    /// <param name="configuracaoCongeladaCanonica">Bytes canônicos (ADR-0100) já produzidos pelo canonicalizador da Application.</param>
+    /// <param name="schemaVersion">Versão do conjunto de blocos do snapshot (ADR-0100 item 8).</param>
+    /// <param name="algoritmoHash">Identificador do algoritmo de hash (ex.: <c>canonical-json/sha256@v1</c>).</param>
+    /// <param name="hashEdital">Hash SHA-256 do documento do Edital (T3, #784).</param>
+    /// <param name="atorUsuarioSub">Sub do usuário autenticado responsável pela publicação (via <c>IUserContext</c>, nunca input do command).</param>
+    /// <param name="clock">Relógio injetado (ADR-0068) — nunca lido implicitamente.</param>
+    public Result<PublicacaoResultado> Publicar(
+        DadosEdital dados,
+        byte[] configuracaoCongeladaCanonica,
+        string schemaVersion,
+        string algoritmoHash,
+        string hashEdital,
+        string atorUsuarioSub,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(dados);
+        ArgumentNullException.ThrowIfNull(configuracaoCongeladaCanonica);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        if (Status != StatusProcesso.Rascunho)
+        {
+            return Result<PublicacaoResultado>.Failure(new DomainError(
+                "ProcessoSeletivo.TransicaoInvalida",
+                $"Só é possível publicar um processo em rascunho — status atual: {Status}."));
+        }
+
+        IReadOnlyList<ItemConformidade> pendencias = [.. AvaliarConformidade().Where(item => !item.Ok)];
+        if (pendencias.Count > 0)
+        {
+            return Result<PublicacaoResultado>.Failure(new DomainError(
+                "ProcessoSeletivo.ConformidadeInsuficiente",
+                $"Processo não conforme para publicação — pendente: {string.Join(", ", pendencias.Select(p => p.Item))}."));
+        }
+
+        Result<Edital> editalResult = Edital.EmitirAbertura(Id, dados, clock);
+        if (editalResult.IsFailure)
+        {
+            return Result<PublicacaoResultado>.Failure(editalResult.Error!);
+        }
+
+        Edital edital = editalResult.Value!;
+
+        SnapshotPublicacao snapshot = SnapshotPublicacao.Congelar(
+            edital.Id,
+            configuracaoCongeladaCanonica,
+            schemaVersion,
+            algoritmoHash,
+            hashEdital,
+            atorUsuarioSub,
+            clock);
+
+        _editais.Add(edital);
+        Status = StatusProcesso.Publicado;
+
+        AddDomainEvent(new ProcessoPublicadoEvent(
+            Id,
+            edital.Id,
+            snapshot.Id,
+            snapshot.HashConfiguracao,
+            snapshot.HashEdital,
+            edital.DataPublicacao!.Value));
+
+        return Result<PublicacaoResultado>.Success(new PublicacaoResultado(edital, snapshot));
+    }
+
+    /// <summary>
+    /// Trava de mutação pós-publicação (CA-04): todo <c>Definir*</c> recusa
+    /// quando o processo já foi publicado — mudança em conteúdo congelável só
+    /// via retificação (T5, #786). Reaproveitada por todos os métodos
+    /// <c>Definir*</c>; <see langword="null"/> quando a mutação é permitida.
+    /// </summary>
+    private DomainError? MutacaoBloqueadaPosPublicacao()
+    {
+        if (Status != StatusProcesso.Publicado)
+        {
+            return null;
+        }
+
+        return new DomainError(
+            "ProcessoSeletivo.MutacaoPosPublicacaoBloqueada",
+            "Processo publicado não aceita mutação direta da configuração — utilize a retificação.");
+    }
 }
+
+/// <summary>
+/// Resultado de <see cref="ProcessoSeletivo.Publicar"/> — o <see cref="Edital"/>
+/// e o <see cref="SnapshotPublicacao"/> recém-criados, para o handler
+/// persistir via repositório sem precisar recriá-los ou tocar a coleção
+/// interna do agregado.
+/// </summary>
+public sealed record PublicacaoResultado(Edital Edital, SnapshotPublicacao Snapshot);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/SnapshotPublicacao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/SnapshotPublicacao.cs
@@ -1,0 +1,120 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using System.Text;
+
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Congelamento append-only da configuração de negócio de um
+/// <see cref="Edital"/> no momento da publicação (RN08, ADR-0100). Um
+/// snapshot por Edital — capturado EXPLICITAMENTE dentro de
+/// <see cref="ProcessoSeletivo.Publicar"/> (evento de negócio único), nunca
+/// por interceptor de <c>SaveChanges</c> (diferente de
+/// <see cref="ObrigatoriedadeLegalHistorico"/>, que registra toda mutação).
+/// </summary>
+/// <remarks>
+/// Implementa <see cref="IForensicEntity"/> per ADR-0063: forensic
+/// append-only, deliberadamente NÃO herda <see cref="Kernel.Domain.Entities.EntityBase"/>
+/// e NÃO carrega soft-delete. <see cref="HashConfiguracao"/> e
+/// <see cref="ConfiguracaoCongelada"/> são DERIVADOS de
+/// <see cref="ConfiguracaoCongeladaCanonica"/> dentro da factory — nunca
+/// aceitos como parâmetros independentes, para que a evidência persistida
+/// nunca possa divergir dos bytes que a fundamentam (ADR-0100 item 6/7).
+/// </remarks>
+public sealed class SnapshotPublicacao : IForensicEntity
+{
+    public Guid Id { get; private init; } = Guid.CreateVersion7();
+
+    public Guid EditalId { get; private init; }
+
+    public string SchemaVersion { get; private init; } = null!;
+
+    public string AlgoritmoHash { get; private init; } = null!;
+
+    /// <summary>Bytes canônicos (ADR-0100) — a base do hash; fonte única de verdade.</summary>
+#pragma warning disable CA1819 // Properties should not return arrays — entidade EF Core mapeia bytea diretamente; sem value-equality de record.
+    public byte[] ConfiguracaoCongeladaCanonica { get; private init; } = null!;
+#pragma warning restore CA1819
+
+    /// <summary>Derivado por parsing UTF-8 dos bytes canônicos — só consulta (jsonb).</summary>
+    public string ConfiguracaoCongelada { get; private init; } = null!;
+
+    /// <summary>SHA-256 (hex minúsculo) de <see cref="ConfiguracaoCongeladaCanonica"/> — nunca recebido como parâmetro.</summary>
+    public string HashConfiguracao { get; private init; } = null!;
+
+    public string HashEdital { get; private init; } = null!;
+
+    public string AtorUsuarioSub { get; private init; } = null!;
+
+    public DateTimeOffset DataPublicacao { get; private init; }
+
+    // Construtor de materialização do EF Core.
+    private SnapshotPublicacao()
+    {
+    }
+
+    /// <summary>
+    /// Congela o snapshot a partir dos bytes canônicos já produzidos pelo
+    /// <c>ISnapshotPublicacaoCanonicalizer</c> (Application) — deriva
+    /// <see cref="HashConfiguracao"/> e <see cref="ConfiguracaoCongelada"/>
+    /// internamente, garantindo que ambos sejam sempre consistentes com os
+    /// bytes persistidos (revisão de plano P2, ADR-0100 §Confirmação).
+    /// </summary>
+    /// <remarks>
+    /// Lança <see cref="ArgumentException"/> em vez de retornar
+    /// <c>Result.Failure</c> — mesmo padrão de
+    /// <see cref="ObrigatoriedadeLegalHistorico.Snapshot"/> (ADR-0063):
+    /// entidades forensic são criadas a partir de invariantes JÁ garantidas
+    /// pelo caller (<see cref="ProcessoSeletivo.Publicar"/> só chama esta
+    /// factory com um <see cref="Edital"/> recém-emitido e bytes canônicos
+    /// recém-produzidos) — as checagens aqui são defesa em profundidade
+    /// contra erro de programação, não regra de negócio exposta ao usuário
+    /// final (ADR-0046 continua valendo para regras de negócio genuínas).
+    /// </remarks>
+    public static SnapshotPublicacao Congelar(
+        Guid editalId,
+        byte[] configuracaoCongeladaCanonica,
+        string schemaVersion,
+        string algoritmoHash,
+        string hashEdital,
+        string atorUsuarioSub,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(configuracaoCongeladaCanonica);
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaVersion);
+        ArgumentException.ThrowIfNullOrWhiteSpace(algoritmoHash);
+        ArgumentException.ThrowIfNullOrWhiteSpace(atorUsuarioSub);
+
+        if (editalId == Guid.Empty)
+        {
+            throw new ArgumentException("O snapshot deve estar vinculado a um Edital.", nameof(editalId));
+        }
+
+        if (configuracaoCongeladaCanonica.Length == 0)
+        {
+            throw new ArgumentException("A configuração congelada não pode ser vazia.", nameof(configuracaoCongeladaCanonica));
+        }
+
+        if (!HashCanonicalComputer.IsValidHashShape(hashEdital))
+        {
+            throw new ArgumentException(
+                "O hash do documento do Edital deve ser um SHA-256 em hexadecimal minúsculo (64 caracteres).",
+                nameof(hashEdital));
+        }
+
+        return new SnapshotPublicacao
+        {
+            EditalId = editalId,
+            SchemaVersion = schemaVersion,
+            AlgoritmoHash = algoritmoHash,
+            ConfiguracaoCongeladaCanonica = configuracaoCongeladaCanonica,
+            ConfiguracaoCongelada = Encoding.UTF8.GetString(configuracaoCongeladaCanonica),
+            HashConfiguracao = HashCanonicalComputer.ComputeSha256Hex(configuracaoCongeladaCanonica),
+            HashEdital = hashEdital,
+            AtorUsuarioSub = atorUsuarioSub,
+            DataPublicacao = clock.GetUtcNow(),
+        };
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/NaturezaEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/NaturezaEdital.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Natureza do <see cref="Entities.Edital"/> emitido pelo ato de publicação do
+/// <see cref="Entities.ProcessoSeletivo"/> (RN08, ADR-0101): <see cref="Abertura"/>
+/// é a primeira publicação do processo; <see cref="Retificacao"/> (T5, #786)
+/// é uma mudança pós-publicação, sempre vinculada ao Edital retificado e com
+/// motivo obrigatório.
+/// </summary>
+public enum NaturezaEdital
+{
+    Nenhuma = 0,
+    Abertura = 1,
+    Retificacao = 2
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/ProcessoPublicadoEvent.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/ProcessoPublicadoEvent.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Events;
+
+using Unifesspa.UniPlus.Kernel.Domain.Events;
+
+/// <summary>
+/// Emitido por <see cref="Entities.ProcessoSeletivo.Publicar"/> (RN08, Story
+/// #759). Carrega os identificadores forenses completos — <see cref="EditalId"/>,
+/// <see cref="SnapshotPublicacaoId"/> e os hashes — para que qualquer
+/// consumidor (drenado via cascading messages, ADR-0005) tenha o fato
+/// completo, sem precisar reconsultar o agregado.
+/// </summary>
+public sealed record ProcessoPublicadoEvent(
+    Guid ProcessoSeletivoId,
+    Guid EditalId,
+    Guid SnapshotPublicacaoId,
+    string HashConfiguracao,
+    string HashEdital,
+    DateTimeOffset OccurredOn) : DomainEventBase(OccurredOn);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/Schemas/ProcessoPublicado.avsc
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Events/Schemas/ProcessoPublicado.avsc
@@ -1,0 +1,46 @@
+{
+  "type": "record",
+  "namespace": "unifesspa.uniplus.selecao.events",
+  "name": "ProcessoPublicado",
+  "doc": "Evento Avro emitido quando um ProcessoSeletivo é publicado (RN08). Subject Confluent SR: processo_seletivo_events-value. Compatibilidade default: BACKWARD.",
+  "fields": [
+    {
+      "name": "EventId",
+      "type": "string",
+      "doc": "UUID v7 do evento (rastreabilidade fim-a-fim, idempotência cross-consumer)."
+    },
+    {
+      "name": "OccurredOn",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Instante de emissão UTC em milissegundos desde a epoch Unix."
+    },
+    {
+      "name": "ProcessoSeletivoId",
+      "type": "string",
+      "doc": "UUID v7 do agregado ProcessoSeletivo (chave estável cross-módulo)."
+    },
+    {
+      "name": "EditalId",
+      "type": "string",
+      "doc": "UUID v7 do Edital de abertura emitido pela publicação."
+    },
+    {
+      "name": "SnapshotPublicacaoId",
+      "type": "string",
+      "doc": "UUID v7 do SnapshotPublicacao append-only congelado nesta publicação."
+    },
+    {
+      "name": "HashConfiguracao",
+      "type": "string",
+      "doc": "SHA-256 (hex minúsculo) da configuração canônica congelada (ADR-0100)."
+    },
+    {
+      "name": "HashEdital",
+      "type": "string",
+      "doc": "SHA-256 (hex minúsculo) do documento (PDF) do Edital confirmado (T3, #784)."
+    }
+  ]
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IProcessoSeletivoRepository.cs
@@ -33,4 +33,13 @@ public interface IProcessoSeletivoRepository : IRepository<ProcessoSeletivo>
         int limit,
         PaginationDirection direction,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adiciona o <see cref="SnapshotPublicacao"/> congelado por
+    /// <see cref="ProcessoSeletivo.Publicar"/> (Story #759, T4 #785). Sem
+    /// repositório próprio para a entidade forense — a issue #759 §4
+    /// estabelece que <see cref="IProcessoSeletivoRepository"/> persiste o
+    /// agregado inteiro, incluindo <see cref="Edital"/> e <see cref="SnapshotPublicacao"/>.
+    /// </summary>
+    Task AdicionarSnapshotPublicacaoAsync(SnapshotPublicacao snapshot, CancellationToken cancellationToken = default);
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/DadosEdital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/DadosEdital.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Dados de entrada do ato de publicação (Story #759, T4 #785): número do
+/// Edital, período de inscrição e a referência ao documento (PDF) confirmado
+/// da T3 (#784) — cujo <c>HashSha256</c> vira <c>hash_edital</c> do
+/// <see cref="Entities.SnapshotPublicacao"/>. Não é persistido isoladamente —
+/// só existe como entrada de <see cref="Entities.ProcessoSeletivo.Publicar"/>.
+/// </summary>
+public sealed record DadosEdital
+{
+    private DadosEdital(
+        string? numero,
+        DateOnly periodoInscricaoInicio,
+        DateOnly periodoInscricaoFim,
+        Guid documentoEditalId)
+    {
+        Numero = numero;
+        PeriodoInscricaoInicio = periodoInscricaoInicio;
+        PeriodoInscricaoFim = periodoInscricaoFim;
+        DocumentoEditalId = documentoEditalId;
+    }
+
+    public string? Numero { get; }
+    public DateOnly PeriodoInscricaoInicio { get; }
+    public DateOnly PeriodoInscricaoFim { get; }
+    public Guid DocumentoEditalId { get; }
+
+    /// <summary>
+    /// Cria os dados do Edital validando que o período de inscrição é
+    /// coerente e que a referência ao documento não é vazia — a existência e
+    /// a confirmação efetiva do documento são responsabilidade do handler
+    /// (exige consulta ao repositório, fora do alcance de um value object).
+    /// </summary>
+    public static Result<DadosEdital> Criar(
+        string? numero,
+        DateOnly periodoInscricaoInicio,
+        DateOnly periodoInscricaoFim,
+        Guid documentoEditalId)
+    {
+        if (documentoEditalId == Guid.Empty)
+        {
+            return Result<DadosEdital>.Failure(new DomainError(
+                "DadosEdital.DocumentoEditalIdObrigatorio",
+                "A referência ao documento do Edital é obrigatória."));
+        }
+
+        if (periodoInscricaoFim < periodoInscricaoInicio)
+        {
+            return Result<DadosEdital>.Failure(new DomainError(
+                "DadosEdital.PeriodoInscricaoInvalido",
+                "O fim do período de inscrição não pode anteceder o início."));
+        }
+
+        return Result<DadosEdital>.Success(new DadosEdital(
+            numero?.Trim(),
+            periodoInscricaoInicio,
+            periodoInscricaoFim,
+            documentoEditalId));
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/HashCanonicalComputer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/HashCanonicalComputer.cs
@@ -183,21 +183,8 @@ public static class HashCanonicalComputer
     /// minúsculo. Fonte única do passo final de hashing — compartilhada entre
     /// o hash de <c>ObrigatoriedadeLegal</c> e o do <c>rol_de_regras</c>.
     /// </summary>
-    private static string HashCanonicalPayload(JsonObject payload)
-    {
-        JsonNode canonical = CanonicalizeRecursive(payload);
-
-        // Use Utf8JsonWriter for byte-stable output (no environment-dependent
-        // line endings, no escape policy variation across runtimes).
-        using MemoryStream buffer = new();
-        using (Utf8JsonWriter writer = new(buffer, new JsonWriterOptions { Indented = false }))
-        {
-            canonical.WriteTo(writer);
-        }
-
-        byte[] hash = SHA256.HashData(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));
-        return Convert.ToHexStringLower(hash);
-    }
+    private static string HashCanonicalPayload(JsonObject payload) =>
+        ComputeSha256Hex(ComputeSnapshotBytes(payload));
 
     /// <summary>
     /// Reordena alfabeticamente as chaves de todos os <see cref="JsonObject"/>
@@ -251,5 +238,80 @@ public static class HashCanonicalComputer
         }
 
         return hash.All(static c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
+    }
+
+    /// <summary>
+    /// Normaliza uma string de negócio para a forma Unicode NFC (ADR-0100
+    /// item 1) — sequências combinantes e formas pré-compostas do mesmo texto
+    /// colapsam para os mesmos bytes antes de entrar no payload canônico.
+    /// Toda string de negócio (nomes, descrições, textos livres) do snapshot
+    /// de publicação passa por aqui antes de ser serializada.
+    /// </summary>
+    public static string NormalizeNfc(string valor)
+    {
+        ArgumentNullException.ThrowIfNull(valor);
+        return valor.Normalize(NormalizationForm.FormC);
+    }
+
+    /// <summary>
+    /// Serializa um decimal de negócio com escala declarada e arredondamento
+    /// half-even (ADR-0100 item 2) — nunca como <c>number</c> JSON de ponto
+    /// flutuante, que reintroduziria ambiguidade de representação entre
+    /// runtimes. O caller declara <paramref name="escala"/> por campo (schema
+    /// do bloco canônico), não um default global.
+    /// </summary>
+    public static string SerializeDecimalCanonical(decimal valor, int escala)
+    {
+        if (escala < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(escala), escala, "Escala decimal não pode ser negativa.");
+        }
+
+        decimal arredondado = Math.Round(valor, escala, MidpointRounding.ToEven);
+        return arredondado.ToString("F" + escala.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Serializa um instante em UTC, RFC 3339, granularidade de segundo, sem
+    /// fração (ADR-0100 item 3) — elimina variação por precisão de relógio ou
+    /// serializador entre runtimes.
+    /// </summary>
+    public static string SerializeInstantCanonical(DateTimeOffset instante) =>
+        instante.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Canonicaliza <paramref name="payload"/> (reordenação recursiva de
+    /// chaves) e serializa via <see cref="Utf8JsonWriter"/> byte-estável,
+    /// retornando os BYTES — não o hash. É a base do
+    /// <c>configuracao_congelada_canonica</c> persistido pelo
+    /// <c>SnapshotPublicacao</c> (ADR-0100 item 6): a aplicação produz os
+    /// bytes uma vez, na publicação; o hash é derivado deles (nunca
+    /// recalculado a partir de uma forma intermediária).
+    /// </summary>
+    public static byte[] ComputeSnapshotBytes(JsonObject payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        JsonNode canonical = CanonicalizeRecursive(payload);
+
+        using MemoryStream buffer = new();
+        using (Utf8JsonWriter writer = new(buffer, new JsonWriterOptions { Indented = false }))
+        {
+            canonical.WriteTo(writer);
+        }
+
+        return buffer.ToArray();
+    }
+
+    /// <summary>
+    /// Extrai o hash SHA-256 (hex minúsculo) de bytes já canônicos — usado
+    /// tanto pela aplicação ao publicar (sobre os bytes recém-produzidos)
+    /// quanto por testes de integração (re-hashear os bytes lidos de volta do
+    /// banco deve bater com o hash persistido, ADR-0100 §Confirmação).
+    /// </summary>
+    public static string ComputeSha256Hex(byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        return Convert.ToHexStringLower(SHA256.HashData(bytes));
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ItemConformidade.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ItemConformidade.cs
@@ -1,0 +1,11 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Veredicto de um item obrigatório do checklist de conformidade estrutural
+/// do <c>ProcessoSeletivo</c> (<see cref="Entities.ProcessoSeletivo.AvaliarConformidade"/>,
+/// Story #758 CA-07 e Story #759 CA-03). Tipo de Domain — a versão
+/// Application-facing (<c>ItemConformidadeDto</c>) é mapeada a partir deste
+/// no query handler, para que o checklist usado pela leitura pública e o
+/// gate de <c>Publicar</c> nunca divirjam.
+/// </summary>
+public sealed record ItemConformidade(string Item, bool Ok);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
@@ -106,6 +106,14 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
         {
             array.Add(new JsonObject
             {
+                // Id incluído (achado Codex, revisão do PR #791): os blocos
+                // "criteriosDesempate" (DESEMPATE-MAIOR-NOTA-ETAPA) e
+                // "classificacao" (ELIM-NOTA-MINIMA-ETAPA) congelam um
+                // etapaRef apontando para este Id — sem ele aqui, o snapshot
+                // teria uma referência não resolvível dentro do próprio JSON
+                // congelado, obrigando a consultar a tabela viva (mutável)
+                // para interpretar um documento que deveria ser autocontido.
+                ["id"] = etapa.Id,
                 ["nome"] = HashCanonicalComputer.NormalizeNfc(etapa.Nome),
                 ["carater"] = etapa.Carater.ToString(),
                 ["peso"] = etapa.Peso is { } peso ? HashCanonicalComputer.SerializeDecimalCanonical(peso, EscalaPadrao) : null,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
@@ -1,0 +1,299 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+
+using System.Globalization;
+using System.Text.Json.Nodes;
+
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Implementação do serializador canônico dos 17 blocos do snapshot de
+/// publicação (ADR-0100). Projeta a configuração viva do agregado num
+/// payload canônico — 11 blocos reais + 6 stubs
+/// <c>{"status":"nao_construido"}</c> para dimensões que a Feature #40 ainda
+/// não implementou (ADR-0100 item 10) — e devolve os bytes via
+/// <see cref="HashCanonicalComputer.ComputeSnapshotBytes"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Todo campo string de negócio passa por <see cref="HashCanonicalComputer.NormalizeNfc"/>;
+/// todo decimal por <see cref="HashCanonicalComputer.SerializeDecimalCanonical"/>
+/// com a escala declarada do campo; instantes por
+/// <see cref="HashCanonicalComputer.SerializeInstantCanonical"/>. A
+/// reordenação de chaves e a serialização byte-estável final acontecem em
+/// <see cref="HashCanonicalComputer.ComputeSnapshotBytes"/> — este tipo só
+/// monta o <see cref="JsonObject"/> com os valores já normalizados.
+/// </para>
+/// <para>
+/// <strong>Leitura do bloco "vagas" vs. "distribuição" (ADR-0100 item 10):</strong>
+/// o modelo atual não tem um motor de cálculo de vagas — <c>ConfiguracaoDistribuicaoVagas</c>
+/// já é o conjunto de INPUTS (voBase, PR, regra, modalidades); o
+/// <c>QuadroDeVagas</c> (quantidade por modalidade) é output derivado de um
+/// motor futuro. Por isso "vagas" serializa como stub
+/// <c>nao_construido</c> e "distribuição" carrega os inputs reais.
+/// </para>
+/// </remarks>
+public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonicalizer
+{
+    private const string SchemaVersionAtual = "1.0";
+    private const string AlgoritmoHashAtual = "canonical-json/sha256@v1";
+    private const int EscalaPadrao = 4;
+    private const int EscalaPercentual = 2;
+
+    private static readonly JsonObject NaoConstruido = new() { ["status"] = "nao_construido" };
+
+    public SnapshotCanonico Canonicalizar(ProcessoSeletivo processo, DadosEdital dados, string hashEdital)
+    {
+        ArgumentNullException.ThrowIfNull(processo);
+        ArgumentNullException.ThrowIfNull(dados);
+        ArgumentException.ThrowIfNullOrWhiteSpace(hashEdital);
+
+        JsonObject payload = new()
+        {
+            ["periodo"] = SerializarPeriodo(dados),
+            ["etapas"] = SerializarEtapas(processo),
+            ["vagas"] = NaoConstruido.DeepClone(),
+            ["distribuicao"] = SerializarDistribuicao(processo),
+            ["modalidades"] = SerializarModalidades(processo),
+            ["ofertas"] = SerializarOfertas(processo),
+            ["atendimento"] = SerializarAtendimento(processo),
+            ["bonusRegional"] = SerializarBonusRegional(processo),
+            ["criteriosDesempate"] = SerializarCriteriosDesempate(processo),
+            ["classificacao"] = SerializarClassificacao(processo),
+            ["hashesEdital"] = SerializarHashesEdital(dados, hashEdital),
+            ["documentosExigidos"] = NaoConstruido.DeepClone(),
+            ["formulario"] = NaoConstruido.DeepClone(),
+            ["cascataRemanejamento"] = NaoConstruido.DeepClone(),
+            ["divulgacao"] = NaoConstruido.DeepClone(),
+            ["cronogramaFases"] = NaoConstruido.DeepClone(),
+            ["identidadesUnidade"] = NaoConstruido.DeepClone(),
+        };
+
+        byte[] bytes = HashCanonicalComputer.ComputeSnapshotBytes(payload);
+        return new SnapshotCanonico(bytes, SchemaVersionAtual, AlgoritmoHashAtual);
+    }
+
+    private static JsonObject SerializarPeriodo(DadosEdital dados) => new()
+    {
+        ["numero"] = dados.Numero is { } numero ? HashCanonicalComputer.NormalizeNfc(numero) : null,
+        ["inicio"] = dados.PeriodoInscricaoInicio.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        ["fim"] = dados.PeriodoInscricaoFim.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+    };
+
+    private static JsonArray SerializarEtapas(ProcessoSeletivo processo)
+    {
+        JsonArray array = [];
+        foreach (EtapaProcesso etapa in processo.Etapas)
+        {
+            array.Add(new JsonObject
+            {
+                ["nome"] = HashCanonicalComputer.NormalizeNfc(etapa.Nome),
+                ["carater"] = etapa.Carater.ToString(),
+                ["peso"] = etapa.Peso is { } peso ? HashCanonicalComputer.SerializeDecimalCanonical(peso, EscalaPadrao) : null,
+                ["notaMinima"] = etapa.NotaMinima is { } notaMinima ? HashCanonicalComputer.SerializeDecimalCanonical(notaMinima, EscalaPadrao) : null,
+                ["ordem"] = etapa.Ordem,
+            });
+        }
+
+        return array;
+    }
+
+    private static JsonArray SerializarDistribuicao(ProcessoSeletivo processo)
+    {
+        JsonArray array = [];
+        foreach (ConfiguracaoDistribuicaoVagas configuracao in processo.DistribuicaoVagas)
+        {
+            array.Add(new JsonObject
+            {
+                ["ofertaCursoOrigemId"] = configuracao.OfertaCursoOrigemId,
+                ["voBase"] = configuracao.VoBase,
+                ["pr"] = HashCanonicalComputer.SerializeDecimalCanonical(configuracao.Pr, EscalaPadrao),
+                ["regraDistribuicao"] = SerializarReferenciaRegra(configuracao.RegraDistribuicao),
+                ["referenciaDemografica"] = configuracao.ReferenciaDemografica is { } referencia
+                    ? SerializarReferenciaDemografica(referencia)
+                    : null,
+            });
+        }
+
+        return array;
+    }
+
+    private static JsonObject SerializarReferenciaDemografica(ReferenciaReservaDemograficaSnapshot referencia) => new()
+    {
+        ["origemId"] = referencia.OrigemId,
+        ["censoReferencia"] = HashCanonicalComputer.NormalizeNfc(referencia.CensoReferencia),
+        ["ppiPercentual"] = HashCanonicalComputer.SerializeDecimalCanonical(referencia.PpiPercentual, EscalaPercentual),
+        ["quilombolaPercentual"] = HashCanonicalComputer.SerializeDecimalCanonical(referencia.QuilombolaPercentual, EscalaPercentual),
+        ["pcdPercentual"] = HashCanonicalComputer.SerializeDecimalCanonical(referencia.PcdPercentual, EscalaPercentual),
+        ["baseLegal"] = HashCanonicalComputer.NormalizeNfc(referencia.BaseLegal),
+    };
+
+    private static JsonArray SerializarModalidades(ProcessoSeletivo processo)
+    {
+        JsonArray array = [];
+        foreach (ConfiguracaoDistribuicaoVagas configuracao in processo.DistribuicaoVagas)
+        {
+            foreach (ModalidadeSelecionada modalidade in configuracao.Modalidades)
+            {
+                array.Add(new JsonObject
+                {
+                    ["ofertaCursoOrigemId"] = configuracao.OfertaCursoOrigemId,
+                    ["modalidadeOrigemId"] = modalidade.ModalidadeOrigemId,
+                    ["codigo"] = HashCanonicalComputer.NormalizeNfc(modalidade.Codigo),
+                    ["descricao"] = modalidade.Descricao is { } descricao ? HashCanonicalComputer.NormalizeNfc(descricao) : null,
+                    ["naturezaLegal"] = modalidade.NaturezaLegal.ToString(),
+                    ["composicaoVagas"] = modalidade.ComposicaoVagas.ToString(),
+                    ["composicaoOrigemCodigo"] = modalidade.ComposicaoOrigemCodigo,
+                    ["regraRemanejamento"] = modalidade.RegraRemanejamento.ToString(),
+                    ["remanejamentoDestino"] = modalidade.RemanejamentoDestino,
+                    ["remanejamentoPar"] = modalidade.RemanejamentoPar,
+                    ["remanejamentoFallback"] = modalidade.RemanejamentoFallback,
+                    ["criteriosCumulativos"] = new JsonArray([.. modalidade.CriteriosCumulativos.Select(static c => (JsonNode?)JsonValue.Create(c))]),
+                    ["acaoQuandoIndeferido"] = modalidade.AcaoQuandoIndeferido,
+                    ["baseLegal"] = HashCanonicalComputer.NormalizeNfc(modalidade.BaseLegal),
+                });
+            }
+        }
+
+        return array;
+    }
+
+    private static JsonArray SerializarOfertas(ProcessoSeletivo processo)
+    {
+        IEnumerable<string> ofertaIds = processo.DistribuicaoVagas
+            .Select(static d => d.OfertaCursoOrigemId.ToString())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static id => id, StringComparer.Ordinal);
+
+        return new JsonArray([.. ofertaIds.Select(static id => (JsonNode?)JsonValue.Create(id))]);
+    }
+
+    private static JsonObject SerializarAtendimento(ProcessoSeletivo processo)
+    {
+        if (processo.OfertaAtendimento is not { } oferta)
+        {
+            return NaoConstruido.DeepClone().AsObject();
+        }
+
+        return new JsonObject
+        {
+            ["condicoes"] = new JsonArray([.. oferta.Condicoes.Select(static c => (JsonNode)new JsonObject
+            {
+                ["condicaoOrigemId"] = c.CondicaoOrigemId,
+                ["condicaoCodigo"] = HashCanonicalComputer.NormalizeNfc(c.CondicaoCodigo),
+                ["condicaoNome"] = HashCanonicalComputer.NormalizeNfc(c.CondicaoNome),
+            })]),
+            ["recursos"] = new JsonArray([.. oferta.Recursos.Select(static r => (JsonNode)new JsonObject
+            {
+                ["recursoOrigemId"] = r.RecursoOrigemId,
+                ["recursoNome"] = HashCanonicalComputer.NormalizeNfc(r.RecursoNome),
+            })]),
+            ["tiposDeficiencia"] = new JsonArray([.. oferta.TiposDeficiencia.Select(static t => (JsonNode)new JsonObject
+            {
+                ["tipoDeficienciaOrigemId"] = t.TipoDeficienciaOrigemId,
+                ["tipoDeficienciaNome"] = HashCanonicalComputer.NormalizeNfc(t.TipoDeficienciaNome),
+            })]),
+        };
+    }
+
+    private static JsonObject SerializarBonusRegional(ProcessoSeletivo processo)
+    {
+        if (processo.BonusRegional is not { } bonus)
+        {
+            return new JsonObject { ["presente"] = false };
+        }
+
+        return new JsonObject
+        {
+            ["presente"] = true,
+            ["regra"] = SerializarReferenciaRegra(bonus.Regra),
+            ["fator"] = HashCanonicalComputer.SerializeDecimalCanonical(bonus.Fator, EscalaPadrao),
+            ["teto"] = bonus.Teto is { } teto ? HashCanonicalComputer.SerializeDecimalCanonical(teto, EscalaPadrao) : null,
+            ["municipioConvenio"] = bonus.MunicipioConvenio is { } municipio ? HashCanonicalComputer.NormalizeNfc(municipio) : null,
+            ["baseLegal"] = bonus.BaseLegal is { } baseLegal ? HashCanonicalComputer.NormalizeNfc(baseLegal) : null,
+        };
+    }
+
+    private static JsonArray SerializarCriteriosDesempate(ProcessoSeletivo processo)
+    {
+        JsonArray array = [];
+        foreach (CriterioDesempate criterio in processo.CriteriosDesempate)
+        {
+            array.Add(new JsonObject
+            {
+                ["ordem"] = criterio.Ordem,
+                ["regra"] = SerializarReferenciaRegra(criterio.Regra),
+                ["args"] = SerializarArgsCriterioDesempate(criterio.Args),
+            });
+        }
+
+        return array;
+    }
+
+    private static JsonObject SerializarArgsCriterioDesempate(ArgsCriterioDesempate args) => args switch
+    {
+        ArgsDesempateMaiorNotaEtapa maiorNotaEtapa => new JsonObject { ["etapaRef"] = maiorNotaEtapa.EtapaRef },
+        ArgsDesempateMaiorIdade => [],
+        ArgsDesempateIdoso idoso => new JsonObject { ["idadeMinima"] = idoso.IdadeMinima },
+        ArgsDesempatePredicadoFato predicadoFato => new JsonObject
+        {
+            ["fato"] = HashCanonicalComputer.NormalizeNfc(predicadoFato.Fato),
+            ["operador"] = HashCanonicalComputer.NormalizeNfc(predicadoFato.Operador),
+            ["valor"] = HashCanonicalComputer.NormalizeNfc(predicadoFato.Valor),
+        },
+        _ => throw new InvalidOperationException($"Variante de {nameof(ArgsCriterioDesempate)} não reconhecida: {args.GetType()}."),
+    };
+
+    private static JsonObject SerializarClassificacao(ProcessoSeletivo processo)
+    {
+        if (processo.Classificacao is not { } classificacao)
+        {
+            return NaoConstruido.DeepClone().AsObject();
+        }
+
+        return new JsonObject
+        {
+            ["regraCalculo"] = SerializarReferenciaRegra(classificacao.RegraCalculo),
+            ["regraArredondamento"] = classificacao.RegraArredondamento is { } arredondamento
+                ? SerializarReferenciaRegra(arredondamento)
+                : null,
+            ["casasArredondamento"] = classificacao.CasasArredondamento,
+            ["regraOrdemAlocacao"] = SerializarReferenciaRegra(classificacao.RegraOrdemAlocacao),
+            ["nOpcoesAlocacao"] = classificacao.NOpcoesAlocacao,
+            ["regrasEliminacao"] = new JsonArray([.. classificacao.RegrasEliminacao.Select(static r => (JsonNode)new JsonObject
+            {
+                ["regra"] = SerializarReferenciaRegra(r.Regra),
+                ["args"] = SerializarArgsRegraEliminacao(r.Args),
+            })]),
+        };
+    }
+
+    private static JsonObject SerializarArgsRegraEliminacao(ArgsRegraEliminacao args) => args switch
+    {
+        ArgsElimNotaMinimaEtapa notaMinima => new JsonObject
+        {
+            ["etapaRef"] = notaMinima.EtapaRef,
+            ["notaMinima"] = HashCanonicalComputer.SerializeDecimalCanonical(notaMinima.NotaMinima, EscalaPadrao),
+        },
+        ArgsElimCorteRedacao corteRedacao => new JsonObject
+        {
+            ["minimo"] = HashCanonicalComputer.SerializeDecimalCanonical(corteRedacao.Minimo, EscalaPadrao),
+        },
+        ArgsElimZeroEmArea => [],
+        _ => throw new InvalidOperationException($"Variante de {nameof(ArgsRegraEliminacao)} não reconhecida: {args.GetType()}."),
+    };
+
+    private static JsonObject SerializarHashesEdital(DadosEdital dados, string hashEdital) => new()
+    {
+        ["documentoEditalId"] = dados.DocumentoEditalId,
+        ["hashSha256"] = hashEdital,
+    };
+
+    private static JsonObject SerializarReferenciaRegra(ReferenciaRegra regra) => new()
+    {
+        ["codigo"] = regra.Codigo,
+        ["versao"] = regra.Versao,
+        ["hash"] = regra.Hash,
+    };
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
@@ -33,6 +33,21 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// motor futuro. Por isso "vagas" serializa como stub
 /// <c>nao_construido</c> e "distribuição" carrega os inputs reais.
 /// </para>
+/// <para>
+/// <strong>Ordenação determinística das coleções (achado de review, PR #791):</strong>
+/// <c>IProcessoSeletivoRepository.ObterComConfiguracaoAsync</c> não aplica
+/// <c>ORDER BY</c> aos <c>Include</c> das coleções filhas — a ordem física
+/// devolvida pelo Postgres para a MESMA linha pode variar entre leituras
+/// (plano de execução, VACUUM, etc.). Como a ordem de um array entra no
+/// hash, todo bloco baseado em coleção é ordenado por uma chave estável
+/// antes de serializar: campo <c>Ordem</c> quando ele é semântico (etapas,
+/// critérios de desempate), identidade de negócio única quando existe
+/// (oferta/modalidade/condição/recurso por seus <c>*OrigemId</c>), ou
+/// <see cref="Kernel.Domain.Entities.EntityBase.Id"/> como fallback quando
+/// não há chave semântica (regras de eliminação — cardinalidade múltipla
+/// sem unicidade natural). Isso garante que reler e recanonicalizar o MESMO
+/// processo sempre produz os mesmos bytes (ADR-0100 §Confirmação).
+/// </para>
 /// </remarks>
 public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonicalizer
 {
@@ -84,7 +99,10 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
     private static JsonArray SerializarEtapas(ProcessoSeletivo processo)
     {
         JsonArray array = [];
-        foreach (EtapaProcesso etapa in processo.Etapas)
+        IOrderedEnumerable<EtapaProcesso> ordenadas = processo.Etapas
+            .OrderBy(static e => e.Ordem ?? int.MaxValue)
+            .ThenBy(static e => e.Id);
+        foreach (EtapaProcesso etapa in ordenadas)
         {
             array.Add(new JsonObject
             {
@@ -102,7 +120,7 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
     private static JsonArray SerializarDistribuicao(ProcessoSeletivo processo)
     {
         JsonArray array = [];
-        foreach (ConfiguracaoDistribuicaoVagas configuracao in processo.DistribuicaoVagas)
+        foreach (ConfiguracaoDistribuicaoVagas configuracao in OrdenarPorOfertaCursoOrigemId(processo.DistribuicaoVagas))
         {
             array.Add(new JsonObject
             {
@@ -132,9 +150,11 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
     private static JsonArray SerializarModalidades(ProcessoSeletivo processo)
     {
         JsonArray array = [];
-        foreach (ConfiguracaoDistribuicaoVagas configuracao in processo.DistribuicaoVagas)
+        foreach (ConfiguracaoDistribuicaoVagas configuracao in OrdenarPorOfertaCursoOrigemId(processo.DistribuicaoVagas))
         {
-            foreach (ModalidadeSelecionada modalidade in configuracao.Modalidades)
+            IOrderedEnumerable<ModalidadeSelecionada> modalidadesOrdenadas = configuracao.Modalidades
+                .OrderBy(static m => m.Codigo, StringComparer.Ordinal);
+            foreach (ModalidadeSelecionada modalidade in modalidadesOrdenadas)
             {
                 array.Add(new JsonObject
                 {
@@ -159,6 +179,14 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
         return array;
     }
 
+    // OfertaCursoOrigemId é único por processo (ConfiguracaoDistribuicaoVagas
+    // — "cada oferta de curso só pode ter uma distribuição de vagas no
+    // processo", validado em ProcessoSeletivo.DefinirDistribuicaoVagas) —
+    // chave de negócio estável, sem empate possível.
+    private static IOrderedEnumerable<ConfiguracaoDistribuicaoVagas> OrdenarPorOfertaCursoOrigemId(
+        IEnumerable<ConfiguracaoDistribuicaoVagas> distribuicoes) =>
+        distribuicoes.OrderBy(static d => d.OfertaCursoOrigemId);
+
     private static JsonArray SerializarOfertas(ProcessoSeletivo processo)
     {
         IEnumerable<string> ofertaIds = processo.DistribuicaoVagas
@@ -178,22 +206,28 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
 
         return new JsonObject
         {
-            ["condicoes"] = new JsonArray([.. oferta.Condicoes.Select(static c => (JsonNode)new JsonObject
-            {
-                ["condicaoOrigemId"] = c.CondicaoOrigemId,
-                ["condicaoCodigo"] = HashCanonicalComputer.NormalizeNfc(c.CondicaoCodigo),
-                ["condicaoNome"] = HashCanonicalComputer.NormalizeNfc(c.CondicaoNome),
-            })]),
-            ["recursos"] = new JsonArray([.. oferta.Recursos.Select(static r => (JsonNode)new JsonObject
-            {
-                ["recursoOrigemId"] = r.RecursoOrigemId,
-                ["recursoNome"] = HashCanonicalComputer.NormalizeNfc(r.RecursoNome),
-            })]),
-            ["tiposDeficiencia"] = new JsonArray([.. oferta.TiposDeficiencia.Select(static t => (JsonNode)new JsonObject
-            {
-                ["tipoDeficienciaOrigemId"] = t.TipoDeficienciaOrigemId,
-                ["tipoDeficienciaNome"] = HashCanonicalComputer.NormalizeNfc(t.TipoDeficienciaNome),
-            })]),
+            ["condicoes"] = new JsonArray([.. oferta.Condicoes
+                .OrderBy(static c => c.CondicaoOrigemId)
+                .Select(static c => (JsonNode)new JsonObject
+                {
+                    ["condicaoOrigemId"] = c.CondicaoOrigemId,
+                    ["condicaoCodigo"] = HashCanonicalComputer.NormalizeNfc(c.CondicaoCodigo),
+                    ["condicaoNome"] = HashCanonicalComputer.NormalizeNfc(c.CondicaoNome),
+                })]),
+            ["recursos"] = new JsonArray([.. oferta.Recursos
+                .OrderBy(static r => r.RecursoOrigemId)
+                .Select(static r => (JsonNode)new JsonObject
+                {
+                    ["recursoOrigemId"] = r.RecursoOrigemId,
+                    ["recursoNome"] = HashCanonicalComputer.NormalizeNfc(r.RecursoNome),
+                })]),
+            ["tiposDeficiencia"] = new JsonArray([.. oferta.TiposDeficiencia
+                .OrderBy(static t => t.TipoDeficienciaOrigemId)
+                .Select(static t => (JsonNode)new JsonObject
+                {
+                    ["tipoDeficienciaOrigemId"] = t.TipoDeficienciaOrigemId,
+                    ["tipoDeficienciaNome"] = HashCanonicalComputer.NormalizeNfc(t.TipoDeficienciaNome),
+                })]),
         };
     }
 
@@ -218,7 +252,7 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
     private static JsonArray SerializarCriteriosDesempate(ProcessoSeletivo processo)
     {
         JsonArray array = [];
-        foreach (CriterioDesempate criterio in processo.CriteriosDesempate)
+        foreach (CriterioDesempate criterio in processo.CriteriosDesempate.OrderBy(static c => c.Ordem))
         {
             array.Add(new JsonObject
             {
@@ -261,11 +295,17 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
             ["casasArredondamento"] = classificacao.CasasArredondamento,
             ["regraOrdemAlocacao"] = SerializarReferenciaRegra(classificacao.RegraOrdemAlocacao),
             ["nOpcoesAlocacao"] = classificacao.NOpcoesAlocacao,
-            ["regrasEliminacao"] = new JsonArray([.. classificacao.RegrasEliminacao.Select(static r => (JsonNode)new JsonObject
-            {
-                ["regra"] = SerializarReferenciaRegra(r.Regra),
-                ["args"] = SerializarArgsRegraEliminacao(r.Args),
-            })]),
+            // RegrasEliminacao não tem chave de negócio única (cardinalidade
+            // múltipla — duas ELIM-NOTA-MINIMA-ETAPA distintas são válidas,
+            // ex. PS Convênios); Id (Guid v7, estável por linha) é o fallback
+            // determinístico contra reordenação física do Postgres entre leituras.
+            ["regrasEliminacao"] = new JsonArray([.. classificacao.RegrasEliminacao
+                .OrderBy(static r => r.Id)
+                .Select(static r => (JsonNode)new JsonObject
+                {
+                    ["regra"] = SerializarReferenciaRegra(r.Regra),
+                    ["args"] = SerializarArgsRegraEliminacao(r.Args),
+                })]),
         };
     }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
 using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Canonicalization;
 using Domain.Interfaces;
 using ExternalServices;
 using Persistence;
@@ -49,6 +50,7 @@ public static class SelecaoInfrastructureRegistration
             serviceProvider.GetRequiredService<SelecaoDbContext>());
 
         services.AddScoped<IProcessoSeletivoRepository, ProcessoSeletivoRepository>();
+        services.AddScoped<ISnapshotPublicacaoCanonicalizer, SnapshotPublicacaoCanonicalizer>();
         services.AddScoped<IObrigatoriedadeLegalRepository, ObrigatoriedadeLegalRepository>();
         services.AddScoped<IDocumentoEditalRepository, DocumentoEditalRepository>();
         services.AddScoped<IRegraCatalogoReader, RegraCatalogoReader>();

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/Avro/ProcessoPublicado.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/Avro/ProcessoPublicado.cs
@@ -1,0 +1,141 @@
+// O namespace abaixo não é PascalCase porque deve casar exatamente com o
+// `namespace` declarado no schema Avro (Apache.Avro NET resolve a classe via
+// reflection usando <namespace>.<name> qualificado). Manter alinhado com
+// `Events/Schemas/ProcessoPublicado.avsc` em Selecao.Domain.
+#pragma warning disable CA1050 // Declare types in namespaces — namespace declarado, mas em lowercase.
+namespace unifesspa.uniplus.selecao.events;
+#pragma warning restore CA1050
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using global::Avro;
+using global::Avro.Specific;
+using ProcessoPublicadoEvent = Unifesspa.UniPlus.Selecao.Domain.Events.ProcessoPublicadoEvent;
+
+/// <summary>
+/// Wire-form Avro do <see cref="ProcessoPublicadoEvent"/> para publicação em Kafka via
+/// Confluent Schema Registry (Apicurio em modo Confluent-compat).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Classe escrita à mão (não codegen) seguindo a interface <c>ISpecificRecord</c> do
+/// Apache Avro 1.12. <b>Namespace e nome devem casar exatamente</b> com o declarado em
+/// <c>Events/Schemas/ProcessoPublicado.avsc</c> (Selecao.Domain) — Apache.Avro NET usa
+/// reflection (<c>Type.GetType("&lt;namespace&gt;.&lt;name&gt;")</c>) na desserialização
+/// para instanciar o tipo. Drift = <c>Avro.AvroException: Unable to find type</c>
+/// no consumer.
+/// </para>
+/// <para>
+/// O schema é carregado uma única vez do embedded resource em
+/// <see cref="ProcessoPublicadoEvent"/>'s assembly (Selecao.Domain) — single source of
+/// truth, evita drift entre o JSON publicado no Apicurio e a forma serializada.
+/// </para>
+/// <para>
+/// Mapeamento <see cref="ProcessoPublicadoEvent"/> → <see cref="ProcessoPublicado"/> fica em
+/// <c>Selecao.Infrastructure.Messaging.ProcessoPublicadoToAvroMapper</c> e é executado
+/// pelo cascading handler <c>ProcessoPublicadoToKafkaCascadeHandler</c> ao consumir o
+/// evento da PG queue intra-módulo. Consumidores cross-módulo recuperam o schema do
+/// Apicurio via schema-id no envelope da mensagem — não dependem deste assembly.
+/// </para>
+/// </remarks>
+[SuppressMessage(
+    "Naming",
+    "CA1707:Identifiers should not contain underscores",
+    Justification = "Namespace lowercase exigido pelo binding Apache.Avro NET (precisa casar com 'namespace' do .avsc).")]
+[SuppressMessage(
+    "Naming",
+    "CA1300:Specify MessageBoxOptions",
+    Justification = "False positive — atributo aplicável a UI; classe é POCO de mensagem.")]
+public sealed class ProcessoPublicado : ISpecificRecord
+{
+    public const string SchemaResourceName = "Unifesspa.UniPlus.Selecao.Domain.Events.Schemas.ProcessoPublicado.avsc";
+
+    private static readonly Lazy<Schema> SchemaInstance = new(LoadSchemaFromDomainAssembly);
+
+    /// <summary>Schema Avro carregado do embedded resource em Selecao.Domain.</summary>
+    public static Schema AvroSchema => SchemaInstance.Value;
+
+    /// <inheritdoc />
+    public Schema Schema => AvroSchema;
+
+    /// <summary>UUID v7 do evento (rastreabilidade fim-a-fim, idempotência cross-consumer).</summary>
+    public string EventId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Instante de emissão UTC. O schema declara <c>{type:long, logicalType:timestamp-millis}</c>;
+    /// Apache.Avro converte automaticamente entre <see cref="DateTime"/> (logical) e
+    /// <see cref="long"/> (base, ms desde epoch Unix) na serialização.
+    /// </summary>
+    public DateTime OccurredOn { get; set; }
+
+    /// <summary>UUID v7 do agregado ProcessoSeletivo (chave estável cross-módulo).</summary>
+    public string ProcessoSeletivoId { get; set; } = string.Empty;
+
+    /// <summary>UUID v7 do Edital de abertura emitido pela publicação.</summary>
+    public string EditalId { get; set; } = string.Empty;
+
+    /// <summary>UUID v7 do SnapshotPublicacao append-only congelado nesta publicação.</summary>
+    public string SnapshotPublicacaoId { get; set; } = string.Empty;
+
+    /// <summary>SHA-256 (hex minúsculo) da configuração canônica congelada (ADR-0100).</summary>
+    public string HashConfiguracao { get; set; } = string.Empty;
+
+    /// <summary>SHA-256 (hex minúsculo) do documento (PDF) do Edital confirmado (T3, #784).</summary>
+    public string HashEdital { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public object Get(int fieldPos) => fieldPos switch
+    {
+        0 => EventId,
+        1 => OccurredOn,
+        2 => ProcessoSeletivoId,
+        3 => EditalId,
+        4 => SnapshotPublicacaoId,
+        5 => HashConfiguracao,
+        6 => HashEdital,
+        _ => throw new AvroRuntimeException($"Posição de campo inválida em ProcessoPublicado.Get: {fieldPos}"),
+    };
+
+    /// <inheritdoc />
+    public void Put(int fieldPos, object fieldValue)
+    {
+        switch (fieldPos)
+        {
+            case 0:
+                EventId = (string)fieldValue;
+                break;
+            case 1:
+                OccurredOn = (DateTime)fieldValue;
+                break;
+            case 2:
+                ProcessoSeletivoId = (string)fieldValue;
+                break;
+            case 3:
+                EditalId = (string)fieldValue;
+                break;
+            case 4:
+                SnapshotPublicacaoId = (string)fieldValue;
+                break;
+            case 5:
+                HashConfiguracao = (string)fieldValue;
+                break;
+            case 6:
+                HashEdital = (string)fieldValue;
+                break;
+            default:
+                throw new AvroRuntimeException($"Posição de campo inválida em ProcessoPublicado.Put: {fieldPos}");
+        }
+    }
+
+    private static Schema LoadSchemaFromDomainAssembly()
+    {
+        System.Reflection.Assembly asm = typeof(ProcessoPublicadoEvent).Assembly;
+        using Stream? stream = asm.GetManifestResourceStream(SchemaResourceName)
+            ?? throw new InvalidOperationException(
+                $"Schema Avro '{SchemaResourceName}' não encontrado como embedded resource em '{asm.FullName}'. " +
+                "Verifique que o arquivo está em Selecao.Domain/Events/Schemas/ e que o csproj inclui <EmbeddedResource Include=\"Events\\Schemas\\*.avsc\" />.");
+        using StreamReader reader = new(stream);
+        return Schema.Parse(reader.ReadToEnd());
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/ProcessoPublicadoToAvroMapper.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/ProcessoPublicadoToAvroMapper.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
+
+using System;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using ProcessoPublicadoAvro = unifesspa.uniplus.selecao.events.ProcessoPublicado;
+
+/// <summary>
+/// Conversão entre <see cref="ProcessoPublicadoEvent"/> (record interno do Domain) e
+/// <see cref="ProcessoPublicadoAvro"/> (forma wire publicada em Kafka via Confluent SR).
+/// </summary>
+/// <remarks>
+/// Mapping puro sem efeitos colaterais. Posicionado em Infrastructure para não infectar
+/// Domain/Application com dependência de Apache.Avro. Executado pelo cascading handler
+/// <c>ProcessoPublicadoToKafkaCascadeHandler</c> que dispara quando o evento é consumido
+/// na PG queue intra-módulo (ADR-0044).
+/// </remarks>
+public static class ProcessoPublicadoToAvroMapper
+{
+    public static ProcessoPublicadoAvro ToAvro(ProcessoPublicadoEvent evt)
+    {
+        ArgumentNullException.ThrowIfNull(evt);
+
+        return new ProcessoPublicadoAvro
+        {
+            EventId = evt.EventId.ToString(),
+            // Apache.Avro com logicalType=timestamp-millis espera DateTime; o serializer
+            // converte para long (ms desde epoch Unix UTC) automaticamente. UtcDateTime
+            // garante Kind=Utc — Apache.Avro arredonda truncando frações de ms.
+            OccurredOn = evt.OccurredOn.UtcDateTime,
+            ProcessoSeletivoId = evt.ProcessoSeletivoId.ToString(),
+            EditalId = evt.EditalId.ToString(),
+            SnapshotPublicacaoId = evt.SnapshotPublicacaoId.ToString(),
+            HashConfiguracao = evt.HashConfiguracao,
+            HashEdital = evt.HashEdital,
+        };
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/ProcessoPublicadoToKafkaCascadeHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/ProcessoPublicadoToKafkaCascadeHandler.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Extensions.Logging;
+
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using ProcessoPublicadoAvro = unifesspa.uniplus.selecao.events.ProcessoPublicado;
+
+/// <summary>
+/// Handler convention-based do Wolverine que projeta <see cref="ProcessoPublicadoEvent"/>
+/// (intra-módulo, PG queue) em <see cref="ProcessoPublicadoAvro"/> (cross-módulo, Kafka)
+/// via cascading message — slice canônico do ADR-0005/ADR-0041 (Story #759, T4 #785).
+/// </summary>
+/// <remarks>
+/// Quando o evento é consumido da PG queue <c>domain-events</c> (ADR-0044), Wolverine
+/// dispara todos os handlers com assinatura compatível em paralelo —
+/// <c>ProcessoPublicadoEventHandler</c> (logging, em Application) e este cascade handler
+/// (em Infrastructure). O retorno deste handler é tratado como mensagem encadeada e
+/// roteada conforme as regras de <c>PublishMessage&lt;ProcessoPublicadoAvro&gt;()</c> em
+/// <c>SelecaoMessagingRegistration</c> (Kafka topic <c>processo_seletivo_events</c> com
+/// serializer Confluent SR Avro).
+/// <para>
+/// O envelope Avro é instalado no outbox dentro da transação do listener da PG queue —
+/// se o publish para Kafka falhar, o Wolverine retenta a partir do outbox, garantindo
+/// at-least-once para o consumidor cross-módulo.
+/// </para>
+/// </remarks>
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção do projeto: handlers de cascade de eventos terminam em Handler, ver ProcessoPublicadoEventHandler.")]
+public sealed partial class ProcessoPublicadoToKafkaCascadeHandler
+{
+    public static ProcessoPublicadoAvro Handle(
+        ProcessoPublicadoEvent @event,
+        ILogger<ProcessoPublicadoToKafkaCascadeHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        LogProjetandoParaKafkaCascade(logger, @event.EventId, @event.ProcessoSeletivoId, @event.EditalId);
+
+        return ProcessoPublicadoToAvroMapper.ToAvro(@event);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Projetando ProcessoPublicadoEvent para Kafka cascade. EventoId={EventoId} ProcessoSeletivoId={ProcessoSeletivoId} EditalId={EditalId}")]
+    private static partial void LogProjetandoParaKafkaCascade(
+        ILogger logger,
+        Guid eventoId,
+        Guid processoSeletivoId,
+        Guid editalId);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EditalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EditalConfiguration.cs
@@ -1,0 +1,91 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Domain.Entities;
+
+/// <summary>
+/// Configuração EF Core do <see cref="Edital"/> — entidade interna do
+/// agregado <see cref="ProcessoSeletivo"/> (Story #759, T4 #785).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class EditalConfiguration : IEntityTypeConfiguration<Edital>
+{
+    private const int NumeroMaxLength = 60;
+    private const int MotivoRetificacaoMaxLength = 2000;
+
+    public void Configure(EntityTypeBuilder<Edital> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("editais", ConfigurarChecks);
+        builder.HasKey(e => e.Id);
+        // Chave Guid v7 gerada no domínio (EntityBase) — mesma convenção do
+        // resto do agregado (ver ProcessoSeletivoConfiguration).
+        builder.Property(e => e.Id).ValueGeneratedNever();
+
+        builder.Property(e => e.Natureza).HasConversion<int>().IsRequired();
+        builder.Property(e => e.Numero).HasMaxLength(NumeroMaxLength);
+        builder.Property(e => e.DataPublicacao);
+        builder.Property(e => e.DocumentoEditalId).IsRequired();
+        builder.Property(e => e.EditalRetificadoId);
+        builder.Property(e => e.MotivoRetificacao).HasMaxLength(MotivoRetificacaoMaxLength);
+
+        // FK para o documento (T3, #784) — sem nav property: o Edital não
+        // navega para o documento, só carrega a referência congelada.
+        builder.HasOne<DocumentoEdital>()
+            .WithMany()
+            .HasForeignKey(e => e.DocumentoEditalId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("fk_editais_documento_edital_id");
+
+        // Auto-referência da cadeia de retificação (ADR-0101) — nulo em
+        // Edital de abertura. Restrict: um Edital retificado nunca é
+        // removido fisicamente enquanto houver retificação apontando para
+        // ele (trilha auditável).
+        builder.HasOne<Edital>()
+            .WithMany()
+            .HasForeignKey(e => e.EditalRetificadoId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("fk_editais_edital_retificado_id");
+
+        // CA-08/ADR-0075: unicidade de data_publicacao entre editais vivos
+        // publicados do mesmo processo — dá ao seletor de snapshot vigente
+        // (T6, #787) a garantia de que nunca há empate.
+        builder.HasIndex(e => new { e.ProcessoSeletivoId, e.DataPublicacao })
+            .IsUnique()
+            .HasFilter("data_publicacao IS NOT NULL")
+            .HasDatabaseName("ux_editais_processo_data_publicacao");
+
+        // Revisão de plano (Fase 6, P2): fecha a corrida de duas publicações
+        // concorrentes do mesmo processo — só um Edital de abertura por
+        // processo, nunca dois, mesmo com duas requisições simultâneas lendo
+        // Status=Rascunho antes de qualquer commit.
+        builder.HasIndex(e => e.ProcessoSeletivoId)
+            .IsUnique()
+            .HasFilter($"natureza = {(int)Domain.Enums.NaturezaEdital.Abertura}")
+            .HasDatabaseName("ux_editais_processo_abertura_unica");
+    }
+
+    // ADR-0101: contrato abertura×retificação — abertura sem os dois campos
+    // de retificação é o único estado válido para essa natureza; retificação
+    // exige os dois preenchidos simultaneamente (tudo-ou-nada por natureza).
+    // Defesa em profundidade: Edital.EmitirAbertura já garante isso em
+    // memória; esta trava cobre gap de validação/concorrência (ADR-0102).
+    private static void ConfigurarChecks(TableBuilder<Edital> table)
+    {
+        int abertura = (int)Domain.Enums.NaturezaEdital.Abertura;
+        int retificacao = (int)Domain.Enums.NaturezaEdital.Retificacao;
+
+        table.HasCheckConstraint(
+            "ck_editais_contrato_natureza",
+            $"(natureza = {abertura} AND edital_retificado_id IS NULL AND motivo_retificacao IS NULL) " +
+            $"OR (natureza = {retificacao} AND edital_retificado_id IS NOT NULL AND motivo_retificacao IS NOT NULL)");
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
@@ -56,6 +56,16 @@ public sealed class ProcessoSeletivoConfiguration : IEntityTypeConfiguration<Pro
             .HasForeignKey<ConfiguracaoClassificacao>(c => c.ProcessoSeletivoId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        // Editais (Story #759, T4 #785): Restrict, não Cascade — um Edital já
+        // publicado é evidência append-only (a cadeia de retificações
+        // referencia EditalRetificadoId); remover fisicamente o processo sem
+        // antes lidar com os editais emitidos é incidente operacional, igual
+        // ao padrão de ObrigatoriedadeLegalHistorico.
+        builder.HasMany(p => p.Editais)
+            .WithOne()
+            .HasForeignKey(e => e.ProcessoSeletivoId)
+            .OnDelete(DeleteBehavior.Restrict);
+
         builder.Navigation(p => p.Etapas)
             .UsePropertyAccessMode(PropertyAccessMode.Field);
 
@@ -63,6 +73,9 @@ public sealed class ProcessoSeletivoConfiguration : IEntityTypeConfiguration<Pro
             .UsePropertyAccessMode(PropertyAccessMode.Field);
 
         builder.Navigation(p => p.CriteriosDesempate)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+        builder.Navigation(p => p.Editais)
             .UsePropertyAccessMode(PropertyAccessMode.Field);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/SnapshotPublicacaoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/SnapshotPublicacaoConfiguration.cs
@@ -1,0 +1,88 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Domain.Entities;
+
+/// <summary>
+/// Configuração EF Core da tabela append-only <c>snapshot_publicacao</c>
+/// (RN08, ADR-0100, Story #759 T4 #785). Mesmo padrão de
+/// <c>ObrigatoriedadeLegalHistoricoConfiguration</c>: sem soft-delete, sem
+/// audit fields, sem updates — qualquer mutação fora de <c>INSERT</c> é
+/// incidente operacional.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class SnapshotPublicacaoConfiguration : IEntityTypeConfiguration<SnapshotPublicacao>
+{
+    private const int HashLength = 64;
+    private const int SchemaVersionMaxLength = 20;
+    private const int AlgoritmoHashMaxLength = 60;
+    private const int AtorUsuarioSubMaxLength = 255;
+
+    public void Configure(EntityTypeBuilder<SnapshotPublicacao> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("snapshot_publicacao");
+        builder.HasKey(s => s.Id);
+
+        builder.Property(s => s.EditalId).IsRequired();
+
+        builder.Property(s => s.SchemaVersion)
+            .HasMaxLength(SchemaVersionMaxLength)
+            .IsRequired();
+
+        builder.Property(s => s.AlgoritmoHash)
+            .HasMaxLength(AlgoritmoHashMaxLength)
+            .IsRequired();
+
+        // Bytes canônicos (ADR-0100 item 6) — base do hash; fonte única de verdade.
+        builder.Property(s => s.ConfiguracaoCongeladaCanonica)
+            .HasColumnType("bytea")
+            .IsRequired();
+
+        // Derivado por parsing UTF-8 dos bytes canônicos — só consulta SQL
+        // (ADR-0100 item 7). O banco não re-serializa nem reordena chaves.
+        builder.Property(s => s.ConfiguracaoCongelada)
+            .HasColumnType("jsonb")
+            .IsRequired();
+
+        builder.Property(s => s.HashConfiguracao)
+            .HasMaxLength(HashLength)
+            .IsFixedLength()
+            .IsRequired();
+
+        builder.Property(s => s.HashEdital)
+            .HasMaxLength(HashLength)
+            .IsFixedLength()
+            .IsRequired();
+
+        builder.Property(s => s.AtorUsuarioSub)
+            .HasMaxLength(AtorUsuarioSubMaxLength)
+            .IsRequired();
+
+        builder.Property(s => s.DataPublicacao)
+            .HasDefaultValueSql("now()")
+            .IsRequired();
+
+        // FK para editais — UNIQUE (1 snapshot por Edital). Sem nav property
+        // — a forensic não navega de volta, mesmo padrão de
+        // ObrigatoriedadeLegalHistorico. Nome explícito: o derivado pelo EF
+        // estoura o limite de 63 chars do PostgreSQL.
+        builder.HasOne<Edital>()
+            .WithOne()
+            .HasForeignKey<SnapshotPublicacao>(s => s.EditalId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .HasConstraintName("fk_snapshot_publicacao_edital_id");
+
+        builder.HasIndex(s => s.EditalId)
+            .IsUnique()
+            .HasDatabaseName("ux_snapshot_publicacao_edital_id");
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708014853_AddEditalSnapshotPublicacao.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708014853_AddEditalSnapshotPublicacao.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708014853_AddEditalSnapshotPublicacao")]
+    partial class AddEditalSnapshotPublicacao
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708014853_AddEditalSnapshotPublicacao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708014853_AddEditalSnapshotPublicacao.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEditalSnapshotPublicacao : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "editais",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    processo_seletivo_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    natureza = table.Column<int>(type: "integer", nullable: false),
+                    numero = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: true),
+                    data_publicacao = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    documento_edital_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    edital_retificado_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    motivo_retificacao = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_editais", x => x.id);
+                    table.CheckConstraint("ck_editais_contrato_natureza", "(natureza = 1 AND edital_retificado_id IS NULL AND motivo_retificacao IS NULL) OR (natureza = 2 AND edital_retificado_id IS NOT NULL AND motivo_retificacao IS NOT NULL)");
+                    table.ForeignKey(
+                        name: "fk_editais_documento_edital_id",
+                        column: x => x.documento_edital_id,
+                        principalSchema: "selecao",
+                        principalTable: "documentos_edital",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_editais_edital_retificado_id",
+                        column: x => x.edital_retificado_id,
+                        principalSchema: "selecao",
+                        principalTable: "editais",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_editais_processos_seletivos_processo_seletivo_id",
+                        column: x => x.processo_seletivo_id,
+                        principalSchema: "selecao",
+                        principalTable: "processos_seletivos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "snapshot_publicacao",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    edital_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    schema_version = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    algoritmo_hash = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    configuracao_congelada_canonica = table.Column<byte[]>(type: "bytea", nullable: false),
+                    configuracao_congelada = table.Column<string>(type: "jsonb", nullable: false),
+                    hash_configuracao = table.Column<string>(type: "character(64)", fixedLength: true, maxLength: 64, nullable: false),
+                    hash_edital = table.Column<string>(type: "character(64)", fixedLength: true, maxLength: 64, nullable: false),
+                    ator_usuario_sub = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    data_publicacao = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_snapshot_publicacao", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_snapshot_publicacao_edital_id",
+                        column: x => x.edital_id,
+                        principalSchema: "selecao",
+                        principalTable: "editais",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_editais_documento_edital_id",
+                schema: "selecao",
+                table: "editais",
+                column: "documento_edital_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_editais_edital_retificado_id",
+                schema: "selecao",
+                table: "editais",
+                column: "edital_retificado_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_editais_processo_abertura_unica",
+                schema: "selecao",
+                table: "editais",
+                column: "processo_seletivo_id",
+                unique: true,
+                filter: "natureza = 1");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_editais_processo_data_publicacao",
+                schema: "selecao",
+                table: "editais",
+                columns: new[] { "processo_seletivo_id", "data_publicacao" },
+                unique: true,
+                filter: "data_publicacao IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_snapshot_publicacao_edital_id",
+                schema: "selecao",
+                table: "snapshot_publicacao",
+                column: "edital_id",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "snapshot_publicacao",
+                schema: "selecao");
+
+            migrationBuilder.DropTable(
+                name: "editais",
+                schema: "selecao");
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
@@ -65,6 +65,12 @@ public sealed class ProcessoSeletivoRepository : IProcessoSeletivoRepository
             .ConfigureAwait(false);
     }
 
+    public async Task AdicionarSnapshotPublicacaoAsync(SnapshotPublicacao snapshot, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        await _context.SnapshotsPublicacao.AddAsync(snapshot, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task<(IReadOnlyList<ProcessoSeletivo> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
         int limit,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
@@ -52,6 +52,20 @@ public sealed class ProcessoSeletivoRepository : IProcessoSeletivoRepository
 
     public async Task<ProcessoSeletivo?> ObterComConfiguracaoAsync(Guid id, CancellationToken cancellationToken = default)
     {
+        // Lock pessimista da linha raiz do agregado (revisão do PR #791,
+        // Story #759 T4): serializa handlers concorrentes (todo Definir* e
+        // Publicar) que carregam o MESMO processo — sem isso, um Definir*
+        // que leu Status=Rascunho antes de uma publicação concorrente pode
+        // persistir mutação DEPOIS do SnapshotPublicacao já ter sido
+        // congelado, furando RN08/CA-04 sem que o guard em memória
+        // (MutacaoBloqueadaPosPublicacao) tenha visibilidade da publicação
+        // alheia. SELECT ... FOR UPDATE roda na MESMA transação ambiente do
+        // Wolverine (EnrollDbContextInTransaction) — a segunda transação
+        // concorrente bloqueia aqui até a primeira committar ou reverter.
+        await _context.Database
+            .ExecuteSqlInterpolatedAsync($"SELECT 1 FROM selecao.processos_seletivos WHERE id = {id} FOR UPDATE", cancellationToken)
+            .ConfigureAwait(false);
+
         return await _context.ProcessosSeletivos
             .Include(p => p.Etapas)
             .Include(p => p.OfertaAtendimento!).ThenInclude(o => o.Condicoes)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/SelecaoDbContext.cs
@@ -88,6 +88,23 @@ public sealed class SelecaoDbContext : DbContext, ISelecaoUnitOfWork
     public DbSet<DocumentoEdital> DocumentosEdital => Set<DocumentoEdital>();
 
     /// <summary>
+    /// Editais emitidos pela publicação/retificação do processo (Story #759,
+    /// T4 #785) — entidade interna do agregado, exposta como <c>DbSet</c>
+    /// para consulta e para o mapeamento EF da coleção
+    /// <see cref="ProcessoSeletivo.Editais"/>; a escrita passa sempre pela
+    /// raiz via <c>IProcessoSeletivoRepository</c>.
+    /// </summary>
+    public DbSet<Edital> Editais => Set<Edital>();
+
+    /// <summary>
+    /// Congelamento append-only da configuração de negócio no momento da
+    /// publicação (RN08, ADR-0100) — <see cref="SnapshotPublicacao"/> é
+    /// <c>IForensicEntity</c>, capturado explicitamente dentro de
+    /// <see cref="ProcessoSeletivo.Publicar"/> (Story #759, T4 #785).
+    /// </summary>
+    public DbSet<SnapshotPublicacao> SnapshotsPublicacao => Set<SnapshotPublicacao>();
+
+    /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do agregado
     /// para permitir gravação adjacente no outbox; entries cifradas at-rest
     /// via <c>IUniPlusEncryptionService</c>.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Unifesspa.UniPlus.Selecao.Infrastructure.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Unifesspa.UniPlus.Selecao.Infrastructure.csproj
@@ -4,6 +4,20 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <!--
+      Apache.Avro: dependência de runtime para os tipos Avro gerados em
+      Messaging/Avro/ (ISpecificRecord). Schema é carregado em Schema.Parse
+      a partir do embedded resource em Selecao.Domain (sem duplicação).
+      ADR-0051: schemas Avro vivem no Domain como recurso; classes ISpecificRecord
+      ficam em Infrastructure para não infectar Domain com dep de Avro.
+    -->
+    <PackageReference Include="Apache.Avro" />
+    <!--
+      Confluent.SchemaRegistry.Serdes.Avro: trazido pela dependência transitiva
+      do Wolverine.Kafka.Serialization.SchemaRegistryAvroSerializer, mas declarado
+      explicitamente para clareza do contrato de produção/consumo Avro.
+    -->
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
@@ -2,6 +2,27 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "Apache.Avro": {
+        "type": "Direct",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "Direct",
+        "requested": "[2.15.0, )",
+        "resolved": "2.15.0",
+        "contentHash": "50C2ENd0o4Wuanoo7NKyX3d+IxzgLecOw8AE2UVTXi//ZQ/Hj+bWl+Io5kuQrnhLclPjX05tpkfsmx2EDFVVVw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.15.0",
+          "Confluent.SchemaRegistry": "2.15.0"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[10.0.9, )",
@@ -1050,16 +1071,6 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
-      "Apache.Avro": {
-        "type": "CentralTransitive",
-        "requested": "[1.12.1, )",
-        "resolved": "1.12.1",
-        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
-        "dependencies": {
-          "Newtonsoft.Json": "13.0.1",
-          "System.CodeDom": "8.0.0"
-        }
-      },
       "Confluent.Kafka": {
         "type": "CentralTransitive",
         "requested": "[2.15.0, )",
@@ -1078,17 +1089,6 @@
           "Confluent.Kafka": "2.15.0",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Newtonsoft.Json": "13.0.1"
-        }
-      },
-      "Confluent.SchemaRegistry.Serdes.Avro": {
-        "type": "CentralTransitive",
-        "requested": "[2.15.0, )",
-        "resolved": "2.15.0",
-        "contentHash": "50C2ENd0o4Wuanoo7NKyX3d+IxzgLecOw8AE2UVTXi//ZQ/Hj+bWl+Io5kuQrnhLclPjX05tpkfsmx2EDFVVVw==",
-        "dependencies": {
-          "Apache.Avro": "1.12.1",
-          "Confluent.Kafka": "2.15.0",
-          "Confluent.SchemaRegistry": "2.15.0"
         }
       },
       "EFCore.NamingConventions": {

--- a/src/shared/Unifesspa.UniPlus.Kernel/Results/Result.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Results/Result.cs
@@ -14,6 +14,15 @@ public sealed class Result
 
     public static Result Success() => new(true, null);
     public static Result Failure(DomainError error) => new(false, error);
+
+    /// <summary>
+    /// <see langword="true"/> quando o resultado falhou com exatamente este
+    /// código de erro. Permite que callers (ex.: controllers) ramifiquem por
+    /// causa específica sem depender diretamente do tipo <see cref="DomainError"/>
+    /// (ADR-0024 — mapeamento de erro é responsabilidade de <c>IDomainErrorMapper</c>;
+    /// este método só expõe o código para decisão de fluxo, nunca o objeto).
+    /// </summary>
+    public bool HasErrorCode(string code) => Error?.Code == code;
 }
 
 public sealed class Result<T>

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -1328,6 +1328,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1352,6 +1353,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
@@ -1423,6 +1423,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1447,6 +1448,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
@@ -1395,6 +1395,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1419,6 +1420,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -1383,6 +1383,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1407,6 +1408,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
@@ -1171,6 +1171,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1195,6 +1196,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
@@ -1351,6 +1351,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1375,6 +1376,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
@@ -1302,6 +1302,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1326,6 +1327,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
@@ -1423,6 +1423,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1447,6 +1448,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirBonusRegionalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirBonusRegionalCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
 
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 using AwesomeAssertions;
 
@@ -132,5 +133,110 @@ public sealed class DefinirBonusRegionalCommandHandlerTests
 
         result.IsFailure.Should().BeTrue();
         result.Error!.Code.Should().Be("ConfiguracaoBonusRegional.RegraTipoInvalido");
+    }
+
+    /// <summary>
+    /// Monta um processo minimamente conforme e já publicado (CA-07 + RN08) —
+    /// mesmo par exigido pelo gate de conformidade de
+    /// <see cref="ProcessoSeletivo.Publicar"/>, replicado aqui para exercitar
+    /// o bloqueio de mutação pós-publicação (CA-04) no handler.
+    /// </summary>
+    private static ProcessoSeletivo NovoProcessoPublicado()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — Publicado", TipoProcesso.SiSU);
+
+        processo.DefinirEtapas([
+            EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1),
+        ]).IsSuccess.Should().BeTrue();
+
+        processo.DefinirOfertaAtendimento(
+            OfertaAtendimentoEspecializado.Criar([], [], []).Value!).IsSuccess.Should().BeTrue();
+
+        string hashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+        Domain.ValueObjects.ReferenciaRegra regraDistribuicao = Domain.ValueObjects.ReferenciaRegra.Criar(
+            RegraDistribuicaoVagasCodigo.Institucional, "v1", hashFixo).Value!;
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(),
+            codigo: "AC",
+            descricao: null,
+            naturezaLegal: NaturezaLegalModalidade.Ampla,
+            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null,
+            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null,
+            remanejamentoPar: null,
+            remanejamentoFallback: null,
+            criteriosCumulativos: [],
+            acaoQuandoIndeferido: null,
+            baseLegal: "Res. Unifesspa 532/2021").Value!;
+        ConfiguracaoDistribuicaoVagas distribuicao = ConfiguracaoDistribuicaoVagas.Criar(
+            ofertaCursoOrigemId: Guid.CreateVersion7(),
+            voBase: 40,
+            pr: 1m,
+            regraDistribuicao: regraDistribuicao,
+            referenciaDemografica: null,
+            modalidades: [modalidade]).Value!;
+        processo.DefinirDistribuicaoVagas([distribuicao]).IsSuccess.Should().BeTrue();
+
+        Domain.ValueObjects.ReferenciaRegra regraCalculo = Domain.ValueObjects.ReferenciaRegra.Criar(
+            RegraCalculoCodigo.ClassificacaoImportada, "v1", hashFixo).Value!;
+        Domain.ValueObjects.ReferenciaRegra regraOrdemAlocacao = Domain.ValueObjects.ReferenciaRegra.Criar(
+            RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", hashFixo).Value!;
+        ConfiguracaoClassificacao classificacao = ConfiguracaoClassificacao.Criar(
+            regraCalculo: regraCalculo,
+            regraArredondamento: null,
+            casasArredondamento: null,
+            regraOrdemAlocacao: regraOrdemAlocacao,
+            nOpcoesAlocacao: 1,
+            regrasEliminacao: []).Value!;
+        processo.DefinirClassificacao(classificacao).IsSuccess.Should().BeTrue();
+
+        Domain.ValueObjects.DadosEdital dados = Domain.ValueObjects.DadosEdital.Criar(
+            numero: "001/2026",
+            periodoInscricaoInicio: new DateOnly(2026, 1, 1),
+            periodoInscricaoFim: new DateOnly(2026, 1, 31),
+            documentoEditalId: Guid.CreateVersion7()).Value!;
+        byte[] bytesCanonicos = System.Text.Encoding.UTF8.GetBytes(
+            new JsonObject { ["status"] = "ok" }.ToJsonString());
+        processo.Publicar(dados, bytesCanonicos, "1.0", "canonical-json/sha256@v1", hashFixo, "user-sub-123", TimeProvider.System)
+            .IsSuccess.Should().BeTrue();
+
+        return processo;
+    }
+
+    [Fact(DisplayName =
+        "Handle com processo já publicado propaga MutacaoPosPublicacaoBloqueada e NÃO persiste (CA-04, achado Codex PR #791)")]
+    public async Task Handle_ProcessoPublicado_PropagaBloqueioENaoPersiste()
+    {
+        ProcessoSeletivo processo = NovoProcessoPublicado();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        mocks.RegraCatalogoReader.ObterAsync(RegraBonusCodigo.Multiplicativo, "v1", Arg.Any<CancellationToken>())
+            .Returns(Regra(RegraBonusCodigo.Multiplicativo, TipoRegra.RegraBonus));
+
+        DefinirBonusRegionalCommand command = new(processo.Id, RegraBonusCodigo.Multiplicativo, "v1", 1.20m, null, "Marabá", "RN05");
+
+        Result result = await DefinirBonusRegionalCommandHandler.Handle(
+            command, mocks.Repository, mocks.RegraCatalogoReader, mocks.UnitOfWork, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada");
+        processo.BonusRegional.Should().BeNull();
+        await mocks.UnitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName =
+        "Handle de remoção (RegraCodigo nulo) com processo já publicado propaga bloqueio e NÃO persiste (CA-04)")]
+    public async Task Handle_RemocaoComProcessoPublicado_PropagaBloqueioENaoPersiste()
+    {
+        ProcessoSeletivo processo = NovoProcessoPublicado();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        DefinirBonusRegionalCommand command = new(processo.Id, null, null, null, null, null, null);
+
+        Result result = await DefinirBonusRegionalCommandHandler.Handle(
+            command, mocks.Repository, mocks.RegraCatalogoReader, mocks.UnitOfWork, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada");
+        await mocks.UnitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
@@ -1171,6 +1171,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1195,6 +1196,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoPublicarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoPublicarTests.cs
@@ -1,0 +1,189 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using System.Text;
+using System.Text.Json.Nodes;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura de <see cref="ProcessoSeletivo.Publicar"/> (RN08, Story #759 T4
+/// #785) — gate de conformidade, transição atômica, congelamento do
+/// <see cref="SnapshotPublicacao"/> e bloqueio de mutação pós-publicação
+/// (CA-04). Mapa de testes de #759: <c>Lifecycle_TransicaoInvalidaRecusada</c>,
+/// <c>Publicacao_RecusaSemParametrosObrigatorios</c>,
+/// <c>Publicacao_AtomicaStatusESnapshot</c>, <c>PosPublicacao_MutacaoBloqueada_422</c>.
+/// </summary>
+public sealed class ProcessoSeletivoPublicarTests
+{
+    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+    private static readonly byte[] BytesCanonicos = Encoding.UTF8.GetBytes(new JsonObject { ["status"] = "ok" }.ToJsonString());
+
+    private static DadosEdital NovosDados() => DadosEdital.Criar(
+        numero: "001/2026",
+        periodoInscricaoInicio: new DateOnly(2026, 1, 1),
+        periodoInscricaoFim: new DateOnly(2026, 1, 31),
+        documentoEditalId: Guid.CreateVersion7()).Value!;
+
+    /// <summary>
+    /// Monta um processo minimamente conforme (CA-07: etapas, oferta de
+    /// atendimento, distribuição de vagas, classificação) — o par exigido
+    /// pelo gate de conformidade de <see cref="ProcessoSeletivo.Publicar"/>.
+    /// </summary>
+    private static ProcessoSeletivo NovoProcessoConforme()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — SiSU", TipoProcesso.SiSU);
+
+        processo.DefinirEtapas([
+            EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1),
+        ]).IsSuccess.Should().BeTrue();
+
+        processo.DefinirOfertaAtendimento(
+            OfertaAtendimentoEspecializado.Criar([], [], []).Value!).IsSuccess.Should().BeTrue();
+
+        ReferenciaRegra regraDistribuicao = ReferenciaRegra.Criar(
+            RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!;
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(),
+            codigo: "AC",
+            descricao: null,
+            naturezaLegal: NaturezaLegalModalidade.Ampla,
+            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null,
+            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null,
+            remanejamentoPar: null,
+            remanejamentoFallback: null,
+            criteriosCumulativos: [],
+            acaoQuandoIndeferido: null,
+            baseLegal: "Res. Unifesspa 532/2021").Value!;
+        ConfiguracaoDistribuicaoVagas distribuicao = ConfiguracaoDistribuicaoVagas.Criar(
+            ofertaCursoOrigemId: Guid.CreateVersion7(),
+            voBase: 40,
+            pr: 1m,
+            regraDistribuicao: regraDistribuicao,
+            referenciaDemografica: null,
+            modalidades: [modalidade]).Value!;
+        processo.DefinirDistribuicaoVagas([distribuicao]).IsSuccess.Should().BeTrue();
+
+        ReferenciaRegra regraCalculo = ReferenciaRegra.Criar(
+            RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!;
+        ReferenciaRegra regraOrdemAlocacao = ReferenciaRegra.Criar(
+            RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!;
+        ConfiguracaoClassificacao classificacao = ConfiguracaoClassificacao.Criar(
+            regraCalculo: regraCalculo,
+            regraArredondamento: null,
+            casasArredondamento: null,
+            regraOrdemAlocacao: regraOrdemAlocacao,
+            nOpcoesAlocacao: 1,
+            regrasEliminacao: []).Value!;
+        processo.DefinirClassificacao(classificacao).IsSuccess.Should().BeTrue();
+
+        return processo;
+    }
+
+    [Fact(DisplayName = "Publicacao_AtomicaStatusESnapshot — processo conforme publica, congela snapshot e transita status")]
+    public void Publicar_ProcessoConforme_TransitaStatusECongelaSnapshot()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        DadosEdital dados = NovosDados();
+
+        Result<PublicacaoResultado> resultado = processo.Publicar(
+            dados, BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.Status.Should().Be(StatusProcesso.Publicado);
+        processo.Editais.Should().ContainSingle();
+        processo.Editais.Single().Should().Be(resultado.Value!.Edital);
+        resultado.Value!.Edital.Natureza.Should().Be(NaturezaEdital.Abertura);
+        resultado.Value!.Edital.DataPublicacao.Should().NotBeNull();
+        resultado.Value!.Snapshot.EditalId.Should().Be(resultado.Value!.Edital.Id);
+        resultado.Value!.Snapshot.HashEdital.Should().Be(HashFixo);
+    }
+
+    [Fact(DisplayName = "Publicacao_AtomicaStatusESnapshot — evento carrega os identificadores forenses completos")]
+    public void Publicar_ProcessoConforme_EmiteEventoComIdentificadoresCompletos()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        DadosEdital dados = NovosDados();
+
+        Result<PublicacaoResultado> resultado = processo.Publicar(
+            dados, BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System);
+
+        resultado.IsSuccess.Should().BeTrue();
+        Domain.Events.ProcessoPublicadoEvent evento = processo.DomainEvents
+            .OfType<Domain.Events.ProcessoPublicadoEvent>().Should().ContainSingle().Subject;
+
+        evento.ProcessoSeletivoId.Should().Be(processo.Id);
+        evento.EditalId.Should().Be(resultado.Value!.Edital.Id);
+        evento.SnapshotPublicacaoId.Should().Be(resultado.Value!.Snapshot.Id);
+        evento.HashConfiguracao.Should().Be(resultado.Value!.Snapshot.HashConfiguracao);
+        evento.HashEdital.Should().Be(HashFixo);
+    }
+
+    [Fact(DisplayName = "Publicacao_RecusaSemParametrosObrigatorios — processo sem etapas recusa com checklist de pendências (CA-03)")]
+    public void Publicar_SemEtapas_RecusaComConformidadeInsuficiente()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS incompleto", TipoProcesso.SiSU);
+        // Nenhuma dimensão obrigatória definida — Etapas/Atendimento/Distribuição/Classificação ausentes.
+
+        Result<PublicacaoResultado> resultado = processo.Publicar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.ConformidadeInsuficiente");
+        processo.Status.Should().Be(StatusProcesso.Rascunho, "publicação recusada não transita o status");
+        processo.Editais.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Lifecycle_TransicaoInvalidaRecusada — publicar processo já publicado é recusado (CA-09)")]
+    public void Publicar_ProcessoJaPublicado_RecusaTransicaoInvalida()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        processo.Publicar(NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System)
+            .IsSuccess.Should().BeTrue();
+
+        Result<PublicacaoResultado> segundaTentativa = processo.Publicar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System);
+
+        segundaTentativa.IsFailure.Should().BeTrue();
+        segundaTentativa.Error!.Code.Should().Be("ProcessoSeletivo.TransicaoInvalida");
+        processo.Editais.Should().ContainSingle("a segunda tentativa não deve emitir um segundo Edital");
+    }
+
+    [Theory(DisplayName = "PosPublicacao_MutacaoBloqueada_422 — todo Definir* recusa mutação após publicação (CA-04)")]
+    [InlineData("etapas")]
+    [InlineData("ofertaAtendimento")]
+    [InlineData("distribuicaoVagas")]
+    [InlineData("bonusRegional")]
+    [InlineData("criteriosDesempate")]
+    [InlineData("classificacao")]
+    public void DefinirX_ProcessoPublicado_RecusaMutacao(string dimensao)
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        processo.Publicar(NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System)
+            .IsSuccess.Should().BeTrue();
+
+        Result resultado = dimensao switch
+        {
+            "etapas" => processo.DefinirEtapas([EtapaProcesso.Criar("Nova Etapa", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1)]),
+            "ofertaAtendimento" => processo.DefinirOfertaAtendimento(OfertaAtendimentoEspecializado.Criar([], [], []).Value!),
+            "distribuicaoVagas" => processo.DefinirDistribuicaoVagas([]),
+            "bonusRegional" => processo.DefinirBonusRegional(null),
+            "criteriosDesempate" => processo.DefinirCriteriosDesempate([]),
+            "classificacao" => processo.DefinirClassificacao(ConfiguracaoClassificacao.Criar(
+                ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!,
+                null, null,
+                ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!,
+                1, []).Value!),
+            _ => throw new InvalidOperationException("Dimensão desconhecida."),
+        };
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/HashCanonicalComputerAdr0100Tests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/HashCanonicalComputerAdr0100Tests.cs
@@ -1,0 +1,127 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.ValueObjects;
+
+using System.Text;
+using System.Text.Json.Nodes;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Extensões do <see cref="HashCanonicalComputer"/> para o contrato de
+/// canonicalização do snapshot de publicação (ADR-0100, Story #759 T4 #785):
+/// normalização NFC, decimais com escala declarada e arredondamento
+/// half-even, instantes RFC 3339 sem fração, e a persistência dos bytes
+/// canônicos como base do hash (<c>Canonicalizacao_HashReproduzivel</c> do
+/// mapa de testes de #759).
+/// </summary>
+public sealed class HashCanonicalComputerAdr0100Tests
+{
+    [Fact(DisplayName = "NormalizeNfc: strings em NFD e NFC produzem o mesmo hash sobre os bytes persistidos")]
+    public void NormalizeNfc_NfdVsNfc_ProduzMesmoHash()
+    {
+        // "café" com 'é' pré-composto (NFC) vs. 'e' + combining acute (NFD) —
+        // bytes UTF-8 diferentes, mesmo texto visualmente.
+        string nfc = "café";
+        string nfd = "café";
+        nfc.Should().NotBe(nfd, "pré-condição: os dois literais têm bytes distintos antes da normalização");
+
+        JsonObject payloadNfc = new() { ["nome"] = HashCanonicalComputer.NormalizeNfc(nfc) };
+        JsonObject payloadNfd = new() { ["nome"] = HashCanonicalComputer.NormalizeNfc(nfd) };
+
+        byte[] bytesNfc = HashCanonicalComputer.ComputeSnapshotBytes(payloadNfc);
+        byte[] bytesNfd = HashCanonicalComputer.ComputeSnapshotBytes(payloadNfd);
+
+        HashCanonicalComputer.ComputeSha256Hex(bytesNfc).Should().Be(HashCanonicalComputer.ComputeSha256Hex(bytesNfd));
+    }
+
+    [Fact(DisplayName = "SerializeDecimalCanonical: representações decimais equivalentes na mesma escala produzem o mesmo hash")]
+    public void SerializeDecimalCanonical_RepresentacoesEquivalentes_ProduzMesmoHash()
+    {
+        // 10.50 e 10.5 são o MESMO valor lógico na escala 2 — half-even não
+        // deveria distingui-los uma vez serializados como string de largura fixa.
+        string serializado1 = HashCanonicalComputer.SerializeDecimalCanonical(10.50m, escala: 2);
+        string serializado2 = HashCanonicalComputer.SerializeDecimalCanonical(10.5m, escala: 2);
+
+        serializado1.Should().Be(serializado2);
+        serializado1.Should().Be("10.50");
+
+        byte[] bytes1 = HashCanonicalComputer.ComputeSnapshotBytes(new JsonObject { ["valor"] = serializado1 });
+        byte[] bytes2 = HashCanonicalComputer.ComputeSnapshotBytes(new JsonObject { ["valor"] = serializado2 });
+        HashCanonicalComputer.ComputeSha256Hex(bytes1).Should().Be(HashCanonicalComputer.ComputeSha256Hex(bytes2));
+    }
+
+    [Fact(DisplayName = "SerializeDecimalCanonical: arredondamento half-even em valores de meio de intervalo exato")]
+    public void SerializeDecimalCanonical_HalfEven_Arredonda()
+    {
+        // Literais decimal exatos (não double) — half-even arredonda para o
+        // dígito par mais próximo em empates exatos: 2.5 → 2, 3.5 → 4.
+        HashCanonicalComputer.SerializeDecimalCanonical(2.5m, escala: 0).Should().Be("2");
+        HashCanonicalComputer.SerializeDecimalCanonical(3.5m, escala: 0).Should().Be("4");
+        HashCanonicalComputer.SerializeDecimalCanonical(1.005m, escala: 2).Should().Be("1.00");
+        HashCanonicalComputer.SerializeDecimalCanonical(1.015m, escala: 2).Should().Be("1.02");
+    }
+
+    [Fact(DisplayName = "SerializeInstantCanonical: instante com e sem fração de segundo produzem o mesmo hash")]
+    public void SerializeInstantCanonical_ComESemFracao_ProduzMesmoHash()
+    {
+        DateTimeOffset comFracao = new(2026, 7, 8, 10, 30, 45, 123, TimeSpan.Zero);
+        DateTimeOffset semFracao = new(2026, 7, 8, 10, 30, 45, 0, TimeSpan.Zero);
+
+        string serializadoComFracao = HashCanonicalComputer.SerializeInstantCanonical(comFracao);
+        string serializadoSemFracao = HashCanonicalComputer.SerializeInstantCanonical(semFracao);
+
+        serializadoComFracao.Should().Be(serializadoSemFracao,
+            "granularidade de segundo — a fração de milissegundo é truncada, não arredondada para o segundo seguinte");
+        serializadoComFracao.Should().Be("2026-07-08T10:30:45Z");
+    }
+
+    [Fact(DisplayName = "ComputeSnapshotBytes + ComputeSha256Hex: mesma configuração produz sempre o mesmo hash")]
+    public void ComputeSnapshotBytesEComputeSha256Hex_MesmaConfiguracao_HashReproduzivel()
+    {
+        JsonObject payload = new()
+        {
+            ["etapas"] = new JsonArray(new JsonObject { ["nome"] = "Prova Objetiva", ["peso"] = "1.00" }),
+            ["bonusRegional"] = new JsonObject { ["presente"] = false },
+        };
+
+        byte[] bytes1 = HashCanonicalComputer.ComputeSnapshotBytes(payload.DeepClone().AsObject());
+        byte[] bytes2 = HashCanonicalComputer.ComputeSnapshotBytes(payload.DeepClone().AsObject());
+
+        string hash1 = HashCanonicalComputer.ComputeSha256Hex(bytes1);
+        string hash2 = HashCanonicalComputer.ComputeSha256Hex(bytes2);
+
+        hash1.Should().Be(hash2);
+        HashCanonicalComputer.IsValidHashShape(hash1).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "ComputeSnapshotBytes: alterar qualquer valor de negócio muda o hash")]
+    public void ComputeSnapshotBytes_MudancaDeValor_MudaHash()
+    {
+        JsonObject payloadBase = new() { ["etapas"] = new JsonArray(new JsonObject { ["nome"] = "Prova Objetiva" }) };
+        JsonObject payloadMudado = new() { ["etapas"] = new JsonArray(new JsonObject { ["nome"] = "Prova Discursiva" }) };
+
+        string hashBase = HashCanonicalComputer.ComputeSha256Hex(HashCanonicalComputer.ComputeSnapshotBytes(payloadBase));
+        string hashMudado = HashCanonicalComputer.ComputeSha256Hex(HashCanonicalComputer.ComputeSnapshotBytes(payloadMudado));
+
+        hashMudado.Should().NotBe(hashBase);
+    }
+
+    [Fact(DisplayName = "ComputeSnapshotBytes: bytes canônicos são JSON UTF-8 válido, re-hasheável de volta")]
+    public void ComputeSnapshotBytes_BytesSaoJsonUtf8Valido()
+    {
+        JsonObject payload = new() { ["chave"] = "valor" };
+        byte[] bytes = HashCanonicalComputer.ComputeSnapshotBytes(payload);
+
+        string texto = Encoding.UTF8.GetString(bytes);
+        JsonNode? reparsed = JsonNode.Parse(texto);
+
+        reparsed.Should().NotBeNull();
+        reparsed!["chave"]!.GetValue<string>().Should().Be("valor");
+
+        // Re-hashear os bytes lidos "de volta" bate com o hash original —
+        // ADR-0100 §Confirmação (base do teste de integração Snapshot_HashConfereAppEBanco).
+        byte[] bytesRelidos = Encoding.UTF8.GetBytes(texto);
+        HashCanonicalComputer.ComputeSha256Hex(bytesRelidos).Should().Be(HashCanonicalComputer.ComputeSha256Hex(bytes));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Messaging/ProcessoPublicadoAvroTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Messaging/ProcessoPublicadoAvroTests.cs
@@ -1,0 +1,162 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Messaging;
+
+using System;
+using System.IO;
+using AwesomeAssertions;
+using Avro.IO;
+using Avro.Specific;
+using Unifesspa.UniPlus.Selecao.Domain.Events;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
+using ProcessoPublicadoAvro = unifesspa.uniplus.selecao.events.ProcessoPublicado;
+
+/// <summary>
+/// Smoke unit tests para o pipeline Avro de <see cref="ProcessoPublicadoEvent"/>
+/// (Story #759, T4 #785): schema parse, mapping puro <c>Event → Avro</c> e
+/// round-trip Avro binary (serialize → deserialize) usando
+/// <see cref="SpecificDefaultWriter"/> / <see cref="SpecificDefaultReader"/>.
+/// </summary>
+/// <remarks>
+/// Não toca rede nem Schema Registry — exercita apenas a camada de wire form.
+/// O caminho cross-process com Confluent SR (header magic byte + schema id +
+/// payload) é testado em integração quando o ambiente fornece Apicurio
+/// (compose local ou cluster standalone).
+/// </remarks>
+[Trait("Category", "Unit")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1859:Use concrete types when possible for improved performance",
+    Justification = "Testes do contrato ISpecificRecord — uso da interface é intencional para verificar a implementação dinâmica do Apache.Avro.")]
+public sealed class ProcessoPublicadoAvroTests
+{
+    [Fact(DisplayName = "Schema é carregado do embedded resource em Selecao.Domain")]
+    public void Schema_DeveSerCarregadoDoEmbeddedResource()
+    {
+        global::Avro.Schema schema = ProcessoPublicadoAvro.AvroSchema;
+
+        schema.Should().NotBeNull();
+        schema.Tag.Should().Be(global::Avro.Schema.Type.Record);
+
+        global::Avro.RecordSchema schemaRecord = (global::Avro.RecordSchema)schema;
+        schemaRecord.Name.Should().Be("ProcessoPublicado");
+        schemaRecord.Namespace.Should().Be("unifesspa.uniplus.selecao.events");
+        schemaRecord.Fields.Select(f => f.Name).Should().BeEquivalentTo(
+            ["EventId", "OccurredOn", "ProcessoSeletivoId", "EditalId", "SnapshotPublicacaoId", "HashConfiguracao", "HashEdital"]);
+    }
+
+    [Fact(DisplayName = "Mapper Event → Avro preserva todos os campos")]
+    public void Mapper_DeveMaperearTodosOsCampos()
+    {
+        ProcessoPublicadoEvent evt = new(
+            ProcessoSeletivoId: Guid.CreateVersion7(),
+            EditalId: Guid.CreateVersion7(),
+            SnapshotPublicacaoId: Guid.CreateVersion7(),
+            HashConfiguracao: new string('a', 64),
+            HashEdital: new string('b', 64),
+            OccurredOn: new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero));
+
+        ProcessoPublicadoAvro avro = ProcessoPublicadoToAvroMapper.ToAvro(evt);
+
+        avro.EventId.Should().Be(evt.EventId.ToString());
+        avro.OccurredOn.Should().Be(evt.OccurredOn.UtcDateTime);
+        avro.ProcessoSeletivoId.Should().Be(evt.ProcessoSeletivoId.ToString());
+        avro.EditalId.Should().Be(evt.EditalId.ToString());
+        avro.SnapshotPublicacaoId.Should().Be(evt.SnapshotPublicacaoId.ToString());
+        avro.HashConfiguracao.Should().Be(evt.HashConfiguracao);
+        avro.HashEdital.Should().Be(evt.HashEdital);
+    }
+
+    [Fact(DisplayName = "Mapper rejeita null")]
+    public void Mapper_NullEvent_DeveLancarArgumentNull()
+    {
+        Action act = () => ProcessoPublicadoToAvroMapper.ToAvro(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact(DisplayName = "Round-trip Avro binary preserva todos os campos")]
+    public void RoundTrip_DevePreservarCampos()
+    {
+        // Construímos o Avro a partir de um evento real para garantir que o
+        // schema usado na escrita seja exatamente o mesmo carregado do recurso —
+        // qualquer drift entre .avsc e a classe ISpecificRecord falhará aqui.
+        ProcessoPublicadoEvent evt = new(
+            ProcessoSeletivoId: Guid.CreateVersion7(),
+            EditalId: Guid.CreateVersion7(),
+            SnapshotPublicacaoId: Guid.CreateVersion7(),
+            HashConfiguracao: new string('c', 64),
+            HashEdital: new string('d', 64),
+            OccurredOn: new DateTimeOffset(2026, 1, 15, 10, 30, 0, TimeSpan.Zero));
+
+        ProcessoPublicadoAvro original = ProcessoPublicadoToAvroMapper.ToAvro(evt);
+
+        SpecificDefaultWriter writer = new(ProcessoPublicadoAvro.AvroSchema);
+        using MemoryStream stream = new();
+        BinaryEncoder encoder = new(stream);
+        writer.Write(original, encoder);
+        encoder.Flush();
+
+        stream.Position = 0;
+        SpecificDefaultReader reader = new(ProcessoPublicadoAvro.AvroSchema, ProcessoPublicadoAvro.AvroSchema);
+        BinaryDecoder decoder = new(stream);
+        ProcessoPublicadoAvro? decoded = reader.Read(reuse: default(ProcessoPublicadoAvro), decoder);
+
+        decoded.Should().NotBeNull();
+        decoded.EventId.Should().Be(original.EventId);
+        // timestamp-millis trunca para ms — original tem ticks (precisão sub-ms),
+        // decoded vem só com ms. Comparar truncado.
+        decoded.OccurredOn.Should().BeCloseTo(original.OccurredOn, TimeSpan.FromMilliseconds(1));
+        decoded.ProcessoSeletivoId.Should().Be(original.ProcessoSeletivoId);
+        decoded.EditalId.Should().Be(original.EditalId);
+        decoded.SnapshotPublicacaoId.Should().Be(original.SnapshotPublicacaoId);
+        decoded.HashConfiguracao.Should().Be(original.HashConfiguracao);
+        decoded.HashEdital.Should().Be(original.HashEdital);
+    }
+
+    [Theory(DisplayName = "ISpecificRecord Get por posição retorna campos esperados")]
+    [InlineData(0, "EventId")]
+    [InlineData(1, "OccurredOn")]
+    [InlineData(2, "ProcessoSeletivoId")]
+    [InlineData(3, "EditalId")]
+    [InlineData(4, "SnapshotPublicacaoId")]
+    [InlineData(5, "HashConfiguracao")]
+    [InlineData(6, "HashEdital")]
+    public void Get_DeveRetornarCampoCorreto(int fieldPos, string expectedFieldName)
+    {
+        ProcessoPublicadoAvro avro = new()
+        {
+            EventId = "evt-id",
+            OccurredOn = new DateTime(2026, 5, 9, 12, 0, 0, DateTimeKind.Utc),
+            ProcessoSeletivoId = "processo-id",
+            EditalId = "edital-id",
+            SnapshotPublicacaoId = "snapshot-id",
+            HashConfiguracao = new string('a', 64),
+            HashEdital = new string('b', 64),
+        };
+
+        ISpecificRecord record = (ISpecificRecord)avro;
+        object value = record.Get(fieldPos);
+
+        value.Should().NotBeNull();
+
+        // Cobertura por nome para evitar drift de ordem entre .avsc e Get/Put.
+        global::Avro.RecordSchema schema = (global::Avro.RecordSchema)ProcessoPublicadoAvro.AvroSchema;
+        schema.Fields[fieldPos].Name.Should().Be(expectedFieldName);
+    }
+
+    [Fact(DisplayName = "ISpecificRecord Get com posição inválida lança AvroRuntimeException")]
+    public void Get_PosicaoInvalida_DeveLancar()
+    {
+        ProcessoPublicadoAvro avro = new();
+        ISpecificRecord record = (ISpecificRecord)avro;
+        Action act = () => record.Get(99);
+        act.Should().Throw<global::Avro.AvroRuntimeException>();
+    }
+
+    [Fact(DisplayName = "ISpecificRecord Put com posição inválida lança AvroRuntimeException")]
+    public void Put_PosicaoInvalida_DeveLancar()
+    {
+        ProcessoPublicadoAvro avro = new();
+        ISpecificRecord record = (ISpecificRecord)avro;
+        Action act = () => record.Put(99, "x");
+        act.Should().Throw<global::Avro.AvroRuntimeException>();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingApiFactory.cs
@@ -2,6 +2,10 @@ namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
 
 using System.Diagnostics.CodeAnalysis;
 
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
 
 /// <summary>
@@ -15,7 +19,8 @@ using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
 /// redundante: o host registra o DbContext via
 /// <c>AddSelecaoInfrastructure</c> com todos os interceptors
 /// (SoftDelete + Auditable + ObrigatoriedadeLegalHistorico) e snake_case por
-/// convenção (<c>UseUniPlusNpgsqlConventions</c>).
+/// convenção (<c>UseUniPlusNpgsqlConventions</c>). Resta apenas o
+/// <see cref="DomainEventCollector"/> que o handler subscritor consome.
 /// </remarks>
 [SuppressMessage(
     "Performance",
@@ -26,5 +31,17 @@ public sealed class CascadingApiFactory : MonolitoApiFactory
     public CascadingApiFactory(string connectionString)
         : base(connectionString, wolverineEnabled: true)
     {
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddSingleton<DomainEventCollector>();
+        });
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingScenariosTests.cs
@@ -1,0 +1,151 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Wolverine;
+
+using Application.Commands.ProcessosSeletivos;
+using Domain.Entities;
+using Domain.Events;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+// Cenários produtivos do outbox cascading (ADR-0005), reconstruídos sobre o
+// slice ProcessoSeletivo (Story #759, T4 #785) — o slice Edital legado que
+// demonstrava isso foi removido por inteiro (#782).
+//
+// Os dois testes têm dupla marcação `Category=OutboxCapability` +
+// `Category=OutboxCascading` — evita ambiguidade entre as duas suítes e
+// mantém o filtro `OutboxCapability` correspondendo ao conjunto demonstrável
+// de capacidades do outbox produtivo nesta fase.
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+[Trait("Category", "OutboxCascading")]
+public sealed class CascadingScenariosTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public CascadingScenariosTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // V8 — caminho feliz: cascading entrega ProcessoPublicadoEvent ao handler
+    // local da queue PG após Publicar+SaveChanges. Atomicidade write+evento
+    // verificada indiretamente: se a transação não tivesse drenado o envelope
+    // junto do SaveChanges, o listener da queue PG não receberia o evento.
+    [Fact(DisplayName =
+        "V8 — cascading entrega ProcessoPublicadoEvent ao handler local PG após Publicar+SaveChanges")]
+    public async Task V8_Cascading_EntregaEvento_AposPublicarViaCommand()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+
+        using HttpClient _ = api.CreateClient();
+
+        DomainEventCollector collector = api.Services.GetRequiredService<DomainEventCollector>();
+        collector.Clear();
+
+        Guid processoId;
+        Guid documentoId;
+        await using (AsyncServiceScope seedScope = api.Services.CreateAsyncScope())
+        {
+            SelecaoDbContext seedDb = seedScope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+            (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+                .SemearAsync(seedDb, $"V8 cascading {Guid.CreateVersion7()}");
+            processoId = processo.Id;
+            documentoId = documento.Id;
+        }
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        IMessageBus bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+
+        var command = new PublicarProcessoSeletivoCommand(
+            processoId,
+            Numero: null,
+            PeriodoInscricaoInicio: DateOnly.FromDateTime(DateTime.UtcNow),
+            PeriodoInscricaoFim: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
+            DocumentoEditalId: documentoId);
+
+        await bus.InvokeAsync(command);
+
+        ProcessoPublicadoEvent? evento = await EsperarEventoAsync(collector, processoId, TimeSpan.FromSeconds(15));
+
+        evento.Should().NotBeNull(
+            "cascading messages do handler devem ser persistidas pelo PersistOrSendAsync na transação ativa e entregues pelo listener da queue PG");
+        evento!.ProcessoSeletivoId.Should().Be(processoId);
+        evento.EditalId.Should().NotBeEmpty();
+
+        bool persistido = await db.Editais.AsNoTracking()
+            .AnyAsync(e => e.Id == evento.EditalId);
+        persistido.Should().BeTrue();
+    }
+
+    // V9 — rollback: exceção pós-SaveChanges deve eliminar entidade e
+    // envelope. O retorno cascading sequer chega a ser executado (throw
+    // antes do return); a IEnvelopeTransaction faz o rollback no catch.
+    [Fact(DisplayName =
+        "V9 — rollback cascading: exceção pós-SaveChanges deixa entidade ausente e envelope sem registro")]
+    public async Task V9_RollbackCascading_DeixaEntidadeEEnvelopeAusentes()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+
+        using HttpClient _ = api.CreateClient();
+
+        DomainEventCollector collector = api.Services.GetRequiredService<DomainEventCollector>();
+        collector.Clear();
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        IMessageBus bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+
+        string nomeProcesso = $"V9 cascading rollback {Guid.CreateVersion7()}";
+        var command = new FalharAposPublicarCascadingCommand(nomeProcesso);
+
+        Func<Task> act = () => bus.InvokeAsync(command);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage(FalharAposPublicarCascadingHandler.MensagemErro);
+
+        bool entidadePersistida = await db.ProcessosSeletivos.AsNoTracking()
+            .AnyAsync(p => p.Nome == nomeProcesso);
+        entidadePersistida.Should().BeFalse(
+            "rollback da transação Wolverine + EF deve eliminar o INSERT do processo (e do edital/snapshot dependentes) — "
+            + "sem a transação ambiente, o SaveChanges já teria committado independente do throw seguinte");
+
+        // O throw acontece ANTES do `return (Result, IEnumerable<object>)` —
+        // CaptureCascadingMessages só roda em retorno normal do handler, então
+        // nenhum envelope chega a ser criado para este ProcessoPublicadoEvent
+        // por construção (não é preciso consultar wolverine_outgoing_envelopes:
+        // não há caminho de código que o escreva neste cenário). A prova
+        // observável de "nada vazou" é o coletor permanecer vazio.
+        await Task.Delay(TimeSpan.FromSeconds(3));
+        collector.Snapshot().Should().BeEmpty(
+            "sem cascading emitido pelo handler que lançou exceção, o subscritor nunca é acionado");
+    }
+
+    internal static async Task<ProcessoPublicadoEvent?> EsperarEventoAsync(
+        DomainEventCollector collector,
+        Guid processoSeletivoIdEsperado,
+        TimeSpan timeout)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + timeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ProcessoPublicadoEvent? candidato = collector.Snapshot()
+                .FirstOrDefault(e => e.ProcessoSeletivoId == processoSeletivoIdEsperado);
+
+            if (candidato is not null)
+            {
+                return candidato;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(150));
+        }
+
+        return null;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestHandlers.cs
@@ -1,0 +1,85 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Application.Abstractions;
+using Domain.Entities;
+using Domain.Events;
+using Domain.ValueObjects;
+using Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+// Handler do cenário de rollback (V9): semeia um processo conforme, publica
+// de verdade (mesma orquestração de ProcessoSeletivo.Publicar do handler
+// produtivo) e força uma exceção logo após o SaveChanges — nunca chega a
+// retornar o IEnumerable<object> de cascading. O codegen do Wolverine
+// reconhece IEnumerable<object> no retorno normal e instala
+// CaptureCascadingMessages no postprocessor; como a chain está dentro de
+// EnrollDbContextInTransaction, o throw pós-SaveChanges reverte também os
+// INSERTs já executados na mesma transação ambiente (ADR-0005).
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Handlers convencionais do Wolverine devem ser públicos.")]
+public sealed class FalharAposPublicarCascadingHandler
+{
+    public const string MensagemErro = "Cenário V9 — exceção forçada após SaveChanges no caminho cascading";
+
+    public static async Task<IEnumerable<object>> Handle(
+        FalharAposPublicarCascadingCommand command,
+        SelecaoDbContext db,
+        ISnapshotPublicacaoCanonicalizer canonicalizer,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(canonicalizer);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+            .SemearAsync(db, command.NomeProcesso)
+            .ConfigureAwait(false);
+
+        Result<DadosEdital> dadosResult = DadosEdital.Criar(
+            numero: null,
+            periodoInscricaoInicio: DateOnly.FromDateTime(DateTime.UtcNow),
+            periodoInscricaoFim: DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)),
+            documentoEditalId: documento.Id);
+
+        SnapshotCanonico canonico = canonicalizer.Canonicalizar(processo, dadosResult.Value!, documento.HashSha256!);
+
+        Result<PublicacaoResultado> publicarResult = processo.Publicar(
+            dadosResult.Value!,
+            canonico.Bytes,
+            canonico.SchemaVersion,
+            canonico.AlgoritmoHash,
+            documento.HashSha256!,
+            atorUsuarioSub: "cascading-v9-test",
+            timeProvider);
+
+        db.SnapshotsPublicacao.Add(publicarResult.Value!.Snapshot);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        throw new InvalidOperationException(MensagemErro);
+    }
+}
+
+// Subscritor in-memory de ProcessoPublicadoEvent — drena pela queue PG
+// "domain-events" registrada na configuração produtiva e grava no coletor.
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Handlers convencionais do Wolverine devem ser públicos.")]
+public sealed class ProcessoPublicadoSubscriberHandler
+{
+    public static void Handle(
+        ProcessoPublicadoEvent @event,
+        DomainEventCollector collector)
+    {
+        ArgumentNullException.ThrowIfNull(@event);
+        ArgumentNullException.ThrowIfNull(collector);
+
+        collector.Record(@event);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestMessages.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/CascadingTestMessages.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Comando de teste exclusivo do cenário V9 (rollback cascading) — publica um
+/// processo recém-semeado e força uma exceção logo após o
+/// <c>SaveChanges</c>, simulando falha pós-persistência. Reusa a orquestração
+/// real de <c>ProcessoSeletivo.Publicar</c> (não um agregado de brinquedo).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Mensagens descobertas pela convenção do Wolverine precisam ser públicas.")]
+public sealed record FalharAposPublicarCascadingCommand(string NomeProcesso);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DomainEventCollector.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DomainEventCollector.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+using Domain.Events;
+
+/// <summary>
+/// Coletor in-memory de <see cref="ProcessoPublicadoEvent"/> usado pelos
+/// testes de outbox cascading (ADR-0005, Story #759 T4 #785) para verificar
+/// que o handler subscritor recebeu o evento drenado pela configuração
+/// produtiva (PG queue → listener no mesmo host).
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "Singleton resolvido via DI nos handlers convencionais do Wolverine; precisa ser público.")]
+public sealed class DomainEventCollector
+{
+    private readonly ConcurrentQueue<ProcessoPublicadoEvent> _eventos = new();
+
+    public void Record(ProcessoPublicadoEvent @event) => _eventos.Enqueue(@event);
+
+    public IReadOnlyCollection<ProcessoPublicadoEvent> Snapshot() => [.. _eventos];
+
+    public void Clear()
+    {
+        while (_eventos.TryDequeue(out _))
+        {
+            // Drena a fila — usar Clear não é threadsafe contra Enqueue concorrente.
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/ProcessoSeletivoPublicavelSeeder.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/ProcessoSeletivoPublicavelSeeder.cs
@@ -1,0 +1,104 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using AwesomeAssertions;
+
+using Domain.Entities;
+using Domain.Enums;
+using Domain.ValueObjects;
+using Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// Monta e persiste um <see cref="ProcessoSeletivo"/> minimamente conforme
+/// (CA-07: etapas, oferta de atendimento, distribuição de vagas,
+/// classificação) mais um <see cref="DocumentoEdital"/> já confirmado — o
+/// par exigido por <c>PublicarProcessoSeletivoCommand</c> para publicar com
+/// sucesso. Reusado pelos cenários de cascading (V8/V9) e pelos testes de
+/// endpoint HTTP — todos exercitam a publicação real, não um agregado de
+/// brinquedo (diferente do precedente <c>Edital</c>, cujo <c>Criar/Publicar</c>
+/// trivial não existe mais no modelo atual).
+/// </summary>
+internal static class ProcessoSeletivoPublicavelSeeder
+{
+    // 64 caracteres hex minúsculos — shape de SHA-256 exigido por
+    // HashCanonicalComputer.IsValidHashShape; valor arbitrário (não é
+    // recomputado, só precisa satisfazer o formato).
+    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+
+    public static async Task<(ProcessoSeletivo Processo, DocumentoEdital Documento)> SemearAsync(
+        SelecaoDbContext db,
+        string nome)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentException.ThrowIfNullOrWhiteSpace(nome);
+
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar(nome, TipoProcesso.SiSU);
+
+        Result etapasResult = processo.DefinirEtapas([
+            EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, notaMinima: null, ordem: 1),
+        ]);
+        etapasResult.IsSuccess.Should().BeTrue(etapasResult.Error?.Message);
+
+        Result ofertaResult = processo.DefinirOfertaAtendimento(
+            OfertaAtendimentoEspecializado.Criar([], [], []).Value!);
+        ofertaResult.IsSuccess.Should().BeTrue(ofertaResult.Error?.Message);
+
+        ReferenciaRegra regraDistribuicao = ReferenciaRegra.Criar(
+            RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!;
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(),
+            codigo: "AC",
+            descricao: "Ampla concorrência",
+            naturezaLegal: NaturezaLegalModalidade.Ampla,
+            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null,
+            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null,
+            remanejamentoPar: null,
+            remanejamentoFallback: null,
+            criteriosCumulativos: [],
+            acaoQuandoIndeferido: null,
+            baseLegal: "Res. Unifesspa 532/2021").Value!;
+        Result<ConfiguracaoDistribuicaoVagas> distribuicaoResult = ConfiguracaoDistribuicaoVagas.Criar(
+            ofertaCursoOrigemId: Guid.CreateVersion7(),
+            voBase: 40,
+            pr: 1m,
+            regraDistribuicao: regraDistribuicao,
+            referenciaDemografica: null,
+            modalidades: [modalidade]);
+        distribuicaoResult.IsSuccess.Should().BeTrue(distribuicaoResult.Error?.Message);
+        Result distribuicaoDefinirResult = processo.DefinirDistribuicaoVagas([distribuicaoResult.Value!]);
+        distribuicaoDefinirResult.IsSuccess.Should().BeTrue(distribuicaoDefinirResult.Error?.Message);
+
+        ReferenciaRegra regraCalculo = ReferenciaRegra.Criar(
+            RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!;
+        ReferenciaRegra regraOrdemAlocacao = ReferenciaRegra.Criar(
+            RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!;
+        Result<ConfiguracaoClassificacao> classificacaoResult = ConfiguracaoClassificacao.Criar(
+            regraCalculo: regraCalculo,
+            regraArredondamento: null,
+            casasArredondamento: null,
+            regraOrdemAlocacao: regraOrdemAlocacao,
+            nOpcoesAlocacao: 1,
+            regrasEliminacao: []);
+        classificacaoResult.IsSuccess.Should().BeTrue(classificacaoResult.Error?.Message);
+        Result classificacaoDefinirResult = processo.DefinirClassificacao(classificacaoResult.Value!);
+        classificacaoDefinirResult.IsSuccess.Should().BeTrue(classificacaoDefinirResult.Error?.Message);
+
+        await db.ProcessosSeletivos.AddAsync(processo);
+
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processo.Id, TimeProvider.System, TimeSpan.FromMinutes(15));
+        Result confirmarResult = documento.Confirmar(1024, HashFixo, TimeProvider.System);
+        confirmarResult.IsSuccess.Should().BeTrue(confirmarResult.Error?.Message);
+        await db.DocumentosEdital.AddAsync(documento);
+
+        await db.SaveChangesAsync();
+
+        // A seed bypassa o handler produtivo — drena eventos residuais (não
+        // deveria haver nenhum, já que Criar/Definir* não emitem, mas evita
+        // vazamento silencioso se essa invariante mudar no futuro).
+        processo.DequeueDomainEvents();
+
+        return (processo, documento);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicacaoConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicacaoConcorrenciaTests.cs
@@ -1,0 +1,135 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Text.Json.Nodes;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Wolverine;
+
+using Application.Commands.ProcessosSeletivos;
+using Domain.Entities;
+using Domain.Enums;
+using Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// Cobertura de concorrência (revisão do PR #791, achado P1): dois handlers
+/// que carregam o MESMO processo via <c>ObterComConfiguracaoAsync</c> — um
+/// <c>DefinirEtapas</c> e um <c>Publicar</c> — não podem produzir um estado
+/// em que o processo está Publicado mas o snapshot congelado diverge da
+/// configuração viva. O lock pessimista (<c>SELECT ... FOR UPDATE</c> em
+/// <c>ProcessoSeletivoRepository.ObterComConfiguracaoAsync</c>) serializa os
+/// dois handlers — a ordem de conclusão não é determinística, mas o
+/// resultado final sempre é consistente numa das duas formas válidas.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+public sealed class PublicacaoConcorrenciaTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public PublicacaoConcorrenciaTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName =
+        "DefinirEtapas concorrente com Publicar nunca deixa snapshot desatualizado com processo publicado (RN08/CA-04)")]
+    public async Task DefinirEtapasConcorrenteComPublicar_NuncaDeixaEstadoInconsistente()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient _ = api.CreateClient();
+
+        Guid processoId;
+        Guid documentoId;
+        await using (AsyncServiceScope seedScope = api.Services.CreateAsyncScope())
+        {
+            SelecaoDbContext seedDb = seedScope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+            (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+                .SemearAsync(seedDb, $"Concorrência {Guid.CreateVersion7()}");
+            processoId = processo.Id;
+            documentoId = documento.Id;
+        }
+
+        var definirEtapasCommand = new DefinirEtapasCommand(
+            processoId,
+            [new EtapaProcessoInput("Prova Discursiva (revisada)", CaraterEtapa.Classificatoria, Peso: 1m, NotaMinima: null, Ordem: 1)]);
+        var publicarCommand = new PublicarProcessoSeletivoCommand(
+            processoId,
+            Numero: null,
+            PeriodoInscricaoInicio: new DateOnly(2026, 1, 1),
+            PeriodoInscricaoFim: new DateOnly(2026, 1, 31),
+            DocumentoEditalId: documentoId);
+
+        // Cada lado da corrida usa seu próprio scope/IMessageBus — os dois
+        // scopes só são descartados no fim do método (após ambas as tasks
+        // serem aguardadas), sem indireção via helper genérico que faça o
+        // analisador CA2025 perder o rastro do ciclo de vida do
+        // IAsyncDisposable em relação à Task que ele origina.
+        await using AsyncServiceScope definirEtapasScope = api.Services.CreateAsyncScope();
+        await using AsyncServiceScope publicarScope = api.Services.CreateAsyncScope();
+        IMessageBus definirEtapasBus = definirEtapasScope.ServiceProvider.GetRequiredService<IMessageBus>();
+        IMessageBus publicarBus = publicarScope.ServiceProvider.GetRequiredService<IMessageBus>();
+
+        Task<Result> definirEtapasTask = definirEtapasBus.InvokeAsync<Result>(definirEtapasCommand);
+        Task<Result> publicarTask = publicarBus.InvokeAsync<Result>(publicarCommand);
+
+        await Task.WhenAll(definirEtapasTask, publicarTask);
+
+        Result definirEtapasResultado = await definirEtapasTask;
+        Result publicarResultado = await publicarTask;
+
+        await using AsyncServiceScope readScope = api.Services.CreateAsyncScope();
+        SelecaoDbContext readDb = readScope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        ProcessoSeletivo processoFinal = await readDb.ProcessosSeletivos
+            .AsNoTracking()
+            .Include(p => p.Etapas)
+            .FirstAsync(p => p.Id == processoId);
+
+        if (definirEtapasResultado.IsFailure)
+        {
+            // Publicar venceu a corrida: DefinirEtapas viu Status=Publicado
+            // (só possível porque o lock forçou seu load a esperar o commit
+            // da publicação) e foi bloqueado — nunca uma mutação stale.
+            definirEtapasResultado.HasErrorCode("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada").Should().BeTrue();
+            publicarResultado.IsSuccess.Should().BeTrue(publicarResultado.Error?.Message);
+            processoFinal.Status.Should().Be(StatusProcesso.Publicado);
+            processoFinal.Etapas.Should().ContainSingle(e => e.Nome == "Prova Objetiva",
+                "a etapa original semeada — DefinirEtapas nunca commitou");
+        }
+        else
+        {
+            // DefinirEtapas venceu a corrida (rodou e commitou antes do lock
+            // de Publicar): Publicar, ao carregar DEPOIS, vê a config nova e
+            // o snapshot já nasce consistente com ela — sem publicação com
+            // dado desatualizado.
+            processoFinal.Etapas.Should().ContainSingle(e => e.Nome == "Prova Discursiva (revisada)");
+            publicarResultado.IsSuccess.Should().BeTrue(publicarResultado.Error?.Message);
+            processoFinal.Status.Should().Be(StatusProcesso.Publicado);
+
+            // Filtra pelo Edital DESTE processo — sob carga de suíte
+            // completa, outros testes do mesmo Collection publicam seus
+            // próprios processos em paralelo (com a etapa padrão do
+            // seeder, "Prova Objetiva"); um FirstAsync() sem filtro pega o
+            // snapshot de QUALQUER um deles, não necessariamente o desta
+            // execução (achado ao investigar flake sob `dotnet test` da
+            // suíte inteira).
+            Guid editalId = await readDb.Editais
+                .AsNoTracking()
+                .Where(e => e.ProcessoSeletivoId == processoId)
+                .Select(e => e.Id)
+                .SingleAsync();
+            SnapshotPublicacao snapshot = await readDb.SnapshotsPublicacao
+                .AsNoTracking()
+                .SingleAsync(s => s.EditalId == editalId);
+            JsonNode configuracao = JsonNode.Parse(snapshot.ConfiguracaoCongelada)!;
+            JsonArray etapasNoSnapshot = configuracao["etapas"]!.AsArray();
+            etapasNoSnapshot.Should().ContainSingle();
+            etapasNoSnapshot[0]!["nome"]!.GetValue<string>().Should().Be(
+                "Prova Discursiva (revisada)",
+                "o snapshot deve refletir a configuração vigente no momento em que Publicar efetivamente carregou o agregado, nunca uma versão anterior");
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarProcessoSeletivoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarProcessoSeletivoEndpointTests.cs
@@ -1,0 +1,278 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Events;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+// Cenário fim-a-fim do fluxo de referência ADR-0005 (Story #759, T4 #785):
+// HTTP request → PublicarProcessoSeletivoCommand → handler convention-based
+// produtivo → ProcessoSeletivo.Publicar() emite ProcessoPublicadoEvent via
+// AddDomainEvent → handler retorna (Result, IEnumerable<object>) com o
+// evento drenado por DequeueDomainEvents().Cast<object>() →
+// CaptureCascadingMessages persiste envelope na MESMA transação do
+// SaveChanges → listener da queue PG entrega ao subscritor
+// (ProcessoPublicadoSubscriberHandler do teste, que registra no coletor; o
+// ProcessoPublicadoEventHandler produtivo também é invocado pela fan-out,
+// executa logging estruturado e não interfere no estado do coletor).
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+[Trait("Category", "OutboxCascading")]
+public sealed class PublicarProcessoSeletivoEndpointTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public PublicarProcessoSeletivoEndpointTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao dispara cascading e entrega ProcessoPublicadoEvent ao subscritor")]
+    public async Task Publicar_FluxoCompleto_DispatchaCascadingMessages()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        DomainEventCollector collector = api.Services.GetRequiredService<DomainEventCollector>();
+        collector.Clear();
+
+        (Guid processoId, Guid documentoId) = await SemearAsync(api, nameof(Publicar_FluxoCompleto_DispatchaCascadingMessages));
+
+        HttpResponseMessage response = await PostPublicarAsync(client, processoId, documentoId, MakeIdempotencyKey());
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        ProcessoPublicadoEvent? evento = await CascadingScenariosTests.EsperarEventoAsync(
+            collector, processoId, TimeSpan.FromSeconds(15));
+
+        evento.Should().NotBeNull(
+            "o handler produtivo retorna o evento via cascading; o listener PG entrega ao subscritor de teste");
+        evento!.ProcessoSeletivoId.Should().Be(processoId);
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        ProcessoSeletivo? persistido = await db.ProcessosSeletivos.AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == processoId);
+        persistido.Should().NotBeNull();
+        persistido!.Status.Should().Be(StatusProcesso.Publicado);
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao retorna 404 quando o processo não existe")]
+    public async Task Publicar_QuandoProcessoNaoExiste_Retorna404()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        Guid inexistente = Guid.CreateVersion7();
+
+        HttpResponseMessage response = await PostPublicarAsync(client, inexistente, Guid.CreateVersion7(), MakeIdempotencyKey());
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.selecao.processo_seletivo.nao_encontrado");
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao com keys diferentes — segunda chamada retorna 422 TransicaoInvalida")]
+    public async Task Publicar_QuandoJaPublicado_Retorna422()
+    {
+        // Cliente com keys distintas força handler a executar duas vezes;
+        // segunda execução vê processo já publicado e retorna 422 (regra de
+        // domínio, não idempotência do middleware Idempotency-Key).
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        (Guid processoId, Guid documentoId) = await SemearAsync(api, nameof(Publicar_QuandoJaPublicado_Retorna422));
+
+        HttpResponseMessage primeira = await PostPublicarAsync(client, processoId, documentoId, MakeIdempotencyKey());
+        primeira.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage segunda = await PostPublicarAsync(client, processoId, documentoId, MakeIdempotencyKey());
+        segunda.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        using JsonDocument doc = JsonDocument.Parse(await segunda.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.selecao.processo_seletivo.transicao_invalida");
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao com mesma Idempotency-Key — replay verbatim com Idempotency-Replayed: true")]
+    public async Task Publicar_MesmaKey_ReplayVerbatim()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        (Guid processoId, Guid documentoId) = await SemearAsync(api, nameof(Publicar_MesmaKey_ReplayVerbatim));
+        string key = MakeIdempotencyKey();
+
+        HttpResponseMessage primeira = await PostPublicarAsync(client, processoId, documentoId, key);
+        primeira.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        primeira.Headers.Contains("Idempotency-Replayed").Should().BeFalse();
+
+        HttpResponseMessage segunda = await PostPublicarAsync(client, processoId, documentoId, key);
+        segunda.StatusCode.Should().Be(HttpStatusCode.NoContent,
+            "mesma key + mesmo body → handler NÃO roda; cache replay verbatim");
+        segunda.Headers.Contains("Idempotency-Replayed").Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao sem Idempotency-Key retorna 400 uniplus.idempotency.key_ausente")]
+    public async Task Publicar_SemKey_Retorna400()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{Guid.CreateVersion7()}/publicacao", UriKind.Relative))
+        {
+            Content = JsonContent.Create(NovoCorpoPublicacao(Guid.CreateVersion7())),
+        };
+        AppendTestAuth(request);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.idempotency.key_ausente");
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao com Idempotency-Key malformada retorna 400 uniplus.idempotency.key_malformada")]
+    public async Task Publicar_KeyMalformada_Retorna400()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{Guid.CreateVersion7()}/publicacao", UriKind.Relative))
+        {
+            Content = JsonContent.Create(NovoCorpoPublicacao(Guid.CreateVersion7())),
+        };
+        AppendTestAuth(request);
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", "invalid key with spaces");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.idempotency.key_malformada");
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao anonymous com Idempotency-Key retorna 401")]
+    public async Task Publicar_Anonymous_Retorna401()
+    {
+        // Endpoint marcado com [RequiresIdempotencyKey] exige principal —
+        // sem auth, filter rejeita para evitar cache poisoning entre clientes.
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{Guid.CreateVersion7()}/publicacao", UriKind.Relative))
+        {
+            Content = JsonContent.Create(NovoCorpoPublicacao(Guid.CreateVersion7())),
+        };
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+        // Sem AppendTestAuth — request anonymous deliberada.
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao com mesma Idempotency-Key e body diferente retorna 422 uniplus.idempotency.body_mismatch")]
+    public async Task Publicar_MesmaKeyBodyDiferente_Retorna422BodyMismatch()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        (Guid processoId, Guid documentoId) = await SemearAsync(api, nameof(Publicar_MesmaKeyBodyDiferente_Retorna422BodyMismatch));
+        string key = MakeIdempotencyKey();
+
+        using HttpRequestMessage primeiraReq = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{processoId}/publicacao", UriKind.Relative))
+        {
+            Content = JsonContent.Create(NovoCorpoPublicacao(documentoId, numero: "001/2026")),
+        };
+        AppendTestAuth(primeiraReq);
+        primeiraReq.Headers.TryAddWithoutValidation("Idempotency-Key", key);
+        HttpResponseMessage primeira = await client.SendAsync(primeiraReq);
+        primeira.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using HttpRequestMessage segundaReq = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{processoId}/publicacao", UriKind.Relative))
+        {
+            Content = JsonContent.Create(NovoCorpoPublicacao(documentoId, numero: "002/2026")),
+        };
+        AppendTestAuth(segundaReq);
+        segundaReq.Headers.TryAddWithoutValidation("Idempotency-Key", key);
+        HttpResponseMessage segunda = await client.SendAsync(segundaReq);
+
+        segunda.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        using JsonDocument doc = JsonDocument.Parse(await segunda.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.idempotency.body_mismatch");
+    }
+
+    private static object NovoCorpoPublicacao(Guid documentoEditalId, string? numero = null) => new
+    {
+        numero,
+        periodoInscricaoInicio = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        periodoInscricaoFim = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        documentoEditalId,
+    };
+
+    private static async Task<HttpResponseMessage> PostPublicarAsync(
+        HttpClient client, Guid processoId, Guid documentoEditalId, string idempotencyKey)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{processoId}/publicacao", UriKind.Relative))
+        {
+            Content = JsonContent.Create(NovoCorpoPublicacao(documentoEditalId)),
+        };
+        AppendTestAuth(request);
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+        return await client.SendAsync(request).ConfigureAwait(false);
+    }
+
+    private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
+
+    /// <summary>
+    /// Adiciona Authorization Bearer + role plataforma-admin ao request —
+    /// exigida por [Authorize(Roles = "plataforma-admin")] no controller.
+    /// </summary>
+    private static void AppendTestAuth(HttpRequestMessage request)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme, TestAuthHandler.TokenValue);
+        request.Headers.TryAddWithoutValidation(TestAuthHandler.RolesHeader, "plataforma-admin");
+    }
+
+    private static async Task<(Guid ProcessoId, Guid DocumentoId)> SemearAsync(CascadingApiFactory api, string nome)
+    {
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+
+        (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+            .SemearAsync(db, $"{nome} {Guid.CreateVersion7()}");
+
+        return (processo.Id, documento.Id);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/PublicacaoSnapshotPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/PublicacaoSnapshotPersistenciaTests.cs
@@ -1,0 +1,186 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ProcessosSeletivos;
+
+using System.Text.Json.Nodes;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Cobertura de integração (Postgres real via Testcontainers) do
+/// congelamento do snapshot de publicação (RN08, ADR-0100, Story #759 T4
+/// #785). Mapa de testes de #759: <c>Snapshot_HashConfereAppEBanco</c>
+/// (re-hashear os bytes lidos de volta do banco bate com o hash persistido
+/// pela app) e <c>Snapshot_ContemBlocosCanonicos</c> (os 17 blocos — 11
+/// reais + 6 stubs <c>nao_construido</c> — estão presentes).
+/// </summary>
+public sealed class PublicacaoSnapshotPersistenciaTests : IClassFixture<ProcessoSeletivoDbFixture>
+{
+    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+    private static readonly SnapshotPublicacaoCanonicalizer Canonicalizer = new();
+
+    private readonly ProcessoSeletivoDbFixture _fixture;
+
+    public PublicacaoSnapshotPersistenciaTests(ProcessoSeletivoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static ReferenciaRegra Regra(string codigo, string hashChar) =>
+        ReferenciaRegra.Criar(codigo, "v1", new string(hashChar[0], 64)).Value!;
+
+    private static ProcessoSeletivo NovoProcessoConforme(string nome)
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar(nome, TipoProcesso.SiSU);
+
+        processo.DefinirEtapas([
+            EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1),
+        ]).IsSuccess.Should().BeTrue();
+
+        processo.DefinirOfertaAtendimento(
+            OfertaAtendimentoEspecializado.Criar([], [], []).Value!).IsSuccess.Should().BeTrue();
+
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(),
+            codigo: "AC",
+            descricao: null,
+            naturezaLegal: NaturezaLegalModalidade.Ampla,
+            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null,
+            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null,
+            remanejamentoPar: null,
+            remanejamentoFallback: null,
+            criteriosCumulativos: [],
+            acaoQuandoIndeferido: null,
+            baseLegal: "Res. Unifesspa 532/2021").Value!;
+        ConfiguracaoDistribuicaoVagas distribuicao = ConfiguracaoDistribuicaoVagas.Criar(
+            ofertaCursoOrigemId: Guid.CreateVersion7(),
+            voBase: 40,
+            pr: 1m,
+            regraDistribuicao: Regra(RegraDistribuicaoVagasCodigo.Institucional, "a"),
+            referenciaDemografica: null,
+            modalidades: [modalidade]).Value!;
+        processo.DefinirDistribuicaoVagas([distribuicao]).IsSuccess.Should().BeTrue();
+
+        ConfiguracaoClassificacao classificacao = ConfiguracaoClassificacao.Criar(
+            regraCalculo: Regra(RegraCalculoCodigo.ClassificacaoImportada, "b"),
+            regraArredondamento: null,
+            casasArredondamento: null,
+            regraOrdemAlocacao: Regra(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "c"),
+            nOpcoesAlocacao: 1,
+            regrasEliminacao: []).Value!;
+        processo.DefinirClassificacao(classificacao).IsSuccess.Should().BeTrue();
+
+        return processo;
+    }
+
+    private async Task<(Guid ProcessoId, Guid EditalId, Guid SnapshotId)> PublicarAsync(string nome)
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme(nome);
+
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processo.Id, TimeProvider.System, TimeSpan.FromMinutes(15));
+        Result confirmarResult = documento.Confirmar(1024, HashFixo, TimeProvider.System);
+        confirmarResult.IsSuccess.Should().BeTrue();
+
+        Result<DadosEdital> dadosResult = DadosEdital.Criar(
+            numero: "001/2026",
+            periodoInscricaoInicio: new DateOnly(2026, 1, 1),
+            periodoInscricaoFim: new DateOnly(2026, 1, 31),
+            documentoEditalId: documento.Id);
+        dadosResult.IsSuccess.Should().BeTrue();
+
+        SnapshotCanonico canonico = Canonicalizer.Canonicalizar(processo, dadosResult.Value!, documento.HashSha256!);
+
+        Result<PublicacaoResultado> publicarResult = processo.Publicar(
+            dadosResult.Value!,
+            canonico.Bytes,
+            canonico.SchemaVersion,
+            canonico.AlgoritmoHash,
+            documento.HashSha256!,
+            atorUsuarioSub: "integration-test-user",
+            TimeProvider.System);
+        publicarResult.IsSuccess.Should().BeTrue(publicarResult.Error?.Message);
+
+        await using SelecaoDbContext writeContext = _fixture.CreateDbContext();
+        ProcessoSeletivoRepository repository = new(writeContext, TimeProvider.System);
+        await repository.AdicionarAsync(processo, CancellationToken.None);
+        await writeContext.DocumentosEdital.AddAsync(documento, CancellationToken.None);
+        await repository.AdicionarSnapshotPublicacaoAsync(publicarResult.Value!.Snapshot, CancellationToken.None);
+        await writeContext.SaveChangesAsync(CancellationToken.None);
+
+        return (processo.Id, publicarResult.Value!.Edital.Id, publicarResult.Value!.Snapshot.Id);
+    }
+
+    [Fact(DisplayName = "Snapshot_HashConfereAppEBanco — re-hashear os bytes lidos do banco bate com o hash persistido pela app")]
+    public async Task Snapshot_HashConfereAppEBanco()
+    {
+        (_, _, Guid snapshotId) = await PublicarAsync(nameof(Snapshot_HashConfereAppEBanco));
+
+        await using SelecaoDbContext readContext = _fixture.CreateDbContext();
+        SnapshotPublicacao snapshot = await readContext.SnapshotsPublicacao
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == snapshotId, CancellationToken.None);
+
+        string hashRecalculado = HashCanonicalComputer.ComputeSha256Hex(snapshot.ConfiguracaoCongeladaCanonica);
+
+        hashRecalculado.Should().Be(snapshot.HashConfiguracao,
+            "ADR-0100 §Confirmação: re-hashear os bytes persistidos deve bater com o hash calculado pela aplicação na publicação");
+    }
+
+    [Fact(DisplayName = "Snapshot_ContemBlocosCanonicos — os 17 blocos (11 reais + 6 stubs) estão presentes")]
+    public async Task Snapshot_ContemBlocosCanonicos()
+    {
+        (_, _, Guid snapshotId) = await PublicarAsync(nameof(Snapshot_ContemBlocosCanonicos));
+
+        await using SelecaoDbContext readContext = _fixture.CreateDbContext();
+        SnapshotPublicacao snapshot = await readContext.SnapshotsPublicacao
+            .AsNoTracking()
+            .FirstAsync(s => s.Id == snapshotId, CancellationToken.None);
+
+        JsonNode payload = JsonNode.Parse(snapshot.ConfiguracaoCongelada)!;
+
+        string[] blocosEsperados =
+        [
+            "periodo", "etapas", "vagas", "distribuicao", "modalidades", "ofertas",
+            "atendimento", "bonusRegional", "criteriosDesempate", "classificacao", "hashesEdital",
+            "documentosExigidos", "formulario", "cascataRemanejamento", "divulgacao",
+            "cronogramaFases", "identidadesUnidade",
+        ];
+        blocosEsperados.Should().HaveCount(17, "pré-condição do próprio teste — ADR-0100 define 17 blocos canônicos");
+
+        JsonObject objeto = payload.AsObject();
+        foreach (string bloco in blocosEsperados)
+        {
+            objeto.Should().ContainKey(bloco, $"o bloco canônico '{bloco}' deve estar presente no snapshot");
+        }
+
+        string[] stubsNaoConstruidos =
+        [
+            "documentosExigidos", "formulario", "cascataRemanejamento",
+            "divulgacao", "cronogramaFases", "identidadesUnidade",
+        ];
+        foreach (string stub in stubsNaoConstruidos)
+        {
+            objeto[stub]!["status"]!.GetValue<string>().Should().Be("nao_construido",
+                $"dimensão '{stub}' ainda não implementada — ADR-0100 item 10");
+        }
+
+        // Bloco "vagas" também é stub nesta fatia — o motor de cálculo de
+        // vagas ainda não existe (ver comentário do SnapshotPublicacaoCanonicalizer).
+        objeto["vagas"]!["status"]!.GetValue<string>().Should().Be("nao_construido");
+
+        // Blocos reais carregam dado de negócio, não o marcador de stub.
+        objeto["etapas"]!.AsArray().Should().NotBeEmpty();
+        objeto["bonusRegional"]!["presente"]!.GetValue<bool>().Should().BeFalse();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -1423,6 +1423,7 @@
           "Serilog.AspNetCore": "[10.0.0, )",
           "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
@@ -1447,6 +1448,8 @@
       "unifesspa.uniplus.selecao.infrastructure": {
         "type": "Project",
         "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.9, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",


### PR DESCRIPTION
## Resumo

Núcleo do arco de publicação do Processo Seletivo (Story #759): valida a conformidade estrutural, congela a configuração num `SnapshotPublicacao` append-only (ADR-0100) e transita o status para Publicado — tudo numa única transação. Sub-issue de #759; depende de T1 (#782), T2 (#783) e T3 (#784), todas já mergeadas.

Closes #785
Refs #759

## Escopo

- **`Edital`** — entidade interna ao agregado `ProcessoSeletivo` (natureza `Abertura` nesta task; `Retificacao` é T5/#786). Sem CRUD/repositório/controller próprios — emitida só por `ProcessoSeletivo.Publicar`.
- **`SnapshotPublicacao`** — `IForensicEntity` append-only (ADR-0063). `Congelar` deriva `HashConfiguracao`/`ConfiguracaoCongelada` dos bytes canônicos internamente (nunca aceita como parâmetros independentes) e segue o precedente de `ObrigatoriedadeLegalHistorico.Snapshot`: lança `ArgumentException` para violação de invariante, não `Result.Failure` — as checagens são defesa em profundidade contra erro de programação, inalcançáveis a partir de input do usuário.
- **`HashCanonicalComputer`** estendido (ADR-0100): normalização NFC, decimais com escala declarada + arredondamento half-even, instantes RFC 3339 UTC sem fração, e produção dos bytes canônicos persistidos como base do hash.
- **Serializador dos 17 blocos canônicos** (`ISnapshotPublicacaoCanonicalizer`, porta em Application/implementação em Infrastructure): 11 blocos reais + 6 stubs `{"status":"nao_construido"}` para dimensões que a Feature #40 ainda não implementa.
- **`ProcessoSeletivo.Publicar`**: gate de conformidade (reaproveita `AvaliarConformidade()`, extraída para eliminar duas fontes de verdade do checklist entre `Publicar` e a leitura pública `GET /conformidade`), transição `Rascunho→Publicado` atômica com o congelamento, recusa transição inválida (publicar já publicado).
- **Bloqueio de mutação pós-publicação** (CA-04): todo `Definir*` recusa com 422 quando o processo já está publicado.
- **Endpoint** `POST /api/selecao/processos-seletivos/{id}/publicacao` — idempotente, HATEOAS consistente com o resto do controller. 422 de conformidade insuficiente carrega `Extensions["pendencias"]`.
- **`ProcessoPublicadoEvent` → Kafka** — novo slice canônico do ADR-0005/ADR-0041 (cascading messages), recriando sobre `ProcessoSeletivo` a demonstração que existia sobre o agregado `Edital` legado (removido em #782): tópico `processo_seletivo_events`, schema Avro `ProcessoPublicado`.
- **Migration** `editais` + `snapshot_publicacao`, com dois índices únicos parciais (ADR-0102): unicidade de `data_publicacao` por processo (CA-08) e abertura única por processo (fecha corrida de publicações concorrentes).
- **Sentinela de CI** `Category=OutboxCascading` restaurado (`MIN_TESTS=0` → `10`, zerado desde #782).
- **Documentação re-ancorada**: `CONTRIBUTING.md`, `docs/guia-wolverine-golden-path.md`, `docs/guia-apicurio-schema-registry.md`, `docs/guia-commits-e-integracao.md` — exemplos trocados do slice `Edital` legado para `ProcessoSeletivo`.

## Decisões registradas no diff (não em ADR novo)

- Tradução de violação de constraint (ADR-0102) segue o padrão já estabelecido no módulo (`UniqueConstraintViolation.cs`, reflection sobre o tipo da exceção, sem `Microsoft.EntityFrameworkCore` em Application) em vez de mover para dentro do repositório — a tradução ocorre no ponto exato em que Application invoca o boundary de persistência (`SalvarAlteracoesAsync`), o que já satisfaz "boundary de persistência" do ADR.
- "Retificação não cruza processos" (ADR-0101) não tem estado exercitável nesta task — `EditalRetificadoId`/`MotivoRetificacao` são sempre nulos até T5/#786 introduzir `EmitirRetificacao`.
- Bloco canônico "vagas" serializa como stub `nao_construido`: o modelo atual não tem motor de cálculo de vagas — `ConfiguracaoDistribuicaoVagas` já é o conjunto de inputs, o `QuadroDeVagas` é output derivado futuro.

## Critérios de aceite de #759 endereçados

- [x] CA-01/CA-02 — publicar congela snapshot com os blocos canônicos + transita status, mesma transação
- [x] CA-03 — publicação recusada com checklist de pendências quando falta parâmetro obrigatório
- [x] CA-04 — mutação de conteúdo congelável pós-publicação bloqueada com 422
- [x] CA-07 — hash reproduzível sobre os bytes canônicos persistidos; qualquer mudança de valor muda o hash
- [x] CA-09 — transição inválida (publicar já publicado) recusada
- [ ] CA-05/CA-06 — retificação (T5, #786 — fora de escopo desta task)
- [ ] CA-08 — seletor de snapshot vigente por instante (T6, #787 — este PR só garante a unicidade de `data_publicacao` que o seletor vai consumir)

## Validação local

- `dotnet build UniPlus.slnx` — 0 erros, 0 warnings
- `Selecao.Domain.UnitTests` (156), `Selecao.Application.UnitTests` (84), `Selecao.ArchTests` (6), `Unifesspa.UniPlus.ArchTests` (17), `Host.IntegrationTests` (21) — todos verdes
- `Selecao.IntegrationTests` — 108/109 na primeira rodada (falha esperada = baseline OpenAPI desatualizada, regenerada em seguida); suíte completa + `Category=OutboxCascading` (10/10) verdes após
- `dotnet restore --locked-mode` — OK (locks regenerados via `--force-evaluate` ao reintroduzir `WolverineFx.Kafka`/`Apache.Avro`/`Confluent.SchemaRegistry.Serdes.Avro`, removidos em #782)
- Baseline OpenAPI regenerada — diff só com o endpoint novo (105 linhas)
- `codex review --uncommitted` rodado antes do commit; 2 achados P2 corrigidos (validação de datas de período ausentes/zeradas e de tamanho do número do Edital)

## Testes-chave do mapa de #759

`Canonicalizacao_HashReproduzivel`, `Snapshot_HashConfereAppEBanco`, `Publicacao_AtomicaStatusESnapshot`, `Snapshot_ContemBlocosCanonicos`, `PosPublicacao_MutacaoBloqueada_422`, `Publicacao_RecusaSemParametrosObrigatorios`, `Lifecycle_TransicaoInvalidaRecusada` — todos implementados e verdes.