### PR TITLE
feat(selecao): seletor de snapshot vigente por instante (T6 #787)

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -1844,6 +1844,84 @@
           }
         }
       }
+    },
+    "/api/selecao/processos-seletivos/{id}/snapshot-vigente": {
+      "get": {
+        "tags": [
+          "ProcessoSeletivo"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "instante",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotVigenteDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotVigenteDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SnapshotVigenteDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -2749,6 +2827,7 @@
         }
       },
       "JsonElement": {},
+      "JsonNode": {},
       "ModalidadeSelecionadaDto": {
         "required": [
           "id",
@@ -3566,6 +3645,47 @@
           "documentoEditalId": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "SnapshotVigenteDto": {
+        "required": [
+          "snapshotPublicacaoId",
+          "dataPublicacao",
+          "natureza",
+          "schemaVersion",
+          "algoritmoHash",
+          "hashConfiguracao",
+          "hashEdital",
+          "configuracao"
+        ],
+        "type": "object",
+        "properties": {
+          "snapshotPublicacaoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "dataPublicacao": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "natureza": {
+            "type": "string"
+          },
+          "schemaVersion": {
+            "type": "string"
+          },
+          "algoritmoHash": {
+            "type": "string"
+          },
+          "hashConfiguracao": {
+            "type": "string"
+          },
+          "hashEdital": {
+            "type": "string"
+          },
+          "configuracao": {
+            "$ref": "#/components/schemas/JsonNode"
           }
         }
       },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -373,6 +373,33 @@ public sealed class ProcessoSeletivoController : ControllerBase
 
         return Ok(conformidade);
     }
+
+    /// <summary>
+    /// Resolve o snapshot congelado vigente do processo num instante (RN08, T6
+    /// #787, ADR-0075/0076): a publicação de maior <c>data_publicacao</c> ≤ o
+    /// instante. Quando <paramref name="instante"/> é omitido, usa o relógio do
+    /// servidor (ADR-0068). É o contrato de LEITURA que o runtime e os
+    /// incrementos downstream consomem — a configuração congelada, não a viva.
+    /// 422 (<c>Snapshot.VigenteAusente</c>) quando não há publicação vigente ≤
+    /// o instante; 404 quando o processo não existe — nunca retorno silencioso.
+    /// </summary>
+    [HttpGet("{id:guid}/snapshot-vigente")]
+    [VendorMediaType(Resource = "snapshot-vigente-processo-seletivo", Versions = [1])]
+    [ProducesResponseType(typeof(SnapshotVigenteDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterSnapshotVigente(
+        Guid id,
+        [FromQuery] DateTimeOffset? instante,
+        CancellationToken cancellationToken)
+    {
+        Result<SnapshotVigenteDto> resultado = await _queryBus
+            .Send(new ObterSnapshotVigenteQuery(id, instante), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? Ok(resultado.Value) : resultado.ToActionResult(_mapper);
+    }
 }
 
 /// <summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -163,6 +163,9 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.mutacao_pos_publicacao_bloqueada", "Processo publicado não aceita mutação direta da configuração")),
         new("ProcessoSeletivo.DocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_encontrado", "Documento do Edital não encontrado ou não pertence a este processo")),
         new("ProcessoSeletivo.DocumentoNaoConfirmado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_confirmado", "Somente um documento confirmado pode ser referenciado na publicação")),
+        // Seletor de snapshot vigente (T6 #787, ADR-0075/0076): não há publicação
+        // vigente ≤ o instante consultado — 422, nunca retorno silencioso.
+        new("Snapshot.VigenteAusente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.snapshot.vigente_ausente", "Nenhuma publicação vigente para o instante")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/SnapshotVigenteDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/SnapshotVigenteDto.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+using System.Text.Json.Nodes;
+
+/// <summary>
+/// Snapshot congelado vigente de um Processo Seletivo num instante (RN08,
+/// Story #759 T6 #787, ADR-0075/0076). É o contrato de LEITURA que o runtime e
+/// os incrementos downstream (inscrição, homologação, classificação) consomem
+/// — a configuração CONGELADA, nunca a viva.
+/// <para>
+/// <see cref="SnapshotPublicacaoId"/> é a referência forense DURÁVEL do
+/// snapshot que governa o ato: por ADR-0075 o ato grava esse id para poder
+/// recarregar exatamente o mesmo snapshot em re-avaliações futuras. É o mesmo
+/// identificador público que o <c>ProcessoPublicadoEvent</c> já carrega no
+/// Kafka — não um id interno vazado. O id do <c>Edital</c> (entidade interna do
+/// agregado) permanece encapsulado; <see cref="HashConfiguracao"/> dá a
+/// identidade endereçável por conteúdo (verificação de integridade/ETag).
+/// </para>
+/// </summary>
+public sealed record SnapshotVigenteDto(
+    Guid SnapshotPublicacaoId,
+    DateTimeOffset DataPublicacao,
+    string Natureza,
+    string SchemaVersion,
+    string AlgoritmoHash,
+    string HashConfiguracao,
+    string HashEdital,
+    JsonNode Configuracao);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterSnapshotVigenteQuery.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterSnapshotVigenteQuery.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ProcessosSeletivos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+using DTOs;
+
+/// <summary>
+/// Resolve o snapshot congelado vigente do Processo Seletivo num instante
+/// EXPLÍCITO (RN08, Story #759 T6 #787, ADR-0075/0076): o Edital vivo publicado
+/// de MAIOR <c>data_publicacao</c> ≤ <see cref="Instante"/>. Quando o instante
+/// é nulo, o handler o resolve do <c>TimeProvider</c> injetado e o repassa
+/// adiante — o seletor nunca lê o relógio por trás do contrato (ADR-0068).
+/// </summary>
+public sealed record ObterSnapshotVigenteQuery(
+    Guid ProcessoSeletivoId,
+    DateTimeOffset? Instante) : IQuery<Result<SnapshotVigenteDto>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterSnapshotVigenteQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterSnapshotVigenteQueryHandler.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Queries.ProcessosSeletivos;
+
+using System.Text.Json.Nodes;
+
+using Domain.Entities;
+using Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+using DTOs;
+
+/// <summary>
+/// Handler convention-based do <see cref="ObterSnapshotVigenteQuery"/> (RN08,
+/// Story #759 T6 #787, ADR-0075/0076/0068): resolve o instante (explícito ou
+/// default do <c>TimeProvider</c>), seleciona a publicação vigente e projeta
+/// o snapshot congelado. Distingue 404 (processo inexistente) de 422
+/// (<c>Snapshot.VigenteAusente</c>) — nunca retorno silencioso.
+/// </summary>
+public static class ObterSnapshotVigenteQueryHandler
+{
+    public static async Task<Result<SnapshotVigenteDto>> Handle(
+        ObterSnapshotVigenteQuery query,
+        IProcessoSeletivoRepository processoSeletivoRepository,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(processoSeletivoRepository);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        // ADR-0075/0068: o instante é sempre explícito no seletor; quando o
+        // cliente o omite, o default vem do TimeProvider injetado — nunca de um
+        // relógio lido dentro do repositório por trás do contrato.
+        DateTimeOffset instante = query.Instante ?? timeProvider.GetUtcNow();
+
+        (Edital Edital, SnapshotPublicacao Snapshot)? vigente = await processoSeletivoRepository
+            .ObterSnapshotVigenteAsync(query.ProcessoSeletivoId, instante, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (vigente is { } resolvido)
+        {
+            return Result<SnapshotVigenteDto>.Success(MapearDto(resolvido.Edital, resolvido.Snapshot));
+        }
+
+        // Só quando não há vigente distingue 404 de 422 — o caminho comum
+        // (existe publicação vigente) resolve em uma única consulta.
+        bool existe = await processoSeletivoRepository
+            .ExisteAsync(query.ProcessoSeletivoId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return existe
+            ? Result<SnapshotVigenteDto>.Failure(new DomainError(
+                "Snapshot.VigenteAusente",
+                $"Nenhuma publicação vigente para o instante {instante:O}."))
+            : Result<SnapshotVigenteDto>.Failure(new DomainError(
+                "ProcessoSeletivo.NaoEncontrado",
+                $"Processo Seletivo {query.ProcessoSeletivoId} não encontrado."));
+    }
+
+    private static SnapshotVigenteDto MapearDto(Edital edital, SnapshotPublicacao snapshot) => new(
+        snapshot.Id,
+        edital.DataPublicacao!.Value,
+        edital.Natureza.ToString(),
+        snapshot.SchemaVersion,
+        snapshot.AlgoritmoHash,
+        snapshot.HashConfiguracao,
+        snapshot.HashEdital,
+        JsonNode.Parse(snapshot.ConfiguracaoCongelada)!);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Interfaces/IProcessoSeletivoRepository.cs
@@ -42,4 +42,26 @@ public interface IProcessoSeletivoRepository : IRepository<ProcessoSeletivo>
     /// agregado inteiro, incluindo <see cref="Edital"/> e <see cref="SnapshotPublicacao"/>.
     /// </summary>
     Task AdicionarSnapshotPublicacaoAsync(SnapshotPublicacao snapshot, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolve a publicação vigente num instante (RN08, Story #759 T6 #787,
+    /// ADR-0075/0076): o <see cref="Edital"/> publicado (<c>DataPublicacao</c>
+    /// não nula) de MAIOR data ≤ <paramref name="instante"/> e o seu
+    /// <see cref="SnapshotPublicacao"/>. <see langword="null"/> quando não há
+    /// Edital publicado ≤ o instante (inclusive processo inexistente ou ainda
+    /// em rascunho). O empate é impossível por
+    /// <c>ux_editais_processo_data_publicacao</c>. Leitura <c>AsNoTracking</c>.
+    /// </summary>
+    Task<(Edital Edital, SnapshotPublicacao Snapshot)?> ObterSnapshotVigenteAsync(
+        Guid processoSeletivoId,
+        DateTimeOffset instante,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// <see langword="true"/> se existe um Processo Seletivo com este id
+    /// (checagem barata via <c>AnyAsync</c>, sem materializar o agregado). Usada
+    /// pelo seletor de snapshot vigente para distinguir 404 (processo
+    /// inexistente) de 422 (sem publicação vigente ≤ o instante).
+    /// </summary>
+    Task<bool> ExisteAsync(Guid id, CancellationToken cancellationToken = default);
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
@@ -88,6 +88,58 @@ public sealed class ProcessoSeletivoRepository : IProcessoSeletivoRepository
         await _context.SnapshotsPublicacao.AddAsync(snapshot, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<(Edital Edital, SnapshotPublicacao Snapshot)?> ObterSnapshotVigenteAsync(
+        Guid processoSeletivoId,
+        DateTimeOffset instante,
+        CancellationToken cancellationToken = default)
+    {
+        // Npgsql exige DateTimeOffset em UTC (offset zero) ao comparar contra
+        // colunas timestamptz — um instante com offset não-UTC (ex.: -03:00
+        // vindo de um Accept RFC 3339) falharia na execução da query. Normaliza
+        // aqui, no boundary que dona a interação com o Npgsql, preservando o
+        // mesmo instante; qualquer chamador fica DB-safe.
+        DateTimeOffset instanteUtc = instante.ToUniversalTime();
+
+        // Publicação vigente = Edital publicado de MAIOR data ≤ instante
+        // (ADR-0075/0076). ux_editais_processo_data_publicacao garante que não
+        // há empate, então OrderByDescending().FirstOrDefault() é determinístico.
+        // O EXISTS através de ProcessosSeletivos herda o filtro global de
+        // soft-delete (ProcessoSeletivo é SoftDeletableEntity; Edital não é):
+        // um processo excluído logicamente não vaza seu snapshot congelado —
+        // cai no mesmo caminho 404 que o resto da API, coerente com ExisteAsync.
+        Edital? edital = await _context.Editais
+            .AsNoTracking()
+            .Where(e => e.ProcessoSeletivoId == processoSeletivoId
+                && e.DataPublicacao != null
+                && e.DataPublicacao <= instanteUtc
+                && _context.ProcessosSeletivos.Any(p => p.Id == processoSeletivoId))
+            .OrderByDescending(e => e.DataPublicacao)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (edital is null)
+        {
+            return null;
+        }
+
+        // Todo Edital publicado tem exatamente um snapshot congelado 1:1 (T4,
+        // ux_snapshot_publicacao_edital_id) — a ausência aqui seria estado
+        // inconsistente e é tratada como "sem vigente" pelo handler.
+        SnapshotPublicacao? snapshot = await _context.SnapshotsPublicacao
+            .AsNoTracking()
+            .FirstOrDefaultAsync(s => s.EditalId == edital.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return snapshot is null ? null : (edital, snapshot);
+    }
+
+    public async Task<bool> ExisteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _context.ProcessosSeletivos
+            .AsNoTracking()
+            .AnyAsync(p => p.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<(IReadOnlyList<ProcessoSeletivo> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
         int limit,

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/ObterSnapshotVigenteEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/ObterSnapshotVigenteEndpointTests.cs
@@ -1,0 +1,240 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Domain.Entities;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+// Contrato HTTP do seletor de snapshot vigente (Story #759, T6 #787,
+// ADR-0075/0076/0068): GET .../snapshot-vigente resolve a publicação vigente
+// num instante e projeta o snapshot congelado; 422 Snapshot.VigenteAusente
+// quando não há vigente ≤ o instante, 404 quando o processo não existe.
+[Collection(CascadingCollection.Name)]
+public sealed class ObterSnapshotVigenteEndpointTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public ObterSnapshotVigenteEndpointTests(CascadingFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName =
+        "GET .../snapshot-vigente após publicar resolve o snapshot da abertura (200 + configuração congelada)")]
+    public async Task ObterSnapshotVigente_AposPublicar_ResolveAbertura()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        (Guid processoId, Guid documentoId) = await SemearAsync(api, nameof(ObterSnapshotVigente_AposPublicar_ResolveAbertura));
+        (await PostPublicarAsync(client, processoId, documentoId)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage response = await GetSnapshotVigenteAsync(client, processoId, instante: null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("natureza").GetString().Should().Be("Abertura");
+        root.GetProperty("schemaVersion").GetString().Should().NotBeNullOrEmpty();
+        root.GetProperty("hashConfiguracao").GetString().Should().NotBeNullOrEmpty();
+        // A configuração congelada volta como objeto aninhado (não string escapada).
+        JsonElement config = root.GetProperty("configuracao");
+        config.ValueKind.Should().Be(JsonValueKind.Object);
+        config.TryGetProperty("periodo", out _).Should().BeTrue();
+        config.TryGetProperty("etapas", out _).Should().BeTrue();
+    }
+
+    [Fact(DisplayName =
+        "GET .../snapshot-vigente após retificar resolve o snapshot da retificação (200)")]
+    public async Task ObterSnapshotVigente_AposRetificar_ResolveRetificacao()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        (Guid processoId, Guid documentoAbertura) = await SemearAsync(api, nameof(ObterSnapshotVigente_AposRetificar_ResolveRetificacao));
+        (await PostPublicarAsync(client, processoId, documentoAbertura)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        Guid documentoRetificacao = await SemearDocumentoConfirmadoAsync(api, processoId);
+        (await PostRetificarAsync(client, processoId, documentoRetificacao)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage response = await GetSnapshotVigenteAsync(client, processoId, instante: null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("natureza").GetString().Should().Be("Retificacao");
+
+        // Confere que o hash bate com o snapshot de retificação persistido.
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        Guid editalRetificacaoId = await db.Editais.AsNoTracking()
+            .Where(e => e.ProcessoSeletivoId == processoId && e.Natureza == Domain.Enums.NaturezaEdital.Retificacao)
+            .Select(e => e.Id)
+            .SingleAsync();
+        SnapshotPublicacao esperado = await db.SnapshotsPublicacao.AsNoTracking()
+            .SingleAsync(s => s.EditalId == editalRetificacaoId);
+        doc.RootElement.GetProperty("hashConfiguracao").GetString().Should().Be(esperado.HashConfiguracao);
+        // A referência forense durável (ADR-0075) — mesmo id do ProcessoPublicadoEvent.
+        doc.RootElement.GetProperty("snapshotPublicacaoId").GetGuid().Should().Be(esperado.Id);
+    }
+
+    [Fact(DisplayName =
+        "GET .../snapshot-vigente em processo em rascunho retorna 422 Snapshot.VigenteAusente (CA-08)")]
+    public async Task ObterSnapshotVigente_ProcessoEmRascunho_Retorna422()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        (Guid processoId, _) = await SemearAsync(api, nameof(ObterSnapshotVigente_ProcessoEmRascunho_Retorna422));
+
+        HttpResponseMessage response = await GetSnapshotVigenteAsync(client, processoId, instante: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString().Should().Be("uniplus.selecao.snapshot.vigente_ausente");
+    }
+
+    [Fact(DisplayName =
+        "GET .../snapshot-vigente com instante anterior à publicação retorna 422 Snapshot.VigenteAusente")]
+    public async Task ObterSnapshotVigente_InstanteAntesDaPublicacao_Retorna422()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        (Guid processoId, Guid documentoId) = await SemearAsync(api, nameof(ObterSnapshotVigente_InstanteAntesDaPublicacao_Retorna422));
+        (await PostPublicarAsync(client, processoId, documentoId)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage response = await GetSnapshotVigenteAsync(
+            client, processoId, instante: new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString().Should().Be("uniplus.selecao.snapshot.vigente_ausente");
+    }
+
+    [Fact(DisplayName =
+        "GET .../snapshot-vigente em processo inexistente retorna 404")]
+    public async Task ObterSnapshotVigente_ProcessoInexistente_Retorna404()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        HttpResponseMessage response = await GetSnapshotVigenteAsync(client, Guid.CreateVersion7(), instante: null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString().Should().Be("uniplus.selecao.processo_seletivo.nao_encontrado");
+    }
+
+    [Fact(DisplayName =
+        "GET .../snapshot-vigente com versão de mídia vendor não suportada retorna 406 (ADR-0028)")]
+    public async Task ObterSnapshotVigente_VersaoDeMidiaNaoSuportada_Retorna406()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        using HttpClient client = api.CreateClient();
+
+        // O filtro de negociação roda antes do handler — 406 independe de o
+        // processo existir. Pede uma v2 inexistente do recurso.
+        using HttpRequestMessage request = new(HttpMethod.Get,
+            new Uri($"/api/selecao/processos-seletivos/{Guid.CreateVersion7()}/snapshot-vigente", UriKind.Relative));
+        AppendTestAuth(request);
+        request.Headers.TryAddWithoutValidation(
+            "Accept", "application/vnd.uniplus.snapshot-vigente-processo-seletivo.v2+json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString().Should().Be("uniplus.contract.versao_nao_suportada");
+    }
+
+    private static async Task<HttpResponseMessage> GetSnapshotVigenteAsync(
+        HttpClient client, Guid processoId, DateTimeOffset? instante)
+    {
+        string rota = $"/api/selecao/processos-seletivos/{processoId}/snapshot-vigente";
+        if (instante is { } valor)
+        {
+            rota += $"?instante={Uri.EscapeDataString(valor.ToString("O", CultureInfo.InvariantCulture))}";
+        }
+
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri(rota, UriKind.Relative));
+        AppendTestAuth(request);
+        return await client.SendAsync(request).ConfigureAwait(false);
+    }
+
+    private static async Task<HttpResponseMessage> PostPublicarAsync(HttpClient client, Guid processoId, Guid documentoEditalId)
+    {
+        object corpo = new
+        {
+            numero = "001/2026",
+            periodoInscricaoInicio = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            periodoInscricaoFim = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(30)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            documentoEditalId,
+        };
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{processoId}/publicacao", UriKind.Relative))
+        {
+            Content = JsonContent.Create(corpo),
+        };
+        AppendTestAuth(request);
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", Guid.CreateVersion7().ToString("N"));
+        return await client.SendAsync(request).ConfigureAwait(false);
+    }
+
+    private static async Task<HttpResponseMessage> PostRetificarAsync(HttpClient client, Guid processoId, Guid documentoEditalId)
+    {
+        object corpo = new
+        {
+            motivo = "Correção do prazo de inscrição",
+            numero = "001/2026-R1",
+            periodoInscricaoInicio = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(1)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            periodoInscricaoFim = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(40)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            documentoEditalId,
+        };
+        using HttpRequestMessage request = new(HttpMethod.Post,
+            new Uri($"/api/selecao/processos-seletivos/{processoId}/retificacoes", UriKind.Relative))
+        {
+            Content = JsonContent.Create(corpo),
+        };
+        AppendTestAuth(request);
+        request.Headers.TryAddWithoutValidation("Idempotency-Key", Guid.CreateVersion7().ToString("N"));
+        return await client.SendAsync(request).ConfigureAwait(false);
+    }
+
+    private static void AppendTestAuth(HttpRequestMessage request)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme, TestAuthHandler.TokenValue);
+        request.Headers.TryAddWithoutValidation(TestAuthHandler.RolesHeader, "plataforma-admin");
+    }
+
+    private static async Task<(Guid ProcessoId, Guid DocumentoId)> SemearAsync(CascadingApiFactory api, string nome)
+    {
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+            .SemearAsync(db, $"{nome} {Guid.CreateVersion7()}");
+        return (processo.Id, documento.Id);
+    }
+
+    private static async Task<Guid> SemearDocumentoConfirmadoAsync(CascadingApiFactory api, Guid processoId)
+    {
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        string hashFixo = string.Concat(Enumerable.Repeat("cd45670189", 7))[..64];
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processoId, TimeProvider.System, TimeSpan.FromMinutes(15));
+        documento.Confirmar(2048, hashFixo, TimeProvider.System).IsSuccess.Should().BeTrue();
+        await db.DocumentosEdital.AddAsync(documento);
+        await db.SaveChangesAsync();
+        return documento.Id;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/SnapshotVigentePersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/SnapshotVigentePersistenciaTests.cs
@@ -1,0 +1,215 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ProcessosSeletivos;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Cobertura de integração (Postgres real via Testcontainers) do seletor de
+/// snapshot vigente (RN08, Story #759 T6 #787, ADR-0075/0076):
+/// <c>ObterSnapshotVigenteAsync</c> resolve o Edital publicado de MAIOR
+/// <c>data_publicacao</c> ≤ o instante. Com abertura (T0) + retificação (T0+1d),
+/// um instante posterior resolve a retificação; um instante em T0 resolve a
+/// abertura; um instante anterior a T0 não resolve nada.
+/// </summary>
+public sealed class SnapshotVigentePersistenciaTests : IClassFixture<ProcessoSeletivoDbFixture>
+{
+    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+    private static readonly SnapshotPublicacaoCanonicalizer Canonicalizer = new();
+    private static readonly DateTimeOffset T0 = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly ProcessoSeletivoDbFixture _fixture;
+
+    public SnapshotVigentePersistenciaTests(ProcessoSeletivoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static ReferenciaRegra Regra(string codigo, string hashChar) =>
+        ReferenciaRegra.Criar(codigo, "v1", new string(hashChar[0], 64)).Value!;
+
+    private static ProcessoSeletivo NovoProcessoConforme(string nome)
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar(nome, TipoProcesso.SiSU);
+        processo.DefinirEtapas([
+            EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1),
+        ]).IsSuccess.Should().BeTrue();
+        processo.DefinirOfertaAtendimento(OfertaAtendimentoEspecializado.Criar([], [], []).Value!).IsSuccess.Should().BeTrue();
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            Guid.CreateVersion7(), "AC", null, NaturezaLegalModalidade.Ampla, ComposicaoVagasModalidade.ResidualDoVo,
+            null, RegraRemanejamentoModalidade.Nenhuma, null, null, null, [], null, "Res. Unifesspa 532/2021").Value!;
+        processo.DefinirDistribuicaoVagas([ConfiguracaoDistribuicaoVagas.Criar(
+            Guid.CreateVersion7(), 40, 1m, Regra(RegraDistribuicaoVagasCodigo.Institucional, "a"), null, [modalidade]).Value!])
+            .IsSuccess.Should().BeTrue();
+        processo.DefinirClassificacao(ConfiguracaoClassificacao.Criar(
+            Regra(RegraCalculoCodigo.ClassificacaoImportada, "b"), null, null,
+            Regra(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "c"), 1, []).Value!).IsSuccess.Should().BeTrue();
+        return processo;
+    }
+
+    private static DocumentoEdital DocumentoConfirmado(Guid processoId)
+    {
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processoId, TimeProvider.System, TimeSpan.FromMinutes(15));
+        documento.Confirmar(1024, HashFixo, TimeProvider.System).IsSuccess.Should().BeTrue();
+        return documento;
+    }
+
+    private static DadosEdital NovosDados(Guid documentoId) => DadosEdital.Criar(
+        "001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31), documentoId).Value!;
+
+    /// <summary>
+    /// Publica a abertura em T0 e retifica em T0+1 dia, persistindo os dois
+    /// Editais e snapshots com <c>data_publicacao</c> distintas (relógio manual).
+    /// </summary>
+    private async Task<(Guid ProcessoId, SnapshotPublicacao SnapshotAbertura, SnapshotPublicacao SnapshotRetificacao)>
+        PublicarERetificarAsync(string nome)
+    {
+        RelogioManual clock = new(T0);
+
+        ProcessoSeletivo processo = NovoProcessoConforme(nome);
+        DocumentoEdital docAbertura = DocumentoConfirmado(processo.Id);
+        DadosEdital dadosAbertura = NovosDados(docAbertura.Id);
+        SnapshotCanonico canonicoAbertura = Canonicalizer.Canonicalizar(processo, dadosAbertura, docAbertura.HashSha256!);
+        Result<PublicacaoResultado> publicar = processo.Publicar(
+            dadosAbertura, canonicoAbertura.Bytes, canonicoAbertura.SchemaVersion, canonicoAbertura.AlgoritmoHash,
+            docAbertura.HashSha256!, "integration-test-user", clock);
+        publicar.IsSuccess.Should().BeTrue(publicar.Error?.Message);
+
+        await using (SelecaoDbContext writeContext = _fixture.CreateDbContext())
+        {
+            ProcessoSeletivoRepository repository = new(writeContext, TimeProvider.System);
+            await repository.AdicionarAsync(processo, CancellationToken.None);
+            await writeContext.DocumentosEdital.AddAsync(docAbertura, CancellationToken.None);
+            await repository.AdicionarSnapshotPublicacaoAsync(publicar.Value!.Snapshot, CancellationToken.None);
+            await writeContext.SaveChangesAsync(CancellationToken.None);
+        }
+
+        clock.Avancar(TimeSpan.FromDays(1));
+
+        DocumentoEdital docRetificacao = DocumentoConfirmado(processo.Id);
+        SnapshotPublicacao snapshotRetificacao;
+        await using (SelecaoDbContext writeContext = _fixture.CreateDbContext())
+        {
+            ProcessoSeletivoRepository repository = new(writeContext, TimeProvider.System);
+            ProcessoSeletivo carregado = (await repository.ObterComConfiguracaoAsync(processo.Id, CancellationToken.None))!;
+            DadosEdital dadosRetificacao = NovosDados(docRetificacao.Id);
+            SnapshotCanonico canonicoRetificacao = Canonicalizer.Canonicalizar(
+                carregado, dadosRetificacao, docRetificacao.HashSha256!,
+                new RetificacaoInfo(carregado.EditalVigente!.Id, "Correção do prazo de inscrição"));
+            Result<PublicacaoResultado> retificar = carregado.Retificar(
+                dadosRetificacao, canonicoRetificacao.Bytes, canonicoRetificacao.SchemaVersion, canonicoRetificacao.AlgoritmoHash,
+                docRetificacao.HashSha256!, "integration-test-user", "Correção do prazo de inscrição", clock);
+            retificar.IsSuccess.Should().BeTrue(retificar.Error?.Message);
+            snapshotRetificacao = retificar.Value!.Snapshot;
+
+            await writeContext.DocumentosEdital.AddAsync(docRetificacao, CancellationToken.None);
+            await repository.AdicionarSnapshotPublicacaoAsync(snapshotRetificacao, CancellationToken.None);
+            await writeContext.SaveChangesAsync(CancellationToken.None);
+        }
+
+        return (processo.Id, publicar.Value!.Snapshot, snapshotRetificacao);
+    }
+
+    [Fact(DisplayName = "Seletor resolve o snapshot de maior data_publicacao ≤ instante — retificação após ela, abertura em T0 (CA-08)")]
+    public async Task ObterSnapshotVigente_ResolveMaiorDataAntesOuIgualAoInstante()
+    {
+        (Guid processoId, SnapshotPublicacao snapshotAbertura, SnapshotPublicacao snapshotRetificacao) =
+            await PublicarERetificarAsync(nameof(ObterSnapshotVigente_ResolveMaiorDataAntesOuIgualAoInstante));
+
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+        ProcessoSeletivoRepository repository = new(context, TimeProvider.System);
+
+        // Instante posterior à retificação → resolve a retificação (maior data).
+        (Edital Edital, SnapshotPublicacao Snapshot)? posterior = await repository
+            .ObterSnapshotVigenteAsync(processoId, T0.AddDays(2), CancellationToken.None);
+        posterior.Should().NotBeNull();
+        posterior!.Value.Edital.Natureza.Should().Be(NaturezaEdital.Retificacao);
+        posterior.Value.Snapshot.HashConfiguracao.Should().Be(snapshotRetificacao.HashConfiguracao);
+
+        // Instante exatamente em T0 → resolve a abertura (retificação, em T0+1d, é excluída).
+        (Edital Edital, SnapshotPublicacao Snapshot)? emT0 = await repository
+            .ObterSnapshotVigenteAsync(processoId, T0, CancellationToken.None);
+        emT0.Should().NotBeNull();
+        emT0!.Value.Edital.Natureza.Should().Be(NaturezaEdital.Abertura);
+        emT0.Value.Snapshot.HashConfiguracao.Should().Be(snapshotAbertura.HashConfiguracao);
+
+        // Mesmo instante de T0, expresso em offset não-UTC (-03:00) — Npgsql
+        // exige UTC para timestamptz; o seletor normaliza e resolve o mesmo.
+        (Edital Edital, SnapshotPublicacao Snapshot)? emT0OffsetNaoUtc = await repository
+            .ObterSnapshotVigenteAsync(processoId, T0.ToOffset(TimeSpan.FromHours(-3)), CancellationToken.None);
+        emT0OffsetNaoUtc.Should().NotBeNull();
+        emT0OffsetNaoUtc!.Value.Snapshot.HashConfiguracao.Should().Be(snapshotAbertura.HashConfiguracao);
+    }
+
+    [Fact(DisplayName = "Seletor não resolve nada quando o instante antecede toda publicação (base do 422)")]
+    public async Task ObterSnapshotVigente_InstanteAntesDaAbertura_RetornaNull()
+    {
+        (Guid processoId, _, _) =
+            await PublicarERetificarAsync(nameof(ObterSnapshotVigente_InstanteAntesDaAbertura_RetornaNull));
+
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+        ProcessoSeletivoRepository repository = new(context, TimeProvider.System);
+
+        (Edital Edital, SnapshotPublicacao Snapshot)? vigente = await repository
+            .ObterSnapshotVigenteAsync(processoId, T0.AddSeconds(-1), CancellationToken.None);
+
+        vigente.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Seletor não resolve snapshot de processo soft-deleted — honra o filtro global de exclusão lógica (base do 404)")]
+    public async Task ObterSnapshotVigente_ProcessoSoftDeleted_RetornaNull()
+    {
+        (Guid processoId, _, _) =
+            await PublicarERetificarAsync(nameof(ObterSnapshotVigente_ProcessoSoftDeleted_RetornaNull));
+
+        await using (SelecaoDbContext deleteContext = _fixture.CreateDbContext())
+        {
+            ProcessoSeletivo processo = await deleteContext.ProcessosSeletivos
+                .SingleAsync(p => p.Id == processoId, CancellationToken.None);
+            processo.MarkAsDeleted("integration-test-user", T0.AddDays(3));
+            await deleteContext.SaveChangesAsync(CancellationToken.None);
+        }
+
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+        ProcessoSeletivoRepository repository = new(context, TimeProvider.System);
+
+        // Edital não é soft-deletable, mas o EXISTS através de ProcessosSeletivos
+        // herda o filtro global — o snapshot de um processo excluído não vaza.
+        (Edital Edital, SnapshotPublicacao Snapshot)? vigente = await repository
+            .ObterSnapshotVigenteAsync(processoId, T0.AddDays(5), CancellationToken.None);
+
+        vigente.Should().BeNull("um processo excluído logicamente cai no mesmo 404 do resto da API");
+        (await repository.ExisteAsync(processoId, CancellationToken.None)).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Seletor não resolve nada para processo inexistente (base do 404)")]
+    public async Task ObterSnapshotVigente_ProcessoInexistente_RetornaNull()
+    {
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+        ProcessoSeletivoRepository repository = new(context, TimeProvider.System);
+
+        (Edital Edital, SnapshotPublicacao Snapshot)? vigente = await repository
+            .ObterSnapshotVigenteAsync(Guid.CreateVersion7(), T0.AddDays(5), CancellationToken.None);
+
+        vigente.Should().BeNull();
+        (await repository.ExisteAsync(Guid.CreateVersion7(), CancellationToken.None)).Should().BeFalse();
+    }
+
+    private sealed class RelogioManual(DateTimeOffset inicio) : TimeProvider
+    {
+        private DateTimeOffset _agora = inicio;
+
+        public override DateTimeOffset GetUtcNow() => _agora;
+
+        public void Avancar(TimeSpan delta) => _agora = _agora.Add(delta);
+    }
+}


### PR DESCRIPTION
## Contexto

Última task do arco de publicação/retificação do Processo Seletivo (Story #759). O runtime e os incrementos downstream leem o **snapshot congelado**, não a configuração viva (ADR-0075/0076) — esta task entrega o **contrato de leitura** que resolve a publicação vigente por instante.

Closes #787

## O que entra

- **`GET /api/selecao/processos-seletivos/{id}/snapshot-vigente`** (`?instante=` opcional): resolve o Edital publicado de maior `data_publicacao` ≤ o instante (único por `ux_editais_processo_data_publicacao`) e projeta o snapshot congelado.
- **Instante explícito (ADR-0068):** quando omitido, o handler resolve o default do `TimeProvider` injetado e o repassa ao seletor — nunca lido por trás do contrato.
- **Sem retorno silencioso:** `422 Snapshot.VigenteAusente` (`uniplus.selecao.snapshot.vigente_ausente`) quando não há publicação vigente ≤ o instante; `404` quando o processo não existe. O caminho comum resolve em uma consulta; a distinção 404/422 só ocorre quando não há vigente.
- **DTO `SnapshotVigenteDto`:** expõe `snapshotPublicacaoId` (referência forense durável que o ato grava por ADR-0075 — mesmo id do `ProcessoPublicadoEvent`), `dataPublicacao`, `natureza`, `schemaVersion`, hashes e a `configuracao` congelada como objeto aninhado. O id do `Edital` (entidade interna do agregado) permanece encapsulado.
- **Negociação de versão por vendor MIME (ADR-0028):** `application/vnd.uniplus.snapshot-vigente-processo-seletivo.v1+json`, consistente com os demais contratos de leitura do controller.

## Critérios de aceite (#787)

- [x] Seletor resolve o snapshot de maior `data_publicacao` ≤ instante (CA-08)
- [x] Abertura + retificação publicadas: instante posterior à retificação resolve o snapshot da retificação; instante em T0 resolve a abertura (CA-08)
- [x] Sem publicação vigente → `Snapshot.VigenteAusente` 422, nunca retorno silencioso (CA-08)
- [x] Baseline OpenAPI regenerada

## Validação local

- Domain 163 · Application 91 · Arch 17 · **Seleção integração 127** (inclui drift-check da baseline OpenAPI) · Host integração 21
- 9 testes novos de T6: 3 de persistência do seletor (timestamps determinísticos via relógio manual — resolve max ≤ instante, null antes da abertura, null p/ inexistente) + 6 de endpoint (200 com DTO/configuração aninhada, 200 pós-retificação, 422 rascunho, 422 instante anterior, 404 inexistente, 406 versão de mídia não suportada)
- `--locked-mode` limpo · `codex review --uncommitted` sem findings