### PR TITLE
docs(adr): decisões do módulo Publicações e da versão de configuração (ADR-0103 a 0105)

### DIFF
--- a/docs/adrs/0103-ato-normativo-generalizado-retificacao-como-relacao.md
+++ b/docs/adrs/0103-ato-normativo-generalizado-retificacao-como-relacao.md
@@ -50,7 +50,7 @@ O ato publicado passa a ter `ato_retificado_id` e `motivo`, com contrato simétr
 
 A invariante que protege a integridade da configuração publicada **não é** "a retificação referencia um ato do mesmo tipo" — essa é falsa, e o aviso que retifica um edital a derruba. A invariante correta é:
 
-```
+```text
 congela(retificador) == congela(retificado)
 ```
 

--- a/docs/adrs/0103-ato-normativo-generalizado-retificacao-como-relacao.md
+++ b/docs/adrs/0103-ato-normativo-generalizado-retificacao-como-relacao.md
@@ -1,0 +1,116 @@
+---
+status: "proposed"
+date: "2026-07-09"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted:
+  - "P.O. CEPS"
+  - "P.O. CRCA"
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0103: Retificação é uma relação entre atos publicados, não um tipo de ato
+
+## Contexto e enunciado do problema
+
+O modelo atual representa a natureza de um edital como um enumerado: `NaturezaEdital { Nenhuma, Abertura, Retificacao }`. A entidade `Edital` carrega, além dele, `EditalRetificadoId` e `MotivoRetificacao`, e um CHECK garante a bijeção `natureza = Retificacao ⟺ EditalRetificadoId IS NOT NULL`.
+
+Se um implica o outro, um dos dois é redundante. A pergunta é qual — e a resposta muda o modelo.
+
+A prática institucional responde. Dois acervos completos de atos reais da Unifesspa foram analisados: o PS Canaã dos Carajás 2026 (CEPS, 20 atos) e o SiSU 2026 — Edição Única (CRCA, 25 atos, cinco chamadas). Neles:
+
+- Um **comunicado sem número** prorroga o prazo de inscrições de um **edital**.
+- Um **aviso** com numeração própria altera o horário de uma **convocação**.
+- Um edital retificado **republica com o mesmo número e a mesma data de publicação**, anotando apenas a data em que a retificação ocorreu.
+- O CRCA publica ao menos sete tipos de ato — convocação, homologação da análise documental, homologação de recursos, lista de espera, confirmação de interesse, aviso, comunicado — e **retifica convocações**.
+
+Nenhum desses casos é representável por um enumerado de duas naturezas. Um comunicado não é "Abertura" nem "Retificacao": é um comunicado, que por acaso emenda outro ato.
+
+Há ainda um custo mensurável. O índice `ux_editais_processo_abertura_unica` filtra por `natureza = 1` — o valor do enumerado **escrito no banco**. Acrescentar um tipo de ato exige migration, deploy e um novo filtro. É a mesma classe de acoplamento que o projeto proibiu ao decidir que `TipoProcesso` é rótulo, nunca ramo de comportamento.
+
+## Drivers da decisão
+
+- **Princípio fundacional do Uni+** — nenhuma regra ramifica comportamento por tipo em código. Adicionar um tipo de ato deve ser linha de cadastro.
+- **Integridade da configuração publicada (RN08)** — a retificação de um ato que congela configuração produz nova versão congelada; a de um ato que não congela, não.
+- **Fidelidade à prática institucional** — o modelo precisa representar os atos que os órgãos efetivamente publicam.
+- **Auditabilidade da linhagem** — reconstruir o que valia em cada instante exige saber qual ato emendou qual.
+
+## Opções consideradas
+
+- **A**: Manter o enumerado e acrescentar valores conforme novos tipos de ato surgirem.
+- **B**: Retificação como **relação** entre atos (`ato_retificado_id` + `motivo`), com o tipo do ato vindo de cadastro.
+- **C**: Manter o enumerado e acrescentar um segundo eixo (`tipo_documento`) ao lado dele.
+
+## Resultado da decisão
+
+**Escolhida:** "B — retificação como relação entre atos", porque a retificação é um vínculo entre dois documentos, e não uma propriedade intrínseca de um deles. O enumerado descrevia a relação a partir de um dos seus extremos, o que só funciona enquanto houver exatamente dois tipos de ato.
+
+O ato publicado passa a ter `ato_retificado_id` e `motivo`, com contrato simétrico: **um existe se e somente se o outro existe**. O tipo do ato vem de um cadastro versionado por vigência, e nenhum índice ou verificação carrega literal de tipo no filtro.
+
+A invariante que protege a integridade da configuração publicada **não é** "a retificação referencia um ato do mesmo tipo" — essa é falsa, e o aviso que retifica um edital a derruba. A invariante correta é:
+
+```
+congela(retificador) == congela(retificado)
+```
+
+É a **classe de congelamento** que protege a RN08, não o rótulo do tipo. Um ato que não congela configuração não emenda um que congela, nem o inverso.
+
+A cadeia de retificação é **linear**: um ato é retificado no máximo uma vez, e duas retificações sucessivas **empilham na cabeça** da cadeia. Isso é o que a prática faz — o Aviso 05 prorroga o prazo já prorrogado pelo Aviso 04 e cita o Aviso 04, não o edital original. Retificar a raiz de uma cadeia já retificada é recusado, com mensagem que nomeia o ato que a retificou.
+
+## Consequências
+
+### Positivas
+
+- Acrescentar um tipo de ato (`CONVOCACAO`, `HOMOLOGACAO_ANALISE`, `LISTA_ESPERA`) passa a ser **linha de cadastro**, sem migration nem deploy.
+- Um aviso pode retificar um edital, e um comunicado sem número pode prorrogar um prazo — como já ocorre na prática.
+- A linhagem do que foi publicado deixa de depender do número do documento, que a retificação repete.
+- A verificação de integridade (`congela(retificador) == congela(retificado)`) é genérica: não enumera tipos.
+
+### Negativas
+
+- O enumerado `NaturezaEdital` é eliminado do domínio, da persistência e do contrato interno, com impacto em índices e possivelmente em códigos de erro.
+- A equivalência do contrato HTTP de `Publicar` e `Retificar` precisa ser **provada por testes de contrato**, não afirmada.
+- A unicidade da raiz de cadeia deixa de ser um índice filtrado por literal e passa a depender de um atributo do cadastro de tipos.
+
+### Neutras
+
+- O vocabulário institucional distingue "retificação" (republicação com o mesmo número) de "prorrogação" (ato autônomo que emenda outro por referência). O modelo trata as duas como a mesma relação; a interface e o texto gerado devem respeitar o rótulo de cada órgão.
+- Sem base em produção, as migrations são decididas pelo mérito do modelo, não pelo custo de migrar dados.
+
+## Confirmação
+
+- **Fitness test**: nenhuma função ou índice do módulo compara o tipo de ato com um literal. O teste planta uma função que viola a regra e verifica que a detecção a acusa, antes de a ausência de detecção valer como evidência.
+- **Teste de domínio**: um ato não congelante que tenta retificar um ato congelante é recusado com erro nomeado, mapeado a HTTP 422 (ADR-0102).
+- **Teste de domínio**: duas retificações sucessivas empilham na cabeça; retificar a raiz já retificada é recusado.
+- **Teste do princípio**: quando a Habilitação chegar, criar os tipos de ato do CRCA deve ser inserir linhas de cadastro. Se exigir alteração no domínio, esta decisão foi mal implementada.
+
+## Prós e contras das opções
+
+### A — Manter o enumerado e acrescentar valores
+
+- Bom, porque não altera nada do que existe.
+- Ruim, porque cada novo tipo de ato vira um valor de enumerado, isto é, **código**. Reencarna no documento a ramificação por tipo que o projeto proibiu no processo seletivo.
+- Ruim, porque não representa um comunicado que retifica um edital: a natureza do ato e a sua relação com outro passam a competir pelo mesmo campo.
+
+### B — Retificação como relação (escolhida)
+
+- Bom, porque separa o que o ato **é** (tipo, cadastro) do que ele **faz** (emenda outro ato, relação).
+- Bom, porque a integridade da RN08 passa a ser protegida pela classe de congelamento, que é genérica.
+- Ruim, porque exige eliminar o enumerado e reescrever índices que dependiam dele.
+
+### C — Enumerado mais um segundo eixo
+
+- Bom, porque preserva o código existente.
+- Ruim, porque mantém a bijeção redundante e acrescenta um terceiro estado a manter em sincronia. O erro categorial permanece, agora acompanhado.
+
+## Mais informações
+
+- [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md) — referência cross-módulo por valor, sem chave estrangeira
+- [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md) — entidades forenses, append-only
+- [ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md) — a configuração vigente é resolvida no instante do ato
+- [ADR-0101](0101-retificacao-novo-edital-novo-snapshot-motivo.md) — retificação produz novo ato e nova versão, com motivo; o servidor infere o alvo
+- [ADR-0102](0102-invariantes-coerencia-processo-guard-rails-422.md) — invariantes de domínio mapeadas a HTTP 422
+- [ADR-0104](0104-versao-configuracao-como-agregado-proprio.md) — a vigência ordena versões, não documentos
+- [ADR-0105](0105-modulo-publicacoes-registro-central-dos-atos.md) — o módulo que possui o ato publicado
+- Evidência empírica: acervos completos do PS Canaã dos Carajás 2026 (CEPS) e do SiSU 2026 — Edição Única (CRCA)

--- a/docs/adrs/0104-versao-configuracao-como-agregado-proprio.md
+++ b/docs/adrs/0104-versao-configuracao-como-agregado-proprio.md
@@ -1,0 +1,130 @@
+---
+status: "proposed"
+date: "2026-07-09"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted:
+  - "Backend (CTIC)"
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0104: A vigência da configuração ordena versões, não documentos
+
+## Contexto e enunciado do problema
+
+Hoje `SnapshotPublicacao` pende de `Edital` por `EditalId`, e `ProcessoSeletivo.EditalVigente` resolve a configuração vigente **ordenando editais** por `DataPublicacao`.
+
+Isso funde duas grandezas ortogonais no mesmo campo:
+
+- o **documento normativo**, que tem órgão, série, número, assinante e uma data de publicação **documental** — a que o PDF declara ("13/03/2026, às 19h00min");
+- a **versão da configuração**, que tem ordem, hash e vigência.
+
+A consequência aparece no banco. Para obter ordem total entre editais, existe o índice `ux_editais_processo_data_publicacao`, que impõe **unicidade da data de publicação** dentro de um processo. Ele serializa o conjunto errado: dois atos podem ser publicados no mesmo instante sem que isso decida coisa alguma, porque o que ordena a configuração é a versão, não o documento.
+
+Pior: a prática institucional torna a data documental **imprópria como chave de ordenação**. Uma retificação **republica com o mesmo número e a mesma data de publicação** do ato original, anotando apenas a data em que a retificação ocorreu. Ordenar por essa data produziria um empate entre a versão retificada e a original.
+
+E há um risco latente. Hoje `DataPublicacao = clock.GetUtcNow()`, de modo que a data documental e o instante do sistema coincidem por construção. No momento em que a data documental passar a ser **declarada** pelo usuário — como o número do ato já é, e como a importação de acervo histórico exigirá —, a retroatividade passa a existir, e a ordenação da configuração vigente passa a poder ser reescrita pelo digitador.
+
+## Drivers da decisão
+
+- **Determinismo do que valia em cada instante** — a resolução da configuração vigente é a base da RN08 e de toda auditoria posterior.
+- **Imunidade à retroatividade** — a data documental deve poder ser declarada sem que isso altere qual configuração vigorava.
+- **Fronteira de módulo** — o documento normativo migra para o módulo `Publicacoes` (ADR-0105); a configuração permanece em `Selecao`.
+- **Ausência de base em produção** — o custo de mudar o modelo agora é baixo.
+
+## Opções consideradas
+
+- **A**: Manter o snapshot como apêndice do edital e ordenar por `DataPublicacao`.
+- **B**: `VersaoConfiguracao` como **agregado próprio**, com `vigente_a_partir_de` (relógio do sistema) ordenando, e vínculo ao ato criador por valor.
+- **C**: Manter o vínculo atual e acrescentar um número de sequência ao edital.
+
+## Resultado da decisão
+
+**Escolhida:** "B — `VersaoConfiguracao` como agregado próprio", porque separar a grandeza que ordena da grandeza que documenta é o antídoto à retroatividade, e porque o seletor de vigência não deve precisar saber o que é um tipo de ato.
+
+```
+VersaoConfiguracao                       [append-only, forense]
+    Id, ProcessoSeletivoId
+    NumeroVersao          -- monotônico por processo; UNIQUE(processo, numero)
+    VigenteAPartirDe      -- relógio do SISTEMA: é o que ORDENA
+    SchemaVersion, AlgoritmoHash, ConfiguracaoCongelada, HashConfiguracao
+    AtoCriadorId          -- referência POR VALOR ao ato publicado; NOT NULL, UNIQUE
+    AtoCriadorHash
+    AtoCriadorRetificaId  -- o ato que o ato criador retifica; nulo na versão 1
+```
+
+`AtoCriadorId` **não é chave estrangeira**: o ato vive no módulo `Publicacoes`, e a referência cross-módulo é por valor (ADR-0061). A garantia forense é local à tabela de versões — `NOT NULL` mais `UNIQUE` — e é **mais forte** que o atual `ux_snapshot_publicacao_edital_id`: toda versão tem exatamente um ato criador, e um ato cria no máximo uma versão.
+
+**Não há ciclo de inserção.** O identificador e o hash da versão são calculados **antes** de persistir. O ato é gravado primeiro e a versão depois — inclusive quando é o ato congelante que a cria e que precisa registrar a referência a ela.
+
+**Exatamente um ato congelante por certame.** O edital de abertura, e suas retificações. Todos os demais atos apenas invocam a versão vigente (ADR-0075), sem criar configuração. `AtoCriadorRetificaId` torna isso verificável **dentro do módulo Seleção**, sem consultar `Publicacoes`: o ato criador da versão `N > 1` retifica o ato criador da versão `N − 1`. Uma versão cujo ato criador não o faça é recusada — é a trava que impede uma segunda cadeia de versões no mesmo certame.
+
+O seletor passa a ser:
+
+```
+WHERE  vigente_a_partir_de <= @instante
+ORDER  BY vigente_a_partir_de DESC, numero_versao DESC
+LIMIT  1
+```
+
+Determinístico mesmo com empate de instante, e o índice de unicidade sobre `data_publicacao` **é removido**: dois atos publicados no mesmo instante deixam de colidir.
+
+## Consequências
+
+### Positivas
+
+- A configuração vigente deixa de depender de qualquer atributo do documento — inclusive do seu tipo. O seletor fica imune à criação de novos tipos de ato.
+- A data documental pode passar a ser declarada, ou importada de acervo histórico, **sem** alterar a ordem das versões.
+- A garantia forense (uma versão, um ato criador) é local e mais forte que a atual.
+- "Exatamente um ato congelante por certame" vira invariante verificável sem consulta cross-módulo.
+
+### Negativas
+
+- O contrato HTTP pretendido não muda (`Publicar`, `Retificar`, `GET .../snapshot-vigente`), mas o **mecanismo** de resolução muda de `Edital.DataPublicacao` para `VersaoConfiguracao.VigenteAPartirDe`. A equivalência precisa ser **provada por testes de contrato**, não afirmada.
+- Persistência, índices e possivelmente códigos de erro mudam.
+- `ProcessoSeletivo.EditalVigente` deixa de existir na forma atual.
+
+### Neutras
+
+- O contrato de canonicalização e o cálculo do hash da configuração congelada permanecem inalterados (ADR-0100).
+- Sem base em produção, as migrations são decididas pelo mérito.
+
+## Confirmação
+
+- **Teste de domínio**: uma versão `N > 1` cujo ato criador não retifica o criador da versão `N − 1` é recusada com erro nomeado (ADR-0102).
+- **Teste de domínio**: a versão 1 não retifica ninguém; contrato simétrico.
+- **Teste de domínio**: um ato tenta criar uma segunda versão e é recusado (`UNIQUE(ato_criador_id)`).
+- **Teste de contrato**: duas versões com a **mesma data documental** e vigências distintas resolvem corretamente em cada instante.
+- **Teste de contrato**: antes da primeira publicação, o seletor devolve vazio, sem recorrer a qualquer versão anterior (ADR-0076).
+- **Fitness test**: nenhuma chave estrangeira liga `VersaoConfiguracao` ao módulo `Publicacoes`.
+
+## Prós e contras das opções
+
+### A — Snapshot como apêndice do edital
+
+- Bom, porque é o que existe.
+- Ruim, porque exige unicidade da data de publicação para obter ordem total — serializando o conjunto errado.
+- Ruim, porque a retificação republica com a mesma data, e o modelo depende dessa data para ordenar.
+- Ruim, porque o seletor precisa passar pelo documento, ficando exposto ao seu tipo.
+
+### B — Versão como agregado próprio (escolhida)
+
+- Bom, porque a vigência ordena versões, e a data documental fica livre.
+- Bom, porque a garantia forense é local e mais forte.
+- Ruim, porque exige provar a equivalência do contrato por testes, e reescrever índices.
+
+### C — Número de sequência no edital
+
+- Bom, porque resolve a ordem total sem criar agregado.
+- Ruim, porque mantém a conflação: o documento continua carregando a ordem da configuração. Um comunicado que não congela nada precisaria de número de sequência, ou de uma regra para não tê-lo.
+
+## Mais informações
+
+- [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md) — referência cross-módulo por valor
+- [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md) — entidades forenses, append-only
+- [ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md) — a configuração vigente é resolvida no instante
+- [ADR-0076](0076-contrato-snapshot-runtime-espelha-publicacao.md) — a ausência aflora; não há recurso silencioso a versão anterior
+- [ADR-0100](0100-canonicalizacao-hash-snapshot-publicacao.md) — canonicalização e hash da configuração congelada
+- [ADR-0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md) — retificação é relação entre atos
+- [ADR-0105](0105-modulo-publicacoes-registro-central-dos-atos.md) — o módulo que possui o ato publicado

--- a/docs/adrs/0104-versao-configuracao-como-agregado-proprio.md
+++ b/docs/adrs/0104-versao-configuracao-como-agregado-proprio.md
@@ -43,7 +43,7 @@ E há um risco latente. Hoje `DataPublicacao = clock.GetUtcNow()`, de modo que a
 
 **Escolhida:** "B — `VersaoConfiguracao` como agregado próprio", porque separar a grandeza que ordena da grandeza que documenta é o antídoto à retroatividade, e porque o seletor de vigência não deve precisar saber o que é um tipo de ato.
 
-```
+```text
 VersaoConfiguracao                       [append-only, forense]
     Id, ProcessoSeletivoId
     NumeroVersao          -- monotônico por processo; UNIQUE(processo, numero)
@@ -62,7 +62,7 @@ VersaoConfiguracao                       [append-only, forense]
 
 O seletor passa a ser:
 
-```
+```sql
 WHERE  vigente_a_partir_de <= @instante
 ORDER  BY vigente_a_partir_de DESC, numero_versao DESC
 LIMIT  1

--- a/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md
+++ b/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md
@@ -1,0 +1,116 @@
+---
+status: "proposed"
+date: "2026-07-09"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted:
+  - "P.O. CEPS"
+  - "P.O. CRCA"
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0105: O ato publicado pertence a um módulo `Publicacoes` que não conhece os domínios
+
+## Contexto e enunciado do problema
+
+Reitoria, CEPS e CRCA publicam atos normativos — editais, avisos, comunicados — hoje espalhados por portais distintos, sem registro comum, sem cadeia de linhagem e sem prova do que foi efetivamente publicado. Com a implantação do Uni+, essas publicações passam a ser concentradas no sistema, e cada setor referencia uma publicação nas suas páginas.
+
+Isso levanta uma pergunta de fronteira: **onde vive o ato publicado?**
+
+A resposta óbvia — dentro do módulo `Selecao`, como a entidade `Edital` faz hoje — é refutada por dois fatos observados nos acervos reais:
+
+1. **Um ato pode não pertencer a certame nenhum.** O `EDITAL Nº 22/2026 – CEPS` seleciona elaboradores e corretores de questões: declara ter por objeto outro edital, não um certame de candidatos. Num módulo que exigisse um processo seletivo, esse ato não teria onde morar.
+
+2. **A numeração é da série `(órgão, ano)` e atravessa certames.** Na sequência do SiSU 2026 do CRCA faltam os Editais 11, 12, 16, 17, 21 e 22 — pertencem a outros processos seletivos correndo em paralelo. O número, portanto, não é derivável do processo nem uma sequência dedicada a ele.
+
+Ao mesmo tempo, a consulta unificada ("todos os atos deste certame") é o **propósito** da centralização, não um efeito colateral. O risco é resolver a consulta acoplando o módulo documental aos domínios — e produzir o agregado que sabe de tudo.
+
+## Drivers da decisão
+
+- **Consulta unificada dos atos** — é a razão institucional de centralizar as publicações.
+- **Existência de atos sem certame** — o modelo deve acomodá-los sem exceção.
+- **Fronteiras de módulo (ADR-0056, R8)** — um módulo não depende do domínio de outro.
+- **Referência cross-módulo por valor (ADR-0061)** — sem chave estrangeira atravessando módulo.
+- **Simplicidade operacional (ADR-0097)** — a topologia é de módulos internos coabitando um processo e um banco.
+
+## Opções consideradas
+
+- **A**: O ato permanece no módulo `Selecao`, e o Ingresso referencia-o.
+- **B**: Cada módulo possui a sua própria tabela de atos.
+- **C**: Módulo **`Publicacoes`** dedicado, que possui a essência documental do ato e **não conhece** os domínios.
+
+## Resultado da decisão
+
+**Escolhida:** "C — módulo `Publicacoes` dedicado", porque o ato publicado é um artefato documental de um órgão, não de um certame, e há atos sem certame algum.
+
+O módulo possui **apenas** a essência documental e normativa do ato: órgão, série, ano, número, tipo, data de publicação, documento, hash e cadeia de retificação. Mais o cadastro de tipos de ato, versionado por vigência.
+
+Ele **não conhece** `ProcessoSeletivo`, `Chamada` nem configuração de certame. Não há coluna, chave estrangeira ou enumerado desses conceitos. **Essa ausência é a trava contra o agregado onipotente**, e é verificável.
+
+Os domínios referenciam o ato **por valor** — `{id, hash}` —, sem chave estrangeira cruzando módulo (ADR-0061). O risco de referência órfã é mitigado pelo hash do documento.
+
+A consulta unificada é servida por um **vínculo genérico**, `(ato, tipo_entidade, entidade_id)`, populado pelos domínios e guardado por `Publicacoes` **sem interpretação**: `tipo_entidade` é um rótulo opaco, sem enumerado fechado e sem chave estrangeira para tabela de domínio. `Selecao` vincula os seus atos ao processo seletivo; `Ingresso`, os seus à chamada. Um ato sem vínculo permanece válido.
+
+O módulo entra como **quinto módulo interno** do monolito modular, com schema `publicacoes` no banco `uniplus`, coerente com a ADR-0097. Não cria uma segunda instância de Wolverine nem um segundo outbox.
+
+## Consequências
+
+### Positivas
+
+- Atos sem certame — seleção interna de elaboradores, atos de outros processos — cabem no modelo sem exceção.
+- A numeração pode atravessar certames, como já ocorre, sem que o modelo precise saber disso.
+- A consulta unificada existe **sem** acoplar o módulo documental aos domínios.
+- A fronteira é verificável: basta constatar que o módulo não possui colunas de domínio.
+- O `Edital` sai do módulo `Selecao`, que passa a possuir apenas a configuração e a sua versão.
+
+### Negativas
+
+- Um módulo a mais para compor no host, com um `DbContext` a mais nas listas travadas por fitness test (`MigrationContextsEsperados`, isolamento cross-módulo, composição do host).
+- A integridade da referência ato ↔ domínio deixa de ser garantida pelo banco e passa a ser garantida pela aplicação, com o hash como mitigação.
+- A consulta "todos os atos deste certame" exige o vínculo estar populado — se um domínio esquecer de gravá-lo, o ato existe mas não aparece na consulta do certame.
+
+### Neutras
+
+- Com schema por módulo (ADR-0097), uma chave estrangeira de `publicacoes` para `selecao` é **tecnicamente possível**. A ausência dela deixa de ser garantida pela física e passa a ser decisão de modelagem, travada por fitness test.
+- O módulo não expõe conceitos de negócio dos domínios; a sua API é sobre documentos.
+
+## Confirmação
+
+- **Fitness test**: o schema `publicacoes` não possui nenhuma coluna chamada `processo_seletivo_id`, `chamada_id` ou `aplicacao_prova_id`.
+- **Fitness test**: nenhuma chave estrangeira do schema `publicacoes` atravessa a fronteira de outro schema de módulo. O teste **planta um canário** — cria a chave estrangeira cross-schema, verifica que o banco a aceita, remove — e só então assere que nenhuma existe. Sem o canário, um schema vazio passaria trivialmente.
+- **Fitness test (R8)**: o módulo não referencia `Domain`, `Application`, `Infrastructure` ou `API` de nenhum outro módulo; só o host compõe.
+- **Teste de domínio**: um ato sem vínculo é registrável e consultável.
+- **Teste de domínio**: uma mesma entidade acumula vários atos; um mesmo ato vincula-se a mais de uma entidade.
+
+## Prós e contras das opções
+
+### A — O ato permanece no módulo `Selecao`
+
+- Bom, porque é o que existe hoje, e nenhum módulo novo é criado.
+- Ruim, porque um ato que não pertence a certame algum não tem onde morar. Um "edital de Seleção" que não é de um processo seletivo é uma contradição de escopo.
+- Ruim, porque o módulo `Ingresso` passaria a depender do domínio de `Selecao` para publicar as suas convocações, violando o R8.
+
+### B — Cada módulo com a sua tabela de atos
+
+- Bom, porque preserva o isolamento de cada módulo.
+- Ruim, porque a consulta unificada — o propósito da centralização — vira uma união entre tabelas disjuntas, com esquemas que derivam entre si com o tempo.
+- Ruim, porque a cadeia de retificação não atravessaria módulos, e ela atravessa: um aviso do CRCA retifica um edital do CRCA, mas um comunicado da Reitoria pode retificar um edital do CEPS.
+
+### C — Módulo `Publicacoes` dedicado (escolhida)
+
+- Bom, porque acomoda o ato sem certame, que existe.
+- Bom, porque a consulta unificada é servida sem que o módulo conheça os domínios.
+- Bom, porque a cadeia de retificação vive num só lugar.
+- Ruim, porque acrescenta um módulo a compor e a operar.
+- Ruim, porque a integridade da referência ato ↔ domínio passa a ser responsabilidade da aplicação.
+
+## Mais informações
+
+- [ADR-0056](0056-modulo-configuracao-e-read-side-via-reader.md) — fitness tests de isolamento cross-módulo (R8)
+- [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md) — referência cross-módulo por valor
+- [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md) — entidades forenses, append-only
+- [ADR-0097](0097-topologia-de-deploy-em-tres-apis-monolito-modular.md) — monolito modular; schema por módulo no banco `uniplus`. **Esta ADR acrescenta o quinto módulo interno.**
+- [ADR-0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md) — retificação é relação entre atos
+- [ADR-0104](0104-versao-configuracao-como-agregado-proprio.md) — a vigência ordena versões, não documentos
+- Evidência empírica: acervos completos do PS Canaã dos Carajás 2026 (CEPS) e do SiSU 2026 — Edição Única (CRCA)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -131,12 +131,15 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0100](0100-canonicalizacao-hash-snapshot-publicacao.md) | Contrato de canonicalização e hash do snapshot de publicação (RN08) | accepted | 2026-07-07 |
 | [0101](0101-retificacao-novo-edital-novo-snapshot-motivo.md) | Retificação de processo publicado é sempre novo Edital + novo snapshot + motivo | accepted | 2026-07-07 |
 | [0102](0102-invariantes-coerencia-processo-guard-rails-422.md) | Invariantes de coerência de processo como guard rails no banco, mapeadas a HTTP 422 | accepted | 2026-07-07 |
+| [0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md) | Retificação é uma relação entre atos publicados, não um tipo de ato | proposed | 2026-07-09 |
+| [0104](0104-versao-configuracao-como-agregado-proprio.md) | A vigência da configuração ordena versões, não documentos | proposed | 2026-07-09 |
+| [0105](0105-modulo-publicacoes-registro-central-dos-atos.md) | O ato publicado pertence a um módulo `Publicacoes` que não conhece os domínios | proposed | 2026-07-09 |
 
-> **Nota de numeração:** a sequência de `0001` a `0102` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0103+`.
+> **Nota de numeração:** a sequência de `0001` a `0105` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0106+`.
 
 ## Como adicionar um novo ADR
 
-1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0102`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
+1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0105`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
 2. Copie [`_template.md`](_template.md).
 3. Renomeie para `NNNN-titulo-em-slug.md` (slug ASCII em minúsculas, hífens como separador).
 4. Preencha frontmatter, contexto, drivers, opções, resultado da decisão (única), consequências.


### PR DESCRIPTION
## O que é

Três ADRs, uma decisão cada, registrando o que a modelagem do fechamento da configuração do Processo Seletivo decidiu e ainda não estava escrito.

As três nascem `proposed` — o aceite é do Tech Lead.

| ADR | Decisão |
|---|---|
| **0103** | Retificação é uma **relação** entre atos publicados, não um tipo de ato |
| **0104** | A vigência da configuração ordena **versões**, não documentos |
| **0105** | O ato publicado pertence a um módulo **`Publicacoes`** que não conhece os domínios |

## Por que agora

As stories da Fase 1 já existem (#805, #798–#801, #802–#804). Sem as ADRs, essas decisões seriam tomadas no primeiro PR de domínio, por quem estivesse implementando — e o que hoje está fundamentado viraria folclore.

## O que sustenta cada uma

**0103** — o próprio código já prova a redundância: existe um CHECK garantindo `natureza = Retificacao ⟺ EditalRetificadoId IS NOT NULL`. Se um implica o outro, um é supérfluo. E o índice `ux_editais_processo_abertura_unica` filtra por `natureza = 1` — o valor do enumerado **escrito no banco**. Acrescentar um tipo de ato exigiria migration e deploy.

**0104** — o índice `ux_editais_processo_data_publicacao` impõe unicidade da data de publicação, só para obter ordem total entre editais. Mas a retificação **republica com a mesma data**, e a data documental passará a ser declarada. A ordem precisa vir de outro lugar.

**0105** — o `EDITAL Nº 22/2026 – CEPS` seleciona elaboradores de questões: não pertence a certame nenhum. E faltam os Editais 11, 12, 16, 17, 21 e 22 na série do SiSU 2026 do CRCA, porque pertencem a outros processos. A numeração atravessa certames.

## Evidência empírica

O desenho foi confrontado com dois acervos completos de atos reais da Unifesspa: o **PS Canaã dos Carajás 2026** (CEPS, 20 atos) e o **SiSU 2026 — Edição Única** (CRCA, 25 atos, cinco chamadas, seis avisos de prorrogação, duas retificações).

## Detalhe que a 0105 deixa explícito

Com schema por módulo (ADR-0097), uma chave estrangeira de `publicacoes` para `selecao` é **tecnicamente possível**. A ausência dela deixa de ser garantida pela física e passa a ser decisão de modelagem.

Por isso a seção de Confirmação exige que o fitness test **plante um canário** — crie a chave estrangeira cross-schema, verifique que o banco a aceita, remova — e só então assere que nenhuma existe. Sem o canário, um schema vazio passaria trivialmente.

## Relacionadas

- Refina a ADR-0097 (acrescenta o quinto módulo interno)
- Fundamenta as stories #805, #798, #799, #800, #801, #802, #803, #804
- A ADR-0105 estabelece precedente para a issue #794 (topologia de persistência da autorização)

## Checklist

- [x] Uma decisão por ADR
- [x] Numeração sem lacunas (0103–0105); índice `docs/adrs/README.md` atualizado
- [x] Todos os links internos validados — 20 referências, nenhuma quebrada
- [x] Sem alteração de código
