### PR TITLE
docs(adr): promove ADR-0103 a ADR-0105 para accepted

### DIFF
--- a/docs/adrs/0103-ato-normativo-generalizado-retificacao-como-relacao.md
+++ b/docs/adrs/0103-ato-normativo-generalizado-retificacao-como-relacao.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 date: "2026-07-09"
 decision-makers:
   - "Tech Lead (CTIC)"

--- a/docs/adrs/0104-versao-configuracao-como-agregado-proprio.md
+++ b/docs/adrs/0104-versao-configuracao-como-agregado-proprio.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 date: "2026-07-09"
 decision-makers:
   - "Tech Lead (CTIC)"

--- a/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md
+++ b/docs/adrs/0105-modulo-publicacoes-registro-central-dos-atos.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 date: "2026-07-09"
 decision-makers:
   - "Tech Lead (CTIC)"

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -131,9 +131,9 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0100](0100-canonicalizacao-hash-snapshot-publicacao.md) | Contrato de canonicalização e hash do snapshot de publicação (RN08) | accepted | 2026-07-07 |
 | [0101](0101-retificacao-novo-edital-novo-snapshot-motivo.md) | Retificação de processo publicado é sempre novo Edital + novo snapshot + motivo | accepted | 2026-07-07 |
 | [0102](0102-invariantes-coerencia-processo-guard-rails-422.md) | Invariantes de coerência de processo como guard rails no banco, mapeadas a HTTP 422 | accepted | 2026-07-07 |
-| [0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md) | Retificação é uma relação entre atos publicados, não um tipo de ato | proposed | 2026-07-09 |
-| [0104](0104-versao-configuracao-como-agregado-proprio.md) | A vigência da configuração ordena versões, não documentos | proposed | 2026-07-09 |
-| [0105](0105-modulo-publicacoes-registro-central-dos-atos.md) | O ato publicado pertence a um módulo `Publicacoes` que não conhece os domínios | proposed | 2026-07-09 |
+| [0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md) | Retificação é uma relação entre atos publicados, não um tipo de ato | accepted | 2026-07-09 |
+| [0104](0104-versao-configuracao-como-agregado-proprio.md) | A vigência da configuração ordena versões, não documentos | accepted | 2026-07-09 |
+| [0105](0105-modulo-publicacoes-registro-central-dos-atos.md) | O ato publicado pertence a um módulo `Publicacoes` que não conhece os domínios | accepted | 2026-07-09 |
 
 > **Nota de numeração:** a sequência de `0001` a `0105` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0106+`.
 


### PR DESCRIPTION
Promove para `accepted` as três decisões mergeadas no PR #806, após revisão do Codex e aprovação.

| ADR | Decisão |
|---|---|
| 0103 | Retificação é uma relação entre atos publicados, não um tipo de ato |
| 0104 | A vigência da configuração ordena versões, não documentos |
| 0105 | O ato publicado pertence a um módulo `Publicacoes` que não conhece os domínios |

A partir daqui são **autoridade sobre a implementação**. Desbloqueia a story #805 (fundação do módulo) e as stories #798–#801 e #802–#804.

Índice `docs/adrs/README.md` atualizado. Sem alteração de código.