### PR TITLE
feat(publicacoes): expõe o cadastro de tipos de ato por HTTP

### DIFF
--- a/contracts/openapi.publicacoes.json
+++ b/contracts/openapi.publicacoes.json
@@ -1,0 +1,1028 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Uni\u002B \u2014 publicacoes",
+    "description": "API REST do Sistema Unificado Unifesspa (Uni\u002B). Contrato can\u00F4nico V1 \u2014 ProblemDetails RFC 9457, pagina\u00E7\u00E3o cursor opaco, vendor MIME versioning. Toda string user-facing em pt-BR (ADR-0022).",
+    "contact": {
+      "name": "CTIC Unifesspa",
+      "url": "https://developers.uniplus.unifesspa.edu.br",
+      "email": "ctic@unifesspa.edu.br"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    },
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.uniplus.unifesspa.edu.br",
+      "description": "Produ\u00E7\u00E3o"
+    },
+    {
+      "url": "https://api.hml.uniplus.unifesspa.edu.br",
+      "description": "Homologa\u00E7\u00E3o"
+    }
+  ],
+  "paths": {
+    "/api/auth/me": {
+      "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Retorna o usu\u00E1rio autenticado",
+        "description": "Retorna informa\u00E7\u00F5es do usu\u00E1rio extra\u00EDdas do access token. Requer autentica\u00E7\u00E3o.",
+        "operationId": "GetAuthenticatedUser",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticatedUserResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/profile/me": {
+      "get": {
+        "tags": [
+          "Profile"
+        ],
+        "summary": "Retorna o perfil do usu\u00E1rio autenticado",
+        "description": "Retorna atributos de identidade e institucionais (CPF, NomeSocial) extra\u00EDdos do access token. Requer autentica\u00E7\u00E3o.",
+        "operationId": "GetAuthenticatedUserProfile",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfileResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/_smoke/storage/upload": {
+      "post": {
+        "tags": [
+          "_smoke"
+        ],
+        "summary": "Smoke E2E \u2014 Storage upload",
+        "description": "Faz upload de um arquivo no bucket configurado para validar conectividade \u002B credentials do MinIO. Restrito a usu\u00E1rios com role admin.",
+        "operationId": "smokeStorageUpload",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "file"
+                ],
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "$ref": "#/components/schemas/IFormFile"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/_smoke/cache/{key}": {
+      "get": {
+        "tags": [
+          "_smoke"
+        ],
+        "summary": "Smoke E2E \u2014 Cache probe",
+        "description": "Faz SET/GET de uma chave tempor\u00E1ria no Redis com TTL 5min para validar conectividade. Restrito a usu\u00E1rios com role admin.",
+        "operationId": "smokeCacheProbe",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/_smoke/messaging/publish": {
+      "post": {
+        "tags": [
+          "_smoke"
+        ],
+        "summary": "Smoke E2E \u2014 Messaging publish",
+        "description": "Publica um SmokePingMessage via Wolverine outbox para validar persist\u00EAncia \u002B transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usu\u00E1rios com role admin.",
+        "operationId": "smokeMessagingPublish",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/publicacoes/tipos-ato": {
+      "get": {
+        "tags": [
+          "TiposAto"
+        ],
+        "parameters": [
+          {
+            "name": "vigentes",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoAtoPublicadoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoAtoPublicadoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoAtoPublicadoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/publicacoes/tipos-ato/{id}": {
+      "get": {
+        "tags": [
+          "TiposAto"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoAtoPublicadoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoAtoPublicadoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoAtoPublicadoDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/publicacoes/tipos-ato/{codigo}/vigente": {
+      "get": {
+        "tags": [
+          "TiposAto"
+        ],
+        "parameters": [
+          {
+            "name": "codigo",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "maxLength": 60,
+              "minLength": 1,
+              "pattern": "^[A-Z]\u002B(_[A-Z]\u002B)*$",
+              "type": "string"
+            }
+          },
+          {
+            "name": "data",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoAtoPublicadoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoAtoPublicadoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoAtoPublicadoDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/publicacoes/admin/tipos-ato": {
+      "post": {
+        "tags": [
+          "TiposAto"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoAtoPublicadoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoAtoPublicadoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoAtoPublicadoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/publicacoes/admin/tipos-ato/{id}": {
+      "put": {
+        "tags": [
+          "TiposAto"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoAtoPublicadoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoAtoPublicadoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoAtoPublicadoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "TiposAto"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AtualizarTipoAtoPublicadoCommand": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "congelaConfiguracao",
+          "unicoPorObjeto",
+          "efeitoIrreversivel",
+          "vigenciaInicio"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "congelaConfiguracao": {
+            "type": "boolean"
+          },
+          "unicoPorObjeto": {
+            "type": "boolean"
+          },
+          "efeitoIrreversivel": {
+            "type": "boolean"
+          },
+          "vigenciaInicio": {
+            "type": "string",
+            "format": "date"
+          },
+          "vigenciaFim": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "AuthenticatedUserResponse": {
+        "required": [
+          "userId",
+          "name",
+          "email",
+          "roles",
+          "timestamp"
+        ],
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "email": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CriarTipoAtoPublicadoCommand": {
+        "required": [
+          "codigo",
+          "nome",
+          "congelaConfiguracao",
+          "unicoPorObjeto",
+          "efeitoIrreversivel",
+          "vigenciaInicio"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "congelaConfiguracao": {
+            "type": "boolean"
+          },
+          "unicoPorObjeto": {
+            "type": "boolean"
+          },
+          "efeitoIrreversivel": {
+            "type": "boolean"
+          },
+          "vigenciaInicio": {
+            "type": "string",
+            "format": "date"
+          },
+          "vigenciaFim": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "IFormFile": {
+        "type": "string",
+        "format": "binary"
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "instance": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "TipoAtoPublicadoDto": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "congelaConfiguracao",
+          "unicoPorObjeto",
+          "efeitoIrreversivel",
+          "vigenciaInicio",
+          "vigenciaFim",
+          "baseLegal",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "congelaConfiguracao": {
+            "type": "boolean"
+          },
+          "unicoPorObjeto": {
+            "type": "boolean"
+          },
+          "efeitoIrreversivel": {
+            "type": "boolean"
+          },
+          "vigenciaInicio": {
+            "type": "string",
+            "format": "date"
+          },
+          "vigenciaFim": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
+          },
+          "baseLegal": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UserProfileResponse": {
+        "required": [
+          "userId",
+          "name",
+          "email",
+          "cpf",
+          "nomeSocial",
+          "roles",
+          "timestamp"
+        ],
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "email": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cpf": {
+            "pattern": "^\\d{11}$",
+            "type": [
+              "null",
+              "string"
+            ],
+            "description": "CPF (apenas d\u00EDgitos, sem formata\u00E7\u00E3o). PII \u2014 sempre mascarar em logs (\u0027***.999.999-**\u0027, ADR-0011)."
+          },
+          "nomeSocial": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Auth"
+    },
+    {
+      "name": "Profile"
+    },
+    {
+      "name": "_smoke"
+    },
+    {
+      "name": "TiposAto"
+    }
+  ]
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/TiposAtoController.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/TiposAtoController.cs
@@ -1,0 +1,244 @@
+namespace Unifesspa.UniPlus.Publicacoes.API.Controllers;
+
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/publicacoes/tipos-ato</c>) e
+/// endpoints admin (<c>POST/PUT/DELETE /api/publicacoes/admin/tipos-ato</c>)
+/// restritos a <c>plataforma-admin</c>.
+/// </summary>
+/// <remarks>
+/// A leitura é pública porque o significado de um código de tipo de ato numa data
+/// é informação de ato publicado — dado institucional, sem PII. A autoria
+/// (<c>created_by</c>) não é exposta.
+/// </remarks>
+[ApiController]
+[Route("api/publicacoes")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class TiposAtoController : ControllerBase
+{
+    private const string ResourceTag = "tipos-ato";
+
+    /// <summary>Mesmo formato exigido pelo agregado: caixa alta, palavras separadas por underscore.</summary>
+    private const string CodigoPattern = "^[A-Z]+(_[A-Z]+)*$";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<TipoAtoPublicadoDto> _linksBuilder;
+
+    public TiposAtoController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<TipoAtoPublicadoDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista tipos de ato, paginados por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029). Traz apenas as versões vigentes hoje
+    /// (<c>vigentes=true</c> por default).
+    /// </summary>
+    /// <remarks>
+    /// Uma versão com vigência futura é planejamento normativo ainda não anunciado.
+    /// O default protege a listagem pública de divulgá-la antes do ato que a
+    /// institui; <c>vigentes=false</c> devolve a série histórica completa.
+    /// </remarks>
+    [HttpGet("tipos-ato")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "tipo-ato", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<TipoAtoPublicadoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken,
+        [FromQuery] bool vigentes = true)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarTiposAtoPublicadoResult resultado = await _queryBus
+            .Send(new ListarTiposAtoPublicadoQuery(page.AfterId, page.Limit, page.Direction, vigentes), cancellationToken)
+            .ConfigureAwait(false);
+
+        TipoAtoPublicadoDto[] comLinks =
+            [.. resultado.Items.Select(t => t with { Links = _linksBuilder.Build(t) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém uma versão de tipo de ato pelo Id. Retorna 404 quando inexistente.</summary>
+    [HttpGet("tipos-ato/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "tipo-ato", Versions = [1])]
+    [ProducesResponseType(typeof(TipoAtoPublicadoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        TipoAtoPublicadoDto? tipo = await _queryBus
+            .Send(new ObterTipoAtoPublicadoPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (tipo is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(tipo with { Links = _linksBuilder.Build(tipo) });
+    }
+
+    /// <summary>
+    /// Resolve o que um código de tipo de ato significava numa data: a única versão
+    /// viva cuja janela semiaberta <c>[inicio, fim)</c> contém a data. Sem
+    /// <c>data</c>, hoje.
+    /// </summary>
+    /// <remarks>
+    /// O formato do código é validado aqui, no boundary. Sem isso, <c>edital_abertura</c>
+    /// devolveria 404 ("não existe") em vez de 400 ("não é um código") — a resposta
+    /// errada para o cliente, que concluiria que o tipo foi removido.
+    /// </remarks>
+    [HttpGet("tipos-ato/{codigo}/vigente")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "tipo-ato", Versions = [1])]
+    [ProducesResponseType(typeof(TipoAtoPublicadoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterVigente(
+        [FromRoute]
+        [StringLength(60, MinimumLength = 1)]
+        [RegularExpression(CodigoPattern, ErrorMessage = "Código do tipo de ato deve usar apenas letras maiúsculas sem acento, separadas por underscore (ex.: EDITAL_ABERTURA).")]
+        string codigo,
+        [FromQuery] DateOnly? data,
+        CancellationToken cancellationToken)
+    {
+        TipoAtoPublicadoDto? tipo = await _queryBus
+            .Send(new ObterTipoAtoPublicadoVigenteQuery(codigo, data), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (tipo is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(tipo with { Links = _linksBuilder.Build(tipo) });
+    }
+
+    /// <summary>
+    /// Cria uma versão de tipo de ato. Restrito a <c>plataforma-admin</c>.
+    /// <c>Idempotency-Key</c> obrigatório (ADR-0027).
+    /// </summary>
+    [HttpPost("admin/tipos-ato")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarTipoAtoPublicadoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(nameof(ObterPorId), new { id = resultado.Value }, resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Atualiza uma versão de tipo de ato. Restrito a <c>plataforma-admin</c>.
+    /// </summary>
+    /// <remarks>
+    /// Sem <c>Idempotency-Key</c>: a ADR-0027 exclui <c>PUT</c> puro, cuja semântica
+    /// já é idempotente — repetir a mesma substituição não acumula efeito.
+    /// </remarks>
+    [HttpPut("admin/tipos-ato/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Atualizar(
+        Guid id,
+        [FromBody] AtualizarTipoAtoPublicadoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        if (id != command.Id)
+        {
+            // Pelo mapeador, e não por um ProblemDetails montado à mão: assim o erro
+            // sai com type, instance e traceId, como todo o resto do contrato.
+            return Result.Failure(new DomainError(
+                TipoAtoPublicadoErrorCodes.IdDivergente,
+                "O Id na URL não corresponde ao Id no corpo da requisição."))
+                .ToActionResult(_mapper);
+        }
+
+        Result resultado = await _commandBus.Send(command, cancellationToken).ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>
+    /// Remove (soft-delete) uma versão de tipo de ato, liberando a sua janela de
+    /// vigência. Restrito a <c>plataforma-admin</c>.
+    /// </summary>
+    [HttpDelete("admin/tipos-ato/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverTipoAtoPublicadoCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Errors/PublicacoesDomainErrorRegistration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Errors/PublicacoesDomainErrorRegistration.cs
@@ -2,11 +2,86 @@ namespace Unifesspa.UniPlus.Publicacoes.API.Errors;
 
 using System.Diagnostics.CodeAnalysis;
 
-using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Microsoft.AspNetCore.Http;
 
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+
+/// <summary>
+/// Mapeia os erros de domínio do módulo Publicações para <c>ProblemDetails</c>
+/// (ADR-0023 / ADR-0024).
+/// </summary>
+/// <remarks>
+/// A distinção entre 409 e 422 segue o critério do projeto: <b>422</b> é invariante
+/// do próprio payload (formato, tamanho, coerência interna da janela); <b>409</b> é
+/// conflito com o estado já gravado. Duas versões vivas do mesmo código valendo no
+/// mesmo dia é a segunda coisa — o payload está internamente coerente, o que ele não
+/// pode é coexistir com o que já existe.
+/// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes",
     Justification = "Instanciada via IServiceProvider.AddSingleton<IDomainErrorRegistration, PublicacoesDomainErrorRegistration>().")]
 internal sealed class PublicacoesDomainErrorRegistration : IDomainErrorRegistration
 {
-    public IEnumerable<KeyValuePair<string, DomainErrorMapping>> GetMappings() => [];
+    public IEnumerable<KeyValuePair<string, DomainErrorMapping>> GetMappings() =>
+    [
+        new(TipoAtoPublicadoErrorCodes.VigenciaSobreposta,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.publicacoes.tipo_ato.vigencia_sobreposta",
+                "Já existe uma versão viva deste tipo de ato vigente em parte do período informado")),
+
+        new(TipoAtoPublicadoErrorCodes.IdDivergente,
+            new DomainErrorMapping(
+                StatusCodes.Status400BadRequest,
+                "uniplus.publicacoes.tipo_ato.id_divergente",
+                "O identificador da URL não corresponde ao do corpo da requisição")),
+
+        new(TipoAtoPublicadoErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.publicacoes.tipo_ato.nao_encontrado",
+                "Tipo de ato não encontrado")),
+
+        new(TipoAtoPublicadoErrorCodes.CodigoObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.tipo_ato.codigo_obrigatorio",
+                "Código do tipo de ato é obrigatório")),
+
+        new(TipoAtoPublicadoErrorCodes.CodigoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.tipo_ato.codigo_tamanho",
+                "Tamanho do código do tipo de ato inválido")),
+
+        new(TipoAtoPublicadoErrorCodes.CodigoFormato,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.tipo_ato.codigo_formato",
+                "Formato do código do tipo de ato inválido")),
+
+        new(TipoAtoPublicadoErrorCodes.NomeObrigatorio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.tipo_ato.nome_obrigatorio",
+                "Nome do tipo de ato é obrigatório")),
+
+        new(TipoAtoPublicadoErrorCodes.NomeTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.tipo_ato.nome_tamanho",
+                "Tamanho do nome do tipo de ato inválido")),
+
+        new(TipoAtoPublicadoErrorCodes.BaseLegalTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.tipo_ato.base_legal_tamanho",
+                "Tamanho da base legal inválido")),
+
+        new(TipoAtoPublicadoErrorCodes.VigenciaFimAnteriorAoInicio,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.tipo_ato.vigencia_fim_anterior_ao_inicio",
+                "Fim da vigência deve ser posterior ao início")),
+    ];
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Hateoas/TipoAtoPublicadoLinksBuilder.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Hateoas/TipoAtoPublicadoLinksBuilder.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Publicacoes.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Publicacoes.API.Controllers;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="TipoAtoPublicadoDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<TipoAtoPublicadoDto>, TipoAtoPublicadoLinksBuilder>().")]
+internal sealed class TipoAtoPublicadoLinksBuilder : IResourceLinksBuilder<TipoAtoPublicadoDto>
+{
+    private const string ControllerName = "TiposAto";
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public TipoAtoPublicadoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(TipoAtoPublicadoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string self = ResolverPath(
+            httpContext, nameof(TiposAtoController.ObterPorId), new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(TiposAtoController.Listar), values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: ControllerName, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: ControllerName, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesModuleRegistration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesModuleRegistration.cs
@@ -6,7 +6,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Publicacoes.Application;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
 using Unifesspa.UniPlus.Publicacoes.API.Errors;
+using Unifesspa.UniPlus.Publicacoes.API.Hateoas;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
 using Unifesspa.UniPlus.Publicacoes.Infrastructure;
 using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
 
@@ -41,6 +44,13 @@ public static class PublicacoesModuleRegistration
         // Erros de domínio do módulo (consumidos por AddDomainErrorMapper, registrado
         // uma vez no host via IEnumerable<IDomainErrorRegistration>).
         services.AddSingleton<IDomainErrorRegistration, PublicacoesDomainErrorRegistration>();
+
+        services.AddSingleton<IResourceLinksBuilder<TipoAtoPublicadoDto>, TipoAtoPublicadoLinksBuilder>();
+
+        // Idempotency-Key (ADR-0027) sobre o DbContext do módulo. Sem este registro o
+        // [RequiresIdempotencyKey] do POST compila e não faz nada: a requisição sem
+        // header alcança o handler, e o replay reexecuta em vez de devolver o cache.
+        services.AddIdempotency<PublicacoesDbContext, PublicacoesApiAssemblyMarker>(configuration);
 
         services.AddPublicacoesApplication();
         services.AddPublicacoesInfrastructure();

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj
@@ -28,4 +28,12 @@
     <ProjectReference Include="..\Unifesspa.UniPlus.Publicacoes.Infrastructure\Unifesspa.UniPlus.Publicacoes.Infrastructure.csproj" />
   </ItemGroup>
 
+  <!-- Coleção Postman versionada junto da API (uma por API, não compartilhada),
+       mas fora do output de publish — sem a exclusão o SDK copia os .json como
+       Content e leva os artefatos de teste (e credenciais dev do environment)
+       para a imagem de runtime. -->
+  <ItemGroup>
+    <Content Remove="postman/**" />
+  </ItemGroup>
+
 </Project>

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/postman/publicacoes.postman_collection.json
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/postman/publicacoes.postman_collection.json
@@ -1,0 +1,402 @@
+{
+  "info": {
+    "name": "Uni+ — Publicações API",
+    "description": "Coleção de testes HTTP do módulo Publicações. Exercita o ciclo de vida do cadastro de tipos de ato — autenticação plataforma-admin via Keycloak (realm unifesspa-dev-local), Idempotency-Key no POST (ADR-0027; o PUT é excluído por ser idempotente por semântica), vendor MIME por recurso (ADR-0028), ProblemDetails RFC 9457 (ADR-0023/0024), HATEOAS Level 1 (ADR-0029), janela de vigência semiaberta [início, fim) e soft-delete. Roda contra o stack local (API UniPlus (monólito) em :5200). Auto-contida e re-executável.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Obter token plataforma-admin",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "const j = pm.response.json();",
+                  "pm.expect(j.access_token, 'access_token presente').to.be.a('string').and.to.have.length.above(0);",
+                  "pm.environment.set('token', j.access_token);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "grant_type",
+                  "value": "password"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{client_id}}"
+                },
+                {
+                  "key": "username",
+                  "value": "{{username}}"
+                },
+                {
+                  "key": "password",
+                  "value": "{{password}}"
+                }
+              ]
+            },
+            "url": "{{keycloak_token_url}}"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Tipos de ato",
+      "item": [
+        {
+          "name": "Criar tipo de ato",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Código único por execução: a coleção é re-executável.",
+                  "const letras = 'ABCDEFGHIJKLMNOP';",
+                  "let sufixo = '';",
+                  "for (let i = 0; i < 8; i++) { sufixo += letras[Math.floor(Math.random() * letras.length)]; }",
+                  "pm.environment.set('tipo_ato_codigo', 'POSTMAN_' + sufixo);"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('201 Created', () => pm.response.to.have.status(201));",
+                  "pm.test('Location aponta para o recurso', () => pm.expect(pm.response.headers.get('Location')).to.include('/api/publicacoes/tipos-ato/'));",
+                  "pm.environment.set('tipo_ato_id', pm.response.json());"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Idempotency-Key",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"codigo\": \"{{tipo_ato_codigo}}\",\n  \"nome\": \"Tipo de ato criado pela coleção\",\n  \"congelaConfiguracao\": true,\n  \"unicoPorObjeto\": false,\n  \"efeitoIrreversivel\": false,\n  \"vigenciaInicio\": \"2026-01-01\",\n  \"vigenciaFim\": null,\n  \"baseLegal\": null\n}"
+            },
+            "url": "{{base_url}}/api/publicacoes/admin/tipos-ato"
+          }
+        },
+        {
+          "name": "Criar com janela sobreposta deve falhar com 409",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('409 Conflict', () => pm.response.to.have.status(409));",
+                  "pm.test('type do ProblemDetails', () => pm.expect(pm.response.json().type).to.include('vigencia_sobreposta'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Idempotency-Key",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"codigo\": \"{{tipo_ato_codigo}}\",\n  \"nome\": \"Duplicata da mesma janela\",\n  \"congelaConfiguracao\": true,\n  \"unicoPorObjeto\": false,\n  \"efeitoIrreversivel\": false,\n  \"vigenciaInicio\": \"2026-06-01\",\n  \"vigenciaFim\": null\n}"
+            },
+            "url": "{{base_url}}/api/publicacoes/admin/tipos-ato"
+          }
+        },
+        {
+          "name": "Criar sem Idempotency-Key deve falhar com 400",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('400 Bad Request', () => pm.response.to.have.status(400));",
+                  "pm.test('code key_ausente', () => pm.expect(pm.response.text()).to.include('key_ausente'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"codigo\": \"SEM_CHAVE\",\n  \"nome\": \"Sem Idempotency-Key\",\n  \"congelaConfiguracao\": false,\n  \"unicoPorObjeto\": false,\n  \"efeitoIrreversivel\": false,\n  \"vigenciaInicio\": \"2026-01-01\"\n}"
+            },
+            "url": "{{base_url}}/api/publicacoes/admin/tipos-ato"
+          }
+        },
+        {
+          "name": "Obter por Id",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "const j = pm.response.json();",
+                  "pm.test('_links.self presente', () => pm.expect(j._links.self).to.include('/api/publicacoes/tipos-ato/'));",
+                  "pm.test('autoria não exposta', () => { pm.expect(j).to.not.have.property('createdBy'); pm.expect(j).to.not.have.property('updatedBy'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/publicacoes/tipos-ato/{{tipo_ato_id}}"
+          }
+        },
+        {
+          "name": "Obter vigente hoje",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "pm.test('é o tipo criado', () => pm.expect(pm.response.json().id).to.eql(pm.environment.get('tipo_ato_id')));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/publicacoes/tipos-ato/{{tipo_ato_codigo}}/vigente"
+          }
+        },
+        {
+          "name": "Obter vigente antes do início devolve 404",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('404 Not Found', () => pm.response.to.have.status(404));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/publicacoes/tipos-ato/{{tipo_ato_codigo}}/vigente?data=2025-12-31"
+          }
+        },
+        {
+          "name": "Obter vigente com código malformado devolve 400",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('400 Bad Request', () => pm.response.to.have.status(400));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/publicacoes/tipos-ato/codigo_minusculo/vigente"
+          }
+        },
+        {
+          "name": "Listar tipos de ato",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 OK', () => pm.response.to.have.status(200));",
+                  "pm.test('vendor MIME', () => pm.expect(pm.response.headers.get('Content-Type')).to.include('application/vnd.uniplus.tipo-ato.v1+json'));",
+                  "pm.test('itens trazem _links', () => pm.expect(pm.response.json()[0]).to.have.property('_links'));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/publicacoes/tipos-ato"
+          }
+        },
+        {
+          "name": "Atualizar tipo de ato (sem Idempotency-Key)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('204 No Content', () => pm.response.to.have.status(204));",
+                  "// PUT puro é idempotente por semântica: a ADR-0027 o exclui do Idempotency-Key."
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"id\": \"{{tipo_ato_id}}\",\n  \"codigo\": \"{{tipo_ato_codigo}}\",\n  \"nome\": \"Nome atualizado pela coleção\",\n  \"congelaConfiguracao\": true,\n  \"unicoPorObjeto\": false,\n  \"efeitoIrreversivel\": false,\n  \"vigenciaInicio\": \"2026-01-01\",\n  \"vigenciaFim\": null\n}"
+            },
+            "url": "{{base_url}}/api/publicacoes/admin/tipos-ato/{{tipo_ato_id}}"
+          }
+        },
+        {
+          "name": "Atualizar com Id divergente devolve 400",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('400 Bad Request', () => pm.response.to.have.status(400));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"id\": \"{{tipo_ato_id}}\",\n  \"codigo\": \"{{tipo_ato_codigo}}\",\n  \"nome\": \"Id divergente\",\n  \"congelaConfiguracao\": true,\n  \"unicoPorObjeto\": false,\n  \"efeitoIrreversivel\": false,\n  \"vigenciaInicio\": \"2026-01-01\"\n}"
+            },
+            "url": "{{base_url}}/api/publicacoes/admin/tipos-ato/00000000-0000-0000-0000-000000000001"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Limpeza",
+      "item": [
+        {
+          "name": "Remover tipo de ato",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('204 No Content', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": "{{base_url}}/api/publicacoes/admin/tipos-ato/{{tipo_ato_id}}"
+          }
+        },
+        {
+          "name": "Removido some da leitura",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('404 Not Found', () => pm.response.to.have.status(404));"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/publicacoes/tipos-ato/{{tipo_ato_id}}"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/postman/publicacoes.postman_environment.json
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/postman/publicacoes.postman_environment.json
@@ -1,0 +1,15 @@
+{
+  "id": "3b7f6d10-4c19-4a83-8e52-publicacoes001",
+  "name": "Uni+ Publicações — local (dev)",
+  "values": [
+    { "key": "base_url", "value": "http://localhost:5200", "type": "default", "enabled": true },
+    { "key": "keycloak_token_url", "value": "http://localhost:8080/realms/unifesspa-dev-local/protocol/openid-connect/token", "type": "default", "enabled": true },
+    { "key": "client_id", "value": "selecao-web", "type": "default", "enabled": true },
+    { "key": "username", "value": "admin", "type": "default", "enabled": true },
+    { "key": "password", "value": "Changeme!123", "type": "secret", "enabled": true },
+    { "key": "token", "value": "", "type": "secret", "enabled": true },
+    { "key": "tipo_ato_id", "value": "", "type": "default", "enabled": true },
+    { "key": "tipo_ato_codigo", "value": "", "type": "default", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/TipoAtoPublicadoDto.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/TipoAtoPublicadoDto.cs
@@ -1,13 +1,18 @@
 namespace Unifesspa.UniPlus.Publicacoes.Application.DTOs;
 
+using System.Text.Json.Serialization;
+
 /// <summary>
 /// DTO de resposta para <c>TipoAtoPublicado</c>. Os três atributos de consequência
 /// são expostos como dados — quem os consome copia-os por valor no ato publicado,
 /// nunca ramifica comportamento por código de tipo (ADR-0103).
 /// </summary>
 /// <remarks>
-/// A janela de vigência é semiaberta: <c>VigenciaFim</c> é o primeiro dia em que
-/// esta versão já não vale, e é nula enquanto a vigência é aberta.
+/// <para>A janela de vigência é semiaberta: <c>VigenciaFim</c> é o primeiro dia em
+/// que esta versão já não vale, e é nula enquanto a vigência é aberta.</para>
+/// <para>Suporta HATEOAS Level 1 via <c>_links</c> (ADR-0029). A autoria
+/// (<c>created_by</c>/<c>updated_by</c>) não é exposta — é dado de auditoria
+/// interna.</para>
 /// </remarks>
 public sealed record TipoAtoPublicadoDto(
     Guid Id,
@@ -19,4 +24,9 @@ public sealed record TipoAtoPublicadoDto(
     DateOnly VigenciaInicio,
     DateOnly? VigenciaFim,
     string? BaseLegal,
-    DateTimeOffset CriadoEm);
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoQuery.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoQuery.cs
@@ -8,7 +8,11 @@ using Unifesspa.UniPlus.Kernel.Pagination;
 /// (ADR-0026 + ADR-0089). O controller decifra o cursor opaco e valida
 /// limit/direction antes de despachar (ADR-0031).
 /// </summary>
+/// <param name="Vigentes">
+/// Quando verdadeiro (o default do endpoint), restringe às versões que valem hoje.
+/// </param>
 public sealed record ListarTiposAtoPublicadoQuery(
     Guid? AfterId,
     int Limit,
-    PaginationDirection Direction) : IQuery<ListarTiposAtoPublicadoResult>;
+    PaginationDirection Direction,
+    bool Vigentes = true) : IQuery<ListarTiposAtoPublicadoResult>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoQueryHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/TiposAtoPublicado/ListarTiposAtoPublicadoQueryHandler.cs
@@ -16,7 +16,7 @@ public static class ListarTiposAtoPublicadoQueryHandler
         ArgumentNullException.ThrowIfNull(repository);
 
         (IReadOnlyList<TipoAtoPublicado> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
-            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, query.Vigentes, cancellationToken)
             .ConfigureAwait(false);
 
         TipoAtoPublicadoDto[] items = [.. itens.Select(t => t.ToDto())];

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/TipoAtoPublicadoErrorCodes.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/TipoAtoPublicadoErrorCodes.cs
@@ -17,4 +17,7 @@ public static class TipoAtoPublicadoErrorCodes
     public const string VigenciaSobreposta = "TipoAtoPublicado.VigenciaSobreposta";
 
     public const string NaoEncontrado = "TipoAtoPublicado.NaoEncontrado";
+
+    /// <summary>O identificador da URL não corresponde ao do corpo da requisição.</summary>
+    public const string IdDivergente = "TipoAtoPublicado.IdDivergente";
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Interfaces/ITipoAtoPublicadoRepository.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Interfaces/ITipoAtoPublicadoRepository.cs
@@ -32,10 +32,17 @@ public interface ITipoAtoPublicadoRepository
     /// (ADR-0026 + ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve
     /// as âncoras de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
     /// </summary>
+    /// <param name="vigentes">
+    /// Quando verdadeiro, devolve apenas as versões cuja janela contém a data de
+    /// hoje. É o default do endpoint público: uma versão com vigência futura é
+    /// planejamento normativo ainda não anunciado, e listá-la a qualquer cliente
+    /// o divulgaria antes do ato que a institui.
+    /// </param>
     Task<(IReadOnlyList<TipoAtoPublicado> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
         int limit,
         PaginationDirection direction,
+        bool vigentes,
         CancellationToken cancellationToken);
 
     Task AdicionarAsync(TipoAtoPublicado tipo, CancellationToken cancellationToken);

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Repositories/TipoAtoPublicadoRepository.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Repositories/TipoAtoPublicadoRepository.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Repositories;
 
 using Microsoft.EntityFrameworkCore;
 
+using System.Linq;
+
 using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 using Unifesspa.UniPlus.Kernel.Pagination;
 using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
@@ -14,11 +16,14 @@ using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
 public sealed class TipoAtoPublicadoRepository : ITipoAtoPublicadoRepository
 {
     private readonly PublicacoesDbContext _dbContext;
+    private readonly TimeProvider _timeProvider;
 
-    public TipoAtoPublicadoRepository(PublicacoesDbContext dbContext)
+    public TipoAtoPublicadoRepository(PublicacoesDbContext dbContext, TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(timeProvider);
         _dbContext = dbContext;
+        _timeProvider = timeProvider;
     }
 
     public Task<TipoAtoPublicado?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
@@ -60,11 +65,23 @@ public sealed class TipoAtoPublicadoRepository : ITipoAtoPublicadoRepository
         Guid? afterId,
         int limit,
         PaginationDirection direction,
+        bool vigentes,
         CancellationToken cancellationToken)
     {
-        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        // Sem OrderBy aqui: o helper keyset (ADR-0089) ordena e fatia. Aplicamos só
+        // os filtros; os EXISTS de flag do helper herdam a mesma query base.
+        IQueryable<TipoAtoPublicado> query = _dbContext.TiposAtoPublicado.AsNoTracking();
+
+        if (vigentes)
+        {
+            DateOnly hoje = DateOnly.FromDateTime(_timeProvider.GetUtcNow().UtcDateTime.Date);
+            query = query.Where(t =>
+                t.VigenciaInicio <= hoje
+                && (t.VigenciaFim == null || t.VigenciaFim > hoje));
+        }
+
         CursorKeysetPage<TipoAtoPublicado> page = await CursorKeyset
-            .ApplyAsync(_dbContext.TiposAtoPublicado.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
             .ConfigureAwait(false);
 
         return (page.Items, page.PrevAfterId, page.NextAfterId);

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/OpenApiSharedSchemasInSyncTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/OpenApiSharedSchemasInSyncTests.cs
@@ -40,6 +40,7 @@ public sealed class OpenApiSharedSchemasInSyncTests
         "openapi.ingresso.json",
         "openapi.organizacao.json",
         "openapi.configuracao.json",
+        "openapi.publicacoes.json",
     ];
 
     private static readonly JsonSerializerOptions CanonicalOptions = new()

--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/OpenApiPorModuloTests.cs
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/OpenApiPorModuloTests.cs
@@ -27,7 +27,7 @@ using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
     Justification = "xUnit exige tipo de teste público.")]
 public sealed class OpenApiPorModuloTests
 {
-    private static readonly string[] Modulos = ["configuracao", "organizacao", "selecao"];
+    private static readonly string[] Modulos = ["configuracao", "organizacao", "selecao", "publicacoes"];
 
     private readonly MonolitoPostgresFixture _fixture;
 
@@ -40,6 +40,7 @@ public sealed class OpenApiPorModuloTests
     [InlineData("configuracao")]
     [InlineData("organizacao")]
     [InlineData("selecao")]
+    [InlineData("publicacoes")]
     public async Task DocDeModulo_NaoVazaPathsDeOutrosModulos(string modulo)
     {
         IReadOnlyList<string> paths = await ObterPathsAsync(modulo);
@@ -57,13 +58,22 @@ public sealed class OpenApiPorModuloTests
         }
     }
 
-    [Fact(DisplayName = "Doc /openapi/configuracao.json contém os próprios endpoints (api/configuracao/*)")]
-    public async Task DocDeModulo_ContemSeusProprios()
+    /// <remarks>
+    /// Generalizado por módulo de propósito: fixo em Configuração, o teste de
+    /// não-vazamento passaria por vacuidade para qualquer módulo cujo documento
+    /// estivesse vazio — um doc sem paths nunca vaza nada.
+    /// </remarks>
+    [Theory(DisplayName = "Doc /openapi/{modulo}.json contém os próprios endpoints (api/{modulo}/*)")]
+    [InlineData("configuracao")]
+    [InlineData("organizacao")]
+    [InlineData("selecao")]
+    [InlineData("publicacoes")]
+    public async Task DocDeModulo_ContemSeusProprios(string modulo)
     {
-        IReadOnlyList<string> paths = await ObterPathsAsync("configuracao");
+        IReadOnlyList<string> paths = await ObterPathsAsync(modulo);
 
         paths.Should().Contain(
-            p => p.StartsWith("/api/configuracao/", StringComparison.Ordinal),
+            p => p.StartsWith($"/api/{modulo}/", StringComparison.Ordinal),
             "o doc do módulo deve conter seus próprios endpoints");
     }
 

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Queries/TipoAtoPublicadoQueryHandlersTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Queries/TipoAtoPublicadoQueryHandlersTests.cs
@@ -56,7 +56,7 @@ public sealed class TipoAtoPublicadoQueryHandlersTests
         Guid after = Guid.NewGuid();
         Guid prev = Guid.NewGuid();
         Guid next = Guid.NewGuid();
-        _repository.ListarPaginadoAsync(after, 25, PaginationDirection.Next, Arg.Any<CancellationToken>())
+        _repository.ListarPaginadoAsync(after, 25, PaginationDirection.Next, true, Arg.Any<CancellationToken>())
             .Returns((new[] { Novo("AVISO") }, prev, next));
 
         ListarTiposAtoPublicadoResult resultado = await ListarTiposAtoPublicadoQueryHandler.Handle(
@@ -66,6 +66,36 @@ public sealed class TipoAtoPublicadoQueryHandlersTests
         resultado.Items.Should().ContainSingle().Which.Codigo.Should().Be("AVISO");
         resultado.AnteriorAfterId.Should().Be(prev);
         resultado.ProximoAfterId.Should().Be(next);
+    }
+
+    [Fact(DisplayName = "Listar repassa o filtro de vigência ao repositório")]
+    public async Task Listar_RepassaFiltroDeVigencia()
+    {
+        _repository.ListarPaginadoAsync(
+            Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<PaginationDirection>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Array.Empty<TipoAtoPublicado>(), (Guid?)null, (Guid?)null));
+
+        await ListarTiposAtoPublicadoQueryHandler.Handle(
+            new ListarTiposAtoPublicadoQuery(null, 25, PaginationDirection.Next, Vigentes: false),
+            _repository, CancellationToken.None);
+
+        await _repository.Received(1).ListarPaginadoAsync(
+            null, 25, PaginationDirection.Next, false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Listar filtra por vigentes quando a query não diz o contrário")]
+    public async Task Listar_DefaultEhVigentes()
+    {
+        _repository.ListarPaginadoAsync(
+            Arg.Any<Guid?>(), Arg.Any<int>(), Arg.Any<PaginationDirection>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns((Array.Empty<TipoAtoPublicado>(), (Guid?)null, (Guid?)null));
+
+        await ListarTiposAtoPublicadoQueryHandler.Handle(
+            new ListarTiposAtoPublicadoQuery(null, 25, PaginationDirection.Next),
+            _repository, CancellationToken.None);
+
+        await _repository.Received(1).ListarPaginadoAsync(
+            null, 25, PaginationDirection.Next, true, Arg.Any<CancellationToken>());
     }
 
     [Fact(DisplayName = "ObterVigente sem data usa o relógio injetado, não DateTime.Now")]

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Infrastructure/PublicacoesApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Infrastructure/PublicacoesApiFactory.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// Factory HTTP-only (Wolverine + migrations desabilitados) usada pelas suítes que
+/// só exercitam o pipeline HTTP/OpenAPI sem Postgres real. Sobe a API UniPlus
+/// (composition root); Publicações é uma library exercitada através dela.
+/// </summary>
+/// <remarks>
+/// A connection string é dummy (não-vazia): em HTTP-only o DbContext é resolvido
+/// lazy e nunca usado. Suítes que tocam o banco usam <see cref="PublicacoesEndpointFixture"/>.
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit 2.x IClassFixture<T> requires the fixture type to be public.")]
+public sealed class PublicacoesApiFactory : MonolitoApiFactory
+{
+    public PublicacoesApiFactory()
+        : base(
+            "Host=localhost;Port=5432;Database=uniplus;Username=uniplus;Password=uniplus_dev",
+            wolverineEnabled: false)
+    {
+    }
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Infrastructure/PublicacoesEndpointCollection.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Infrastructure/PublicacoesEndpointCollection.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+// DisableParallelization=true protege as env vars ConnectionStrings__* — a fixture
+// base as escreve process-wide — contra interleaving com outras coleções de teste.
+[CollectionDefinition(Name, DisableParallelization = true)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit ICollectionFixture<T> requires the collection definition type to be public.")]
+[SuppressMessage(
+    "Naming",
+    "CA1711:Identifiers should not have incorrect suffix",
+    Justification = "Convenção de nome de coleção xUnit termina com 'Collection'.")]
+public sealed class PublicacoesEndpointCollection : ICollectionFixture<PublicacoesEndpointFixture>
+{
+    public const string Name = "publicacoes-endpoint";
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Infrastructure/PublicacoesEndpointFixture.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Infrastructure/PublicacoesEndpointFixture.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// Fixture de coleção que provisiona Postgres efêmero e sobe a API UniPlus com
+/// Wolverine habilitado — exercita os endpoints de Publicações (via query/command
+/// bus) no monólito real. Herda toda a infra de <see cref="MonolitoPostgresFixture"/>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit ICollectionFixture<T> requires the fixture type to be public.")]
+public sealed class PublicacoesEndpointFixture : MonolitoPostgresFixture;

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/OpenApiEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/OpenApiEndpointTests.cs
@@ -1,0 +1,99 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests;
+
+using System.IO;
+using System.Net;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Smoke + drift check do endpoint <c>/openapi/publicacoes.json</c>: runtime
+/// gera o spec OpenAPI 3.x do módulo Publicações e compara com o baseline
+/// committed em <c>contracts/openapi.publicacoes.json</c> (ADR-0030).
+/// </summary>
+public sealed class OpenApiEndpointTests : IClassFixture<PublicacoesApiFactory>
+{
+    private const string BaselineRelativePath = "contracts/openapi.publicacoes.json";
+    private const string UpdateBaselineEnvVar = "UPDATE_OPENAPI_BASELINE";
+
+    private readonly PublicacoesApiFactory _factory;
+
+    public OpenApiEndpointTests(PublicacoesApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact(DisplayName = "GET /openapi/publicacoes.json retorna 200 com documento OpenAPI válido e metadata Uni+")]
+    public async Task GetOpenApiDocument_RetornaSpecJsonComMetadataInjetada()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri("/openapi/publicacoes.json", UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        string body = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+        JsonElement root = doc.RootElement;
+
+        root.GetProperty("openapi").GetString().Should().StartWith("3.");
+        root.GetProperty("info").GetProperty("version").GetString().Should().Be("1.0.0");
+    }
+
+    [Fact(DisplayName = "Spec runtime de Publicações bate com baseline committed em contracts/")]
+    public async Task SpecRuntime_DeveCasarComBaselineCommitted()
+    {
+        using HttpClient client = _factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri("/openapi/publicacoes.json", UriKind.Relative));
+        response.EnsureSuccessStatusCode();
+
+        string runtimeSpec = NormalizeJson(await response.Content.ReadAsStringAsync());
+        string baselinePath = ResolveRepoPath(BaselineRelativePath);
+
+        if (string.Equals(Environment.GetEnvironmentVariable(UpdateBaselineEnvVar), "1", StringComparison.Ordinal))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(baselinePath)!);
+            await File.WriteAllTextAsync(baselinePath, runtimeSpec + "\n");
+            return;
+        }
+
+        File.Exists(baselinePath).Should().BeTrue(
+            $"baseline {BaselineRelativePath} precisa estar committed; rode `{UpdateBaselineEnvVar}=1 dotnet test --filter SpecRuntime` e commit o arquivo gerado.");
+
+        string committedSpec = NormalizeJson(await File.ReadAllTextAsync(baselinePath));
+
+        runtimeSpec.Should().Be(committedSpec,
+            $"contrato OpenAPI mudou — regerar a baseline com `{UpdateBaselineEnvVar}=1 dotnet test --filter SpecRuntime` e revisar o diff antes de commit (ADR-0030).");
+    }
+
+    private static string NormalizeJson(string raw)
+    {
+        using JsonDocument document = JsonDocument.Parse(raw);
+        return JsonSerializer.Serialize(document.RootElement, JsonNormalizationOptions);
+    }
+
+    private static readonly JsonSerializerOptions JsonNormalizationOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    private static string ResolveRepoPath(string relative)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(relative);
+        if (Path.IsPathRooted(relative))
+            throw new ArgumentException("Caminho deve ser relativo à raiz do repositório.", nameof(relative));
+
+        string? current = AppContext.BaseDirectory;
+        while (current is not null && !File.Exists(Path.Join(current, "UniPlus.slnx")))
+            current = Path.GetDirectoryName(current);
+
+        if (current is null)
+            throw new DirectoryNotFoundException("UniPlus.slnx não encontrado a partir de AppContext.BaseDirectory.");
+
+        // Path.Join (não Combine): concatena sem a semântica de descartar o
+        // primeiro segmento quando o segundo é enraizado — o caminho relativo já
+        // é validado acima, então a junção é sempre raiz-do-repo + relativo.
+        return Path.Join(current, relative);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/CriarTipoAtoPublicadoCorridaTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/CriarTipoAtoPublicadoCorridaTests.cs
@@ -49,7 +49,7 @@ public sealed class CriarTipoAtoPublicadoCorridaTests
         string codigo = CodigoUnico();
 
         await using PublicacoesDbContext ctx = _fixture.CreateDbContext("admin");
-        var real = new TipoAtoPublicadoRepository(ctx);
+        var real = new TipoAtoPublicadoRepository(ctx, TimeProvider.System);
 
         // Primeira versão, gravada normalmente.
         Result<Guid> primeira = await CriarTipoAtoPublicadoCommandHandler.Handle(
@@ -58,7 +58,7 @@ public sealed class CriarTipoAtoPublicadoCorridaTests
 
         // Segunda versão, com a consulta prévia cega — o estado do banco mudou sob ela.
         await using PublicacoesDbContext ctx2 = _fixture.CreateDbContext("admin");
-        var cego = new RepositorioComConsultaObsoleta(new TipoAtoPublicadoRepository(ctx2));
+        var cego = new RepositorioComConsultaObsoleta(new TipoAtoPublicadoRepository(ctx2, TimeProvider.System));
 
         Result<Guid> segunda = await CriarTipoAtoPublicadoCommandHandler.Handle(
             Comando(codigo), cego, ctx2, CancellationToken.None);
@@ -73,14 +73,14 @@ public sealed class CriarTipoAtoPublicadoCorridaTests
         string codigo = CodigoUnico();
 
         await using PublicacoesDbContext ctx = _fixture.CreateDbContext("admin");
-        var repositorio = new TipoAtoPublicadoRepository(ctx);
+        var repositorio = new TipoAtoPublicadoRepository(ctx, TimeProvider.System);
 
         (await CriarTipoAtoPublicadoCommandHandler.Handle(Comando(codigo), repositorio, ctx, CancellationToken.None))
             .IsSuccess.Should().BeTrue();
 
         await using PublicacoesDbContext ctx2 = _fixture.CreateDbContext("admin");
         Result<Guid> segunda = await CriarTipoAtoPublicadoCommandHandler.Handle(
-            Comando(codigo), new TipoAtoPublicadoRepository(ctx2), ctx2, CancellationToken.None);
+            Comando(codigo), new TipoAtoPublicadoRepository(ctx2, TimeProvider.System), ctx2, CancellationToken.None);
 
         segunda.IsFailure.Should().BeTrue();
         segunda.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.VigenciaSobreposta);
@@ -119,8 +119,8 @@ public sealed class CriarTipoAtoPublicadoCorridaTests
             _real.ObterVigenteAsync(codigo, data, ct);
 
         public Task<(IReadOnlyList<TipoAtoPublicado> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
-            Guid? afterId, int limit, PaginationDirection direction, CancellationToken ct) =>
-            _real.ListarPaginadoAsync(afterId, limit, direction, ct);
+            Guid? afterId, int limit, PaginationDirection direction, bool vigentes, CancellationToken ct) =>
+            _real.ListarPaginadoAsync(afterId, limit, direction, vigentes, ct);
 
         public Task AdicionarAsync(TipoAtoPublicado tipo, CancellationToken ct) => _real.AdicionarAsync(tipo, ct);
 

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/TipoAtoPublicadoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/TipoAtoPublicadoEndpointTests.cs
@@ -1,0 +1,543 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.TiposAtoPublicado;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Endpoints de <c>TipoAtoPublicado</c> contra o monólito real com Postgres efêmero:
+/// routing, vendor media type, HATEOAS, autenticação/autorização, idempotência,
+/// conflito de vigência (409) e invariantes de payload (400/422).
+/// </summary>
+[Collection(PublicacoesEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class TipoAtoPublicadoEndpointTests
+{
+    private const string Base = "/api/publicacoes/tipos-ato";
+    private const string Admin = "/api/publicacoes/admin/tipos-ato";
+    private const string Inicio = "2026-01-01";
+
+    private readonly PublicacoesEndpointFixture _fixture;
+
+    public TipoAtoPublicadoEndpointTests(PublicacoesEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // ── Leitura pública ──────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET tipos-ato retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri(Base, UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.tipo-ato.v1+json");
+    }
+
+    [Fact(DisplayName = "GET tipos-ato/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{Base}/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "GET tipos-ato/{id} devolve _links.self e _links.collection resolvidos")]
+    public async Task ObterPorId_TrazLinksResolvidos()
+    {
+        string codigo = CodigoUnico();
+        Guid id = await CriarAsync(codigo);
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri($"{Base}/{id}", UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement links = doc.RootElement.GetProperty("_links");
+
+        // Asserir o valor, não a presença: um LinkGenerator apontando para a action
+        // errada devolveria um path qualquer e passaria por qualquer teste de status.
+        links.GetProperty("self").GetString().Should().Be($"{Base}/{id}");
+        links.GetProperty("collection").GetString().Should().Be(Base);
+    }
+
+    [Fact(DisplayName = "GET tipos-ato traz _links em cada item da coleção")]
+    public async Task Listar_ItensTrazemLinks()
+    {
+        Guid id = await CriarAsync(CodigoUnico());
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(new Uri($"{Base}?limit=100", UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement item = doc.RootElement.EnumerateArray()
+            .Single(e => e.GetProperty("id").GetGuid() == id);
+
+        item.GetProperty("_links").GetProperty("self").GetString().Should().Be($"{Base}/{id}");
+    }
+
+    [Fact(DisplayName = "A listagem pública não expõe versões de vigência futura")]
+    public async Task Listar_NaoExpoeVersaoFutura()
+    {
+        string codigo = CodigoUnico();
+        Guid futura = await CriarAsync(codigo, inicio: "2099-01-01");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // Uma versão que ainda não vale é planejamento normativo não anunciado.
+        (await IdsAsync(client, $"{Base}?limit=100")).Should().NotContain(futura);
+
+        // A série histórica continua acessível a quem a pedir explicitamente.
+        (await IdsAsync(client, $"{Base}?limit=100&vigentes=false")).Should().Contain(futura);
+    }
+
+    [Fact(DisplayName = "A listagem pública não expõe versões já encerradas")]
+    public async Task Listar_NaoExpoeVersaoEncerrada()
+    {
+        string codigo = CodigoUnico();
+        Guid encerrada = await CriarAsync(codigo, inicio: "2020-01-01", fim: "2021-01-01");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        (await IdsAsync(client, $"{Base}?limit=100")).Should().NotContain(encerrada);
+        (await IdsAsync(client, $"{Base}?limit=100&vigentes=false")).Should().Contain(encerrada);
+    }
+
+    [Fact(DisplayName = "A autoria não é exposta no contrato público")]
+    public async Task Dto_NaoExpoeAutoria()
+    {
+        Guid id = await CriarAsync(CodigoUnico());
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        string body = await client.GetStringAsync(new Uri($"{Base}/{id}", UriKind.Relative));
+
+        using JsonDocument doc = JsonDocument.Parse(body);
+        doc.RootElement.TryGetProperty("createdBy", out _).Should().BeFalse();
+        doc.RootElement.TryGetProperty("updatedBy", out _).Should().BeFalse();
+    }
+
+    // ── Vigente ──────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET tipos-ato/{codigo}/vigente numa data histórica devolve a versão de então")]
+    public async Task ObterVigente_DataHistorica_DevolveVersaoDaEpoca()
+    {
+        string codigo = CodigoUnico();
+        Guid antiga = await CriarAsync(codigo, inicio: "2026-01-01", fim: "2026-06-01", congela: false);
+        Guid nova = await CriarAsync(codigo, inicio: "2026-06-01", fim: null, congela: true);
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        (await VigenteIdAsync(client, codigo, "2026-03-15")).Should().Be(antiga);
+        (await VigenteIdAsync(client, codigo, "2026-05-31")).Should().Be(antiga);
+
+        // O fim é exclusivo: no dia da fronteira já vale a sucessora.
+        (await VigenteIdAsync(client, codigo, "2026-06-01")).Should().Be(nova);
+    }
+
+    [Fact(DisplayName = "GET vigente sem data usa hoje")]
+    public async Task ObterVigente_SemData_UsaHoje()
+    {
+        string codigo = CodigoUnico();
+        Guid id = await CriarAsync(codigo, inicio: "2020-01-01");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{Base}/{codigo}/vigente", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("id").GetGuid().Should().Be(id);
+    }
+
+    [Fact(DisplayName = "GET vigente de código inexistente retorna 404")]
+    public async Task ObterVigente_CodigoInexistente_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{Base}/{CodigoUnico()}/vigente", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Theory(DisplayName = "GET vigente com código malformado retorna 400, não 404")]
+    [InlineData("edital_abertura")]
+    [InlineData("Edital")]
+    [InlineData("EDITAL-ABERTURA")]
+    [InlineData("EDITAL__ABERTURA")]
+    public async Task ObterVigente_CodigoMalformado_Retorna400(string codigo)
+    {
+        // 404 diria "este tipo não existe"; a verdade é "isto não é um código".
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{Base}/{codigo}/vigente", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "GET vigente com um GUID no lugar do código retorna 400")]
+    public async Task ObterVigente_ComGuid_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{Base}/{Guid.NewGuid()}/vigente", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── Autorização ──────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST admin sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(Admin, UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        (await client.SendAsync(request)).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST admin autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(Admin, UriKind.Relative));
+        Autenticar(request, role: "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(Payload(CodigoUnico()));
+
+        (await client.SendAsync(request)).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "DELETE admin sem autenticação retorna 401")]
+    public async Task Remover_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+
+        HttpResponseMessage response = await client.DeleteAsync(
+            new Uri($"{Admin}/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── Idempotência ─────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Criar_SemIdempotencyKey_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(Admin, UriKind.Relative));
+        Autenticar(request);
+        request.Content = JsonContent.Create(Payload(CodigoUnico()));
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        // Prova que AddIdempotency está registrado: sem ele o filtro não existe e a
+        // requisição alcançaria o handler, devolvendo 201.
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST repetido com a mesma chave e o mesmo corpo devolve a resposta cacheada")]
+    public async Task Criar_ReplayLegitimo_DevolveCache()
+    {
+        string chave = Guid.NewGuid().ToString();
+        object payload = Payload(CodigoUnico());
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage primeira = await PostAsync(client, payload, chave);
+        primeira.StatusCode.Should().Be(HttpStatusCode.Created);
+        string corpoPrimeira = await primeira.Content.ReadAsStringAsync();
+
+        HttpResponseMessage segunda = await PostAsync(client, payload, chave);
+        segunda.StatusCode.Should().Be(HttpStatusCode.Created);
+        (await segunda.Content.ReadAsStringAsync()).Should().Be(corpoPrimeira);
+    }
+
+    [Fact(DisplayName = "POST com a mesma chave e corpo diferente retorna 422 body_mismatch")]
+    public async Task Criar_MesmaChaveCorpoDiferente_Retorna422()
+    {
+        string chave = Guid.NewGuid().ToString();
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        (await PostAsync(client, Payload(CodigoUnico()), chave)).StatusCode
+            .Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage segunda = await PostAsync(client, Payload(CodigoUnico()), chave);
+
+        segunda.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        (await segunda.Content.ReadAsStringAsync())
+            .Should().Contain("uniplus.idempotency.body_mismatch");
+    }
+
+    // ── Escrita ──────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST cria e devolve 201 com Location apontando para o recurso")]
+    public async Task Criar_Retorna201ComLocation()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await PostAsync(client, Payload(CodigoUnico()));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location!.AbsolutePath.Should().StartWith($"{Base}/");
+    }
+
+    [Fact(DisplayName = "POST com janela sobreposta retorna 409 com o type do ProblemDetails")]
+    public async Task Criar_ComSobreposicao_Retorna409()
+    {
+        string codigo = CodigoUnico();
+        await CriarAsync(codigo);
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await PostAsync(client, Payload(codigo));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await response.Content.ReadAsStringAsync())
+            .Should().Contain("uniplus.publicacoes.tipo_ato.vigencia_sobreposta");
+    }
+
+    [Fact(DisplayName = "POST com janela adjacente é aceito — o fim é exclusivo")]
+    public async Task Criar_ComJanelaAdjacente_Retorna201()
+    {
+        string codigo = CodigoUnico();
+        await CriarAsync(codigo, inicio: "2026-01-01", fim: "2026-06-01");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await PostAsync(
+            client, Payload(codigo, inicio: "2026-06-01", fim: null));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact(DisplayName = "POST com código minúsculo retorna 422 — validação do command")]
+    public async Task Criar_ComCodigoMinusculo_Retorna422()
+    {
+        // Falha de FluentValidation no pipeline do Wolverine vira ValidationException,
+        // que o GlobalExceptionMiddleware escreve como 422 `uniplus.validacao`. O 400
+        // fica para o que o binding recusa antes do command existir (rota, corpo).
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await PostAsync(client, Payload("edital_abertura"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        (await response.Content.ReadAsStringAsync()).Should().Contain("uniplus.validacao");
+    }
+
+    [Fact(DisplayName = "POST com janela vazia retorna 422 — o fim é exclusivo")]
+    public async Task Criar_ComJanelaVazia_Retorna422()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await PostAsync(
+            client, Payload(CodigoUnico(), inicio: Inicio, fim: Inicio));
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "PUT atualiza e retorna 204, sem exigir Idempotency-Key")]
+    public async Task Atualizar_Retorna204SemIdempotencyKey()
+    {
+        string codigo = CodigoUnico();
+        Guid id = await CriarAsync(codigo);
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Put, new Uri($"{Admin}/{id}", UriKind.Relative));
+        Autenticar(request);
+        request.Content = JsonContent.Create(Payload(codigo, id: id, nome: "Nome atualizado"));
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        // A ADR-0027 exclui PUT puro do Idempotency-Key: repetir a mesma substituição
+        // é inócuo por construção.
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        string body = await client.GetStringAsync(new Uri($"{Base}/{id}", UriKind.Relative));
+        using JsonDocument doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("nome").GetString().Should().Be("Nome atualizado");
+    }
+
+    [Fact(DisplayName = "PUT com Id divergente retorna 400 com o ProblemDetails canônico")]
+    public async Task Atualizar_IdDivergente_Retorna400()
+    {
+        string codigo = CodigoUnico();
+        Guid id = await CriarAsync(codigo);
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Put, new Uri($"{Admin}/{Guid.NewGuid()}", UriKind.Relative));
+        Autenticar(request);
+        request.Content = JsonContent.Create(Payload(codigo, id: id));
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+        // Sem `type`, o cliente não classifica o erro — só lê a mensagem.
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("type").GetString()
+            .Should().EndWith("uniplus.publicacoes.tipo_ato.id_divergente");
+    }
+
+    [Fact(DisplayName = "PUT de tipo inexistente retorna 404")]
+    public async Task Atualizar_Inexistente_Retorna404()
+    {
+        Guid id = Guid.NewGuid();
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Put, new Uri($"{Admin}/{id}", UriKind.Relative));
+        Autenticar(request);
+        request.Content = JsonContent.Create(Payload(CodigoUnico(), id: id));
+
+        (await client.SendAsync(request)).StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "DELETE remove, retorna 204 e o tipo some da leitura")]
+    public async Task Remover_Retorna204ESomeDaLeitura()
+    {
+        string codigo = CodigoUnico();
+        Guid id = await CriarAsync(codigo);
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Delete, new Uri($"{Admin}/{id}", UriKind.Relative));
+        Autenticar(request);
+
+        (await client.SendAsync(request)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        (await client.GetAsync(new Uri($"{Base}/{id}", UriKind.Relative))).StatusCode
+            .Should().Be(HttpStatusCode.NotFound);
+        (await client.GetAsync(new Uri($"{Base}/{codigo}/vigente", UriKind.Relative))).StatusCode
+            .Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "DELETE de tipo inexistente retorna 404")]
+    public async Task Remover_Inexistente_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Delete, new Uri($"{Admin}/{Guid.NewGuid()}", UriKind.Relative));
+        Autenticar(request);
+
+        (await client.SendAsync(request)).StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Negociação de conteúdo ───────────────────────────────────────────────
+
+    [Fact(DisplayName = "Accept com vendor MIME de versão inexistente retorna 406")]
+    public async Task Listar_ComVersaoInexistente_Retorna406()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Get, new Uri(Base, UriKind.Relative));
+        request.Headers.Add("Accept", "application/vnd.uniplus.tipo-ato.v99+json");
+
+        (await client.SendAsync(request)).StatusCode.Should().Be(HttpStatusCode.NotAcceptable);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static void Autenticar(HttpRequestMessage request, string role = "plataforma-admin")
+    {
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, role);
+    }
+
+    private static object Payload(
+        string codigo,
+        Guid? id = null,
+        string nome = "Tipo de ato de teste",
+        string inicio = Inicio,
+        string? fim = null,
+        bool congela = true) =>
+        id is { } identificador
+            ? new
+            {
+                id = identificador,
+                codigo,
+                nome,
+                congelaConfiguracao = congela,
+                unicoPorObjeto = false,
+                efeitoIrreversivel = false,
+                vigenciaInicio = inicio,
+                vigenciaFim = fim,
+            }
+            : new
+            {
+                codigo,
+                nome,
+                congelaConfiguracao = congela,
+                unicoPorObjeto = false,
+                efeitoIrreversivel = false,
+                vigenciaInicio = inicio,
+                vigenciaFim = fim,
+            };
+
+    private static async Task<HttpResponseMessage> PostAsync(
+        HttpClient client, object payload, string? chave = null)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(Admin, UriKind.Relative));
+        Autenticar(request);
+        request.Headers.Add("Idempotency-Key", chave ?? Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(payload);
+
+        return await client.SendAsync(request);
+    }
+
+    private async Task<Guid> CriarAsync(
+        string codigo, string inicio = Inicio, string? fim = null, bool congela = true)
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await PostAsync(client, Payload(codigo, inicio: inicio, fim: fim, congela: congela));
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        return JsonSerializer.Deserialize<Guid>(await response.Content.ReadAsStringAsync());
+    }
+
+    private static async Task<Guid> VigenteIdAsync(HttpClient client, string codigo, string data)
+    {
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/publicacoes/tipos-ato/{codigo}/vigente?data={data}", UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("id").GetGuid();
+    }
+
+    private static async Task<IReadOnlyList<Guid>> IdsAsync(HttpClient client, string url)
+    {
+        HttpResponseMessage response = await client.GetAsync(new Uri(url, UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return [.. doc.RootElement.EnumerateArray().Select(e => e.GetProperty("id").GetGuid())];
+    }
+
+    /// <summary>Código único no formato UPPER_SNAKE, para não colidir entre testes.</summary>
+    private static string CodigoUnico()
+    {
+        string hex = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)[..12];
+        return "ENDPOINT_" + string.Concat(hex.Select(c => (char)('A' + Convert.ToInt32(c.ToString(), 16))));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/TipoAtoPublicadoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/TipoAtoPublicadoPersistenceTests.cs
@@ -132,7 +132,7 @@ public sealed class TipoAtoPublicadoPersistenceTests
         await Gravar(nova);
 
         await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
-        var repo = new TipoAtoPublicadoRepository(ctx);
+        var repo = new TipoAtoPublicadoRepository(ctx, TimeProvider.System);
 
         // Véspera: a antiga. Dia da fronteira: já a nova — o fim é exclusivo.
         (await repo.ObterVigenteAsync(codigo, Meio.AddDays(-1), default))!.Id.Should().Be(antiga.Id);
@@ -149,7 +149,7 @@ public sealed class TipoAtoPublicadoPersistenceTests
         await Gravar(Novo(codigo, Meio, vigenciaFim: null, congela: true));
 
         await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
-        var repo = new TipoAtoPublicadoRepository(ctx);
+        var repo = new TipoAtoPublicadoRepository(ctx, TimeProvider.System);
 
         TipoAtoPublicado? vigenteEmMarco = await repo.ObterVigenteAsync(codigo, new DateOnly(2026, 3, 15), default);
 
@@ -165,7 +165,7 @@ public sealed class TipoAtoPublicadoPersistenceTests
         await Gravar(Novo(codigo, Inicio, vigenciaFim: null));
 
         await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
-        var repo = new TipoAtoPublicadoRepository(ctx);
+        var repo = new TipoAtoPublicadoRepository(ctx, TimeProvider.System);
 
         (await repo.ObterVigenteAsync(codigo, Inicio.AddDays(-1), default)).Should().BeNull();
     }
@@ -207,7 +207,7 @@ public sealed class TipoAtoPublicadoPersistenceTests
         await Gravar(recriado);
 
         await using PublicacoesDbContext leitura = _fixture.CreateDbContext(userId: null);
-        var repo = new TipoAtoPublicadoRepository(leitura);
+        var repo = new TipoAtoPublicadoRepository(leitura, TimeProvider.System);
 
         (await repo.ObterVigenteAsync(codigo, Inicio, default))!.Id.Should().Be(recriado.Id);
 
@@ -243,7 +243,7 @@ public sealed class TipoAtoPublicadoPersistenceTests
         await Gravar(existente);
 
         await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
-        var repo = new TipoAtoPublicadoRepository(ctx);
+        var repo = new TipoAtoPublicadoRepository(ctx, TimeProvider.System);
 
         // Cruza.
         (await repo.ExisteSobreposicaoDeVigenciaAsync(codigo, Meio, null, null, default))

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Unifesspa.UniPlus.Publicacoes.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Unifesspa.UniPlus.Publicacoes.IntegrationTests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Npgsql" />
@@ -16,8 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj" />
     <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Unifesspa.UniPlus.Publicacoes.Application.csproj" />
     <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Unifesspa.UniPlus.Publicacoes.Infrastructure.csproj" />
+    <ProjectReference Include="../Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj" />
+    <ProjectReference Include="../Unifesspa.UniPlus.Monolito.TestSupport/Unifesspa.UniPlus.Monolito.TestSupport.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/packages.lock.json
@@ -14,6 +14,17 @@
         "resolved": "8.0.1",
         "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
       },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "Mt+5CtYz+xmog1S1TJt2owVKU8YquZtNy9bmO+kfrrtjEDZPzCw1qZ7o97PLpIEpt3yy4F5YdAUh9nKPm0CX5Q==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.9",
+          "Microsoft.Extensions.Hosting": "10.0.9"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
         "requested": "[10.0.9, )",
@@ -254,6 +265,11 @@
         "resolved": "2.15.0",
         "contentHash": "DzG2YcqWPT3Ly91aeDYsgsVcJXlOMiK9oqyRdPvQz9ZMbcV8Ob0rQA6fNUQ4sarmzFk4phqwPlVQxtZDGLP69w=="
       },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "mR4y30XFsVbn7EwV3Ic5/KMBO5QGwukTJE2ztGmpAST5ACX+Z+9r+Y6D1eibJojsOIW5KHpM4myo9/aRALJOyg=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "9.0.0",
@@ -435,11 +451,11 @@
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "H4SWETCh/cC5L1WtWchHR6LntGk3rDTTznZMssr4cL8IbDmMWBxY+MOGDc/ASnqNolLKPIWHWeuC1ddiL/iNPw==",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -452,63 +468,63 @@
       },
       "Microsoft.Extensions.Configuration.Binder": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "tMF9wNh+hlyYDWB8mrFCQHQmWHlRosol1b/N2Jrefy1bFLnuTlgSYmPyHNmz8xVQgs7DpXytBRWxGhG+mSTp0g==",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
         }
       },
       "Microsoft.Extensions.Configuration.CommandLine": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "CRj5clwZciVs46GMhAthkFq3+JiNM15Bz9CRlCZLBmRdggD6RwoBphRJ+EUDK2f+cZZ1L2zqVaQrn1KueoU5Kg==",
+        "resolved": "10.0.9",
+        "contentHash": "8D4HaqxWdm5M/nuhQffjPoR1ekhlpyKTXjFMAT5KlP0dvxkJe5JLAP6MAsuUEUxKWG09Bi5aAUaYMFKrMqWHqA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
         }
       },
       "Microsoft.Extensions.Configuration.EnvironmentVariables": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "TmFegsI/uCdwMBD4yKpmO+OkjVNHQL49Dh/ep83NI5rPUEoBK9OdsJo1zURc1A2FuS/R/Pos3wsTjlyLnguBLA==",
+        "resolved": "10.0.9",
+        "contentHash": "JhKySWIL8+N4yFt4HPm1rGKCHooze+MBdTdpXc0bd/PGm31TrSUi2m0Nek1y441Wlv/RE6VH0W/DCv2xnmy8FA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
         }
       },
       "Microsoft.Extensions.Configuration.FileExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "LqCTyF0twrG4tyEN6PpSC5ewRBDwCBazRUfCOdRddwaQ3n2S57GDDeYOlTLcbV/V2dxSSZWg5Ofr48h6BsBmxw==",
+        "resolved": "10.0.9",
+        "contentHash": "NgLB9cYnIb0/djSDcnqo4GIGGWooxGmr/gCUe3/CRXcKqLizOFui8MyW4EVkTB/KNJL+oXdMXnD6ZRm3Y+qkrQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BIOPTEAZoeWbHlDT9Zudu+rpecZizFwhdIFRiyZKDml7JbayXmfTXKUt+ezifsSXfBkWDdJM10oDOxo8pufEng==",
+        "resolved": "10.0.9",
+        "contentHash": "LiFKJgc9jZEW+7RhcSfsvCwoikt1lDdOqOn+whZC5zVHyg/gExftHl2QPtmfiHsEdDNg+Y+BDr6835tOfj8Y7A==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9"
         }
       },
       "Microsoft.Extensions.Configuration.UserSecrets": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "B4qHB6gQ2B3I52YRohSV7wetp01BQzi8jDmrtiVm6e4l8vH5vjqwxWcR5wumGWjdBkj1asJLLsDIocdyTQSP0A==",
+        "resolved": "10.0.9",
+        "contentHash": "ockJRreRW/HbGwoyHzYOxMucFBimvAZ8lKNwQLMHrS6mwkDUaCJMWzzeE+Rm9vgFlv2o/xqk8fm+FpqrDCnkTA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Json": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Json": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -526,26 +542,26 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "DHXzj/FKmUDmhzw7AHbMXbNNcgO8Cb9PDbYOUDICjFAdIALy2WbC6pm+dFKiAUNtcYMucZu2iMVw1ef/sdcZFw=="
+        "resolved": "10.0.9",
+        "contentHash": "SCDTQ6HubnRvTUjR7dgMKHZvNoCb03t44ttHL8trlFTGgfDteWn/0nRdOxDhcI+lTWhKgd/flCVJEtAOPhSLNg=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "xjkxIPgrT0mKTfBwb+CVqZnRchyZgzKIfDQOp8z+WUC6vPe3WokIf71z+hJPkH0YBUYJwa7Z/al1R087ib9oiw==",
+        "resolved": "10.0.9",
+        "contentHash": "NLXI3PbTe39q6/sgs7JYhmfPf7bMzReUoAJ0q9Po6yhfM+0anZa7PrEva4W2SdiLWGyB9eKZS9THGt2BP40xJg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
         }
       },
       "Microsoft.Extensions.Diagnostics.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "SfK89ytD61S7DgzorFljSkUeluC1ncn6dtZgwc0ot39f/BEYWBl5jpgvodxduoYAs1d9HG8faCDRZxE95UMo2A==",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
         }
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
@@ -555,66 +571,66 @@
       },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "/ppSdehKk3fuXjlqCDgSOtjRK/pSHU8eWgzSHfHdwVm5BP4Dgejehkw+PtxKG2j98qTDEHDst2Y99aNsmJldmw==",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
       "Microsoft.Extensions.FileProviders.Physical": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "UZUQ74lQMmvcprlG8w+XpxBbyRDQqfb7GAnccITw32hdkUBlmm9yNC4xl4aR9YjgV3ounZcub194sdmLSfBmPA==",
+        "resolved": "10.0.9",
+        "contentHash": "zm8WVod4swgprGrkxkuSILlbXqdDRqF+3y6U0I7jlmj4PMyKN6d8pzXZHUn5lr/gZVULzk/+FeTYlTupt6akpg==",
         "dependencies": {
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileSystemGlobbing": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
       "Microsoft.Extensions.FileSystemGlobbing": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "5hfVl/e+bx1px2UkN+1xXhd3hu7Ui6ENItBzckFaRDQXfr+SHT/7qrCDrlQekCF/PBtEu2vtk87U2+gDEF8EhQ=="
+        "resolved": "10.0.9",
+        "contentHash": "mvRf9qOH/LslWIee/h+lsElnoUyKotEwoPL31soqScmO/eoxObaTCLCdx2DdqPdRi9LnB+7qKZ49jfyrLZuc+w=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "yKJiVdXkSfe9foojGpBRbuDPQI8YD71IO/aE8ehGjRHE0VkEF/YWkW6StthwuFF146pc2lypZrpk/Tks6Plwhw==",
+        "resolved": "10.0.9",
+        "contentHash": "HTgnvmK0ubesUFO16pLC+i9+RS8lEGd6TmDouuy75FsAgIFrSwUVhYCqG2IENzBJwgxGc/6Rsulfsvd9ZG/XkA==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
-          "Microsoft.Extensions.Configuration.CommandLine": "10.0.0",
-          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
-          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Json": "10.0.0",
-          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Diagnostics": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Physical": "10.0.0",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
-          "Microsoft.Extensions.Logging.Console": "10.0.0",
-          "Microsoft.Extensions.Logging.Debug": "10.0.0",
-          "Microsoft.Extensions.Logging.EventLog": "10.0.0",
-          "Microsoft.Extensions.Logging.EventSource": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.9",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.9",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Json": "10.0.9",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
+          "Microsoft.Extensions.Logging.Console": "10.0.9",
+          "Microsoft.Extensions.Logging.Debug": "10.0.9",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.9",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
         }
       },
       "Microsoft.Extensions.Hosting.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "KrN6TGFwCwqOkLLk/idW/XtDQh+8In+CL9T4M1Dx+5ScsjTq4TlVbal8q532m82UYrMr6RiQJF2HvYCN0QwVsA==",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
-          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
         }
       },
       "Microsoft.Extensions.Logging": {
@@ -629,63 +645,63 @@
       },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "j8zcwhS6bYB6FEfaY3nYSgHdpiL2T+/V3xjpHtslVAegyI1JUbB9yAt/BFdvZdsNbY0Udm4xFtvfT/hUwcOOOg==",
+        "resolved": "10.0.9",
+        "contentHash": "bUth5ip7YsZMXWZS42IRTI0zDrPEqdE+xnsmcL0Pk784grWKApDvc5UoMi2tP2qYJ5ylFzeVDuDu08sFATq1bg==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration": "10.0.0",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.0"
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
         }
       },
       "Microsoft.Extensions.Logging.Console": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "treWetuksp8LVb09fCJ5zNhNJjyDkqzVm83XxcrlWQnAdXznR140UUXo8PyEPBvFlHhjKhFQZEOP3Sk/ByCvEw==",
+        "resolved": "10.0.9",
+        "contentHash": "WyZEG/O8jKqBOBF6/M6IJqiEyWFBUv6PDyzNoXDA0mBZwKtkuf7GiZ/0/8eU8OpLKKQL0O95oPOY1szrWIKofQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
         }
       },
       "Microsoft.Extensions.Logging.Debug": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "A/4vBtVaySLBGj4qluye+KSbeVCCMa6GcTbxf2YgnSDHs9b9105+VojBJ1eJPel8F1ny0JOh+Ci3vgCKn69tNQ==",
+        "resolved": "10.0.9",
+        "contentHash": "r/A0ahpXmZH/8ltPjrFFWp12BIizK9cCVJXPcHyOad8e4eIX7P/geW+uBYdczkeCAaMebT4jEU7snOm4GnmKfA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
         }
       },
       "Microsoft.Extensions.Logging.EventLog": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "EWda5nSXhzQZr3yJ3+XgIApOek+Hm+txhWCEzWNVPp/OfimL4qmvctgXu87m+S2RXw/AoUP8aLMNicJ2KWblVA==",
+        "resolved": "10.0.9",
+        "contentHash": "goAl30/WwmdnWDPRwATaDPIK0iuDBnQSMTH2XYGVB1SwReg7hglhvDNjjpNhT25US3GF4I5q6BhTNs6nFYzEfg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "System.Diagnostics.EventLog": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "System.Diagnostics.EventLog": "10.0.9"
         }
       },
       "Microsoft.Extensions.Logging.EventSource": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "+Qc+kgoJi1w2A/Jm+7h04LcK2JoJkwAxKg7kBakkNRcemTmRGocqPa7rVNVGorTYruFrUS25GwkFNtOECnjhXg==",
+        "resolved": "10.0.9",
+        "contentHash": "tHynPVHbTicuaDpS2JVTxX0qA5VTg15CXgVKTwWvvudb5BvW5aVew8MMyek6LrDGAom7UbON1jf1T5GhpTilFA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -704,14 +720,14 @@
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "tL9cSl3maS5FPzp/3MtlZI21ExWhni0nnUCF8HY4npTsINw45n9SNDbkKXBMtFyUFGSsQep25fHIDN4f/Vp3AQ==",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
         "dependencies": {
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
         }
       },
       "Microsoft.Extensions.Primitives": {
@@ -1043,8 +1059,8 @@
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
+        "resolved": "10.0.9",
+        "contentHash": "s2PcxHK4IYQ6gmD3VSBkym9tWGkFisKjcjWBdl7a+n4Yy66ae4beJ1ZdjDp060SSll4W3Rt4H2LW87dWckv+QQ=="
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
@@ -1151,10 +1167,84 @@
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
         }
       },
+      "unifesspa.uniplus.configuracao.api": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Postgresql": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Domain": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.configuracao.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Confluent.Kafka": "[2.15.0, )",
+          "Confluent.SchemaRegistry": "[2.15.0, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.9, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Npgsql": "[10.0.3, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "Unifesspa.UniPlus.Configuracao.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )",
+          "WolverineFx.EntityFrameworkCore": "[5.39.5, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
+          "WolverineFx.Postgresql": "[5.39.5, )"
+        }
+      },
       "unifesspa.uniplus.governance.contracts": {
         "type": "Project",
         "dependencies": {
           "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.host": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.API": "[1.0.0, )",
+          "Unifesspa.UniPlus.Ingresso.API": "[1.0.0, )",
+          "Unifesspa.UniPlus.OrganizacaoInstitucional.API": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.API": "[1.0.0, )",
+          "Unifesspa.UniPlus.Selecao.API": "[1.0.0, )",
+          "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
       "unifesspa.uniplus.infrastructure.core": {
@@ -1195,8 +1285,104 @@
           "WolverineFx.Postgresql": "[5.39.5, )"
         }
       },
+      "unifesspa.uniplus.ingresso.api": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.Ingresso.Infrastructure": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.ingresso.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.ingresso.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.9, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Ingresso.Domain": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.integrationtests.fixtures": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.0.9, )",
+          "Testcontainers": "[4.13.0, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )",
+          "xunit": "[2.9.3, )"
+        }
+      },
       "unifesspa.uniplus.kernel": {
         "type": "Project"
+      },
+      "unifesspa.uniplus.monolito.testsupport": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.0.9, )",
+          "Testcontainers.PostgreSql": "[4.13.0, )",
+          "Unifesspa.UniPlus.Host": "[1.0.0, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.IntegrationTests.Fixtures": "[1.0.0, )",
+          "xunit": "[2.9.3, )"
+        }
+      },
+      "unifesspa.uniplus.organizacaoinstitucional.api": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.OrganizacaoInstitucional.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Postgresql": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.organizacaoinstitucional.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.OrganizacaoInstitucional.Domain": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.organizacaoinstitucional.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.organizacaoinstitucional.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.9, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.OrganizacaoInstitucional.Application": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.publicacoes.api": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Publicacoes.Infrastructure": "[1.0.0, )",
+          "WolverineFx": "[5.39.5, )"
+        }
       },
       "unifesspa.uniplus.publicacoes.application": {
         "type": "Project",
@@ -1224,6 +1410,48 @@
           "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Application": "[1.0.0, )",
           "Unifesspa.UniPlus.Publicacoes.Domain": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.selecao.api": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )",
+          "Unifesspa.UniPlus.Selecao.Infrastructure": "[1.0.0, )",
+          "WolverineFx.Kafka": "[5.39.5, )",
+          "WolverineFx.Postgresql": "[5.39.5, )"
+        }
+      },
+      "unifesspa.uniplus.selecao.application": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "FluentValidation.DependencyInjectionExtensions": "[12.1.1, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Configuracao.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "Unifesspa.UniPlus.Selecao.Domain": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.selecao.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.selecao.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.9, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.9, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.2, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Selecao.Application": "[1.0.0, )"
         }
       },
       "Apache.Avro": {


### PR DESCRIPTION
Closes #811 · Refs #798, #795

Terceira das quatro tasks da story. Expõe o cadastro de tipos de ato por HTTP, gera o baseline OpenAPI do módulo e a coleção Postman que a #812 vai consumir.

Nenhum projeto novo: a ADR-0097 fixa três executáveis, e o `Publicacoes.API` já era class library referenciada pelo host.

## Endpoints

| Verbo | Rota | Auth |
|---|---|---|
| `GET` | `/api/publicacoes/tipos-ato?vigentes=true` | anônimo |
| `GET` | `/api/publicacoes/tipos-ato/{id:guid}` | anônimo |
| `GET` | `/api/publicacoes/tipos-ato/{codigo}/vigente?data=` | anônimo |
| `POST` | `/api/publicacoes/admin/tipos-ato` | `plataforma-admin` |
| `PUT` | `/api/publicacoes/admin/tipos-ato/{id:guid}` | `plataforma-admin` |
| `DELETE` | `/api/publicacoes/admin/tipos-ato/{id:guid}` | `plataforma-admin` |

Leitura pública fora de `/admin`, escrita sob `/admin`. É a topologia de `ObrigatoriedadeLegalController` — o precedente mais próximo, porque também é um cadastro versionado por vigência.

## Três decisões que a revisão do plano corrigiu antes do código

### A listagem pública não expõe versões que não valem hoje

Uma versão de vigência futura é planejamento normativo ainda não anunciado. Listá-la a qualquer cliente a divulgaria antes do ato que a institui — e o mesmo raciocínio vale, invertido, para as encerradas. `vigentes=true` é o default, e `vigentes=false` devolve a série histórica a quem a pedir. É o que `ObrigatoriedadeLegal` já faz.

Provado por contraprova: com o default trocado para `false`, os dois testes novos falham.

### A idempotência estava **inoperante** no módulo

A #809 criou o `DbSet<IdempotencyEntry>` e a tabela `idempotency_cache`. Faltava `AddIdempotency<PublicacoesDbContext, PublicacoesApiAssemblyMarker>(configuration)` no `PublicacoesModuleRegistration` — sem ele, o `[RequiresIdempotencyKey]` do `POST` **compila e não faz nada**: a requisição sem header alcança o handler e devolve 201, e o replay reexecuta em vez de devolver a resposta cacheada.

O teste `POST sem Idempotency-Key retorna 400` é o que amarra isso, e o `POST com a mesma chave e corpo diferente retorna 422 body_mismatch` cobre o outro ramo da ADR-0027.

### O `PUT` **não** leva `[RequiresIdempotencyKey]`

A ADR-0027 é explícita: *"Endpoints `GET`, `PUT` puros (substituição completa, naturalmente idempotente), `DELETE` e `HEAD` **não** recebem o atributo."*

Ia copiar o `TiposDocumentoController`, que o marca. Levantei o repositório: **17 de 17** controllers com `PUT` carregam o atributo. Não é deslize isolado — é prática consolidada divergindo da decisão registrada. Segui a ADR, e a divergência foi para a **#815**: um `PUT` puro repetido é inócuo por construção, então o atributo não previne efeito acumulativo nenhum; só obriga um header e grava uma linha de cache com TTL de 24h por atualização. Conformar o código ou revisar a ADR é escolha do Tech Lead.

## O que os testes que falharam me ensinaram

Três testes de endpoint falharam na primeira execução, e os três estavam certos:

- **`Location` é absoluto**, não relativo.
- **Falha de FluentValidation vira 422**, não 400. No Uni+, o `GlobalExceptionMiddleware` escreve `422 uniplus.validacao` para `ValidationException`; o 400 fica para o que o binding recusa antes de o command existir. Meu plano dizia 400.

Daí a validação do código no boundary da rota: sem ela, `GET tipos-ato/edital_abertura/vigente` devolveria **404** — "este tipo não existe" — quando a verdade é "isto não é um código". Uma constraint de rota também daria 404; `[RegularExpression]` dá 400.

## Correções da revisão do diff

- **O erro de `Id` divergente passou a sair pelo mapeador de erros de domínio**, e não por um `ProblemDetails` montado à mão. Assim carrega `type`, `instance` e `traceId`, como o resto do contrato. O teste assere o `type`, não só o status.
- **O teste de isolamento do OpenAPI foi generalizado por módulo.** Estava fixo em Configuração: preso a um só, o teste de não-vazamento passaria por vacuidade para qualquer documento vazio, porque um documento sem paths não vaza nada.

## Validação

Cada asserção estrutural foi provada por contraprova antes de valer como evidência.

| O que | Como |
|---|---|
| O `GroupName` por módulo é o que impede o vazamento | Removi Publicações do `ModuleApiGroupingConvention`: os endpoints vazaram para os documentos de configuracao, organizacao e selecao, e os três testes falharam. |
| O teste "contém os próprios endpoints" não é vácuo | Troquei a rota do controller para `api/rota-errada`: só o caso `publicacoes` falhou. |
| O default `vigentes=true` protege a listagem | Troquei para `false`: os dois testes de exposição falharam. |
| A coleção Postman é executável | `npx newman` contra a stack real: 13 requisições, 21 asserções, zero falhas. Ele pegou um bug meu — o request que testa a ausência do `Idempotency-Key` estava enviando o header. |

- `dotnet build UniPlus.slnx` — 0 warnings (`TreatWarningsAsErrors`).
- `dotnet test UniPlus.slnx` — 23 projetos, nenhuma falha. `Host.IntegrationTests` foi de 26 a 30 testes.
- 48 testes de integração do módulo (endpoints, persistência, corrida, OpenAPI).
- `spectral lint` — 0 errors (o CI usa `--fail-severity=error`).
- HATEOAS asserido pelo **valor** dos links, não pela presença: um `LinkGenerator` apontando para a action errada passaria por qualquer teste de status.

## Follow-up aberto

**#816** — os cinco baselines OpenAPI não declaram o vendor media type nas respostas, nem `components.securitySchemes`, nem o header `Location` do 201. É lacuna do gerador compartilhado, não deste módulo; corrigir num só baseline produziria a inconsistência oposta. A regra Spectral que a própria ADR-0028 promete não existe — se existisse, os cinco falhariam.
