### PR TITLE
feat(publicacoes): registra os 16 tipos de ato por seed e trava a ADR-0103

### DIFF
--- a/docker/keycloak/realm-export-dev-local.json
+++ b/docker/keycloak/realm-export-dev-local.json
@@ -1251,6 +1251,35 @@
         "offline_access",
         "microprofile-jwt"
       ]
+    },
+    {
+      "clientId": "uniplus-api-bootstrap",
+      "name": "Uni+ — bootstrap de catálogos (seed)",
+      "description": "Service account usada pelo seed de catálogos (ADR-0062). Obtém token plataforma-admin via client_credentials e faz POST nos endpoints admin. Secret de desenvolvimento; em standalone/HML/PROD vem do uniplus-infra.",
+      "enabled": true,
+      "publicClient": false,
+      "bearerOnly": false,
+      "serviceAccountsEnabled": true,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "secret": "bootstrap-dev-secret",
+      "protocol": "openid-connect",
+      "attributes": {
+        "use.refresh.tokens": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "uniplus-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "uniplus",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
     }
   ],
   "clientScopes": [
@@ -3229,6 +3258,14 @@
         }
       ],
       "requiredActions": []
+    },
+    {
+      "username": "service-account-uniplus-api-bootstrap",
+      "enabled": true,
+      "serviceAccountClientId": "uniplus-api-bootstrap",
+      "realmRoles": [
+        "plataforma-admin"
+      ]
     }
   ],
   "eventsExpiration": 2592000

--- a/seeds/seed-tipos-ato.json
+++ b/seeds/seed-tipos-ato.json
@@ -1,0 +1,162 @@
+[
+  {
+    "codigo": "EDITAL_ABERTURA",
+    "nome": "Edital de abertura",
+    "congelaConfiguracao": true,
+    "unicoPorObjeto": true,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "EDITAL_RETIFICACAO",
+    "nome": "Edital de retificação",
+    "congelaConfiguracao": true,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "AVISO",
+    "nome": "Aviso",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "COMUNICADO",
+    "nome": "Comunicado",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "CONVOCACAO",
+    "nome": "Convocação",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "HOMOLOGACAO_INSCRICOES",
+    "nome": "Homologação das inscrições",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": true,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "HOMOLOGACAO_ANALISE_DOCUMENTAL",
+    "nome": "Homologação da análise documental",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "HOMOLOGACAO_RECURSOS",
+    "nome": "Homologação dos recursos",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "RESULTADO_PRELIMINAR",
+    "nome": "Resultado preliminar",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "RESULTADO_FINAL",
+    "nome": "Resultado final",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": true,
+    "efeitoIrreversivel": true,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "LISTA_ESPERA",
+    "nome": "Lista de espera",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "CONFIRMACAO_INTERESSE",
+    "nome": "Confirmação de interesse",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "GABARITO_PRELIMINAR",
+    "nome": "Gabarito preliminar",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "GABARITO_DEFINITIVO",
+    "nome": "Gabarito definitivo",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": true,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "CHAMADA",
+    "nome": "Chamada",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  },
+  {
+    "codigo": "ERRATA",
+    "nome": "Errata",
+    "congelaConfiguracao": false,
+    "unicoPorObjeto": false,
+    "efeitoIrreversivel": false,
+    "vigenciaInicio": "2026-01-01",
+    "vigenciaFim": null,
+    "baseLegal": null
+  }
+]

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/PublicacoesSemRamificacaoPorTipoAtoTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/PublicacoesSemRamificacaoPorTipoAtoTests.cs
@@ -1,0 +1,236 @@
+namespace Unifesspa.UniPlus.ArchTests.SolutionRules;
+
+using System.IO;
+using System.Text.RegularExpressions;
+
+using AwesomeAssertions;
+
+using TestSupport;
+
+/// <summary>
+/// Fitness function da ADR-0103: nenhuma regra do módulo Publicações ramifica
+/// comportamento pelo código do tipo de ato. Acrescentar <c>CONVOCACAO</c>,
+/// <c>LISTA_ESPERA</c> ou <c>HOMOLOGACAO_ANALISE_DOCUMENTAL</c> deve ser linha de
+/// cadastro — jamais um PR no domínio.
+/// </summary>
+/// <remarks>
+/// <para>Os três atributos de consequência (<c>congela_configuracao</c>,
+/// <c>unico_por_objeto</c>, <c>efeito_irreversivel</c>) são dados lidos e copiados
+/// por valor. Um <c>if (tipo.Codigo == "CONVOCACAO")</c> é a violação: reencarna no
+/// documento a ramificação por tipo que o projeto proibiu no processo seletivo.</para>
+/// <para>Duas armadilhas que este teste evita, e que a ausência de detecção esconderia:</para>
+/// <list type="number">
+///   <item>Um diretório inexistente (path errado, projeto renomeado) faria a varredura
+///     não ler arquivo nenhum e passar. Por isso a existência dos roots e a contagem
+///     mínima de arquivos examinados são <b>asseridas</b>, não pressupostas.</item>
+///   <item>Uma consulta de detecção errada nunca acusaria nada. Por isso o detector é
+///     alimentado primeiro com uma violação plantada, e só depois de acusá-la é que a
+///     sua ausência sobre o código real vale como evidência.</item>
+/// </list>
+/// <para>Comentários são ignorados: o próprio <c>TipoAtoPublicado</c> cita a violação
+/// na sua documentação, e a mensagem de erro de formato usa <c>EDITAL_ABERTURA</c>
+/// como exemplo. Nenhum dos dois ramifica coisa alguma — e a mensagem escapa porque a
+/// regra procura o literal <b>inteiro</b> em UPPER_SNAKE, não o trecho dentro de uma frase.</para>
+/// </remarks>
+public sealed partial class PublicacoesSemRamificacaoPorTipoAtoTests
+{
+    /// <summary>
+    /// Literal de string cujo conteúdo inteiro é UPPER_SNAKE — a forma de todo código
+    /// de tipo de ato.
+    /// </summary>
+    /// <remarks>
+    /// Deliberadamente <b>independente de sintaxe</b>. Detectar por posição
+    /// (<c>== "X"</c>, <c>case "X"</c>) deixa passar o mesmo ramo escrito de outro jeito:
+    /// <c>"X" == tipo.Codigo</c>, <c>tipo.Codigo switch { "X" =&gt; … }</c>,
+    /// <c>tipo.Codigo is "X"</c>, <c>static readonly string X = "X"</c>. Proibir o
+    /// literal em qualquer posição fecha todas de uma vez, e o custo é ter de justificar
+    /// um literal legítimo caso apareça — hoje não há nenhum.
+    /// </remarks>
+    [GeneratedRegex(@"""[A-Z]+(_[A-Z]+)*""")]
+    private static partial Regex LiteralDeTipo();
+
+    /// <summary>Literal UPPER_SNAKE dentro de SQL cru — índice ou CHECK filtrando por tipo.</summary>
+    [GeneratedRegex(@"'[A-Z]+(_[A-Z]+)*'")]
+    private static partial Regex LiteralEmSql();
+
+    private static readonly string[] Camadas =
+    [
+        "Unifesspa.UniPlus.Publicacoes.Domain",
+        "Unifesspa.UniPlus.Publicacoes.Application",
+        "Unifesspa.UniPlus.Publicacoes.Infrastructure",
+        "Unifesspa.UniPlus.Publicacoes.API",
+    ];
+
+    [Theory(DisplayName = "O detector acusa a ramificação escrita de qualquer forma — canários C#")]
+    [InlineData(@"if (tipo.Codigo == ""CONVOCACAO"") { return 0.5m; }")]
+    [InlineData(@"if (""CONVOCACAO"" == tipo.Codigo) { return 0.5m; }")]
+    [InlineData(@"if (tipo.Codigo != ""CONVOCACAO"") { return 0m; }")]
+    [InlineData(@"if (tipo.Codigo.Equals(""CONVOCACAO"", StringComparison.Ordinal)) { return 0.5m; }")]
+    [InlineData(@"if (string.Equals(""CONVOCACAO"", tipo.Codigo, StringComparison.Ordinal)) { return 0.5m; }")]
+    [InlineData(@"switch (tipo.Codigo) { case ""RESULTADO_FINAL"": return 1.0m; }")]
+    [InlineData(@"return tipo.Codigo switch { ""CONVOCACAO"" => 0.5m, _ => 0m };")]
+    [InlineData(@"if (tipo.Codigo is ""CONVOCACAO"") { return 0.5m; }")]
+    [InlineData(@"if (tipo.Codigo is not ""CONVOCACAO"") { return 0m; }")]
+    [InlineData(@"private const string Convocacao = ""CONVOCACAO"";")]
+    [InlineData(@"private static readonly string Convocacao = ""CONVOCACAO"";")]
+    [InlineData(@"private static readonly string[] Congelantes = [""EDITAL_ABERTURA""];")]
+    public void Detector_AcusaViolacaoPlantada(string canario)
+    {
+        ArgumentNullException.ThrowIfNull(canario);
+
+        // Sem esta asserção, a ausência de achados sobre o código real não significaria nada.
+        // Cada linha é o mesmo ramo por tipo, escrito de um jeito que uma detecção
+        // posicional deixaria passar.
+        Violacoes(canario, LiteralDeTipo()).Should().NotBeEmpty();
+    }
+
+    [Theory(DisplayName = "O detector não acusa o que não é código de tipo")]
+    [InlineData(@"private const string CodigoPattern = ""^[A-Z]+(_[A-Z]+)*$"";")]
+    [InlineData(@"private const string ExclusionViolationSqlState = ""23P01"";")]
+    [InlineData(@"private const string VigenciaConstraint = ""ex_tipo_ato_publicado_codigo_vigencia"";")]
+    [InlineData(@"public const string Schema = ""publicacoes"";")]
+    [InlineData(@"return Result.Failure(new DomainError(Codes.CodigoFormato, ""Use UPPER_SNAKE (ex.: EDITAL_ABERTURA)."");")]
+    public void Detector_NaoAcusaFalsoPositivo(string trecho)
+    {
+        ArgumentNullException.ThrowIfNull(trecho);
+
+        // O agregado documenta a violação e a mensagem de erro usa um código como
+        // exemplo. Nenhum dos dois ramifica coisa alguma.
+        Violacoes(trecho, LiteralDeTipo()).Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "O detector acusa um literal de tipo em SQL cru — canário SQL")]
+    public void Detector_AcusaLiteralEmSql()
+    {
+        const string canario = """
+            migrationBuilder.Sql("CREATE INDEX ix ON t (id) WHERE codigo = 'CONVOCACAO';");
+            """;
+
+        Violacoes(canario, LiteralEmSql()).Should().ContainSingle();
+    }
+
+    [Fact(DisplayName = "ADR-0103: nenhum arquivo de Publicações ramifica por código de tipo de ato")]
+    public void Publicacoes_NaoRamificaPorCodigoDeTipo()
+    {
+        string solutionRoot = SolutionRootLocator.Locate();
+        List<string> violacoes = [];
+        int arquivosExaminados = 0;
+
+        foreach (string camada in Camadas)
+        {
+            string root = Path.Combine(solutionRoot, "src", "publicacoes", camada);
+
+            // Um root inexistente faria a varredura passar sem ler nada.
+            Directory.Exists(root).Should().BeTrue($"a camada {camada} precisa existir para ser varrida");
+
+            foreach (string arquivo in ArquivosFonte(root))
+            {
+                arquivosExaminados++;
+                string codigo = SemComentarios(File.ReadAllLines(arquivo));
+
+                foreach (Match m in LiteralDeTipo().Matches(codigo))
+                {
+                    violacoes.Add($"{Path.GetRelativePath(solutionRoot, arquivo)}: {m.Value.Trim()}");
+                }
+            }
+        }
+
+        arquivosExaminados.Should().BeGreaterThan(20, "as quatro camadas juntas têm dezenas de arquivos");
+
+        violacoes.Should().BeEmpty(
+            "acrescentar um tipo de ato deve ser linha de cadastro (ADR-0103); "
+            + "os três atributos de consequência são dados lidos, nunca ramos de comportamento");
+    }
+
+    [Fact(DisplayName = "ADR-0103: nenhuma migration de Publicações filtra por código de tipo de ato")]
+    public void Migrations_NaoFiltramPorCodigoDeTipo()
+    {
+        string solutionRoot = SolutionRootLocator.Locate();
+        string root = Path.Combine(
+            solutionRoot, "src", "publicacoes",
+            "Unifesspa.UniPlus.Publicacoes.Infrastructure", "Persistence", "Migrations");
+
+        Directory.Exists(root).Should().BeTrue("as migrations do módulo precisam existir");
+
+        List<string> violacoes = [];
+        int arquivosExaminados = 0;
+
+        foreach (string arquivo in ArquivosFonte(root))
+        {
+            arquivosExaminados++;
+            string codigo = SemComentarios(File.ReadAllLines(arquivo));
+
+            foreach (Match m in LiteralEmSql().Matches(codigo))
+            {
+                violacoes.Add($"{Path.GetRelativePath(solutionRoot, arquivo)}: {m.Value}");
+            }
+        }
+
+        arquivosExaminados.Should().BeGreaterThan(0, "há ao menos uma migration no módulo");
+
+        violacoes.Should().BeEmpty(
+            "um índice ou CHECK filtrando por literal de tipo tornaria o cadastro dependente de deploy");
+    }
+
+    private static IEnumerable<string> ArquivosFonte(string root) =>
+        Directory
+            .EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(static p => !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(static p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+    private static IReadOnlyList<string> Violacoes(string codigo, Regex detector) =>
+        [.. detector.Matches(SemComentarios(codigo.Split('\n'))).Select(m => m.Value)];
+
+    /// <summary>
+    /// Remove comentários de linha e de bloco. A documentação do agregado cita a
+    /// violação como exemplo do que é proibido; contá-la seria acusar o texto que
+    /// explica a regra.
+    /// </summary>
+    private static string SemComentarios(IReadOnlyList<string> linhas)
+    {
+        System.Text.StringBuilder sb = new();
+        bool emBloco = false;
+
+        foreach (string linha in linhas)
+        {
+            string atual = linha;
+
+            if (emBloco)
+            {
+                int fim = atual.IndexOf("*/", StringComparison.Ordinal);
+                if (fim < 0)
+                {
+                    continue;
+                }
+
+                atual = atual[(fim + 2)..];
+                emBloco = false;
+            }
+
+            int abre = atual.IndexOf("/*", StringComparison.Ordinal);
+            if (abre >= 0)
+            {
+                int fecha = atual.IndexOf("*/", abre + 2, StringComparison.Ordinal);
+                if (fecha < 0)
+                {
+                    emBloco = true;
+                    atual = atual[..abre];
+                }
+                else
+                {
+                    atual = atual[..abre] + atual[(fecha + 2)..];
+                }
+            }
+
+            int linhaComentario = atual.IndexOf("//", StringComparison.Ordinal);
+            if (linhaComentario >= 0)
+            {
+                atual = atual[..linhaComentario];
+            }
+
+            sb.AppendLine(atual);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/SeedTiposAtoTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/SeedTiposAtoTests.cs
@@ -107,6 +107,11 @@ public sealed partial class SeedTiposAtoTests
 
     private static LinhaSeed[] Carregar()
     {
+        // Path.Combine descarta os segmentos anteriores quando um deles é enraizado.
+        // O precedente é OpenApiEndpointTests.ResolveRepoPath, que valida o mesmo.
+        Path.IsPathRooted(CaminhoRelativo).Should().BeFalse(
+            "o caminho do seed é relativo à raiz do repositório");
+
         string caminho = Path.Combine(SolutionRootLocator.Locate(), CaminhoRelativo);
 
         File.Exists(caminho).Should().BeTrue($"o seed dos tipos de ato precisa existir em {CaminhoRelativo}");

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/SeedTiposAtoTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/SeedTiposAtoTests.cs
@@ -1,0 +1,133 @@
+namespace Unifesspa.UniPlus.ArchTests.SolutionRules;
+
+using System.IO;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+using AwesomeAssertions;
+
+using TestSupport;
+
+/// <summary>
+/// Guarda o arquivo de seed dos tipos de ato (<c>seeds/seed-tipos-ato.json</c>) contra
+/// edições que passariam despercebidas: um código fora do formato, uma janela de
+/// vigência incoerente, ou a quebra da invariante da ADR-0103.
+/// </summary>
+/// <remarks>
+/// Estes testes leem o **arquivo real**. Um teste que construísse os dados em memória
+/// e os verificasse contra si mesmo passaria por construção, e trocar um valor no JSON
+/// não o quebraria — que é exatamente o acidente contra o qual o arquivo precisa de
+/// proteção.
+/// </remarks>
+public sealed partial class SeedTiposAtoTests
+{
+    [GeneratedRegex(@"^[A-Z]+(_[A-Z]+)*$")]
+    private static partial Regex FormatoCodigo();
+
+    private const string CaminhoRelativo = "seeds/seed-tipos-ato.json";
+
+    private static readonly JsonSerializerOptions Opcoes = new(JsonSerializerDefaults.Web);
+
+    [Fact(DisplayName = "O arquivo de seed existe e traz os 16 tipos de ato")]
+    public void Seed_TrazOsDezesseisTipos()
+    {
+        LinhaSeed[] linhas = Carregar();
+
+        linhas.Should().HaveCount(16);
+        linhas.Select(l => l.Codigo).Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact(DisplayName = "Todo código do seed respeita o formato que o agregado exige")]
+    public void Seed_CodigosNoFormatoUpperSnake()
+    {
+        foreach (LinhaSeed linha in Carregar())
+        {
+            FormatoCodigo().IsMatch(linha.Codigo).Should().BeTrue(
+                $"'{linha.Codigo}' precisa ser UPPER_SNAKE, senão o POST do seed volta 422");
+        }
+    }
+
+    [Fact(DisplayName = "Todo tipo do seed nasce com vigência aberta")]
+    public void Seed_VigenciaAberta()
+    {
+        foreach (LinhaSeed linha in Carregar())
+        {
+            linha.VigenciaInicio.Should().Be("2026-01-01", $"{linha.Codigo} deve compartilhar o início de vigência");
+            linha.VigenciaFim.Should().BeNull($"{linha.Codigo} não pode nascer encerrado");
+        }
+    }
+
+    [Fact(DisplayName = "Todo tipo do seed tem nome em pt-BR, não derivado do código")]
+    public void Seed_NomesExplicitos()
+    {
+        foreach (LinhaSeed linha in Carregar())
+        {
+            linha.Nome.Should().NotBeNullOrWhiteSpace();
+            linha.Nome.Should().NotBe(linha.Codigo, $"{linha.Codigo} precisa de um nome legível, não do próprio código");
+            linha.Nome.Length.Should().BeGreaterThanOrEqualTo(2);
+        }
+    }
+
+    [Fact(DisplayName = "ADR-0103: congela(retificador) == congela(retificado)")]
+    public void Seed_RetificadorECongelanteComoORetificado()
+    {
+        Dictionary<string, LinhaSeed> porCodigo = Carregar().ToDictionary(l => l.Codigo, StringComparer.Ordinal);
+
+        // Não é o rótulo do tipo que protege a integridade da configuração publicada
+        // (RN08), é a classe de congelamento. Se um edital de abertura congela e a sua
+        // retificação não, a retificação deixaria de produzir a nova versão congelada —
+        // e nenhum teste de endpoint perceberia.
+        porCodigo.Should().ContainKey("EDITAL_ABERTURA");
+        porCodigo.Should().ContainKey("EDITAL_RETIFICACAO");
+
+        porCodigo["EDITAL_RETIFICACAO"].CongelaConfiguracao
+            .Should().Be(porCodigo["EDITAL_ABERTURA"].CongelaConfiguracao);
+
+        porCodigo["EDITAL_ABERTURA"].CongelaConfiguracao.Should().BeTrue(
+            "o edital de abertura é o ato que congela a configuração do certame");
+    }
+
+    [Fact(DisplayName = "Só os atos que encerram um resultado têm efeito irreversível")]
+    public void Seed_EfeitoIrreversivelRestrito()
+    {
+        IReadOnlyList<string> irreversiveis =
+            [.. Carregar().Where(l => l.EfeitoIrreversivel).Select(l => l.Codigo).Order(StringComparer.Ordinal)];
+
+        irreversiveis.Should().BeEquivalentTo(["GABARITO_DEFINITIVO", "RESULTADO_FINAL"]);
+    }
+
+    [Fact(DisplayName = "Só os atos que o objeto admite uma vez são únicos por objeto")]
+    public void Seed_UnicoPorObjetoRestrito()
+    {
+        IReadOnlyList<string> unicos =
+            [.. Carregar().Where(l => l.UnicoPorObjeto).Select(l => l.Codigo).Order(StringComparer.Ordinal)];
+
+        unicos.Should().BeEquivalentTo(["EDITAL_ABERTURA", "HOMOLOGACAO_INSCRICOES", "RESULTADO_FINAL"]);
+    }
+
+    private static LinhaSeed[] Carregar()
+    {
+        string caminho = Path.Combine(SolutionRootLocator.Locate(), CaminhoRelativo);
+
+        File.Exists(caminho).Should().BeTrue($"o seed dos tipos de ato precisa existir em {CaminhoRelativo}");
+
+        LinhaSeed[]? linhas = JsonSerializer.Deserialize<LinhaSeed[]>(File.ReadAllText(caminho), Opcoes);
+
+        linhas.Should().NotBeNull();
+        return linhas!;
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Performance",
+        "CA1812:Avoid uninstantiated internal classes",
+        Justification = "Instanciada por System.Text.Json ao desserializar o arquivo de seed.")]
+    private sealed record LinhaSeed(
+        string Codigo,
+        string Nome,
+        bool CongelaConfiguracao,
+        bool UnicoPorObjeto,
+        bool EfeitoIrreversivel,
+        string VigenciaInicio,
+        string? VigenciaFim,
+        string? BaseLegal);
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/PrincipioDoCadastroTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/PrincipioDoCadastroTests.cs
@@ -1,0 +1,164 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.TiposAtoPublicado;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// O princípio da ADR-0103, exercitado pela API: acrescentar um tipo de ato é linha
+/// de cadastro, e dois tipos com a mesma configuração comportam-se identicamente.
+/// </summary>
+/// <remarks>
+/// <para>A prova estrutural — nenhum <c>if</c> por código de tipo em
+/// <c>src/publicacoes/</c> — vive no fitness test
+/// <c>PublicacoesSemRamificacaoPorTipoAtoTests</c>. Aqui prova-se o comportamento:
+/// um código nunca visto pelo código-fonte percorre todo o ciclo de vida sem que
+/// nada precise saber o que ele significa.</para>
+/// <para>Se um ramo por código existisse, os dois tipos desta suíte divergiriam —
+/// e nenhum teste de status os pegaria, porque ambos responderiam 200.</para>
+/// </remarks>
+[Collection(PublicacoesEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class PrincipioDoCadastroTests
+{
+    private const string Base = "/api/publicacoes/tipos-ato";
+    private const string Admin = "/api/publicacoes/admin/tipos-ato";
+
+    private readonly PublicacoesEndpointFixture _fixture;
+
+    public PrincipioDoCadastroTests(PublicacoesEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Dois tipos com a mesma configuração comportam-se identicamente")]
+    public async Task DoisTiposComMesmaConfiguracao_SaoIndistinguiveis()
+    {
+        string alfa = CodigoUnico();
+        string beta = CodigoUnico();
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid idAlfa = await CriarAsync(client, alfa, congela: true, unico: true, irreversivel: true);
+        Guid idBeta = await CriarAsync(client, beta, congela: true, unico: true, irreversivel: true);
+
+        JsonElement corpoAlfa = await LerAsync(client, $"{Base}/{idAlfa}");
+        JsonElement corpoBeta = await LerAsync(client, $"{Base}/{idBeta}");
+
+        // Mesmas chaves, mesma forma. O que varia é a identidade e o rótulo.
+        Nomes(corpoAlfa).Should().BeEquivalentTo(Nomes(corpoBeta));
+
+        foreach (string campo in new[] { "congelaConfiguracao", "unicoPorObjeto", "efeitoIrreversivel" })
+        {
+            corpoAlfa.GetProperty(campo).GetBoolean()
+                .Should().Be(corpoBeta.GetProperty(campo).GetBoolean(), $"{campo} foi informado igual nos dois");
+        }
+
+        // E o mesmo vale para a resolução por data e para o ciclo de escrita.
+        (await LerAsync(client, $"{Base}/{alfa}/vigente")).GetProperty("id").GetGuid().Should().Be(idAlfa);
+        (await LerAsync(client, $"{Base}/{beta}/vigente")).GetProperty("id").GetGuid().Should().Be(idBeta);
+
+        (await RemoverAsync(client, idAlfa)).Should().Be(await RemoverAsync(client, idBeta));
+    }
+
+    [Fact(DisplayName = "Um código que o código-fonte nunca viu percorre o ciclo de vida inteiro")]
+    public async Task CodigoDesconhecido_PercorreOCicloDeVida()
+    {
+        // Nenhum arquivo de src/publicacoes/ conhece este código. Se acrescentar um
+        // tipo exigisse alteração no domínio, este teste falharia.
+        string codigo = CodigoUnico();
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid id = await CriarAsync(client, codigo, congela: false, unico: false, irreversivel: false);
+
+        (await LerAsync(client, $"{Base}/{id}")).GetProperty("codigo").GetString().Should().Be(codigo);
+        (await LerAsync(client, $"{Base}/{codigo}/vigente")).GetProperty("id").GetGuid().Should().Be(id);
+
+        using HttpRequestMessage put = new(HttpMethod.Put, new Uri($"{Admin}/{id}", UriKind.Relative));
+        Autenticar(put);
+        put.Content = JsonContent.Create(new
+        {
+            id,
+            codigo,
+            nome = "Renomeado sem que nada saiba o que ele é",
+            congelaConfiguracao = true,
+            unicoPorObjeto = true,
+            efeitoIrreversivel = true,
+            vigenciaInicio = "2026-01-01",
+            vigenciaFim = (string?)null,
+        });
+        (await client.SendAsync(put)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        JsonElement atualizado = await LerAsync(client, $"{Base}/{id}");
+        atualizado.GetProperty("congelaConfiguracao").GetBoolean().Should().BeTrue(
+            "os atributos de consequência são dados: mudam por PUT, não por deploy");
+
+        (await RemoverAsync(client, id)).Should().Be(HttpStatusCode.NoContent);
+    }
+
+    private static void Autenticar(HttpRequestMessage request)
+    {
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+    }
+
+    private static async Task<Guid> CriarAsync(
+        HttpClient client, string codigo, bool congela, bool unico, bool irreversivel)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(Admin, UriKind.Relative));
+        Autenticar(request);
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(new
+        {
+            codigo,
+            nome = "Tipo de ato de teste",
+            congelaConfiguracao = congela,
+            unicoPorObjeto = unico,
+            efeitoIrreversivel = irreversivel,
+            vigenciaInicio = "2026-01-01",
+            vigenciaFim = (string?)null,
+        });
+
+        HttpResponseMessage response = await client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        return JsonSerializer.Deserialize<Guid>(await response.Content.ReadAsStringAsync());
+    }
+
+    private static async Task<JsonElement> LerAsync(HttpClient client, string url)
+    {
+        HttpResponseMessage response = await client.GetAsync(new Uri(url, UriKind.Relative));
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.Clone();
+    }
+
+    private static async Task<HttpStatusCode> RemoverAsync(HttpClient client, Guid id)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Delete, new Uri($"{Admin}/{id}", UriKind.Relative));
+        Autenticar(request);
+
+        return (await client.SendAsync(request)).StatusCode;
+    }
+
+    private static IReadOnlyList<string> Nomes(JsonElement corpo) =>
+        [.. corpo.EnumerateObject().Select(p => p.Name).Order(StringComparer.Ordinal)];
+
+    private static string CodigoUnico()
+    {
+        string hex = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)[..12];
+        return "PRINCIPIO_" + string.Concat(hex.Select(c => (char)('A' + Convert.ToInt32(c.ToString(), 16))));
+    }
+}

--- a/tools/seeds/README.md
+++ b/tools/seeds/README.md
@@ -18,6 +18,24 @@ Pré-requisito no dev: a stack de smoke no ar (API em `:5200`, Keycloak em `:808
 
 O `run.sh` propaga o exit code do Newman — um seed que falha derruba o passo de bootstrap do pipeline.
 
+### Fora do dev
+
+Os templates `standalone` e `hml` trazem apenas o que é público. O secret do client de bootstrap **não é versionado**: vem do `uniplus-infra`, por variável de ambiente.
+
+```bash
+BOOTSTRAP_CLIENT_SECRET=*** ENV=standalone bash tools/seeds/run.sh
+```
+
+Sem ele, o script para antes de chamar o Newman e nomeia a causa — em vez de deixar o token endpoint devolver 401 e a falha aparecer no primeiro request.
+
+Um ambiente inteiro pode vir de fora do repositório, montado pelo pipeline:
+
+```bash
+SEED_ENV_FILE=/run/secrets/prod.postman_environment.json bash tools/seeds/run.sh
+```
+
+Qualquer variável do ambiente pode ser sobrescrita sem editar arquivo: `BASE_URL`, `KEYCLOAK_TOKEN_URL`, `BOOTSTRAP_CLIENT_ID`, `BOOTSTRAP_CLIENT_SECRET`.
+
 ## Reexecutar é seguro, e não pelo motivo óbvio
 
 Cada linha faz **preflight**: consulta `GET /tipos-ato/{codigo}/vigente` antes de escrever. Se o tipo já existe, **todos** os campos são comparados com o arquivo de seed — código, nome, os três atributos de consequência, a janela de vigência e a base legal — e o `POST` é **pulado**. Se qualquer um divergir, o seed **falha**, em vez de sobrescrever em silêncio ou de aceitar uma linha que não é a que o arquivo declara.
@@ -36,7 +54,7 @@ Por isso a chave é `{{$guid}}`, gerada por execução, e o request assere que a
 
 `client_credentials` contra o Keycloak, com o client confidencial `uniplus-api-bootstrap` (service account com a realm role `plataforma-admin`). O token é cacheado na coleção até 60 s antes de expirar.
 
-Em `dev`, o client e o secret vivem no realm export versionado (`docker/keycloak/realm-export-dev-local.json`) — são credenciais de desenvolvimento, sem valor fora da máquina local. Em **standalone, HML e PROD** o client é precondição de deploy e o secret vem do `uniplus-infra`: **nunca** versionado neste repositório.
+Em `dev`, o client e o secret vivem no realm export versionado (`docker/keycloak/realm-export-dev-local.json`) — são credenciais de desenvolvimento, sem valor fora da máquina local. Em **standalone, HML e PROD** o client é precondição de deploy e o secret vem do `uniplus-infra`, por `BOOTSTRAP_CLIENT_SECRET`: **nunca** versionado neste repositório.
 
 ## Estrutura
 
@@ -44,10 +62,14 @@ Em `dev`, o client e o secret vivem no realm export versionado (`docker/keycloak
 seeds/
   seed-tipos-ato.json                     ← dados: array flat, camelCase, um objeto por linha
 tools/seeds/
-  seed-catalogos.postman_collection.json  ← um folder por catálogo (preflight + POST)
-  envs/dev.postman_environment.json
+  seed-catalogos.postman_collection.json  ← um folder por catálogo (preflight + POST + releitura)
+  envs/dev.postman_environment.json        ← secret de desenvolvimento, sem valor fora da máquina local
+  envs/standalone.postman_environment.json ← secret vazio: vem do uniplus-infra
+  envs/hml.postman_environment.json        ← idem
   run.sh
 ```
+
+O corpo do `POST` é montado a partir da linha do arquivo, campo a campo, e o request **relê o recurso criado** pelo `Location` para conferir o que foi de fato gravado. O `POST` devolve só o `id`: sem a releitura, um corpo incompleto persistiria valores errados e o Newman reportaria sucesso.
 
 O Newman é **pinado por versão exata** no `run.sh`. Um bootstrap cuja ferramenta muda sozinha entre execuções não é bootstrap.
 

--- a/tools/seeds/README.md
+++ b/tools/seeds/README.md
@@ -1,0 +1,62 @@
+# Seed de catálogos
+
+Bootstrap dos cadastros administráveis, conforme a [ADR-0062](../../docs/adrs/0062-seed-de-catalogos-via-newman-e-endpoints-admin.md).
+
+Cada linha entra pelos **endpoints admin da API**, não por `HasData`/`InsertData`. A diferença não é estética: `InsertData` grava direto na tabela, fabrica um `CreatedBy` sintético e passa por fora do `AuditableInterceptor`. Pelo endpoint, a linha percorre validação, invariantes de domínio e auditoria como qualquer outra escrita, e o `CreatedBy` fica sendo o `sub` do service account — o que torna a trilha legível: linhas do bootstrap distinguem-se das que um humano cadastrou pela UI.
+
+## Uso
+
+```bash
+# Todos os catálogos, ambiente dev (stack local em :5200)
+ENV=dev bash tools/seeds/run.sh
+
+# Um catálogo específico
+ENV=dev CATALOG="Tipos de ato" bash tools/seeds/run.sh
+```
+
+Pré-requisito no dev: a stack de smoke no ar (API em `:5200`, Keycloak em `:8080`, realm `unifesspa-dev-local`). Ver `CONTRIBUTING.md`, seção *Smoke / Newman*.
+
+O `run.sh` propaga o exit code do Newman — um seed que falha derruba o passo de bootstrap do pipeline.
+
+## Reexecutar é seguro, e não pelo motivo óbvio
+
+Cada linha faz **preflight**: consulta `GET /tipos-ato/{codigo}/vigente` antes de escrever. Se o tipo já existe, **todos** os campos são comparados com o arquivo de seed — código, nome, os três atributos de consequência, a janela de vigência e a base legal — e o `POST` é **pulado**. Se qualquer um divergir, o seed **falha**, em vez de sobrescrever em silêncio ou de aceitar uma linha que não é a que o arquivo declara.
+
+No script da coleção o pulo é `pm.execution.skipRequest()`. `setNextRequest(null)` não serviria: ele encerra a iteração **depois** que o request atual roda, e o `POST` chegaria ao servidor de qualquer forma.
+
+### Por que a `Idempotency-Key` **não** é derivada do código
+
+A ADR-0062 sugere `Idempotency-Key: {recurso}-{codigo}`, estável entre execuções. Isso é sutilmente perigoso aqui, e o motivo merece registro.
+
+O cache de idempotência guarda a resposta por 24 horas ([ADR-0027](../../docs/adrs/0027-idempotency-key-store-postgresql.md)). Considere: o seed roda, cria `AVISO`; alguém remove `AVISO` pela UI; o seed roda de novo no mesmo dia. O preflight devolve 404 — corretamente, o tipo não existe — e libera o `POST`. Com a chave estável, o `POST` casa a entrada em cache, recebe o **201 original de volta**, e nada é criado. O seed termina verde, e `AVISO` continua ausente.
+
+Por isso a chave é `{{$guid}}`, gerada por execução, e o request assere que a resposta **não** traz `Idempotency-Replayed: true`. A idempotência do seed vem do preflight; a chave existe apenas para satisfazer o `[RequiresIdempotencyKey]` do endpoint. Quem protege o retry de transporte é o próprio preflight: reexecutar depois de uma resposta perdida encontra o tipo criado e pula.
+
+## Autenticação
+
+`client_credentials` contra o Keycloak, com o client confidencial `uniplus-api-bootstrap` (service account com a realm role `plataforma-admin`). O token é cacheado na coleção até 60 s antes de expirar.
+
+Em `dev`, o client e o secret vivem no realm export versionado (`docker/keycloak/realm-export-dev-local.json`) — são credenciais de desenvolvimento, sem valor fora da máquina local. Em **standalone, HML e PROD** o client é precondição de deploy e o secret vem do `uniplus-infra`: **nunca** versionado neste repositório.
+
+## Estrutura
+
+```
+seeds/
+  seed-tipos-ato.json                     ← dados: array flat, camelCase, um objeto por linha
+tools/seeds/
+  seed-catalogos.postman_collection.json  ← um folder por catálogo (preflight + POST)
+  envs/dev.postman_environment.json
+  run.sh
+```
+
+O Newman é **pinado por versão exata** no `run.sh`. Um bootstrap cuja ferramenta muda sozinha entre execuções não é bootstrap.
+
+## Acrescentar um catálogo
+
+1. Criar `seeds/seed-<catalogo>.json`, no shape que o endpoint admin espera no body.
+2. Acrescentar um folder na coleção, com o par preflight + `POST`.
+3. Registrar o par no mapa `CATALOGOS` do `run.sh`.
+
+## Acrescentar um tipo de ato
+
+Uma linha em `seeds/seed-tipos-ato.json`, e rodar de novo. Se isso exigir tocar em `src/publicacoes/`, a [ADR-0103](../../docs/adrs/0103-ato-normativo-generalizado-retificacao-como-relacao.md) foi violada — e o fitness test `PublicacoesSemRamificacaoPorTipoAtoTests` deve ter acusado antes.

--- a/tools/seeds/envs/dev.postman_environment.json
+++ b/tools/seeds/envs/dev.postman_environment.json
@@ -1,0 +1,49 @@
+{
+  "id": "1a2b3c4d-0000-4000-8000-seeddev000001",
+  "name": "Uni+ Seed — dev (local)",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:5200",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "keycloak_token_url",
+      "value": "http://localhost:8080/realms/unifesspa-dev-local/protocol/openid-connect/token",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "bootstrap_client_id",
+      "value": "uniplus-api-bootstrap",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "bootstrap_client_secret",
+      "value": "bootstrap-dev-secret",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "access_token_expira_em",
+      "value": "0",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "deve_criar",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/tools/seeds/envs/hml.postman_environment.json
+++ b/tools/seeds/envs/hml.postman_environment.json
@@ -1,0 +1,49 @@
+{
+  "id": "1a2b3c4d-0000-4000-8000-seedhml000001",
+  "name": "Uni+ Seed — homologação",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "https://api-hml.uniplus.unifesspa.edu.br",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "keycloak_token_url",
+      "value": "https://auth-hml.uniplus.unifesspa.edu.br/realms/unifesspa/protocol/openid-connect/token",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "bootstrap_client_id",
+      "value": "uniplus-api-bootstrap",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "bootstrap_client_secret",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "access_token_expira_em",
+      "value": "0",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "deve_criar",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/tools/seeds/envs/standalone.postman_environment.json
+++ b/tools/seeds/envs/standalone.postman_environment.json
@@ -1,0 +1,49 @@
+{
+  "id": "1a2b3c4d-0000-4000-8000-seedstandalone",
+  "name": "Uni+ Seed — standalone",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "https://api.uniplus.unifesspa.edu.br",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "keycloak_token_url",
+      "value": "https://auth.uniplus.unifesspa.edu.br/realms/unifesspa/protocol/openid-connect/token",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "bootstrap_client_id",
+      "value": "uniplus-api-bootstrap",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "bootstrap_client_secret",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "access_token_expira_em",
+      "value": "0",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "deve_criar",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/tools/seeds/run.sh
+++ b/tools/seeds/run.sh
@@ -6,29 +6,75 @@
 # pelo mesmo AuditableInterceptor de qualquer escrita, e o CreatedBy é o `sub` do
 # service account — a trilha distingue o que veio do bootstrap do que veio da UI.
 #
-# Idempotente: cada linha faz preflight de leitura antes de escrever. Reexecutar é
-# seguro a qualquer momento, inclusive depois das 24h de TTL do cache de
-# idempotência (ADR-0027), que protege o retry de transporte, não o rerun do seed.
+# Idempotente: cada linha faz preflight de leitura antes de escrever, e o request
+# relê o recurso criado. Reexecutar é seguro a qualquer momento, inclusive depois
+# das 24h de TTL do cache de idempotência (ADR-0027), que protege o retry de
+# transporte, não o rerun do seed.
 #
 # Uso:
 #   ENV=dev bash tools/seeds/run.sh
 #   ENV=standalone CATALOG="Tipos de ato" bash tools/seeds/run.sh
+#
+# Fora do dev, o secret do client de bootstrap NÃO é versionado: ele vem do
+# uniplus-infra, por variável de ambiente. Os templates de standalone/hml trazem
+# apenas o que é público, e o script recusa rodar sem o secret.
+#
+#   BOOTSTRAP_CLIENT_SECRET=***  ENV=standalone bash tools/seeds/run.sh
+#
+# Um ambiente completamente externo (ex.: gerado pelo pipeline) pode ser apontado
+# diretamente, sem viver neste repositório:
+#
+#   SEED_ENV_FILE=/run/secrets/prod.postman_environment.json bash tools/seeds/run.sh
 set -euo pipefail
 
 # Pinado: `npx newman` sem versão pega o que a rede der no dia, e um seed que muda
 # de comportamento sozinho não é bootstrap, é surpresa.
 readonly NEWMAN_VERSION="6.2.1"
 
-readonly RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly RAIZ
 readonly COLECAO="${RAIZ}/tools/seeds/seed-catalogos.postman_collection.json"
 
 ENV="${ENV:-dev}"
-readonly ARQUIVO_ENV="${RAIZ}/tools/seeds/envs/${ENV}.postman_environment.json"
+
+# SEED_ENV_FILE tem precedência: permite que o deploy forneça um arquivo de ambiente
+# que não vive no repositório.
+if [[ -n "${SEED_ENV_FILE:-}" ]]; then
+  ARQUIVO_ENV="${SEED_ENV_FILE}"
+else
+  ARQUIVO_ENV="${RAIZ}/tools/seeds/envs/${ENV}.postman_environment.json"
+fi
+readonly ARQUIVO_ENV
 
 if [[ ! -f "${ARQUIVO_ENV}" ]]; then
-  echo "erro: ambiente '${ENV}' não encontrado em tools/seeds/envs/" >&2
-  echo "disponíveis: $(ls -1 "${RAIZ}/tools/seeds/envs" | sed 's/\.postman_environment\.json//' | tr '\n' ' ')" >&2
+  echo "erro: arquivo de ambiente não encontrado: ${ARQUIVO_ENV}" >&2
+  echo "       use ENV=<nome> (templates em tools/seeds/envs/) ou SEED_ENV_FILE=<caminho>" >&2
+  echo "       ambientes versionados: $(ls -1 "${RAIZ}/tools/seeds/envs" | sed 's/\.postman_environment\.json//' | tr '\n' ' ')" >&2
   exit 1
+fi
+
+# Sobrescritas por variável de ambiente. Fora do dev o secret nunca está no arquivo.
+declare -a OVERRIDES=()
+[[ -n "${BASE_URL:-}" ]] && OVERRIDES+=(--env-var "base_url=${BASE_URL}")
+[[ -n "${KEYCLOAK_TOKEN_URL:-}" ]] && OVERRIDES+=(--env-var "keycloak_token_url=${KEYCLOAK_TOKEN_URL}")
+[[ -n "${BOOTSTRAP_CLIENT_ID:-}" ]] && OVERRIDES+=(--env-var "bootstrap_client_id=${BOOTSTRAP_CLIENT_ID}")
+[[ -n "${BOOTSTRAP_CLIENT_SECRET:-}" ]] && OVERRIDES+=(--env-var "bootstrap_client_secret=${BOOTSTRAP_CLIENT_SECRET}")
+
+# Um secret vazio produziria um 401 no token endpoint e uma falha obscura no primeiro
+# request. Falhar aqui nomeia a causa.
+if [[ "${ENV}" != "dev" && -z "${BOOTSTRAP_CLIENT_SECRET:-}" ]]; then
+  secret_no_arquivo="$(python3 -c "
+import json, sys
+with open('${ARQUIVO_ENV}') as f:
+    valores = {v['key']: v.get('value', '') for v in json.load(f).get('values', [])}
+sys.stdout.write(valores.get('bootstrap_client_secret', ''))
+" 2>/dev/null || true)"
+
+  if [[ -z "${secret_no_arquivo}" ]]; then
+    echo "erro: BOOTSTRAP_CLIENT_SECRET não informado e ausente em ${ARQUIVO_ENV}" >&2
+    echo "       fora do dev o secret vem do uniplus-infra, nunca do repositório" >&2
+    exit 1
+  fi
 fi
 
 # Um catálogo, um arquivo de dados, um folder na coleção.
@@ -52,7 +98,7 @@ executar() {
     --iteration-data "${dados}" \
     --reporters cli \
     --reporter-cli-no-banner \
-    "$@"
+    ${OVERRIDES[@]+"${OVERRIDES[@]}"}
 }
 
 if [[ -n "${CATALOG:-}" ]]; then

--- a/tools/seeds/run.sh
+++ b/tools/seeds/run.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Bootstrap dos catálogos administráveis (ADR-0062).
+#
+# Registra cada linha dos arquivos `seeds/seed-*.json` pelos endpoints admin da API,
+# autenticando por client_credentials. Não usa HasData/InsertData: as linhas passam
+# pelo mesmo AuditableInterceptor de qualquer escrita, e o CreatedBy é o `sub` do
+# service account — a trilha distingue o que veio do bootstrap do que veio da UI.
+#
+# Idempotente: cada linha faz preflight de leitura antes de escrever. Reexecutar é
+# seguro a qualquer momento, inclusive depois das 24h de TTL do cache de
+# idempotência (ADR-0027), que protege o retry de transporte, não o rerun do seed.
+#
+# Uso:
+#   ENV=dev bash tools/seeds/run.sh
+#   ENV=standalone CATALOG="Tipos de ato" bash tools/seeds/run.sh
+set -euo pipefail
+
+# Pinado: `npx newman` sem versão pega o que a rede der no dia, e um seed que muda
+# de comportamento sozinho não é bootstrap, é surpresa.
+readonly NEWMAN_VERSION="6.2.1"
+
+readonly RAIZ="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly COLECAO="${RAIZ}/tools/seeds/seed-catalogos.postman_collection.json"
+
+ENV="${ENV:-dev}"
+readonly ARQUIVO_ENV="${RAIZ}/tools/seeds/envs/${ENV}.postman_environment.json"
+
+if [[ ! -f "${ARQUIVO_ENV}" ]]; then
+  echo "erro: ambiente '${ENV}' não encontrado em tools/seeds/envs/" >&2
+  echo "disponíveis: $(ls -1 "${RAIZ}/tools/seeds/envs" | sed 's/\.postman_environment\.json//' | tr '\n' ' ')" >&2
+  exit 1
+fi
+
+# Um catálogo, um arquivo de dados, um folder na coleção.
+declare -A CATALOGOS=(
+  ["Tipos de ato"]="seeds/seed-tipos-ato.json"
+)
+
+executar() {
+  local folder="$1"
+  local dados="${RAIZ}/${CATALOGOS[$folder]}"
+
+  if [[ ! -f "${dados}" ]]; then
+    echo "erro: arquivo de seed ausente: ${dados}" >&2
+    exit 1
+  fi
+
+  echo "==> ${folder} (${ENV})"
+  npx --yes "newman@${NEWMAN_VERSION}" run "${COLECAO}" \
+    --environment "${ARQUIVO_ENV}" \
+    --folder "${folder}" \
+    --iteration-data "${dados}" \
+    --reporters cli \
+    --reporter-cli-no-banner \
+    "$@"
+}
+
+if [[ -n "${CATALOG:-}" ]]; then
+  if [[ ! -v CATALOGOS["${CATALOG}"] ]]; then
+    echo "erro: catálogo '${CATALOG}' desconhecido" >&2
+    echo "disponíveis: ${!CATALOGOS[*]}" >&2
+    exit 1
+  fi
+  executar "${CATALOG}"
+else
+  for folder in "${!CATALOGOS[@]}"; do
+    executar "${folder}"
+  done
+fi
+
+echo "bootstrap concluído (${ENV})"

--- a/tools/seeds/seed-catalogos.postman_collection.json
+++ b/tools/seeds/seed-catalogos.postman_collection.json
@@ -1,0 +1,157 @@
+{
+  "info": {
+    "name": "Uni+ — Seed de catálogos",
+    "description": "Bootstrap dos catálogos administráveis (ADR-0062): obtém token plataforma-admin por client_credentials e registra cada linha pelos endpoints admin, com o mesmo AuditableInterceptor de qualquer escrita — sem HasData, sem CreatedBy sintético.\n\nIdempotente por preflight: cada linha lê antes de escrever, compara todos os campos com o arquivo de seed, e só cria o que falta. A Idempotency-Key é gerada por execução, não derivada do código: uma chave estável faria o POST devolver a resposta cacheada (ADR-0027, TTL de 24h) e o seed terminaria verde sem recriar um tipo que tivesse sido removido.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{access_token}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Token de service account, cacheado até 60s antes de expirar.",
+          "const agora = Math.floor(Date.now() / 1000);",
+          "const expira = Number(pm.environment.get('access_token_expira_em') || 0);",
+          "if (pm.environment.get('access_token') && agora < expira - 60) { return; }",
+          "",
+          "pm.sendRequest({",
+          "  url: pm.environment.get('keycloak_token_url'),",
+          "  method: 'POST',",
+          "  header: { 'Content-Type': 'application/x-www-form-urlencoded' },",
+          "  body: { mode: 'urlencoded', urlencoded: [",
+          "    { key: 'grant_type', value: 'client_credentials' },",
+          "    { key: 'client_id', value: pm.environment.get('bootstrap_client_id') },",
+          "    { key: 'client_secret', value: pm.environment.get('bootstrap_client_secret') },",
+          "  ]}",
+          "}, (err, res) => {",
+          "  if (err) { throw new Error('falha ao obter token de bootstrap: ' + err); }",
+          "  if (res.code !== 200) { throw new Error('token endpoint devolveu ' + res.code + ': ' + res.text()); }",
+          "  const j = res.json();",
+          "  pm.environment.set('access_token', j.access_token);",
+          "  pm.environment.set('access_token_expira_em', agora + Number(j.expires_in));",
+          "});"
+        ]
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "Tipos de ato",
+      "item": [
+        {
+          "name": "Preflight — o tipo já existe?",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 404 significa 'ainda não existe' e libera o POST.",
+                  "// 200 significa 'já existe': comparamos todos os campos do seed e falhamos se",
+                  "// divergirem, porque um seed que sobrescreve em silêncio é pior que um que quebra.",
+                  "pm.test('preflight devolve 200 ou 404', () => pm.expect(pm.response.code).to.be.oneOf([200, 404]));",
+                  "",
+                  "if (pm.response.code === 404) {",
+                  "  pm.environment.set('deve_criar', 'true');",
+                  "  return;",
+                  "}",
+                  "",
+                  "pm.environment.set('deve_criar', 'false');",
+                  "const existente = pm.response.json();",
+                  "const codigo = pm.iterationData.get('codigo');",
+                  "",
+                  "// Booleanos, texto e datas: tudo que o arquivo de seed declara.",
+                  "const campos = ['codigo', 'nome', 'congelaConfiguracao', 'unicoPorObjeto', 'efeitoIrreversivel', 'vigenciaInicio', 'vigenciaFim', 'baseLegal'];",
+                  "pm.test(`${codigo} já cadastrado bate com o seed`, () => {",
+                  "  campos.forEach((campo) => {",
+                  "    const esperado = pm.iterationData.get(campo);",
+                  "    const encontrado = existente[campo] === undefined ? null : existente[campo];",
+                  "    pm.expect(encontrado, campo).to.eql(esperado === undefined ? null : esperado);",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": "{{base_url}}/api/publicacoes/tipos-ato/{{codigo}}/vigente?data={{vigenciaInicio}}"
+          }
+        },
+        {
+          "name": "Registrar tipo de ato",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Pula a escrita quando o preflight encontrou a linha íntegra.",
+                  "//",
+                  "// `pm.execution.skipRequest()` pula ESTE request. `setNextRequest(null)` não serve:",
+                  "// ele encerra a iteração DEPOIS de o request atual rodar, e o POST chegaria ao",
+                  "// servidor de qualquer forma — devolvendo 201 do cache de idempotência enquanto",
+                  "// ele durasse, e 409 vigencia_sobreposta assim que expirasse.",
+                  "if (pm.environment.get('deve_criar') !== 'true') {",
+                  "  console.log(`${pm.iterationData.get('codigo')}: já cadastrado, nada a fazer`);",
+                  "  pm.execution.skipRequest();",
+                  "}"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test(`${pm.iterationData.get('codigo')} registrado (201)`, () => pm.response.to.have.status(201));",
+                  "pm.test('Location aponta para o recurso', () => pm.expect(pm.response.headers.get('Location')).to.include('/api/publicacoes/tipos-ato/'));",
+                  "pm.test('a resposta não veio do cache de idempotência', () => {",
+                  "  // Uma chave reaproveitada devolveria a resposta cacheada com este header, e o",
+                  "  // seed terminaria verde sem ter criado nada — por exemplo se o tipo tivesse sido",
+                  "  // removido depois da execução anterior, dentro das 24h de TTL.",
+                  "  pm.expect(pm.response.headers.get('Idempotency-Replayed')).to.be.oneOf([null, undefined]);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/vnd.uniplus.tipo-ato.v1+json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Idempotency-Key",
+                "value": "{{$guid}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"codigo\": \"{{codigo}}\",\n  \"nome\": \"{{nome}}\",\n  \"congelaConfiguracao\": {{congelaConfiguracao}},\n  \"unicoPorObjeto\": {{unicoPorObjeto}},\n  \"efeitoIrreversivel\": {{efeitoIrreversivel}},\n  \"vigenciaInicio\": \"{{vigenciaInicio}}\",\n  \"vigenciaFim\": null,\n  \"baseLegal\": null\n}"
+            },
+            "url": "{{base_url}}/api/publicacoes/admin/tipos-ato"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tools/seeds/seed-catalogos.postman_collection.json
+++ b/tools/seeds/seed-catalogos.postman_collection.json
@@ -102,12 +102,26 @@
                   "//",
                   "// `pm.execution.skipRequest()` pula ESTE request. `setNextRequest(null)` não serve:",
                   "// ele encerra a iteração DEPOIS de o request atual rodar, e o POST chegaria ao",
-                  "// servidor de qualquer forma — devolvendo 201 do cache de idempotência enquanto",
-                  "// ele durasse, e 409 vigencia_sobreposta assim que expirasse.",
+                  "// servidor de qualquer forma.",
                   "if (pm.environment.get('deve_criar') !== 'true') {",
                   "  console.log(`${pm.iterationData.get('codigo')}: já cadastrado, nada a fazer`);",
                   "  pm.execution.skipRequest();",
-                  "}"
+                  "}",
+                  "",
+                  "// O corpo sai da linha do arquivo, campo a campo. Escrevê-lo com `null` fixo em",
+                  "// vigenciaFim/baseLegal gravaria nulo para qualquer linha que os informasse, e o",
+                  "// Newman diria sucesso — a resposta do POST é só o id.",
+                  "const corpo = {",
+                  "  codigo: pm.iterationData.get('codigo'),",
+                  "  nome: pm.iterationData.get('nome'),",
+                  "  congelaConfiguracao: pm.iterationData.get('congelaConfiguracao'),",
+                  "  unicoPorObjeto: pm.iterationData.get('unicoPorObjeto'),",
+                  "  efeitoIrreversivel: pm.iterationData.get('efeitoIrreversivel'),",
+                  "  vigenciaInicio: pm.iterationData.get('vigenciaInicio'),",
+                  "  vigenciaFim: pm.iterationData.get('vigenciaFim') ?? null,",
+                  "  baseLegal: pm.iterationData.get('baseLegal') ?? null,",
+                  "};",
+                  "pm.variables.set('corpo_json', JSON.stringify(corpo));"
                 ]
               }
             },
@@ -116,14 +130,36 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test(`${pm.iterationData.get('codigo')} registrado (201)`, () => pm.response.to.have.status(201));",
-                  "pm.test('Location aponta para o recurso', () => pm.expect(pm.response.headers.get('Location')).to.include('/api/publicacoes/tipos-ato/'));",
+                  "const codigo = pm.iterationData.get('codigo');",
+                  "pm.test(`${codigo} registrado (201)`, () => pm.response.to.have.status(201));",
+                  "",
+                  "const local = pm.response.headers.get('Location');",
+                  "pm.test('Location aponta para o recurso', () => pm.expect(local).to.include('/api/publicacoes/tipos-ato/'));",
+                  "",
                   "pm.test('a resposta não veio do cache de idempotência', () => {",
                   "  // Uma chave reaproveitada devolveria a resposta cacheada com este header, e o",
                   "  // seed terminaria verde sem ter criado nada — por exemplo se o tipo tivesse sido",
                   "  // removido depois da execução anterior, dentro das 24h de TTL.",
                   "  pm.expect(pm.response.headers.get('Idempotency-Replayed')).to.be.oneOf([null, undefined]);",
-                  "});"
+                  "});",
+                  "",
+                  "// Lê de volta o que foi gravado. O POST devolve só o id: sem esta leitura, um",
+                  "// corpo incompleto persistiria valores errados e o Newman reportaria sucesso.",
+                  "if (pm.response.code === 201 && local) {",
+                  "  pm.sendRequest({ url: local, method: 'GET' }, (err, res) => {",
+                  "    pm.test(`${codigo} foi gravado como o arquivo de seed declara`, () => {",
+                  "      pm.expect(err, 'erro ao reler o recurso criado').to.be.null;",
+                  "      pm.expect(res.code, 'status da releitura').to.eql(200);",
+                  "      const gravado = res.json();",
+                  "      const campos = ['codigo', 'nome', 'congelaConfiguracao', 'unicoPorObjeto', 'efeitoIrreversivel', 'vigenciaInicio', 'vigenciaFim', 'baseLegal'];",
+                  "      campos.forEach((campo) => {",
+                  "        const esperado = pm.iterationData.get(campo) ?? null;",
+                  "        const encontrado = gravado[campo] === undefined ? null : gravado[campo];",
+                  "        pm.expect(encontrado, campo).to.eql(esperado);",
+                  "      });",
+                  "    });",
+                  "  });",
+                  "}"
                 ]
               }
             }
@@ -146,7 +182,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"codigo\": \"{{codigo}}\",\n  \"nome\": \"{{nome}}\",\n  \"congelaConfiguracao\": {{congelaConfiguracao}},\n  \"unicoPorObjeto\": {{unicoPorObjeto}},\n  \"efeitoIrreversivel\": {{efeitoIrreversivel}},\n  \"vigenciaInicio\": \"{{vigenciaInicio}}\",\n  \"vigenciaFim\": null,\n  \"baseLegal\": null\n}"
+              "raw": "{{corpo_json}}"
             },
             "url": "{{base_url}}/api/publicacoes/admin/tipos-ato"
           }


### PR DESCRIPTION
Closes #812 · Refs #798, #795

Última das quatro tasks da story. Registra os 16 tipos de ato por seed e trava, com fitness test, o princípio que a ADR-0103 estabelece: acrescentar um tipo de ato é linha de cadastro, jamais um PR no domínio.

## Primeira aplicação viva da ADR-0062

Ela prescreve a estrutura `seeds/` + `tools/seeds/` (coleção, envs, `run.sh`, README) desde maio. **Nada disso existia no repositório** — não havia um único diretório `seeds/`. É a mesma situação da exclusion constraint da ADR-0060, que a #809 implementou pela primeira vez.

O seed entra pelos endpoints admin, não por `HasData`. A diferença não é estética: `InsertData` grava direto na tabela, fabrica um `CreatedBy` sintético e passa por fora do `AuditableInterceptor`. Pelo endpoint, a linha percorre validação, invariantes e auditoria como qualquer escrita, e o `CreatedBy` fica sendo o `sub` do service account.

Também não existia o client de bootstrap: **nenhum client do realm dev-local tinha `serviceAccountsEnabled`**, e o seed falharia ao obter o token, antes da primeira linha. Entra `uniplus-api-bootstrap`, confidencial, com a realm role `plataforma-admin`. Em standalone/HML/PROD o secret vem do `uniplus-infra` — nunca versionado aqui.

## O bug que a chave determinística esconde

A ADR-0062 manda usar `Idempotency-Key: {recurso}-{codigo}`, estável entre execuções, e diz para o request aceitar *"201 na primeira execução ou 200 no re-run via cache"*. Fui ao código: o replay devolve o status **original** (201, não 200) e o cache expira em **24 horas**.

Disso decorre uma falha silenciosa, que reproduzi contra a stack real:

1. O seed roda e cria os 16 tipos.
2. Alguém remove `AVISO` pela UI.
3. O seed roda de novo, **no mesmo dia**. O preflight devolve 404 — corretamente, o tipo não existe — e libera o `POST`.
4. Com a chave estável, o `POST` casa a entrada em cache e recebe o **201 original de volta**. Nada é criado.
5. O seed termina **verde**, e `AVISO` continua ausente.

```
CANÁRIO (chave determinística):  tipos vivos após o seed: 15   ← AVISO não voltou
CORRIGIDO (chave por execução):  tipos vivos após o seed: 16   ← AVISO voltou
```

A chave passou a ser `{{$guid}}`, e o request assere que a resposta **não** traz `Idempotency-Replayed: true` — de modo que reintroduzir a chave estável quebra o seed em vez de silenciá-lo. A idempotência vem do preflight; a chave existe só para satisfazer o `[RequiresIdempotencyKey]` do endpoint.

## O preflight que não pulava nada

Meu primeiro preflight usava `setNextRequest(null)`, que encerra a iteração **depois** de o request atual rodar — o `POST` ia ao servidor de qualquer jeito. Enquanto o cache estava quente, ele devolvia 201 e tudo parecia certo. Apaguei o cache para simular as 24 horas: 32 asserções caíram, com `409 vigencia_sobreposta`.

A correção é `pm.execution.skipRequest()`. Sem esse experimento, eu teria entregue um seed que só *parece* idempotente.

O preflight compara **todos** os campos do arquivo, não só os três booleanos. Adulterei o nome de `CONVOCACAO` no banco e o seed falhou, como deve:

```
AssertionError  CONVOCACAO já cadastrado bate com o seed
iteration: 5    nome: expected 'Nome adulterado' to deeply equal 'Convocação'
```

## Uma suspeita minha que estava errada

Eu supunha que o `POST` com `Content-Type: application/vnd.uniplus.tipo-ato.v1+json` daria 415, porque o `[VendorMediaType]` só está nos `GET`. Sondei contra a API: devolve **201**. O atributo negocia o `Accept` (saída); o `Content-Type` (entrada) é do input formatter, que aceita `application/*+json` por padrão. A ADR estava certa, e eu ia "consertar" o que não estava quebrado.

## O fitness test procura o literal, não a sintaxe

Detectar por posição (`== "X"`, `case "X"`) deixa passar o mesmo ramo escrito de outro jeito: `"X" == tipo.Codigo`, `tipo.Codigo switch { "X" => … }`, `tipo.Codigo is "X"`, `static readonly string X = "X"`. A regra proíbe o **literal inteiro em UPPER_SNAKE em qualquer posição**, e 12 casos de teste cobrem as formas sintáticas. Cinco casos garantem que ele não acusa o que não é código de tipo — o `CodigoPattern`, o SQLSTATE `23P01`, o nome da constraint, o schema, e a mensagem de erro que usa `EDITAL_ABERTURA` como exemplo dentro de uma frase.

Ele também **falha se não tiver o que examinar**: o modelo que copiei (`DominioNaoUsaGuidNewGuidTests`) faz `if (!Directory.Exists(root)) continue`, e um caminho errado o deixaria verde sem ler arquivo nenhum.

## Validação

Cada asserção estrutural foi provada por contraprova antes de valer como evidência.

| O que | Como |
|---|---|
| O fitness test acusa a ramificação | Plantei `if (query.Codigo == "CONVOCACAO")` num handler **real**: acusou, com arquivo e trecho. |
| O fitness test acusa filtro em SQL | Plantei `WHERE codigo = 'CONVOCACAO'` numa migration **real**: acusou. |
| A chave determinística é o bug | Reproduzido contra a stack real: 15 tipos, `AVISO` ausente, seed verde na versão antiga; a asserção nova acusa. |
| O preflight compara tudo | Adulterei o nome de `CONVOCACAO` no banco: o seed falhou na iteração 5. |
| O seed é idempotente | Três execuções seguidas — banco vazio, cache quente, cache limpo: 16 tipos, sem duplicar, sem `POST` supérfluo. |
| `SeedTiposAtoTests` depende do arquivo | Troquei `congela` de `EDITAL_RETIFICACAO` para `false`: o teste da invariante da ADR-0103 falhou. |

- `dotnet build UniPlus.slnx` — 0 warnings.
- `dotnet test UniPlus.slnx` — 23 projetos, nenhuma falha. `ArchTests` foi a 44 testes; `Publicacoes.IntegrationTests` a 50.
- `bash tools/seeds/run.sh` contra a stack real: 16 iterações, 64 asserções, zero falhas; `created_by` = `sub` do service account.

## Um critério da issue que **não** entreguei, e por quê

O critério *"`congela_configuracao` é lido e **copiado por valor**, jamais consultado para decidir fluxo"* tem duas metades. A segunda o fitness test prova. A primeira **não é testável agora**: o agregado que copia — `AtoNormativo` — só nasce na #799. Não há o que testar, e um teste que fingisse testar seria pior que a sua ausência. A prova da cópia por valor pertence à task que implementar a publicação do ato.
