### PR TITLE
feat(publicacoes): registra a cadeia de retificação linear de atos

### DIFF
--- a/contracts/openapi.publicacoes.json
+++ b/contracts/openapi.publicacoes.json
@@ -438,6 +438,16 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Unprocessable Entity",
             "content": {
@@ -1010,12 +1020,15 @@
           "tipoCodigo",
           "congelaConfiguracao",
           "efeitoIrreversivel",
+          "unicoPorObjeto",
           "dataPublicacao",
           "documentoHash",
           "assinante",
           "registradoEm",
           "versaoInvocadaId",
-          "versaoInvocadaHash"
+          "versaoInvocadaHash",
+          "atoRetificadoId",
+          "motivoRetificacao"
         ],
         "type": "object",
         "properties": {
@@ -1052,6 +1065,9 @@
           "efeitoIrreversivel": {
             "type": "boolean"
           },
+          "unicoPorObjeto": {
+            "type": "boolean"
+          },
           "dataPublicacao": {
             "type": "string",
             "format": "date"
@@ -1074,6 +1090,19 @@
             "format": "uuid"
           },
           "versaoInvocadaHash": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "atoRetificadoId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "motivoRetificacao": {
             "type": [
               "null",
               "string"
@@ -1353,6 +1382,19 @@
             "format": "uuid"
           },
           "versaoInvocadaHash": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "atoRetificadoId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "motivoRetificacao": {
             "type": [
               "null",
               "string"

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/AtosNormativosController.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/AtosNormativosController.cs
@@ -112,9 +112,12 @@ public sealed class AtosNormativosController : ControllerBase
     }
 
     /// <summary>
-    /// Registra um ato publicado. Restrito a <c>plataforma-admin</c>.
-    /// <c>Idempotency-Key</c> obrigatório (ADR-0027). A resposta traz o Id, o
-    /// instante forense de registro e eventuais avisos de numeração (AC4).
+    /// Registra um ato publicado — publicação nova ou retificação de outro ato,
+    /// quando o corpo traz o par <c>atoRetificadoId</c>/<c>motivoRetificacao</c>
+    /// (ADR-0103). Restrito a <c>plataforma-admin</c>. <c>Idempotency-Key</c>
+    /// obrigatório (ADR-0027). A resposta traz o Id, o instante forense de registro
+    /// e eventuais avisos de numeração (AC4). Uma retificação que quebra a cadeia
+    /// linear (o ato-alvo já foi retificado) responde 409.
     /// </summary>
     [HttpPost("admin/atos")]
     [Authorize(Roles = "plataforma-admin")]
@@ -123,6 +126,7 @@ public sealed class AtosNormativosController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<IActionResult> Registrar(
         [FromBody] RegistrarAtoNormativoCommand command,

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Errors/PublicacoesDomainErrorRegistration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Errors/PublicacoesDomainErrorRegistration.cs
@@ -101,5 +101,25 @@ internal sealed class PublicacoesDomainErrorRegistration : IDomainErrorRegistrat
                 StatusCodes.Status404NotFound,
                 "uniplus.publicacoes.ato_normativo.nao_encontrado",
                 "Ato normativo não encontrado")),
+
+        new(AtoNormativoErrorCodes.AtoRetificadoNaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.ato_normativo.ato_retificado_nao_encontrado",
+                "O ato retificado não corresponde a nenhum ato registrado")),
+
+        new(AtoNormativoErrorCodes.ClasseDeCongelamentoDivergente,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.ato_normativo.classe_congelamento_divergente",
+                "A classe de congelamento do ato que retifica deve coincidir com a do ato retificado")),
+
+        // 409 e não 422: é conflito com o estado já gravado — o ato-alvo já tem um
+        // retificador —, o mesmo critério que classifica a vigência sobreposta como 409.
+        new(AtoNormativoErrorCodes.RaizJaRetificada,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.publicacoes.ato_normativo.raiz_ja_retificada",
+                "O ato que se tentou retificar já foi retificado por outro (a cadeia é linear)")),
     ];
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Avisos/AvisoNumeracaoCalculator.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Avisos/AvisoNumeracaoCalculator.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.Publicacoes.Application.Avisos;
 
 using System.Globalization;
+using System.Linq;
 
 using Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
 using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
@@ -9,20 +10,22 @@ using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
 
 /// <summary>
 /// Computa o aviso de número duplicado (AC4) de um ato — diagnóstico do estado
-/// atual, derivado na leitura, nunca persistido. Compartilhado entre o registro
-/// (exclui nada: o próprio ato ainda não existe) e o detalhe (exclui o próprio
-/// ato do conjunto de conflitantes).
+/// atual, derivado na leitura, nunca persistido. Compartilhado entre o registro e
+/// o detalhe; o conjunto <c>excluir</c> tira do diagnóstico os atos que não são
+/// colisão: o próprio ato (no detalhe) e o ato que este retifica (uma
+/// republicação com o mesmo número é a mesma linhagem, não uma duplicata — ADR-0103).
 /// </summary>
 internal static class AvisoNumeracaoCalculator
 {
     public static async Task<IReadOnlyList<AvisoNumeracao>> CalcularAsync(
         IAtoNormativoRepository atosRepository,
         AtoNormativo ato,
-        Guid? excluirId,
+        IReadOnlyCollection<Guid> excluir,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(atosRepository);
         ArgumentNullException.ThrowIfNull(ato);
+        ArgumentNullException.ThrowIfNull(excluir);
 
         if (ato.Numero is null)
         {
@@ -31,8 +34,14 @@ internal static class AvisoNumeracaoCalculator
 
         IReadOnlyList<Guid> conflitantes = await atosRepository
             .ListarIdsComMesmaNumeracaoAsync(
-                ato.Orgao, ato.Serie, ato.Ano, ato.Numero, excluirId, cancellationToken)
+                ato.Orgao, ato.Serie, ato.Ano, ato.Numero, excluirId: null, cancellationToken)
             .ConfigureAwait(false);
+
+        if (excluir.Count > 0)
+        {
+            HashSet<Guid> excluirSet = [.. excluir];
+            conflitantes = [.. conflitantes.Where(id => !excluirSet.Contains(id))];
+        }
 
         if (conflitantes.Count == 0)
         {

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/AtoNormativoRegras.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/AtoNormativoRegras.cs
@@ -12,6 +12,7 @@ internal static class AtoNormativoRegras
     public const int NumeroMaxLength = 60;
     public const int TipoCodigoMaxLength = 60;
     public const int AssinanteMaxLength = 200;
+    public const int MotivoRetificacaoMaxLength = 1000;
 
     /// <summary>SHA-256 em hexadecimal minúsculo, 64 caracteres.</summary>
     public const string HashPattern = "^[0-9a-f]{64}$";
@@ -31,6 +32,9 @@ internal static class AtoNormativoRegras
     public const string VersaoInvocadaIncompleta = "A versão invocada é o par (id, hash) completo, ou nenhum dos dois — um identificador sem hash não prova nada.";
     public const string VersaoInvocadaIdObrigatorio = "Identificador da versão invocada não pode ser vazio.";
     public const string VersaoInvocadaHashFormato = "Hash da versão invocada deve ser um SHA-256 em hexadecimal minúsculo (64 caracteres).";
+    public const string RetificacaoIncompleta = "A retificação é o par (ato retificado, motivo) completo, ou nenhum dos dois — um sem o outro não registra linhagem.";
+    public const string AtoRetificadoIdObrigatorio = "Identificador do ato retificado não pode ser vazio.";
+    public const string MotivoRetificacaoTamanho = "Motivo da retificação deve ter no máximo 1000 caracteres.";
 
     /// <summary>Código do aviso de número duplicado (AC4).</summary>
     public const string AvisoNumeroDuplicado = "NumeroDuplicado";

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommand.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommand.cs
@@ -14,7 +14,10 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <para>O par <see cref="VersaoInvocadaId"/>/<see cref="VersaoInvocadaHash"/> é
 /// recebido por valor, completo ou ausente (AC7): Publicações não resolve a
 /// versão de configuração — ela vive noutro módulo e chega já resolvida.</para>
-/// <para>Retificação e vínculo genérico ato↔entidade não entram aqui — são #800 e #801.</para>
+/// <para>O par <see cref="AtoRetificadoId"/>/<see cref="MotivoRetificacao"/> torna
+/// o registro uma retificação (ADR-0103), quando presente — simétrico (um existe
+/// se e somente se o outro existe). É o mesmo comando de publicar: retificar é
+/// publicar um ato que emenda outro. O vínculo genérico ato↔entidade ainda é #801.</para>
 /// </remarks>
 public sealed record RegistrarAtoNormativoCommand(
     string Orgao,
@@ -26,4 +29,6 @@ public sealed record RegistrarAtoNormativoCommand(
     string DocumentoHash,
     string Assinante,
     Guid? VersaoInvocadaId = null,
-    string? VersaoInvocadaHash = null) : ICommand<Result<RegistrarAtoNormativoResult>>;
+    string? VersaoInvocadaHash = null,
+    Guid? AtoRetificadoId = null,
+    string? MotivoRetificacao = null) : ICommand<Result<RegistrarAtoNormativoResult>>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandHandler.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
 
+using System.Globalization;
+
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
 using Unifesspa.UniPlus.Publicacoes.Application.Avisos;
@@ -50,6 +52,16 @@ public static class RegistrarAtoNormativoCommandHandler
             return Result<RegistrarAtoNormativoResult>.Failure(versaoResult.Error!);
         }
 
+        // ADR-0103: quando o registro emenda outro ato, as invariantes da cadeia que
+        // dependem do ato retificado (existência, classe de congelamento coincidente,
+        // linearidade) são verificadas aqui, com o retificado em mãos.
+        DomainError? retificacaoErro = await ValidarRetificacaoAsync(
+            command, tipo, atosRepository, cancellationToken).ConfigureAwait(false);
+        if (retificacaoErro is not null)
+        {
+            return Result<RegistrarAtoNormativoResult>.Failure(retificacaoErro);
+        }
+
         AtoNormativo ato = AtoNormativo.Registrar(
             command.Orgao,
             command.Serie,
@@ -58,29 +70,129 @@ public static class RegistrarAtoNormativoCommandHandler
             command.TipoCodigo,
             tipo.CongelaConfiguracao,
             tipo.EfeitoIrreversivel,
+            tipo.UnicoPorObjeto,
             command.DataPublicacao,
             command.DocumentoHash,
             command.Assinante,
             timeProvider.GetUtcNow(),
-            versaoResult?.Value);
+            versaoResult?.Value,
+            command.AtoRetificadoId,
+            command.MotivoRetificacao);
 
-        // AC4: colisão de numeração é aviso, jamais recusa. No registro o próprio
-        // ato ainda não existe, então todos os que compartilham a numeração são
-        // conflitantes. O aviso do POST é best-effort: como o número não tem
-        // unicidade, dois registros concorrentes da mesma numeração podem ambos
-        // observar zero conflitos e responder sem aviso — a consulta de detalhe
-        // recomputa e enxerga ambos. Serializar aqui exigiria advisory lock para
-        // um aviso que, por decisão de negócio, nunca bloqueia o registro.
+        // AC4: colisão de numeração é aviso, jamais recusa. No registro o próprio ato
+        // ainda não existe, então todos os que compartilham a numeração são
+        // conflitantes — menos a linhagem que este ato passa a integrar: uma
+        // republicação com o mesmo número dentro da cadeia de retificação não é
+        // duplicata, é a mesma linhagem (ADR-0103). Exclui a cadeia inteira do ato
+        // retificado, não só o pai direto. O aviso é best-effort: como o número não
+        // tem unicidade, dois registros concorrentes da mesma numeração podem ambos
+        // observar zero conflitos; a consulta de detalhe recomputa e enxerga ambos.
+        IReadOnlyCollection<Guid> excluirDoAviso = command.AtoRetificadoId is { } retificadoId
+            ? await atosRepository.ListarIdsDaCadeiaAsync(retificadoId, cancellationToken).ConfigureAwait(false)
+            : [];
         IReadOnlyList<AvisoNumeracao> avisos = await AvisoNumeracaoCalculator
-            .CalcularAsync(atosRepository, ato, excluirId: null, cancellationToken)
+            .CalcularAsync(atosRepository, ato, excluirDoAviso, cancellationToken)
             .ConfigureAwait(false);
 
         await atosRepository.AdicionarAsync(ato, cancellationToken).ConfigureAwait(false);
-        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsLinearidadeConflict(constraint))
+        {
+            // Corrida check-then-act: dois atos tentaram retificar a mesma raiz ao
+            // mesmo tempo. O índice único parcial deixou passar só um; o outro vira
+            // recusa nomeada, não erro 500.
+            return Result<RegistrarAtoNormativoResult>.Failure(new DomainError(
+                AtoNormativoErrorCodes.RaizJaRetificada,
+                RaizJaRetificadaConcorrenteMensagem(command.AtoRetificadoId)));
+        }
 
         return Result<RegistrarAtoNormativoResult>.Success(
             new RegistrarAtoNormativoResult(ato.Id, ato.RegistradoEm, avisos));
     }
+
+    /// <summary>
+    /// Verifica as invariantes da cadeia de retificação que dependem do ato
+    /// retificado (ADR-0103). Devolve o <see cref="DomainError"/> da primeira
+    /// violação, ou <see langword="null"/> quando o registro não é retificação ou
+    /// passa em todas. A garantia dura da linearidade contra a corrida é do índice
+    /// único parcial; esta consulta dá a mensagem legível no caso comum.
+    /// </summary>
+    private static async Task<DomainError?> ValidarRetificacaoAsync(
+        RegistrarAtoNormativoCommand command,
+        TipoAtoPublicado tipo,
+        IAtoNormativoRepository atosRepository,
+        CancellationToken cancellationToken)
+    {
+        if (command.AtoRetificadoId is not { } retificadoId)
+        {
+            return null;
+        }
+
+        AtoNormativo? retificado = await atosRepository
+            .ObterPorIdParaLeituraAsync(retificadoId, cancellationToken)
+            .ConfigureAwait(false);
+        if (retificado is null)
+        {
+            return new DomainError(
+                AtoNormativoErrorCodes.AtoRetificadoNaoEncontrado,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "O ato retificado {0} não corresponde a nenhum ato registrado.",
+                    retificadoId));
+        }
+
+        // congela(retificador) == congela(retificado): a classe de congelamento do
+        // novo ato é a do tipo vigente já resolvido; a do retificado é o snapshot que
+        // ele congelou no próprio registro. É essa classe, não o rótulo do tipo, que
+        // protege a integridade da configuração publicada (RN08).
+        if (retificado.CongelaConfiguracao != tipo.CongelaConfiguracao)
+        {
+            return new DomainError(
+                AtoNormativoErrorCodes.ClasseDeCongelamentoDivergente,
+                "A classe de congelamento do ato que retifica deve coincidir com a do ato retificado: "
+                + "um ato não congelante não emenda um congelante, nem o inverso.");
+        }
+
+        // Linearidade: se a raiz já foi retificada, a nova retificação deveria emendar
+        // a cabeça da cadeia, não a raiz. Nomeia quem já a retificou.
+        AtoNormativo? retificador = await atosRepository
+            .ObterRetificadorAsync(retificadoId, cancellationToken)
+            .ConfigureAwait(false);
+        if (retificador is not null)
+        {
+            return new DomainError(
+                AtoNormativoErrorCodes.RaizJaRetificada,
+                RaizJaRetificadaMensagem(retificadoId, retificador));
+        }
+
+        return null;
+    }
+
+    private static string RaizJaRetificadaMensagem(Guid retificadoId, AtoNormativo retificador)
+    {
+        string numero = retificador.Numero is null ? "sem número" : "nº " + retificador.Numero;
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "O ato {0} já foi retificado pelo ato {1} ({2} {3}/{4}). A cadeia é linear: "
+            + "retifique a cabeça da cadeia, não uma raiz já retificada.",
+            retificadoId,
+            retificador.Id,
+            retificador.Serie,
+            numero,
+            retificador.Ano);
+    }
+
+    private static string RaizJaRetificadaConcorrenteMensagem(Guid? retificadoId) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "O ato {0} já foi retificado por outro ato registrado concorrentemente. "
+            + "A cadeia é linear: retifique a cabeça da cadeia.",
+            retificadoId);
 
     private static Result<ReferenciaVersaoConfiguracao>? ResolverVersaoInvocada(
         RegistrarAtoNormativoCommand command)

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandValidator.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandValidator.cs
@@ -59,5 +59,21 @@ public sealed class RegistrarAtoNormativoCommandValidator
         RuleFor(x => x.VersaoInvocadaHash)
             .Matches(AtoNormativoRegras.HashPattern).WithMessage(AtoNormativoRegras.VersaoInvocadaHashFormato)
             .When(x => x.VersaoInvocadaHash is not null);
+
+        // A retificação é o par (ato retificado, motivo), completo ou ausente (ADR-0103).
+        RuleFor(x => x)
+            .Must(x => x.AtoRetificadoId.HasValue == (AtoNormativoRegras.Normalizar(x.MotivoRetificacao) is not null))
+            .WithMessage(AtoNormativoRegras.RetificacaoIncompleta)
+            .OverridePropertyName(nameof(RegistrarAtoNormativoCommand.MotivoRetificacao));
+
+        // Id zerado não é referência: um Guid.Empty não aponta ato algum.
+        RuleFor(x => x.AtoRetificadoId)
+            .Must(id => id != Guid.Empty).WithMessage(AtoNormativoRegras.AtoRetificadoIdObrigatorio)
+            .When(x => x.AtoRetificadoId.HasValue);
+
+        RuleFor(x => AtoNormativoRegras.Normalizar(x.MotivoRetificacao))
+            .MaximumLength(AtoNormativoRegras.MotivoRetificacaoMaxLength).WithMessage(AtoNormativoRegras.MotivoRetificacaoTamanho)
+            .OverridePropertyName(nameof(RegistrarAtoNormativoCommand.MotivoRetificacao))
+            .When(x => AtoNormativoRegras.Normalizar(x.MotivoRetificacao) is not null);
     }
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/UniqueConstraintViolation.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/UniqueConstraintViolation.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+
+/// <summary>
+/// Mapeia a violação <c>23505</c> (unique_violation) do índice único parcial
+/// <c>ux_ato_normativo_retificado</c> para o <c>DomainError</c> apropriado — a
+/// garantia dura da linearidade da cadeia de retificação (ADR-0103) contra a
+/// corrida check-then-act do handler. Acessa <c>SqlState</c> e
+/// <c>ConstraintName</c> por reflection no inner exception; o shape é estável na
+/// API pública do <c>Npgsql.PostgresException</c>. A inspeção do tipo da exceção
+/// por <see cref="System.Type.FullName"/> evita dependência direta do pacote
+/// <c>Microsoft.EntityFrameworkCore</c> nesta camada (Clean Architecture —
+/// Application referencia apenas Domain, Kernel e abstrações).
+/// </summary>
+/// <remarks>
+/// Mesmo padrão de <c>ExclusionConstraintViolation</c> do cadastro de tipos de
+/// ato, com o SQLSTATE de unicidade em vez do de exclusão. A consulta prévia do
+/// handler (<c>ObterRetificadorAsync</c>) dá a mensagem que nomeia o retificador
+/// no caso comum; o índice único fecha a corrida — entre a consulta e o
+/// <c>SaveChanges</c> cabe outra transação, e só o banco a vê.
+/// </remarks>
+internal static class UniqueConstraintViolation
+{
+    private const string UniqueViolationSqlState = "23505";
+
+    private const string LinearidadeConstraint = "ux_ato_normativo_retificado";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary>
+    /// Retorna o nome da constraint violada quando a exceção é uma
+    /// <c>DbUpdateException</c> envolvendo uma <c>PostgresException</c> com
+    /// <c>SqlState = "23505"</c>. <see langword="null"/> caso contrário — o caller
+    /// deve propagar a exceção.
+    /// </summary>
+    public static string? GetViolatedConstraint(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        if (!string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Exception? inner = ex.InnerException;
+        if (inner is null)
+        {
+            return null;
+        }
+
+        Type innerType = inner.GetType();
+        string? sqlState = innerType.GetProperty("SqlState")?.GetValue(inner) as string;
+        if (sqlState != UniqueViolationSqlState)
+        {
+            return null;
+        }
+
+        return innerType.GetProperty("ConstraintName")?.GetValue(inner) as string;
+    }
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é a que impede um mesmo
+    /// ato de ser retificado duas vezes (cadeia linear, ADR-0103).
+    /// </summary>
+    public static bool IsLinearidadeConflict(string? constraint) =>
+        string.Equals(constraint, LinearidadeConstraint, StringComparison.Ordinal);
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/AtoNormativoDto.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/DTOs/AtoNormativoDto.cs
@@ -4,13 +4,17 @@ using System.Text.Json.Serialization;
 
 /// <summary>
 /// DTO de resposta para <c>AtoNormativo</c>. Expõe a essência documental do ato,
-/// os atributos de consequência copiados por valor do catálogo e — quando o ato
-/// invoca configuração — o par <c>{id, hash}</c> da versão que o governou.
+/// os atributos de consequência copiados por valor do catálogo, — quando o ato
+/// invoca configuração — o par <c>{id, hash}</c> da versão que o governou, e — quando
+/// o ato emenda outro — a linhagem de retificação (<c>AtoRetificadoId</c> + motivo).
 /// </summary>
 /// <remarks>
 /// <para><c>DataPublicacao</c> é documental (o que o PDF declara);
 /// <c>RegistradoEm</c> é o instante forense em que o registro entrou no sistema.
 /// São grandezas distintas — só a segunda ordena no relógio do sistema.</para>
+/// <para><c>AtoRetificadoId</c>/<c>MotivoRetificacao</c> são o par simétrico da
+/// retificação (ADR-0103): ambos presentes num ato que emenda outro, ambos nulos
+/// no ato que não emenda ninguém.</para>
 /// <para><c>Avisos</c> é nulo (omitido) na listagem, para evitar N+1; no detalhe
 /// (GET por id) é recomputado — lista vazia significa "sem colisão de número".</para>
 /// <para>Suporta HATEOAS Level 1 via <c>_links</c> (ADR-0029).</para>
@@ -24,12 +28,15 @@ public sealed record AtoNormativoDto(
     string TipoCodigo,
     bool CongelaConfiguracao,
     bool EfeitoIrreversivel,
+    bool UnicoPorObjeto,
     DateOnly DataPublicacao,
     string DocumentoHash,
     string Assinante,
     DateTimeOffset RegistradoEm,
     Guid? VersaoInvocadaId,
-    string? VersaoInvocadaHash)
+    string? VersaoInvocadaHash,
+    Guid? AtoRetificadoId,
+    string? MotivoRetificacao)
 {
     /// <summary>
     /// Avisos de numeração recomputados na leitura. Nulo quando não computados

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Mappings/AtoNormativoMapping.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Mappings/AtoNormativoMapping.cs
@@ -22,11 +22,14 @@ public static class AtoNormativoMapping
             ato.TipoCodigo,
             ato.CongelaConfiguracao,
             ato.EfeitoIrreversivel,
+            ato.UnicoPorObjeto,
             ato.DataPublicacao,
             ato.DocumentoHash,
             ato.Assinante,
             ato.RegistradoEm,
             ato.VersaoInvocada?.Id,
-            ato.VersaoInvocada?.Hash);
+            ato.VersaoInvocada?.Hash,
+            ato.AtoRetificadoId,
+            ato.MotivoRetificacao);
     }
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ObterAtoNormativoPorIdQueryHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ObterAtoNormativoPorIdQueryHandler.cs
@@ -24,9 +24,15 @@ public static class ObterAtoNormativoPorIdQueryHandler
             return null;
         }
 
-        // Recomputa o aviso (AC4), excluindo o próprio ato do conjunto de conflitantes.
+        // Recomputa o aviso (AC4), excluindo do conjunto de conflitantes a linhagem
+        // inteira: o próprio ato, a raiz e as demais retificações empilhadas. Uma
+        // republicação com o mesmo número dentro da cadeia não é colisão (ADR-0103).
+        // A cadeia sempre contém o próprio ato.
+        IReadOnlyList<Guid> cadeia = await repository
+            .ListarIdsDaCadeiaAsync(ato.Id, cancellationToken)
+            .ConfigureAwait(false);
         IReadOnlyList<AvisoNumeracao> avisos = await AvisoNumeracaoCalculator
-            .CalcularAsync(repository, ato, excluirId: ato.Id, cancellationToken)
+            .CalcularAsync(repository, ato, cadeia, cancellationToken)
             .ConfigureAwait(false);
 
         return ato.ToDto() with { Avisos = avisos };

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/AtoNormativo.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/AtoNormativo.cs
@@ -39,8 +39,14 @@ using Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
 /// ato nenhum.
 /// </para>
 /// <para>
-/// Retificação (relação entre atos) e o vínculo genérico ato↔entidade não
-/// pertencem a este agregado ainda — nascem em stories próprias (#800 e #801).
+/// <b>Retificação é relação, não tipo</b> (ADR-0103). Um ato pode retificar outro
+/// pelo par <see cref="AtoRetificadoId"/> + <see cref="MotivoRetificacao"/>,
+/// simétrico (um existe se e somente se o outro existe). A cadeia é linear — um
+/// ato é retificado no máximo uma vez — e empilha na cabeça: uma segunda
+/// retificação retifica a primeira, não a raiz. As invariantes que dependem do
+/// ato retificado (classe de congelamento coincidente, linearidade) vivem no
+/// handler, que as consulta no repositório; aqui fica só a simetria de shape. O
+/// vínculo genérico ato↔entidade ainda nasce em story própria (#801).
 /// </para>
 /// </remarks>
 public sealed class AtoNormativo : IForensicEntity
@@ -50,6 +56,7 @@ public sealed class AtoNormativo : IForensicEntity
     private const int NumeroMaxLength = 60;
     private const int TipoCodigoMaxLength = 60;
     private const int AssinanteMaxLength = 200;
+    private const int MotivoRetificacaoMaxLength = 1000;
 
     public Guid Id { get; private init; } = Guid.CreateVersion7();
 
@@ -74,6 +81,15 @@ public sealed class AtoNormativo : IForensicEntity
     /// <summary>Se a publicação do ato não pode ser desfeita — copiado por valor do catálogo.</summary>
     public bool EfeitoIrreversivel { get; private init; }
 
+    /// <summary>
+    /// Se o objeto do ato admite um único ato vivo deste tipo — copiado por valor
+    /// do catálogo, no instante do registro (ADR-0075), como os demais atributos de
+    /// consequência. A unicidade da raiz de cadeia por objeto (#801) ancora-se neste
+    /// snapshot: consultar o catálogo vigente no futuro tornaria a regra histórica
+    /// instável, porque o cadastro é editável.
+    /// </summary>
+    public bool UnicoPorObjeto { get; private init; }
+
     /// <summary>Data que o documento declara. Documental — nunca ordena vigência.</summary>
     public DateOnly DataPublicacao { get; private init; }
 
@@ -92,6 +108,20 @@ public sealed class AtoNormativo : IForensicEntity
     /// </summary>
     public ReferenciaVersaoConfiguracao? VersaoInvocada { get; private init; }
 
+    /// <summary>
+    /// Ato que este retifica, quando é uma retificação (ADR-0103). Nulo num ato que
+    /// não emenda outro. Referência intra-módulo por FK — permitida, pois a ADR-0061
+    /// só proíbe FK atravessando a fronteira de outro módulo. Simétrico com
+    /// <see cref="MotivoRetificacao"/>.
+    /// </summary>
+    public Guid? AtoRetificadoId { get; private init; }
+
+    /// <summary>
+    /// Motivo declarado da retificação. Simétrico com <see cref="AtoRetificadoId"/> —
+    /// um existe se e somente se o outro existe.
+    /// </summary>
+    public string? MotivoRetificacao { get; private init; }
+
     // EF Core materialization
     private AtoNormativo()
     {
@@ -99,11 +129,15 @@ public sealed class AtoNormativo : IForensicEntity
 
     /// <summary>
     /// Registra um ato publicado. Os atributos de consequência
-    /// (<paramref name="congelaConfiguracao"/>, <paramref name="efeitoIrreversivel"/>)
-    /// já vêm resolvidos por valor do catálogo vigente; a validação de negócio
-    /// (existência de versão vigente, formato do payload) é responsabilidade do
-    /// handler e do validator. Aqui ficam as invariantes de última linha, que
-    /// lançam — o agregado nunca materializa em estado inválido.
+    /// (<paramref name="congelaConfiguracao"/>, <paramref name="efeitoIrreversivel"/>,
+    /// <paramref name="unicoPorObjeto"/>) já vêm resolvidos por valor do catálogo
+    /// vigente; a validação de negócio (existência de versão vigente, formato do
+    /// payload) é responsabilidade do handler e do validator. Aqui ficam as
+    /// invariantes de última linha, que lançam — o agregado nunca materializa em
+    /// estado inválido. As regras de retificação que dependem do ato retificado
+    /// (classe de congelamento coincidente, linearidade da cadeia) são do handler,
+    /// que as consulta no repositório; a factory garante só a simetria de shape do
+    /// par (<paramref name="atoRetificadoId"/>, <paramref name="motivoRetificacao"/>).
     /// </summary>
     public static AtoNormativo Registrar(
         string orgao,
@@ -113,17 +147,21 @@ public sealed class AtoNormativo : IForensicEntity
         string tipoCodigo,
         bool congelaConfiguracao,
         bool efeitoIrreversivel,
+        bool unicoPorObjeto,
         DateOnly dataPublicacao,
         string documentoHash,
         string assinante,
         DateTimeOffset registradoEm,
-        ReferenciaVersaoConfiguracao? versaoInvocada)
+        ReferenciaVersaoConfiguracao? versaoInvocada,
+        Guid? atoRetificadoId = null,
+        string? motivoRetificacao = null)
     {
         string orgaoNorm = ExigirTexto(orgao, OrgaoMaxLength, nameof(orgao));
         string serieNorm = ExigirTexto(serie, SerieMaxLength, nameof(serie));
         string tipoCodigoNorm = ExigirTexto(tipoCodigo, TipoCodigoMaxLength, nameof(tipoCodigo));
         string assinanteNorm = ExigirTexto(assinante, AssinanteMaxLength, nameof(assinante));
         string? numeroNorm = NormalizarOpcional(numero, NumeroMaxLength, nameof(numero));
+        string? motivoNorm = NormalizarOpcional(motivoRetificacao, MotivoRetificacaoMaxLength, nameof(motivoRetificacao));
 
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(ano);
 
@@ -132,6 +170,24 @@ public sealed class AtoNormativo : IForensicEntity
             throw new ArgumentException(
                 "Hash do documento deve ser um SHA-256 em hexadecimal minúsculo (64 caracteres).",
                 nameof(documentoHash));
+        }
+
+        if (atoRetificadoId == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "Identificador do ato retificado não pode ser vazio.",
+                nameof(atoRetificadoId));
+        }
+
+        // Simetria da retificação (ADR-0103): a linhagem é o par (ato retificado,
+        // motivo) — um sem o outro não registra emenda alguma. A auto-referência é
+        // impossível por esta via (o Id é gerado aqui, fresco); o insert cru fica
+        // barrado por CHECK no banco.
+        if ((atoRetificadoId is not null) != (motivoNorm is not null))
+        {
+            throw new ArgumentException(
+                "A retificação é o par (ato retificado, motivo) completo, ou nenhum dos dois.",
+                nameof(atoRetificadoId));
         }
 
         return new AtoNormativo
@@ -143,11 +199,14 @@ public sealed class AtoNormativo : IForensicEntity
             TipoCodigo = tipoCodigoNorm,
             CongelaConfiguracao = congelaConfiguracao,
             EfeitoIrreversivel = efeitoIrreversivel,
+            UnicoPorObjeto = unicoPorObjeto,
             DataPublicacao = dataPublicacao,
             DocumentoHash = documentoHash,
             Assinante = assinanteNorm,
             RegistradoEm = registradoEm,
             VersaoInvocada = versaoInvocada,
+            AtoRetificadoId = atoRetificadoId,
+            MotivoRetificacao = motivoNorm,
         };
     }
 

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/AtoNormativoErrorCodes.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/AtoNormativoErrorCodes.cs
@@ -17,4 +17,25 @@ public static class AtoNormativoErrorCodes
 
     /// <summary>O identificador da URL não corresponde a nenhum ato registrado.</summary>
     public const string NaoEncontrado = "AtoNormativo.NaoEncontrado";
+
+    /// <summary>
+    /// A retificação referencia um <c>ato_retificado_id</c> que não corresponde a
+    /// nenhum ato registrado. Não há linhagem para emendar.
+    /// </summary>
+    public const string AtoRetificadoNaoEncontrado = "AtoNormativo.AtoRetificadoNaoEncontrado";
+
+    /// <summary>
+    /// A classe de congelamento do retificador diverge da do retificado: um ato não
+    /// congelante não emenda um congelante, nem o inverso (ADR-0103). É a
+    /// <c>congela_configuracao</c> que protege a integridade da configuração
+    /// publicada (RN08), não o rótulo do tipo.
+    /// </summary>
+    public const string ClasseDeCongelamentoDivergente = "AtoNormativo.ClasseDeCongelamentoDivergente";
+
+    /// <summary>
+    /// O ato que se tentou retificar já foi retificado por outro: a cadeia é linear
+    /// e empilha na cabeça (ADR-0103). Uma nova retificação deve emendar a cabeça da
+    /// cadeia, não uma raiz já retificada. A mensagem nomeia o ato que já a retificou.
+    /// </summary>
+    public const string RaizJaRetificada = "AtoNormativo.RaizJaRetificada";
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Interfaces/IAtoNormativoRepository.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Interfaces/IAtoNormativoRepository.cs
@@ -17,6 +17,26 @@ public interface IAtoNormativoRepository
     Task<AtoNormativo?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Devolve o ato que já retifica <paramref name="atoRetificadoId"/>, ou nulo se
+    /// nenhum o retificou ainda. Sustenta a linearidade da cadeia (ADR-0103): dá a
+    /// mensagem que nomeia o retificador no caso comum. A garantia dura contra a
+    /// corrida check-then-act é do índice único parcial em <c>ato_retificado_id</c>,
+    /// não desta consulta.
+    /// </summary>
+    Task<AtoNormativo?> ObterRetificadorAsync(Guid atoRetificadoId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Devolve os identificadores de todos os atos da cadeia de retificação linear à
+    /// qual <paramref name="atoId"/> pertence — a raiz, o próprio ato e as demais
+    /// retificações empilhadas. Sobe de <paramref name="atoId"/> até a raiz e desce
+    /// dela até a cabeça. Base para excluir a linhagem inteira do aviso de duplicata:
+    /// uma republicação com o mesmo número dentro da cadeia não é colisão, é a mesma
+    /// linhagem (ADR-0103). Lista com o próprio <paramref name="atoId"/> quando ele
+    /// não participa de retificação alguma.
+    /// </summary>
+    Task<IReadOnlyList<Guid>> ListarIdsDaCadeiaAsync(Guid atoId, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Devolve os identificadores dos atos que compartilham a mesma numeração
     /// <c>(orgao, serie, ano, numero)</c>, excluindo <paramref name="excluirId"/>
     /// quando informado (o próprio ato, na recomputação do aviso durante a leitura).

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/AtoNormativoConfiguration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/AtoNormativoConfiguration.cs
@@ -16,6 +16,7 @@ internal sealed class AtoNormativoConfiguration : IEntityTypeConfiguration<AtoNo
     private const int NumeroMaxLength = 60;
     private const int TipoCodigoMaxLength = 60;
     private const int AssinanteMaxLength = 200;
+    private const int MotivoRetificacaoMaxLength = 1000;
     private const int HashLength = 64;
 
     public void Configure(EntityTypeBuilder<AtoNormativo> builder)
@@ -52,6 +53,25 @@ internal sealed class AtoNormativoConfiguration : IEntityTypeConfiguration<AtoNo
                 // Ano é declarado pelo órgão; importação de acervo histórico admite
                 // anos antigos, então não há teto — apenas positividade.
                 t.HasCheckConstraint("ck_ato_normativo_ano_positivo", "ano > 0");
+
+                // Retificação simétrica (ADR-0103): a linhagem é o par (ato
+                // retificado, motivo) — completo ou ausente. O motivo tem de ter
+                // conteúdo (btrim não-vazio): a factory normaliza motivo em branco para
+                // ausente, então um motivo só-espaços seria uma retificação sem razão
+                // registrada — inaceitável num registro append-only. Defesa contra
+                // insert cru; o guard de domínio já recusa.
+                t.HasCheckConstraint(
+                    "ck_ato_normativo_retificacao_completa",
+                    "(ato_retificado_id IS NULL AND motivo_retificacao IS NULL) "
+                    + "OR (ato_retificado_id IS NOT NULL AND motivo_retificacao IS NOT NULL "
+                    + "AND btrim(motivo_retificacao) <> '')");
+
+                // Um ato não retifica a si mesmo. Impossível pela factory (o Id é
+                // gerado no registro, e o cliente não conhece um Id ainda inexistente);
+                // o CHECK fecha a brecha do insert cru.
+                t.HasCheckConstraint(
+                    "ck_ato_normativo_nao_autorretifica",
+                    "ato_retificado_id IS NULL OR ato_retificado_id <> id");
             });
 
         builder.HasKey(a => a.Id);
@@ -64,6 +84,7 @@ internal sealed class AtoNormativoConfiguration : IEntityTypeConfiguration<AtoNo
 
         builder.Property(a => a.CongelaConfiguracao).IsRequired();
         builder.Property(a => a.EfeitoIrreversivel).IsRequired();
+        builder.Property(a => a.UnicoPorObjeto).IsRequired();
 
         builder.Property(a => a.DataPublicacao).IsRequired();
 
@@ -89,10 +110,32 @@ internal sealed class AtoNormativoConfiguration : IEntityTypeConfiguration<AtoNo
         });
         builder.Navigation(a => a.VersaoInvocada).IsRequired(false);
 
+        builder.Property(a => a.AtoRetificadoId);
+        builder.Property(a => a.MotivoRetificacao).HasMaxLength(MotivoRetificacaoMaxLength);
+
+        // FK self-referencial intra-módulo (ADR-0061 só proíbe FK cross-módulo). Sem
+        // navegação — o agregado forense não expõe travessia de cadeia; a linhagem é
+        // consultada pelo repositório. Restrict: coerente com o append-only, que já
+        // bloqueia DELETE por trigger.
+        builder.HasOne<AtoNormativo>()
+            .WithMany()
+            .HasForeignKey(a => a.AtoRetificadoId)
+            .HasConstraintName("fk_ato_normativo_ato_retificado")
+            .OnDelete(DeleteBehavior.Restrict);
+
         // Lookup por numeração para o aviso de duplicata (AC4). NÃO é único: o
         // número é declarado, não gerado — dois atos com a mesma numeração são
         // aceitos, e a colisão vira aviso, jamais recusa.
         builder.HasIndex(a => new { a.Orgao, a.Serie, a.Ano, a.Numero })
             .HasDatabaseName("ix_ato_normativo_numeracao");
+
+        // Linearidade da cadeia (ADR-0103): um ato é retificado no máximo uma vez.
+        // Índice único parcial — garantia dura à prova da corrida check-then-act do
+        // handler. Parcial porque a maioria dos atos não retifica ninguém (nulo não
+        // colide com nulo no Postgres, mas o filtro deixa o índice enxuto).
+        builder.HasIndex(a => a.AtoRetificadoId)
+            .IsUnique()
+            .HasFilter("ato_retificado_id IS NOT NULL")
+            .HasDatabaseName("ux_ato_normativo_retificado");
     }
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260711000608_AddCadeiaRetificacaoAtoNormativo.Designer.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260711000608_AddCadeiaRetificacaoAtoNormativo.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(PublicacoesDbContext))]
-    partial class PublicacoesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711000608_AddCadeiaRetificacaoAtoNormativo")]
+    partial class AddCadeiaRetificacaoAtoNormativo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260711000608_AddCadeiaRetificacaoAtoNormativo.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260711000608_AddCadeiaRetificacaoAtoNormativo.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCadeiaRetificacaoAtoNormativo : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ato_retificado_id",
+                schema: "publicacoes",
+                table: "ato_normativo",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "motivo_retificacao",
+                schema: "publicacoes",
+                table: "ato_normativo",
+                type: "character varying(1000)",
+                maxLength: 1000,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "unico_por_objeto",
+                schema: "publicacoes",
+                table: "ato_normativo",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "ux_ato_normativo_retificado",
+                schema: "publicacoes",
+                table: "ato_normativo",
+                column: "ato_retificado_id",
+                unique: true,
+                filter: "ato_retificado_id IS NOT NULL");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_ato_normativo_nao_autorretifica",
+                schema: "publicacoes",
+                table: "ato_normativo",
+                sql: "ato_retificado_id IS NULL OR ato_retificado_id <> id");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_ato_normativo_retificacao_completa",
+                schema: "publicacoes",
+                table: "ato_normativo",
+                sql: "(ato_retificado_id IS NULL AND motivo_retificacao IS NULL) OR (ato_retificado_id IS NOT NULL AND motivo_retificacao IS NOT NULL AND btrim(motivo_retificacao) <> '')");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_ato_normativo_ato_retificado",
+                schema: "publicacoes",
+                table: "ato_normativo",
+                column: "ato_retificado_id",
+                principalSchema: "publicacoes",
+                principalTable: "ato_normativo",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_ato_normativo_ato_retificado",
+                schema: "publicacoes",
+                table: "ato_normativo");
+
+            migrationBuilder.DropIndex(
+                name: "ux_ato_normativo_retificado",
+                schema: "publicacoes",
+                table: "ato_normativo");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_ato_normativo_nao_autorretifica",
+                schema: "publicacoes",
+                table: "ato_normativo");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_ato_normativo_retificacao_completa",
+                schema: "publicacoes",
+                table: "ato_normativo");
+
+            migrationBuilder.DropColumn(
+                name: "ato_retificado_id",
+                schema: "publicacoes",
+                table: "ato_normativo");
+
+            migrationBuilder.DropColumn(
+                name: "motivo_retificacao",
+                schema: "publicacoes",
+                table: "ato_normativo");
+
+            migrationBuilder.DropColumn(
+                name: "unico_por_objeto",
+                schema: "publicacoes",
+                table: "ato_normativo");
+        }
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Repositories/AtoNormativoRepository.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Repositories/AtoNormativoRepository.cs
@@ -36,6 +36,50 @@ public sealed class AtoNormativoRepository : IAtoNormativoRepository
             .FirstOrDefaultAsync(a => a.Id == id, cancellationToken);
     }
 
+    public Task<AtoNormativo?> ObterRetificadorAsync(Guid atoRetificadoId, CancellationToken cancellationToken)
+    {
+        // O índice único parcial em ato_retificado_id garante no máximo um; aqui a
+        // leitura é AsNoTracking porque serve só à mensagem que nomeia o retificador.
+        return _dbContext.AtosNormativos
+            .AsNoTracking()
+            .FirstOrDefaultAsync(a => a.AtoRetificadoId == atoRetificadoId, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<Guid>> ListarIdsDaCadeiaAsync(Guid atoId, CancellationToken cancellationToken)
+    {
+        // A cadeia de retificação é linear (garantida pelo índice único parcial em
+        // ato_retificado_id) e acíclica (append-only, CHECK de não-autorreferência).
+        // Sobe de atoId até a raiz e desce dela até a cabeça, devolvendo a linhagem
+        // inteira. A recursão em SQL é necessária: a profundidade é arbitrária e um
+        // JOIN fixo não a cobre. O parâmetro é interpolado com segurança pelo EF.
+        FormattableString sql = $"""
+            WITH RECURSIVE ancestrais AS (
+                SELECT id, ato_retificado_id
+                FROM publicacoes.ato_normativo
+                WHERE id = {atoId}
+                UNION ALL
+                SELECT a.id, a.ato_retificado_id
+                FROM publicacoes.ato_normativo a
+                JOIN ancestrais an ON a.id = an.ato_retificado_id
+            ),
+            cadeia AS (
+                SELECT id, ato_retificado_id
+                FROM publicacoes.ato_normativo
+                WHERE id IN (SELECT id FROM ancestrais WHERE ato_retificado_id IS NULL)
+                UNION ALL
+                SELECT a.id, a.ato_retificado_id
+                FROM publicacoes.ato_normativo a
+                JOIN cadeia c ON a.ato_retificado_id = c.id
+            )
+            SELECT id AS "Value" FROM cadeia
+            """;
+
+        return await _dbContext.Database
+            .SqlQuery<Guid>(sql)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<Guid>> ListarIdsComMesmaNumeracaoAsync(
         string orgao,
         string serie,

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/RegistrarAtoNormativoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/RegistrarAtoNormativoCommandHandlerTests.cs
@@ -105,18 +105,157 @@ public sealed class RegistrarAtoNormativoCommandHandlerTests
         resultado.Value!.Avisos.Should().BeEmpty();
     }
 
+    [Fact(DisplayName = "Retificar ato inexistente é recusado (AtoRetificadoNaoEncontrado)")]
+    public async Task Handle_RetificaAtoInexistente_Falha()
+    {
+        VigenteComConsequencia(congela: false, efeito: false);
+        Guid retificadoId = Guid.CreateVersion7();
+        _atos.ObterPorIdParaLeituraAsync(retificadoId, Arg.Any<CancellationToken>())
+            .Returns((AtoNormativo?)null);
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando() with { AtoRetificadoId = retificadoId, MotivoRetificacao = "corrige o anexo II" });
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AtoNormativoErrorCodes.AtoRetificadoNaoEncontrado);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Retificar com classe de congelamento divergente é recusado")]
+    public async Task Handle_RetificaCongelaDivergente_Falha()
+    {
+        // Novo ato: tipo não congelante. Retificado: congelante. Classes divergem.
+        VigenteComConsequencia(congela: false, efeito: false);
+        AtoNormativo retificado = AtoExistente(congela: true);
+        _atos.ObterPorIdParaLeituraAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(retificado);
+        _atos.ObterRetificadorAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns((AtoNormativo?)null);
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando() with { AtoRetificadoId = retificado.Id, MotivoRetificacao = "corrige o anexo II" });
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AtoNormativoErrorCodes.ClasseDeCongelamentoDivergente);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Tipo diferente com a mesma classe de congelamento pode retificar, e a retificação não muda o tipo")]
+    public async Task Handle_RetificaMesmaClasse_Registra()
+    {
+        // Novo ato tipo EDITAL_ABERTURA congelante; retificado tipo AVISO congelante —
+        // rótulos distintos, mesma classe de congelamento (um aviso retifica um edital).
+        VigenteComConsequencia(congela: true, efeito: false);
+        SemConflitoDeNumero();
+        AtoNormativo retificado = AtoExistente(congela: true, tipoCodigo: "AVISO");
+        _atos.ObterPorIdParaLeituraAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(retificado);
+        _atos.ObterRetificadorAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns((AtoNormativo?)null);
+
+        AtoNormativo? capturado = null;
+        await _atos.AdicionarAsync(Arg.Do<AtoNormativo>(a => capturado = a), Arg.Any<CancellationToken>());
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando() with { AtoRetificadoId = retificado.Id, MotivoRetificacao = "corrige o anexo II" });
+
+        resultado.IsSuccess.Should().BeTrue();
+        capturado!.AtoRetificadoId.Should().Be(retificado.Id);
+        capturado.MotivoRetificacao.Should().Be("corrige o anexo II");
+        // A retificação não muda o tipo: o novo ato mantém o próprio tipo
+        // (EDITAL_ABERTURA), não herda o do retificado (AVISO).
+        retificado.TipoCodigo.Should().Be("AVISO");
+        capturado.TipoCodigo.Should().Be("EDITAL_ABERTURA");
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Retificar a raiz de cadeia já retificada é recusado, nomeando o retificador")]
+    public async Task Handle_RetificaRaizJaRetificada_Falha()
+    {
+        VigenteComConsequencia(congela: false, efeito: false);
+        AtoNormativo retificado = AtoExistente(congela: false);
+        AtoNormativo jaRetificador = AtoExistente(congela: false);
+        _atos.ObterPorIdParaLeituraAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(retificado);
+        _atos.ObterRetificadorAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(jaRetificador);
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando() with { AtoRetificadoId = retificado.Id, MotivoRetificacao = "corrige o anexo II" });
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AtoNormativoErrorCodes.RaizJaRetificada);
+        resultado.Error.Message.Should().Contain(jaRetificador.Id.ToString());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Segunda retificação empilha na cabeça (retifica R1, ainda não retificado) e é aceita")]
+    public async Task Handle_RetificaCabecaDaCadeia_Registra()
+    {
+        VigenteComConsequencia(congela: false, efeito: false);
+        SemConflitoDeNumero();
+        AtoNormativo cabeca = AtoExistente(congela: false);
+        _atos.ObterPorIdParaLeituraAsync(cabeca.Id, Arg.Any<CancellationToken>()).Returns(cabeca);
+        _atos.ObterRetificadorAsync(cabeca.Id, Arg.Any<CancellationToken>()).Returns((AtoNormativo?)null);
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando() with { AtoRetificadoId = cabeca.Id, MotivoRetificacao = "corrige o anexo II" });
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Copia unico_por_objeto do catálogo vigente por valor")]
+    public async Task Handle_CopiaUnicoPorObjeto()
+    {
+        VigenteComConsequencia(congela: false, efeito: false, unico: true);
+        SemConflitoDeNumero();
+        AtoNormativo? capturado = null;
+        await _atos.AdicionarAsync(Arg.Do<AtoNormativo>(a => capturado = a), Arg.Any<CancellationToken>());
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(Comando());
+
+        resultado.IsSuccess.Should().BeTrue();
+        capturado!.UnicoPorObjeto.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Retificação exclui o ato retificado do aviso de numeração (mesma linhagem, não colisão)")]
+    public async Task Handle_RetificacaoExcluiRetificadoDoAviso()
+    {
+        VigenteComConsequencia(congela: false, efeito: false);
+        AtoNormativo retificado = AtoExistente(congela: false);
+        _atos.ObterPorIdParaLeituraAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(retificado);
+        _atos.ObterRetificadorAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns((AtoNormativo?)null);
+        // A cadeia do retificado (aqui, só ele — é a raiz) é excluída do aviso.
+        _atos.ListarIdsDaCadeiaAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns([retificado.Id]);
+        // O retificado compartilha a numeração (republicação com o mesmo número); é o
+        // único conflitante — deve ser excluído, resultando em nenhum aviso.
+        _atos.ListarIdsComMesmaNumeracaoAsync("CEPS", "EDITAL", 2026, "13", null, Arg.Any<CancellationToken>())
+            .Returns([retificado.Id]);
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando() with { AtoRetificadoId = retificado.Id, MotivoRetificacao = "corrige o anexo II" });
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Avisos.Should().BeEmpty();
+    }
+
     private Task<Result<RegistrarAtoNormativoResult>> Executar(RegistrarAtoNormativoCommand comando) =>
         RegistrarAtoNormativoCommandHandler.Handle(
             comando, _tipos, _atos, _unitOfWork, _relogio, CancellationToken.None);
 
-    private void VigenteComConsequencia(bool congela, bool efeito)
+    private void VigenteComConsequencia(bool congela, bool efeito, bool unico = false)
     {
         TipoAtoPublicado tipo = TipoAtoPublicado.Criar(
-            "EDITAL_ABERTURA", "Edital de abertura", congela, unicoPorObjeto: false,
+            "EDITAL_ABERTURA", "Edital de abertura", congela, unicoPorObjeto: unico,
             efeito, new DateOnly(2026, 1, 1), null, null).Value!;
         _tipos.ObterVigenteAsync("EDITAL_ABERTURA", Publicacao, Arg.Any<CancellationToken>())
             .Returns(tipo);
     }
+
+    private static AtoNormativo AtoExistente(bool congela, string tipoCodigo = "EDITAL_ABERTURA") =>
+        AtoNormativo.Registrar(
+            "CEPS", "EDITAL", 2026, "13", tipoCodigo,
+            congelaConfiguracao: congela, efeitoIrreversivel: false, unicoPorObjeto: false,
+            dataPublicacao: Publicacao,
+            documentoHash: HashValido,
+            assinante: "Jairo Belchior",
+            registradoEm: Agora,
+            versaoInvocada: null);
 
     private void SemConflitoDeNumero() =>
         _atos.ListarIdsComMesmaNumeracaoAsync(

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Queries/AtoNormativoQueryHandlersTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Queries/AtoNormativoQueryHandlersTests.cs
@@ -39,9 +39,13 @@ public sealed class AtoNormativoQueryHandlersTests
     {
         AtoNormativo ato = NovoAto();
         _atos.ObterPorIdParaLeituraAsync(ato.Id, Arg.Any<CancellationToken>()).Returns(ato);
+        // Ato sem retificação: a cadeia é só ele mesmo.
+        _atos.ListarIdsDaCadeiaAsync(ato.Id, Arg.Any<CancellationToken>()).Returns([ato.Id]);
         Guid outro = Guid.CreateVersion7();
+        // O calculator consulta todos os conflitantes (excluirId nulo) e exclui a
+        // cadeia (aqui, só o próprio ato) em memória; `outro` sobrevive, o aviso aparece.
         _atos.ListarIdsComMesmaNumeracaoAsync(
-            "CEPS", "EDITAL", 2026, "13", ato.Id, Arg.Any<CancellationToken>())
+            "CEPS", "EDITAL", 2026, "13", null, Arg.Any<CancellationToken>())
             .Returns([outro]);
 
         AtoNormativoDto? dto = await ObterAtoNormativoPorIdQueryHandler.Handle(
@@ -50,6 +54,50 @@ public sealed class AtoNormativoQueryHandlersTests
         dto.Should().NotBeNull();
         dto!.Avisos.Should().ContainSingle();
         dto.Avisos![0].Codigo.Should().Be("NumeroDuplicado");
+    }
+
+    [Fact(DisplayName = "Detalhe de retificação exclui o ato retificado dos avisos, mantendo a colisão externa")]
+    public async Task ObterPorId_Retificacao_ExcluiRetificadoMantemColisaoExterna()
+    {
+        Guid raizId = Guid.CreateVersion7();
+        Guid externo = Guid.CreateVersion7();
+        AtoNormativo retificador = NovoRetificador(raizId);
+        _atos.ObterPorIdParaLeituraAsync(retificador.Id, Arg.Any<CancellationToken>()).Returns(retificador);
+        // A cadeia: raiz → retificador.
+        _atos.ListarIdsDaCadeiaAsync(retificador.Id, Arg.Any<CancellationToken>())
+            .Returns([raizId, retificador.Id]);
+        // Conflitantes pela numeração: a raiz (mesma linhagem — deve sair) e um ato externo.
+        _atos.ListarIdsComMesmaNumeracaoAsync("CEPS", "EDITAL", 2026, "13", null, Arg.Any<CancellationToken>())
+            .Returns([raizId, externo]);
+
+        AtoNormativoDto? dto = await ObterAtoNormativoPorIdQueryHandler.Handle(
+            new ObterAtoNormativoPorIdQuery(retificador.Id), _atos, CancellationToken.None);
+
+        dto!.Avisos.Should().ContainSingle();
+        dto.Avisos![0].AtosConflitantes.Should().Contain(externo).And.NotContain(raizId);
+    }
+
+    [Fact(DisplayName = "Detalhe da cabeça de uma cadeia profunda exclui a linhagem inteira dos avisos")]
+    public async Task ObterPorId_CadeiaProfunda_ExcluiLinhagemInteira()
+    {
+        Guid raizId = Guid.CreateVersion7();
+        Guid meioId = Guid.CreateVersion7();
+        Guid externo = Guid.CreateVersion7();
+        AtoNormativo cabeca = NovoRetificador(meioId); // a cabeça retifica o meio
+        _atos.ObterPorIdParaLeituraAsync(cabeca.Id, Arg.Any<CancellationToken>()).Returns(cabeca);
+        // A cadeia inteira: raiz → meio → cabeça.
+        _atos.ListarIdsDaCadeiaAsync(cabeca.Id, Arg.Any<CancellationToken>())
+            .Returns([raizId, meioId, cabeca.Id]);
+        // Mesma numeração: raiz e meio (mesma linhagem, republicação) e um ato externo.
+        _atos.ListarIdsComMesmaNumeracaoAsync("CEPS", "EDITAL", 2026, "13", null, Arg.Any<CancellationToken>())
+            .Returns([raizId, meioId, externo]);
+
+        AtoNormativoDto? dto = await ObterAtoNormativoPorIdQueryHandler.Handle(
+            new ObterAtoNormativoPorIdQuery(cabeca.Id), _atos, CancellationToken.None);
+
+        dto!.Avisos.Should().ContainSingle();
+        dto.Avisos![0].AtosConflitantes.Should().Contain(externo)
+            .And.NotContain(raizId).And.NotContain(meioId);
     }
 
     [Fact(DisplayName = "Listar projeta os atos sem avisos (evita N+1)")]
@@ -69,10 +117,22 @@ public sealed class AtoNormativoQueryHandlersTests
     private static AtoNormativo NovoAto() =>
         AtoNormativo.Registrar(
             "CEPS", "EDITAL", 2026, "13", "EDITAL_ABERTURA",
-            congelaConfiguracao: false, efeitoIrreversivel: false,
+            congelaConfiguracao: false, efeitoIrreversivel: false, unicoPorObjeto: false,
             dataPublicacao: new DateOnly(2026, 3, 13),
             documentoHash: HashValido,
             assinante: "Jairo Belchior",
             registradoEm: new DateTimeOffset(2026, 3, 13, 19, 0, 0, TimeSpan.Zero),
             versaoInvocada: null);
+
+    private static AtoNormativo NovoRetificador(Guid atoRetificadoId) =>
+        AtoNormativo.Registrar(
+            "CEPS", "EDITAL", 2026, "13", "EDITAL_ABERTURA",
+            congelaConfiguracao: false, efeitoIrreversivel: false, unicoPorObjeto: false,
+            dataPublicacao: new DateOnly(2026, 3, 13),
+            documentoHash: HashValido,
+            assinante: "Jairo Belchior",
+            registradoEm: new DateTimeOffset(2026, 3, 13, 19, 0, 0, TimeSpan.Zero),
+            versaoInvocada: null,
+            atoRetificadoId: atoRetificadoId,
+            motivoRetificacao: "corrige o anexo II");
 }

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Validators/RegistrarAtoNormativoCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Validators/RegistrarAtoNormativoCommandValidatorTests.cs
@@ -92,6 +92,46 @@ public sealed class RegistrarAtoNormativoCommandValidatorTests
             .IsValid.Should().BeFalse();
     }
 
+    [Fact(DisplayName = "Retificação só com ato retificado (sem motivo) é recusada")]
+    public void RetificacaoSoAto()
+    {
+        _validator.Validate(
+            Comando() with { AtoRetificadoId = Guid.CreateVersion7(), MotivoRetificacao = null })
+            .IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Retificação só com motivo (sem ato retificado) é recusada")]
+    public void RetificacaoSoMotivo()
+    {
+        _validator.Validate(
+            Comando() with { AtoRetificadoId = null, MotivoRetificacao = "corrige o anexo II" })
+            .IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Retificação com o par (ato retificado, motivo) completo passa")]
+    public void RetificacaoParCompleto()
+    {
+        _validator.Validate(
+            Comando() with { AtoRetificadoId = Guid.CreateVersion7(), MotivoRetificacao = "corrige o anexo II" })
+            .IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Retificação com ato retificado vazio (Guid.Empty) é recusada")]
+    public void RetificacaoAtoVazio()
+    {
+        _validator.Validate(
+            Comando() with { AtoRetificadoId = Guid.Empty, MotivoRetificacao = "corrige o anexo II" })
+            .IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Motivo de retificação acima do limite (1000) é recusado")]
+    public void RetificacaoMotivoLongo()
+    {
+        _validator.Validate(
+            Comando() with { AtoRetificadoId = Guid.CreateVersion7(), MotivoRetificacao = new string('x', 1001) })
+            .IsValid.Should().BeFalse();
+    }
+
     private static RegistrarAtoNormativoCommand Comando() =>
         new(
             Orgao: "CEPS",

--- a/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/AtoNormativoTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/AtoNormativoTests.cs
@@ -10,7 +10,8 @@ using Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
 
 /// <summary>
 /// Invariantes de domínio do ato normativo append-only: normalização, shape do
-/// hash do documento, positividade do ano e o par {id, hash} da versão invocada.
+/// hash do documento, positividade do ano, o par {id, hash} da versão invocada e
+/// a simetria de shape do par de retificação (ADR-0103).
 /// </summary>
 [SuppressMessage(
     "Performance",
@@ -33,6 +34,7 @@ public sealed class AtoNormativoTests
             tipoCodigo: "  EDITAL_ABERTURA  ",
             congelaConfiguracao: true,
             efeitoIrreversivel: false,
+            unicoPorObjeto: true,
             dataPublicacao: Publicacao,
             documentoHash: HashValido,
             assinante: "  Jairo Belchior  ",
@@ -47,11 +49,14 @@ public sealed class AtoNormativoTests
         ato.TipoCodigo.Should().Be("EDITAL_ABERTURA");
         ato.CongelaConfiguracao.Should().BeTrue();
         ato.EfeitoIrreversivel.Should().BeFalse();
+        ato.UnicoPorObjeto.Should().BeTrue();
         ato.DataPublicacao.Should().Be(Publicacao);
         ato.DocumentoHash.Should().Be(HashValido);
         ato.Assinante.Should().Be("Jairo Belchior");
         ato.RegistradoEm.Should().Be(Registro);
         ato.VersaoInvocada.Should().BeNull();
+        ato.AtoRetificadoId.Should().BeNull();
+        ato.MotivoRetificacao.Should().BeNull();
     }
 
     [Fact(DisplayName = "Número em branco vira nulo (ato sem número é válido)")]
@@ -105,22 +110,81 @@ public sealed class AtoNormativoTests
         acao.Should().Throw<ArgumentOutOfRangeException>();
     }
 
+    [Fact(DisplayName = "Registrar copia unico_por_objeto por valor do catálogo")]
+    public void Registrar_CopiaUnicoPorObjeto()
+    {
+        AtoNormativo ato = Registrar(unicoPorObjeto: true);
+        ato.UnicoPorObjeto.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Retificação preenche o par (ato retificado, motivo) e normaliza o motivo")]
+    public void Registrar_ComRetificacao_PreencheParENormaliza()
+    {
+        Guid retificado = Guid.CreateVersion7();
+        AtoNormativo ato = Registrar(atoRetificadoId: retificado, motivoRetificacao: "  corrige o anexo II  ");
+
+        ato.AtoRetificadoId.Should().Be(retificado);
+        ato.MotivoRetificacao.Should().Be("corrige o anexo II");
+    }
+
+    [Theory(DisplayName = "Par de retificação incompleto (só um dos dois) é recusado")]
+    [InlineData(true, false)]   // só ato retificado
+    [InlineData(false, true)]   // só motivo
+    public void Registrar_ComRetificacaoIncompleta_Lanca(bool temRetificado, bool temMotivo)
+    {
+        Guid? retificado = temRetificado ? Guid.CreateVersion7() : null;
+        string? motivo = temMotivo ? "corrige o anexo II" : null;
+
+        Action acao = () => Registrar(atoRetificadoId: retificado, motivoRetificacao: motivo);
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Fact(DisplayName = "Motivo em branco normaliza para ausente (par ausente é válido)")]
+    public void Registrar_ComMotivoEmBranco_TrataComoAusente()
+    {
+        AtoNormativo ato = Registrar(atoRetificadoId: null, motivoRetificacao: "   ");
+        ato.AtoRetificadoId.Should().BeNull();
+        ato.MotivoRetificacao.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Motivo acima do limite (1000) é recusado")]
+    public void Registrar_ComMotivoLongoDemais_Lanca()
+    {
+        Action acao = () => Registrar(
+            atoRetificadoId: Guid.CreateVersion7(),
+            motivoRetificacao: new string('x', 1001));
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Fact(DisplayName = "Ato retificado com id vazio (Guid.Empty) é recusado")]
+    public void Registrar_ComAtoRetificadoIdVazio_Lanca()
+    {
+        Action acao = () => Registrar(atoRetificadoId: Guid.Empty, motivoRetificacao: "corrige o anexo II");
+        acao.Should().Throw<ArgumentException>();
+    }
+
     private static AtoNormativo Registrar(
         string orgao = "CEPS",
         string serie = "EDITAL",
         int ano = 2026,
         string? numero = "13",
         string tipoCodigo = "EDITAL_ABERTURA",
+        bool unicoPorObjeto = false,
         string documentoHash = HashValido,
         string assinante = "Jairo Belchior",
-        ReferenciaVersaoConfiguracao? versao = null) =>
+        ReferenciaVersaoConfiguracao? versao = null,
+        Guid? atoRetificadoId = null,
+        string? motivoRetificacao = null) =>
         AtoNormativo.Registrar(
             orgao, serie, ano, numero, tipoCodigo,
             congelaConfiguracao: false,
             efeitoIrreversivel: false,
+            unicoPorObjeto: unicoPorObjeto,
             dataPublicacao: Publicacao,
             documentoHash: documentoHash,
             assinante: assinante,
             registradoEm: Registro,
-            versaoInvocada: versao);
+            versaoInvocada: versao,
+            atoRetificadoId: atoRetificadoId,
+            motivoRetificacao: motivoRetificacao);
 }

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtoNormativoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtoNormativoEndpointTests.cs
@@ -255,6 +255,126 @@ public sealed class AtoNormativoEndpointTests
         conflitantes.EnumerateArray().Select(e => e.GetGuid()).Should().Contain(primeiroId);
     }
 
+    // ── Cadeia de retificação (ADR-0103) ─────────────────────────────────────
+
+    [Fact(DisplayName = "POST de retificação com a mesma classe de congelamento retorna 201 e expõe a linhagem")]
+    public async Task Registrar_Retificacao_Retorna201ComLinhagem()
+    {
+        string tipo = await CriarTipoVigenteAsync(congela: true);
+        string serie = SerieUnica();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid raizId = await PostAtoIdAsync(client, PayloadAto(tipo, serie, "13"));
+        Guid retId = await PostAtoIdAsync(
+            client, PayloadRetificacao(tipo, serie, "13", raizId, "corrige o anexo II"));
+
+        using JsonDocument detalhe = JsonDocument.Parse(
+            await client.GetStringAsync(new Uri($"{BaseAtos}/{retId}", UriKind.Relative)));
+        detalhe.RootElement.GetProperty("atoRetificadoId").GetGuid().Should().Be(raizId);
+        detalhe.RootElement.GetProperty("motivoRetificacao").GetString().Should().Be("corrige o anexo II");
+    }
+
+    [Fact(DisplayName = "POST de retificação com classe de congelamento divergente retorna 422")]
+    public async Task Registrar_RetificacaoCongelaDivergente_Retorna422()
+    {
+        string tipoCongelante = await CriarTipoVigenteAsync(congela: true);
+        string tipoNaoCongelante = await CriarTipoVigenteAsync(congela: false);
+        string serie = SerieUnica();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid raizId = await PostAtoIdAsync(client, PayloadAto(tipoCongelante, serie, "13"));
+
+        HttpResponseMessage retResp = await PostAtoAsync(
+            client, PayloadRetificacao(tipoNaoCongelante, serie, "14", raizId, "corrige"));
+
+        retResp.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        (await retResp.Content.ReadAsStringAsync())
+            .Should().Contain("uniplus.publicacoes.ato_normativo.classe_congelamento_divergente");
+    }
+
+    [Fact(DisplayName = "POST que retifica ato inexistente retorna 422")]
+    public async Task Registrar_RetificaInexistente_Retorna422()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage resp = await PostAtoAsync(
+            client, PayloadRetificacao(tipo, SerieUnica(), "13", Guid.CreateVersion7(), "corrige"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        (await resp.Content.ReadAsStringAsync())
+            .Should().Contain("uniplus.publicacoes.ato_normativo.ato_retificado_nao_encontrado");
+    }
+
+    [Fact(DisplayName = "POST que retifica uma raiz já retificada retorna 409")]
+    public async Task Registrar_RetificaRaizJaRetificada_Retorna409()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+        string serie = SerieUnica();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid raizId = await PostAtoIdAsync(client, PayloadAto(tipo, serie, "13"));
+        await PostAtoIdAsync(client, PayloadRetificacao(tipo, serie, "13", raizId, "primeira"));
+
+        HttpResponseMessage segunda = await PostAtoAsync(
+            client, PayloadRetificacao(tipo, serie, "13", raizId, "segunda"));
+
+        segunda.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await segunda.Content.ReadAsStringAsync())
+            .Should().Contain("uniplus.publicacoes.ato_normativo.raiz_ja_retificada");
+    }
+
+    [Fact(DisplayName = "POST que retifica a cabeça da cadeia (R2 emenda R1) retorna 201")]
+    public async Task Registrar_EmpilhaNaCabeca_Retorna201()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+        string serie = SerieUnica();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid raizId = await PostAtoIdAsync(client, PayloadAto(tipo, serie, "13"));
+        Guid r1Id = await PostAtoIdAsync(client, PayloadRetificacao(tipo, serie, "13", raizId, "primeira"));
+
+        HttpResponseMessage r2 = await PostAtoAsync(
+            client, PayloadRetificacao(tipo, serie, "13", r1Id, "segunda"));
+
+        r2.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact(DisplayName = "Um aviso (tipo distinto, série e número próprios) retifica um edital quando a classe de congelamento coincide")]
+    public async Task Registrar_AvisoRetificaEdital_MesmaClasse_Retorna201()
+    {
+        // Dois tipos congelantes distintos: um edital e um aviso, cada um com sua
+        // numeração — o caso real do CRCA, em que um aviso emenda um edital.
+        string edital = await CriarTipoVigenteAsync(congela: true);
+        string aviso = await CriarTipoVigenteAsync(congela: true);
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid editalId = await PostAtoIdAsync(client, PayloadAto(edital, SerieUnica(), "13"));
+
+        HttpResponseMessage resp = await PostAtoAsync(
+            client, PayloadRetificacao(aviso, SerieUnica(), "50", editalId, "prorroga o prazo de inscrições"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact(DisplayName = "Detalhe da 3ª versão de uma cadeia (mesmo número) não avisa duplicata dentro da linhagem")]
+    public async Task ObterPorId_CadeiaProfundaMesmoNumero_NaoAvisaLinhagem()
+    {
+        string tipo = await CriarTipoVigenteAsync();
+        string serie = SerieUnica();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // A → B → C, todos com o mesmo número: republicações da mesma linhagem.
+        Guid a = await PostAtoIdAsync(client, PayloadAto(tipo, serie, "13"));
+        Guid b = await PostAtoIdAsync(client, PayloadRetificacao(tipo, serie, "13", a, "segunda versão"));
+        Guid c = await PostAtoIdAsync(client, PayloadRetificacao(tipo, serie, "13", b, "terceira versão"));
+
+        // O detalhe da cabeça não reporta A nem B como duplicata — é a mesma linhagem.
+        using JsonDocument detalhe = JsonDocument.Parse(
+            await client.GetStringAsync(new Uri($"{BaseAtos}/{c}", UriKind.Relative)));
+        detalhe.RootElement.GetProperty("avisos").GetArrayLength().Should().Be(0);
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static void Autenticar(HttpRequestMessage request, string role = "plataforma-admin")
@@ -275,6 +395,30 @@ public sealed class AtoNormativoEndpointTests
             documentoHash = HashValido,
             assinante = "Jairo Belchior",
         };
+
+    private static object PayloadRetificacao(
+        string tipoCodigo, string serie, string? numero, Guid atoRetificadoId, string motivo) =>
+        new
+        {
+            orgao = "CEPS",
+            serie,
+            ano = 2026,
+            numero,
+            tipoCodigo,
+            dataPublicacao = Publicacao,
+            documentoHash = HashValido,
+            assinante = "Jairo Belchior",
+            atoRetificadoId,
+            motivoRetificacao = motivo,
+        };
+
+    private static async Task<Guid> PostAtoIdAsync(HttpClient client, object payload)
+    {
+        HttpResponseMessage resp = await PostAtoAsync(client, payload);
+        resp.StatusCode.Should().Be(HttpStatusCode.Created);
+        return JsonDocument.Parse(await resp.Content.ReadAsStringAsync())
+            .RootElement.GetProperty("atoId").GetGuid();
+    }
 
     private static async Task<HttpResponseMessage> PostAtoAsync(
         HttpClient client, object payload, string? chave = null)

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtoNormativoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtoNormativoPersistenceTests.cs
@@ -29,6 +29,8 @@ public sealed class AtoNormativoPersistenceTests
 {
     private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     private const string CheckViolation = "23514";
+    private const string UniqueViolation = "23505";
+    private const string ForeignKeyViolation = "23503";
     private static readonly DateOnly Publicacao = new(2026, 3, 13);
     private static readonly DateTimeOffset Registro = new(2026, 3, 13, 19, 0, 0, TimeSpan.Zero);
 
@@ -194,6 +196,141 @@ public sealed class AtoNormativoPersistenceTests
         (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
     }
 
+    // ── Cadeia de retificação (ADR-0103) ─────────────────────────────────────
+
+    [Fact(DisplayName = "Retificação persiste e relê o par (ato retificado, motivo) e o snapshot unico_por_objeto")]
+    public async Task Insert_Retificacao_PersisteCampos()
+    {
+        AtoNormativo raiz = Novo(numero: "13");
+        await Gravar(raiz);
+        AtoNormativo retificador = Novo(
+            numero: "13", atoRetificadoId: raiz.Id, motivoRetificacao: "corrige o anexo II");
+        await Gravar(retificador);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        AtoNormativo persistido = await ctx.AtosNormativos.SingleAsync(a => a.Id == retificador.Id);
+
+        persistido.AtoRetificadoId.Should().Be(raiz.Id);
+        persistido.MotivoRetificacao.Should().Be("corrige o anexo II");
+        persistido.UnicoPorObjeto.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "FK self-ref recusa retificação a um ato inexistente")]
+    public async Task Insert_RetificaInexistente_ViolaFk()
+    {
+        AtoNormativo retificador = Novo(
+            numero: "13", atoRetificadoId: Guid.CreateVersion7(), motivoRetificacao: "corrige");
+
+        Func<Task> gravar = () => Gravar(retificador);
+
+        DbUpdateException ex = (await gravar.Should().ThrowAsync<DbUpdateException>()).Which;
+        (ex.InnerException as PostgresException)!.SqlState.Should().Be(ForeignKeyViolation);
+    }
+
+    [Fact(DisplayName = "Índice único parcial recusa retificar o mesmo ato duas vezes (cadeia linear)")]
+    public async Task Insert_RetificaDuasVezes_ViolaUnique()
+    {
+        AtoNormativo raiz = Novo(numero: "13");
+        await Gravar(raiz);
+        await Gravar(Novo(numero: "13", atoRetificadoId: raiz.Id, motivoRetificacao: "primeira"));
+
+        Func<Task> segunda = () => Gravar(
+            Novo(numero: "13", atoRetificadoId: raiz.Id, motivoRetificacao: "segunda"));
+
+        DbUpdateException ex = (await segunda.Should().ThrowAsync<DbUpdateException>()).Which;
+        PostgresException pg = (ex.InnerException as PostgresException)!;
+        pg.SqlState.Should().Be(UniqueViolation);
+        // O nome da constraint violada é exatamente o que UniqueConstraintViolation
+        // procura para traduzir a corrida check-then-act em RaizJaRetificada (409).
+        pg.ConstraintName.Should().Be("ux_ato_normativo_retificado");
+    }
+
+    [Fact(DisplayName = "Duas retificações empilham na cabeça: R2 retifica R1 (não a raiz), aceito")]
+    public async Task Insert_EmpilhaNaCabeca_Aceito()
+    {
+        AtoNormativo raiz = Novo(numero: "13");
+        await Gravar(raiz);
+        AtoNormativo r1 = Novo(numero: "13", atoRetificadoId: raiz.Id, motivoRetificacao: "primeira");
+        await Gravar(r1);
+
+        // R2 emenda R1, a cabeça da cadeia; R1 ainda não foi retificado, então passa.
+        Func<Task> r2 = () => Gravar(
+            Novo(numero: "13", atoRetificadoId: r1.Id, motivoRetificacao: "segunda"));
+
+        await r2.Should().NotThrowAsync();
+    }
+
+    [Fact(DisplayName = "ListarIdsDaCadeia devolve a linhagem inteira a partir de qualquer elo (A→B→C)")]
+    public async Task ListarIdsDaCadeia_DevolveLinhagemInteira()
+    {
+        AtoNormativo a = Novo(numero: "13");
+        await Gravar(a);
+        AtoNormativo b = Novo(numero: "13", atoRetificadoId: a.Id, motivoRetificacao: "segunda versão");
+        await Gravar(b);
+        AtoNormativo c = Novo(numero: "13", atoRetificadoId: b.Id, motivoRetificacao: "terceira versão");
+        await Gravar(c);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var repo = new AtoNormativoRepository(ctx);
+
+        Guid[] esperada = [a.Id, b.Id, c.Id];
+        // A partir da raiz, do meio ou da cabeça, a cadeia inteira é devolvida.
+        (await repo.ListarIdsDaCadeiaAsync(a.Id, default)).Should().BeEquivalentTo(esperada);
+        (await repo.ListarIdsDaCadeiaAsync(b.Id, default)).Should().BeEquivalentTo(esperada);
+        (await repo.ListarIdsDaCadeiaAsync(c.Id, default)).Should().BeEquivalentTo(esperada);
+    }
+
+    [Fact(DisplayName = "ListarIdsDaCadeia de um ato sem retificação devolve só ele")]
+    public async Task ListarIdsDaCadeia_SemRetificacao_SoOProprio()
+    {
+        AtoNormativo solo = Novo(numero: "77");
+        await Gravar(solo);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var repo = new AtoNormativoRepository(ctx);
+
+        (await repo.ListarIdsDaCadeiaAsync(solo.Id, default))
+            .Should().ContainSingle().Which.Should().Be(solo.Id);
+    }
+
+    [Fact(DisplayName = "CHECK recusa retificação incompleta (só ato retificado, insert cru)")]
+    public async Task CheckRetificacaoCompleta_RecusaSoAto()
+    {
+        AtoNormativo raiz = Novo(numero: "13");
+        await Gravar(raiz);
+
+        Func<Task> insercao = () => InserirCru(atoRetificadoId: raiz.Id, motivoRetificacao: null);
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
+    [Fact(DisplayName = "CHECK recusa retificação incompleta (só motivo, insert cru)")]
+    public async Task CheckRetificacaoCompleta_RecusaSoMotivo()
+    {
+        Func<Task> insercao = () => InserirCru(atoRetificadoId: null, motivoRetificacao: "corrige");
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
+    [Theory(DisplayName = "CHECK recusa retificação com motivo em branco (vazio ou só espaços, insert cru)")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CheckRetificacaoCompleta_RecusaMotivoEmBranco(string motivo)
+    {
+        AtoNormativo raiz = Novo(numero: "13");
+        await Gravar(raiz);
+
+        // Motivo presente porém sem conteúdo: uma retificação sem razão registrada, que
+        // a factory normaliza para ausente e o CHECK (btrim) barra no insert cru.
+        Func<Task> insercao = () => InserirCru(atoRetificadoId: raiz.Id, motivoRetificacao: motivo);
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
+    [Fact(DisplayName = "CHECK recusa auto-retificação (id = ato_retificado_id, insert cru)")]
+    public async Task CheckNaoAutorretifica_RecusaSelfRef()
+    {
+        Func<Task> insercao = () => InserirCruAutorreferente();
+        (await insercao.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be(CheckViolation);
+    }
+
     [Fact(DisplayName = "ListarIdsComMesmaNumeracao devolve os conflitantes, ignorando o próprio ato")]
     public async Task ListarIdsComMesmaNumeracao_IgnoraProprio()
     {
@@ -300,19 +437,25 @@ public sealed class AtoNormativoPersistenceTests
         int ano = 2026,
         string documentoHash = HashValido,
         Guid? versaoId = null,
-        string? versaoHash = null)
+        string? versaoHash = null,
+        Guid? atoRetificadoId = null,
+        string? motivoRetificacao = null)
     {
         await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
         await ctx.Database.OpenConnectionAsync();
 
+        // unico_por_objeto omitido de propósito: a coluna é NOT NULL DEFAULT false,
+        // e o insert cru exercita justamente o caminho que não a informa.
         await using var command = new NpgsqlCommand(
             """
             INSERT INTO publicacoes.ato_normativo
                 (id, orgao, serie, ano, numero, tipo_codigo, congela_configuracao, efeito_irreversivel,
-                 data_publicacao, documento_hash, assinante, registrado_em, versao_invocada_id, versao_invocada_hash)
+                 data_publicacao, documento_hash, assinante, registrado_em, versao_invocada_id, versao_invocada_hash,
+                 ato_retificado_id, motivo_retificacao)
             VALUES
                 (gen_random_uuid(), 'CEPS', 'EDITAL', @ano, '13', 'EDITAL_ABERTURA', false, false,
-                 @data, @hash, 'Assinante', now(), @versao_id, @versao_hash)
+                 @data, @hash, 'Assinante', now(), @versao_id, @versao_hash,
+                 @ato_retificado_id, @motivo_retificacao)
             """,
             (NpgsqlConnection)ctx.Database.GetDbConnection());
 
@@ -321,11 +464,47 @@ public sealed class AtoNormativoPersistenceTests
         command.Parameters.AddWithValue("hash", documentoHash);
         command.Parameters.AddWithValue("versao_id", versaoId ?? (object)DBNull.Value);
         command.Parameters.AddWithValue("versao_hash", versaoHash ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("ato_retificado_id", atoRetificadoId ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("motivo_retificacao", (object?)motivoRetificacao ?? DBNull.Value);
 
         await command.ExecuteNonQueryAsync();
     }
 
-    private static AtoNormativo Novo(string? numero = "13", ReferenciaVersaoConfiguracao? versao = null) =>
+    [SuppressMessage(
+        "Security",
+        "CA2100:Review SQL queries for security vulnerabilities",
+        Justification = "SQL fixo dos testes de integração, sem entrada de usuário; parâmetros via NpgsqlParameter.")]
+    private async Task InserirCruAutorreferente()
+    {
+        Guid id = Guid.CreateVersion7();
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        await ctx.Database.OpenConnectionAsync();
+
+        // id = ato_retificado_id na mesma linha: a auto-retificação que o CHECK barra.
+        await using var command = new NpgsqlCommand(
+            """
+            INSERT INTO publicacoes.ato_normativo
+                (id, orgao, serie, ano, numero, tipo_codigo, congela_configuracao, efeito_irreversivel,
+                 data_publicacao, documento_hash, assinante, registrado_em, ato_retificado_id, motivo_retificacao)
+            VALUES
+                (@id, 'CEPS', 'EDITAL', 2026, '13', 'EDITAL_ABERTURA', false, false,
+                 @data, @hash, 'Assinante', now(), @id, 'corrige')
+            """,
+            (NpgsqlConnection)ctx.Database.GetDbConnection());
+
+        command.Parameters.AddWithValue("id", id);
+        command.Parameters.AddWithValue("data", Publicacao);
+        command.Parameters.AddWithValue("hash", HashValido);
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static AtoNormativo Novo(
+        string? numero = "13",
+        ReferenciaVersaoConfiguracao? versao = null,
+        Guid? atoRetificadoId = null,
+        string? motivoRetificacao = null) =>
         AtoNormativo.Registrar(
             orgao: "CEPS",
             serie: "EDITAL",
@@ -334,9 +513,12 @@ public sealed class AtoNormativoPersistenceTests
             tipoCodigo: "EDITAL_ABERTURA",
             congelaConfiguracao: false,
             efeitoIrreversivel: false,
+            unicoPorObjeto: false,
             dataPublicacao: Publicacao,
             documentoHash: HashValido,
             assinante: "Jairo Belchior",
             registradoEm: Registro,
-            versaoInvocada: versao);
+            versaoInvocada: versao,
+            atoRetificadoId: atoRetificadoId,
+            motivoRetificacao: motivoRetificacao);
 }


### PR DESCRIPTION
## Objetivo

Registrar que um ato retifica outro, com o motivo, de forma que a linhagem do que foi publicado seja auditável e não dependa do número nem do tipo do documento. Retificação é uma **relação entre atos**, não um valor de enum de tipo (ADR-0103).

Closes #800
Refs #796

## O que muda

Um `AtoNormativo` passa a poder retificar outro pelo par `(ato_retificado_id, motivo)`, exposto no mesmo `POST /api/publicacoes/admin/atos` — retificar é publicar um ato que emenda outro (ADR-0106), sem endpoint dedicado.

### Invariantes da cadeia

| Regra | Onde | Recusa |
|---|---|---|
| Par simétrico (um existe sse e somente se o outro) | factory + validator + CHECK `ck_ato_normativo_retificacao_completa` | 400 / 422 |
| Motivo com conteúdo (não só espaços) | factory normaliza; CHECK exige `btrim(...) <> ''` | 400 / 422 |
| Não retifica a si mesmo | CHECK `ck_ato_normativo_nao_autorretifica` (via factory é impossível — Id fresco) | 422 |
| Ato retificado existe | handler | 422 |
| `congela(retificador) == congela(retificado)` | handler (é a classe de congelamento que protege a RN08, não o rótulo do tipo) | 422 |
| Tipo diferente pode retificar se a classe coincide | — (um aviso retifica um edital) | aceito |
| Cadeia linear (retificado no máximo uma vez) | índice único parcial `ux_ato_normativo_retificado` | — |
| Empilha na cabeça (R2 emenda R1) | — | aceito |
| Retificar raiz já retificada, nomeando o retificador | handler (`ObterRetificadorAsync`) + corrida capturada em `SaveChanges` | **409** |
| Retificação não muda o tipo do ato | — | — |

A **linearidade** é garantida pelo índice único parcial (à prova da corrida check-then-act); a consulta prévia dá a mensagem legível que nomeia o retificador, e a corrida concorrente (SQLSTATE 23505) é traduzida na mesma recusa nomeada — nunca 500.

### Snapshot forense completo

O `AtoNormativo` passa a copiar também `unico_por_objeto` por valor do catálogo, ao lado de `congela` e `efeito` (ADR-0075). Os três atributos de consequência ficam congelados no instante do registro — consultar o catálogo editável no futuro tornaria a regra histórica instável.

### Persistência

- FK self-referencial **intra-módulo** (ADR-0061 só proíbe FK cross-módulo), `Restrict` — coerente com o append-only imposto por trigger (ADR-0063).
- Dois CHECKs (simetria com motivo não-vazio; auto-retificação) e o índice único parcial de linearidade.
- Migration `AddCadeiaRetificacaoAtoNormativo`; baseline OpenAPI regenerado.

## Escopo — `unico_por_objeto` remanejado para #801

A story listava um décimo critério: "para tipos `unico_por_objeto`, no máximo **uma raiz de cadeia por objeto**". Esse critério depende da noção de **objeto de um ato** — o vínculo `(tipo_entidade, entidade_id)` — que nasce na #801 (confirmado pela ADR-0106). Sem o vínculo, não há objeto ao qual ancorar a unicidade de raiz.

Este PR entrega os outros nove critérios (a mecânica completa da cadeia) e **congela o atributo `unico_por_objeto` no snapshot**, deixando a #801 pronta para implementar a unicidade concorrente por objeto sem retrabalho de migration. O critério de unicidade por objeto acompanha a #801.

## Testes

Suíte completa da solução verde (`dotnet test UniPlus.slnx`), incluindo:

- **Domínio**: simetria do par, limite/normalização do motivo, snapshot de `unico_por_objeto`.
- **Aplicação**: existência do retificado, classe coincidente com tipos distintos (aviso × edital) provando que a retificação não muda o tipo, linearidade nomeada, empilhamento, exclusão do retificado do aviso de numeração no registro e no detalhe.
- **Persistência** (Postgres real): FK, CHECKs (simetria, motivo em branco, auto-retificação), índice único de linearidade — por insert cru; o teste do índice afere o nome da constraint que o tradutor de corrida procura.
- **Endpoint**: 201 na retificação com linhagem exposta, 422 na divergência/inexistência, 409 na raiz já retificada.
- **Fitness ADR-0103** (nenhum literal de tipo em código/SQL) verde; **baseline OpenAPI** conferido.

## Rollback

Reversível pela migration `Down` (remove colunas, FK, CHECKs e índice). Sem base em produção; sem dado a migrar.
