### PR TITLE
feat(publicacoes): adiciona a camada Application do cadastro de tipos de ato

### DIFF
--- a/UniPlus.slnx
+++ b/UniPlus.slnx
@@ -29,6 +29,7 @@
   </Folder>
   <Folder Name="/src/publicacoes/">
     <Project Path="src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj" />
+    <Project Path="src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Unifesspa.UniPlus.Publicacoes.Application.csproj" />
     <Project Path="src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Unifesspa.UniPlus.Publicacoes.Domain.csproj" />
     <Project Path="src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Unifesspa.UniPlus.Publicacoes.Infrastructure.csproj" />
   </Folder>
@@ -67,6 +68,7 @@
     <Project Path="tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Unifesspa.UniPlus.Configuracao.Application.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Unifesspa.UniPlus.Configuracao.IntegrationTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Unifesspa.UniPlus.Publicacoes.IntegrationTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Host.IntegrationTests/Unifesspa.UniPlus.Host.IntegrationTests.csproj" />
   </Folder>

--- a/src/host/Unifesspa.UniPlus.Host/Program.cs
+++ b/src/host/Unifesspa.UniPlus.Host/Program.cs
@@ -4,6 +4,7 @@ using Unifesspa.UniPlus.Configuracao.API;
 using Unifesspa.UniPlus.Configuracao.Application;
 using Unifesspa.UniPlus.Ingresso.API;
 using Unifesspa.UniPlus.Publicacoes.API;
+using Unifesspa.UniPlus.Publicacoes.Application;
 using Unifesspa.UniPlus.Infrastructure.Core.Authentication;
 using Unifesspa.UniPlus.Infrastructure.Core.Cors;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
@@ -98,6 +99,7 @@ builder.Host.UseWolverineOutboxCascading(
     {
         opts.Discovery.IncludeAssembly(typeof(ConfiguracaoApplicationServiceRegistration).Assembly);
         opts.Discovery.IncludeAssembly(typeof(OrganizacaoInstitucionalApplicationServiceRegistration).Assembly);
+        opts.Discovery.IncludeAssembly(typeof(PublicacoesApplicationServiceRegistration).Assembly);
         opts.Discovery.IncludeAssembly(typeof(CriarProcessoSeletivoCommand).Assembly);
         opts.Discovery.IncludeAssembly(typeof(ProcessoPublicadoToKafkaCascadeHandler).Assembly);
 
@@ -109,6 +111,7 @@ builder.Host.UseWolverineOutboxCascading(
         SelecaoCodegenRegistration.ConfigurarCodegenWolverine(opts);
         ConfiguracaoCodegenRegistration.ConfigurarCodegenWolverine(opts);
         OrganizacaoInstitucionalCodegenRegistration.ConfigurarCodegenWolverine(opts);
+        PublicacoesCodegenRegistration.ConfigurarCodegenWolverine(opts);
 
         // Routing do Selecao (PG queue domain-events + Kafka processo_seletivo_events) —
         // religa a mensageria externa antes deferida no monólito.

--- a/src/host/Unifesspa.UniPlus.Host/packages.lock.json
+++ b/src/host/Unifesspa.UniPlus.Host/packages.lock.json
@@ -1159,7 +1159,20 @@
         "dependencies": {
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Serilog.AspNetCore": "[10.0.0, )",
-          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )"
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.publicacoes.domain": {
@@ -1175,6 +1188,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesCodegenRegistration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesCodegenRegistration.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Publicacoes.API;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+
+using Wolverine;
+
+/// <summary>
+/// Opt-ins de codegen Wolverine do módulo Publicações (ADR-0098). Declara que
+/// <see cref="IPublicacoesUnitOfWork"/> usa service location <em>intencionalmente</em>
+/// sob a política <c>ServiceLocationPolicy.NotAllowed</c> (forward-compat com o
+/// default do Wolverine 6.0).
+/// </summary>
+/// <remarks>
+/// <para>A UoW encaminha (forwarding) para a MESMA instância do
+/// <c>PublicacoesDbContext</c> — registrada como lambda Scoped opaca ao codegen.
+/// O root fix <c>AddScoped&lt;IPublicacoesUnitOfWork, PublicacoesDbContext&gt;()</c>
+/// é PROIBIDO: criaria uma 2ª instância de DbContext por escopo e quebraria a
+/// atomicidade write+evento do outbox (ADR-0004). Usa-se
+/// <c>AlwaysUseServiceLocationFor&lt;T&gt;()</c>, o mecanismo sancionado pela doc do
+/// Wolverine para forwarding/EF Core DbContext.</para>
+/// <para>Composto pelo host no <c>configureRouting</c>; o helper compartilhado
+/// permanece agnóstico dos tipos do módulo (Clean Arch).</para>
+/// </remarks>
+[SuppressMessage(
+    "Design",
+    "CA1515:Consider making public types internal",
+    Justification = "Referenciado pelo composition root (host do monólito modular) fora deste assembly.")]
+public static class PublicacoesCodegenRegistration
+{
+    /// <summary>
+    /// Aplica os opt-ins de codegen das Publicações ao <paramref name="opts"/>.
+    /// </summary>
+    public static void ConfigurarCodegenWolverine(WolverineOptions opts)
+    {
+        ArgumentNullException.ThrowIfNull(opts);
+
+        opts.CodeGeneration.AlwaysUseServiceLocationFor<IPublicacoesUnitOfWork>();
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesModuleRegistration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesModuleRegistration.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Publicacoes.Application;
 using Unifesspa.UniPlus.Publicacoes.API.Errors;
 using Unifesspa.UniPlus.Publicacoes.Infrastructure;
 using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
@@ -14,14 +15,12 @@ using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
 /// monólito modular (ADR-0097). Reúne o que é específico do módulo — OpenAPI
 /// doc, registro de erros de domínio, Infrastructure e migrations on startup.
 ///
-/// Publicações nasce como módulo esqueleto: schema próprio, sem entidades e sem
-/// endpoints. O cadastro de tipos de ato, o ato normativo e o vínculo
-/// ato↔entidade chegam nas stories seguintes.
-///
 /// O módulo não referencia Domain, Application, Infrastructure ou API de nenhum
 /// outro módulo (ADR-0105): ele possui a essência documental do ato, e nada mais.
-/// Como não há handlers, o assembly não entra no discovery do Wolverine — a
-/// primeira story que introduzir um handler deve compor o discovery no host.
+///
+/// Os handlers vivem no assembly Application e são descobertos pelo Wolverine, que
+/// os inclui explicitamente no <c>Discovery</c> do composition root — junto com o
+/// opt-in de codegen de <see cref="PublicacoesCodegenRegistration"/>.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage(
     "Design",
@@ -43,6 +42,7 @@ public static class PublicacoesModuleRegistration
         // uma vez no host via IEnumerable<IDomainErrorRegistration>).
         services.AddSingleton<IDomainErrorRegistration, PublicacoesDomainErrorRegistration>();
 
+        services.AddPublicacoesApplication();
         services.AddPublicacoesInfrastructure();
 
         // Migrations EF Core aplicadas no host StartAsync via IHostedService, ANTES

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj
@@ -9,6 +9,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="WolverineFx" />
   </ItemGroup>
 
   <!-- Implicit usings que o Sdk.Web adicionava e o Sdk padrão não traz. -->
@@ -23,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Unifesspa.UniPlus.Publicacoes.Application\Unifesspa.UniPlus.Publicacoes.Application.csproj" />
     <ProjectReference Include="..\Unifesspa.UniPlus.Publicacoes.Infrastructure\Unifesspa.UniPlus.Publicacoes.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/packages.lock.json
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/packages.lock.json
@@ -26,6 +26,29 @@
           "Serilog.Sinks.File": "7.0.0"
         }
       },
+      "WolverineFx": {
+        "type": "Direct",
+        "requested": "[5.39.5, )",
+        "resolved": "5.39.5",
+        "contentHash": "rnyz+ZConabOTi/U8N7UQAOaMc9P03hHyFrXZ6///6X0qtsHQ+VKDZtHe87AZJmY7By2w9As9puY6/jGCg5ZCA==",
+        "dependencies": {
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
+          "JasperFx.RuntimeCompiler": "4.5.0",
+          "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
         "resolved": "8.4.0",
@@ -1014,6 +1037,17 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
       "unifesspa.uniplus.publicacoes.domain": {
         "type": "Project",
         "dependencies": {
@@ -1027,6 +1061,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },
@@ -1087,6 +1122,16 @@
         "requested": "[12.1.1, )",
         "resolved": "12.1.1",
         "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
         "type": "CentralTransitive",
@@ -1285,29 +1330,6 @@
         "requested": "[1.17.5.1, )",
         "resolved": "1.17.5.1",
         "contentHash": "1O/F+AQCkyK4K709pBDYEbDDfJ12OlaE5lnOs9dffq+KxqrnPxh8FIdQtEst9yBJmC7I0BptftzTJyRSwhZR/A=="
-      },
-      "WolverineFx": {
-        "type": "CentralTransitive",
-        "requested": "[5.39.5, )",
-        "resolved": "5.39.5",
-        "contentHash": "rnyz+ZConabOTi/U8N7UQAOaMc9P03hHyFrXZ6///6X0qtsHQ+VKDZtHe87AZJmY7By2w9As9puY6/jGCg5ZCA==",
-        "dependencies": {
-          "JasperFx": "1.31.0",
-          "JasperFx.Events": "1.36.0",
-          "JasperFx.RuntimeCompiler": "4.5.0",
-          "JasperFx.SourceGeneration": "1.1.0",
-          "Microsoft.Extensions.Caching.Memory": "10.0.0",
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
-          "Microsoft.Extensions.Configuration.Json": "10.0.0",
-          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Hosting": "10.0.0",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Microsoft.Extensions.ObjectPool": "10.0.2",
-          "NewId": "4.0.1",
-          "Newtonsoft.Json": "13.0.3"
-        }
       },
       "WolverineFx.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Abstractions/IPublicacoesUnitOfWork.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Abstractions/IPublicacoesUnitOfWork.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+
+using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
+
+/// <summary>
+/// UnitOfWork do módulo Publicações. Especialização sem novos membros de
+/// <see cref="IUnitOfWork"/> que dá um tipo de registro próprio ao módulo —
+/// garante o isolamento da transação no monólito modular, onde vários módulos
+/// coexistem no mesmo container e um <see cref="IUnitOfWork"/> compartilhado
+/// colidiria no contêiner de DI (o último registro venceria).
+/// </summary>
+public interface IPublicacoesUnitOfWork : IUnitOfWork
+{
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/AtualizarTipoAtoPublicadoCommand.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/AtualizarTipoAtoPublicadoCommand.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Atualiza uma versão de tipo de ato. O <c>Codigo</c> é editável: o consumo é por
+/// cópia de valor no ato publicado, então renomear o código vivo não altera nenhum
+/// ato já publicado.
+/// </summary>
+public sealed record AtualizarTipoAtoPublicadoCommand(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    bool CongelaConfiguracao,
+    bool UnicoPorObjeto,
+    bool EfeitoIrreversivel,
+    DateOnly VigenciaInicio,
+    DateOnly? VigenciaFim = null,
+    string? BaseLegal = null) : ICommand<Result>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/AtualizarTipoAtoPublicadoCommandHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/AtualizarTipoAtoPublicadoCommandHandler.cs
@@ -1,0 +1,80 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+/// <summary>
+/// Handler do <see cref="AtualizarTipoAtoPublicadoCommand"/>. Revalida a
+/// sobreposição apenas quando o código ou a janela mudam — alterar o nome ou os
+/// atributos de consequência não pode criar conflito.
+/// </summary>
+public static class AtualizarTipoAtoPublicadoCommandHandler
+{
+    public static async Task<Result> Handle(
+        AtualizarTipoAtoPublicadoCommand command,
+        ITipoAtoPublicadoRepository repository,
+        IPublicacoesUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        TipoAtoPublicado? tipo = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (tipo is null)
+        {
+            return Result.Failure(NaoEncontradoErro());
+        }
+
+        if (JanelaOuCodigoMudou(tipo, command))
+        {
+            bool sobreposta = await repository.ExisteSobreposicaoDeVigenciaAsync(
+                command.Codigo, command.VigenciaInicio, command.VigenciaFim, command.Id, cancellationToken)
+                .ConfigureAwait(false);
+            if (sobreposta)
+            {
+                return Result.Failure(CriarTipoAtoPublicadoCommandHandler.VigenciaSobrepostaErro(command.Codigo));
+            }
+        }
+
+        Result atualizacao = tipo.Atualizar(
+            command.Codigo,
+            command.Nome,
+            command.CongelaConfiguracao,
+            command.UnicoPorObjeto,
+            command.EfeitoIrreversivel,
+            command.VigenciaInicio,
+            command.VigenciaFim,
+            command.BaseLegal);
+
+        if (atualizacao.IsFailure)
+        {
+            return atualizacao;
+        }
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ExclusionConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && ExclusionConstraintViolation.IsVigenciaConflict(constraint))
+        {
+            return Result.Failure(CriarTipoAtoPublicadoCommandHandler.VigenciaSobrepostaErro(command.Codigo));
+        }
+
+        return Result.Success();
+    }
+
+    private static bool JanelaOuCodigoMudou(TipoAtoPublicado tipo, AtualizarTipoAtoPublicadoCommand command) =>
+        !string.Equals(tipo.Codigo, command.Codigo.Trim(), StringComparison.Ordinal)
+        || tipo.VigenciaInicio != command.VigenciaInicio
+        || tipo.VigenciaFim != command.VigenciaFim;
+
+    private static DomainError NaoEncontradoErro() =>
+        new(TipoAtoPublicadoErrorCodes.NaoEncontrado, "Tipo de ato não encontrado.");
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/AtualizarTipoAtoPublicadoCommandValidator.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/AtualizarTipoAtoPublicadoCommandValidator.cs
@@ -1,0 +1,38 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+using FluentValidation;
+
+/// <summary>
+/// Espelha o <see cref="CriarTipoAtoPublicadoCommandValidator"/>, acrescido do
+/// identificador. As regras avaliam o valor normalizado, como o agregado faz.
+/// </summary>
+public sealed class AtualizarTipoAtoPublicadoCommandValidator
+    : AbstractValidator<AtualizarTipoAtoPublicadoCommand>
+{
+    public AtualizarTipoAtoPublicadoCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage(TipoAtoPublicadoRegras.IdObrigatorio);
+
+        RuleFor(x => TipoAtoPublicadoRegras.Normalizar(x.Codigo))
+            .NotEmpty().WithMessage(TipoAtoPublicadoRegras.CodigoObrigatorio)
+            .MaximumLength(TipoAtoPublicadoRegras.CodigoMaxLength).WithMessage(TipoAtoPublicadoRegras.CodigoTamanho)
+            .Matches(TipoAtoPublicadoRegras.CodigoPattern).WithMessage(TipoAtoPublicadoRegras.CodigoFormato)
+            .OverridePropertyName(nameof(AtualizarTipoAtoPublicadoCommand.Codigo));
+
+        RuleFor(x => TipoAtoPublicadoRegras.Normalizar(x.Nome))
+            .NotEmpty().WithMessage(TipoAtoPublicadoRegras.NomeObrigatorio)
+            .Length(TipoAtoPublicadoRegras.NomeMinLength, TipoAtoPublicadoRegras.NomeMaxLength)
+            .WithMessage(TipoAtoPublicadoRegras.NomeTamanho)
+            .OverridePropertyName(nameof(AtualizarTipoAtoPublicadoCommand.Nome));
+
+        RuleFor(x => TipoAtoPublicadoRegras.Normalizar(x.BaseLegal))
+            .MaximumLength(TipoAtoPublicadoRegras.BaseLegalMaxLength).WithMessage(TipoAtoPublicadoRegras.BaseLegalTamanho)
+            .OverridePropertyName(nameof(AtualizarTipoAtoPublicadoCommand.BaseLegal))
+            .When(x => x.BaseLegal is not null);
+
+        RuleFor(x => x.VigenciaFim)
+            .GreaterThan(x => x.VigenciaInicio).WithMessage(TipoAtoPublicadoRegras.VigenciaFim)
+            .When(x => x.VigenciaFim.HasValue);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/CriarTipoAtoPublicadoCommand.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/CriarTipoAtoPublicadoCommand.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria uma versão de tipo de ato: código (UPPER_SNAKE), nome, os três atributos de
+/// consequência, a janela semiaberta de vigência e a base legal opcional. O ator de
+/// auditoria (<c>created_by</c>) é carimbado server-side via <c>IUserContext</c>,
+/// não no payload.
+/// </summary>
+public sealed record CriarTipoAtoPublicadoCommand(
+    string Codigo,
+    string Nome,
+    bool CongelaConfiguracao,
+    bool UnicoPorObjeto,
+    bool EfeitoIrreversivel,
+    DateOnly VigenciaInicio,
+    DateOnly? VigenciaFim = null,
+    string? BaseLegal = null) : ICommand<Result<Guid>>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/CriarTipoAtoPublicadoCommandHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/CriarTipoAtoPublicadoCommandHandler.cs
@@ -1,0 +1,73 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+/// <summary>
+/// Handler do <see cref="CriarTipoAtoPublicadoCommand"/> (convention-based
+/// Wolverine): confere que nenhuma versão viva do mesmo código intercepta a janela
+/// informada, cria o agregado, persiste e commita.
+/// </summary>
+/// <remarks>
+/// A consulta prévia dá a mensagem legível no caso comum; a exclusion constraint
+/// fecha a corrida check-then-act. São papéis distintos, não duplicação: entre a
+/// consulta e o <c>SaveChanges</c> cabe outra transação, e só o banco a vê.
+/// </remarks>
+public static class CriarTipoAtoPublicadoCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarTipoAtoPublicadoCommand command,
+        ITipoAtoPublicadoRepository repository,
+        IPublicacoesUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        bool sobreposta = await repository.ExisteSobreposicaoDeVigenciaAsync(
+            command.Codigo, command.VigenciaInicio, command.VigenciaFim, null, cancellationToken)
+            .ConfigureAwait(false);
+        if (sobreposta)
+        {
+            return Result<Guid>.Failure(VigenciaSobrepostaErro(command.Codigo));
+        }
+
+        Result<TipoAtoPublicado> tipoResult = TipoAtoPublicado.Criar(
+            command.Codigo,
+            command.Nome,
+            command.CongelaConfiguracao,
+            command.UnicoPorObjeto,
+            command.EfeitoIrreversivel,
+            command.VigenciaInicio,
+            command.VigenciaFim,
+            command.BaseLegal);
+
+        if (tipoResult.IsFailure)
+        {
+            return Result<Guid>.Failure(tipoResult.Error!);
+        }
+
+        TipoAtoPublicado tipo = tipoResult.Value!;
+        await repository.AdicionarAsync(tipo, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ExclusionConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && ExclusionConstraintViolation.IsVigenciaConflict(constraint))
+        {
+            return Result<Guid>.Failure(VigenciaSobrepostaErro(command.Codigo));
+        }
+
+        return Result<Guid>.Success(tipo.Id);
+    }
+
+    internal static DomainError VigenciaSobrepostaErro(string codigo) =>
+        new(TipoAtoPublicadoErrorCodes.VigenciaSobreposta,
+            $"Já existe uma versão viva do tipo de ato '{codigo}' vigente em parte do período informado.");
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/CriarTipoAtoPublicadoCommandValidator.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/CriarTipoAtoPublicadoCommandValidator.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+using FluentValidation;
+
+/// <summary>
+/// Antecipa a recusa que o agregado faria, devolvendo 400 antes de o handler tocar
+/// o repositório.
+/// </summary>
+/// <remarks>
+/// As regras avaliam o valor <b>normalizado</b>, como o agregado faz. Validar o texto
+/// cru divergiria nos dois sentidos: <c>"  EDITAL_ABERTURA  "</c> seria recusado aqui
+/// embora o domínio o aceite, e <c>" E"</c> passaria o comprimento mínimo aqui para
+/// ser recusado adiante, com outro status. Como a expressão não é um acesso a membro,
+/// o nome da propriedade no <c>ProblemDetails</c> vem de <c>OverridePropertyName</c>.
+/// </remarks>
+public sealed class CriarTipoAtoPublicadoCommandValidator
+    : AbstractValidator<CriarTipoAtoPublicadoCommand>
+{
+    public CriarTipoAtoPublicadoCommandValidator()
+    {
+        RuleFor(x => TipoAtoPublicadoRegras.Normalizar(x.Codigo))
+            .NotEmpty().WithMessage(TipoAtoPublicadoRegras.CodigoObrigatorio)
+            .MaximumLength(TipoAtoPublicadoRegras.CodigoMaxLength).WithMessage(TipoAtoPublicadoRegras.CodigoTamanho)
+            .Matches(TipoAtoPublicadoRegras.CodigoPattern).WithMessage(TipoAtoPublicadoRegras.CodigoFormato)
+            .OverridePropertyName(nameof(CriarTipoAtoPublicadoCommand.Codigo));
+
+        RuleFor(x => TipoAtoPublicadoRegras.Normalizar(x.Nome))
+            .NotEmpty().WithMessage(TipoAtoPublicadoRegras.NomeObrigatorio)
+            .Length(TipoAtoPublicadoRegras.NomeMinLength, TipoAtoPublicadoRegras.NomeMaxLength)
+            .WithMessage(TipoAtoPublicadoRegras.NomeTamanho)
+            .OverridePropertyName(nameof(CriarTipoAtoPublicadoCommand.Nome));
+
+        RuleFor(x => TipoAtoPublicadoRegras.Normalizar(x.BaseLegal))
+            .MaximumLength(TipoAtoPublicadoRegras.BaseLegalMaxLength).WithMessage(TipoAtoPublicadoRegras.BaseLegalTamanho)
+            .OverridePropertyName(nameof(CriarTipoAtoPublicadoCommand.BaseLegal))
+            .When(x => x.BaseLegal is not null);
+
+        RuleFor(x => x.VigenciaFim)
+            .GreaterThan(x => x.VigenciaInicio).WithMessage(TipoAtoPublicadoRegras.VigenciaFim)
+            .When(x => x.VigenciaFim.HasValue);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/ExclusionConstraintViolation.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/ExclusionConstraintViolation.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+/// <summary>
+/// Mapeia a violação <c>23P01</c> da exclusion constraint
+/// <c>ex_tipo_ato_publicado_codigo_vigencia</c> para o <c>DomainError</c>
+/// apropriado. Acessa <c>SqlState</c> e <c>ConstraintName</c> por reflection no
+/// inner exception — o shape é estável na API pública do
+/// <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção por
+/// <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> nesta camada (Clean Architecture —
+/// Application referencia apenas Domain, Kernel e abstrações).
+/// </summary>
+/// <remarks>
+/// <para>Mesmo padrão dos helpers <c>UniqueConstraintViolation</c> dos cadastros de
+/// Configuração e Seleção, com o SQLSTATE de exclusão em vez do de unicidade.</para>
+/// <para>O PostgreSQL preenche o nome da constraint em toda a classe 23 de erros, e
+/// os caminhos que lançam <c>EXCLUSION_VIOLATION</c> o incluem. Quando o nome vier
+/// ausente, a exceção <b>propaga</b>: converter uma exclusion constraint desconhecida
+/// num conflito de vigência seria mentir sobre a causa.</para>
+/// </remarks>
+internal static class ExclusionConstraintViolation
+{
+    private const string ExclusionViolationSqlState = "23P01";
+
+    private const string VigenciaConstraint = "ex_tipo_ato_publicado_codigo_vigencia";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> envolvendo uma <c>PostgresException</c> com
+    /// <c>SqlState = "23P01"</c>. <see langword="null"/> caso contrário — o caller
+    /// deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != ExclusionViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é a que impede duas versões
+    /// vivas do mesmo código de valerem no mesmo dia.
+    /// </summary>
+    public static bool IsVigenciaConflict(string? constraint) =>
+        string.Equals(constraint, VigenciaConstraint, StringComparison.Ordinal);
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/RemoverTipoAtoPublicadoCommand.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/RemoverTipoAtoPublicadoCommand.cs
@@ -1,0 +1,10 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Remove (soft-delete) uma versão de tipo de ato, liberando a sua janela de
+/// vigência para uma nova versão do mesmo código.
+/// </summary>
+public sealed record RemoverTipoAtoPublicadoCommand(Guid Id) : ICommand<Result>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/RemoverTipoAtoPublicadoCommandHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/RemoverTipoAtoPublicadoCommandHandler.cs
@@ -1,0 +1,42 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+/// <summary>
+/// Handler do <see cref="RemoverTipoAtoPublicadoCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c>. A remoção nunca é bloqueada: o ato publicado copia
+/// os atributos do tipo por valor no instante da publicação (ADR-0103), de modo que
+/// nenhum ato passa a apontar para um tipo ausente.
+/// </summary>
+public static class RemoverTipoAtoPublicadoCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverTipoAtoPublicadoCommand command,
+        ITipoAtoPublicadoRepository repository,
+        IPublicacoesUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        TipoAtoPublicado? tipo = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (tipo is null)
+        {
+            return Result.Failure(new DomainError(
+                TipoAtoPublicadoErrorCodes.NaoEncontrado,
+                "Tipo de ato não encontrado."));
+        }
+
+        repository.Remover(tipo);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/RemoverTipoAtoPublicadoCommandValidator.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/RemoverTipoAtoPublicadoCommandValidator.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+using FluentValidation;
+
+public sealed class RemoverTipoAtoPublicadoCommandValidator
+    : AbstractValidator<RemoverTipoAtoPublicadoCommand>
+{
+    public RemoverTipoAtoPublicadoCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty().WithMessage(TipoAtoPublicadoRegras.IdObrigatorio);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/TipoAtoPublicadoRegras.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/TipoAtoPublicadoRegras.cs
@@ -1,0 +1,38 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+/// <summary>
+/// Limites e formato compartilhados pelos validators de criação e atualização.
+/// O agregado é a autoridade — o validator apenas antecipa a recusa, devolvendo
+/// 400 antes de o handler tocar no repositório.
+/// </summary>
+internal static class TipoAtoPublicadoRegras
+{
+    public const int CodigoMaxLength = 60;
+    public const int NomeMinLength = 2;
+    public const int NomeMaxLength = 200;
+    public const int BaseLegalMaxLength = 500;
+
+    /// <summary>Caixa alta sem acento, palavras separadas por um único underscore.</summary>
+    public const string CodigoPattern = "^[A-Z]+(_[A-Z]+)*$";
+
+    public const string CodigoObrigatorio = "Código do tipo de ato é obrigatório.";
+    public const string CodigoTamanho = "Código do tipo de ato deve ter no máximo 60 caracteres.";
+    public const string CodigoFormato =
+        "Código do tipo de ato deve usar apenas letras maiúsculas sem acento, separadas por underscore (ex.: EDITAL_ABERTURA).";
+    public const string NomeObrigatorio = "Nome do tipo de ato é obrigatório.";
+    public const string NomeTamanho = "Nome do tipo de ato deve ter entre 2 e 200 caracteres.";
+    public const string BaseLegalTamanho = "Base legal deve ter no máximo 500 caracteres.";
+
+    /// <summary>O fim da vigência é exclusivo: uma janela cujo fim iguala o início não contém dia algum.</summary>
+    public const string VigenciaFim = "Fim da vigência é exclusivo e deve ser posterior ao início.";
+
+    public const string IdObrigatorio = "Identificador do tipo de ato é obrigatório.";
+
+    /// <summary>
+    /// Mesma normalização do agregado. O validator precisa avaliar o valor que será
+    /// persistido, não o que veio no payload: sem isto, "  EDITAL_ABERTURA  " seria
+    /// recusado com 400 embora o domínio o aceite, e " E" passaria o comprimento
+    /// mínimo aqui para ser recusado adiante com outro status.
+    /// </summary>
+    public static string? Normalizar(string? valor) => valor?.Trim();
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/TipoAtoPublicadoDto.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/TipoAtoPublicadoDto.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>
+/// DTO de resposta para <c>TipoAtoPublicado</c>. Os três atributos de consequência
+/// são expostos como dados — quem os consome copia-os por valor no ato publicado,
+/// nunca ramifica comportamento por código de tipo (ADR-0103).
+/// </summary>
+/// <remarks>
+/// A janela de vigência é semiaberta: <c>VigenciaFim</c> é o primeiro dia em que
+/// esta versão já não vale, e é nula enquanto a vigência é aberta.
+/// </remarks>
+public sealed record TipoAtoPublicadoDto(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    bool CongelaConfiguracao,
+    bool UnicoPorObjeto,
+    bool EfeitoIrreversivel,
+    DateOnly VigenciaInicio,
+    DateOnly? VigenciaFim,
+    string? BaseLegal,
+    DateTimeOffset CriadoEm);

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DependencyInjection.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DependencyInjection.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application;
+
+using FluentValidation;
+
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Registra recursos da camada Application do módulo Publicações. Os handlers são
+/// descobertos pelo Wolverine (convention-based) a partir deste assembly, incluído
+/// explicitamente no <c>Discovery</c> do composition root.
+/// </summary>
+public static class PublicacoesApplicationServiceRegistration
+{
+    public static IServiceCollection AddPublicacoesApplication(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        System.Reflection.Assembly assembly = typeof(PublicacoesApplicationServiceRegistration).Assembly;
+        services.AddValidatorsFromAssembly(assembly);
+
+        return services;
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Mappings/TipoAtoPublicadoMapping.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Mappings/TipoAtoPublicadoMapping.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Mappings;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+public static class TipoAtoPublicadoMapping
+{
+    public static TipoAtoPublicadoDto ToDto(this TipoAtoPublicado tipo)
+    {
+        ArgumentNullException.ThrowIfNull(tipo);
+        return new TipoAtoPublicadoDto(
+            tipo.Id,
+            tipo.Codigo,
+            tipo.Nome,
+            tipo.CongelaConfiguracao,
+            tipo.UnicoPorObjeto,
+            tipo.EfeitoIrreversivel,
+            tipo.VigenciaInicio,
+            tipo.VigenciaFim,
+            tipo.BaseLegal,
+            tipo.CreatedAt);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/PublicacoesApplicationAssemblyMarker.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/PublicacoesApplicationAssemblyMarker.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application;
+
+/// <summary>
+/// Marker para carregadores de assembly (ArchUnitNET) e para o
+/// <c>Discovery.IncludeAssembly</c> do Wolverine no composition root.
+/// </summary>
+public sealed class PublicacoesApplicationAssemblyMarker
+{
+    private PublicacoesApplicationAssemblyMarker()
+    {
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoQuery.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista as versões vivas de tipos de ato, paginadas por cursor bidirecional
+/// (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e valida
+/// limit/direction antes de despachar (ADR-0031).
+/// </summary>
+public sealed record ListarTiposAtoPublicadoQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarTiposAtoPublicadoResult>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoQueryHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Mappings;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+public static class ListarTiposAtoPublicadoQueryHandler
+{
+    public static async Task<ListarTiposAtoPublicadoResult> Handle(
+        ListarTiposAtoPublicadoQuery query,
+        ITipoAtoPublicadoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<TipoAtoPublicado> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        TipoAtoPublicadoDto[] items = [.. itens.Select(t => t.ToDto())];
+        return new ListarTiposAtoPublicadoResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoResult.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarTiposAtoPublicadoQuery"/>: lote projetado + âncoras
+/// opcionais para o controller construir os cursores prev/next. Não vaza entidades
+/// de domínio.
+/// </summary>
+public sealed record ListarTiposAtoPublicadoResult(
+    IReadOnlyList<TipoAtoPublicadoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ObterTipoAtoPublicadoPorIdQuery.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ObterTipoAtoPublicadoPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+public sealed record ObterTipoAtoPublicadoPorIdQuery(Guid Id) : IQuery<TipoAtoPublicadoDto?>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ObterTipoAtoPublicadoPorIdQueryHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ObterTipoAtoPublicadoPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Mappings;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+public static class ObterTipoAtoPublicadoPorIdQueryHandler
+{
+    public static async Task<TipoAtoPublicadoDto?> Handle(
+        ObterTipoAtoPublicadoPorIdQuery query,
+        ITipoAtoPublicadoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        TipoAtoPublicado? tipo = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return tipo?.ToDto();
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ObterTipoAtoPublicadoVigenteQuery.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ObterTipoAtoPublicadoVigenteQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>
+/// Resolve o significado de um código de tipo de ato numa data: a única versão viva
+/// cuja janela semiaberta <c>[inicio, fim)</c> contém <paramref name="Data"/>.
+/// </summary>
+/// <param name="Codigo">Código do tipo de ato, em UPPER_SNAKE.</param>
+/// <param name="Data">Data de referência. Nula significa hoje.</param>
+public sealed record ObterTipoAtoPublicadoVigenteQuery(
+    string Codigo,
+    DateOnly? Data) : IQuery<TipoAtoPublicadoDto?>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ObterTipoAtoPublicadoVigenteQueryHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ObterTipoAtoPublicadoVigenteQueryHandler.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Mappings;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+public static class ObterTipoAtoPublicadoVigenteQueryHandler
+{
+    public static async Task<TipoAtoPublicadoDto?> Handle(
+        ObterTipoAtoPublicadoVigenteQuery query,
+        ITipoAtoPublicadoRepository repository,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        DateOnly data = query.Data
+            ?? DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime.Date);
+
+        TipoAtoPublicado? tipo = await repository
+            .ObterVigenteAsync(query.Codigo, data, cancellationToken)
+            .ConfigureAwait(false);
+
+        return tipo?.ToDto();
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Unifesspa.UniPlus.Publicacoes.Application.csproj
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Unifesspa.UniPlus.Publicacoes.Application.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="WolverineFx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\shared\Unifesspa.UniPlus.Kernel\Unifesspa.UniPlus.Kernel.csproj" />
+    <ProjectReference Include="..\..\shared\Unifesspa.UniPlus.Application.Abstractions\Unifesspa.UniPlus.Application.Abstractions.csproj" />
+    <ProjectReference Include="..\Unifesspa.UniPlus.Publicacoes.Domain\Unifesspa.UniPlus.Publicacoes.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/packages.lock.json
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/packages.lock.json
@@ -1,0 +1,637 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "FluentValidation": {
+        "type": "Direct",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "Direct",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "WolverineFx": {
+        "type": "Direct",
+        "requested": "[5.39.5, )",
+        "resolved": "5.39.5",
+        "contentHash": "rnyz+ZConabOTi/U8N7UQAOaMc9P03hHyFrXZ6///6X0qtsHQ+VKDZtHe87AZJmY7By2w9As9puY6/jGCg5ZCA==",
+        "dependencies": {
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
+          "JasperFx.RuntimeCompiler": "4.5.0",
+          "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "FastExpressionCompiler": {
+        "type": "Transitive",
+        "resolved": "5.3.0",
+        "contentHash": "XRmGW48Gdm7B70WUtTJJUnmuc8jRDmOhhjG/a3rix/nXChnrkETaSvA0j2VrcsH4MNeYLe60LA5o5JABmbneag=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "ImTools": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "dms0JfLKC9AQbQX/EdpRjn59EjEvaCxIgv1z9YxbEQb5SiOVoo7vlIKdEySeEwUkWhN05rZnNpUpG+aw5VqPVQ=="
+      },
+      "JasperFx": {
+        "type": "Transitive",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
+        "dependencies": {
+          "FastExpressionCompiler": "5.3.0",
+          "ImTools": "4.0.0",
+          "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
+          "Polly.Core": "8.6.5",
+          "Spectre.Console": "0.55.0"
+        }
+      },
+      "JasperFx.Events": {
+        "type": "Transitive",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
+        "dependencies": {
+          "JasperFx": "1.31.0"
+        }
+      },
+      "JasperFx.RuntimeCompiler": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "SGJlU1kD8lX8A5p0hBWTPDV7dvPzoUB37IZjprWgA+L5yZZNyBElpn6UPNo7ZuXLKKwlSSt8BWTr99vxpxT3JA==",
+        "dependencies": {
+          "JasperFx": "1.28.0",
+          "Microsoft.CodeAnalysis": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "JasperFx.SourceGeneration": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "yIOaiA/OrlXQLGPjxFDubHnOU8MCzPTz465xBGRITMm4fDf7DbWKogb2SZC2jYLWEj27q3smTz1Z7lU4h1KkOQ=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bUubrBD6tRJE3V1kvRloYc6NymH3R5oFKjAS9e0ELNx6u0ZR+zjps9dDQyjgqN/rArzl7f+21KGszj3YRN7F2Q=="
+      },
+      "Microsoft.CodeAnalysis": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "X7vItpZDkGm4NS2wp4P1S07Z1e61LaBWDW5tPXE1c6z5/x9KbF2RymhAPoYg7Qoiyk7odEZ6EjBEJ47p3dBpYQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1sGloRYbG3743ut/+vuXy9/WaRQTm7mDtp71rBaVSmKpFntvo5Hcro1ubg6/3SeeLtiFYJl7V3Dk0Fo3CGlnHA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Scripting.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/KgZdm6kRTrR/O2jqXxU5GWREYhtVmqcNWczyPt8hsQkFGFK/C6CrLWfG44FCUn0aPHGDRBHYjXlGosQ/H8oXw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Scripting": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "XTulByMNxqXGCgMeODUoG2h4oK4/nLv1BcawRVcjv+UZHMpoaymtdaq3cJqlNrEvYEcbU48g5swJ3RhY1m3fBg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "sUBWvHs2HgHGA+b716dgjS7JiXGen5ntyohAurPLR1ZiZzFp3FlnVA7GrMTqVGdVJTVqiC3c4K8k1bk0gj6IPg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Nom4UuZVEZGaV6Qa+joJR/BawXZMtflvQJFKc0SaUc3LrZr/8LmRY5cn8mbvLOWIVfwWkQz+cVE6eQKu9qa65g==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "Zcoy6H9mSoGyvr7UvlGokEZrlZkcPCICPZr8mCsSt9U/N8eeCwCXwKF5bShdA66R0obxBCwP4AxomQHvVkC/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "krK19MKp0BNiR9rpBDW7PKSrTMLVlifS9am3CVc4O1Jq6GWz0o4F+sw5OSL4L3mVd56W8l6JRgghUa2KB51vOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "d2kDKnCsJvY7mBVhcjPSp9BkJk48DsaHPg5u+Oy4f8XaOqnEedRy/USyvnpHL92wpJ6DrTPy7htppUUzskbCXQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Logging.Console": "10.0.0",
+          "Microsoft.Extensions.Logging.Debug": "10.0.0",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "KrN6TGFwCwqOkLLk/idW/XtDQh+8In+CL9T4M1Dx+5ScsjTq4TlVbal8q532m82UYrMr6RiQJF2HvYCN0QwVsA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "System.Diagnostics.EventLog": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+      },
+      "NewId": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "jegBasNndmG21G3BmT51suFDCIz/sLN81j+IxmkZ4iWoaDi8LygeHiyNnYbXz5OQh9nCRJFIx1+PJrlYi1Gc9Q=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.5",
+        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+      },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
+      },
+      "unifesspa.uniplus.application.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      },
+      "unifesspa.uniplus.publicacoes.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      }
+    }
+  }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/DependencyInjection.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/DependencyInjection.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Publicacoes.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
 using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
 using Persistence;
 using Persistence.Repositories;
@@ -12,10 +13,9 @@ public static class PublicacoesInfrastructureRegistration
     private const string ConnectionStringName = "PublicacoesDb";
 
     /// <summary>
-    /// Registra a infraestrutura do módulo Publicações (DbContext, interceptors e
-    /// repositórios). Wire-up centralizado em <see cref="UniPlusDbContextOptionsExtensions"/>.
-    ///
-    /// Sem unit of work: nenhum handler existe ainda para consumi-la.
+    /// Registra a infraestrutura do módulo Publicações (DbContext, interceptors,
+    /// unit of work e repositórios). Wire-up centralizado em
+    /// <see cref="UniPlusDbContextOptionsExtensions"/>.
     /// </summary>
     public static IServiceCollection AddPublicacoesInfrastructure(this IServiceCollection services)
     {
@@ -25,6 +25,12 @@ public static class PublicacoesInfrastructureRegistration
 
         services.AddDbContext<PublicacoesDbContext>((serviceProvider, options) =>
             options.UseUniPlusNpgsqlConventions<PublicacoesDbContext>(serviceProvider, ConnectionStringName, schema: PublicacoesDbContext.Schema));
+
+        // Forwarding para a MESMA instância do DbContext do escopo. Registrar
+        // AddScoped<IPublicacoesUnitOfWork, PublicacoesDbContext>() criaria uma segunda
+        // instância por escopo e quebraria a atomicidade write+evento do outbox (ADR-0004).
+        services.AddScoped<IPublicacoesUnitOfWork>(serviceProvider =>
+            serviceProvider.GetRequiredService<PublicacoesDbContext>());
 
         services.AddScoped<ITipoAtoPublicadoRepository, TipoAtoPublicadoRepository>();
 

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/PublicacoesDbContext.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/PublicacoesDbContext.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
 using Unifesspa.UniPlus.Infrastructure.Core.Persistence;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
 using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
 
 /// <summary>
@@ -16,7 +17,7 @@ using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
 /// de certame — nenhuma coluna, nenhuma chave estrangeira desses conceitos
 /// entra aqui.
 /// </summary>
-public sealed class PublicacoesDbContext : DbContext
+public sealed class PublicacoesDbContext : DbContext, IPublicacoesUnitOfWork
 {
     /// <summary>
     /// Schema do módulo no banco único do monólito modular (ADR-0097). Tabelas,
@@ -48,5 +49,10 @@ public sealed class PublicacoesDbContext : DbContext
         // tipo ISoftDeletable, após os ApplyConfigurations registrarem os tipos.
         modelBuilder.AplicarFiltroGlobalSoftDelete();
         base.OnModelCreating(modelBuilder);
+    }
+
+    public async Task<int> SalvarAlteracoesAsync(CancellationToken cancellationToken = default)
+    {
+        return await SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Unifesspa.UniPlus.Publicacoes.Infrastructure.csproj
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Unifesspa.UniPlus.Publicacoes.Infrastructure.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\shared\Unifesspa.UniPlus.Infrastructure.Core\Unifesspa.UniPlus.Infrastructure.Core.csproj" />
+    <ProjectReference Include="..\Unifesspa.UniPlus.Publicacoes.Application\Unifesspa.UniPlus.Publicacoes.Application.csproj" />
     <ProjectReference Include="..\Unifesspa.UniPlus.Publicacoes.Domain\Unifesspa.UniPlus.Publicacoes.Domain.csproj" />
   </ItemGroup>
 

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/packages.lock.json
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/packages.lock.json
@@ -1025,6 +1025,17 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
       "unifesspa.uniplus.publicacoes.domain": {
         "type": "Project",
         "dependencies": {
@@ -1088,6 +1099,16 @@
         "requested": "[12.1.1, )",
         "resolved": "12.1.1",
         "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/CrossModuleReadIsolationTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/CrossModuleReadIsolationTests.cs
@@ -321,6 +321,7 @@ public sealed class CrossModuleReadIsolationTests
 
             // Publicacoes
             typeof(global::Unifesspa.UniPlus.Publicacoes.Domain.PublicacoesDomainAssemblyMarker).Assembly,
+            typeof(global::Unifesspa.UniPlus.Publicacoes.Application.PublicacoesApplicationAssemblyMarker).Assembly,
             typeof(global::Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.PublicacoesDbContext).Assembly,
             typeof(global::Unifesspa.UniPlus.Publicacoes.API.PublicacoesApiAssemblyMarker).Assembly,
         ];

--- a/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
@@ -44,6 +44,7 @@
     <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Unifesspa.UniPlus.Configuracao.Infrastructure.csproj" />
     <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.API/Unifesspa.UniPlus.Configuracao.API.csproj" />
     <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Unifesspa.UniPlus.Publicacoes.Domain.csproj" />
+    <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Unifesspa.UniPlus.Publicacoes.Application.csproj" />
     <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Unifesspa.UniPlus.Publicacoes.Infrastructure.csproj" />
     <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj" />
     <ProjectReference Include="../../src/shared/Unifesspa.UniPlus.Governance.Contracts/Unifesspa.UniPlus.Governance.Contracts.csproj" />

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -1326,7 +1326,20 @@
         "dependencies": {
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Serilog.AspNetCore": "[10.0.0, )",
-          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )"
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.publicacoes.domain": {
@@ -1342,6 +1355,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
@@ -1421,7 +1421,20 @@
         "dependencies": {
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Serilog.AspNetCore": "[10.0.0, )",
-          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )"
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.publicacoes.domain": {
@@ -1437,6 +1450,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/PublicacoesHandlersNoBusTests.cs
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/PublicacoesHandlersNoBusTests.cs
@@ -1,0 +1,100 @@
+namespace Unifesspa.UniPlus.Host.IntegrationTests;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Host.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+
+/// <summary>
+/// Prova que os handlers do módulo Publicações são alcançáveis pelo bus no
+/// composition root real.
+/// </summary>
+/// <remarks>
+/// <para>O <c>Program.cs</c> inclui os assemblies do Wolverine um a um, e declara
+/// separadamente os opt-ins de codegen de cada unit of work (ADR-0098). Esquecer
+/// qualquer um dos dois **compila**, passa nos testes unitários com dublê e no
+/// CI — e estoura no primeiro <c>Send</c> em produção. Só um teste que atravessa
+/// o bus do host real expõe a falta.</para>
+/// <para>Por isso o command percorre o caminho inteiro: validação FluentValidation
+/// pelo middleware, handler, repositório, unit of work encaminhada para a mesma
+/// instância de <c>DbContext</c>, e a leitura de volta pela query.</para>
+/// </remarks>
+[Collection(MonolitoHostCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class PublicacoesHandlersNoBusTests
+{
+    private static readonly DateOnly Inicio = new(2026, 1, 1);
+
+    private readonly MonolitoPostgresFixture _fixture;
+
+    public PublicacoesHandlersNoBusTests(MonolitoPostgresFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "O command de criação atravessa o bus e a query devolve o tipo gravado")]
+    public async Task CommandEQuery_AtravessamOBusDoHostReal()
+    {
+        using IServiceScope scope = _fixture.Factory.Services.CreateScope();
+        ICommandBus commandBus = scope.ServiceProvider.GetRequiredService<ICommandBus>();
+        IQueryBus queryBus = scope.ServiceProvider.GetRequiredService<IQueryBus>();
+
+        var comando = new CriarTipoAtoPublicadoCommand(
+            Codigo: "BUS_TESTE",
+            Nome: "Tipo de ato exercitado pelo bus",
+            CongelaConfiguracao: true,
+            UnicoPorObjeto: false,
+            EfeitoIrreversivel: false,
+            VigenciaInicio: Inicio);
+
+        Result<Guid> criado = await commandBus.Send(comando, CancellationToken.None);
+
+        criado.IsSuccess.Should().BeTrue(
+            "o assembly Publicacoes.Application precisa estar no Discovery do Wolverine "
+            + "e a IPublicacoesUnitOfWork declarada no opt-in de codegen");
+
+        TipoAtoPublicadoDto? lido = await queryBus.Send(
+            new ObterTipoAtoPublicadoPorIdQuery(criado.Value), CancellationToken.None);
+
+        lido.Should().NotBeNull();
+        lido!.Codigo.Should().Be("BUS_TESTE");
+        lido.CongelaConfiguracao.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "A query de tipo vigente atravessa o bus e resolve a data de referência")]
+    public async Task QueryVigente_AtravessaOBus()
+    {
+        using IServiceScope scope = _fixture.Factory.Services.CreateScope();
+        ICommandBus commandBus = scope.ServiceProvider.GetRequiredService<ICommandBus>();
+        IQueryBus queryBus = scope.ServiceProvider.GetRequiredService<IQueryBus>();
+
+        Result<Guid> criado = await commandBus.Send(
+            new CriarTipoAtoPublicadoCommand(
+                "BUS_VIGENTE", "Tipo vigente", false, false, false, Inicio, Inicio.AddYears(1)),
+            CancellationToken.None);
+        criado.IsSuccess.Should().BeTrue();
+
+        TipoAtoPublicadoDto? dentro = await queryBus.Send(
+            new ObterTipoAtoPublicadoVigenteQuery("BUS_VIGENTE", Inicio.AddMonths(6)),
+            CancellationToken.None);
+        dentro.Should().NotBeNull();
+
+        // O fim é exclusivo: no dia em que a janela fecha, nenhuma versão vale.
+        TipoAtoPublicadoDto? noFim = await queryBus.Send(
+            new ObterTipoAtoPublicadoVigenteQuery("BUS_VIGENTE", Inicio.AddYears(1)),
+            CancellationToken.None);
+        noFim.Should().BeNull();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/Unifesspa.UniPlus.Host.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/Unifesspa.UniPlus.Host.IntegrationTests.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="../../src/host/Unifesspa.UniPlus.Host/Unifesspa.UniPlus.Host.csproj" />
     <ProjectReference Include="../../src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.csproj" />
+    <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Unifesspa.UniPlus.Publicacoes.Application.csproj" />
     <ProjectReference Include="../../src/shared/Unifesspa.UniPlus.Governance.Contracts/Unifesspa.UniPlus.Governance.Contracts.csproj" />
     <ProjectReference Include="../../src/shared/Unifesspa.UniPlus.Infrastructure.Core/Unifesspa.UniPlus.Infrastructure.Core.csproj" />
     <ProjectReference Include="../Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj" />

--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
@@ -1393,7 +1393,20 @@
         "dependencies": {
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Serilog.AspNetCore": "[10.0.0, )",
-          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )"
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.publicacoes.domain": {
@@ -1409,6 +1422,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -1381,7 +1381,20 @@
         "dependencies": {
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Serilog.AspNetCore": "[10.0.0, )",
-          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )"
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.publicacoes.domain": {
@@ -1397,6 +1410,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
@@ -1349,7 +1349,20 @@
         "dependencies": {
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Serilog.AspNetCore": "[10.0.0, )",
-          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )"
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.publicacoes.domain": {
@@ -1365,6 +1378,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
@@ -1300,7 +1300,20 @@
         "dependencies": {
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Serilog.AspNetCore": "[10.0.0, )",
-          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )"
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.publicacoes.domain": {
@@ -1316,6 +1329,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
@@ -1421,7 +1421,20 @@
         "dependencies": {
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Serilog.AspNetCore": "[10.0.0, )",
-          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )"
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.publicacoes.domain": {
@@ -1437,6 +1450,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/AtualizarTipoAtoPublicadoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/AtualizarTipoAtoPublicadoCommandHandlerTests.cs
@@ -1,0 +1,135 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.Commands;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class AtualizarTipoAtoPublicadoCommandHandlerTests
+{
+    private static readonly DateOnly Inicio = new(2026, 1, 1);
+
+    private readonly ITipoAtoPublicadoRepository _repository = Substitute.For<ITipoAtoPublicadoRepository>();
+    private readonly IPublicacoesUnitOfWork _unitOfWork = Substitute.For<IPublicacoesUnitOfWork>();
+
+    [Fact(DisplayName = "Recusa quando o tipo de ato não existe")]
+    public async Task Handle_NaoEncontrado_Falha()
+    {
+        _repository.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((TipoAtoPublicado?)null);
+
+        Result resultado = await AtualizarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(Guid.NewGuid()), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.NaoEncontrado);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Não consulta sobreposição quando código e janela não mudam")]
+    public async Task Handle_SoMudaNome_NaoConsultaSobreposicao()
+    {
+        TipoAtoPublicado existente = Existente();
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(existente.Id) with { Nome = "Outro nome" }, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+
+        // A janela não mudou, logo nenhuma sobreposição pode ter surgido: a consulta
+        // seria um round-trip inútil por update.
+        await _repository.DidNotReceive().ExisteSobreposicaoDeVigenciaAsync(
+            Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Theory(DisplayName = "Consulta sobreposição quando o código ou a janela mudam")]
+    [InlineData("EDITAL_RETIFICACAO", 2026, 1, 1, null)]
+    [InlineData("EDITAL_ABERTURA", 2026, 3, 1, null)]
+    [InlineData("EDITAL_ABERTURA", 2026, 1, 1, 2027)]
+    public async Task Handle_MudaJanelaOuCodigo_ConsultaSobreposicao(
+        string codigo, int ano, int mes, int dia, int? anoFim)
+    {
+        TipoAtoPublicado existente = Existente();
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.ExisteSobreposicaoDeVigenciaAsync(
+            Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        DateOnly? fim = anoFim is { } a ? new DateOnly(a, 1, 1) : null;
+        AtualizarTipoAtoPublicadoCommand comando = Comando(existente.Id) with
+        {
+            Codigo = codigo,
+            VigenciaInicio = new DateOnly(ano, mes, dia),
+            VigenciaFim = fim,
+        };
+
+        await AtualizarTipoAtoPublicadoCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        // A própria versão é excluída da checagem — senão ela colidiria consigo mesma.
+        await _repository.Received(1).ExisteSobreposicaoDeVigenciaAsync(
+            codigo, comando.VigenciaInicio, fim, existente.Id, Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Recusa quando a nova janela intercepta outra versão viva")]
+    public async Task Handle_ComSobreposicao_Falha()
+    {
+        TipoAtoPublicado existente = Existente();
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.ExisteSobreposicaoDeVigenciaAsync(
+            Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result resultado = await AtualizarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(existente.Id) with { VigenciaInicio = Inicio.AddMonths(2) },
+            _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.VigenciaSobreposta);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Propaga o erro do agregado e não commita")]
+    public async Task Handle_ComPayloadInvalido_NaoCommita()
+    {
+        TipoAtoPublicado existente = Existente();
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        Result resultado = await AtualizarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(existente.Id) with { Nome = "E" }, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.NomeTamanho);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static TipoAtoPublicado Existente() =>
+        TipoAtoPublicado.Criar(
+            "EDITAL_ABERTURA", "Edital de abertura",
+            congelaConfiguracao: true, unicoPorObjeto: true, efeitoIrreversivel: false,
+            vigenciaInicio: Inicio, vigenciaFim: null, baseLegal: null).Value!;
+
+    private static AtualizarTipoAtoPublicadoCommand Comando(Guid id) =>
+        new(
+            Id: id,
+            Codigo: "EDITAL_ABERTURA",
+            Nome: "Edital de abertura",
+            CongelaConfiguracao: true,
+            UnicoPorObjeto: true,
+            EfeitoIrreversivel: false,
+            VigenciaInicio: Inicio);
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/CriarTipoAtoPublicadoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/CriarTipoAtoPublicadoCommandHandlerTests.cs
@@ -1,0 +1,99 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.Commands;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class CriarTipoAtoPublicadoCommandHandlerTests
+{
+    private static readonly DateOnly Inicio = new(2026, 1, 1);
+
+    private readonly ITipoAtoPublicadoRepository _repository = Substitute.For<ITipoAtoPublicadoRepository>();
+    private readonly IPublicacoesUnitOfWork _unitOfWork = Substitute.For<IPublicacoesUnitOfWork>();
+
+    [Fact(DisplayName = "Cria, persiste e commita quando não há sobreposição")]
+    public async Task Handle_SemSobreposicao_Cria()
+    {
+        _repository.ExisteSobreposicaoDeVigenciaAsync(
+            "EDITAL_ABERTURA", Inicio, null, null, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<TipoAtoPublicado>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Recusa quando a janela intercepta uma versão viva do mesmo código")]
+    public async Task Handle_ComSobreposicao_Falha()
+    {
+        _repository.ExisteSobreposicaoDeVigenciaAsync(
+            Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        Result<Guid> resultado = await CriarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.VigenciaSobreposta);
+
+        // Nada é escrito nem commitado: a recusa acontece antes de tocar o agregado.
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<TipoAtoPublicado>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Propaga o erro do agregado quando o código é inválido")]
+    public async Task Handle_ComCodigoInvalido_PropagaErroDeDominio()
+    {
+        _repository.ExisteSobreposicaoDeVigenciaAsync(
+            Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        Result<Guid> resultado = await CriarTipoAtoPublicadoCommandHandler.Handle(
+            Comando() with { Codigo = "edital abertura" }, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.CodigoFormato);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "A checagem de sobreposição recebe exatamente a janela do comando")]
+    public async Task Handle_ConsultaComAJanelaInformada()
+    {
+        DateOnly fim = Inicio.AddYears(1);
+        _repository.ExisteSobreposicaoDeVigenciaAsync(
+            Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        await CriarTipoAtoPublicadoCommandHandler.Handle(
+            Comando() with { VigenciaFim = fim }, _repository, _unitOfWork, CancellationToken.None);
+
+        await _repository.Received(1).ExisteSobreposicaoDeVigenciaAsync(
+            "EDITAL_ABERTURA", Inicio, fim, null, Arg.Any<CancellationToken>());
+    }
+
+    private static CriarTipoAtoPublicadoCommand Comando() =>
+        new(
+            Codigo: "EDITAL_ABERTURA",
+            Nome: "Edital de abertura",
+            CongelaConfiguracao: true,
+            UnicoPorObjeto: true,
+            EfeitoIrreversivel: false,
+            VigenciaInicio: Inicio);
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/RemoverTipoAtoPublicadoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/RemoverTipoAtoPublicadoCommandHandlerTests.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.Commands;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class RemoverTipoAtoPublicadoCommandHandlerTests
+{
+    private readonly ITipoAtoPublicadoRepository _repository = Substitute.For<ITipoAtoPublicadoRepository>();
+    private readonly IPublicacoesUnitOfWork _unitOfWork = Substitute.For<IPublicacoesUnitOfWork>();
+
+    [Fact(DisplayName = "Recusa quando o tipo de ato não existe")]
+    public async Task Handle_NaoEncontrado_Falha()
+    {
+        _repository.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((TipoAtoPublicado?)null);
+
+        Result resultado = await RemoverTipoAtoPublicadoCommandHandler.Handle(
+            new RemoverTipoAtoPublicadoCommand(Guid.NewGuid()), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.NaoEncontrado);
+        _repository.DidNotReceive().Remover(Arg.Any<TipoAtoPublicado>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Remove e commita — a remoção nunca é bloqueada")]
+    public async Task Handle_Encontrado_Remove()
+    {
+        TipoAtoPublicado tipo = TipoAtoPublicado.Criar(
+            "AVISO", "Aviso", false, false, false, new DateOnly(2026, 1, 1), null, null).Value!;
+        _repository.ObterPorIdAsync(tipo.Id, Arg.Any<CancellationToken>()).Returns(tipo);
+
+        Result resultado = await RemoverTipoAtoPublicadoCommandHandler.Handle(
+            new RemoverTipoAtoPublicadoCommand(tipo.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(tipo);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Queries/TipoAtoPublicadoQueryHandlersTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Queries/TipoAtoPublicadoQueryHandlersTests.cs
@@ -1,0 +1,117 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.Queries;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class TipoAtoPublicadoQueryHandlersTests
+{
+    private static readonly DateOnly Inicio = new(2026, 1, 1);
+
+    private readonly ITipoAtoPublicadoRepository _repository = Substitute.For<ITipoAtoPublicadoRepository>();
+
+    [Fact(DisplayName = "ObterPorId projeta em DTO, com os três atributos de consequência")]
+    public async Task ObterPorId_Projeta()
+    {
+        TipoAtoPublicado tipo = Novo("RESULTADO_FINAL", congela: false, irreversivel: true);
+        _repository.ObterPorIdParaLeituraAsync(tipo.Id, Arg.Any<CancellationToken>()).Returns(tipo);
+
+        TipoAtoPublicadoDto? dto = await ObterTipoAtoPublicadoPorIdQueryHandler.Handle(
+            new ObterTipoAtoPublicadoPorIdQuery(tipo.Id), _repository, CancellationToken.None);
+
+        dto.Should().NotBeNull();
+        dto!.Codigo.Should().Be("RESULTADO_FINAL");
+        dto.CongelaConfiguracao.Should().BeFalse();
+        dto.EfeitoIrreversivel.Should().BeTrue();
+        dto.VigenciaFim.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "ObterPorId devolve nulo quando não existe")]
+    public async Task ObterPorId_Inexistente_Nulo()
+    {
+        _repository.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((TipoAtoPublicado?)null);
+
+        TipoAtoPublicadoDto? dto = await ObterTipoAtoPublicadoPorIdQueryHandler.Handle(
+            new ObterTipoAtoPublicadoPorIdQuery(Guid.NewGuid()), _repository, CancellationToken.None);
+
+        dto.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Listar repassa cursor, limite e direção, e devolve as âncoras")]
+    public async Task Listar_RepassaCursorEAncoras()
+    {
+        Guid after = Guid.NewGuid();
+        Guid prev = Guid.NewGuid();
+        Guid next = Guid.NewGuid();
+        _repository.ListarPaginadoAsync(after, 25, PaginationDirection.Next, Arg.Any<CancellationToken>())
+            .Returns((new[] { Novo("AVISO") }, prev, next));
+
+        ListarTiposAtoPublicadoResult resultado = await ListarTiposAtoPublicadoQueryHandler.Handle(
+            new ListarTiposAtoPublicadoQuery(after, 25, PaginationDirection.Next),
+            _repository, CancellationToken.None);
+
+        resultado.Items.Should().ContainSingle().Which.Codigo.Should().Be("AVISO");
+        resultado.AnteriorAfterId.Should().Be(prev);
+        resultado.ProximoAfterId.Should().Be(next);
+    }
+
+    [Fact(DisplayName = "ObterVigente sem data usa o relógio injetado, não DateTime.Now")]
+    public async Task ObterVigente_SemData_UsaRelogioInjetado()
+    {
+        var agora = new DateTimeOffset(2026, 6, 15, 23, 30, 0, TimeSpan.Zero);
+        _repository.ObterVigenteAsync("AVISO", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(Novo("AVISO"));
+
+        await ObterTipoAtoPublicadoVigenteQueryHandler.Handle(
+            new ObterTipoAtoPublicadoVigenteQuery("AVISO", null),
+            _repository, new RelogioFixo(agora), CancellationToken.None);
+
+        await _repository.Received(1).ObterVigenteAsync(
+            "AVISO", new DateOnly(2026, 6, 15), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "ObterVigente com data histórica consulta exatamente aquela data")]
+    public async Task ObterVigente_ComData_ConsultaADataInformada()
+    {
+        var data = new DateOnly(2026, 3, 15);
+        _repository.ObterVigenteAsync("AVISO", data, Arg.Any<CancellationToken>()).Returns(Novo("AVISO"));
+
+        TipoAtoPublicadoDto? dto = await ObterTipoAtoPublicadoVigenteQueryHandler.Handle(
+            new ObterTipoAtoPublicadoVigenteQuery("AVISO", data),
+            _repository, new RelogioFixo(DateTimeOffset.UnixEpoch), CancellationToken.None);
+
+        dto.Should().NotBeNull();
+        await _repository.Received(1).ObterVigenteAsync("AVISO", data, Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "ObterVigente devolve nulo quando nenhuma versão vale na data")]
+    public async Task ObterVigente_SemVersao_Nulo()
+    {
+        _repository.ObterVigenteAsync(Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns((TipoAtoPublicado?)null);
+
+        TipoAtoPublicadoDto? dto = await ObterTipoAtoPublicadoVigenteQueryHandler.Handle(
+            new ObterTipoAtoPublicadoVigenteQuery("AVISO", new DateOnly(2020, 1, 1)),
+            _repository, new RelogioFixo(DateTimeOffset.UnixEpoch), CancellationToken.None);
+
+        dto.Should().BeNull();
+    }
+
+    private static TipoAtoPublicado Novo(string codigo, bool congela = true, bool irreversivel = false) =>
+        TipoAtoPublicado.Criar(
+            codigo, "Nome do tipo", congela, unicoPorObjeto: false, efeitoIrreversivel: irreversivel,
+            vigenciaInicio: Inicio, vigenciaFim: null, baseLegal: null).Value!;
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/RelogioFixo.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/RelogioFixo.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests;
+
+/// <summary>
+/// <see cref="TimeProvider"/> parado num instante, para os testes que exercitam o
+/// fallback "hoje" das queries. Evita depender de um pacote de fakes só por isto.
+/// </summary>
+internal sealed class RelogioFixo : TimeProvider
+{
+    private readonly DateTimeOffset _agora;
+
+    public RelogioFixo(DateTimeOffset agora) => _agora = agora;
+
+    public override DateTimeOffset GetUtcNow() => _agora;
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="AwesomeAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Unifesspa.UniPlus.Publicacoes.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Validators/TipoAtoPublicadoValidatorsTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Validators/TipoAtoPublicadoValidatorsTests.cs
@@ -1,0 +1,169 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.Validators;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+
+/// <summary>
+/// O agregado é a autoridade sobre as invariantes; o validator apenas antecipa a
+/// recusa, devolvendo 400 antes de o handler tocar o repositório. Estes testes
+/// garantem que os dois não divergem.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class TipoAtoPublicadoValidatorsTests
+{
+    private static readonly DateOnly Inicio = new(2026, 1, 1);
+
+    private readonly CriarTipoAtoPublicadoCommandValidator _criar = new();
+    private readonly AtualizarTipoAtoPublicadoCommandValidator _atualizar = new();
+    private readonly RemoverTipoAtoPublicadoCommandValidator _remover = new();
+
+    [Fact(DisplayName = "Criar: comando válido passa")]
+    public void Criar_Valido()
+    {
+        _criar.Validate(Criar()).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Criar: código fora do formato UPPER_SNAKE é recusado")]
+    [InlineData("convocacao")]
+    [InlineData("Convocacao")]
+    [InlineData("_EDITAL")]
+    [InlineData("EDITAL_")]
+    [InlineData("EDITAL__ABERTURA")]
+    [InlineData("EDITAL-ABERTURA")]
+    [InlineData("EDITAL 2026")]
+    [InlineData("RETIFICAÇÃO")]
+    public void Criar_CodigoInvalido(string codigo)
+    {
+        ValidationResult resultado = _criar.Validate(Criar() with { Codigo = codigo });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoAtoPublicadoCommand.Codigo));
+    }
+
+    [Fact(DisplayName = "Criar: janela vazia é recusada — o fim é exclusivo")]
+    public void Criar_JanelaVazia()
+    {
+        _criar.Validate(Criar() with { VigenciaFim = Inicio }).IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar: janela invertida é recusada")]
+    public void Criar_JanelaInvertida()
+    {
+        _criar.Validate(Criar() with { VigenciaFim = Inicio.AddDays(-1) }).IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar: janela de um único dia é aceita")]
+    public void Criar_JanelaDeUmDia()
+    {
+        _criar.Validate(Criar() with { VigenciaFim = Inicio.AddDays(1) }).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Criar: vigência aberta é aceita")]
+    public void Criar_VigenciaAberta()
+    {
+        _criar.Validate(Criar() with { VigenciaFim = null }).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Criar: nome fora do intervalo de tamanho é recusado")]
+    [InlineData("")]
+    [InlineData("E")]
+    public void Criar_NomeInvalido(string nome)
+    {
+        _criar.Validate(Criar() with { Nome = nome }).IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar: base legal acima do limite é recusada")]
+    public void Criar_BaseLegalLonga()
+    {
+        _criar.Validate(Criar() with { BaseLegal = new string('x', 501) }).IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar: código com espaços ao redor é aceito — o domínio normaliza")]
+    public void Criar_CodigoComEspacos_Aceito()
+    {
+        // O agregado faz Trim antes de validar o formato. Se o validator olhasse o
+        // texto cru, recusaria com 400 um payload que o domínio aceita.
+        _criar.Validate(Criar() with { Codigo = "  EDITAL_ABERTURA  " }).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Criar: nome de um caractere entre espaços é recusado aqui, não adiante")]
+    public void Criar_NomeCurtoEntreEspacos_Recusado()
+    {
+        // " E" tem dois caracteres crus, mas um só depois do Trim. Sem normalizar, o
+        // validator deixaria passar e o agregado recusaria com outro status.
+        ValidationResult resultado = _criar.Validate(Criar() with { Nome = " E" });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoAtoPublicadoCommand.Nome));
+    }
+
+    [Fact(DisplayName = "Criar: base legal no limite com espaços ao redor é aceita")]
+    public void Criar_BaseLegalNoLimiteComEspacos_Aceita()
+    {
+        string baseLegal = "  " + new string('x', 500) + "  ";
+
+        _criar.Validate(Criar() with { BaseLegal = baseLegal }).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Criar: código só com espaços é recusado como obrigatório")]
+    public void Criar_CodigoSoEspacos_Recusado()
+    {
+        ValidationResult resultado = _criar.Validate(Criar() with { Codigo = "    " });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarTipoAtoPublicadoCommand.Codigo));
+    }
+
+    [Fact(DisplayName = "Atualizar: código com espaços ao redor é aceito")]
+    public void Atualizar_CodigoComEspacos_Aceito()
+    {
+        _atualizar.Validate(Atualizar() with { Codigo = " AVISO " }).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Atualizar: identificador vazio é recusado")]
+    public void Atualizar_IdVazio()
+    {
+        ValidationResult resultado = _atualizar.Validate(Atualizar() with { Id = Guid.Empty });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(AtualizarTipoAtoPublicadoCommand.Id));
+    }
+
+    [Fact(DisplayName = "Atualizar: comando válido passa")]
+    public void Atualizar_Valido()
+    {
+        _atualizar.Validate(Atualizar()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Atualizar: código minúsculo é recusado")]
+    public void Atualizar_CodigoMinusculo()
+    {
+        _atualizar.Validate(Atualizar() with { Codigo = "aviso" }).IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Remover: identificador vazio é recusado")]
+    public void Remover_IdVazio()
+    {
+        _remover.Validate(new RemoverTipoAtoPublicadoCommand(Guid.Empty)).IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Remover: identificador informado passa")]
+    public void Remover_Valido()
+    {
+        _remover.Validate(new RemoverTipoAtoPublicadoCommand(Guid.NewGuid())).IsValid.Should().BeTrue();
+    }
+
+    private static CriarTipoAtoPublicadoCommand Criar() =>
+        new("EDITAL_ABERTURA", "Edital de abertura", true, true, false, Inicio);
+
+    private static AtualizarTipoAtoPublicadoCommand Atualizar() =>
+        new(Guid.NewGuid(), "EDITAL_ABERTURA", "Edital de abertura", true, true, false, Inicio);
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/packages.lock.json
@@ -1,0 +1,763 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.4.0, )",
+        "resolved": "9.4.0",
+        "contentHash": "dJxkWiQ8D+xT6Gr2sSL83+Mar+Vpy2JTcUPxFcckpPJ8VYBfSgnk+zqpS6t7kcGnjz8NLyF14qfuoL4bKzzoew=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.7.0, )",
+        "resolved": "18.7.0",
+        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.7.0",
+          "Microsoft.TestPlatform.TestHost": "18.7.0"
+        }
+      },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[5.3.0, )",
+        "resolved": "5.3.0",
+        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "FastExpressionCompiler": {
+        "type": "Transitive",
+        "resolved": "5.3.0",
+        "contentHash": "XRmGW48Gdm7B70WUtTJJUnmuc8jRDmOhhjG/a3rix/nXChnrkETaSvA0j2VrcsH4MNeYLe60LA5o5JABmbneag=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "ImTools": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "dms0JfLKC9AQbQX/EdpRjn59EjEvaCxIgv1z9YxbEQb5SiOVoo7vlIKdEySeEwUkWhN05rZnNpUpG+aw5VqPVQ=="
+      },
+      "JasperFx": {
+        "type": "Transitive",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
+        "dependencies": {
+          "FastExpressionCompiler": "5.3.0",
+          "ImTools": "4.0.0",
+          "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
+          "Polly.Core": "8.6.5",
+          "Spectre.Console": "0.55.0"
+        }
+      },
+      "JasperFx.Events": {
+        "type": "Transitive",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
+        "dependencies": {
+          "JasperFx": "1.31.0"
+        }
+      },
+      "JasperFx.RuntimeCompiler": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "SGJlU1kD8lX8A5p0hBWTPDV7dvPzoUB37IZjprWgA+L5yZZNyBElpn6UPNo7ZuXLKKwlSSt8BWTr99vxpxT3JA==",
+        "dependencies": {
+          "JasperFx": "1.28.0",
+          "Microsoft.CodeAnalysis": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "JasperFx.SourceGeneration": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "yIOaiA/OrlXQLGPjxFDubHnOU8MCzPTz465xBGRITMm4fDf7DbWKogb2SZC2jYLWEj27q3smTz1Z7lU4h1KkOQ=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bUubrBD6tRJE3V1kvRloYc6NymH3R5oFKjAS9e0ELNx6u0ZR+zjps9dDQyjgqN/rArzl7f+21KGszj3YRN7F2Q=="
+      },
+      "Microsoft.CodeAnalysis": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "X7vItpZDkGm4NS2wp4P1S07Z1e61LaBWDW5tPXE1c6z5/x9KbF2RymhAPoYg7Qoiyk7odEZ6EjBEJ47p3dBpYQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1sGloRYbG3743ut/+vuXy9/WaRQTm7mDtp71rBaVSmKpFntvo5Hcro1ubg6/3SeeLtiFYJl7V3Dk0Fo3CGlnHA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Scripting.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/KgZdm6kRTrR/O2jqXxU5GWREYhtVmqcNWczyPt8hsQkFGFK/C6CrLWfG44FCUn0aPHGDRBHYjXlGosQ/H8oXw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Scripting": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "XTulByMNxqXGCgMeODUoG2h4oK4/nLv1BcawRVcjv+UZHMpoaymtdaq3cJqlNrEvYEcbU48g5swJ3RhY1m3fBg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "sUBWvHs2HgHGA+b716dgjS7JiXGen5ntyohAurPLR1ZiZzFp3FlnVA7GrMTqVGdVJTVqiC3c4K8k1bk0gj6IPg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Nom4UuZVEZGaV6Qa+joJR/BawXZMtflvQJFKc0SaUc3LrZr/8LmRY5cn8mbvLOWIVfwWkQz+cVE6eQKu9qa65g==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.7.0",
+        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "Zcoy6H9mSoGyvr7UvlGokEZrlZkcPCICPZr8mCsSt9U/N8eeCwCXwKF5bShdA66R0obxBCwP4AxomQHvVkC/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "krK19MKp0BNiR9rpBDW7PKSrTMLVlifS9am3CVc4O1Jq6GWz0o4F+sw5OSL4L3mVd56W8l6JRgghUa2KB51vOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "d2kDKnCsJvY7mBVhcjPSp9BkJk48DsaHPg5u+Oy4f8XaOqnEedRy/USyvnpHL92wpJ6DrTPy7htppUUzskbCXQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.7",
+        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Logging.Console": "10.0.0",
+          "Microsoft.Extensions.Logging.Debug": "10.0.0",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "KrN6TGFwCwqOkLLk/idW/XtDQh+8In+CL9T4M1Dx+5ScsjTq4TlVbal8q532m82UYrMr6RiQJF2HvYCN0QwVsA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "System.Diagnostics.EventLog": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "Microsoft.Extensions.Primitives": "10.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.7.0",
+        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.7.0",
+        "contentHash": "kYwfmebCs8992zaxEDkvG7S+YEouTeKfYVKUFEkwh1W2dIoOaevBt80XSKVXCUFEhusjOIm1sFfHBnoJgygrRA==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.7.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "NewId": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "jegBasNndmG21G3BmT51suFDCIz/sLN81j+IxmkZ4iWoaDi8LygeHiyNnYbXz5OQh9nCRJFIx1+PJrlYi1Gc9Q=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.5",
+        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+      },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "unifesspa.uniplus.application.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+        }
+      },
+      "WolverineFx": {
+        "type": "CentralTransitive",
+        "requested": "[5.39.5, )",
+        "resolved": "5.39.5",
+        "contentHash": "rnyz+ZConabOTi/U8N7UQAOaMc9P03hHyFrXZ6///6X0qtsHQ+VKDZtHe87AZJmY7By2w9As9puY6/jGCg5ZCA==",
+        "dependencies": {
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
+          "JasperFx.RuntimeCompiler": "4.5.0",
+          "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      }
+    }
+  }
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/CriarTipoAtoPublicadoCorridaTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/CriarTipoAtoPublicadoCorridaTests.cs
@@ -1,0 +1,129 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.TiposAtoPublicado;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Prova, contra Postgres real, que a corrida check-then-act vira erro de domínio e
+/// não uma exceção que escaparia como HTTP 500.
+/// </summary>
+/// <remarks>
+/// <para>A tradução depende de o Npgsql preencher <c>ConstraintName</c> num
+/// <c>23P01</c>. Um teste com repositório dublê jamais veria isso: ele passaria
+/// mesmo que o nome viesse nulo e o <c>catch</c> nunca casasse.</para>
+/// <para>A corrida real é simulada suprimindo a consulta prévia do handler — o que
+/// é exatamente o que uma transação concorrente faz: torna obsoleta a resposta que
+/// a consulta deu um instante antes.</para>
+/// </remarks>
+[Collection(PublicacoesDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class CriarTipoAtoPublicadoCorridaTests
+{
+    private static readonly DateOnly Inicio = new(2026, 1, 1);
+
+    private readonly PublicacoesDbFixture _fixture;
+
+    public CriarTipoAtoPublicadoCorridaTests(PublicacoesDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "A violação da exclusion constraint vira VigenciaSobreposta, não exceção")]
+    public async Task Handle_QuandoAConsultaPreviaFicaObsoleta_TraduzOErroDoBanco()
+    {
+        string codigo = CodigoUnico();
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext("admin");
+        var real = new TipoAtoPublicadoRepository(ctx);
+
+        // Primeira versão, gravada normalmente.
+        Result<Guid> primeira = await CriarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(codigo), real, ctx, CancellationToken.None);
+        primeira.IsSuccess.Should().BeTrue();
+
+        // Segunda versão, com a consulta prévia cega — o estado do banco mudou sob ela.
+        await using PublicacoesDbContext ctx2 = _fixture.CreateDbContext("admin");
+        var cego = new RepositorioComConsultaObsoleta(new TipoAtoPublicadoRepository(ctx2));
+
+        Result<Guid> segunda = await CriarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(codigo), cego, ctx2, CancellationToken.None);
+
+        segunda.IsFailure.Should().BeTrue();
+        segunda.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.VigenciaSobreposta);
+    }
+
+    [Fact(DisplayName = "Sem corrida, a consulta prévia recusa antes de tocar o banco")]
+    public async Task Handle_ComSobreposicaoConhecida_RecusaPelaConsultaPrevia()
+    {
+        string codigo = CodigoUnico();
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext("admin");
+        var repositorio = new TipoAtoPublicadoRepository(ctx);
+
+        (await CriarTipoAtoPublicadoCommandHandler.Handle(Comando(codigo), repositorio, ctx, CancellationToken.None))
+            .IsSuccess.Should().BeTrue();
+
+        await using PublicacoesDbContext ctx2 = _fixture.CreateDbContext("admin");
+        Result<Guid> segunda = await CriarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(codigo), new TipoAtoPublicadoRepository(ctx2), ctx2, CancellationToken.None);
+
+        segunda.IsFailure.Should().BeTrue();
+        segunda.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.VigenciaSobreposta);
+    }
+
+    private static CriarTipoAtoPublicadoCommand Comando(string codigo) =>
+        new(codigo, "Tipo de ato de teste", true, false, false, Inicio);
+
+    private static string CodigoUnico()
+    {
+        string hex = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)[..12];
+        return "CORRIDA_" + string.Concat(hex.Select(c => (char)('A' + Convert.ToInt32(c.ToString(), 16))));
+    }
+
+    /// <summary>
+    /// Delega tudo ao repositório real, exceto a consulta de sobreposição, que
+    /// responde "não há" — como responderia se outra transação tivesse gravado a
+    /// versão conflitante logo depois da consulta.
+    /// </summary>
+    private sealed class RepositorioComConsultaObsoleta : ITipoAtoPublicadoRepository
+    {
+        private readonly ITipoAtoPublicadoRepository _real;
+
+        public RepositorioComConsultaObsoleta(ITipoAtoPublicadoRepository real) => _real = real;
+
+        public Task<bool> ExisteSobreposicaoDeVigenciaAsync(
+            string codigo, DateOnly vigenciaInicio, DateOnly? vigenciaFim, Guid? excluirId, CancellationToken ct) =>
+            Task.FromResult(false);
+
+        public Task<TipoAtoPublicado?> ObterPorIdAsync(Guid id, CancellationToken ct) => _real.ObterPorIdAsync(id, ct);
+
+        public Task<TipoAtoPublicado?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken ct) =>
+            _real.ObterPorIdParaLeituraAsync(id, ct);
+
+        public Task<TipoAtoPublicado?> ObterVigenteAsync(string codigo, DateOnly data, CancellationToken ct) =>
+            _real.ObterVigenteAsync(codigo, data, ct);
+
+        public Task<(IReadOnlyList<TipoAtoPublicado> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+            Guid? afterId, int limit, PaginationDirection direction, CancellationToken ct) =>
+            _real.ListarPaginadoAsync(afterId, limit, direction, ct);
+
+        public Task AdicionarAsync(TipoAtoPublicado tipo, CancellationToken ct) => _real.AdicionarAsync(tipo, ct);
+
+        public void Remover(TipoAtoPublicado tipo) => _real.Remover(tipo);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/TipoAtoPublicadoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/TipoAtoPublicadoPersistenceTests.cs
@@ -30,6 +30,7 @@ public sealed class TipoAtoPublicadoPersistenceTests
     private const string Admin = "admin-publicacoes";
     private const string ExclusionViolation = "23P01";
     private const string CheckViolation = "23514";
+    private const string NomeDaExclusionConstraint = "ex_tipo_ato_publicado_codigo_vigencia";
 
     private static readonly DateOnly Inicio = new(2026, 1, 1);
     private static readonly DateOnly Meio = new(2026, 6, 1);
@@ -97,8 +98,14 @@ public sealed class TipoAtoPublicadoPersistenceTests
         Func<Task> segundaInsercao = () => Gravar(Novo(codigo, Meio, Fim.AddYears(1)));
 
         DbUpdateException erro = (await segundaInsercao.Should().ThrowAsync<DbUpdateException>()).Which;
-        erro.InnerException.Should().BeOfType<PostgresException>()
-            .Which.SqlState.Should().Be(ExclusionViolation);
+        PostgresException pg = erro.InnerException.Should().BeOfType<PostgresException>().Which;
+        pg.SqlState.Should().Be(ExclusionViolation);
+
+        // O nome da constraint é o que a camada Application usa para distinguir esta
+        // violação de qualquer outra exclusion constraint futura. Se o PostgreSQL
+        // deixasse de informá-lo, a tradução para erro de domínio falharia em silêncio
+        // e a corrida viraria 500.
+        pg.ConstraintName.Should().Be(NomeDaExclusionConstraint);
     }
 
     [Fact(DisplayName = "Vigência aberta cruza qualquer janela futura do mesmo código")]

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Unifesspa.UniPlus.Publicacoes.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Unifesspa.UniPlus.Publicacoes.IntegrationTests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Unifesspa.UniPlus.Publicacoes.Application.csproj" />
     <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Unifesspa.UniPlus.Publicacoes.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/packages.lock.json
@@ -1198,6 +1198,17 @@
       "unifesspa.uniplus.kernel": {
         "type": "Project"
       },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
       "unifesspa.uniplus.publicacoes.domain": {
         "type": "Project",
         "dependencies": {
@@ -1211,6 +1222,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },
@@ -1271,6 +1283,16 @@
         "requested": "[12.1.1, )",
         "resolved": "12.1.1",
         "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "FluentValidation.DependencyInjectionExtensions": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "D0VXh4dtjjX2aQizuaa0g6R8X3U1JaVqJPfGCvLwZX9t/O2h7tkpbitbadQMfwcgSPdDbI2vDxuwRMv/Uf9dHA==",
+        "dependencies": {
+          "FluentValidation": "12.1.1",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "2.1.0"
+        }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
         "type": "CentralTransitive",

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -1421,7 +1421,20 @@
         "dependencies": {
           "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
           "Serilog.AspNetCore": "[10.0.0, )",
-          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )"
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.publicacoes.domain": {
@@ -1437,6 +1450,7 @@
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
         }
       },


### PR DESCRIPTION
Closes #810 · Refs #798, #795

Segunda das quatro tasks da story. Entrega a camada `Application` do cadastro de tipos de ato: commands de criação, atualização e remoção; queries por identificador, por página e pela versão vigente numa data. Os endpoints são a #811.

## Duas linhas do composition root que nenhum teste unitário protegeria

O `Program.cs` inclui os assemblies do Wolverine **um a um**, e declara separadamente o opt-in de codegen de cada unit of work. Faltando qualquer uma das duas linhas, o projeto **compila**, os testes unitários com dublê **passam**, o CI fica **verde** — e o primeiro `ICommandBus.Send` estoura em runtime.

Por isso `PublicacoesHandlersNoBusTests` sobe o `Program.cs` real, com Wolverine e Postgres, e envia o command pelo bus. Removi cada linha, uma de cada vez, e confirmei que o teste cai nas duas:

| Canário | Resultado |
|---|---|
| sem `Discovery.IncludeAssembly(...Publicacoes.Application...)` | 2 testes falham |
| sem `PublicacoesCodegenRegistration.ConfigurarCodegenWolverine(opts)` | 2 testes falham |
| ambas presentes | 2 testes passam |

O opt-in de codegen não é burocracia: sob `ServiceLocationPolicy.NotAllowed` (ADR-0098), a `IPublicacoesUnitOfWork` é uma lambda scoped opaca ao gerador. E não pode virar `AddScoped<IPublicacoesUnitOfWork, PublicacoesDbContext>()` — isso criaria uma **segunda** instância de `DbContext` por escopo e quebraria a atomicidade write+evento do outbox (ADR-0004). O forwarding para a mesma instância é o único registro correto.

## A corrida, e o que a prova dela exige

A sobreposição de vigência é recusada por dois caminhos que produzem o mesmo erro de domínio:

1. **A consulta prévia**, que dá a mensagem legível no caso comum.
2. **A captura do SQLSTATE `23P01`**, que fecha a corrida check-then-act — entre a consulta e o `SaveChanges` cabe outra transação, e só o banco a vê.

O segundo caminho depende de o PostgreSQL informar o **nome** da constraint. Se viesse nulo, o `catch` nunca casaria, a corrida viraria HTTP 500 — e um teste com dublê passaria alegremente, porque o dublê não sabe o que o Postgres devolve. Sondei contra o banco real:

```
SqlState=23P01  ConstraintName=[ex_tipo_ato_publicado_codigo_vigencia]
```

Vem preenchido, e o PostgreSQL o faz para toda a classe 23 de erros. O teste de persistência passou a assertar o nome, e `CriarTipoAtoPublicadoCorridaTests` força a violação real cegando a consulta prévia — que é exatamente o que uma transação concorrente faz com ela: torna obsoleta a resposta dada um instante antes.

Consequência de desenho: **sem fallback** por SQLSTATE isolado nem parse de mensagem. Se o nome faltar, a exceção propaga — converter uma exclusion constraint desconhecida num 409 seria mentir sobre a causa.

## Os validators avaliam o valor normalizado

O agregado faz `Trim` antes de validar. Sobre o texto cru, o validator divergiria **nos dois sentidos**:

- `"  EDITAL_ABERTURA  "` seria recusado com 400, embora o domínio o aceite.
- `" E"` passaria o comprimento mínimo (dois caracteres crus) para ser recusado adiante, com outro status.

Plantei o canário — validator de volta ao texto cru — e os dois testes novos falharam. Restaurado, passam.

`Transform` não serve: foi removido na FluentValidation 12. A forma correta é `RuleFor` sobre a expressão normalizada com `OverridePropertyName`, para que o `ProblemDetails` continue nomeando a propriedade certa.

## Outras decisões

- **`Atualizar` só consulta sobreposição quando o código ou a janela mudam.** Trocar o nome não pode criar conflito, e a consulta seria um round-trip por update. É o que `AtualizarTipoDocumentoCommandHandler` já faz com a unicidade do código.
- **`ObterVigenteAsync` mantém `SingleOrDefaultAsync`.** Duas versões vigentes seriam corrupção do catálogo; desempatar entregaria em silêncio um `congela_configuracao` possivelmente errado. Explodir é o comportamento certo.
- **O DTO nasce sem `_links`.** Sem controller, seria campo sem consumidor — entra na #811 com o HATEOAS.
- **`ObterTipoAtoPublicadoVigenteQuery` com `Data` nula usa `TimeProvider`** (ADR-0068), nunca `DateTime.Now`.

## Validação

- `dotnet build UniPlus.slnx` — 0 warnings (`TreatWarningsAsErrors`).
- `dotnet test UniPlus.slnx` — 22 projetos, nenhuma falha. Inclui `ArchTests` (a regra "handlers nunca tocam `DbContext`" continua verde) e `CrossModuleReadIsolationTests`, que ganhou a âncora do assembly novo.
- 45 testes unitários de Application (handlers, queries, validators), 14 de persistência, 2 no bus do host.
- `packages.lock.json` regenerados com `--force-evaluate` e verificados com `--locked-mode`.

## Correção que atravessa para a #811

Sobreposição de vigência mapeia para **409 Conflict**, não 422 — o precedente é `TipoDocumentoErrorCodes.CodigoJaExiste`. O 422 do repositório é para invariante de payload; 409 é para conflito com o estado existente. Registrado na issue.
