### PR TITLE
feat(publicacoes): registro de ato normativo append-only com número declarado

### DIFF
--- a/contracts/openapi.publicacoes.json
+++ b/contracts/openapi.publicacoes.json
@@ -162,6 +162,296 @@
         }
       }
     },
+    "/api/publicacoes/atos": {
+      "get": {
+        "tags": [
+          "AtosNormativos"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AtoNormativoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AtoNormativoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AtoNormativoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/publicacoes/atos/{id}": {
+      "get": {
+        "tags": [
+          "AtosNormativos"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtoNormativoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtoNormativoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AtoNormativoDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/publicacoes/admin/atos": {
+      "post": {
+        "tags": [
+          "AtosNormativos"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegistrarAtoNormativoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegistrarAtoNormativoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/RegistrarAtoNormativoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistrarAtoNormativoResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistrarAtoNormativoResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegistrarAtoNormativoResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
     "/api/publicacoes/tipos-ato": {
       "get": {
         "tags": [
@@ -710,6 +1000,105 @@
   },
   "components": {
     "schemas": {
+      "AtoNormativoDto": {
+        "required": [
+          "id",
+          "orgao",
+          "serie",
+          "ano",
+          "numero",
+          "tipoCodigo",
+          "congelaConfiguracao",
+          "efeitoIrreversivel",
+          "dataPublicacao",
+          "documentoHash",
+          "assinante",
+          "registradoEm",
+          "versaoInvocadaId",
+          "versaoInvocadaHash"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "orgao": {
+            "type": "string"
+          },
+          "serie": {
+            "type": "string"
+          },
+          "ano": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "numero": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tipoCodigo": {
+            "type": "string"
+          },
+          "congelaConfiguracao": {
+            "type": "boolean"
+          },
+          "efeitoIrreversivel": {
+            "type": "boolean"
+          },
+          "dataPublicacao": {
+            "type": "string",
+            "format": "date"
+          },
+          "documentoHash": {
+            "type": "string"
+          },
+          "assinante": {
+            "type": "string"
+          },
+          "registradoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "versaoInvocadaId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "versaoInvocadaHash": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "avisos": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/AvisoNumeracao"
+            }
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "AtualizarTipoAtoPublicadoCommand": {
         "required": [
           "id",
@@ -800,6 +1189,29 @@
           }
         }
       },
+      "AvisoNumeracao": {
+        "required": [
+          "codigo",
+          "mensagem",
+          "atosConflitantes"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "mensagem": {
+            "type": "string"
+          },
+          "atosConflitantes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
       "CriarTipoAtoPublicadoCommand": {
         "required": [
           "codigo",
@@ -884,6 +1296,91 @@
               "null",
               "string"
             ]
+          }
+        }
+      },
+      "RegistrarAtoNormativoCommand": {
+        "required": [
+          "orgao",
+          "serie",
+          "ano",
+          "numero",
+          "tipoCodigo",
+          "dataPublicacao",
+          "documentoHash",
+          "assinante"
+        ],
+        "type": "object",
+        "properties": {
+          "orgao": {
+            "type": "string"
+          },
+          "serie": {
+            "type": "string"
+          },
+          "ano": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "numero": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tipoCodigo": {
+            "type": "string"
+          },
+          "dataPublicacao": {
+            "type": "string",
+            "format": "date"
+          },
+          "documentoHash": {
+            "type": "string"
+          },
+          "assinante": {
+            "type": "string"
+          },
+          "versaoInvocadaId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "versaoInvocadaHash": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "RegistrarAtoNormativoResult": {
+        "required": [
+          "atoId",
+          "registradoEm",
+          "avisos"
+        ],
+        "type": "object",
+        "properties": {
+          "atoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "registradoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "avisos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvisoNumeracao"
+            }
           }
         }
       },
@@ -1020,6 +1517,9 @@
     },
     {
       "name": "_smoke"
+    },
+    {
+      "name": "AtosNormativos"
     },
     {
       "name": "TiposAto"

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/AtosNormativosController.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/AtosNormativosController.cs
@@ -1,0 +1,145 @@
+namespace Unifesspa.UniPlus.Publicacoes.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/publicacoes/atos</c>) e o endpoint
+/// admin de registro (<c>POST /api/publicacoes/admin/atos</c>) restrito a
+/// <c>plataforma-admin</c>.
+/// </summary>
+/// <remarks>
+/// A leitura é pública: um ato publicado é, por definição, um documento tornado
+/// público. O <c>assinante</c> é dado pessoal (nome), porém de publicação
+/// legítima no próprio ato — não é PII sensível a mascarar, e sim informação que
+/// o documento já torna pública. O registro é append-only; não há atualização nem
+/// remoção via HTTP (o ato é prova, o passado documental não se muta).
+/// </remarks>
+[ApiController]
+[Route("api/publicacoes")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class AtosNormativosController : ControllerBase
+{
+    private const string ResourceTag = "atos";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<AtoNormativoDto> _linksBuilder;
+
+    public AtosNormativosController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<AtoNormativoDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista os atos publicados, paginados por cursor opaco bidirecional
+    /// (ADR-0026 + ADR-0089). Navegação via header <c>Link</c>; cada item carrega
+    /// seu <c>_links.self</c> (ADR-0029). Os itens não trazem avisos de numeração —
+    /// esses são recomputados só no detalhe do ato.
+    /// </summary>
+    [HttpGet("atos")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "ato-normativo", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<AtoNormativoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarAtosNormativosResult resultado = await _queryBus
+            .Send(new ListarAtosNormativosQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        AtoNormativoDto[] comLinks =
+            [.. resultado.Items.Select(a => a with { Links = _linksBuilder.Build(a) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Obtém um ato pelo Id, com os avisos de numeração recomputados (AC4). Retorna
+    /// 404 quando inexistente.
+    /// </summary>
+    [HttpGet("atos/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "ato-normativo", Versions = [1])]
+    [ProducesResponseType(typeof(AtoNormativoDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        AtoNormativoDto? ato = await _queryBus
+            .Send(new ObterAtoNormativoPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (ato is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(ato with { Links = _linksBuilder.Build(ato) });
+    }
+
+    /// <summary>
+    /// Registra um ato publicado. Restrito a <c>plataforma-admin</c>.
+    /// <c>Idempotency-Key</c> obrigatório (ADR-0027). A resposta traz o Id, o
+    /// instante forense de registro e eventuais avisos de numeração (AC4).
+    /// </summary>
+    [HttpPost("admin/atos")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(RegistrarAtoNormativoResult), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Registrar(
+        [FromBody] RegistrarAtoNormativoCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<RegistrarAtoNormativoResult> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId), new { id = resultado.Value!.AtoId }, resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Errors/PublicacoesDomainErrorRegistration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Errors/PublicacoesDomainErrorRegistration.cs
@@ -83,5 +83,23 @@ internal sealed class PublicacoesDomainErrorRegistration : IDomainErrorRegistrat
                 StatusCodes.Status422UnprocessableEntity,
                 "uniplus.publicacoes.tipo_ato.vigencia_fim_anterior_ao_inicio",
                 "Fim da vigência deve ser posterior ao início")),
+
+        new(AtoNormativoErrorCodes.TipoSemVersaoVigente,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.ato_normativo.tipo_sem_versao_vigente",
+                "Não há versão vigente do tipo de ato na data de publicação")),
+
+        new(AtoNormativoErrorCodes.VersaoInvocadaIncompleta,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.ato_normativo.versao_invocada_incompleta",
+                "A versão invocada deve trazer o par (id, hash) completo ou nenhum dos dois")),
+
+        new(AtoNormativoErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.publicacoes.ato_normativo.nao_encontrado",
+                "Ato normativo não encontrado")),
     ];
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Hateoas/AtoNormativoLinksBuilder.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Hateoas/AtoNormativoLinksBuilder.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Publicacoes.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Publicacoes.API.Controllers;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="AtoNormativoDto"/>. Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<AtoNormativoDto>, AtoNormativoLinksBuilder>().")]
+internal sealed class AtoNormativoLinksBuilder : IResourceLinksBuilder<AtoNormativoDto>
+{
+    private const string ControllerName = "AtosNormativos";
+
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public AtoNormativoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(AtoNormativoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+
+        string self = ResolverPath(
+            httpContext, nameof(AtosNormativosController.ObterPorId), new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(AtosNormativosController.Listar), values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: ControllerName, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: ControllerName, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesModuleRegistration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesModuleRegistration.cs
@@ -46,6 +46,7 @@ public static class PublicacoesModuleRegistration
         services.AddSingleton<IDomainErrorRegistration, PublicacoesDomainErrorRegistration>();
 
         services.AddSingleton<IResourceLinksBuilder<TipoAtoPublicadoDto>, TipoAtoPublicadoLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<AtoNormativoDto>, AtoNormativoLinksBuilder>();
 
         // Idempotency-Key (ADR-0027) sobre o DbContext do módulo. Sem este registro o
         // [RequiresIdempotencyKey] do POST compila e não faz nada: a requisição sem

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Avisos/AvisoNumeracaoCalculator.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Avisos/AvisoNumeracaoCalculator.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Avisos;
+
+using System.Globalization;
+
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+/// <summary>
+/// Computa o aviso de número duplicado (AC4) de um ato — diagnóstico do estado
+/// atual, derivado na leitura, nunca persistido. Compartilhado entre o registro
+/// (exclui nada: o próprio ato ainda não existe) e o detalhe (exclui o próprio
+/// ato do conjunto de conflitantes).
+/// </summary>
+internal static class AvisoNumeracaoCalculator
+{
+    public static async Task<IReadOnlyList<AvisoNumeracao>> CalcularAsync(
+        IAtoNormativoRepository atosRepository,
+        AtoNormativo ato,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(atosRepository);
+        ArgumentNullException.ThrowIfNull(ato);
+
+        if (ato.Numero is null)
+        {
+            return [];
+        }
+
+        IReadOnlyList<Guid> conflitantes = await atosRepository
+            .ListarIdsComMesmaNumeracaoAsync(
+                ato.Orgao, ato.Serie, ato.Ano, ato.Numero, excluirId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (conflitantes.Count == 0)
+        {
+            return [];
+        }
+
+        string mensagem = string.Format(
+            CultureInfo.InvariantCulture,
+            "Número {0} {1}/{2} do órgão {3} já consta em {4} outro(s) ato(s).",
+            ato.Serie,
+            ato.Numero,
+            ato.Ano,
+            ato.Orgao,
+            conflitantes.Count);
+
+        return [new AvisoNumeracao(AtoNormativoRegras.AvisoNumeroDuplicado, mensagem, conflitantes)];
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/AtoNormativoRegras.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/AtoNormativoRegras.cs
@@ -1,0 +1,40 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+
+/// <summary>
+/// Limites, padrões e mensagens do registro de ato normativo, compartilhados
+/// entre o validator e (por espelhamento) as invariantes do agregado. As regras
+/// avaliam o valor <b>normalizado</b> (trim), como a factory faz.
+/// </summary>
+internal static class AtoNormativoRegras
+{
+    public const int OrgaoMaxLength = 200;
+    public const int SerieMaxLength = 100;
+    public const int NumeroMaxLength = 60;
+    public const int TipoCodigoMaxLength = 60;
+    public const int AssinanteMaxLength = 200;
+
+    /// <summary>SHA-256 em hexadecimal minúsculo, 64 caracteres.</summary>
+    public const string HashPattern = "^[0-9a-f]{64}$";
+
+    public const string OrgaoObrigatorio = "Órgão publicador é obrigatório.";
+    public const string OrgaoTamanho = "Órgão publicador deve ter no máximo 200 caracteres.";
+    public const string SerieObrigatoria = "Série é obrigatória.";
+    public const string SerieTamanho = "Série deve ter no máximo 100 caracteres.";
+    public const string AnoInvalido = "Ano deve ser um inteiro positivo.";
+    public const string NumeroTamanho = "Número deve ter no máximo 60 caracteres.";
+    public const string TipoCodigoObrigatorio = "Código do tipo de ato é obrigatório.";
+    public const string TipoCodigoTamanho = "Código do tipo de ato deve ter no máximo 60 caracteres.";
+    public const string DocumentoHashObrigatorio = "Hash do documento é obrigatório.";
+    public const string DocumentoHashFormato = "Hash do documento deve ser um SHA-256 em hexadecimal minúsculo (64 caracteres).";
+    public const string AssinanteObrigatorio = "Assinante é obrigatório.";
+    public const string AssinanteTamanho = "Assinante deve ter no máximo 200 caracteres.";
+    public const string VersaoInvocadaIncompleta = "A versão invocada é o par (id, hash) completo, ou nenhum dos dois — um identificador sem hash não prova nada.";
+    public const string VersaoInvocadaIdObrigatorio = "Identificador da versão invocada não pode ser vazio.";
+    public const string VersaoInvocadaHashFormato = "Hash da versão invocada deve ser um SHA-256 em hexadecimal minúsculo (64 caracteres).";
+
+    /// <summary>Código do aviso de número duplicado (AC4).</summary>
+    public const string AvisoNumeroDuplicado = "NumeroDuplicado";
+
+    public static string? Normalizar(string? valor) =>
+        string.IsNullOrWhiteSpace(valor) ? null : valor.Trim();
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommand.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommand.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Registra um ato publicado. O tipo é resolvido no catálogo vigente na
+/// <paramref name="DataPublicacao"/> e seus atributos de consequência
+/// (<c>congela_configuracao</c>, <c>efeito_irreversivel</c>) são copiados por
+/// valor server-side — o cliente não os informa, então não há como divergirem
+/// do catálogo (AC5).
+/// </summary>
+/// <remarks>
+/// <para>O par <see cref="VersaoInvocadaId"/>/<see cref="VersaoInvocadaHash"/> é
+/// recebido por valor, completo ou ausente (AC7): Publicações não resolve a
+/// versão de configuração — ela vive noutro módulo e chega já resolvida.</para>
+/// <para>Retificação e vínculo genérico ato↔entidade não entram aqui — são #800 e #801.</para>
+/// </remarks>
+public sealed record RegistrarAtoNormativoCommand(
+    string Orgao,
+    string Serie,
+    int Ano,
+    string? Numero,
+    string TipoCodigo,
+    DateOnly DataPublicacao,
+    string DocumentoHash,
+    string Assinante,
+    Guid? VersaoInvocadaId = null,
+    string? VersaoInvocadaHash = null) : ICommand<Result<RegistrarAtoNormativoResult>>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandHandler.cs
@@ -1,0 +1,114 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+using Unifesspa.UniPlus.Publicacoes.Application.Avisos;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+using Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
+
+/// <summary>
+/// Handler do <see cref="RegistrarAtoNormativoCommand"/> (convention-based
+/// Wolverine): resolve o tipo vigente na data de publicação, copia por valor os
+/// atributos de consequência, registra o ato append-only e computa o aviso de
+/// número duplicado (AC4).
+/// </summary>
+public static class RegistrarAtoNormativoCommandHandler
+{
+    public static async Task<Result<RegistrarAtoNormativoResult>> Handle(
+        RegistrarAtoNormativoCommand command,
+        ITipoAtoPublicadoRepository tiposRepository,
+        IAtoNormativoRepository atosRepository,
+        IPublicacoesUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(tiposRepository);
+        ArgumentNullException.ThrowIfNull(atosRepository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        // AC6: sem versão do tipo vigente na data, não há de onde copiar os
+        // atributos de consequência — recusa nomeada.
+        TipoAtoPublicado? tipo = await tiposRepository
+            .ObterVigenteAsync(command.TipoCodigo, command.DataPublicacao, cancellationToken)
+            .ConfigureAwait(false);
+        if (tipo is null)
+        {
+            return Result<RegistrarAtoNormativoResult>.Failure(new DomainError(
+                AtoNormativoErrorCodes.TipoSemVersaoVigente,
+                $"Não há versão vigente do tipo de ato '{command.TipoCodigo}' na data de publicação {command.DataPublicacao:yyyy-MM-dd}."));
+        }
+
+        // AC7: o par {id, hash} é recebido por valor, completo ou ausente.
+        Result<ReferenciaVersaoConfiguracao>? versaoResult = ResolverVersaoInvocada(command);
+        if (versaoResult is { IsFailure: true })
+        {
+            return Result<RegistrarAtoNormativoResult>.Failure(versaoResult.Error!);
+        }
+
+        AtoNormativo ato = AtoNormativo.Registrar(
+            command.Orgao,
+            command.Serie,
+            command.Ano,
+            command.Numero,
+            command.TipoCodigo,
+            tipo.CongelaConfiguracao,
+            tipo.EfeitoIrreversivel,
+            command.DataPublicacao,
+            command.DocumentoHash,
+            command.Assinante,
+            timeProvider.GetUtcNow(),
+            versaoResult?.Value);
+
+        // AC4: colisão de numeração é aviso, jamais recusa. No registro o próprio
+        // ato ainda não existe, então todos os que compartilham a numeração são
+        // conflitantes. O aviso do POST é best-effort: como o número não tem
+        // unicidade, dois registros concorrentes da mesma numeração podem ambos
+        // observar zero conflitos e responder sem aviso — a consulta de detalhe
+        // recomputa e enxerga ambos. Serializar aqui exigiria advisory lock para
+        // um aviso que, por decisão de negócio, nunca bloqueia o registro.
+        IReadOnlyList<AvisoNumeracao> avisos = await AvisoNumeracaoCalculator
+            .CalcularAsync(atosRepository, ato, excluirId: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        await atosRepository.AdicionarAsync(ato, cancellationToken).ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<RegistrarAtoNormativoResult>.Success(
+            new RegistrarAtoNormativoResult(ato.Id, ato.RegistradoEm, avisos));
+    }
+
+    private static Result<ReferenciaVersaoConfiguracao>? ResolverVersaoInvocada(
+        RegistrarAtoNormativoCommand command)
+    {
+        bool temId = command.VersaoInvocadaId.HasValue;
+        bool temHash = command.VersaoInvocadaHash is not null;
+
+        if (!temId && !temHash)
+        {
+            return null;
+        }
+
+        if (temId != temHash)
+        {
+            return Result<ReferenciaVersaoConfiguracao>.Failure(new DomainError(
+                AtoNormativoErrorCodes.VersaoInvocadaIncompleta,
+                AtoNormativoRegras.VersaoInvocadaIncompleta));
+        }
+
+        Result<ReferenciaVersaoConfiguracao> versao = ReferenciaVersaoConfiguracao.Criar(
+            command.VersaoInvocadaId!.Value, command.VersaoInvocadaHash!);
+
+        // O validator já rejeita id vazio e hash malformado; se ainda assim a
+        // factory recusar (defesa em profundidade), traduz para um código mapeado
+        // em vez de vazar o erro do value object como "erro não mapeado".
+        return versao.IsFailure
+            ? Result<ReferenciaVersaoConfiguracao>.Failure(new DomainError(
+                AtoNormativoErrorCodes.VersaoInvocadaIncompleta, versao.Error!.Message))
+            : versao;
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandValidator.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandValidator.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+
+using FluentValidation;
+
+/// <summary>
+/// Antecipa a recusa de shape que o agregado faria, devolvendo 400 antes de o
+/// handler tocar o repositório. As regras de texto avaliam o valor
+/// <b>normalizado</b> (trim), como a factory; por isso o nome da propriedade no
+/// <c>ProblemDetails</c> vem de <c>OverridePropertyName</c>.
+/// </summary>
+public sealed class RegistrarAtoNormativoCommandValidator
+    : AbstractValidator<RegistrarAtoNormativoCommand>
+{
+    public RegistrarAtoNormativoCommandValidator()
+    {
+        RuleFor(x => AtoNormativoRegras.Normalizar(x.Orgao))
+            .NotEmpty().WithMessage(AtoNormativoRegras.OrgaoObrigatorio)
+            .MaximumLength(AtoNormativoRegras.OrgaoMaxLength).WithMessage(AtoNormativoRegras.OrgaoTamanho)
+            .OverridePropertyName(nameof(RegistrarAtoNormativoCommand.Orgao));
+
+        RuleFor(x => AtoNormativoRegras.Normalizar(x.Serie))
+            .NotEmpty().WithMessage(AtoNormativoRegras.SerieObrigatoria)
+            .MaximumLength(AtoNormativoRegras.SerieMaxLength).WithMessage(AtoNormativoRegras.SerieTamanho)
+            .OverridePropertyName(nameof(RegistrarAtoNormativoCommand.Serie));
+
+        RuleFor(x => x.Ano)
+            .GreaterThan(0).WithMessage(AtoNormativoRegras.AnoInvalido);
+
+        RuleFor(x => AtoNormativoRegras.Normalizar(x.Numero))
+            .MaximumLength(AtoNormativoRegras.NumeroMaxLength).WithMessage(AtoNormativoRegras.NumeroTamanho)
+            .OverridePropertyName(nameof(RegistrarAtoNormativoCommand.Numero))
+            .When(x => x.Numero is not null);
+
+        RuleFor(x => AtoNormativoRegras.Normalizar(x.TipoCodigo))
+            .NotEmpty().WithMessage(AtoNormativoRegras.TipoCodigoObrigatorio)
+            .MaximumLength(AtoNormativoRegras.TipoCodigoMaxLength).WithMessage(AtoNormativoRegras.TipoCodigoTamanho)
+            .OverridePropertyName(nameof(RegistrarAtoNormativoCommand.TipoCodigo));
+
+        RuleFor(x => x.DocumentoHash)
+            .NotEmpty().WithMessage(AtoNormativoRegras.DocumentoHashObrigatorio)
+            .Matches(AtoNormativoRegras.HashPattern).WithMessage(AtoNormativoRegras.DocumentoHashFormato);
+
+        RuleFor(x => AtoNormativoRegras.Normalizar(x.Assinante))
+            .NotEmpty().WithMessage(AtoNormativoRegras.AssinanteObrigatorio)
+            .MaximumLength(AtoNormativoRegras.AssinanteMaxLength).WithMessage(AtoNormativoRegras.AssinanteTamanho)
+            .OverridePropertyName(nameof(RegistrarAtoNormativoCommand.Assinante));
+
+        // O par {id, hash} é completo ou ausente (AC7).
+        RuleFor(x => x)
+            .Must(x => x.VersaoInvocadaId.HasValue == (x.VersaoInvocadaHash is not null))
+            .WithMessage(AtoNormativoRegras.VersaoInvocadaIncompleta)
+            .OverridePropertyName(nameof(RegistrarAtoNormativoCommand.VersaoInvocadaHash));
+
+        // Id zerado não é referência: um Guid.Empty não aponta versão alguma.
+        RuleFor(x => x.VersaoInvocadaId)
+            .Must(id => id != Guid.Empty).WithMessage(AtoNormativoRegras.VersaoInvocadaIdObrigatorio)
+            .When(x => x.VersaoInvocadaId.HasValue);
+
+        RuleFor(x => x.VersaoInvocadaHash)
+            .Matches(AtoNormativoRegras.HashPattern).WithMessage(AtoNormativoRegras.VersaoInvocadaHashFormato)
+            .When(x => x.VersaoInvocadaHash is not null);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoResult.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoResult.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>
+/// Resultado do registro de um ato: o identificador atribuído, o instante
+/// forense em que o registro entrou no sistema (<see cref="RegistradoEm"/> — o
+/// que a ADR-0106 exige propagar de volta a quem orquestra) e os avisos de
+/// numeração detectados no momento do registro (AC4).
+/// </summary>
+public sealed record RegistrarAtoNormativoResult(
+    Guid AtoId,
+    DateTimeOffset RegistradoEm,
+    IReadOnlyList<AvisoNumeracao> Avisos);

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/AtoNormativoDto.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/AtoNormativoDto.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta para <c>AtoNormativo</c>. Expõe a essência documental do ato,
+/// os atributos de consequência copiados por valor do catálogo e — quando o ato
+/// invoca configuração — o par <c>{id, hash}</c> da versão que o governou.
+/// </summary>
+/// <remarks>
+/// <para><c>DataPublicacao</c> é documental (o que o PDF declara);
+/// <c>RegistradoEm</c> é o instante forense em que o registro entrou no sistema.
+/// São grandezas distintas — só a segunda ordena no relógio do sistema.</para>
+/// <para><c>Avisos</c> é nulo (omitido) na listagem, para evitar N+1; no detalhe
+/// (GET por id) é recomputado — lista vazia significa "sem colisão de número".</para>
+/// <para>Suporta HATEOAS Level 1 via <c>_links</c> (ADR-0029).</para>
+/// </remarks>
+public sealed record AtoNormativoDto(
+    Guid Id,
+    string Orgao,
+    string Serie,
+    int Ano,
+    string? Numero,
+    string TipoCodigo,
+    bool CongelaConfiguracao,
+    bool EfeitoIrreversivel,
+    DateOnly DataPublicacao,
+    string DocumentoHash,
+    string Assinante,
+    DateTimeOffset RegistradoEm,
+    Guid? VersaoInvocadaId,
+    string? VersaoInvocadaHash)
+{
+    /// <summary>
+    /// Avisos de numeração recomputados na leitura. Nulo quando não computados
+    /// (listagem); lista possivelmente vazia no detalhe do ato.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<AvisoNumeracao>? Avisos { get; init; }
+
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/AvisoNumeracao.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/AvisoNumeracao.cs
@@ -1,0 +1,18 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>
+/// Aviso de numeração duplicada (AC4 da #799): há outro(s) ato(s) com a mesma
+/// numeração <c>(orgao, serie, ano, numero)</c>. O número é declarado, não
+/// gerado — colisão é aviso, jamais recusa; é o que pega o erro humano de reusar
+/// um número já gasto.
+/// </summary>
+/// <remarks>
+/// Diagnóstico do <b>estado atual</b>, computado na leitura — não é prova imutável
+/// registrada no ato. Entre a consulta e um insert concorrente cabe uma corrida,
+/// tolerada porque o aviso não bloqueia o registro; uma consulta posterior recomputa
+/// e enxerga ambos os atos.
+/// </remarks>
+public sealed record AvisoNumeracao(
+    string Codigo,
+    string Mensagem,
+    IReadOnlyList<Guid> AtosConflitantes);

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Mappings/AtoNormativoMapping.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Mappings/AtoNormativoMapping.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Mappings;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+public static class AtoNormativoMapping
+{
+    /// <summary>
+    /// Projeta o ato em DTO. <c>Avisos</c> fica nulo — a recomputação do aviso de
+    /// numeração (AC4) é responsabilidade de quem monta a resposta de detalhe, para
+    /// não incorrer em N+1 na listagem.
+    /// </summary>
+    public static AtoNormativoDto ToDto(this AtoNormativo ato)
+    {
+        ArgumentNullException.ThrowIfNull(ato);
+        return new AtoNormativoDto(
+            ato.Id,
+            ato.Orgao,
+            ato.Serie,
+            ato.Ano,
+            ato.Numero,
+            ato.TipoCodigo,
+            ato.CongelaConfiguracao,
+            ato.EfeitoIrreversivel,
+            ato.DataPublicacao,
+            ato.DocumentoHash,
+            ato.Assinante,
+            ato.RegistradoEm,
+            ato.VersaoInvocada?.Id,
+            ato.VersaoInvocada?.Hash);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosNormativosQuery.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosNormativosQuery.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista os atos publicados, paginados por cursor bidirecional (ADR-0026 +
+/// ADR-0089). O controller decifra o cursor opaco e valida limit/direction antes
+/// de despachar (ADR-0031). Os itens da lista não trazem avisos de numeração —
+/// esses são recomputados só no detalhe, para evitar N+1.
+/// </summary>
+public sealed record ListarAtosNormativosQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarAtosNormativosResult>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosNormativosQueryHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosNormativosQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Mappings;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+public static class ListarAtosNormativosQueryHandler
+{
+    public static async Task<ListarAtosNormativosResult> Handle(
+        ListarAtosNormativosQuery query,
+        IAtoNormativoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<AtoNormativo> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        AtoNormativoDto[] items = [.. itens.Select(a => a.ToDto())];
+        return new ListarAtosNormativosResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosNormativosResult.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosNormativosResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarAtosNormativosQuery"/>: lote projetado + âncoras
+/// opcionais para o controller construir os cursores prev/next. Não vaza entidades
+/// de domínio.
+/// </summary>
+public sealed record ListarAtosNormativosResult(
+    IReadOnlyList<AtoNormativoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ObterAtoNormativoPorIdQuery.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ObterAtoNormativoPorIdQuery.cs
@@ -1,0 +1,7 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>Obtém um ato pelo identificador, com os avisos de numeração recomputados (AC4).</summary>
+public sealed record ObterAtoNormativoPorIdQuery(Guid Id) : IQuery<AtoNormativoDto?>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ObterAtoNormativoPorIdQueryHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ObterAtoNormativoPorIdQueryHandler.cs
@@ -1,0 +1,34 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+
+using Unifesspa.UniPlus.Publicacoes.Application.Avisos;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Mappings;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+public static class ObterAtoNormativoPorIdQueryHandler
+{
+    public static async Task<AtoNormativoDto?> Handle(
+        ObterAtoNormativoPorIdQuery query,
+        IAtoNormativoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        AtoNormativo? ato = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (ato is null)
+        {
+            return null;
+        }
+
+        // Recomputa o aviso (AC4), excluindo o próprio ato do conjunto de conflitantes.
+        IReadOnlyList<AvisoNumeracao> avisos = await AvisoNumeracaoCalculator
+            .CalcularAsync(repository, ato, excluirId: ato.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return ato.ToDto() with { Avisos = avisos };
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/AtoNormativo.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/AtoNormativo.cs
@@ -1,0 +1,185 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
+
+/// <summary>
+/// Ato publicado — o registro central e append-only de que algo foi publicado
+/// (ADR-0105). Guarda a essência documental do ato (órgão, série, ano, número,
+/// tipo, data de publicação, hash do documento, assinante) e, por valor, os
+/// atributos de consequência do catálogo e a versão de configuração que o
+/// governou. É a <b>prova</b> do publicado: o passado documental não se muta.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementa <see cref="IForensicEntity"/> (ADR-0063): append-only, não herda
+/// <see cref="Kernel.Domain.Entities.EntityBase"/> e não carrega soft-delete.
+/// Só recebe <c>INSERT</c> — <c>UPDATE</c>/<c>DELETE</c> são bloqueados no banco
+/// por trigger (a factory não expõe mutadores; o trigger fecha a brecha de um
+/// <c>UPDATE</c>/<c>DELETE</c> cru fora do agregado).
+/// </para>
+/// <para>
+/// <b>Número declarado, não gerado.</b> O sistema não opina sobre a política de
+/// numeração de cada órgão: <see cref="Numero"/> é opcional e não tem unicidade
+/// imposta — dois atos com o mesmo <c>(orgao, serie, ano, numero)</c> são aceitos.
+/// A colisão de número gera um <i>aviso</i> consultável (computado na leitura),
+/// jamais recusa.
+/// </para>
+/// <para>
+/// <b>Data documental ≠ ordem de vigência.</b> <see cref="DataPublicacao"/> é o
+/// que o documento declara e nunca ordena vigência; a ordem pertence à versão de
+/// configuração, no relógio do sistema. <see cref="RegistradoEm"/> é o instante
+/// forense em que o registro entrou no sistema — distinto da data documental.
+/// </para>
+/// <para>
+/// <b>Cópia por valor.</b> <see cref="CongelaConfiguracao"/> e
+/// <see cref="EfeitoIrreversivel"/> são copiados do <c>TipoAtoPublicado</c>
+/// vigente na data de publicação, no instante do registro — nunca consultados de
+/// volta para decidir fluxo (ADR-0103). Editar o catálogo depois não reescreve
+/// ato nenhum.
+/// </para>
+/// <para>
+/// Retificação (relação entre atos) e o vínculo genérico ato↔entidade não
+/// pertencem a este agregado ainda — nascem em stories próprias (#800 e #801).
+/// </para>
+/// </remarks>
+public sealed class AtoNormativo : IForensicEntity
+{
+    private const int OrgaoMaxLength = 200;
+    private const int SerieMaxLength = 100;
+    private const int NumeroMaxLength = 60;
+    private const int TipoCodigoMaxLength = 60;
+    private const int AssinanteMaxLength = 200;
+
+    public Guid Id { get; private init; } = Guid.CreateVersion7();
+
+    /// <summary>Órgão publicador que emitiu o ato (ex.: CEPS, CRCA).</summary>
+    public string Orgao { get; private init; } = null!;
+
+    /// <summary>Série de numeração do ato (ex.: EDITAL, AVISO) — atravessa certames.</summary>
+    public string Serie { get; private init; } = null!;
+
+    /// <summary>Ano da numeração declarada pelo órgão.</summary>
+    public int Ano { get; private init; }
+
+    /// <summary>Número que o órgão deu ao ato. Opcional — há atos sem número (ex.: comunicado).</summary>
+    public string? Numero { get; private init; }
+
+    /// <summary>Código do tipo de ato no catálogo (<c>TipoAtoPublicado</c>) vigente na data de publicação.</summary>
+    public string TipoCodigo { get; private init; } = null!;
+
+    /// <summary>Se o ato produz nova versão congelada da configuração — copiado por valor do catálogo (RN08).</summary>
+    public bool CongelaConfiguracao { get; private init; }
+
+    /// <summary>Se a publicação do ato não pode ser desfeita — copiado por valor do catálogo.</summary>
+    public bool EfeitoIrreversivel { get; private init; }
+
+    /// <summary>Data que o documento declara. Documental — nunca ordena vigência.</summary>
+    public DateOnly DataPublicacao { get; private init; }
+
+    /// <summary>Hash SHA-256 do PDF publicado. É o que prova o publicado.</summary>
+    public string DocumentoHash { get; private init; } = null!;
+
+    /// <summary>Nome de quem assina o ato.</summary>
+    public string Assinante { get; private init; } = null!;
+
+    /// <summary>Instante forense em que o registro entrou no sistema (relógio do sistema, não o documento).</summary>
+    public DateTimeOffset RegistradoEm { get; private init; }
+
+    /// <summary>
+    /// Versão de configuração que governou o ato, por valor <c>{id, hash}</c>
+    /// (ADR-0075). Nula quando o ato não invoca configuração (ato autônomo).
+    /// </summary>
+    public ReferenciaVersaoConfiguracao? VersaoInvocada { get; private init; }
+
+    // EF Core materialization
+    private AtoNormativo()
+    {
+    }
+
+    /// <summary>
+    /// Registra um ato publicado. Os atributos de consequência
+    /// (<paramref name="congelaConfiguracao"/>, <paramref name="efeitoIrreversivel"/>)
+    /// já vêm resolvidos por valor do catálogo vigente; a validação de negócio
+    /// (existência de versão vigente, formato do payload) é responsabilidade do
+    /// handler e do validator. Aqui ficam as invariantes de última linha, que
+    /// lançam — o agregado nunca materializa em estado inválido.
+    /// </summary>
+    public static AtoNormativo Registrar(
+        string orgao,
+        string serie,
+        int ano,
+        string? numero,
+        string tipoCodigo,
+        bool congelaConfiguracao,
+        bool efeitoIrreversivel,
+        DateOnly dataPublicacao,
+        string documentoHash,
+        string assinante,
+        DateTimeOffset registradoEm,
+        ReferenciaVersaoConfiguracao? versaoInvocada)
+    {
+        string orgaoNorm = ExigirTexto(orgao, OrgaoMaxLength, nameof(orgao));
+        string serieNorm = ExigirTexto(serie, SerieMaxLength, nameof(serie));
+        string tipoCodigoNorm = ExigirTexto(tipoCodigo, TipoCodigoMaxLength, nameof(tipoCodigo));
+        string assinanteNorm = ExigirTexto(assinante, AssinanteMaxLength, nameof(assinante));
+        string? numeroNorm = NormalizarOpcional(numero, NumeroMaxLength, nameof(numero));
+
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(ano);
+
+        if (!HashSha256.TemFormatoValido(documentoHash))
+        {
+            throw new ArgumentException(
+                "Hash do documento deve ser um SHA-256 em hexadecimal minúsculo (64 caracteres).",
+                nameof(documentoHash));
+        }
+
+        return new AtoNormativo
+        {
+            Orgao = orgaoNorm,
+            Serie = serieNorm,
+            Ano = ano,
+            Numero = numeroNorm,
+            TipoCodigo = tipoCodigoNorm,
+            CongelaConfiguracao = congelaConfiguracao,
+            EfeitoIrreversivel = efeitoIrreversivel,
+            DataPublicacao = dataPublicacao,
+            DocumentoHash = documentoHash,
+            Assinante = assinanteNorm,
+            RegistradoEm = registradoEm,
+            VersaoInvocada = versaoInvocada,
+        };
+    }
+
+    private static string ExigirTexto(string valor, int maxLength, string paramName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(valor, paramName);
+        string norm = valor.Trim();
+        if (norm.Length > maxLength)
+        {
+            throw new ArgumentException(
+                $"'{paramName}' deve ter no máximo {maxLength} caracteres.",
+                paramName);
+        }
+
+        return norm;
+    }
+
+    private static string? NormalizarOpcional(string? valor, int maxLength, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return null;
+        }
+
+        string norm = valor.Trim();
+        if (norm.Length > maxLength)
+        {
+            throw new ArgumentException(
+                $"'{paramName}' deve ter no máximo {maxLength} caracteres.",
+                paramName);
+        }
+
+        return norm;
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/AtoNormativoErrorCodes.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/AtoNormativoErrorCodes.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+
+public static class AtoNormativoErrorCodes
+{
+    /// <summary>
+    /// O tipo informado não tem versão do catálogo vigente na data de publicação
+    /// do ato. Sem versão vigente não há de onde copiar <c>congela_configuracao</c>
+    /// e <c>efeito_irreversivel</c>, então o registro é recusado.
+    /// </summary>
+    public const string TipoSemVersaoVigente = "AtoNormativo.TipoSemVersaoVigente";
+
+    /// <summary>
+    /// O par <c>{versao_invocada_id, versao_invocada_hash}</c> veio pela metade —
+    /// um identificador sem hash, ou um hash sem identificador. É completo ou ausente.
+    /// </summary>
+    public const string VersaoInvocadaIncompleta = "AtoNormativo.VersaoInvocadaIncompleta";
+
+    /// <summary>O identificador da URL não corresponde a nenhum ato registrado.</summary>
+    public const string NaoEncontrado = "AtoNormativo.NaoEncontrado";
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Interfaces/IAtoNormativoRepository.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Interfaces/IAtoNormativoRepository.cs
@@ -1,0 +1,45 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+/// <summary>
+/// Repositório da entidade <see cref="AtoNormativo"/> (schema <c>publicacoes</c>,
+/// ADR-0097). O ato é append-only (ADR-0063): há inserção e leitura, nunca
+/// atualização nem remoção — daí a ausência de <c>Remover</c>/<c>Atualizar</c>.
+/// </summary>
+public interface IAtoNormativoRepository
+{
+    /// <summary>Insere um novo ato. A persistência efetiva ocorre no <c>SalvarAlteracoesAsync</c> da unidade de trabalho.</summary>
+    Task AdicionarAsync(AtoNormativo ato, CancellationToken cancellationToken);
+
+    /// <summary>Carrega o ato para leitura (<c>AsNoTracking</c>) — projeção em DTO. Nulo se não existir.</summary>
+    Task<AtoNormativo?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Devolve os identificadores dos atos que compartilham a mesma numeração
+    /// <c>(orgao, serie, ano, numero)</c>, excluindo <paramref name="excluirId"/>
+    /// quando informado (o próprio ato, na recomputação do aviso durante a leitura).
+    /// Base do aviso de número duplicado (AC4) — diagnóstico do estado atual, não
+    /// prova imutável: entre esta consulta e um insert concorrente cabe uma corrida,
+    /// tolerada porque o aviso não bloqueia o registro.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> ListarIdsComMesmaNumeracaoAsync(
+        string orgao,
+        string serie,
+        int ano,
+        string numero,
+        Guid? excluirId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista atos paginados por cursor keyset bidirecional (ADR-0026 + ADR-0089):
+    /// ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras de
+    /// <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<AtoNormativo> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/ValueObjects/HashSha256.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/ValueObjects/HashSha256.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
+
+using System.Text.RegularExpressions;
+
+/// <summary>
+/// Predicado de formato de um hash SHA-256 em hexadecimal minúsculo (64
+/// caracteres). Cópia local em <c>Publicacoes.Domain</c> — o computador de hash
+/// canônico vive em <c>Selecao.Domain</c> e o isolamento de módulo (R8/ADR-0056)
+/// proíbe Publicações de referenciá-lo. Aqui só se valida o <b>formato</b>: o
+/// hash em si é prova recebida pronta (o hash do PDF publicado, ou o hash da
+/// versão de configuração que governou o ato), nunca recomputado por este módulo.
+/// </summary>
+public static partial class HashSha256
+{
+    /// <summary>Verdadeiro quando <paramref name="valor"/> é um SHA-256 hex minúsculo de 64 caracteres.</summary>
+    public static bool TemFormatoValido(string? valor) =>
+        valor is not null && Formato().IsMatch(valor);
+
+    [GeneratedRegex(@"^[0-9a-f]{64}$", RegexOptions.CultureInvariant)]
+    private static partial Regex Formato();
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/ValueObjects/ReferenciaVersaoConfiguracao.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/ValueObjects/ReferenciaVersaoConfiguracao.cs
@@ -1,0 +1,61 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Referência, <b>por valor</b>, à versão de configuração que governou um ato
+/// no instante em que foi publicado — o par <c>{id, hash}</c> (ADR-0075). O
+/// <c>id</c> aponta a versão no módulo que a produziu (Seleção); o <c>hash</c>
+/// prova que a definição aplicada não mudou depois. Não há chave estrangeira
+/// cruzando módulo (ADR-0061/0105): a versão vive noutro schema, e a integridade
+/// referencial é substituída pela prova criptográfica do hash.
+/// </summary>
+/// <remarks>
+/// <para>
+/// O par é <b>completo ou ausente</b>: um identificador sem hash não prova nada,
+/// então a factory recusa qualquer uma das metades isolada. Um ato pode não ter
+/// versão invocada (ato autônomo, sem vínculo com configuração) — nesse caso a
+/// referência simplesmente não existe (a propriedade fica nula no agregado).
+/// </para>
+/// <para>
+/// Só se valida o <b>formato</b> do hash aqui. Que a versão <c>id</c> exista de
+/// fato com aquele <c>hash</c> é responsabilidade de quem resolve a referência
+/// no módulo de origem — Publicações a recebe já resolvida, por valor.
+/// </para>
+/// </remarks>
+public sealed record ReferenciaVersaoConfiguracao
+{
+    private ReferenciaVersaoConfiguracao(Guid id, string hash)
+    {
+        Id = id;
+        Hash = hash;
+    }
+
+    public Guid Id { get; }
+    public string Hash { get; }
+
+    /// <summary>
+    /// Cria a referência validando que <paramref name="id"/> não é
+    /// <see cref="Guid.Empty"/> e que <paramref name="hash"/> tem o formato de um
+    /// SHA-256 hex minúsculo (64 caracteres).
+    /// </summary>
+    public static Result<ReferenciaVersaoConfiguracao> Criar(Guid id, string hash)
+    {
+        if (id == Guid.Empty)
+        {
+            return Result<ReferenciaVersaoConfiguracao>.Failure(new DomainError(
+                "ReferenciaVersaoConfiguracao.IdObrigatorio",
+                "Identificador da versão de configuração é obrigatório."));
+        }
+
+        if (!HashSha256.TemFormatoValido(hash))
+        {
+            return Result<ReferenciaVersaoConfiguracao>.Failure(new DomainError(
+                "ReferenciaVersaoConfiguracao.HashInvalido",
+                "Hash da versão de configuração deve ser um SHA-256 em hexadecimal minúsculo (64 caracteres)."));
+        }
+
+        return Result<ReferenciaVersaoConfiguracao>.Success(
+            new ReferenciaVersaoConfiguracao(id, hash));
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/DependencyInjection.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/DependencyInjection.cs
@@ -33,6 +33,7 @@ public static class PublicacoesInfrastructureRegistration
             serviceProvider.GetRequiredService<PublicacoesDbContext>());
 
         services.AddScoped<ITipoAtoPublicadoRepository, TipoAtoPublicadoRepository>();
+        services.AddScoped<IAtoNormativoRepository, AtoNormativoRepository>();
 
         return services;
     }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/AtoNormativoConfiguration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/AtoNormativoConfiguration.cs
@@ -1,0 +1,98 @@
+namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class AtoNormativoConfiguration : IEntityTypeConfiguration<AtoNormativo>
+{
+    private const int OrgaoMaxLength = 200;
+    private const int SerieMaxLength = 100;
+    private const int NumeroMaxLength = 60;
+    private const int TipoCodigoMaxLength = 60;
+    private const int AssinanteMaxLength = 200;
+    private const int HashLength = 64;
+
+    public void Configure(EntityTypeBuilder<AtoNormativo> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            "ato_normativo",
+            t =>
+            {
+                // Defesa em profundidade do formato do hash do documento contra
+                // inserts crus (o guard de domínio já recusa). SHA-256 hex minúsculo.
+                t.HasCheckConstraint(
+                    "ck_ato_normativo_documento_hash",
+                    "documento_hash ~ '^[0-9a-f]{64}$'");
+
+                // O par {id, hash} da versão invocada é completo ou ausente: um
+                // identificador sem hash não prova nada (ADR-0075).
+                t.HasCheckConstraint(
+                    "ck_ato_normativo_versao_completa",
+                    "(versao_invocada_id IS NULL AND versao_invocada_hash IS NULL) "
+                    + "OR (versao_invocada_id IS NOT NULL AND versao_invocada_hash IS NOT NULL)");
+
+                // Formato do hash da versão quando presente.
+                t.HasCheckConstraint(
+                    "ck_ato_normativo_versao_hash",
+                    "versao_invocada_hash IS NULL OR versao_invocada_hash ~ '^[0-9a-f]{64}$'");
+
+                // Um Guid.Empty não referencia versão alguma — defesa contra insert cru.
+                t.HasCheckConstraint(
+                    "ck_ato_normativo_versao_id_nao_zero",
+                    "versao_invocada_id IS NULL OR versao_invocada_id <> '00000000-0000-0000-0000-000000000000'");
+
+                // Ano é declarado pelo órgão; importação de acervo histórico admite
+                // anos antigos, então não há teto — apenas positividade.
+                t.HasCheckConstraint("ck_ato_normativo_ano_positivo", "ano > 0");
+            });
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.Orgao).HasMaxLength(OrgaoMaxLength).IsRequired();
+        builder.Property(a => a.Serie).HasMaxLength(SerieMaxLength).IsRequired();
+        builder.Property(a => a.Ano).IsRequired();
+        builder.Property(a => a.Numero).HasMaxLength(NumeroMaxLength);
+        builder.Property(a => a.TipoCodigo).HasMaxLength(TipoCodigoMaxLength).IsRequired();
+
+        builder.Property(a => a.CongelaConfiguracao).IsRequired();
+        builder.Property(a => a.EfeitoIrreversivel).IsRequired();
+
+        builder.Property(a => a.DataPublicacao).IsRequired();
+
+        builder.Property(a => a.DocumentoHash)
+            .HasMaxLength(HashLength)
+            .IsFixedLength()
+            .IsRequired();
+
+        builder.Property(a => a.Assinante).HasMaxLength(AssinanteMaxLength).IsRequired();
+
+        builder.Property(a => a.RegistradoEm).IsRequired();
+
+        // Versão de configuração que governou o ato, por valor {id, hash} (ADR-0075),
+        // sem chave estrangeira cruzando módulo (ADR-0061). Owned opcional: ambas as
+        // colunas são nulas juntas quando o ato não invoca configuração.
+        builder.OwnsOne(a => a.VersaoInvocada, versao =>
+        {
+            versao.Property(v => v.Id).HasColumnName("versao_invocada_id");
+            versao.Property(v => v.Hash)
+                .HasColumnName("versao_invocada_hash")
+                .HasMaxLength(HashLength)
+                .IsFixedLength();
+        });
+        builder.Navigation(a => a.VersaoInvocada).IsRequired(false);
+
+        // Lookup por numeração para o aviso de duplicata (AC4). NÃO é único: o
+        // número é declarado, não gerado — dois atos com a mesma numeração são
+        // aceitos, e a colisão vira aviso, jamais recusa.
+        builder.HasIndex(a => new { a.Orgao, a.Serie, a.Ano, a.Numero })
+            .HasDatabaseName("ix_ato_normativo_numeracao");
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260710221403_AddAtoNormativo.Designer.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260710221403_AddAtoNormativo.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(PublicacoesDbContext))]
-    partial class PublicacoesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260710221403_AddAtoNormativo")]
+    partial class AddAtoNormativo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260710221403_AddAtoNormativo.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260710221403_AddAtoNormativo.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAtoNormativo : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ato_normativo",
+                schema: "publicacoes",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    orgao = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    serie = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    ano = table.Column<int>(type: "integer", nullable: false),
+                    numero = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: true),
+                    tipo_codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    congela_configuracao = table.Column<bool>(type: "boolean", nullable: false),
+                    efeito_irreversivel = table.Column<bool>(type: "boolean", nullable: false),
+                    data_publicacao = table.Column<DateOnly>(type: "date", nullable: false),
+                    documento_hash = table.Column<string>(type: "character(64)", fixedLength: true, maxLength: 64, nullable: false),
+                    assinante = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    registrado_em = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    versao_invocada_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    versao_invocada_hash = table.Column<string>(type: "character(64)", fixedLength: true, maxLength: 64, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_ato_normativo", x => x.id);
+                    table.CheckConstraint("ck_ato_normativo_ano_positivo", "ano > 0");
+                    table.CheckConstraint("ck_ato_normativo_documento_hash", "documento_hash ~ '^[0-9a-f]{64}$'");
+                    table.CheckConstraint("ck_ato_normativo_versao_completa", "(versao_invocada_id IS NULL AND versao_invocada_hash IS NULL) OR (versao_invocada_id IS NOT NULL AND versao_invocada_hash IS NOT NULL)");
+                    table.CheckConstraint("ck_ato_normativo_versao_hash", "versao_invocada_hash IS NULL OR versao_invocada_hash ~ '^[0-9a-f]{64}$'");
+                    table.CheckConstraint("ck_ato_normativo_versao_id_nao_zero", "versao_invocada_id IS NULL OR versao_invocada_id <> '00000000-0000-0000-0000-000000000000'");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ato_normativo_numeracao",
+                schema: "publicacoes",
+                table: "ato_normativo",
+                columns: new[] { "orgao", "serie", "ano", "numero" });
+
+            // Enforcement de banco do append-only (ADR-0063). A entidade forense
+            // não expõe mutadores e nenhum handler chama Update/Remove — o trigger
+            // fecha a última brecha: um UPDATE/DELETE cru fora do agregado. O ato
+            // publicado é prova legal; corromper o passado documental é bloqueado
+            // pelo próprio banco, não só por convenção de código.
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION publicacoes.fn_ato_normativo_somente_insercao()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $$
+                BEGIN
+                    RAISE EXCEPTION
+                        'ato_normativo é append-only (ADR-0063): operação % é bloqueada; o passado documental não se muta.', TG_OP
+                        USING ERRCODE = 'restrict_violation';
+                END;
+                $$;
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE TRIGGER trg_ato_normativo_somente_insercao
+                    BEFORE UPDATE OR DELETE ON publicacoes.ato_normativo
+                    FOR EACH ROW
+                    EXECUTE FUNCTION publicacoes.fn_ato_normativo_somente_insercao();
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_ato_normativo_somente_insercao ON publicacoes.ato_normativo;");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS publicacoes.fn_ato_normativo_somente_insercao();");
+
+            migrationBuilder.DropTable(
+                name: "ato_normativo",
+                schema: "publicacoes");
+        }
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/PublicacoesDbContext.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/PublicacoesDbContext.cs
@@ -11,11 +11,11 @@ using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
 /// DbContext do módulo Publicações — o registro central dos atos normativos
 /// publicados por Reitoria, CEPS e CRCA (ADR-0105).
 ///
-/// Hospeda o cadastro de tipos de ato e o cache de Idempotency-Key (ADR-0027)
-/// adjacente. O ato normativo e o vínculo ato↔entidade chegam nas stories
-/// seguintes. O módulo não conhece ProcessoSeletivo, Chamada nem configuração
-/// de certame — nenhuma coluna, nenhuma chave estrangeira desses conceitos
-/// entra aqui.
+/// Hospeda o cadastro de tipos de ato, o ato normativo append-only e o cache de
+/// Idempotency-Key (ADR-0027) adjacente. O vínculo genérico ato↔entidade chega
+/// na story seguinte (#801). O módulo não conhece ProcessoSeletivo, Chamada nem
+/// configuração de certame — nenhuma coluna, nenhuma chave estrangeira desses
+/// conceitos entra aqui.
 /// </summary>
 public sealed class PublicacoesDbContext : DbContext, IPublicacoesUnitOfWork
 {
@@ -30,6 +30,12 @@ public sealed class PublicacoesDbContext : DbContext, IPublicacoesUnitOfWork
     }
 
     public DbSet<TipoAtoPublicado> TiposAtoPublicado => Set<TipoAtoPublicado>();
+
+    /// <summary>
+    /// Atos normativos publicados — registro central e append-only (ADR-0063/0105).
+    /// Só recebe <c>INSERT</c>; <c>UPDATE</c>/<c>DELETE</c> são bloqueados por trigger.
+    /// </summary>
+    public DbSet<AtoNormativo> AtosNormativos => Set<AtoNormativo>();
 
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no schema do módulo para permitir

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Repositories/AtoNormativoRepository.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Repositories/AtoNormativoRepository.cs
@@ -1,0 +1,83 @@
+namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using System.Linq;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em PublicacoesInfrastructureRegistration.")]
+public sealed class AtoNormativoRepository : IAtoNormativoRepository
+{
+    private readonly PublicacoesDbContext _dbContext;
+
+    public AtoNormativoRepository(PublicacoesDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task AdicionarAsync(AtoNormativo ato, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(ato);
+        await _dbContext.AtosNormativos.AddAsync(ato, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<AtoNormativo?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.AtosNormativos
+            .AsNoTracking()
+            .FirstOrDefaultAsync(a => a.Id == id, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Guid>> ListarIdsComMesmaNumeracaoAsync(
+        string orgao,
+        string serie,
+        int ano,
+        string numero,
+        Guid? excluirId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orgao);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serie);
+        ArgumentException.ThrowIfNullOrWhiteSpace(numero);
+
+        string orgaoNorm = orgao.Trim();
+        string serieNorm = serie.Trim();
+        string numeroNorm = numero.Trim();
+
+        return await _dbContext.AtosNormativos
+            .AsNoTracking()
+            .Where(a => a.Orgao == orgaoNorm
+                && a.Serie == serieNorm
+                && a.Ano == ano
+                && a.Numero == numeroNorm
+                && (excluirId == null || a.Id != excluirId))
+            .Select(a => a.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<(IReadOnlyList<AtoNormativo> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Sem OrderBy aqui: o helper keyset (ADR-0089) ordena por Id (Guid v7) e
+        // fatia, devolvendo as âncoras de prev/next.
+        IQueryable<AtoNormativo> query = _dbContext.AtosNormativos.AsNoTracking();
+
+        CursorKeysetPage<AtoNormativo> page = await CursorKeyset
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorKeyset.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorKeyset.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 
 using Microsoft.EntityFrameworkCore;
 
-using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
 using Unifesspa.UniPlus.Kernel.Pagination;
 
 /// <summary>
@@ -47,7 +47,7 @@ public static class CursorKeyset
         int limit,
         PaginationDirection direction,
         CancellationToken cancellationToken = default)
-        where T : EntityBase
+        where T : IIdentificavel
     {
         ArgumentNullException.ThrowIfNull(filtered);
 
@@ -61,7 +61,7 @@ public static class CursorKeyset
         Guid? afterId,
         int limit,
         CancellationToken cancellationToken)
-        where T : EntityBase
+        where T : IIdentificavel
     {
         IQueryable<T> forward = afterId is { } anchor
             ? filtered.Where(e => e.Id.CompareTo(anchor) > 0)
@@ -101,7 +101,7 @@ public static class CursorKeyset
         Guid? afterId,
         int limit,
         CancellationToken cancellationToken)
-        where T : EntityBase
+        where T : IIdentificavel
     {
         IQueryable<T> backward = afterId is { } anchor
             ? filtered.Where(e => e.Id.CompareTo(anchor) < 0)

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Entities/EntityBase.cs
@@ -1,8 +1,9 @@
 namespace Unifesspa.UniPlus.Kernel.Domain.Entities;
 
 using Events;
+using Interfaces;
 
-public abstract class EntityBase
+public abstract class EntityBase : IIdentificavel
 {
     // UUIDv7 (RFC 9562 §5.7) — 48 bits de unix_ts_ms no prefixo + 74 bits aleatórios.
     // Adotado em todas as entidades de domínio (ADR-0032). Ganhos:

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Interfaces/IForensicEntity.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Interfaces/IForensicEntity.cs
@@ -27,8 +27,6 @@ namespace Unifesspa.UniPlus.Kernel.Domain.Interfaces;
 /// <c>area_interesse_binding_historico</c>) também implementam quando vierem.
 /// </para>
 /// </remarks>
-public interface IForensicEntity
+public interface IForensicEntity : IIdentificavel
 {
-    /// <summary>Identificador único da linha (UUID v7 do timestamp do snapshot).</summary>
-    Guid Id { get; }
 }

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Interfaces/IIdentificavel.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Interfaces/IIdentificavel.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+/// <summary>
+/// Contrato mínimo de identidade: uma entidade persistida com um
+/// <see cref="Id"/> <see cref="Guid"/> v7 (ADR-0032), ordenável temporalmente.
+/// Base comum de <see cref="Entities.EntityBase"/> e de
+/// <see cref="IForensicEntity"/> — as duas famílias de entidade do projeto
+/// (mutável com soft-delete opt-in vs. append-only forense) compartilham só
+/// isto: um Id ordenável.
+/// </summary>
+/// <remarks>
+/// Existe para que utilitários agnósticos ao ciclo de vida — a paginação keyset
+/// (ADR-0089), que ordena e fatia por <see cref="Id"/> — operem sobre ambas as
+/// famílias sem acoplar-se a <see cref="Entities.EntityBase"/>, que carrega
+/// muito mais do que o keyset precisa.
+/// </remarks>
+public interface IIdentificavel
+{
+    /// <summary>Identificador único da entidade (UUID v7, ordenável por tempo).</summary>
+    Guid Id { get; }
+}

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/ForensicEntityConventionsTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/ForensicEntityConventionsTests.cs
@@ -86,9 +86,10 @@ public sealed class ForensicEntityConventionsTests
             typeof(EntityBase).Assembly,
             // Apenas assemblies de Domain que JÁ definem IForensicEntity ficam aqui;
             // como typeof(EntityBase).Assembly é Kernel (sem implementações), e as
-            // implementações vivem em Selecao.Domain, basta carregar pelo tipo de
-            // domínio referenciado.
+            // implementações vivem nos módulos, basta carregar pelo tipo de domínio
+            // referenciado de cada um.
             typeof(Selecao.Domain.Entities.ObrigatoriedadeLegal).Assembly,
+            typeof(Publicacoes.Domain.Entities.AtoNormativo).Assembly,
         ];
 
         return [.. assemblies

--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/PublicacoesHandlersNoBusTests.cs
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/PublicacoesHandlersNoBusTests.cs
@@ -10,8 +10,10 @@ using Unifesspa.UniPlus.Application.Abstractions.Messaging;
 using Unifesspa.UniPlus.Host.IntegrationTests.Infrastructure;
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
 using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
 using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
 using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
 using Unifesspa.UniPlus.Publicacoes.Application.Queries.TiposAtoPublicado;
 
 /// <summary>
@@ -96,5 +98,44 @@ public sealed class PublicacoesHandlersNoBusTests
             new ObterTipoAtoPublicadoVigenteQuery("BUS_VIGENTE", Inicio.AddYears(1)),
             CancellationToken.None);
         noFim.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "O registro de ato atravessa o bus, resolve o tipo vigente e copia por valor")]
+    public async Task RegistrarAto_AtravessaOBus()
+    {
+        using IServiceScope scope = _fixture.Factory.Services.CreateScope();
+        ICommandBus commandBus = scope.ServiceProvider.GetRequiredService<ICommandBus>();
+        IQueryBus queryBus = scope.ServiceProvider.GetRequiredService<IQueryBus>();
+
+        Result<Guid> tipo = await commandBus.Send(
+            new CriarTipoAtoPublicadoCommand(
+                "BUS_ATO_TIPO", "Tipo para ato exercitado pelo bus",
+                CongelaConfiguracao: true, UnicoPorObjeto: false, EfeitoIrreversivel: false,
+                VigenciaInicio: Inicio),
+            CancellationToken.None);
+        tipo.IsSuccess.Should().BeTrue();
+
+        Result<RegistrarAtoNormativoResult> registrado = await commandBus.Send(
+            new RegistrarAtoNormativoCommand(
+                Orgao: "CEPS",
+                Serie: "BUS_EDITAL",
+                Ano: 2026,
+                Numero: "1",
+                TipoCodigo: "BUS_ATO_TIPO",
+                DataPublicacao: Inicio.AddMonths(2),
+                DocumentoHash: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+                Assinante: "Jairo Belchior"),
+            CancellationToken.None);
+
+        registrado.IsSuccess.Should().BeTrue(
+            "o handler de registro precisa resolver ITipoAtoPublicadoRepository, "
+            + "IAtoNormativoRepository e a IPublicacoesUnitOfWork encaminhada pelo codegen (ADR-0098)");
+
+        AtoNormativoDto? lido = await queryBus.Send(
+            new ObterAtoNormativoPorIdQuery(registrado.Value!.AtoId), CancellationToken.None);
+
+        lido.Should().NotBeNull();
+        // O tipo vigente congela configuração — copiado por valor no ato (AC5).
+        lido!.CongelaConfiguracao.Should().BeTrue();
     }
 }

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/RegistrarAtoNormativoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/RegistrarAtoNormativoCommandHandlerTests.cs
@@ -1,0 +1,137 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.Commands;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class RegistrarAtoNormativoCommandHandlerTests
+{
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    private static readonly DateOnly Publicacao = new(2026, 3, 13);
+    private static readonly DateTimeOffset Agora = new(2026, 3, 13, 19, 0, 0, TimeSpan.Zero);
+
+    private readonly ITipoAtoPublicadoRepository _tipos = Substitute.For<ITipoAtoPublicadoRepository>();
+    private readonly IAtoNormativoRepository _atos = Substitute.For<IAtoNormativoRepository>();
+    private readonly IPublicacoesUnitOfWork _unitOfWork = Substitute.For<IPublicacoesUnitOfWork>();
+    private readonly TimeProvider _relogio = new RelogioFixo(Agora);
+
+    [Fact(DisplayName = "Recusa quando não há tipo vigente na data de publicação")]
+    public async Task Handle_SemTipoVigente_Falha()
+    {
+        _tipos.ObterVigenteAsync("EDITAL_ABERTURA", Publicacao, Arg.Any<CancellationToken>())
+            .Returns((TipoAtoPublicado?)null);
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(Comando());
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AtoNormativoErrorCodes.TipoSemVersaoVigente);
+        await _atos.DidNotReceive().AdicionarAsync(Arg.Any<AtoNormativo>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Copia congela/efeito do catálogo vigente por valor e registra")]
+    public async Task Handle_ComTipoVigente_CopiaERegistra()
+    {
+        VigenteComConsequencia(congela: true, efeito: true);
+        SemConflitoDeNumero();
+
+        AtoNormativo? capturado = null;
+        await _atos.AdicionarAsync(Arg.Do<AtoNormativo>(a => capturado = a), Arg.Any<CancellationToken>());
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(Comando());
+
+        resultado.IsSuccess.Should().BeTrue();
+        capturado.Should().NotBeNull();
+        capturado!.CongelaConfiguracao.Should().BeTrue();
+        capturado.EfeitoIrreversivel.Should().BeTrue();
+        capturado.RegistradoEm.Should().Be(Agora);
+        resultado.Value!.RegistradoEm.Should().Be(Agora);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Par de versão incompleto (só id) é recusado")]
+    public async Task Handle_ComVersaoInvocadaIncompleta_Falha()
+    {
+        VigenteComConsequencia(congela: false, efeito: false);
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando() with { VersaoInvocadaId = Guid.CreateVersion7(), VersaoInvocadaHash = null });
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AtoNormativoErrorCodes.VersaoInvocadaIncompleta);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Número já usado gera aviso, sem impedir o registro")]
+    public async Task Handle_ComNumeroDuplicado_AvisaERegistra()
+    {
+        VigenteComConsequencia(congela: false, efeito: false);
+        Guid outro = Guid.CreateVersion7();
+        _atos.ListarIdsComMesmaNumeracaoAsync(
+            "CEPS", "EDITAL", 2026, "13", null, Arg.Any<CancellationToken>())
+            .Returns([outro]);
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(Comando());
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Avisos.Should().ContainSingle();
+        resultado.Value.Avisos[0].Codigo.Should().Be("NumeroDuplicado");
+        resultado.Value.Avisos[0].AtosConflitantes.Should().ContainSingle().Which.Should().Be(outro);
+        await _atos.Received(1).AdicionarAsync(Arg.Any<AtoNormativo>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Número único não gera aviso")]
+    public async Task Handle_ComNumeroUnico_SemAviso()
+    {
+        VigenteComConsequencia(congela: false, efeito: false);
+        SemConflitoDeNumero();
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(Comando());
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Avisos.Should().BeEmpty();
+    }
+
+    private Task<Result<RegistrarAtoNormativoResult>> Executar(RegistrarAtoNormativoCommand comando) =>
+        RegistrarAtoNormativoCommandHandler.Handle(
+            comando, _tipos, _atos, _unitOfWork, _relogio, CancellationToken.None);
+
+    private void VigenteComConsequencia(bool congela, bool efeito)
+    {
+        TipoAtoPublicado tipo = TipoAtoPublicado.Criar(
+            "EDITAL_ABERTURA", "Edital de abertura", congela, unicoPorObjeto: false,
+            efeito, new DateOnly(2026, 1, 1), null, null).Value!;
+        _tipos.ObterVigenteAsync("EDITAL_ABERTURA", Publicacao, Arg.Any<CancellationToken>())
+            .Returns(tipo);
+    }
+
+    private void SemConflitoDeNumero() =>
+        _atos.ListarIdsComMesmaNumeracaoAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(),
+            Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+    private static RegistrarAtoNormativoCommand Comando() =>
+        new(
+            Orgao: "CEPS",
+            Serie: "EDITAL",
+            Ano: 2026,
+            Numero: "13",
+            TipoCodigo: "EDITAL_ABERTURA",
+            DataPublicacao: Publicacao,
+            DocumentoHash: HashValido,
+            Assinante: "Jairo Belchior");
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Queries/AtoNormativoQueryHandlersTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Queries/AtoNormativoQueryHandlersTests.cs
@@ -1,0 +1,78 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.Queries;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class AtoNormativoQueryHandlersTests
+{
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    private readonly IAtoNormativoRepository _atos = Substitute.For<IAtoNormativoRepository>();
+
+    [Fact(DisplayName = "ObterPorId devolve null quando o ato não existe")]
+    public async Task ObterPorId_Inexistente_Null()
+    {
+        _atos.ObterPorIdParaLeituraAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns((AtoNormativo?)null);
+
+        AtoNormativoDto? dto = await ObterAtoNormativoPorIdQueryHandler.Handle(
+            new ObterAtoNormativoPorIdQuery(Guid.CreateVersion7()), _atos, CancellationToken.None);
+
+        dto.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "ObterPorId recomputa o aviso excluindo o próprio ato")]
+    public async Task ObterPorId_RecomputaAvisoExcluindoProprio()
+    {
+        AtoNormativo ato = NovoAto();
+        _atos.ObterPorIdParaLeituraAsync(ato.Id, Arg.Any<CancellationToken>()).Returns(ato);
+        Guid outro = Guid.CreateVersion7();
+        _atos.ListarIdsComMesmaNumeracaoAsync(
+            "CEPS", "EDITAL", 2026, "13", ato.Id, Arg.Any<CancellationToken>())
+            .Returns([outro]);
+
+        AtoNormativoDto? dto = await ObterAtoNormativoPorIdQueryHandler.Handle(
+            new ObterAtoNormativoPorIdQuery(ato.Id), _atos, CancellationToken.None);
+
+        dto.Should().NotBeNull();
+        dto!.Avisos.Should().ContainSingle();
+        dto.Avisos![0].Codigo.Should().Be("NumeroDuplicado");
+    }
+
+    [Fact(DisplayName = "Listar projeta os atos sem avisos (evita N+1)")]
+    public async Task Listar_SemAvisos()
+    {
+        AtoNormativo ato = NovoAto();
+        _atos.ListarPaginadoAsync(null, 20, PaginationDirection.Next, Arg.Any<CancellationToken>())
+            .Returns(([ato], (Guid?)null, (Guid?)null));
+
+        ListarAtosNormativosResult resultado = await ListarAtosNormativosQueryHandler.Handle(
+            new ListarAtosNormativosQuery(null, 20, PaginationDirection.Next), _atos, CancellationToken.None);
+
+        resultado.Items.Should().ContainSingle();
+        resultado.Items[0].Avisos.Should().BeNull();
+    }
+
+    private static AtoNormativo NovoAto() =>
+        AtoNormativo.Registrar(
+            "CEPS", "EDITAL", 2026, "13", "EDITAL_ABERTURA",
+            congelaConfiguracao: false, efeitoIrreversivel: false,
+            dataPublicacao: new DateOnly(2026, 3, 13),
+            documentoHash: HashValido,
+            assinante: "Jairo Belchior",
+            registradoEm: new DateTimeOffset(2026, 3, 13, 19, 0, 0, TimeSpan.Zero),
+            versaoInvocada: null);
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Validators/RegistrarAtoNormativoCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Validators/RegistrarAtoNormativoCommandValidatorTests.cs
@@ -1,0 +1,105 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.Validators;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+
+/// <summary>
+/// O agregado é a autoridade sobre as invariantes de shape; o validator antecipa a
+/// recusa em 400 antes de o handler tocar o repositório. Estes testes garantem que
+/// os dois não divergem.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class RegistrarAtoNormativoCommandValidatorTests
+{
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    private readonly RegistrarAtoNormativoCommandValidator _validator = new();
+
+    [Fact(DisplayName = "Comando válido passa")]
+    public void Valido()
+    {
+        _validator.Validate(Comando()).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Ato sem número é válido (número é opcional)")]
+    public void SemNumero_Valido()
+    {
+        _validator.Validate(Comando() with { Numero = null }).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Órgão em branco é recusado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void OrgaoEmBranco(string orgao)
+    {
+        _validator.Validate(Comando() with { Orgao = orgao }).IsValid.Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "Ano não-positivo é recusado")]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void AnoNaoPositivo(int ano)
+    {
+        _validator.Validate(Comando() with { Ano = ano }).IsValid.Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "Hash do documento fora do formato SHA-256 é recusado")]
+    [InlineData("abc")]
+    [InlineData("0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef")]
+    public void DocumentoHashInvalido(string hash)
+    {
+        _validator.Validate(Comando() with { DocumentoHash = hash }).IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Par de versão incompleto (só id) é recusado")]
+    public void VersaoInvocadaSoId()
+    {
+        ValidationResult resultado = _validator.Validate(
+            Comando() with { VersaoInvocadaId = Guid.CreateVersion7(), VersaoInvocadaHash = null });
+
+        resultado.IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Par de versão incompleto (só hash) é recusado")]
+    public void VersaoInvocadaSoHash()
+    {
+        _validator.Validate(
+            Comando() with { VersaoInvocadaId = null, VersaoInvocadaHash = HashValido })
+            .IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Par de versão completo e válido passa")]
+    public void VersaoInvocadaCompleta()
+    {
+        _validator.Validate(
+            Comando() with { VersaoInvocadaId = Guid.CreateVersion7(), VersaoInvocadaHash = HashValido })
+            .IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Par de versão com id vazio (Guid.Empty) é recusado")]
+    public void VersaoInvocadaIdVazio()
+    {
+        _validator.Validate(
+            Comando() with { VersaoInvocadaId = Guid.Empty, VersaoInvocadaHash = HashValido })
+            .IsValid.Should().BeFalse();
+    }
+
+    private static RegistrarAtoNormativoCommand Comando() =>
+        new(
+            Orgao: "CEPS",
+            Serie: "EDITAL",
+            Ano: 2026,
+            Numero: "13",
+            TipoCodigo: "EDITAL_ABERTURA",
+            DataPublicacao: new DateOnly(2026, 3, 13),
+            DocumentoHash: HashValido,
+            Assinante: "Jairo Belchior");
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/AtoNormativoTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/AtoNormativoTests.cs
@@ -1,0 +1,126 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.UnitTests;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
+
+/// <summary>
+/// Invariantes de domínio do ato normativo append-only: normalização, shape do
+/// hash do documento, positividade do ano e o par {id, hash} da versão invocada.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class AtoNormativoTests
+{
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    private static readonly DateOnly Publicacao = new(2026, 3, 13);
+    private static readonly DateTimeOffset Registro = new(2026, 3, 13, 19, 0, 0, TimeSpan.Zero);
+
+    [Fact(DisplayName = "Registrar normaliza os textos e preenche os campos")]
+    public void Registrar_ComCamposValidos_NormalizaEPreenche()
+    {
+        AtoNormativo ato = AtoNormativo.Registrar(
+            orgao: "  CEPS  ",
+            serie: "  EDITAL  ",
+            ano: 2026,
+            numero: "  13  ",
+            tipoCodigo: "  EDITAL_ABERTURA  ",
+            congelaConfiguracao: true,
+            efeitoIrreversivel: false,
+            dataPublicacao: Publicacao,
+            documentoHash: HashValido,
+            assinante: "  Jairo Belchior  ",
+            registradoEm: Registro,
+            versaoInvocada: null);
+
+        ato.Id.Should().NotBe(Guid.Empty);
+        ato.Orgao.Should().Be("CEPS");
+        ato.Serie.Should().Be("EDITAL");
+        ato.Ano.Should().Be(2026);
+        ato.Numero.Should().Be("13");
+        ato.TipoCodigo.Should().Be("EDITAL_ABERTURA");
+        ato.CongelaConfiguracao.Should().BeTrue();
+        ato.EfeitoIrreversivel.Should().BeFalse();
+        ato.DataPublicacao.Should().Be(Publicacao);
+        ato.DocumentoHash.Should().Be(HashValido);
+        ato.Assinante.Should().Be("Jairo Belchior");
+        ato.RegistradoEm.Should().Be(Registro);
+        ato.VersaoInvocada.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Número em branco vira nulo (ato sem número é válido)")]
+    public void Registrar_ComNumeroEmBranco_ArmazenaNulo()
+    {
+        AtoNormativo ato = Registrar(numero: "   ");
+        ato.Numero.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Guarda a versão invocada por valor quando informada")]
+    public void Registrar_ComVersaoInvocada_Guarda()
+    {
+        ReferenciaVersaoConfiguracao versao = ReferenciaVersaoConfiguracao
+            .Criar(Guid.CreateVersion7(), HashValido).Value!;
+
+        AtoNormativo ato = Registrar(versao: versao);
+
+        ato.VersaoInvocada.Should().Be(versao);
+    }
+
+    [Theory(DisplayName = "Hash do documento fora do formato SHA-256 é recusado")]
+    [InlineData("")]
+    [InlineData("abc")]
+    [InlineData("0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef")] // maiúsculo
+    [InlineData("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde")]  // 63 chars
+    [InlineData("zzzz456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")] // não-hex
+    public void Registrar_ComDocumentoHashInvalido_Lanca(string hash)
+    {
+        Action acao = () => Registrar(documentoHash: hash);
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Theory(DisplayName = "Órgão, série, tipo e assinante em branco são recusados")]
+    [InlineData("", "EDITAL", "EDITAL_ABERTURA", "Assinante")]
+    [InlineData("CEPS", " ", "EDITAL_ABERTURA", "Assinante")]
+    [InlineData("CEPS", "EDITAL", "", "Assinante")]
+    [InlineData("CEPS", "EDITAL", "EDITAL_ABERTURA", "  ")]
+    public void Registrar_ComTextoObrigatorioEmBranco_Lanca(
+        string orgao, string serie, string tipoCodigo, string assinante)
+    {
+        Action acao = () => Registrar(orgao: orgao, serie: serie, tipoCodigo: tipoCodigo, assinante: assinante);
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Theory(DisplayName = "Ano não-positivo é recusado")]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Registrar_ComAnoNaoPositivo_Lanca(int ano)
+    {
+        Action acao = () => Registrar(ano: ano);
+        acao.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    private static AtoNormativo Registrar(
+        string orgao = "CEPS",
+        string serie = "EDITAL",
+        int ano = 2026,
+        string? numero = "13",
+        string tipoCodigo = "EDITAL_ABERTURA",
+        string documentoHash = HashValido,
+        string assinante = "Jairo Belchior",
+        ReferenciaVersaoConfiguracao? versao = null) =>
+        AtoNormativo.Registrar(
+            orgao, serie, ano, numero, tipoCodigo,
+            congelaConfiguracao: false,
+            efeitoIrreversivel: false,
+            dataPublicacao: Publicacao,
+            documentoHash: documentoHash,
+            assinante: assinante,
+            registradoEm: Registro,
+            versaoInvocada: versao);
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/ReferenciaVersaoConfiguracaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/ReferenciaVersaoConfiguracaoTests.cs
@@ -1,0 +1,53 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.UnitTests;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
+
+/// <summary>
+/// Invariantes do par por valor {id, hash} da versão de configuração invocada.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class ReferenciaVersaoConfiguracaoTests
+{
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    [Fact(DisplayName = "Criar aceita id v7 e hash SHA-256 hex minúsculo")]
+    public void Criar_ComParValido_Sucesso()
+    {
+        Guid id = Guid.CreateVersion7();
+
+        Result<ReferenciaVersaoConfiguracao> resultado = ReferenciaVersaoConfiguracao.Criar(id, HashValido);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Id.Should().Be(id);
+        resultado.Value.Hash.Should().Be(HashValido);
+    }
+
+    [Fact(DisplayName = "Id vazio é recusado")]
+    public void Criar_ComIdVazio_Falha()
+    {
+        Result<ReferenciaVersaoConfiguracao> resultado = ReferenciaVersaoConfiguracao.Criar(Guid.Empty, HashValido);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ReferenciaVersaoConfiguracao.IdObrigatorio");
+    }
+
+    [Theory(DisplayName = "Hash fora do formato SHA-256 é recusado")]
+    [InlineData("")]
+    [InlineData("abc")]
+    [InlineData("0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef")]
+    public void Criar_ComHashInvalido_Falha(string hash)
+    {
+        Result<ReferenciaVersaoConfiguracao> resultado = ReferenciaVersaoConfiguracao.Criar(Guid.CreateVersion7(), hash);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ReferenciaVersaoConfiguracao.HashInvalido");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtoNormativoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtoNormativoEndpointTests.cs
@@ -1,0 +1,324 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.AtosNormativos;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Endpoints de <c>AtoNormativo</c> contra o monólito real com Postgres efêmero:
+/// registro, autorização, idempotência, resolução do tipo vigente, cópia por
+/// valor, aviso de numeração (AC4) e o append-only exposto por HTTP.
+/// </summary>
+[Collection(PublicacoesEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class AtoNormativoEndpointTests
+{
+    private const string BaseAtos = "/api/publicacoes/atos";
+    private const string AdminAtos = "/api/publicacoes/admin/atos";
+    private const string AdminTipos = "/api/publicacoes/admin/tipos-ato";
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    private const string Publicacao = "2026-03-13";
+
+    private readonly PublicacoesEndpointFixture _fixture;
+
+    public AtoNormativoEndpointTests(PublicacoesEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // ── Leitura pública ──────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET atos retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri(BaseAtos, UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.ato-normativo.v1+json");
+    }
+
+    [Fact(DisplayName = "GET atos/{id} retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{BaseAtos}/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Autorização ──────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST admin sem autenticação retorna 401")]
+    public async Task Registrar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminAtos, UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        (await client.SendAsync(request)).StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST admin sem role plataforma-admin retorna 403")]
+    public async Task Registrar_SemRoleAdmin_Retorna403()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminAtos, UriKind.Relative));
+        Autenticar(request, role: "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(PayloadAto("EDITAL_ABERTURA", "EDITAL", "1"));
+
+        (await client.SendAsync(request)).StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Idempotência ─────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST sem Idempotency-Key retorna 400")]
+    public async Task Registrar_SemIdempotencyKey_Retorna400()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminAtos, UriKind.Relative));
+        Autenticar(request);
+        request.Content = JsonContent.Create(PayloadAto(tipo, SerieUnica(), "1"));
+
+        (await client.SendAsync(request)).StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "POST repetido com a mesma chave e o mesmo corpo devolve a resposta cacheada")]
+    public async Task Registrar_ReplayLegitimo_DevolveCache()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+        object payload = PayloadAto(tipo, SerieUnica(), "1");
+        string chave = Guid.NewGuid().ToString();
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage primeira = await PostAtoAsync(client, payload, chave);
+        primeira.StatusCode.Should().Be(HttpStatusCode.Created);
+        string corpoPrimeira = await primeira.Content.ReadAsStringAsync();
+
+        HttpResponseMessage segunda = await PostAtoAsync(client, payload, chave);
+        segunda.StatusCode.Should().Be(HttpStatusCode.Created);
+        (await segunda.Content.ReadAsStringAsync()).Should().Be(corpoPrimeira);
+    }
+
+    // ── Registro ─────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST registra, devolve 201 com Location e copia congela/efeito do catálogo")]
+    public async Task Registrar_Retorna201_CopiaConsequencia()
+    {
+        string tipo = await CriarTipoVigenteAsync(congela: true, efeito: true);
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await PostAtoAsync(client, PayloadAto(tipo, SerieUnica(), "13"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        response.Headers.Location!.AbsolutePath.Should().StartWith($"{BaseAtos}/");
+
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Guid atoId = doc.RootElement.GetProperty("atoId").GetGuid();
+        doc.RootElement.GetProperty("registradoEm").GetDateTimeOffset().Should().NotBe(default);
+
+        // A consequência gravada é a do catálogo vigente, copiada por valor (AC5).
+        using JsonDocument detalhe = JsonDocument.Parse(
+            await client.GetStringAsync(new Uri($"{BaseAtos}/{atoId}", UriKind.Relative)));
+        detalhe.RootElement.GetProperty("congelaConfiguracao").GetBoolean().Should().BeTrue();
+        detalhe.RootElement.GetProperty("efeitoIrreversivel").GetBoolean().Should().BeTrue();
+        detalhe.RootElement.GetProperty("_links").GetProperty("self").GetString()
+            .Should().Be($"{BaseAtos}/{atoId}");
+    }
+
+    [Fact(DisplayName = "POST de ato sem número é aceito (número é opcional)")]
+    public async Task Registrar_SemNumero_Retorna201()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await PostAtoAsync(client, PayloadAto(tipo, SerieUnica(), numero: null));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact(DisplayName = "POST de tipo sem versão vigente na data retorna 422 nomeado")]
+    public async Task Registrar_TipoSemVigencia_Retorna422()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // Tipo nunca cadastrado: não há versão vigente para copiar.
+        HttpResponseMessage response = await PostAtoAsync(
+            client, PayloadAto("TIPO_INEXISTENTE_" + Sufixo(), SerieUnica(), "1"));
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        (await response.Content.ReadAsStringAsync())
+            .Should().Contain("uniplus.publicacoes.ato_normativo.tipo_sem_versao_vigente");
+    }
+
+    [Fact(DisplayName = "POST com par de versão incompleto retorna 422")]
+    public async Task Registrar_VersaoInvocadaIncompleta_Retorna422()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+
+        object payload = new
+        {
+            orgao = "CEPS",
+            serie = SerieUnica(),
+            ano = 2026,
+            numero = "1",
+            tipoCodigo = tipo,
+            dataPublicacao = Publicacao,
+            documentoHash = HashValido,
+            assinante = "Jairo Belchior",
+            versaoInvocadaId = Guid.CreateVersion7(),
+            versaoInvocadaHash = (string?)null,
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await PostAtoAsync(client, payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "POST com id de versão zerado (Guid.Empty) retorna 422, não 500")]
+    public async Task Registrar_VersaoInvocadaIdVazio_Retorna422()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+
+        object payload = new
+        {
+            orgao = "CEPS",
+            serie = SerieUnica(),
+            ano = 2026,
+            numero = "1",
+            tipoCodigo = tipo,
+            dataPublicacao = Publicacao,
+            documentoHash = HashValido,
+            assinante = "Jairo Belchior",
+            versaoInvocadaId = Guid.Empty,
+            versaoInvocadaHash = HashValido,
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await PostAtoAsync(client, payload);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // ── Aviso de numeração (AC4) ─────────────────────────────────────────────
+
+    [Fact(DisplayName = "Número já usado gera aviso no registro, sem impedir; detalhe recomputa")]
+    public async Task Registrar_NumeroDuplicado_Avisa()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+        string serie = SerieUnica();
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // Primeiro ato: sem conflito.
+        HttpResponseMessage primeira = await PostAtoAsync(client, PayloadAto(tipo, serie, "13"));
+        primeira.StatusCode.Should().Be(HttpStatusCode.Created);
+        Guid primeiroId = JsonDocument.Parse(await primeira.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("atoId").GetGuid();
+
+        // Segundo ato, mesma numeração: aceito, com aviso.
+        HttpResponseMessage segunda = await PostAtoAsync(client, PayloadAto(tipo, serie, "13"));
+        segunda.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        using JsonDocument doc = JsonDocument.Parse(await segunda.Content.ReadAsStringAsync());
+        JsonElement avisos = doc.RootElement.GetProperty("avisos");
+        avisos.GetArrayLength().Should().Be(1);
+        avisos[0].GetProperty("codigo").GetString().Should().Be("NumeroDuplicado");
+        Guid segundoId = doc.RootElement.GetProperty("atoId").GetGuid();
+
+        // O detalhe do segundo ato recomputa o aviso, apontando o primeiro.
+        using JsonDocument detalhe = JsonDocument.Parse(
+            await client.GetStringAsync(new Uri($"{BaseAtos}/{segundoId}", UriKind.Relative)));
+        JsonElement conflitantes = detalhe.RootElement
+            .GetProperty("avisos")[0].GetProperty("atosConflitantes");
+        conflitantes.EnumerateArray().Select(e => e.GetGuid()).Should().Contain(primeiroId);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static void Autenticar(HttpRequestMessage request, string role = "plataforma-admin")
+    {
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, role);
+    }
+
+    private static object PayloadAto(string tipoCodigo, string serie, string? numero) =>
+        new
+        {
+            orgao = "CEPS",
+            serie,
+            ano = 2026,
+            numero,
+            tipoCodigo,
+            dataPublicacao = Publicacao,
+            documentoHash = HashValido,
+            assinante = "Jairo Belchior",
+        };
+
+    private static async Task<HttpResponseMessage> PostAtoAsync(
+        HttpClient client, object payload, string? chave = null)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminAtos, UriKind.Relative));
+        Autenticar(request);
+        request.Headers.Add("Idempotency-Key", chave ?? Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(payload);
+
+        return await client.SendAsync(request);
+    }
+
+    /// <summary>Cadastra um tipo de ato vigente (janela ampla) e devolve o código.</summary>
+    private async Task<string> CriarTipoVigenteAsync(bool congela = false, bool efeito = false)
+    {
+        string codigo = "ATO_TIPO_" + Sufixo();
+        object payload = new
+        {
+            codigo,
+            nome = "Tipo para ato de teste",
+            congelaConfiguracao = congela,
+            unicoPorObjeto = false,
+            efeitoIrreversivel = efeito,
+            vigenciaInicio = "2020-01-01",
+            vigenciaFim = (string?)null,
+        };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminTipos, UriKind.Relative));
+        Autenticar(request);
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(payload);
+
+        HttpResponseMessage response = await client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        return codigo;
+    }
+
+    /// <summary>Série única no teste, para isolar a numeração do aviso entre casos.</summary>
+    private static string SerieUnica() => "EDITAL_" + Sufixo();
+
+    private static string Sufixo()
+    {
+        string hex = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture)[..12];
+        return string.Concat(hex.Select(c => (char)('A' + Convert.ToInt32(c.ToString(), 16))));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtoNormativoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtoNormativoPersistenceTests.cs
@@ -1,0 +1,342 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.AtosNormativos;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Npgsql;
+
+using Unifesspa.UniPlus.Kernel.Pagination;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
+using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração do ato normativo contra Postgres real: o append-only imposto por
+/// trigger (UPDATE/DELETE crus bloqueados), os CHECKs de shape, a ausência de
+/// unicidade do número, e o round-trip do par por valor {id, hash}.
+/// </summary>
+[Collection(PublicacoesDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class AtoNormativoPersistenceTests
+{
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    private const string CheckViolation = "23514";
+    private static readonly DateOnly Publicacao = new(2026, 3, 13);
+    private static readonly DateTimeOffset Registro = new(2026, 3, 13, 19, 0, 0, TimeSpan.Zero);
+
+    private readonly PublicacoesDbFixture _fixture;
+
+    public AtoNormativoPersistenceTests(PublicacoesDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Persiste e relê os campos do ato, com a versão invocada por valor")]
+    public async Task Insert_PersisteCampos_ComVersaoInvocada()
+    {
+        ReferenciaVersaoConfiguracao versao = ReferenciaVersaoConfiguracao
+            .Criar(Guid.CreateVersion7(), HashValido).Value!;
+        AtoNormativo ato = Novo(numero: "13", versao: versao);
+        await Gravar(ato);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        AtoNormativo persistido = await ctx.AtosNormativos.SingleAsync(a => a.Id == ato.Id);
+
+        persistido.Orgao.Should().Be("CEPS");
+        persistido.Numero.Should().Be("13");
+        persistido.DocumentoHash.Should().Be(HashValido);
+        persistido.RegistradoEm.Should().Be(Registro);
+        persistido.VersaoInvocada.Should().NotBeNull();
+        persistido.VersaoInvocada!.Id.Should().Be(versao.Id);
+        persistido.VersaoInvocada.Hash.Should().Be(versao.Hash);
+    }
+
+    [Fact(DisplayName = "Ato sem versão invocada persiste com o par ausente (owned opcional)")]
+    public async Task Insert_SemVersaoInvocada_ParAusente()
+    {
+        AtoNormativo ato = Novo(numero: null, versao: null);
+        await Gravar(ato);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        AtoNormativo persistido = await ctx.AtosNormativos.SingleAsync(a => a.Id == ato.Id);
+
+        persistido.Numero.Should().BeNull();
+        persistido.VersaoInvocada.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "UPDATE cru é bloqueado pelo trigger append-only")]
+    public async Task Update_Cru_Bloqueado()
+    {
+        AtoNormativo ato = Novo();
+        await Gravar(ato);
+
+        Func<Task> update = () => ExecutarSql(
+            "UPDATE publicacoes.ato_normativo SET assinante = 'Outro' WHERE id = @id",
+            ("id", ato.Id));
+
+        (await update.Should().ThrowAsync<PostgresException>())
+            .Which.MessageText.Should().Contain("append-only");
+    }
+
+    [Fact(DisplayName = "DELETE cru é bloqueado pelo trigger append-only")]
+    public async Task Delete_Cru_Bloqueado()
+    {
+        AtoNormativo ato = Novo();
+        await Gravar(ato);
+
+        Func<Task> delete = () => ExecutarSql(
+            "DELETE FROM publicacoes.ato_normativo WHERE id = @id",
+            ("id", ato.Id));
+
+        await delete.Should().ThrowAsync<PostgresException>();
+
+        // A prova de que o bloqueio é do banco: a linha continua lá.
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        (await ctx.AtosNormativos.AnyAsync(a => a.Id == ato.Id)).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "O trigger append-only existe no catálogo do banco")]
+    public async Task Trigger_ExisteNoCatalogo()
+    {
+        object? nome = await ExecutarScalar(
+            """
+            SELECT tgname::text
+            FROM pg_trigger
+            WHERE tgname = 'trg_ato_normativo_somente_insercao'
+              AND NOT tgisinternal
+            """);
+
+        nome.Should().Be("trg_ato_normativo_somente_insercao");
+    }
+
+    [Fact(DisplayName = "Dois atos com a mesma numeração são aceitos — número não tem unicidade")]
+    public async Task Insert_MesmaNumeracao_Aceito()
+    {
+        await Gravar(Novo(numero: "13"));
+        Func<Task> segunda = () => Gravar(Novo(numero: "13"));
+
+        await segunda.Should().NotThrowAsync();
+    }
+
+    [Fact(DisplayName = "Três atos do mesmo certame no mesmo dia são aceitos (sem ordem total)")]
+    public async Task Insert_TresNoMesmoDia_Aceito()
+    {
+        await Gravar(Novo(numero: "13"));
+        await Gravar(Novo(numero: "14"));
+        await Gravar(Novo(numero: "15"));
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        int doDia = await ctx.AtosNormativos.CountAsync(a => a.DataPublicacao == Publicacao);
+        doDia.Should().BeGreaterThanOrEqualTo(3);
+    }
+
+    [Fact(DisplayName = "O índice de numeração existe e NÃO é único")]
+    public async Task IndiceNumeracao_ExisteENaoEUnico()
+    {
+        object? indisunique = await ExecutarScalar(
+            """
+            SELECT i.indisunique
+            FROM pg_class c
+            JOIN pg_index i ON i.indexrelid = c.oid
+            WHERE c.relname = 'ix_ato_normativo_numeracao'
+            """);
+
+        indisunique.Should().Be(false);
+    }
+
+    [Fact(DisplayName = "CHECK recusa hash de documento fora do formato (insert cru)")]
+    public async Task CheckDocumentoHash_RecusaFormatoInvalido()
+    {
+        Func<Task> insercao = () => InserirCru(documentoHash: "nao-e-hash");
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
+    [Fact(DisplayName = "CHECK recusa par de versão incompleto (só id, insert cru)")]
+    public async Task CheckVersaoCompleta_RecusaParIncompleto()
+    {
+        Func<Task> insercao = () => InserirCru(versaoId: Guid.CreateVersion7(), versaoHash: null);
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
+    [Fact(DisplayName = "CHECK recusa par de versão incompleto (só hash, insert cru)")]
+    public async Task CheckVersaoCompleta_RecusaSoHash()
+    {
+        Func<Task> insercao = () => InserirCru(versaoId: null, versaoHash: HashValido);
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
+    [Fact(DisplayName = "CHECK recusa hash de versão fora do formato (insert cru)")]
+    public async Task CheckVersaoHash_RecusaFormatoInvalido()
+    {
+        Func<Task> insercao = () => InserirCru(versaoId: Guid.CreateVersion7(), versaoHash: new string('g', 64));
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
+    [Fact(DisplayName = "CHECK recusa versão com id zerado (insert cru)")]
+    public async Task CheckVersaoIdNaoZero_RecusaGuidEmpty()
+    {
+        Func<Task> insercao = () => InserirCru(versaoId: Guid.Empty, versaoHash: HashValido);
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
+    [Fact(DisplayName = "CHECK recusa ano não-positivo (insert cru)")]
+    public async Task CheckAno_RecusaNaoPositivo()
+    {
+        Func<Task> insercao = () => InserirCru(ano: 0);
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
+    [Fact(DisplayName = "ListarIdsComMesmaNumeracao devolve os conflitantes, ignorando o próprio ato")]
+    public async Task ListarIdsComMesmaNumeracao_IgnoraProprio()
+    {
+        AtoNormativo a1 = Novo(numero: "99");
+        AtoNormativo a2 = Novo(numero: "99");
+        await Gravar(a1);
+        await Gravar(a2);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var repo = new AtoNormativoRepository(ctx);
+
+        IReadOnlyList<Guid> conflitantesDeA1 = await repo.ListarIdsComMesmaNumeracaoAsync(
+            "CEPS", "EDITAL", 2026, "99", a1.Id, default);
+
+        conflitantesDeA1.Should().Contain(a2.Id).And.NotContain(a1.Id);
+    }
+
+    [Fact(DisplayName = "Listagem paginada por cursor devolve os atos em ordem de Id")]
+    public async Task ListarPaginado_OrdenaPorId()
+    {
+        AtoNormativo a1 = Novo(numero: "201");
+        AtoNormativo a2 = Novo(numero: "202");
+        await Gravar(a1);
+        await Gravar(a2);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var repo = new AtoNormativoRepository(ctx);
+
+        (IReadOnlyList<AtoNormativo> itens, _, _) = await repo.ListarPaginadoAsync(
+            afterId: null, limit: 100, PaginationDirection.Next, default);
+
+        itens.Select(a => a.Id).Should().ContainInOrder(
+            new[] { a1.Id, a2.Id }.OrderBy(id => id));
+    }
+
+    [Fact(DisplayName = "Paginação Prev sobre a entidade forense devolve a página anterior em ordem ascendente")]
+    public async Task ListarPaginado_Prev_FuncionaComEntidadeForense()
+    {
+        // A entidade forense não é EntityBase; a paginação keyset (relaxada para
+        // IIdentificavel) precisa ordená-la e fatiá-la corretamente também no sentido Prev.
+        AtoNormativo a1 = Novo(numero: "301");
+        AtoNormativo a2 = Novo(numero: "302");
+        AtoNormativo a3 = Novo(numero: "303");
+        await Gravar(a1);
+        await Gravar(a2);
+        await Gravar(a3);
+
+        Guid[] ordenados = new[] { a1.Id, a2.Id, a3.Id }.OrderBy(id => id).ToArray();
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var repo = new AtoNormativoRepository(ctx);
+
+        // Ancorado no maior dos três, Prev traz os anteriores em ordem ascendente
+        // (o probe é cortado ainda em DESC e a lista revertida). Limit alto e
+        // asserções relativas porque o container é compartilhado entre os testes.
+        (IReadOnlyList<AtoNormativo> anteriores, _, _) = await repo.ListarPaginadoAsync(
+            afterId: ordenados[2], limit: 100, PaginationDirection.Prev, default);
+
+        IReadOnlyList<Guid> ids = [.. anteriores.Select(a => a.Id)];
+        ids.Should().NotContain(ordenados[2], "Prev exclui a âncora");
+        ids.Should().ContainInOrder(ordenados[0], ordenados[1]);
+        ids.Should().BeInAscendingOrder();
+    }
+
+    private async Task Gravar(AtoNormativo ato)
+    {
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        ctx.AtosNormativos.Add(ato);
+        await ctx.SaveChangesAsync();
+    }
+
+    [SuppressMessage(
+        "Security",
+        "CA2100:Review SQL queries for security vulnerabilities",
+        Justification = "SQL fixo dos testes de integração, sem entrada de usuário; parâmetros via NpgsqlParameter.")]
+    private async Task ExecutarSql(string sql, params (string Nome, object Valor)[] parametros)
+    {
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        await ctx.Database.OpenConnectionAsync();
+
+        await using var command = new NpgsqlCommand(sql, (NpgsqlConnection)ctx.Database.GetDbConnection());
+        foreach ((string nome, object valor) in parametros)
+        {
+            command.Parameters.AddWithValue(nome, valor);
+        }
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    [SuppressMessage(
+        "Security",
+        "CA2100:Review SQL queries for security vulnerabilities",
+        Justification = "SQL fixo dos testes de integração, sem entrada de usuário.")]
+    private async Task<object?> ExecutarScalar(string sql)
+    {
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        await ctx.Database.OpenConnectionAsync();
+
+        await using var command = new NpgsqlCommand(sql, (NpgsqlConnection)ctx.Database.GetDbConnection());
+        return await command.ExecuteScalarAsync();
+    }
+
+    private async Task InserirCru(
+        int ano = 2026,
+        string documentoHash = HashValido,
+        Guid? versaoId = null,
+        string? versaoHash = null)
+    {
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        await ctx.Database.OpenConnectionAsync();
+
+        await using var command = new NpgsqlCommand(
+            """
+            INSERT INTO publicacoes.ato_normativo
+                (id, orgao, serie, ano, numero, tipo_codigo, congela_configuracao, efeito_irreversivel,
+                 data_publicacao, documento_hash, assinante, registrado_em, versao_invocada_id, versao_invocada_hash)
+            VALUES
+                (gen_random_uuid(), 'CEPS', 'EDITAL', @ano, '13', 'EDITAL_ABERTURA', false, false,
+                 @data, @hash, 'Assinante', now(), @versao_id, @versao_hash)
+            """,
+            (NpgsqlConnection)ctx.Database.GetDbConnection());
+
+        command.Parameters.AddWithValue("ano", ano);
+        command.Parameters.AddWithValue("data", Publicacao);
+        command.Parameters.AddWithValue("hash", documentoHash);
+        command.Parameters.AddWithValue("versao_id", versaoId ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("versao_hash", versaoHash ?? (object)DBNull.Value);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static AtoNormativo Novo(string? numero = "13", ReferenciaVersaoConfiguracao? versao = null) =>
+        AtoNormativo.Registrar(
+            orgao: "CEPS",
+            serie: "EDITAL",
+            ano: 2026,
+            numero: numero,
+            tipoCodigo: "EDITAL_ABERTURA",
+            congelaConfiguracao: false,
+            efeitoIrreversivel: false,
+            dataPublicacao: Publicacao,
+            documentoHash: HashValido,
+            assinante: "Jairo Belchior",
+            registradoEm: Registro,
+            versaoInvocada: versao);
+}


### PR DESCRIPTION
## Contexto

Implementa a Story #799, a fundação do agregado **`AtoNormativo`** no módulo Publicações: o registro central e append-only da prova documental de que algo foi publicado (ADR-0105). É o gargalo do grafo de dependência da Feature #796 — desbloqueia #800 (cadeia de retificação), #801 (vínculo genérico) e #820 (Seleção aciona Publicações).

O `AtoNormativoSpike` do spike #819 era descartável; esta é a entidade real.

## Critérios de aceite

- [x] O ato tem `orgao`, `serie`, `ano`, `numero` (opcional), tipo, `data_publicacao`, `documento_hash` e `assinante`.
- [x] Append-only: `UPDATE`/`DELETE` bloqueados (ADR-0063) — **por trigger no banco**, não só por convenção.
- [x] `numero` sem unicidade — dois atos com `(órgão, série, ano, número)` iguais são aceitos.
- [x] Número já usado, quando não é retificação daquele, produz **aviso** consultável — não recusa.
- [x] Copia `congela_configuracao`/`efeito_irreversivel` do catálogo vigente na data; cópia divergente é impossível (derivada server-side).
- [x] Tipo sem versão vigente na data é recusado, com erro nomeado (422).
- [x] Grava a versão que governou por valor `{id, hash}` (ADR-0075), sem FK cross-módulo (ADR-0061).
- [x] Ato sem entidade vinculada é válido e registrável.
- [x] Três atos do mesmo certame no mesmo dia são aceitos — sem ordem total.

## Destaques técnicos

- **Append-only real:** trigger `BEFORE UPDATE OR DELETE` que lança exceção, indo além da convenção V1 da ADR-0063 (que deixou o trigger para hardening) — o ato é prova legal, e o passado documental é protegido pelo próprio banco. Testes exercem `UPDATE`/`DELETE` crus e confirmam o bloqueio.
- **`IIdentificavel`:** base comum extraída de `EntityBase` e `IForensicEntity` para que o `CursorKeyset` pagine a entidade forense sem acoplar-se a `EntityBase` — o helper só depende do `Id` ordenável (Guid v7). Mudança puramente aditiva; todos os consumidores de cursor seguem funcionando (validado em Seleção/Configuração/Organização).
- **Aviso derivado (AC4):** diagnóstico do estado atual recomputado na leitura, nunca persistido; excluído o próprio ato. Best-effort no POST sob concorrência (o detalhe recomputa) — sem advisory lock, pois o aviso jamais bloqueia o registro.
- **Cópia por valor server-side (AC5):** o handler resolve o tipo vigente e copia as consequências; o cliente não as informa, então não há como divergirem do catálogo.

## Decisões de escopo (fronteiras)

- **Retificação** (cadeia linear, invariante `congela(retificador)==congela(retificado)`) fica para **#800** — o ato ainda não modela relação entre atos.
- **Vínculo genérico** `EntidadeTipo`/`EntidadeId` fica para **#801**.
- **Contrato cross-módulo** (`Publicacoes.Contracts` + porta/adapter em Seleção) fica para **#820**.
- O par `{versao_invocada_id, versao_invocada_hash}` é **recebido por valor** — Publicações nunca resolve a versão (assimetria ADR-0105); `VersaoConfiguracao` nascerá em #802.

## Testes

- Domínio: 45 (entidade forense, VO do par, shape de hash).
- Application: 67 (handler, validator, queries — dublês NSubstitute).
- Integração (Postgres real): 26 — persistência, trigger append-only, CHECKs (via insert cru), índice não-único, owned type round-trip, paginação `Prev` forense, endpoints (201/401/403/404/422, idempotência, aviso, cópia por valor).
- Wiring no monólito real (bus + codegen), fitness forense e contrato OpenAPI regenerado.

Suíte completa verde localmente, incluindo os módulos afetados pela mudança no shared.

Closes #799
Refs #796