### PR TITLE
feat(selecao): retificação do Processo Seletivo (T5, #786)

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -3538,7 +3538,6 @@
       },
       "RetificarProcessoSeletivoRequest": {
         "required": [
-          "editalRetificadoId",
           "motivo",
           "numero",
           "periodoInscricaoInicio",
@@ -3547,10 +3546,6 @@
         ],
         "type": "object",
         "properties": {
-          "editalRetificadoId": {
-            "type": "string",
-            "format": "uuid"
-          },
           "motivo": {
             "type": "string"
           },

--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -1709,6 +1709,82 @@
         "x-uniplus-idempotent": true
       }
     },
+    "/api/selecao/processos-seletivos/{id}/retificacoes": {
+      "post": {
+        "tags": [
+          "ProcessoSeletivo"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetificarProcessoSeletivoRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetificarProcessoSeletivoRequest"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/RetificarProcessoSeletivoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
     "/api/selecao/processos-seletivos/{id}/conformidade": {
       "get": {
         "tags": [
@@ -3457,6 +3533,44 @@
               "string"
             ],
             "format": "double"
+          }
+        }
+      },
+      "RetificarProcessoSeletivoRequest": {
+        "required": [
+          "editalRetificadoId",
+          "motivo",
+          "numero",
+          "periodoInscricaoInicio",
+          "periodoInscricaoFim",
+          "documentoEditalId"
+        ],
+        "type": "object",
+        "properties": {
+          "editalRetificadoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "motivo": {
+            "type": "string"
+          },
+          "numero": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "periodoInscricaoInicio": {
+            "type": "string",
+            "format": "date"
+          },
+          "periodoInscricaoFim": {
+            "type": "string",
+            "format": "date"
+          },
+          "documentoEditalId": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -342,7 +342,6 @@ public sealed class ProcessoSeletivoController : ControllerBase
         Result resultado = await _commandBus.Send(
             new RetificarProcessoSeletivoCommand(
                 id,
-                request.EditalRetificadoId,
                 request.Motivo,
                 request.Numero,
                 request.PeriodoInscricaoInicio,
@@ -387,11 +386,12 @@ public sealed record PublicarProcessoSeletivoRequest(
     Guid DocumentoEditalId);
 
 /// <summary>
-/// Corpo de <see cref="ProcessoSeletivoController.Retificar"/> — omite
-/// <c>ProcessoSeletivoId</c> (vem da rota).
+/// Corpo de <see cref="ProcessoSeletivoController.Retificar"/> — carrega só os
+/// dados próprios da retificação. Omite <c>ProcessoSeletivoId</c> (vem da rota)
+/// e não recebe id de Edital: o Edital sucedido é o vigente, resolvido no
+/// servidor (a retificação endereça o agregado, não uma entidade interna).
 /// </summary>
 public sealed record RetificarProcessoSeletivoRequest(
-    Guid EditalRetificadoId,
     string Motivo,
     string? Numero,
     DateOnly PeriodoInscricaoInicio,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -322,6 +322,38 @@ public sealed class ProcessoSeletivoController : ControllerBase
     }
 
     /// <summary>
+    /// Retifica o processo já publicado (RN08, Story #759, T5 #786, ADR-0101):
+    /// emite um novo Edital de natureza retificação vinculado ao Edital
+    /// vigente, com motivo obrigatório, e congela um novo
+    /// <c>SnapshotPublicacao</c> — o snapshot anterior permanece imutável.
+    /// </summary>
+    [HttpPost("{id:guid}/retificacoes")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Retificar(
+        Guid id,
+        [FromBody] RetificarProcessoSeletivoRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Result resultado = await _commandBus.Send(
+            new RetificarProcessoSeletivoCommand(
+                id,
+                request.EditalRetificadoId,
+                request.Motivo,
+                request.Numero,
+                request.PeriodoInscricaoInicio,
+                request.PeriodoInscricaoFim,
+                request.DocumentoEditalId),
+            cancellationToken);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
     /// Consulta a conformidade estrutural do processo (CA-07): checklist com
     /// cada item obrigatório marcado ok/pendente, sem alterar o processo.
     /// </summary>
@@ -349,6 +381,18 @@ public sealed class ProcessoSeletivoController : ControllerBase
 /// <c>ProcessoSeletivoId</c> (vem da rota).
 /// </summary>
 public sealed record PublicarProcessoSeletivoRequest(
+    string? Numero,
+    DateOnly PeriodoInscricaoInicio,
+    DateOnly PeriodoInscricaoFim,
+    Guid DocumentoEditalId);
+
+/// <summary>
+/// Corpo de <see cref="ProcessoSeletivoController.Retificar"/> — omite
+/// <c>ProcessoSeletivoId</c> (vem da rota).
+/// </summary>
+public sealed record RetificarProcessoSeletivoRequest(
+    Guid EditalRetificadoId,
+    string Motivo,
     string? Numero,
     DateOnly PeriodoInscricaoInicio,
     DateOnly PeriodoInscricaoFim,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -153,6 +153,7 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("Edital.ContratoNaturezaInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.contrato_natureza_invalido", "Abertura não carrega edital retificado nem motivo; retificação exige ambos")),
         new("Edital.EditalRetificadoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.edital_retificado_obrigatorio", "A retificação deve referenciar o Edital anterior")),
         new("Edital.MotivoRetificacaoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.motivo_retificacao_obrigatorio", "O motivo da retificação é obrigatório")),
+        new("Edital.RetificacaoJaExiste", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.retificacao_ja_existe", "Este Edital já foi retificado — a cadeia de retificação é linear")),
         // SnapshotPublicacao.Congelar (ADR-0063): entidade forensic — guards
         // de invariante lançam ArgumentException (defesa em profundidade
         // contra erro de programação do caller, nunca alcançável a partir de

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -151,6 +151,8 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("Edital.DataPublicacaoDuplicada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.data_publicacao_duplicada", "Já existe um Edital publicado neste processo com a mesma data de publicação")),
         new("Edital.AberturaJaExiste", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.abertura_ja_existe", "Este processo já tem um Edital de abertura publicado")),
         new("Edital.ContratoNaturezaInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.contrato_natureza_invalido", "Abertura não carrega edital retificado nem motivo; retificação exige ambos")),
+        new("Edital.EditalRetificadoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.edital_retificado_obrigatorio", "A retificação deve referenciar o Edital anterior")),
+        new("Edital.MotivoRetificacaoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.edital.motivo_retificacao_obrigatorio", "O motivo da retificação é obrigatório")),
         // SnapshotPublicacao.Congelar (ADR-0063): entidade forensic — guards
         // de invariante lançam ArgumentException (defesa em profundidade
         // contra erro de programação do caller, nunca alcançável a partir de
@@ -160,6 +162,7 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.mutacao_pos_publicacao_bloqueada", "Processo publicado não aceita mutação direta da configuração")),
         new("ProcessoSeletivo.DocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_encontrado", "Documento do Edital não encontrado ou não pertence a este processo")),
         new("ProcessoSeletivo.DocumentoNaoConfirmado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_confirmado", "Somente um documento confirmado pode ser referenciado na publicação")),
+        new("ProcessoSeletivo.EditalRetificadoInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.edital_retificado_invalido", "A retificação deve referenciar o Edital vigente deste processo")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -163,7 +163,6 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.mutacao_pos_publicacao_bloqueada", "Processo publicado não aceita mutação direta da configuração")),
         new("ProcessoSeletivo.DocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_encontrado", "Documento do Edital não encontrado ou não pertence a este processo")),
         new("ProcessoSeletivo.DocumentoNaoConfirmado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_confirmado", "Somente um documento confirmado pode ser referenciado na publicação")),
-        new("ProcessoSeletivo.EditalRetificadoInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.edital_retificado_invalido", "A retificação deve referenciar o Edital vigente deste processo")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/ISnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/ISnapshotPublicacaoCanonicalizer.cs
@@ -14,14 +14,28 @@ public sealed record SnapshotCanonico(byte[] Bytes, string SchemaVersion, string
 #pragma warning restore CA1819
 
 /// <summary>
+/// Informação do ato de retificação (ADR-0101, T5 #786) acrescentada ao
+/// snapshot como um bloco adicional (<c>retificacao</c>) além dos 17 blocos
+/// canônicos. <see langword="null"/> na publicação de abertura — o snapshot
+/// de abertura mantém exatamente os 17 blocos, sem o bloco de retificação.
+/// </summary>
+public sealed record RetificacaoInfo(Guid EditalRetificadoId, string Motivo);
+
+/// <summary>
 /// Porta do serializador canônico dos 17 blocos do snapshot de publicação
 /// (ADR-0100) — implementação em Infrastructure. Projeta a configuração viva
 /// do <see cref="ProcessoSeletivo"/> num payload canônico (11 blocos reais +
 /// 6 stubs <c>{"status":"nao_construido"}</c> para dimensões ainda não
 /// implementadas), serializa e devolve os bytes que
-/// <c>SnapshotPublicacao.Congelar</c> persiste como base do hash.
+/// <c>SnapshotPublicacao.Congelar</c> persiste como base do hash. Quando
+/// <paramref name="retificacao"/> é informada (T5 #786), acrescenta o 18º
+/// bloco <c>retificacao</c> preservando os 17 anteriores intactos (ADR-0101).
 /// </summary>
 public interface ISnapshotPublicacaoCanonicalizer
 {
-    SnapshotCanonico Canonicalizar(ProcessoSeletivo processo, DadosEdital dados, string hashEdital);
+    SnapshotCanonico Canonicalizar(
+        ProcessoSeletivo processo,
+        DadosEdital dados,
+        string hashEdital,
+        RetificacaoInfo? retificacao = null);
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommand.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Kernel.Results;
+
+/// <summary>
+/// Retifica um processo já publicado (RN08, Story #759, T5 #786, ADR-0101):
+/// emite um novo Edital de natureza retificação vinculado ao Edital vigente,
+/// com motivo obrigatório, e congela um novo <c>SnapshotPublicacao</c> — o
+/// snapshot anterior permanece imutável, tudo na mesma transação. O ator
+/// (<c>IUserContext.UserId</c>) nunca é input do command — vem do contexto
+/// autenticado.
+/// </summary>
+public sealed record RetificarProcessoSeletivoCommand(
+    Guid ProcessoSeletivoId,
+    Guid EditalRetificadoId,
+    string Motivo,
+    string? Numero,
+    DateOnly PeriodoInscricaoInicio,
+    DateOnly PeriodoInscricaoFim,
+    Guid DocumentoEditalId) : ICommand<Result>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommand.cs
@@ -5,15 +5,17 @@ using Kernel.Results;
 
 /// <summary>
 /// Retifica um processo já publicado (RN08, Story #759, T5 #786, ADR-0101):
-/// emite um novo Edital de natureza retificação vinculado ao Edital vigente,
+/// emite um novo Edital de natureza retificação sucedendo o Edital vigente,
 /// com motivo obrigatório, e congela um novo <c>SnapshotPublicacao</c> — o
 /// snapshot anterior permanece imutável, tudo na mesma transação. O ator
 /// (<c>IUserContext.UserId</c>) nunca é input do command — vem do contexto
-/// autenticado.
+/// autenticado. O Edital sucedido é o vigente do próprio agregado, resolvido
+/// no servidor: como <c>Edital</c> é entidade interna do agregado
+/// <c>ProcessoSeletivo</c> e a cadeia é linear, o cliente endereça apenas a
+/// raiz (o <c>ProcessoSeletivoId</c>), nunca um id de Edital interno.
 /// </summary>
 public sealed record RetificarProcessoSeletivoCommand(
     Guid ProcessoSeletivoId,
-    Guid EditalRetificadoId,
     string Motivo,
     string? Numero,
     DateOnly PeriodoInscricaoInicio,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
@@ -1,0 +1,136 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using Abstractions;
+using Domain.Entities;
+using Domain.Interfaces;
+using Domain.ValueObjects;
+using Kernel.Results;
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+
+/// <summary>
+/// Handler convention-based do <see cref="RetificarProcessoSeletivoCommand"/>
+/// (RN08, Story #759 T5 #786, ADR-0101 + ADR-0005): carrega o agregado com a
+/// cadeia de Editais, valida o documento confirmado (T3), canonicaliza a
+/// configuração acrescida do bloco de retificação (ADR-0100/0101) e delega a
+/// orquestração de negócio a <see cref="ProcessoSeletivo.Retificar"/>.
+/// Cascading messages — o <see cref="Domain.Events.ProcessoPublicadoEvent"/>
+/// só é drenado depois do <c>SaveChanges</c> bem-sucedido.
+/// </summary>
+public static class RetificarProcessoSeletivoCommandHandler
+{
+    public static async Task<(Result Resposta, IEnumerable<object> Eventos)> Handle(
+        RetificarProcessoSeletivoCommand command,
+        IProcessoSeletivoRepository processoSeletivoRepository,
+        IDocumentoEditalRepository documentoEditalRepository,
+        ISnapshotPublicacaoCanonicalizer canonicalizer,
+        ISelecaoUnitOfWork unitOfWork,
+        IUserContext userContext,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(processoSeletivoRepository);
+        ArgumentNullException.ThrowIfNull(documentoEditalRepository);
+        ArgumentNullException.ThrowIfNull(canonicalizer);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(userContext);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        ProcessoSeletivo? processo = await processoSeletivoRepository
+            .ObterComConfiguracaoAsync(command.ProcessoSeletivoId, cancellationToken)
+            .ConfigureAwait(false);
+        if (processo is null)
+        {
+            return (Result.Failure(new DomainError(
+                "ProcessoSeletivo.NaoEncontrado",
+                $"Processo Seletivo {command.ProcessoSeletivoId} não encontrado.")), []);
+        }
+
+        DocumentoEdital? documento = await documentoEditalRepository
+            .ObterPorIdAsync(command.DocumentoEditalId, cancellationToken)
+            .ConfigureAwait(false);
+        if (documento is null || documento.ProcessoSeletivoId != command.ProcessoSeletivoId)
+        {
+            return (Result.Failure(new DomainError(
+                "ProcessoSeletivo.DocumentoNaoEncontrado",
+                $"Documento do Edital {command.DocumentoEditalId} não encontrado ou não pertence a este processo.")), []);
+        }
+
+        if (documento.Status != Domain.Enums.StatusDocumentoEdital.Confirmado)
+        {
+            return (Result.Failure(new DomainError(
+                "ProcessoSeletivo.DocumentoNaoConfirmado",
+                "Somente um documento confirmado pode ser referenciado na retificação.")), []);
+        }
+
+        Result<DadosEdital> dadosResult = DadosEdital.Criar(
+            command.Numero,
+            command.PeriodoInscricaoInicio,
+            command.PeriodoInscricaoFim,
+            command.DocumentoEditalId);
+        if (dadosResult.IsFailure)
+        {
+            return (Result.Failure(dadosResult.Error!), []);
+        }
+
+        DadosEdital dados = dadosResult.Value!;
+
+        SnapshotCanonico canonico = canonicalizer.Canonicalizar(
+            processo,
+            dados,
+            documento.HashSha256!,
+            new RetificacaoInfo(command.EditalRetificadoId, command.Motivo));
+
+        string atorUsuarioSub = userContext.UserId ?? "system";
+
+        Result<PublicacaoResultado> retificarResult = processo.Retificar(
+            dados,
+            canonico.Bytes,
+            canonico.SchemaVersion,
+            canonico.AlgoritmoHash,
+            documento.HashSha256!,
+            atorUsuarioSub,
+            command.EditalRetificadoId,
+            command.Motivo,
+            timeProvider);
+        if (retificarResult.IsFailure)
+        {
+            return (Result.Failure(retificarResult.Error!), []);
+        }
+
+        await processoSeletivoRepository
+            .AdicionarSnapshotPublicacaoAsync(retificarResult.Value!.Snapshot, cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint)
+        {
+            // Traduz violação de guard rail de banco (ADR-0102) — corrida de
+            // duas retificações concorrentes do mesmo processo, ou gap de
+            // validação em memória. Filtro do `when` garante que outras
+            // exceções não mapeadas propagam intactas.
+            if (UniqueConstraintViolation.IsDataPublicacaoDuplicada(constraint))
+            {
+                return (Result.Failure(new DomainError(
+                    "Edital.DataPublicacaoDuplicada",
+                    "Já existe um Edital publicado neste processo com a mesma data de publicação.")), []);
+            }
+
+            if (UniqueConstraintViolation.IsContratoNaturezaInvalido(constraint))
+            {
+                return (Result.Failure(new DomainError(
+                    "Edital.ContratoNaturezaInvalido",
+                    "Abertura não carrega edital retificado nem motivo; retificação exige ambos.")), []);
+            }
+
+            throw;
+        }
+
+        // ADR-0005 + ADR-0041: drenagem por cascading messages, DEPOIS do
+        // SaveChanges bem-sucedido — nunca antes (janela de perda em rollback).
+        return (Result.Success(), processo.DequeueDomainEvents().Cast<object>());
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
@@ -89,12 +89,16 @@ public static class RetificarProcessoSeletivoCommandHandler
                 $"Só é possível retificar um processo publicado — status atual: {processo.Status}.")), []);
         }
 
-        // Normaliza o motivo UMA vez, aqui, e usa o mesmo valor nos dois
-        // caminhos: o bloco 'retificacao' do snapshot e o MotivoRetificacao do
-        // Edital. Sem isso, o Edital guardaria motivo.Trim() enquanto o
-        // snapshot congelaria o motivo cru — divergência que quebra a
-        // reconciliação do snapshot congelado contra a linha do Edital.
-        string motivo = command.Motivo.Trim();
+        // Normaliza o motivo UMA vez, aqui (Trim + NFC), e usa o mesmo valor
+        // nos dois caminhos: o bloco 'retificacao' do snapshot e o
+        // MotivoRetificacao do Edital. O canonicalizer aplica NormalizeNfc ao
+        // congelar o snapshot; se o Edital guardasse o valor sem a mesma
+        // normalização, um input Unicode decomposto (ex.: "correção" em NFD)
+        // divergiria entre a coluna motivo_retificacao e o bloco congelado,
+        // quebrando a reconciliação. Postgres não normaliza texto, então a
+        // paridade tem de ser garantida na aplicação. NormalizeNfc é
+        // idempotente — reaplicá-lo no canonicalizer não altera o valor.
+        string motivo = HashCanonicalComputer.NormalizeNfc(command.Motivo.Trim());
 
         SnapshotCanonico canonico = canonicalizer.Canonicalizar(
             processo,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
@@ -75,11 +75,18 @@ public static class RetificarProcessoSeletivoCommandHandler
 
         DadosEdital dados = dadosResult.Value!;
 
+        // Normaliza o motivo UMA vez, aqui, e usa o mesmo valor nos dois
+        // caminhos: o bloco 'retificacao' do snapshot e o MotivoRetificacao do
+        // Edital. Sem isso, o Edital guardaria motivo.Trim() enquanto o
+        // snapshot congelaria o motivo cru — divergência que quebra a
+        // reconciliação do snapshot congelado contra a linha do Edital.
+        string motivo = command.Motivo.Trim();
+
         SnapshotCanonico canonico = canonicalizer.Canonicalizar(
             processo,
             dados,
             documento.HashSha256!,
-            new RetificacaoInfo(command.EditalRetificadoId, command.Motivo));
+            new RetificacaoInfo(command.EditalRetificadoId, motivo));
 
         string atorUsuarioSub = userContext.UserId ?? "system";
 
@@ -91,7 +98,7 @@ public static class RetificarProcessoSeletivoCommandHandler
             documento.HashSha256!,
             atorUsuarioSub,
             command.EditalRetificadoId,
-            command.Motivo,
+            motivo,
             timeProvider);
         if (retificarResult.IsFailure)
         {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
@@ -75,6 +75,20 @@ public static class RetificarProcessoSeletivoCommandHandler
 
         DadosEdital dados = dadosResult.Value!;
 
+        // O Edital sucedido é o vigente do próprio agregado — não um id vindo
+        // do cliente (Edital é entidade interna do agregado ProcessoSeletivo e
+        // a cadeia é linear). Precisamos do id do vigente já aqui para congelar
+        // o bloco 'retificacao' do snapshot; se o processo não foi publicado
+        // não há vigente e a retificação é inválida — mesma transição barrada
+        // por ProcessoSeletivo.Retificar, antecipada para não canonicalizar em
+        // vão.
+        if (processo.EditalVigente is not { } vigente)
+        {
+            return (Result.Failure(new DomainError(
+                "ProcessoSeletivo.TransicaoInvalida",
+                $"Só é possível retificar um processo publicado — status atual: {processo.Status}.")), []);
+        }
+
         // Normaliza o motivo UMA vez, aqui, e usa o mesmo valor nos dois
         // caminhos: o bloco 'retificacao' do snapshot e o MotivoRetificacao do
         // Edital. Sem isso, o Edital guardaria motivo.Trim() enquanto o
@@ -86,7 +100,7 @@ public static class RetificarProcessoSeletivoCommandHandler
             processo,
             dados,
             documento.HashSha256!,
-            new RetificacaoInfo(command.EditalRetificadoId, motivo));
+            new RetificacaoInfo(vigente.Id, motivo));
 
         string atorUsuarioSub = userContext.UserId ?? "system";
 
@@ -97,7 +111,6 @@ public static class RetificarProcessoSeletivoCommandHandler
             canonico.AlgoritmoHash,
             documento.HashSha256!,
             atorUsuarioSub,
-            command.EditalRetificadoId,
             motivo,
             timeProvider);
         if (retificarResult.IsFailure)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
@@ -133,6 +133,13 @@ public static class RetificarProcessoSeletivoCommandHandler
                     "Abertura não carrega edital retificado nem motivo; retificação exige ambos.")), []);
             }
 
+            if (UniqueConstraintViolation.IsRetificacaoDuplicada(constraint))
+            {
+                return (Result.Failure(new DomainError(
+                    "Edital.RetificacaoJaExiste",
+                    "Este Edital já foi retificado — a cadeia de retificação é linear.")), []);
+            }
+
             throw;
         }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/UniqueConstraintViolation.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/UniqueConstraintViolation.cs
@@ -25,6 +25,7 @@ internal static class UniqueConstraintViolation
     private const string DataPublicacaoConstraint = "ux_editais_processo_data_publicacao";
     private const string AberturaUnicaConstraint = "ux_editais_processo_abertura_unica";
     private const string ContratoNaturezaConstraint = "ck_editais_contrato_natureza";
+    private const string RetificadoUnicoConstraint = "ux_editais_edital_retificado_unico";
 
     private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
 
@@ -70,4 +71,8 @@ internal static class UniqueConstraintViolation
     /// <summary><see langword="true"/> quando a constraint violada é o CHECK do contrato abertura×retificação (ADR-0101).</summary>
     public static bool IsContratoNaturezaInvalido(string? constraint) =>
         string.Equals(constraint, ContratoNaturezaConstraint, StringComparison.Ordinal);
+
+    /// <summary><see langword="true"/> quando a constraint violada é a de retificação única por Edital (cadeia linear, ADR-0101).</summary>
+    public static bool IsRetificacaoDuplicada(string? constraint) =>
+        string.Equals(constraint, RetificadoUnicoConstraint, StringComparison.Ordinal);
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/RetificarProcessoSeletivoCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/RetificarProcessoSeletivoCommandValidator.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+
+using FluentValidation;
+
+using Commands.ProcessosSeletivos;
+
+public sealed class RetificarProcessoSeletivoCommandValidator : AbstractValidator<RetificarProcessoSeletivoCommand>
+{
+    // Espelha a coluna varchar(60) de EditalConfiguration.Numero.
+    private const int NumeroMaxLength = 60;
+
+    // Espelha a coluna varchar(2000) de EditalConfiguration.MotivoRetificacao —
+    // sem este limite, um motivo acima do tamanho da coluna só falharia no
+    // SaveChanges (erro de infraestrutura), nunca como 422.
+    private const int MotivoMaxLength = 2000;
+
+    public RetificarProcessoSeletivoCommandValidator()
+    {
+        RuleFor(x => x.ProcessoSeletivoId)
+            .NotEmpty()
+            .WithMessage("Id do processo seletivo é obrigatório.");
+
+        RuleFor(x => x.EditalRetificadoId)
+            .NotEmpty()
+            .WithMessage("Referência ao Edital retificado é obrigatória.");
+
+        RuleFor(x => x.Motivo)
+            .NotEmpty()
+            .WithMessage("Motivo da retificação é obrigatório.")
+            .MaximumLength(MotivoMaxLength)
+            .WithMessage($"Motivo da retificação deve ter no máximo {MotivoMaxLength} caracteres.");
+
+        RuleFor(x => x.DocumentoEditalId)
+            .NotEmpty()
+            .WithMessage("Referência ao documento do Edital é obrigatória.");
+
+        RuleFor(x => x.Numero)
+            .MaximumLength(NumeroMaxLength)
+            .WithMessage($"Número do Edital deve ter no máximo {NumeroMaxLength} caracteres.");
+
+        // DateOnly não-nullable: campo omitido do JSON binda para
+        // default(DateOnly) — sem esta checagem, os dois defaults passariam
+        // trivialmente na comparação abaixo, congelando período inválido.
+        RuleFor(x => x.PeriodoInscricaoInicio)
+            .NotEqual(default(DateOnly))
+            .WithMessage("Início do período de inscrição é obrigatório.");
+
+        RuleFor(x => x.PeriodoInscricaoFim)
+            .NotEqual(default(DateOnly))
+            .WithMessage("Fim do período de inscrição é obrigatório.")
+            .GreaterThanOrEqualTo(x => x.PeriodoInscricaoInicio)
+            .WithMessage("O fim do período de inscrição não pode anteceder o início.");
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/RetificarProcessoSeletivoCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/RetificarProcessoSeletivoCommandValidator.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
 using FluentValidation;
 
 using Commands.ProcessosSeletivos;
+using Domain.ValueObjects;
 
 public sealed class RetificarProcessoSeletivoCommandValidator : AbstractValidator<RetificarProcessoSeletivoCommand>
 {
@@ -11,7 +12,11 @@ public sealed class RetificarProcessoSeletivoCommandValidator : AbstractValidato
 
     // Espelha a coluna varchar(2000) de EditalConfiguration.MotivoRetificacao —
     // sem este limite, um motivo acima do tamanho da coluna só falharia no
-    // SaveChanges (erro de infraestrutura), nunca como 422.
+    // SaveChanges (erro de infraestrutura), nunca como 422. O limite é aferido
+    // sobre o valor NORMALIZADO (Trim + NFC), que é o efetivamente persistido:
+    // a normalização NFC pode expandir code points de composição-excluída
+    // (ex.: U+0958 → U+0915 U+093C), então validar o comprimento cru deixaria
+    // passar um input que estoura a coluna só depois da normalização.
     private const int MotivoMaxLength = 2000;
 
     public RetificarProcessoSeletivoCommandValidator()
@@ -23,7 +28,8 @@ public sealed class RetificarProcessoSeletivoCommandValidator : AbstractValidato
         RuleFor(x => x.Motivo)
             .NotEmpty()
             .WithMessage("Motivo da retificação é obrigatório.")
-            .MaximumLength(MotivoMaxLength)
+            .Must(motivo => motivo is null
+                || HashCanonicalComputer.NormalizeNfc(motivo.Trim()).Length <= MotivoMaxLength)
             .WithMessage($"Motivo da retificação deve ter no máximo {MotivoMaxLength} caracteres.");
 
         RuleFor(x => x.DocumentoEditalId)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/RetificarProcessoSeletivoCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/RetificarProcessoSeletivoCommandValidator.cs
@@ -20,10 +20,6 @@ public sealed class RetificarProcessoSeletivoCommandValidator : AbstractValidato
             .NotEmpty()
             .WithMessage("Id do processo seletivo é obrigatório.");
 
-        RuleFor(x => x.EditalRetificadoId)
-            .NotEmpty()
-            .WithMessage("Referência ao Edital retificado é obrigatória.");
-
         RuleFor(x => x.Motivo)
             .NotEmpty()
             .WithMessage("Motivo da retificação é obrigatório.")

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/Edital.cs
@@ -65,4 +65,57 @@ public sealed class Edital : EntityBase
             MotivoRetificacao = null,
         });
     }
+
+    /// <summary>
+    /// Emite um Edital de retificação (natureza <see cref="NaturezaEdital.Retificacao"/>,
+    /// ADR-0101, T5 #786) — vinculado ao Edital anterior da cadeia e com
+    /// motivo obrigatório. Contrato tudo-ou-nada da natureza: retificação
+    /// exige <paramref name="editalRetificadoId"/> e <paramref name="motivo"/>
+    /// simultaneamente (defesa em profundidade sobre o CHECK
+    /// <c>ck_editais_contrato_natureza</c>). A pertença do edital retificado ao
+    /// mesmo processo é responsabilidade da raiz
+    /// (<see cref="ProcessoSeletivo.Retificar"/>), que carrega a cadeia completa.
+    /// </summary>
+    public static Result<Edital> EmitirRetificacao(
+        Guid processoSeletivoId,
+        DadosEdital dados,
+        Guid editalRetificadoId,
+        string motivo,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(dados);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        if (processoSeletivoId == Guid.Empty)
+        {
+            return Result<Edital>.Failure(new DomainError(
+                "Edital.ProcessoSeletivoIdObrigatorio",
+                "O Edital deve estar vinculado a um Processo Seletivo."));
+        }
+
+        if (editalRetificadoId == Guid.Empty)
+        {
+            return Result<Edital>.Failure(new DomainError(
+                "Edital.EditalRetificadoObrigatorio",
+                "A retificação deve referenciar o Edital anterior."));
+        }
+
+        if (string.IsNullOrWhiteSpace(motivo))
+        {
+            return Result<Edital>.Failure(new DomainError(
+                "Edital.MotivoRetificacaoObrigatorio",
+                "O motivo da retificação é obrigatório."));
+        }
+
+        return Result<Edital>.Success(new Edital
+        {
+            ProcessoSeletivoId = processoSeletivoId,
+            Natureza = NaturezaEdital.Retificacao,
+            Numero = dados.Numero,
+            DataPublicacao = clock.GetUtcNow(),
+            DocumentoEditalId = dados.DocumentoEditalId,
+            EditalRetificadoId = editalRetificadoId,
+            MotivoRetificacao = motivo.Trim(),
+        });
+    }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -467,6 +467,89 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     }
 
     /// <summary>
+    /// Retifica um processo já publicado (RN08, Story #759 T5 #786, ADR-0101):
+    /// emite um novo <see cref="Edital"/> de natureza retificação, vinculado ao
+    /// Edital vigente da cadeia e com motivo obrigatório, e congela um novo
+    /// <see cref="SnapshotPublicacao"/> — o snapshot anterior permanece
+    /// intocado (append-only). O status continua Publicado. Os bytes canônicos
+    /// já vêm do <c>ISnapshotPublicacaoCanonicalizer</c> (Application) com o
+    /// bloco de retificação incluído; esta raiz não os produz (ADR-0042).
+    /// </summary>
+    /// <param name="editalRetificadoId">Edital vigente (topo da cadeia) que esta retificação sucede — deve pertencer a este processo (CA-06).</param>
+    /// <param name="motivo">Justificativa obrigatória do ato de retificação (ADR-0101).</param>
+    public Result<PublicacaoResultado> Retificar(
+        DadosEdital dados,
+        byte[] configuracaoCongeladaCanonica,
+        string schemaVersion,
+        string algoritmoHash,
+        string hashEdital,
+        string atorUsuarioSub,
+        Guid editalRetificadoId,
+        string motivo,
+        TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(dados);
+        ArgumentNullException.ThrowIfNull(configuracaoCongeladaCanonica);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        if (Status != StatusProcesso.Publicado)
+        {
+            return Result<PublicacaoResultado>.Failure(new DomainError(
+                "ProcessoSeletivo.TransicaoInvalida",
+                $"Só é possível retificar um processo publicado — status atual: {Status}."));
+        }
+
+        // CA-06 + ADR-0101: a retificação não cruza processos E sucede o
+        // Edital VIGENTE (topo da cadeia — maior data de publicação, único
+        // por ux_editais_processo_data_publicacao). Referenciar um edital de
+        // outro processo, ou um nó que não é o topo, ramificaria a cadeia que
+        // o seletor de snapshot vigente (T6) espera linear.
+        Edital? vigente = _editais
+            .Where(static e => e.DataPublicacao is not null)
+            .OrderByDescending(static e => e.DataPublicacao!.Value)
+            .FirstOrDefault();
+        if (vigente is null || vigente.Id != editalRetificadoId)
+        {
+            return Result<PublicacaoResultado>.Failure(new DomainError(
+                "ProcessoSeletivo.EditalRetificadoInvalido",
+                "A retificação deve referenciar o Edital vigente (o mais recente) deste processo."));
+        }
+
+        Result<Edital> editalResult = Edital.EmitirRetificacao(Id, dados, editalRetificadoId, motivo, clock);
+        if (editalResult.IsFailure)
+        {
+            return Result<PublicacaoResultado>.Failure(editalResult.Error!);
+        }
+
+        Edital edital = editalResult.Value!;
+
+        SnapshotPublicacao snapshot = SnapshotPublicacao.Congelar(
+            edital.Id,
+            configuracaoCongeladaCanonica,
+            schemaVersion,
+            algoritmoHash,
+            hashEdital,
+            atorUsuarioSub,
+            clock);
+
+        _editais.Add(edital);
+
+        // Reaproveita ProcessoPublicadoEvent (não um evento distinto): o fato
+        // de negócio drenado é "emitido novo Edital + snapshot", idêntico em
+        // forma ao da abertura — o payload (edital/snapshot/hashes/data) serve
+        // aos dois. Evita um segundo schema Avro/tópico sem consumidor.
+        AddDomainEvent(new ProcessoPublicadoEvent(
+            Id,
+            edital.Id,
+            snapshot.Id,
+            snapshot.HashConfiguracao,
+            snapshot.HashEdital,
+            edital.DataPublicacao!.Value));
+
+        return Result<PublicacaoResultado>.Success(new PublicacaoResultado(edital, snapshot));
+    }
+
+    /// <summary>
     /// Trava de mutação pós-publicação (CA-04): todo <c>Definir*</c> recusa
     /// quando o processo já foi publicado — mudança em conteúdo congelável só
     /// via retificação (T5, #786). Reaproveitada por todos os métodos

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -62,6 +62,20 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     private readonly List<Edital> _editais = [];
     public IReadOnlyCollection<Edital> Editais => _editais.AsReadOnly();
 
+    /// <summary>
+    /// Edital vigente da cadeia de publicação: o de maior data de publicação
+    /// (topo da cadeia linear, ADR-0101) — único por instante graças a
+    /// <c>ux_editais_processo_data_publicacao</c>. <see langword="null"/>
+    /// enquanto o processo não foi publicado. É a raiz — não o cliente — quem
+    /// determina qual Edital uma retificação sucede; este acessor é a fonte
+    /// única dessa definição, consumida pela raiz e pelo handler (que precisa
+    /// do id do vigente para congelar o bloco de retificação do snapshot).
+    /// </summary>
+    public Edital? EditalVigente => _editais
+        .Where(static e => e.DataPublicacao is not null)
+        .OrderByDescending(static e => e.DataPublicacao!.Value)
+        .FirstOrDefault();
+
     private ProcessoSeletivo() { }
 
     public static ProcessoSeletivo Criar(string nome, TipoProcesso tipo)
@@ -475,7 +489,6 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// já vêm do <c>ISnapshotPublicacaoCanonicalizer</c> (Application) com o
     /// bloco de retificação incluído; esta raiz não os produz (ADR-0042).
     /// </summary>
-    /// <param name="editalRetificadoId">Edital vigente (topo da cadeia) que esta retificação sucede — deve pertencer a este processo (CA-06).</param>
     /// <param name="motivo">Justificativa obrigatória do ato de retificação (ADR-0101).</param>
     public Result<PublicacaoResultado> Retificar(
         DadosEdital dados,
@@ -484,7 +497,6 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         string algoritmoHash,
         string hashEdital,
         string atorUsuarioSub,
-        Guid editalRetificadoId,
         string motivo,
         TimeProvider clock)
     {
@@ -499,23 +511,21 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 $"Só é possível retificar um processo publicado — status atual: {Status}."));
         }
 
-        // CA-06 + ADR-0101: a retificação não cruza processos E sucede o
-        // Edital VIGENTE (topo da cadeia — maior data de publicação, único
-        // por ux_editais_processo_data_publicacao). Referenciar um edital de
-        // outro processo, ou um nó que não é o topo, ramificaria a cadeia que
-        // o seletor de snapshot vigente (T6) espera linear.
-        Edital? vigente = _editais
-            .Where(static e => e.DataPublicacao is not null)
-            .OrderByDescending(static e => e.DataPublicacao!.Value)
-            .FirstOrDefault();
-        if (vigente is null || vigente.Id != editalRetificadoId)
+        // ADR-0101: a retificação sempre sucede o Edital VIGENTE (topo da
+        // cadeia — maior data de publicação, único por
+        // ux_editais_processo_data_publicacao). O alvo é estado do agregado,
+        // não input do cliente: qual Edital interno é sucedido é decisão da
+        // raiz, e mantê-la no vigente garante que a cadeia permaneça linear.
+        // Publicado implica ao menos um Edital publicado — o null aqui só
+        // cobriria um estado inconsistente.
+        if (EditalVigente is not { } vigente)
         {
             return Result<PublicacaoResultado>.Failure(new DomainError(
-                "ProcessoSeletivo.EditalRetificadoInvalido",
-                "A retificação deve referenciar o Edital vigente (o mais recente) deste processo."));
+                "ProcessoSeletivo.TransicaoInvalida",
+                "Processo publicado sem Edital vigente — estado inconsistente."));
         }
 
-        Result<Edital> editalResult = Edital.EmitirRetificacao(Id, dados, editalRetificadoId, motivo, clock);
+        Result<Edital> editalResult = Edital.EmitirRetificacao(Id, dados, vigente.Id, motivo, clock);
         if (editalResult.IsFailure)
         {
             return Result<PublicacaoResultado>.Failure(editalResult.Error!);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
@@ -58,7 +58,11 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
 
     private static readonly JsonObject NaoConstruido = new() { ["status"] = "nao_construido" };
 
-    public SnapshotCanonico Canonicalizar(ProcessoSeletivo processo, DadosEdital dados, string hashEdital)
+    public SnapshotCanonico Canonicalizar(
+        ProcessoSeletivo processo,
+        DadosEdital dados,
+        string hashEdital,
+        RetificacaoInfo? retificacao = null)
     {
         ArgumentNullException.ThrowIfNull(processo);
         ArgumentNullException.ThrowIfNull(dados);
@@ -84,6 +88,19 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
             ["cronogramaFases"] = NaoConstruido.DeepClone(),
             ["identidadesUnidade"] = NaoConstruido.DeepClone(),
         };
+
+        // ADR-0101: a retificação ACRESCENTA um 18º bloco preservando os 17
+        // anteriores. A abertura não escreve esta chave — seu payload é
+        // byte-a-byte o mesmo do T4 (a reordenação de chaves em
+        // ComputeSnapshotBytes independe da ordem de inserção aqui).
+        if (retificacao is not null)
+        {
+            payload["retificacao"] = new JsonObject
+            {
+                ["editalRetificadoId"] = retificacao.EditalRetificadoId,
+                ["motivo"] = HashCanonicalComputer.NormalizeNfc(retificacao.Motivo),
+            };
+        }
 
         byte[] bytes = HashCanonicalComputer.ComputeSnapshotBytes(payload);
         return new SnapshotCanonico(bytes, SchemaVersionAtual, AlgoritmoHashAtual);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EditalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/EditalConfiguration.cs
@@ -71,6 +71,18 @@ internal sealed class EditalConfiguration : IEntityTypeConfiguration<Edital>
             .IsUnique()
             .HasFilter($"natureza = {(int)Domain.Enums.NaturezaEdital.Abertura}")
             .HasDatabaseName("ux_editais_processo_abertura_unica");
+
+        // T5 #786 (ADR-0101, cadeia linear): cada Edital é retificado no
+        // máximo uma vez — backstop de banco simétrico ao da abertura única.
+        // O lock pessimista de ObterComConfiguracaoAsync já serializa
+        // retificações do mesmo processo (o guard em memória sempre vê a
+        // cadeia atualizada), mas esta trava garante a linearidade como
+        // invariante de banco, fechando qualquer janela residual sem que a
+        // cadeia possa ramificar.
+        builder.HasIndex(e => e.EditalRetificadoId)
+            .IsUnique()
+            .HasFilter("edital_retificado_id IS NOT NULL")
+            .HasDatabaseName("ux_editais_edital_retificado_unico");
     }
 
     // ADR-0101: contrato abertura×retificação — abertura sem os dois campos

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708120000_AddIndiceRetificacaoUnica.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708120000_AddIndiceRetificacaoUnica.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,10 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260708120000_AddIndiceRetificacaoUnica")]
+    partial class AddIndiceRetificacaoUnica
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708120000_AddIndiceRetificacaoUnica.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708120000_AddIndiceRetificacaoUnica.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIndiceRetificacaoUnica : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Cadeia de retificação linear (ADR-0101/ADR-0102): cada Edital é
+            // retificado no máximo uma vez. O índice de convenção da FK sobre
+            // edital_retificado_id (não único) é promovido a índice único
+            // parcial — simétrico a ux_editais_processo_abertura_unica. Fecha a
+            // corrida de duas retificações concorrentes do mesmo Edital como
+            // invariante de banco, sem manter um índice redundante: o parcial
+            // continua cobrindo as buscas por FK nas linhas de retificação
+            // (as de abertura têm edital_retificado_id nulo e nunca são alvo).
+            migrationBuilder.DropIndex(
+                name: "ix_editais_edital_retificado_id",
+                schema: "selecao",
+                table: "editais");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_editais_edital_retificado_unico",
+                schema: "selecao",
+                table: "editais",
+                column: "edital_retificado_id",
+                unique: true,
+                filter: "edital_retificado_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ux_editais_edital_retificado_unico",
+                schema: "selecao",
+                table: "editais");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_editais_edital_retificado_id",
+                schema: "selecao",
+                table: "editais",
+                column: "edital_retificado_id");
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
@@ -75,6 +75,9 @@ public sealed class ProcessoSeletivoRepository : IProcessoSeletivoRepository
             .Include(p => p.BonusRegional)
             .Include(p => p.CriteriosDesempate)
             .Include(p => p.Classificacao!).ThenInclude(c => c.RegrasEliminacao)
+            // Editais carregados para a retificação (T5 #786) validar que o
+            // edital retificado é o vigente deste processo (ProcessoSeletivo.Retificar).
+            .Include(p => p.Editais)
             .FirstOrDefaultAsync(p => p.Id == id, cancellationToken)
             .ConfigureAwait(false);
     }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/RetificarProcessoSeletivoCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/RetificarProcessoSeletivoCommandValidatorTests.cs
@@ -39,6 +39,20 @@ public sealed class RetificarProcessoSeletivoCommandValidatorTests
         resultado.Errors.Should().Contain(e => e.PropertyName == nameof(RetificarProcessoSeletivoCommand.Motivo));
     }
 
+    [Fact(DisplayName = "Motivo dentro do limite cru mas que estoura o limite após NFC é recusado")]
+    public void MotivoQueExpandeComNfc_AcimaDoLimite_Recusado()
+    {
+        // U+0958 (DEVANAGARI QA) é composição-excluída: NFC o decompõe em dois
+        // code points (U+0915 U+093C). 1001 chars crus (≤ 2000) viram 2002 após
+        // NFC — o valor efetivamente persistido estoura a coluna varchar(2000).
+        string motivoQueExpande = new('\u0958', 1001);
+
+        ValidationResult resultado = Validator.Validate(ComandoValido() with { Motivo = motivoQueExpande });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(RetificarProcessoSeletivoCommand.Motivo));
+    }
+
     [Fact(DisplayName = "Fim do período anterior ao início é recusado")]
     public void PeriodoInvertido_Recusado()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/RetificarProcessoSeletivoCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/RetificarProcessoSeletivoCommandValidatorTests.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+
+/// <summary>
+/// Cobertura do <see cref="RetificarProcessoSeletivoCommandValidator"/>
+/// (Story #759 T5 #786) — motivo obrigatório (ADR-0101), período válido e
+/// referências obrigatórias mapeadas a 422 no boundary, antes do handler.
+/// </summary>
+public sealed class RetificarProcessoSeletivoCommandValidatorTests
+{
+    private static readonly RetificarProcessoSeletivoCommandValidator Validator = new();
+
+    private static RetificarProcessoSeletivoCommand ComandoValido() => new(
+        ProcessoSeletivoId: Guid.CreateVersion7(),
+        EditalRetificadoId: Guid.CreateVersion7(),
+        Motivo: "Correção do prazo de inscrição",
+        Numero: "001/2026-R1",
+        PeriodoInscricaoInicio: new DateOnly(2026, 1, 2),
+        PeriodoInscricaoFim: new DateOnly(2026, 2, 1),
+        DocumentoEditalId: Guid.CreateVersion7());
+
+    [Fact(DisplayName = "Comando válido passa na validação")]
+    public void Valido_Passa()
+    {
+        ValidationResult resultado = Validator.Validate(ComandoValido());
+        resultado.IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Motivo vazio é recusado (ADR-0101)")]
+    public void MotivoVazio_Recusado()
+    {
+        ValidationResult resultado = Validator.Validate(ComandoValido() with { Motivo = "" });
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(RetificarProcessoSeletivoCommand.Motivo));
+    }
+
+    [Fact(DisplayName = "EditalRetificadoId vazio é recusado")]
+    public void EditalRetificadoVazio_Recusado()
+    {
+        ValidationResult resultado = Validator.Validate(ComandoValido() with { EditalRetificadoId = Guid.Empty });
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(RetificarProcessoSeletivoCommand.EditalRetificadoId));
+    }
+
+    [Fact(DisplayName = "Fim do período anterior ao início é recusado")]
+    public void PeriodoInvertido_Recusado()
+    {
+        ValidationResult resultado = Validator.Validate(ComandoValido() with
+        {
+            PeriodoInscricaoInicio = new DateOnly(2026, 2, 1),
+            PeriodoInscricaoFim = new DateOnly(2026, 1, 2),
+        });
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(RetificarProcessoSeletivoCommand.PeriodoInscricaoFim));
+    }
+
+    [Fact(DisplayName = "Período com defaults (campos omitidos) é recusado")]
+    public void PeriodoDefault_Recusado()
+    {
+        ValidationResult resultado = Validator.Validate(ComandoValido() with
+        {
+            PeriodoInscricaoInicio = default,
+            PeriodoInscricaoFim = default,
+        });
+        resultado.IsValid.Should().BeFalse();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/RetificarProcessoSeletivoCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/RetificarProcessoSeletivoCommandValidatorTests.cs
@@ -18,7 +18,6 @@ public sealed class RetificarProcessoSeletivoCommandValidatorTests
 
     private static RetificarProcessoSeletivoCommand ComandoValido() => new(
         ProcessoSeletivoId: Guid.CreateVersion7(),
-        EditalRetificadoId: Guid.CreateVersion7(),
         Motivo: "Correção do prazo de inscrição",
         Numero: "001/2026-R1",
         PeriodoInscricaoInicio: new DateOnly(2026, 1, 2),
@@ -38,14 +37,6 @@ public sealed class RetificarProcessoSeletivoCommandValidatorTests
         ValidationResult resultado = Validator.Validate(ComandoValido() with { Motivo = "" });
         resultado.IsValid.Should().BeFalse();
         resultado.Errors.Should().Contain(e => e.PropertyName == nameof(RetificarProcessoSeletivoCommand.Motivo));
-    }
-
-    [Fact(DisplayName = "EditalRetificadoId vazio é recusado")]
-    public void EditalRetificadoVazio_Recusado()
-    {
-        ValidationResult resultado = Validator.Validate(ComandoValido() with { EditalRetificadoId = Guid.Empty });
-        resultado.IsValid.Should().BeFalse();
-        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(RetificarProcessoSeletivoCommand.EditalRetificadoId));
     }
 
     [Fact(DisplayName = "Fim do período anterior ao início é recusado")]

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
@@ -100,7 +100,7 @@ public sealed class ProcessoSeletivoRetificarTests
 
         Result<PublicacaoResultado> resultado = processo.Retificar(
             NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
-            editalRetificadoId: abertura.Id, motivo: "Correção do prazo de inscrição", clock: clock);
+            motivo: "Correção do prazo de inscrição", clock: clock);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
         processo.Status.Should().Be(StatusProcesso.Publicado, "retificar não altera o status Publicado");
@@ -118,13 +118,13 @@ public sealed class ProcessoSeletivoRetificarTests
     public void Retificar_ProcessoPublicado_EmiteEventoComNovosIdentificadores()
     {
         RelogioManual clock = Relogio();
-        ProcessoSeletivo processo = NovoProcessoPublicado(clock, out Edital abertura);
+        ProcessoSeletivo processo = NovoProcessoPublicado(clock, out _);
         processo.ClearDomainEvents(); // descarta o evento da abertura
         clock.Avancar(TimeSpan.FromMinutes(1));
 
         Result<PublicacaoResultado> resultado = processo.Retificar(
             NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
-            abertura.Id, "Ajuste de vaga", clock);
+            "Ajuste de vaga", clock);
 
         resultado.IsSuccess.Should().BeTrue();
         Domain.Events.ProcessoPublicadoEvent evento = processo.DomainEvents
@@ -140,47 +140,37 @@ public sealed class ProcessoSeletivoRetificarTests
 
         Result<PublicacaoResultado> resultado = processo.Retificar(
             NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
-            editalRetificadoId: Guid.CreateVersion7(), motivo: "qualquer", clock: Relogio());
+            motivo: "qualquer", clock: Relogio());
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("ProcessoSeletivo.TransicaoInvalida");
         processo.Editais.Should().BeEmpty();
     }
 
-    [Fact(DisplayName = "Retificacao_MesmoProcesso — retificar referenciando edital que não é o vigente é recusado (CA-06)")]
-    public void Retificar_EditalRetificadoNaoVigente_Recusa()
-    {
-        RelogioManual clock = Relogio();
-        ProcessoSeletivo processo = NovoProcessoPublicado(clock, out _);
-        clock.Avancar(TimeSpan.FromMinutes(1));
-
-        // Id arbitrário (ex.: edital de outro processo) — não é o vigente.
-        Result<PublicacaoResultado> resultado = processo.Retificar(
-            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
-            editalRetificadoId: Guid.CreateVersion7(), motivo: "motivo", clock: clock);
-
-        resultado.IsFailure.Should().BeTrue();
-        resultado.Error!.Code.Should().Be("ProcessoSeletivo.EditalRetificadoInvalido");
-        processo.Editais.Should().ContainSingle("a retificação recusada não emite um segundo Edital");
-    }
-
-    [Fact(DisplayName = "Retificacao — segunda retificação deve suceder a primeira, não a abertura (cadeia linear)")]
-    public void Retificar_SegundaRetificacao_ReferenciandoAbertura_Recusa()
+    [Fact(DisplayName = "Retificacao_MesmoProcesso — segunda retificação sucede o vigente, formando cadeia linear abertura→R1→R2 (CA-06)")]
+    public void Retificar_SegundaRetificacao_SucedeVigente_CadeiaLinear()
     {
         RelogioManual clock = Relogio();
         ProcessoSeletivo processo = NovoProcessoPublicado(clock, out Edital abertura);
         clock.Avancar(TimeSpan.FromMinutes(1));
-        processo.Retificar(NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
-            abertura.Id, "primeira retificação", clock).IsSuccess.Should().BeTrue();
+
+        Result<PublicacaoResultado> primeira = processo.Retificar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
+            motivo: "primeira retificação", clock: clock);
+        primeira.IsSuccess.Should().BeTrue(primeira.Error?.Message);
         clock.Avancar(TimeSpan.FromMinutes(1));
 
-        // Tenta suceder a abertura de novo — mas o vigente agora é a 1ª retificação.
-        Result<PublicacaoResultado> resultado = processo.Retificar(
+        // A segunda retificação sucede automaticamente o vigente (a 1ª
+        // retificação), não a abertura — o alvo é resolvido pela raiz.
+        Result<PublicacaoResultado> segunda = processo.Retificar(
             NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
-            abertura.Id, "segunda retificação", clock);
+            motivo: "segunda retificação", clock: clock);
 
-        resultado.IsFailure.Should().BeTrue();
-        resultado.Error!.Code.Should().Be("ProcessoSeletivo.EditalRetificadoInvalido");
+        segunda.IsSuccess.Should().BeTrue(segunda.Error?.Message);
+        primeira.Value!.Edital.EditalRetificadoId.Should().Be(abertura.Id, "R1 sucede a abertura");
+        segunda.Value!.Edital.EditalRetificadoId.Should().Be(primeira.Value!.Edital.Id, "R2 sucede R1 — cada Edital retificado uma única vez");
+        processo.Editais.Should().HaveCount(3);
+        processo.EditalVigente!.Id.Should().Be(segunda.Value!.Edital.Id, "o vigente avança para a última retificação");
     }
 
     [Fact(DisplayName = "Edital_ContratoAberturaRetificacao — EmitirRetificacao sem motivo é recusado")]

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
@@ -1,0 +1,234 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using System.Text;
+using System.Text.Json.Nodes;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura de <see cref="ProcessoSeletivo.Retificar"/> e
+/// <see cref="Edital.EmitirRetificacao"/> (RN08, Story #759 T5 #786,
+/// ADR-0101) — novo Edital de retificação vinculado ao vigente, motivo
+/// obrigatório, novo snapshot, snapshot anterior intocado, status permanece
+/// Publicado. Mapa de testes de #759: <c>Retificacao_NovoEditalSnapshotMotivo</c>,
+/// <c>Edital_ContratoAberturaRetificacao</c>, <c>Retificacao_MesmoProcesso</c>.
+/// </summary>
+public sealed class ProcessoSeletivoRetificarTests
+{
+    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+    private static readonly byte[] BytesCanonicos = Encoding.UTF8.GetBytes(new JsonObject { ["status"] = "ok" }.ToJsonString());
+
+    private static DadosEdital NovosDados() => DadosEdital.Criar(
+        numero: "001/2026",
+        periodoInscricaoInicio: new DateOnly(2026, 1, 1),
+        periodoInscricaoFim: new DateOnly(2026, 1, 31),
+        documentoEditalId: Guid.CreateVersion7()).Value!;
+
+    // Relógio que avança a cada leitura — a data de publicação da retificação
+    // precisa diferir da abertura (unicidade por processo, ux_editais_processo_data_publicacao).
+    private static RelogioManual Relogio() => new(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+
+    private static ProcessoSeletivo NovoProcessoConforme()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — SiSU", TipoProcesso.SiSU);
+
+        processo.DefinirEtapas([
+            EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1),
+        ]).IsSuccess.Should().BeTrue();
+
+        processo.DefinirOfertaAtendimento(
+            OfertaAtendimentoEspecializado.Criar([], [], []).Value!).IsSuccess.Should().BeTrue();
+
+        ReferenciaRegra regraDistribuicao = ReferenciaRegra.Criar(
+            RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!;
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(),
+            codigo: "AC",
+            descricao: null,
+            naturezaLegal: NaturezaLegalModalidade.Ampla,
+            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null,
+            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null,
+            remanejamentoPar: null,
+            remanejamentoFallback: null,
+            criteriosCumulativos: [],
+            acaoQuandoIndeferido: null,
+            baseLegal: "Res. Unifesspa 532/2021").Value!;
+        ConfiguracaoDistribuicaoVagas distribuicao = ConfiguracaoDistribuicaoVagas.Criar(
+            ofertaCursoOrigemId: Guid.CreateVersion7(),
+            voBase: 40,
+            pr: 1m,
+            regraDistribuicao: regraDistribuicao,
+            referenciaDemografica: null,
+            modalidades: [modalidade]).Value!;
+        processo.DefinirDistribuicaoVagas([distribuicao]).IsSuccess.Should().BeTrue();
+
+        ConfiguracaoClassificacao classificacao = ConfiguracaoClassificacao.Criar(
+            regraCalculo: ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!,
+            regraArredondamento: null,
+            casasArredondamento: null,
+            regraOrdemAlocacao: ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!,
+            nOpcoesAlocacao: 1,
+            regrasEliminacao: []).Value!;
+        processo.DefinirClassificacao(classificacao).IsSuccess.Should().BeTrue();
+
+        return processo;
+    }
+
+    private static ProcessoSeletivo NovoProcessoPublicado(RelogioManual clock, out Edital abertura)
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        Result<PublicacaoResultado> publicacao = processo.Publicar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", clock);
+        publicacao.IsSuccess.Should().BeTrue(publicacao.Error?.Message);
+        abertura = publicacao.Value!.Edital;
+        return processo;
+    }
+
+    [Fact(DisplayName = "Retificacao_NovoEditalSnapshotMotivo — retificar processo publicado emite Edital de retificação vinculado ao vigente")]
+    public void Retificar_ProcessoPublicado_EmiteEditalRetificacaoVinculado()
+    {
+        RelogioManual clock = Relogio();
+        ProcessoSeletivo processo = NovoProcessoPublicado(clock, out Edital abertura);
+        clock.Avancar(TimeSpan.FromMinutes(1));
+
+        Result<PublicacaoResultado> resultado = processo.Retificar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
+            editalRetificadoId: abertura.Id, motivo: "Correção do prazo de inscrição", clock: clock);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.Status.Should().Be(StatusProcesso.Publicado, "retificar não altera o status Publicado");
+        processo.Editais.Should().HaveCount(2);
+
+        Edital retificacao = resultado.Value!.Edital;
+        retificacao.Natureza.Should().Be(NaturezaEdital.Retificacao);
+        retificacao.EditalRetificadoId.Should().Be(abertura.Id);
+        retificacao.MotivoRetificacao.Should().Be("Correção do prazo de inscrição");
+        retificacao.DataPublicacao.Should().NotBeNull().And.NotBe(abertura.DataPublicacao);
+        resultado.Value!.Snapshot.EditalId.Should().Be(retificacao.Id);
+    }
+
+    [Fact(DisplayName = "Retificacao_NovoEditalSnapshotMotivo — retificação emite evento com os identificadores do novo Edital/snapshot")]
+    public void Retificar_ProcessoPublicado_EmiteEventoComNovosIdentificadores()
+    {
+        RelogioManual clock = Relogio();
+        ProcessoSeletivo processo = NovoProcessoPublicado(clock, out Edital abertura);
+        processo.ClearDomainEvents(); // descarta o evento da abertura
+        clock.Avancar(TimeSpan.FromMinutes(1));
+
+        Result<PublicacaoResultado> resultado = processo.Retificar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
+            abertura.Id, "Ajuste de vaga", clock);
+
+        resultado.IsSuccess.Should().BeTrue();
+        Domain.Events.ProcessoPublicadoEvent evento = processo.DomainEvents
+            .OfType<Domain.Events.ProcessoPublicadoEvent>().Should().ContainSingle().Subject;
+        evento.EditalId.Should().Be(resultado.Value!.Edital.Id);
+        evento.SnapshotPublicacaoId.Should().Be(resultado.Value!.Snapshot.Id);
+    }
+
+    [Fact(DisplayName = "Lifecycle — retificar processo ainda em rascunho é recusado (CA-09)")]
+    public void Retificar_ProcessoRascunho_RecusaTransicaoInvalida()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+
+        Result<PublicacaoResultado> resultado = processo.Retificar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
+            editalRetificadoId: Guid.CreateVersion7(), motivo: "qualquer", clock: Relogio());
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.TransicaoInvalida");
+        processo.Editais.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Retificacao_MesmoProcesso — retificar referenciando edital que não é o vigente é recusado (CA-06)")]
+    public void Retificar_EditalRetificadoNaoVigente_Recusa()
+    {
+        RelogioManual clock = Relogio();
+        ProcessoSeletivo processo = NovoProcessoPublicado(clock, out _);
+        clock.Avancar(TimeSpan.FromMinutes(1));
+
+        // Id arbitrário (ex.: edital de outro processo) — não é o vigente.
+        Result<PublicacaoResultado> resultado = processo.Retificar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
+            editalRetificadoId: Guid.CreateVersion7(), motivo: "motivo", clock: clock);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.EditalRetificadoInvalido");
+        processo.Editais.Should().ContainSingle("a retificação recusada não emite um segundo Edital");
+    }
+
+    [Fact(DisplayName = "Retificacao — segunda retificação deve suceder a primeira, não a abertura (cadeia linear)")]
+    public void Retificar_SegundaRetificacao_ReferenciandoAbertura_Recusa()
+    {
+        RelogioManual clock = Relogio();
+        ProcessoSeletivo processo = NovoProcessoPublicado(clock, out Edital abertura);
+        clock.Avancar(TimeSpan.FromMinutes(1));
+        processo.Retificar(NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
+            abertura.Id, "primeira retificação", clock).IsSuccess.Should().BeTrue();
+        clock.Avancar(TimeSpan.FromMinutes(1));
+
+        // Tenta suceder a abertura de novo — mas o vigente agora é a 1ª retificação.
+        Result<PublicacaoResultado> resultado = processo.Retificar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
+            abertura.Id, "segunda retificação", clock);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.EditalRetificadoInvalido");
+    }
+
+    [Fact(DisplayName = "Edital_ContratoAberturaRetificacao — EmitirRetificacao sem motivo é recusado")]
+    public void EmitirRetificacao_MotivoVazio_Recusa()
+    {
+        Result<Edital> resultado = Edital.EmitirRetificacao(
+            Guid.CreateVersion7(), NovosDados(), Guid.CreateVersion7(), motivo: "   ", clock: Relogio());
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Edital.MotivoRetificacaoObrigatorio");
+    }
+
+    [Fact(DisplayName = "Edital_ContratoAberturaRetificacao — EmitirRetificacao sem edital retificado é recusado")]
+    public void EmitirRetificacao_SemEditalRetificado_Recusa()
+    {
+        Result<Edital> resultado = Edital.EmitirRetificacao(
+            Guid.CreateVersion7(), NovosDados(), editalRetificadoId: Guid.Empty, motivo: "motivo", clock: Relogio());
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("Edital.EditalRetificadoObrigatorio");
+    }
+
+    [Fact(DisplayName = "Edital_ContratoAberturaRetificacao — EmitirRetificacao preenche os dois campos de retificação")]
+    public void EmitirRetificacao_Valida_PreencheContratoRetificacao()
+    {
+        Guid retificadoId = Guid.CreateVersion7();
+
+        Result<Edital> resultado = Edital.EmitirRetificacao(
+            Guid.CreateVersion7(), NovosDados(), retificadoId, motivo: "  Adequação a decisão superveniente  ", clock: Relogio());
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Natureza.Should().Be(NaturezaEdital.Retificacao);
+        resultado.Value!.EditalRetificadoId.Should().Be(retificadoId);
+        resultado.Value!.MotivoRetificacao.Should().Be("Adequação a decisão superveniente", "o motivo é normalizado com Trim");
+    }
+
+    /// <summary>
+    /// Relógio manual determinístico — evita depender de
+    /// <c>Microsoft.Extensions.TimeProvider.Testing</c> na camada de teste do
+    /// Domain (que só referencia Domain + Kernel). Permite dar instantes
+    /// distintos à abertura e à retificação (unicidade de data_publicacao).
+    /// </summary>
+    private sealed class RelogioManual(DateTimeOffset inicio) : TimeProvider
+    {
+        private DateTimeOffset _agora = inicio;
+
+        public override DateTimeOffset GetUtcNow() => _agora;
+
+        public void Avancar(TimeSpan delta) => _agora = _agora.Add(delta);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificacaoConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificacaoConcorrenciaTests.cs
@@ -15,15 +15,16 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
 /// <summary>
 /// Cobertura de concorrência da retificação (Story #759 T5 #786, ADR-0101/0102):
-/// duas retificações do MESMO Edital vigente disparadas simultaneamente não
-/// podem ramificar a cadeia — a linearidade "cada Edital é retificado no máximo
-/// uma vez" tem de valer sob corrida. O lock pessimista
-/// (<c>SELECT ... FOR UPDATE</c> em <c>ObterComConfiguracaoAsync</c>) serializa
-/// os handlers: quando a segunda retificação recarrega o agregado, o vigente já
-/// é o Edital de retificação recém-criado, e o guard de vigência a recusa. Se a
-/// serialização falhasse e ambas passassem pelo guard em memória, o índice único
-/// parcial <c>ux_editais_edital_retificado_unico</c> é o backstop de banco — em
-/// qualquer caminho, exatamente uma retificação vence e a cadeia não ramifica.
+/// duas retificações do mesmo processo disparadas simultaneamente não podem
+/// ramificar a cadeia — a linearidade "nenhum Edital é sucedido por dois ramos"
+/// tem de valer sob corrida. O lock pessimista (<c>SELECT ... FOR UPDATE</c> em
+/// <c>ObterComConfiguracaoAsync</c>) serializa os handlers: quando a segunda
+/// retificação recarrega o agregado, o vigente já é o Edital de retificação
+/// recém-criado, então ela sucede ESSE — empilhando em cadeia linear
+/// (abertura→R1→R2), sem ramificar. Se a serialização falhasse e ambas lessem o
+/// mesmo vigente, o índice único parcial <c>ux_editais_edital_retificado_unico</c>
+/// é o backstop de banco que barra a segunda. Em qualquer caminho a cadeia
+/// permanece estritamente linear.
 /// </summary>
 [Collection(CascadingCollection.Name)]
 public sealed class RetificacaoConcorrenciaTests
@@ -36,7 +37,7 @@ public sealed class RetificacaoConcorrenciaTests
     }
 
     [Fact(DisplayName =
-        "Duas retificações concorrentes do mesmo Edital vigente não ramificam a cadeia (ADR-0101/0102)")]
+        "Duas retificações concorrentes do mesmo processo não ramificam a cadeia (ADR-0101/0102)")]
     public async Task DuasRetificacoesConcorrentes_NaoRamificamCadeia()
     {
         CascadingApiFactory api = _fixture.Factory;
@@ -86,7 +87,6 @@ public sealed class RetificacaoConcorrenciaTests
 
         var retificarCommand = new RetificarProcessoSeletivoCommand(
             processoId,
-            editalAberturaId,
             "Correção concorrente do prazo de inscrição",
             Numero: "001/2026-R1",
             PeriodoInscricaoInicio: new DateOnly(2026, 2, 1),
@@ -105,28 +105,35 @@ public sealed class RetificacaoConcorrenciaTests
         Result resultadoA = await retificarTaskA;
         Result resultadoB = await retificarTaskB;
 
-        // Exatamente uma retificação vence; a outra é recusada — nunca as duas.
-        new[] { resultadoA, resultadoB }.Count(r => r.IsSuccess).Should().Be(1,
-            "o lock pessimista + guard de vigência serializam as retificações do mesmo processo");
+        // Ao menos uma retificação conclui. Sob o lock as duas serializam e
+        // ambas concluem (empilhando); num cenário sem lock, o índice único
+        // barra a segunda (falha com Edital.RetificacaoJaExiste). O invariante
+        // testado é a NÃO-RAMIFICAÇÃO da cadeia, não o número de vencedores.
+        int sucessos = new[] { resultadoA, resultadoB }.Count(r => r.IsSuccess);
+        sucessos.Should().BeGreaterThanOrEqualTo(1, "ao menos uma retificação conclui");
+        Result? perdedor = new[] { resultadoA, resultadoB }.FirstOrDefault(r => r.IsFailure);
+        if (perdedor is not null)
+        {
+            perdedor.HasErrorCode("Edital.RetificacaoJaExiste").Should().BeTrue(
+                "a retificação que perde a corrida sem o lock é barrada pelo índice único de banco");
+        }
 
-        Result perdedor = resultadoA.IsFailure ? resultadoA : resultadoB;
-        bool codigoDeLinearidade =
-            perdedor.HasErrorCode("ProcessoSeletivo.EditalRetificadoInvalido")
-            || perdedor.HasErrorCode("Edital.RetificacaoJaExiste");
-        codigoDeLinearidade.Should().BeTrue(
-            "a segunda retificação recarrega a cadeia com o novo vigente (guard em memória) " +
-            "ou é barrada pelo índice único de banco — ambos preservam a linearidade");
-
-        // A cadeia não ramificou: exatamente 1 abertura + 1 retificação.
         await using AsyncServiceScope readScope = api.Services.CreateAsyncScope();
         SelecaoDbContext readDb = readScope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
         List<Edital> editais = await readDb.Set<Edital>().AsNoTracking()
             .Where(e => e.ProcessoSeletivoId == processoId)
             .ToListAsync();
 
-        editais.Should().HaveCount(2);
-        editais.Count(e => e.Natureza == NaturezaEdital.Retificacao).Should().Be(1,
-            "a linearidade da cadeia (ADR-0101) impede um segundo ramo de retificação sobre o mesmo Edital");
+        // Invariante de linearidade (ADR-0101): nenhum Edital é sucedido por
+        // mais de um ramo de retificação.
+        editais.Where(e => e.EditalRetificadoId is not null)
+            .GroupBy(e => e.EditalRetificadoId)
+            .Where(g => g.Count() > 1)
+            .Should().BeEmpty("nenhum Edital pode ser sucedido por dois ramos — a cadeia é linear");
+
+        // Cada retificação concluída acrescenta exatamente um Edital de
+        // retificação; a abertura é sucedida por no máximo um deles.
+        editais.Count(e => e.Natureza == NaturezaEdital.Retificacao).Should().Be(sucessos);
         editais.Should().ContainSingle(e => e.EditalRetificadoId == editalAberturaId);
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificacaoConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificacaoConcorrenciaTests.cs
@@ -1,0 +1,132 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Wolverine;
+
+using Application.Commands.ProcessosSeletivos;
+using Domain.Entities;
+using Domain.Enums;
+using Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// Cobertura de concorrência da retificação (Story #759 T5 #786, ADR-0101/0102):
+/// duas retificações do MESMO Edital vigente disparadas simultaneamente não
+/// podem ramificar a cadeia — a linearidade "cada Edital é retificado no máximo
+/// uma vez" tem de valer sob corrida. O lock pessimista
+/// (<c>SELECT ... FOR UPDATE</c> em <c>ObterComConfiguracaoAsync</c>) serializa
+/// os handlers: quando a segunda retificação recarrega o agregado, o vigente já
+/// é o Edital de retificação recém-criado, e o guard de vigência a recusa. Se a
+/// serialização falhasse e ambas passassem pelo guard em memória, o índice único
+/// parcial <c>ux_editais_edital_retificado_unico</c> é o backstop de banco — em
+/// qualquer caminho, exatamente uma retificação vence e a cadeia não ramifica.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+public sealed class RetificacaoConcorrenciaTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public RetificacaoConcorrenciaTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName =
+        "Duas retificações concorrentes do mesmo Edital vigente não ramificam a cadeia (ADR-0101/0102)")]
+    public async Task DuasRetificacoesConcorrentes_NaoRamificamCadeia()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+
+        Guid processoId;
+        Guid documentoAbertura;
+        await using (AsyncServiceScope seedScope = api.Services.CreateAsyncScope())
+        {
+            SelecaoDbContext seedDb = seedScope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+            (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+                .SemearAsync(seedDb, $"Concorrência retificação {Guid.CreateVersion7()}");
+            processoId = processo.Id;
+            documentoAbertura = documento.Id;
+        }
+
+        // Publica a abertura pelo bus (mesmo caminho do handler HTTP).
+        var publicarCommand = new PublicarProcessoSeletivoCommand(
+            processoId,
+            Numero: null,
+            PeriodoInscricaoInicio: new DateOnly(2026, 1, 1),
+            PeriodoInscricaoFim: new DateOnly(2026, 1, 31),
+            DocumentoEditalId: documentoAbertura);
+        await using (AsyncServiceScope publicarScope = api.Services.CreateAsyncScope())
+        {
+            IMessageBus publicarBus = publicarScope.ServiceProvider.GetRequiredService<IMessageBus>();
+            Result publicarResultado = await publicarBus.InvokeAsync<Result>(publicarCommand);
+            publicarResultado.IsSuccess.Should().BeTrue(publicarResultado.Error?.Message);
+        }
+
+        Guid editalAberturaId;
+        Guid documentoRetificacao;
+        await using (AsyncServiceScope preparoScope = api.Services.CreateAsyncScope())
+        {
+            SelecaoDbContext db = preparoScope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+            editalAberturaId = await db.Set<Edital>().AsNoTracking()
+                .Where(e => e.ProcessoSeletivoId == processoId)
+                .Select(e => e.Id)
+                .SingleAsync();
+
+            string hashFixo = string.Concat(Enumerable.Repeat("ef67012345", 7))[..64];
+            DocumentoEdital documento = DocumentoEdital.IniciarPendente(processoId, TimeProvider.System, TimeSpan.FromMinutes(15));
+            documento.Confirmar(2048, hashFixo, TimeProvider.System).IsSuccess.Should().BeTrue();
+            await db.DocumentosEdital.AddAsync(documento);
+            await db.SaveChangesAsync();
+            documentoRetificacao = documento.Id;
+        }
+
+        var retificarCommand = new RetificarProcessoSeletivoCommand(
+            processoId,
+            editalAberturaId,
+            "Correção concorrente do prazo de inscrição",
+            Numero: "001/2026-R1",
+            PeriodoInscricaoInicio: new DateOnly(2026, 2, 1),
+            PeriodoInscricaoFim: new DateOnly(2026, 2, 28),
+            DocumentoEditalId: documentoRetificacao);
+
+        await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
+        await using AsyncServiceScope scopeB = api.Services.CreateAsyncScope();
+        IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
+        IMessageBus busB = scopeB.ServiceProvider.GetRequiredService<IMessageBus>();
+
+        Task<Result> retificarTaskA = busA.InvokeAsync<Result>(retificarCommand);
+        Task<Result> retificarTaskB = busB.InvokeAsync<Result>(retificarCommand);
+        await Task.WhenAll(retificarTaskA, retificarTaskB);
+
+        Result resultadoA = await retificarTaskA;
+        Result resultadoB = await retificarTaskB;
+
+        // Exatamente uma retificação vence; a outra é recusada — nunca as duas.
+        new[] { resultadoA, resultadoB }.Count(r => r.IsSuccess).Should().Be(1,
+            "o lock pessimista + guard de vigência serializam as retificações do mesmo processo");
+
+        Result perdedor = resultadoA.IsFailure ? resultadoA : resultadoB;
+        bool codigoDeLinearidade =
+            perdedor.HasErrorCode("ProcessoSeletivo.EditalRetificadoInvalido")
+            || perdedor.HasErrorCode("Edital.RetificacaoJaExiste");
+        codigoDeLinearidade.Should().BeTrue(
+            "a segunda retificação recarrega a cadeia com o novo vigente (guard em memória) " +
+            "ou é barrada pelo índice único de banco — ambos preservam a linearidade");
+
+        // A cadeia não ramificou: exatamente 1 abertura + 1 retificação.
+        await using AsyncServiceScope readScope = api.Services.CreateAsyncScope();
+        SelecaoDbContext readDb = readScope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        List<Edital> editais = await readDb.Set<Edital>().AsNoTracking()
+            .Where(e => e.ProcessoSeletivoId == processoId)
+            .ToListAsync();
+
+        editais.Should().HaveCount(2);
+        editais.Count(e => e.Natureza == NaturezaEdital.Retificacao).Should().Be(1,
+            "a linearidade da cadeia (ADR-0101) impede um segundo ramo de retificação sobre o mesmo Edital");
+        editais.Should().ContainSingle(e => e.EditalRetificadoId == editalAberturaId);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificarProcessoSeletivoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificarProcessoSeletivoEndpointTests.cs
@@ -1,0 +1,215 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Events;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+// Cenário fim-a-fim da retificação (Story #759, T5 #786, ADR-0101): publica
+// via HTTP, depois retifica o Edital vigente — novo Edital de retificação +
+// novo snapshot, cascading do ProcessoPublicadoEvent (reusado; a retificação
+// é, em forma, outra emissão de Edital+snapshot). Reusa a mesma infra de
+// cascading do fluxo de publicação.
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+[Trait("Category", "OutboxCascading")]
+public sealed class RetificarProcessoSeletivoEndpointTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public RetificarProcessoSeletivoEndpointTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/retificacoes emite Edital de retificação + snapshot e dispara cascading")]
+    public async Task Retificar_FluxoCompleto_EmiteRetificacaoEDispatchaCascading()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        DomainEventCollector collector = api.Services.GetRequiredService<DomainEventCollector>();
+
+        (Guid processoId, Guid documentoAbertura) = await SemearAsync(api, nameof(Retificar_FluxoCompleto_EmiteRetificacaoEDispatchaCascading));
+
+        // Publica o Edital de abertura.
+        HttpResponseMessage publicar = await PostPublicarAsync(client, processoId, documentoAbertura, MakeIdempotencyKey());
+        publicar.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        Guid editalAberturaId = await ObterEditalUnicoAsync(api, processoId);
+        Guid documentoRetificacao = await SemearDocumentoConfirmadoAsync(api, processoId);
+
+        // Retifica o Edital vigente (a abertura).
+        HttpResponseMessage retificar = await PostRetificarAsync(
+            client, processoId, editalAberturaId, documentoRetificacao, "Correção do prazo de inscrição", MakeIdempotencyKey());
+        retificar.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Lê o Edital de retificação persistido e espera o evento que carrega
+        // ESTE editalId — a entrega cascading é assíncrona e o coletor também
+        // guarda o evento da abertura (mesmo processoId); filtrar por editalId
+        // evita a corrida de pegar o evento errado.
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        List<Edital> editais = await db.Set<Edital>().AsNoTracking()
+            .Where(e => e.ProcessoSeletivoId == processoId).ToListAsync();
+        editais.Should().HaveCount(2);
+        Edital retificacao = editais.Single(e => e.Natureza == NaturezaEdital.Retificacao);
+        retificacao.EditalRetificadoId.Should().Be(editalAberturaId);
+        retificacao.MotivoRetificacao.Should().Be("Correção do prazo de inscrição");
+
+        ProcessoPublicadoEvent? evento = await EsperarEventoPorEditalAsync(
+            collector, retificacao.Id, TimeSpan.FromSeconds(15));
+        evento.Should().NotBeNull("a retificação drena ProcessoPublicadoEvent pelo mesmo caminho cascading");
+        evento!.ProcessoSeletivoId.Should().Be(processoId);
+    }
+
+    private static async Task<ProcessoPublicadoEvent?> EsperarEventoPorEditalAsync(
+        DomainEventCollector collector, Guid editalIdEsperado, TimeSpan timeout)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ProcessoPublicadoEvent? candidato = collector.Snapshot()
+                .FirstOrDefault(e => e.EditalId == editalIdEsperado);
+            if (candidato is not null)
+            {
+                return candidato;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(150));
+        }
+
+        return null;
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/retificacoes em processo ainda em rascunho retorna 422 TransicaoInvalida (CA-09)")]
+    public async Task Retificar_ProcessoRascunho_Retorna422()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        (Guid processoId, Guid documentoId) = await SemearAsync(api, nameof(Retificar_ProcessoRascunho_Retorna422));
+
+        HttpResponseMessage response = await PostRetificarAsync(
+            client, processoId, Guid.CreateVersion7(), documentoId, "motivo", MakeIdempotencyKey());
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.selecao.processo_seletivo.transicao_invalida");
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/retificacoes em processo inexistente retorna 404")]
+    public async Task Retificar_ProcessoInexistente_Retorna404()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        HttpResponseMessage response = await PostRetificarAsync(
+            client, Guid.CreateVersion7(), Guid.CreateVersion7(), Guid.CreateVersion7(), "motivo", MakeIdempotencyKey());
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.selecao.processo_seletivo.nao_encontrado");
+    }
+
+    private static object NovoCorpoPublicacao(Guid documentoEditalId) => new
+    {
+        numero = "001/2026",
+        periodoInscricaoInicio = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        periodoInscricaoFim = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        documentoEditalId,
+    };
+
+    private static object NovoCorpoRetificacao(Guid editalRetificadoId, Guid documentoEditalId, string motivo) => new
+    {
+        editalRetificadoId,
+        motivo,
+        numero = "001/2026-R1",
+        periodoInscricaoInicio = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        periodoInscricaoFim = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(40)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+        documentoEditalId,
+    };
+
+    private static async Task<HttpResponseMessage> PostPublicarAsync(
+        HttpClient client, Guid processoId, Guid documentoEditalId, string idempotencyKey)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{processoId}/publicacao", UriKind.Relative))
+        {
+            Content = JsonContent.Create(NovoCorpoPublicacao(documentoEditalId)),
+        };
+        AppendTestAuth(request);
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+        return await client.SendAsync(request).ConfigureAwait(false);
+    }
+
+    private static async Task<HttpResponseMessage> PostRetificarAsync(
+        HttpClient client, Guid processoId, Guid editalRetificadoId, Guid documentoEditalId, string motivo, string idempotencyKey)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{processoId}/retificacoes", UriKind.Relative))
+        {
+            Content = JsonContent.Create(NovoCorpoRetificacao(editalRetificadoId, documentoEditalId, motivo)),
+        };
+        AppendTestAuth(request);
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+        return await client.SendAsync(request).ConfigureAwait(false);
+    }
+
+    private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
+
+    private static void AppendTestAuth(HttpRequestMessage request)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme, TestAuthHandler.TokenValue);
+        request.Headers.TryAddWithoutValidation(TestAuthHandler.RolesHeader, "plataforma-admin");
+    }
+
+    private static async Task<(Guid ProcessoId, Guid DocumentoId)> SemearAsync(CascadingApiFactory api, string nome)
+    {
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+            .SemearAsync(db, $"{nome} {Guid.CreateVersion7()}");
+        return (processo.Id, documento.Id);
+    }
+
+    private static async Task<Guid> SemearDocumentoConfirmadoAsync(CascadingApiFactory api, Guid processoId)
+    {
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        string hashFixo = string.Concat(Enumerable.Repeat("cd45670189", 7))[..64];
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processoId, TimeProvider.System, TimeSpan.FromMinutes(15));
+        documento.Confirmar(2048, hashFixo, TimeProvider.System).IsSuccess.Should().BeTrue();
+        await db.DocumentosEdital.AddAsync(documento);
+        await db.SaveChangesAsync();
+        return documento.Id;
+    }
+
+    private static async Task<Guid> ObterEditalUnicoAsync(CascadingApiFactory api, Guid processoId)
+    {
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        return await db.Set<Edital>().AsNoTracking()
+            .Where(e => e.ProcessoSeletivoId == processoId)
+            .Select(e => e.Id)
+            .SingleAsync();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificarProcessoSeletivoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificarProcessoSeletivoEndpointTests.cs
@@ -4,7 +4,9 @@ using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 using AwesomeAssertions;
 
@@ -75,6 +77,44 @@ public sealed class RetificarProcessoSeletivoEndpointTests
             collector, retificacao.Id, TimeSpan.FromSeconds(15));
         evento.Should().NotBeNull("a retificação drena ProcessoPublicadoEvent pelo mesmo caminho cascading");
         evento!.ProcessoSeletivoId.Should().Be(processoId);
+    }
+
+    [Fact(DisplayName =
+        "Retificação com motivo Unicode decomposto congela o mesmo valor NFC no snapshot e na coluna do Edital")]
+    public async Task Retificar_MotivoUnicodeDecomposto_SnapshotEEditalReconciliam()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        (Guid processoId, Guid documentoAbertura) = await SemearAsync(api, nameof(Retificar_MotivoUnicodeDecomposto_SnapshotEEditalReconciliam));
+        HttpResponseMessage publicar = await PostPublicarAsync(client, processoId, documentoAbertura, MakeIdempotencyKey());
+        publicar.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        Guid documentoRetificacao = await SemearDocumentoConfirmadoAsync(api, processoId);
+
+        // Motivo em forma DECOMPOSTA (NFD): ç = c + U+0327, ã = a + U+0303. O
+        // handler deve normalizar para NFC uma vez e congelar o mesmo valor nos
+        // dois lados (coluna do Edital e bloco 'retificacao' do snapshot).
+        string motivoDecomposto = "correção do prazo de inscrição".Normalize(NormalizationForm.FormD);
+        HttpResponseMessage retificar = await PostRetificarAsync(
+            client, processoId, documentoRetificacao, motivoDecomposto, MakeIdempotencyKey());
+        retificar.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        Edital retificacao = await db.Set<Edital>().AsNoTracking()
+            .SingleAsync(e => e.ProcessoSeletivoId == processoId && e.Natureza == NaturezaEdital.Retificacao);
+        SnapshotPublicacao snapshot = await db.SnapshotsPublicacao.AsNoTracking()
+            .SingleAsync(s => s.EditalId == retificacao.Id);
+        string motivoNoSnapshot = JsonNode.Parse(snapshot.ConfiguracaoCongelada)!
+            .AsObject()["retificacao"]!["motivo"]!.GetValue<string>();
+
+        // A coluna do Edital e o bloco congelado guardam o MESMO valor NFC — a
+        // reconciliação do snapshot forense contra a linha do Edital vale mesmo
+        // com input decomposto (Postgres não normaliza texto).
+        retificacao.MotivoRetificacao.Should().Be(motivoNoSnapshot);
+        retificacao.MotivoRetificacao.Should().Be(
+            "correção do prazo de inscrição".Normalize(NormalizationForm.FormC));
     }
 
     private static async Task<ProcessoPublicadoEvent?> EsperarEventoPorEditalAsync(

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificarProcessoSeletivoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/RetificarProcessoSeletivoEndpointTests.cs
@@ -52,9 +52,10 @@ public sealed class RetificarProcessoSeletivoEndpointTests
         Guid editalAberturaId = await ObterEditalUnicoAsync(api, processoId);
         Guid documentoRetificacao = await SemearDocumentoConfirmadoAsync(api, processoId);
 
-        // Retifica o Edital vigente (a abertura).
+        // Retifica: o servidor infere o Edital vigente (a abertura) — o cliente
+        // não informa id de Edital interno, só endereça o processo.
         HttpResponseMessage retificar = await PostRetificarAsync(
-            client, processoId, editalAberturaId, documentoRetificacao, "Correção do prazo de inscrição", MakeIdempotencyKey());
+            client, processoId, documentoRetificacao, "Correção do prazo de inscrição", MakeIdempotencyKey());
         retificar.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
         // Lê o Edital de retificação persistido e espera o evento que carrega
@@ -105,7 +106,7 @@ public sealed class RetificarProcessoSeletivoEndpointTests
         (Guid processoId, Guid documentoId) = await SemearAsync(api, nameof(Retificar_ProcessoRascunho_Retorna422));
 
         HttpResponseMessage response = await PostRetificarAsync(
-            client, processoId, Guid.CreateVersion7(), documentoId, "motivo", MakeIdempotencyKey());
+            client, processoId, documentoId, "motivo", MakeIdempotencyKey());
 
         response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
         using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
@@ -121,7 +122,7 @@ public sealed class RetificarProcessoSeletivoEndpointTests
         using HttpClient client = api.CreateClient();
 
         HttpResponseMessage response = await PostRetificarAsync(
-            client, Guid.CreateVersion7(), Guid.CreateVersion7(), Guid.CreateVersion7(), "motivo", MakeIdempotencyKey());
+            client, Guid.CreateVersion7(), Guid.CreateVersion7(), "motivo", MakeIdempotencyKey());
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
         using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
@@ -137,9 +138,8 @@ public sealed class RetificarProcessoSeletivoEndpointTests
         documentoEditalId,
     };
 
-    private static object NovoCorpoRetificacao(Guid editalRetificadoId, Guid documentoEditalId, string motivo) => new
+    private static object NovoCorpoRetificacao(Guid documentoEditalId, string motivo) => new
     {
-        editalRetificadoId,
         motivo,
         numero = "001/2026-R1",
         periodoInscricaoInicio = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
@@ -161,12 +161,12 @@ public sealed class RetificarProcessoSeletivoEndpointTests
     }
 
     private static async Task<HttpResponseMessage> PostRetificarAsync(
-        HttpClient client, Guid processoId, Guid editalRetificadoId, Guid documentoEditalId, string motivo, string idempotencyKey)
+        HttpClient client, Guid processoId, Guid documentoEditalId, string motivo, string idempotencyKey)
     {
         using HttpRequestMessage request = new(HttpMethod.Post,
             new Uri($"/api/selecao/processos-seletivos/{processoId}/retificacoes", UriKind.Relative))
         {
-            Content = JsonContent.Create(NovoCorpoRetificacao(editalRetificadoId, documentoEditalId, motivo)),
+            Content = JsonContent.Create(NovoCorpoRetificacao(documentoEditalId, motivo)),
         };
         AppendTestAuth(request);
         request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RetificacaoPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RetificacaoPersistenciaTests.cs
@@ -107,10 +107,10 @@ public sealed class RetificacaoPersistenciaTests : IClassFixture<ProcessoSeletiv
             DadosEdital dadosRetificacao = NovosDados(docRetificacao.Id);
             SnapshotCanonico canonicoRetificacao = Canonicalizer.Canonicalizar(
                 carregado, dadosRetificacao, docRetificacao.HashSha256!,
-                new RetificacaoInfo(publicar.Value!.Edital.Id, "Correção do prazo de inscrição"));
+                new RetificacaoInfo(carregado.EditalVigente!.Id, "Correção do prazo de inscrição"));
             Result<PublicacaoResultado> retificar = carregado.Retificar(
                 dadosRetificacao, canonicoRetificacao.Bytes, canonicoRetificacao.SchemaVersion, canonicoRetificacao.AlgoritmoHash,
-                docRetificacao.HashSha256!, "integration-test-user", publicar.Value!.Edital.Id, "Correção do prazo de inscrição", clock);
+                docRetificacao.HashSha256!, "integration-test-user", "Correção do prazo de inscrição", clock);
             retificar.IsSuccess.Should().BeTrue(retificar.Error?.Message);
             snapshotRetificacao = retificar.Value!.Snapshot;
             retificacaoEdital = retificar.Value!.Edital;

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RetificacaoPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RetificacaoPersistenciaTests.cs
@@ -1,0 +1,209 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ProcessosSeletivos;
+
+using System.Text.Json.Nodes;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Cobertura de integração (Postgres real via Testcontainers) da retificação
+/// (RN08, ADR-0101, Story #759 T5 #786): a retificação emite um novo Edital
+/// vinculado ao vigente + novo snapshot com o bloco de retificação preservando
+/// os 17 blocos anteriores; o snapshot da abertura permanece imutável. Mapa de
+/// testes de #759: <c>Retificacao_NovoEditalSnapshotMotivo</c>.
+/// </summary>
+public sealed class RetificacaoPersistenciaTests : IClassFixture<ProcessoSeletivoDbFixture>
+{
+    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+    private static readonly SnapshotPublicacaoCanonicalizer Canonicalizer = new();
+
+    private readonly ProcessoSeletivoDbFixture _fixture;
+
+    public RetificacaoPersistenciaTests(ProcessoSeletivoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static ReferenciaRegra Regra(string codigo, string hashChar) =>
+        ReferenciaRegra.Criar(codigo, "v1", new string(hashChar[0], 64)).Value!;
+
+    private static ProcessoSeletivo NovoProcessoConforme(string nome)
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar(nome, TipoProcesso.SiSU);
+        processo.DefinirEtapas([
+            EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1),
+        ]).IsSuccess.Should().BeTrue();
+        processo.DefinirOfertaAtendimento(OfertaAtendimentoEspecializado.Criar([], [], []).Value!).IsSuccess.Should().BeTrue();
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            Guid.CreateVersion7(), "AC", null, NaturezaLegalModalidade.Ampla, ComposicaoVagasModalidade.ResidualDoVo,
+            null, RegraRemanejamentoModalidade.Nenhuma, null, null, null, [], null, "Res. Unifesspa 532/2021").Value!;
+        processo.DefinirDistribuicaoVagas([ConfiguracaoDistribuicaoVagas.Criar(
+            Guid.CreateVersion7(), 40, 1m, Regra(RegraDistribuicaoVagasCodigo.Institucional, "a"), null, [modalidade]).Value!])
+            .IsSuccess.Should().BeTrue();
+        processo.DefinirClassificacao(ConfiguracaoClassificacao.Criar(
+            Regra(RegraCalculoCodigo.ClassificacaoImportada, "b"), null, null,
+            Regra(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "c"), 1, []).Value!).IsSuccess.Should().BeTrue();
+        return processo;
+    }
+
+    private static DocumentoEdital DocumentoConfirmado(Guid processoId)
+    {
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processoId, TimeProvider.System, TimeSpan.FromMinutes(15));
+        documento.Confirmar(1024, HashFixo, TimeProvider.System).IsSuccess.Should().BeTrue();
+        return documento;
+    }
+
+    private static DadosEdital NovosDados(Guid documentoId) => DadosEdital.Criar(
+        "001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31), documentoId).Value!;
+
+    /// <summary>
+    /// Publica um processo e o retifica em seguida — persistindo os dois
+    /// Editais e os dois snapshots. Usa um relógio manual para dar instantes
+    /// distintos à abertura e à retificação (ux_editais_processo_data_publicacao).
+    /// </summary>
+    private async Task<(ProcessoSeletivo Processo, Edital Abertura, SnapshotPublicacao SnapshotAbertura, Edital Retificacao, SnapshotPublicacao SnapshotRetificacao)>
+        PublicarERetificarAsync(string nome)
+    {
+        RelogioManual clock = new(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+
+        ProcessoSeletivo processo = NovoProcessoConforme(nome);
+        DocumentoEdital docAbertura = DocumentoConfirmado(processo.Id);
+        DadosEdital dadosAbertura = NovosDados(docAbertura.Id);
+        SnapshotCanonico canonicoAbertura = Canonicalizer.Canonicalizar(processo, dadosAbertura, docAbertura.HashSha256!);
+        Result<PublicacaoResultado> publicar = processo.Publicar(
+            dadosAbertura, canonicoAbertura.Bytes, canonicoAbertura.SchemaVersion, canonicoAbertura.AlgoritmoHash,
+            docAbertura.HashSha256!, "integration-test-user", clock);
+        publicar.IsSuccess.Should().BeTrue(publicar.Error?.Message);
+
+        await using (SelecaoDbContext writeContext = _fixture.CreateDbContext())
+        {
+            ProcessoSeletivoRepository repository = new(writeContext, TimeProvider.System);
+            await repository.AdicionarAsync(processo, CancellationToken.None);
+            await writeContext.DocumentosEdital.AddAsync(docAbertura, CancellationToken.None);
+            await repository.AdicionarSnapshotPublicacaoAsync(publicar.Value!.Snapshot, CancellationToken.None);
+            await writeContext.SaveChangesAsync(CancellationToken.None);
+        }
+
+        clock.Avancar(TimeSpan.FromDays(1));
+
+        // Recarrega o agregado tracked (com a cadeia de Editais) — como o handler faz.
+        DocumentoEdital docRetificacao = DocumentoConfirmado(processo.Id);
+        SnapshotPublicacao snapshotRetificacao;
+        Edital retificacaoEdital;
+        await using (SelecaoDbContext writeContext = _fixture.CreateDbContext())
+        {
+            ProcessoSeletivoRepository repository = new(writeContext, TimeProvider.System);
+            ProcessoSeletivo carregado = (await repository.ObterComConfiguracaoAsync(processo.Id, CancellationToken.None))!;
+            DadosEdital dadosRetificacao = NovosDados(docRetificacao.Id);
+            SnapshotCanonico canonicoRetificacao = Canonicalizer.Canonicalizar(
+                carregado, dadosRetificacao, docRetificacao.HashSha256!,
+                new RetificacaoInfo(publicar.Value!.Edital.Id, "Correção do prazo de inscrição"));
+            Result<PublicacaoResultado> retificar = carregado.Retificar(
+                dadosRetificacao, canonicoRetificacao.Bytes, canonicoRetificacao.SchemaVersion, canonicoRetificacao.AlgoritmoHash,
+                docRetificacao.HashSha256!, "integration-test-user", publicar.Value!.Edital.Id, "Correção do prazo de inscrição", clock);
+            retificar.IsSuccess.Should().BeTrue(retificar.Error?.Message);
+            snapshotRetificacao = retificar.Value!.Snapshot;
+            retificacaoEdital = retificar.Value!.Edital;
+
+            await writeContext.DocumentosEdital.AddAsync(docRetificacao, CancellationToken.None);
+            await repository.AdicionarSnapshotPublicacaoAsync(snapshotRetificacao, CancellationToken.None);
+            await writeContext.SaveChangesAsync(CancellationToken.None);
+        }
+
+        return (processo, publicar.Value!.Edital, publicar.Value!.Snapshot, retificacaoEdital, snapshotRetificacao);
+    }
+
+    [Fact(DisplayName = "Retificacao persiste um segundo Edital (retificação) vinculado ao vigente + segundo snapshot")]
+    public async Task Retificacao_PersisteNovoEditalESnapshot()
+    {
+        (ProcessoSeletivo processo, Edital abertura, _, Edital retificacao, _) =
+            await PublicarERetificarAsync(nameof(Retificacao_PersisteNovoEditalESnapshot));
+
+        await using SelecaoDbContext readContext = _fixture.CreateDbContext();
+        List<Edital> editais = await readContext.Set<Edital>()
+            .AsNoTracking()
+            .Where(e => e.ProcessoSeletivoId == processo.Id)
+            .ToListAsync(CancellationToken.None);
+
+        editais.Should().HaveCount(2);
+        editais.Should().ContainSingle(e => e.Natureza == NaturezaEdital.Abertura && e.Id == abertura.Id);
+        Edital retificacaoPersistida = editais.Single(e => e.Natureza == NaturezaEdital.Retificacao);
+        retificacaoPersistida.Id.Should().Be(retificacao.Id);
+        retificacaoPersistida.EditalRetificadoId.Should().Be(abertura.Id);
+        retificacaoPersistida.MotivoRetificacao.Should().Be("Correção do prazo de inscrição");
+
+        int totalSnapshots = await readContext.SnapshotsPublicacao
+            .AsNoTracking()
+            .CountAsync(s => s.EditalId == abertura.Id || s.EditalId == retificacao.Id, CancellationToken.None);
+        totalSnapshots.Should().Be(2);
+    }
+
+    [Fact(DisplayName = "Snapshot de retificação carrega o bloco retificacao + os 17 blocos; o snapshot da abertura permanece imutável")]
+    public async Task Retificacao_SnapshotComBlocoRetificacao_AnteriorImutavel()
+    {
+        (_, _, SnapshotPublicacao snapshotAbertura, _, SnapshotPublicacao snapshotRetificacao) =
+            await PublicarERetificarAsync(nameof(Retificacao_SnapshotComBlocoRetificacao_AnteriorImutavel));
+
+        await using SelecaoDbContext readContext = _fixture.CreateDbContext();
+
+        SnapshotPublicacao retificacaoLida = await readContext.SnapshotsPublicacao
+            .AsNoTracking().FirstAsync(s => s.Id == snapshotRetificacao.Id, CancellationToken.None);
+        JsonObject payloadRetificacao = JsonNode.Parse(retificacaoLida.ConfiguracaoCongelada)!.AsObject();
+
+        // Os 17 blocos canônicos continuam presentes...
+        foreach (string bloco in new[]
+        {
+            "periodo", "etapas", "vagas", "distribuicao", "modalidades", "ofertas", "atendimento",
+            "bonusRegional", "criteriosDesempate", "classificacao", "hashesEdital", "documentosExigidos",
+            "formulario", "cascataRemanejamento", "divulgacao", "cronogramaFases", "identidadesUnidade",
+        })
+        {
+            payloadRetificacao.Should().ContainKey(bloco);
+        }
+
+        // ...e o 18º bloco de retificação foi acrescentado (ADR-0101).
+        payloadRetificacao.Should().ContainKey("retificacao");
+        payloadRetificacao["retificacao"]!["motivo"]!.GetValue<string>().Should().Be("Correção do prazo de inscrição");
+
+        // O snapshot da abertura permanece byte-a-byte idêntico (append-only).
+        SnapshotPublicacao aberturaLida = await readContext.SnapshotsPublicacao
+            .AsNoTracking().FirstAsync(s => s.Id == snapshotAbertura.Id, CancellationToken.None);
+        aberturaLida.HashConfiguracao.Should().Be(snapshotAbertura.HashConfiguracao);
+        aberturaLida.ConfiguracaoCongeladaCanonica.Should().Equal(snapshotAbertura.ConfiguracaoCongeladaCanonica);
+        JsonNode.Parse(aberturaLida.ConfiguracaoCongelada)!.AsObject().Should().NotContainKey("retificacao",
+            "o snapshot da abertura nunca carrega o bloco de retificação");
+    }
+
+    [Fact(DisplayName = "Snapshot_HashConfereAppEBanco (retificação) — re-hashear os bytes lidos do banco bate com o hash persistido")]
+    public async Task Retificacao_HashConfereAppEBanco()
+    {
+        (_, _, _, _, SnapshotPublicacao snapshotRetificacao) =
+            await PublicarERetificarAsync(nameof(Retificacao_HashConfereAppEBanco));
+
+        await using SelecaoDbContext readContext = _fixture.CreateDbContext();
+        SnapshotPublicacao lida = await readContext.SnapshotsPublicacao
+            .AsNoTracking().FirstAsync(s => s.Id == snapshotRetificacao.Id, CancellationToken.None);
+
+        HashCanonicalComputer.ComputeSha256Hex(lida.ConfiguracaoCongeladaCanonica)
+            .Should().Be(lida.HashConfiguracao);
+    }
+
+    private sealed class RelogioManual(DateTimeOffset inicio) : TimeProvider
+    {
+        private DateTimeOffset _agora = inicio;
+
+        public override DateTimeOffset GetUtcNow() => _agora;
+
+        public void Avancar(TimeSpan delta) => _agora = _agora.Add(delta);
+    }
+}


### PR DESCRIPTION
Implementa a **retificação** de um processo já publicado (RN08, Story #759, T5, ADR-0101) — a 5ª das 6 tasks do arco Publicar.

Closes #786

## O que muda
- **`Edital.EmitirRetificacao`** — factory da variante retificação (contrato tudo-ou-nada: `editalRetificadoId` + `motivo` obrigatórios).
- **`ProcessoSeletivo.Retificar(DadosEdital, …, editalRetificadoId, motivo, clock)`** — exige processo `Publicado` (CA-09) e que o edital retificado seja o **vigente** do próprio processo (topo da cadeia por `data_publicacao` — CA-06 + cadeia linear, ADR-0101). Emite novo Edital + congela novo `SnapshotPublicacao`; o snapshot anterior permanece imutável; status segue `Publicado`.
- **`ISnapshotPublicacaoCanonicalizer`** ganha `RetificacaoInfo` opcional — a retificação acrescenta o 18º bloco `retificacao` (motivo + referência) preservando os 17 blocos anteriores **byte-a-byte** (a abertura não escreve o bloco; output do T4 intocado).
- **`RetificarProcessoSeletivoCommand`/handler/validator** + endpoint **`POST /api/selecao/processos-seletivos/{id}/retificacoes`** — reusa o mapeamento de constraint de banco → 422 (ADR-0102) e o `ProcessoPublicadoEvent` (a retificação é, em forma, outra emissão de Edital+snapshot; evita um 2º schema Avro/tópico sem consumidor).
- **Repositório** carrega a coleção de `Editais` no `ObterComConfiguracaoAsync` para a raiz validar o edital vigente.

**Sem migration nova** — o schema do Edital (colunas de retificação, self-FK `fk_editais_edital_retificado_id`, CHECK `ck_editais_contrato_natureza` que já aceita a variante retificação) foi construído na T4 (#785) antecipando esta fatia.

## Critérios de aceite (#786)
- [x] Retificar cria Edital `retificacao` + novo snapshot com bloco de retificação; snapshot anterior imutável (CA-05)
- [x] Contrato abertura×retificação endurecido por constraint; violação → 422 (CA-06) — defesa em profundidade sobre o guard de domínio
- [x] Retificação apontando edital que não é o vigente do processo recusada (CA-06)
- [x] Retificar processo ainda em rascunho recusado (CA-09)
- [x] Baseline OpenAPI regenerada (aditiva — só o endpoint `/retificacoes`)

## Validação local
- Build `UniPlus.slnx`: 0 erros, 0 warnings
- Domain 164 · Application 91 · Selecao.Integration 115 (Testcontainers, Postgres real) · Selecao.ArchTests 6 · ArchTests (solução) 17 · Host.IntegrationTests 21 · `dotnet restore --locked-mode` OK
- Baseline OpenAPI: diff puramente aditivo (114 linhas, 0 removidas)

## Nota de review
`codex review --uncommitted` (pré-commit) levantou 1 achado P1 alegando que a linha 46 de `RetificacaoPersistenciaTests.cs` seria uma invocação genérica inválida (`DefinirOfertaAtendimento<…>`). É falso positivo: a linha é uma chamada normal com argumento entre parênteses e collection expressions `[], [], []` (idêntica ao padrão do T4), não há `<` de genérico, e o projeto de integração compila com 0 erros e roda verde.