### PR TITLE
feat(publicacoes): vínculo genérico ato ↔ entidade e consulta unificada

### DIFF
--- a/contracts/openapi.publicacoes.json
+++ b/contracts/openapi.publicacoes.json
@@ -288,6 +288,149 @@
         "x-uniplus-paginated": true
       }
     },
+    "/api/publicacoes/entidades/{entidadeTipo}/{entidadeId}/atos": {
+      "get": {
+        "tags": [
+          "AtosNormativos"
+        ],
+        "parameters": [
+          {
+            "name": "entidadeTipo",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "entidadeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AtoNormativoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AtoNormativoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AtoNormativoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
     "/api/publicacoes/atos/{id}": {
       "get": {
         "tags": [
@@ -1399,6 +1542,15 @@
               "null",
               "string"
             ]
+          },
+          "vinculos": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/VinculoEntidadeInput"
+            }
           }
         }
       },
@@ -1545,6 +1697,22 @@
           "timestamp": {
             "type": "string",
             "format": "date-time"
+          }
+        }
+      },
+      "VinculoEntidadeInput": {
+        "required": [
+          "entidadeTipo",
+          "entidadeId"
+        ],
+        "type": "object",
+        "properties": {
+          "entidadeTipo": {
+            "type": "string"
+          },
+          "entidadeId": {
+            "type": "string",
+            "format": "uuid"
           }
         }
       }

--- a/docs/adrs/0107-vaga-de-linhagem-unica-por-objeto.md
+++ b/docs/adrs/0107-vaga-de-linhagem-unica-por-objeto.md
@@ -1,0 +1,123 @@
+---
+status: "accepted"
+date: "2026-07-11"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted:
+  - "P.O. CEPS"
+  - "P.O. CRCA"
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0107: A unicidade de ato por objeto é uma vaga que a linhagem reserva, não um índice sobre o ato
+
+## Contexto e enunciado do problema
+
+O cadastro de tipos de ato marca alguns deles como **únicos por objeto**: um processo seletivo tem um edital de abertura, e não dois; uma chamada tem uma convocação, e não duas. Avisos e comunicados, ao contrário, repetem-se à vontade.
+
+A ADR-0103 registrou a consequência sem resolvê-la: "a unicidade da raiz de cadeia deixa de ser um índice filtrado por literal e passa a depender de um atributo do cadastro de tipos". Faltava dizer **onde** essa unicidade é imposta — e a resposta não é óbvia, porque o predicado atravessa duas tabelas: o atributo `unico_por_objeto` e a linhagem estão no ato (`publicacoes.ato_normativo`); o objeto, no vínculo (`publicacoes.vinculo_ato_entidade`, ADR-0105). O Postgres não impõe unicidade entre tabelas.
+
+O que se quer garantir é uma frase só:
+
+```text
+para um tipo único por objeto, um objeto é tratado por no máximo UMA linhagem de atos
+```
+
+**Linhagem**, e não ato: a segunda versão de um edital de abertura é uma retificação dele (ADR-0103), e retificações do mesmo edital pertencem à mesma linhagem — a cadeia inteira, identificada pela sua raiz. Um objeto pode e deve acumular vários atos daquela linhagem: a convocação, a retificação da convocação, a retificação da retificação.
+
+## Drivers da decisão
+
+- **A garantia tem de ser do banco.** Duas transações concorrentes que consultem "o objeto está livre?" e insiram em seguida passam ambas. É o mesmo raciocínio que levou a linearidade da cadeia (ADR-0103) a um índice único parcial, e não a uma verificação no handler.
+- **O catálogo de tipos é editável** — o que faz do "tipo do ato" um alvo móvel, e obriga a decidir qual identidade é estável.
+- **O registro é append-only** (ADR-0063): nada do que se grava aqui se muta ou se apaga.
+- **Fronteira do módulo** (ADR-0105): o objeto é opaco. Não há, e não pode haver, chave estrangeira para `processo_seletivo` ou `chamada`.
+
+## Opções consideradas
+
+- **A**: Verificar na aplicação, antes de gravar.
+- **B**: Denormalizar "este ato é raiz de cadeia" no vínculo, e criar um índice único parcial sobre `(objeto, tipo)` filtrando por raiz.
+- **C**: **Uma vaga por `(objeto, tipo)`**, reservada em nome da linhagem, com índice único e verificação do histórico de atos.
+
+## Resultado da decisão
+
+**Escolhida: "C — a vaga que a linhagem reserva".**
+
+A tabela `publicacoes.linhagem_unica_por_objeto` guarda uma linha por `(entidade_tipo, entidade_id, tipo_codigo)` — a **vaga** do objeto para aquele tipo de ato — apontando para a `raiz_id` da linhagem que a ocupa. O índice único sobre essa tripla é a garantia dura, e é o banco que a impõe, inclusive contra duas transações concorrentes.
+
+Registrar um ato de tipo único por objeto, que se vincula a entidades, passa por duas verificações, e **cada uma vê o que a outra não vê**:
+
+1. **O histórico de atos.** Um ato do mesmo tipo já vinculado ao objeto, fora desta linhagem, é conflito — e a consulta o encontra ainda que ele não tenha reservado vaga alguma. Isso importa porque `unico_por_objeto` é editável: um ato publicado quando o tipo ainda **não** era único por objeto não reservou vaga, e sem esta verificação um ato posterior, publicado depois de o atributo virar, encontraria a vaga livre — e o objeto acabaria com duas linhagens vivas, sem que ninguém tivesse feito nada de errado.
+2. **A vaga.** O índice único, que fecha a corrida entre transações concorrentes — invisível a qualquer consulta, por definição.
+
+A recusa é **409**, e não 422: o payload está coerente; o que não cabe é o estado já gravado (mesmo critério de `RaizJaRetificada` e `VigenciaSobreposta`).
+
+Quatro triggers sustentam a estrutura contra o `INSERT` cru, no espírito dos CHECKs que o ato já tem:
+
+- **Append-only** em `vinculo_ato_entidade` e em `linhagem_unica_por_objeto`: mutar um vínculo reescreveria de que objeto o ato tratava; mutar uma vaga transferiria o objeto de uma linhagem a outra sem que ato algum o dissesse.
+- **Coerência da vaga com o ato** (deferred): o tipo tem de ser o do ato, a raiz tem de ser a raiz verdadeira da sua cadeia, o ato tem de estar vinculado ao objeto, e o tipo tem de ser único por objeto.
+- **Correspondência reversa** (deferred): todo vínculo de um ato único por objeto exige a vaga daquele objeto reservada em nome da sua linhagem. É ela que faz o índice único valer alguma coisa — sem ela, gravar o vínculo e omitir a vaga (um importador, um seed, uma regressão) deixaria o objeto livre para uma segunda linhagem, e o índice, que só vê as vagas que existem, nada acusaria.
+
+### Duas consequências que esta ADR decide, e não apenas registra
+
+**1. O código do tipo de ato passa a ser imutável.** A vaga é chaveada por `tipo_codigo` (copiado por valor do catálogo, ADR-0075). Se o código pudesse ser renomeado, bastaria renomeá-lo para abrir uma vaga nova no mesmo objeto — e o certame teria dois editais de abertura vivos. O código já era, de fato, a identidade do tipo: é por ele que a exclusion constraint agrupa a série de vigências. Renomear uma versão a desgarraria das demais, partindo o tipo em dois. **Renomear passa a ser criar outro tipo**; nome, atributos de consequência, vigência e base legal seguem editáveis.
+
+**2. A vaga é monotônica: ocupada, nunca se libera.** Não há revogação de ato publicado, e a vaga acompanha essa natureza. A consequência é dura e é aceita conscientemente: um ato publicado com o objeto errado — o operador digitou o identificador de outro certame — ocupa a vaga daquele objeto **para sempre**, e o certame errado fica impedido de receber um ato legítimo daquele tipo. Publicar a retificação corrige a narrativa documental, mas não devolve a vaga: a retificação pertence à mesma linhagem, e é essa linhagem que ocupa o objeto.
+
+Enquanto não houver base em produção, o custo disso é nulo. Quando houver, será preciso um mecanismo administrativo, auditável e **append-only** — um ato de anulação de vínculo, não um `DELETE` — e ele é assunto de story própria. Registrar a limitação aqui é preferível a inventar agora um mecanismo de liberação que ninguém pediu e cuja semântica institucional (quem pode anular? com que ato?) ainda não foi decidida pelo CEPS.
+
+## Consequências
+
+### Positivas
+
+- A invariante é imposta pelo banco, e não pela boa vontade do handler.
+- A verificação do histórico torna a regra estável mesmo com o catálogo mudando debaixo dela.
+- Retificações da linhagem que ocupa o objeto passam sem atrito, que é o que a prática faz.
+- A fronteira do módulo continua de pé: a vaga é chaveada por um par opaco, sem chave estrangeira para domínio algum.
+
+### Negativas
+
+- Uma tabela a mais, e quatro triggers, para uma invariante que "parecia" um índice.
+- Uma vaga ocupada por engano não se libera (ver acima).
+- O `tipo_codigo` deixa de ser editável, o que contraria o que a story do cadastro (#798) assumira.
+
+### Neutras
+
+- Um ato único por objeto **sem vínculo** não reserva vaga: sem objeto, não há vaga a ocupar. A regra é *por objeto*.
+- Alternar `unico_por_objeto` no catálogo não reescreve o passado — nenhum ato já publicado muda. O que a alternância muda é o que o próximo ato encontra ao ser registrado.
+
+## Prós e contras das opções
+
+### A — Verificar só na aplicação
+
+- Bom, porque não acrescenta tabela nem trigger.
+- Ruim, porque duas transações concorrentes verificam "livre", e ambas gravam. É exatamente a falha que a ADR-0103 fechou com um índice único; repeti-la aqui seria desaprender.
+
+### B — Índice único parcial sobre "o ato é raiz"
+
+- Bom, porque não acrescenta tabela.
+- Ruim, porque **não fecha a invariante**. Basta publicar uma raiz sem vínculo e, na retificação dela, vincular o objeto já tratado por outra linhagem: a retificação não é raiz, escapa do filtro do índice, e o objeto acaba com duas linhagens vivas. A chave da regra é a linhagem, não a posição do ato dentro dela.
+
+### C — A vaga que a linhagem reserva (escolhida)
+
+- Bom, porque a chave que o banco trava é exatamente a frase que se quer garantir.
+- Bom, porque a verificação do histórico cobre o que a tabela não pode saber (os atos que precedem a existência da vaga).
+- Ruim, porque a vaga é estado derivado, e estado derivado precisa de triggers para não divergir do que o deriva.
+
+## Confirmação
+
+- **Teste de integração**: duas raízes distintas do mesmo tipo único por objeto, vinculadas ao mesmo objeto — a segunda é recusada com 409.
+- **Teste de integração**: a retificação da linhagem que ocupa o objeto é aceita, e aparece na consulta do objeto.
+- **Teste de integração (o furo da opção B)**: raiz publicada sem vínculo, retificada por um ato que vincula o objeto de outra linhagem — recusada.
+- **Teste de integração (o furo do catálogo editável)**: ato publicado quando o tipo não era único por objeto, atributo alterado depois, novo ato de outra linhagem no mesmo objeto — recusado.
+- **Teste de integração**: `INSERT` cru de vaga incoerente com o ato (tipo divergente, raiz falsa, objeto não vinculado, ato não único) é bloqueado pelo trigger.
+- **Teste de integração**: `INSERT` cru de vínculo de ato único por objeto sem a vaga correspondente é bloqueado pelo trigger.
+- **Teste de domínio**: o código do tipo de ato não muda no `Atualizar`.
+
+## Mais informações
+
+- [ADR-0063](0063-entidades-forensics-isentas-de-soft-delete.md) — entidades forenses, append-only
+- [ADR-0075](0075-snapshot-do-ato-resolvido-no-instante.md) — os atributos de consequência são copiados por valor no instante do ato
+- [ADR-0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md) — retificação é relação; a cadeia é linear
+- [ADR-0105](0105-modulo-publicacoes-registro-central-dos-atos.md) — o vínculo genérico ato ↔ entidade, opaco ao módulo
+- [ADR-0061](0061-referencia-cross-modulo-via-snapshot-copy.md) — sem chave estrangeira atravessando módulo

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -135,8 +135,9 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0104](0104-versao-configuracao-como-agregado-proprio.md) | A vigência da configuração ordena versões, não documentos | accepted | 2026-07-09 |
 | [0105](0105-modulo-publicacoes-registro-central-dos-atos.md) | O ato publicado pertence a um módulo `Publicacoes` que não conhece os domínios | accepted | 2026-07-09 |
 | [0106](0106-orquestracao-sincrona-selecao-publicacoes-ato-primeiro.md) | Publicar um Edital registra o ato em Publicações de forma síncrona, antes de concluir | accepted | 2026-07-10 |
+| [0107](0107-vaga-de-linhagem-unica-por-objeto.md) | A unicidade de ato por objeto é uma vaga que a linhagem reserva, não um índice sobre o ato | accepted | 2026-07-11 |
 
-> **Nota de numeração:** a sequência de `0001` a `0106` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0107+`.
+> **Nota de numeração:** a sequência de `0001` a `0107` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0108+`.
 
 ## Como adicionar um novo ADR
 

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/AtosNormativosController.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/AtosNormativosController.cs
@@ -1,6 +1,8 @@
 namespace Unifesspa.UniPlus.Publicacoes.API.Controllers;
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.RegularExpressions;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -34,9 +36,12 @@ using Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
     "Performance",
     "CA1515:Consider making public types internal",
     Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
-public sealed class AtosNormativosController : ControllerBase
+public sealed partial class AtosNormativosController : ControllerBase
 {
     private const string ResourceTag = "atos";
+    private const string ResourceTagEntidade = "entidade-atos";
+    private const string RouteEntidadeTipo = "entidadeTipo";
+    private const string RouteEntidadeId = "entidadeId";
 
     private readonly ICommandBus _commandBus;
     private readonly IQueryBus _queryBus;
@@ -84,6 +89,84 @@ public sealed class AtosNormativosController : ControllerBase
 
         return await this.OkPaginatedAsync(
             comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Lista os atos publicados que tratam de uma entidade — a consulta unificada
+    /// (ADR-0105): todos os atos de um certame num só lugar, em ordem cronológica de
+    /// publicação.
+    /// </summary>
+    /// <remarks>
+    /// <para>O par <c>(entidadeTipo, entidadeId)</c> é opaco para o módulo, que não
+    /// conhece os domínios e por isso <b>não sabe se a entidade existe</b>. Entidade
+    /// inexistente e entidade sem ato algum devolvem, ambas, uma coleção vazia — nunca
+    /// 404. Distingui-las exigiria perguntar a outro módulo, e é justamente essa pergunta
+    /// que a fronteira proíbe.</para>
+    /// <para>Ordem: data de publicação ascendente, com o <c>Id</c> (Guid v7) de
+    /// desempate — a retificação republica a mesma data. Paginação por cursor opaco
+    /// escopado à entidade: um cursor emitido aqui não navega a coleção de outra
+    /// entidade.</para>
+    /// </remarks>
+    [HttpGet("entidades/{entidadeTipo}/{entidadeId:guid}/atos")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "ato-normativo", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<AtoNormativoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> ListarDaEntidade(
+        string entidadeTipo,
+        Guid entidadeId,
+        [FromCursor(
+            ResourceTagEntidade,
+            RequireSortKey = true,
+            ScopeRouteValues = [RouteEntidadeTipo, RouteEntidadeId])] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        // A forma do rótulo é conferida — o valor, jamais. Sem esta recusa, um rótulo
+        // fora da grafia canônica (minúsculo, com hífen) devolveria a mesma coleção vazia
+        // de uma entidade sem atos, e o erro de digitação passaria por resultado legítimo.
+        if (!FormatoDoTipoDeEntidade().IsMatch(entidadeTipo))
+        {
+            return Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Tipo de entidade inválido",
+                detail: "O tipo da entidade deve ser um rótulo em maiúsculas, com grupos separados por sublinhado.");
+        }
+
+        // A âncora do cursor é o par (data de publicação, Id), e a data chega como texto.
+        // Decodificar o wire é do boundary (ADR-0031): sem esta recusa, uma âncora
+        // malformada só falharia lá dentro, ao construir a chave do seek — e um cursor
+        // adulterado viraria 500 em vez de 400.
+        if (page.AfterSortKey is { } ancora
+            && !DateOnly.TryParseExact(ancora, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+        {
+            return Problem(
+                statusCode: StatusCodes.Status400BadRequest,
+                title: "Cursor inválido",
+                detail: "O cursor informado é inválido.");
+        }
+
+        ListarAtosDaEntidadeResult resultado = await _queryBus
+            .Send(
+                new ListarAtosDaEntidadeQuery(
+                    entidadeTipo, entidadeId, page.AfterSortKey, page.AfterId, page.Limit, page.Direction),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        AtoNormativoDto[] comLinks =
+            [.. resultado.Items.Select(a => a with { Links = _linksBuilder.Build(a) })];
+
+        return await this.OkPaginatedOrdenadoAsync(
+            comLinks,
+            resultado.Anterior,
+            resultado.Proximo,
+            page,
+            EtiquetaDaEntidade(entidadeTipo, entidadeId),
             cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
@@ -146,4 +229,17 @@ public sealed class AtosNormativosController : ControllerBase
 
         return resultado.ToActionResult(_mapper);
     }
+
+    /// <summary>
+    /// Etiqueta do cursor da coleção desta entidade. Composta pelo mesmo utilitário que
+    /// o binder usa para conferi-la — se cada lado a montasse à sua maneira, nenhum
+    /// cursor emitido aqui passaria na leitura.
+    /// </summary>
+    private static string EtiquetaDaEntidade(string entidadeTipo, Guid entidadeId) =>
+        CursorResourceTag.Compose(
+            ResourceTagEntidade, [entidadeTipo, entidadeId.ToString()]);
+
+    /// <summary>Grafia canônica do rótulo opaco da entidade (a mesma que o domínio exige).</summary>
+    [GeneratedRegex(@"^[A-Z0-9]+(_[A-Z0-9]+)*$")]
+    private static partial Regex FormatoDoTipoDeEntidade();
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Errors/PublicacoesDomainErrorRegistration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Errors/PublicacoesDomainErrorRegistration.cs
@@ -60,6 +60,12 @@ internal sealed class PublicacoesDomainErrorRegistration : IDomainErrorRegistrat
                 "uniplus.publicacoes.tipo_ato.codigo_formato",
                 "Formato do código do tipo de ato inválido")),
 
+        new(TipoAtoPublicadoErrorCodes.CodigoImutavel,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.publicacoes.tipo_ato.codigo_imutavel",
+                "O código do tipo de ato é a sua identidade e não pode ser alterado")),
+
         new(TipoAtoPublicadoErrorCodes.NomeObrigatorio,
             new DomainErrorMapping(
                 StatusCodes.Status422UnprocessableEntity,
@@ -121,5 +127,13 @@ internal sealed class PublicacoesDomainErrorRegistration : IDomainErrorRegistrat
                 StatusCodes.Status409Conflict,
                 "uniplus.publicacoes.ato_normativo.raiz_ja_retificada",
                 "O ato que se tentou retificar já foi retificado por outro (a cadeia é linear)")),
+
+        // 409 pelo mesmo critério: o payload está coerente, mas o objeto vinculado já é
+        // tratado por outra linhagem de atos deste tipo (ADR-0107).
+        new(AtoNormativoErrorCodes.ObjetoJaTemAtoVivoDoTipo,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.publicacoes.ato_normativo.objeto_ja_tem_ato_vivo_do_tipo",
+                "O tipo admite um único ato vivo por objeto, e a entidade vinculada já é tratada por outra linhagem")),
     ];
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/AtoNormativoRegras.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/AtoNormativoRegras.cs
@@ -13,9 +13,18 @@ internal static class AtoNormativoRegras
     public const int TipoCodigoMaxLength = 60;
     public const int AssinanteMaxLength = 200;
     public const int MotivoRetificacaoMaxLength = 1000;
+    public const int EntidadeTipoMaxLength = 60;
 
     /// <summary>SHA-256 em hexadecimal minúsculo, 64 caracteres.</summary>
     public const string HashPattern = "^[0-9a-f]{64}$";
+
+    /// <summary>
+    /// Forma canônica do rótulo da entidade vinculada. Verifica a <b>forma</b>, jamais o
+    /// valor: não há lista de tipos permitidos, e não pode haver — o rótulo é opaco
+    /// (ADR-0105). O que se exige é grafia única, sem a qual a mesma entidade se
+    /// partiria em duas na consulta unificada.
+    /// </summary>
+    public const string EntidadeTipoPattern = "^[A-Z0-9]+(_[A-Z0-9]+)*$";
 
     public const string OrgaoObrigatorio = "Órgão publicador é obrigatório.";
     public const string OrgaoTamanho = "Órgão publicador deve ter no máximo 200 caracteres.";
@@ -35,6 +44,13 @@ internal static class AtoNormativoRegras
     public const string RetificacaoIncompleta = "A retificação é o par (ato retificado, motivo) completo, ou nenhum dos dois — um sem o outro não registra linhagem.";
     public const string AtoRetificadoIdObrigatorio = "Identificador do ato retificado não pode ser vazio.";
     public const string MotivoRetificacaoTamanho = "Motivo da retificação deve ter no máximo 1000 caracteres.";
+
+    public const string EntidadeTipoObrigatorio = "Tipo da entidade vinculada é obrigatório.";
+    public const string EntidadeTipoTamanho = "Tipo da entidade vinculada deve ter no máximo 60 caracteres.";
+    public const string EntidadeTipoFormato = "Tipo da entidade vinculada deve ser um rótulo em maiúsculas, com grupos separados por sublinhado.";
+    public const string EntidadeIdObrigatorio = "Identificador da entidade vinculada não pode ser vazio.";
+    public const string VinculoDuplicado = "A mesma entidade não pode ser vinculada duas vezes ao mesmo ato.";
+    public const string VinculoNulo = "A lista de vínculos não admite elemento nulo.";
 
     /// <summary>Código do aviso de número duplicado (AC4).</summary>
     public const string AvisoNumeroDuplicado = "NumeroDuplicado";

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommand.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommand.cs
@@ -17,7 +17,16 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <para>O par <see cref="AtoRetificadoId"/>/<see cref="MotivoRetificacao"/> torna
 /// o registro uma retificação (ADR-0103), quando presente — simétrico (um existe
 /// se e somente se o outro existe). É o mesmo comando de publicar: retificar é
-/// publicar um ato que emenda outro. O vínculo genérico ato↔entidade ainda é #801.</para>
+/// publicar um ato que emenda outro.</para>
+/// <para><see cref="Vinculos"/> liga o ato às entidades de que ele trata (ADR-0105).
+/// É o domínio quem os informa — <c>Selecao</c> ao publicar um edital, <c>Ingresso</c>
+/// ao convocar uma chamada —, e Publicações os guarda sem interpretar. Ausente ou vazio
+/// num ato que não trata de objeto algum, o que é legítimo.</para>
+/// <para>Uma retificação <b>herda</b> os vínculos do ato que emenda, e não precisa
+/// repeti-los: quem emenda um ato trata do mesmo objeto que ele, e uma retificação que
+/// não os herdasse sumiria da consulta do certame — que passaria a exibir a versão
+/// superada, escondendo a que a emenda. Declarar entidades novas continua permitido: o
+/// ato retificador pode passar a tratar de objeto que o retificado não declarava.</para>
 /// </remarks>
 public sealed record RegistrarAtoNormativoCommand(
     string Orgao,
@@ -31,4 +40,13 @@ public sealed record RegistrarAtoNormativoCommand(
     Guid? VersaoInvocadaId = null,
     string? VersaoInvocadaHash = null,
     Guid? AtoRetificadoId = null,
-    string? MotivoRetificacao = null) : ICommand<Result<RegistrarAtoNormativoResult>>;
+    string? MotivoRetificacao = null,
+    IReadOnlyList<VinculoEntidadeInput>? Vinculos = null) : ICommand<Result<RegistrarAtoNormativoResult>>;
+
+/// <summary>
+/// Entidade de outro domínio a que o ato se liga. O par é <b>opaco</b> para
+/// Publicações: <paramref name="EntidadeTipo"/> não tem lista de valores permitidos
+/// (só forma canônica UPPER_SNAKE), e <paramref name="EntidadeId"/> não tem chave
+/// estrangeira — o módulo não conhece, e não deve conhecer, o que há do outro lado.
+/// </summary>
+public sealed record VinculoEntidadeInput(string EntidadeTipo, Guid EntidadeId);

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandHandler.cs
@@ -62,6 +62,16 @@ public static class RegistrarAtoNormativoCommandHandler
             return Result<RegistrarAtoNormativoResult>.Failure(retificacaoErro);
         }
 
+        // A linhagem a que este ato pertence: ele mesmo, quando não emenda ninguém; a
+        // raiz da cadeia do ato retificado, quando emenda. É a chave da vaga do objeto —
+        // uma retificação não disputa a vaga que a sua própria linhagem já ocupa.
+        IReadOnlyList<Guid> idsDaPropriaCadeia = command.AtoRetificadoId is { } retificadoId
+            ? await atosRepository.ListarIdsDaCadeiaAsync(retificadoId, cancellationToken).ConfigureAwait(false)
+            : [];
+
+        IReadOnlyList<(string EntidadeTipo, Guid EntidadeId)> vinculos = await ResolverVinculosAsync(
+            command, atosRepository, cancellationToken).ConfigureAwait(false);
+
         AtoNormativo ato = AtoNormativo.Registrar(
             command.Orgao,
             command.Serie,
@@ -77,7 +87,19 @@ public static class RegistrarAtoNormativoCommandHandler
             timeProvider.GetUtcNow(),
             versaoResult?.Value,
             command.AtoRetificadoId,
-            command.MotivoRetificacao);
+            command.MotivoRetificacao,
+            vinculos);
+
+        Guid raizDaLinhagem = command.AtoRetificadoId is { } paraRaiz
+            ? await atosRepository.ObterRaizDaCadeiaAsync(paraRaiz, cancellationToken).ConfigureAwait(false)
+            : ato.Id;
+
+        DomainError? unicidadeErro = await ReservarVagasDoObjetoAsync(
+            ato, idsDaPropriaCadeia, raizDaLinhagem, atosRepository, cancellationToken).ConfigureAwait(false);
+        if (unicidadeErro is not null)
+        {
+            return Result<RegistrarAtoNormativoResult>.Failure(unicidadeErro);
+        }
 
         // AC4: colisão de numeração é aviso, jamais recusa. No registro o próprio ato
         // ainda não existe, então todos os que compartilham a numeração são
@@ -87,11 +109,8 @@ public static class RegistrarAtoNormativoCommandHandler
         // retificado, não só o pai direto. O aviso é best-effort: como o número não
         // tem unicidade, dois registros concorrentes da mesma numeração podem ambos
         // observar zero conflitos; a consulta de detalhe recomputa e enxerga ambos.
-        IReadOnlyCollection<Guid> excluirDoAviso = command.AtoRetificadoId is { } retificadoId
-            ? await atosRepository.ListarIdsDaCadeiaAsync(retificadoId, cancellationToken).ConfigureAwait(false)
-            : [];
         IReadOnlyList<AvisoNumeracao> avisos = await AvisoNumeracaoCalculator
-            .CalcularAsync(atosRepository, ato, excluirDoAviso, cancellationToken)
+            .CalcularAsync(atosRepository, ato, idsDaPropriaCadeia, cancellationToken)
             .ConfigureAwait(false);
 
         await atosRepository.AdicionarAsync(ato, cancellationToken).ConfigureAwait(false);
@@ -110,10 +129,179 @@ public static class RegistrarAtoNormativoCommandHandler
                 AtoNormativoErrorCodes.RaizJaRetificada,
                 RaizJaRetificadaConcorrenteMensagem(command.AtoRetificadoId)));
         }
+        catch (Exception ex) when (UniqueConstraintViolation.GetViolatedConstraint(ex) is { } constraint
+            && UniqueConstraintViolation.IsLinhagemUnicaConflict(constraint))
+        {
+            // Corrida check-then-act: outra linhagem reservou a vaga do objeto entre a
+            // consulta acima e este commit. O índice único deixou passar só uma.
+            return Result<RegistrarAtoNormativoResult>.Failure(new DomainError(
+                AtoNormativoErrorCodes.ObjetoJaTemAtoVivoDoTipo,
+                "A vaga do objeto vinculado foi ocupada por um ato registrado concorrentemente. "
+                + "O tipo admite um único ato vivo por objeto — consulte os atos da entidade "
+                + "antes de reenviar."));
+        }
 
         return Result<RegistrarAtoNormativoResult>.Success(
             new RegistrarAtoNormativoResult(ato.Id, ato.RegistradoEm, avisos));
     }
+
+    /// <summary>
+    /// Resolve os vínculos do ato: os declarados no comando, mais — quando o ato emenda
+    /// outro — os do ato retificado, que a retificação <b>herda</b>.
+    /// </summary>
+    /// <remarks>
+    /// A herança não é conveniência: sem ela, uma retificação registrada sem repetir os
+    /// vínculos sumiria da consulta do certame, e a consulta passaria a exibir a versão
+    /// superada escondendo a que a emenda — o oposto do que o módulo existe para fazer.
+    /// Quem emenda um ato trata do mesmo objeto que ele. Acrescentar entidades novas
+    /// continua permitido: o ato retificador pode passar a tratar de um objeto que o
+    /// retificado não declarava.
+    /// </remarks>
+    private static async Task<IReadOnlyList<(string EntidadeTipo, Guid EntidadeId)>> ResolverVinculosAsync(
+        RegistrarAtoNormativoCommand command,
+        IAtoNormativoRepository atosRepository,
+        CancellationToken cancellationToken)
+    {
+        // O elemento nulo já foi recusado pelo validator (422); descartá-lo aqui evita
+        // que um chamador interno — Selecao via ICommandBus, sem passar pelo HTTP —
+        // derrube o handler com uma referência nula.
+        List<(string EntidadeTipo, Guid EntidadeId)> declarados =
+            [.. (command.Vinculos ?? [])
+                .Where(v => v is not null)
+                .Select(v => (v.EntidadeTipo.Trim(), v.EntidadeId))];
+
+        if (command.AtoRetificadoId is not { } retificadoId)
+        {
+            return Ordenados(declarados);
+        }
+
+        IReadOnlyList<(string EntidadeTipo, Guid EntidadeId)> herdados = await atosRepository
+            .ListarVinculosDoAtoAsync(retificadoId, cancellationToken)
+            .ConfigureAwait(false);
+
+        HashSet<(string, Guid)> vistos = [.. declarados];
+        declarados.AddRange(herdados.Where(h => vistos.Add(h)));
+
+        return Ordenados(declarados);
+    }
+
+    /// <summary>
+    /// Ordem determinística das entidades, e não estética: as vagas do objeto são
+    /// reservadas nesta ordem, e duas transações que reservem o mesmo par de objetos em
+    /// ordens opostas travariam uma na outra.
+    /// </summary>
+    private static IReadOnlyList<(string EntidadeTipo, Guid EntidadeId)> Ordenados(
+        List<(string EntidadeTipo, Guid EntidadeId)> vinculos) =>
+        [.. vinculos
+            .OrderBy(v => v.EntidadeTipo, StringComparer.Ordinal)
+            .ThenBy(v => v.EntidadeId)];
+
+    /// <summary>
+    /// Reserva, para cada entidade vinculada, a vaga do objeto em nome da linhagem do
+    /// ato — quando o tipo admite um único ato vivo por objeto (ADR-0107). Devolve o
+    /// <see cref="DomainError"/> da primeira colisão, ou <see langword="null"/> quando o
+    /// tipo não é único por objeto, o ato não vincula entidade alguma, ou todas as vagas
+    /// foram reservadas.
+    /// </summary>
+    /// <remarks>
+    /// São duas verificações, e cada uma cobre o que a outra não vê:
+    /// <list type="number">
+    ///   <item>o <b>histórico de atos</b> — um ato do mesmo tipo já vinculado ao objeto,
+    ///     fora desta linhagem, colide. Enxerga inclusive o ato publicado quando o tipo
+    ///     ainda não era único por objeto (o catálogo é editável) e que, por isso, não
+    ///     reservou vaga nenhuma;</item>
+    ///   <item>a <b>vaga</b> — o índice único que o banco trava, e que fecha a corrida
+    ///     entre duas transações concorrentes, invisível a qualquer consulta.</item>
+    /// </list>
+    /// A vaga já ocupada <i>pela própria linhagem</i> não é reservada de novo: a segunda
+    /// versão de um ato vivo é uma retificação, e a vaga é da linhagem, não do ato.
+    /// </remarks>
+    private static async Task<DomainError?> ReservarVagasDoObjetoAsync(
+        AtoNormativo ato,
+        IReadOnlyList<Guid> idsDaPropriaCadeia,
+        Guid raizDaLinhagem,
+        IAtoNormativoRepository atosRepository,
+        CancellationToken cancellationToken)
+    {
+        if (!ato.UnicoPorObjeto || ato.Vinculos.Count == 0)
+        {
+            return null;
+        }
+
+        // O próprio ato ainda não está gravado, mas já integra a linhagem: incluí-lo
+        // evita que ele se veja como conflito de si mesmo em qualquer consulta futura.
+        Guid[] daLinhagem = [.. idsDaPropriaCadeia, ato.Id];
+
+        // Duas fases, e a ordem importa: nada é reservado enquanto houver um vínculo por
+        // examinar. Reservar durante o exame deixaria, num ato com dois objetos em que só
+        // o segundo conflita, a vaga do primeiro pendurada na unidade de trabalho — e a
+        // recusa do ato inteiro não a desfaria por si só.
+        List<LinhagemUnicaPorObjeto> aReservar = [];
+
+        foreach (VinculoAtoEntidade vinculo in ato.Vinculos)
+        {
+            AtoNormativo? conflitante = await atosRepository
+                .ObterAtoConflitanteNoObjetoAsync(
+                    vinculo.EntidadeTipo, vinculo.EntidadeId, ato.TipoCodigo, daLinhagem, cancellationToken)
+                .ConfigureAwait(false);
+            if (conflitante is not null)
+            {
+                return new DomainError(
+                    AtoNormativoErrorCodes.ObjetoJaTemAtoVivoDoTipo,
+                    ObjetoJaTemAtoVivoMensagem(vinculo, ato.TipoCodigo, conflitante));
+            }
+
+            LinhagemUnicaPorObjeto? vaga = await atosRepository
+                .ObterLinhagemDoObjetoAsync(
+                    vinculo.EntidadeTipo, vinculo.EntidadeId, ato.TipoCodigo, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (vaga is null)
+            {
+                aReservar.Add(LinhagemUnicaPorObjeto.Criar(ato, vinculo, raizDaLinhagem));
+                continue;
+            }
+
+            // A vaga existe: só a própria linhagem pode reencontrá-la — a consulta ao
+            // histórico já teria barrado qualquer outra, e esta é a rede de segurança.
+            if (vaga.RaizId != raizDaLinhagem)
+            {
+                return new DomainError(
+                    AtoNormativoErrorCodes.ObjetoJaTemAtoVivoDoTipo,
+                    ObjetoJaTemAtoVivoPorLinhagemMensagem(vinculo, ato.TipoCodigo, vaga));
+            }
+        }
+
+        foreach (LinhagemUnicaPorObjeto vaga in aReservar)
+        {
+            await atosRepository.AdicionarLinhagemAsync(vaga, cancellationToken).ConfigureAwait(false);
+        }
+
+        return null;
+    }
+
+    private static string ObjetoJaTemAtoVivoMensagem(
+        VinculoAtoEntidade vinculo, string tipoCodigo, AtoNormativo conflitante) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "O tipo de ato '{0}' admite um único ato vivo por objeto, e a entidade {1}/{2} já é "
+            + "tratada pelo ato {3}. Para publicar outra versão, retifique a linhagem existente.",
+            tipoCodigo,
+            vinculo.EntidadeTipo,
+            vinculo.EntidadeId,
+            conflitante.Id);
+
+    private static string ObjetoJaTemAtoVivoPorLinhagemMensagem(
+        VinculoAtoEntidade vinculo, string tipoCodigo, LinhagemUnicaPorObjeto vaga) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "O tipo de ato '{0}' admite um único ato vivo por objeto, e a entidade {1}/{2} já é "
+            + "tratada pela linhagem de atos que nasce em {3}. Para publicar outra versão, "
+            + "retifique essa linhagem.",
+            tipoCodigo,
+            vinculo.EntidadeTipo,
+            vinculo.EntidadeId,
+            vaga.RaizId);
 
     /// <summary>
     /// Verifica as invariantes da cadeia de retificação que dependem do ato

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandValidator.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/RegistrarAtoNormativoCommandValidator.cs
@@ -75,5 +75,49 @@ public sealed class RegistrarAtoNormativoCommandValidator
             .MaximumLength(AtoNormativoRegras.MotivoRetificacaoMaxLength).WithMessage(AtoNormativoRegras.MotivoRetificacaoTamanho)
             .OverridePropertyName(nameof(RegistrarAtoNormativoCommand.MotivoRetificacao))
             .When(x => AtoNormativoRegras.Normalizar(x.MotivoRetificacao) is not null);
+
+        // Vínculos com entidades de outros domínios (ADR-0105). A forma do rótulo é
+        // verificada; o valor, jamais — não há tipos permitidos, e não pode haver.
+        //
+        // O elemento nulo é recusado explicitamente: a anotação de nulidade do record não
+        // impede um `"vinculos": [null]` no corpo, e sem esta regra o nulo atravessaria a
+        // validação e estouraria no handler — 500 onde cabe 422.
+        RuleForEach(x => x.Vinculos)
+            .NotNull().WithMessage(AtoNormativoRegras.VinculoNulo)
+            .When(x => x.Vinculos is not null);
+
+        RuleForEach(x => x.Vinculos)
+            .ChildRules(vinculo =>
+            {
+                vinculo.RuleFor(v => AtoNormativoRegras.Normalizar(v.EntidadeTipo))
+                    .NotEmpty().WithMessage(AtoNormativoRegras.EntidadeTipoObrigatorio)
+                    .MaximumLength(AtoNormativoRegras.EntidadeTipoMaxLength).WithMessage(AtoNormativoRegras.EntidadeTipoTamanho)
+                    .Matches(AtoNormativoRegras.EntidadeTipoPattern).WithMessage(AtoNormativoRegras.EntidadeTipoFormato)
+                    .OverridePropertyName(nameof(VinculoEntidadeInput.EntidadeTipo));
+
+                vinculo.RuleFor(v => v.EntidadeId)
+                    .NotEmpty().WithMessage(AtoNormativoRegras.EntidadeIdObrigatorio);
+            })
+            .When(x => x.Vinculos is not null && x.Vinculos.All(v => v is not null));
+
+        // O vínculo é único por trio (ato, tipo, id): repetir a mesma entidade no mesmo
+        // ato não acrescenta vínculo nenhum, e o payload está internamente incoerente.
+        RuleFor(x => x.Vinculos)
+            .Must(SemEntidadeRepetida).WithMessage(AtoNormativoRegras.VinculoDuplicado)
+            .When(x => x.Vinculos is { Count: > 1 });
+    }
+
+    private static bool SemEntidadeRepetida(IReadOnlyList<VinculoEntidadeInput>? vinculos)
+    {
+        if (vinculos is null)
+        {
+            return true;
+        }
+
+        // O elemento nulo tem regra própria; aqui ele não é duplicata de coisa alguma.
+        HashSet<(string, Guid)> vistos = new(vinculos.Count);
+        return vinculos
+            .Where(v => v is not null)
+            .All(v => vistos.Add((AtoNormativoRegras.Normalizar(v.EntidadeTipo) ?? string.Empty, v.EntidadeId)));
     }
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/UniqueConstraintViolation.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/AtosNormativos/UniqueConstraintViolation.cs
@@ -24,6 +24,8 @@ internal static class UniqueConstraintViolation
 
     private const string LinearidadeConstraint = "ux_ato_normativo_retificado";
 
+    private const string LinhagemUnicaConstraint = "ux_linhagem_unica_por_objeto";
+
     private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
 
     /// <summary>
@@ -63,4 +65,12 @@ internal static class UniqueConstraintViolation
     /// </summary>
     public static bool IsLinearidadeConflict(string? constraint) =>
         string.Equals(constraint, LinearidadeConstraint, StringComparison.Ordinal);
+
+    /// <summary>
+    /// <see langword="true"/> quando a constraint violada é a vaga do objeto: outra
+    /// linhagem reservou-a entre a consulta do handler e o <c>SaveChanges</c>
+    /// (ADR-0107). É o que fecha a corrida check-then-act da unicidade por objeto.
+    /// </summary>
+    public static bool IsLinhagemUnicaConflict(string? constraint) =>
+        string.Equals(constraint, LinhagemUnicaConstraint, StringComparison.Ordinal);
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosDaEntidadeQuery.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosDaEntidadeQuery.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Todos os atos publicados que tratam de uma entidade — a consulta unificada que é o
+/// propósito do módulo (ADR-0105). Ordenada pela data de publicação, com o <c>Id</c>
+/// (Guid v7) de desempate: a retificação republica a mesma data, e a data sozinha não
+/// ordena de forma estável.
+/// </summary>
+/// <remarks>
+/// <para>O par <c>(EntidadeTipo, EntidadeId)</c> é <b>opaco</b>: Publicações não sabe se
+/// a entidade existe — não conhece os domínios, e perguntar-lhes derrubaria a fronteira
+/// que este módulo existe para manter. Entidade inexistente e entidade sem ato algum
+/// respondem, ambas, uma coleção vazia; nunca 404.</para>
+/// <para>Paginação por cursor opaco (ADR-0026) com keyset ordenado (ADR-0094): a âncora é
+/// o par <c>(data de publicação, Id)</c>, e o cursor é escopado à entidade — o de um
+/// certame não navega a coleção de outro.</para>
+/// </remarks>
+public sealed record ListarAtosDaEntidadeQuery(
+    string EntidadeTipo,
+    Guid EntidadeId,
+    string? AfterSortKey,
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarAtosDaEntidadeResult>;

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosDaEntidadeQueryHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosDaEntidadeQueryHandler.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+using Unifesspa.UniPlus.Publicacoes.Application.Mappings;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+public static class ListarAtosDaEntidadeQueryHandler
+{
+    public static async Task<ListarAtosDaEntidadeResult> Handle(
+        ListarAtosDaEntidadeQuery query,
+        IAtoNormativoRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<AtoNormativo> itens, (string SortKey, Guid Id)? anterior, (string SortKey, Guid Id)? proximo) =
+            await repository
+                .ListarPorEntidadeAsync(
+                    query.EntidadeTipo,
+                    query.EntidadeId,
+                    query.AfterSortKey,
+                    query.AfterId,
+                    query.Limit,
+                    query.Direction,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+        AtoNormativoDto[] items = [.. itens.Select(a => a.ToDto())];
+        return new ListarAtosDaEntidadeResult(items, anterior, proximo);
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosDaEntidadeResult.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Queries/AtosNormativos/ListarAtosDaEntidadeResult.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
+
+using Unifesspa.UniPlus.Publicacoes.Application.DTOs;
+
+/// <summary>
+/// Página de atos de uma entidade. As âncoras são o par <c>(data de publicação, Id)</c>
+/// do primeiro e do último item (ADR-0094); nulas quando não há aquele lado.
+/// </summary>
+public sealed record ListarAtosDaEntidadeResult(
+    IReadOnlyList<AtoNormativoDto> Items,
+    (string SortKey, Guid Id)? Anterior,
+    (string SortKey, Guid Id)? Proximo);

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/AtoNormativo.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/AtoNormativo.cs
@@ -45,8 +45,13 @@ using Unifesspa.UniPlus.Publicacoes.Domain.ValueObjects;
 /// ato é retificado no máximo uma vez — e empilha na cabeça: uma segunda
 /// retificação retifica a primeira, não a raiz. As invariantes que dependem do
 /// ato retificado (classe de congelamento coincidente, linearidade) vivem no
-/// handler, que as consulta no repositório; aqui fica só a simetria de shape. O
-/// vínculo genérico ato↔entidade ainda nasce em story própria (#801).
+/// handler, que as consulta no repositório; aqui fica só a simetria de shape.
+/// </para>
+/// <para>
+/// <b>Vínculo com entidades de outros domínios</b> (ADR-0105): o ato carrega os
+/// pares <c>(entidade_tipo, entidade_id)</c> que o ligam ao objeto de que trata —
+/// opacos para o módulo. Um ato sem vínculo algum é válido: há atos que não
+/// pertencem a certame nenhum. Ver <see cref="VinculoAtoEntidade"/>.
 /// </para>
 /// </remarks>
 public sealed class AtoNormativo : IForensicEntity
@@ -122,6 +127,15 @@ public sealed class AtoNormativo : IForensicEntity
     /// </summary>
     public string? MotivoRetificacao { get; private init; }
 
+    /// <summary>
+    /// Entidades de outros domínios a que este ato se liga (ADR-0105). Vazio num ato
+    /// que não trata de objeto algum — o edital que seleciona elaboradores de questões
+    /// não pertence a certame nenhum, e é válido assim.
+    /// </summary>
+    public IReadOnlyCollection<VinculoAtoEntidade> Vinculos => _vinculos.AsReadOnly();
+
+    private readonly List<VinculoAtoEntidade> _vinculos = [];
+
     // EF Core materialization
     private AtoNormativo()
     {
@@ -138,6 +152,11 @@ public sealed class AtoNormativo : IForensicEntity
     /// (classe de congelamento coincidente, linearidade da cadeia) são do handler,
     /// que as consulta no repositório; a factory garante só a simetria de shape do
     /// par (<paramref name="atoRetificadoId"/>, <paramref name="motivoRetificacao"/>).
+    ///
+    /// Os <paramref name="vinculos"/> são construídos a partir do ato recém-criado, de
+    /// modo que nenhum deles possa apontar para outro ato. A unicidade da linhagem por
+    /// objeto (tipos <c>unico_por_objeto</c>) depende do estado já gravado e é do
+    /// handler, não daqui.
     /// </summary>
     public static AtoNormativo Registrar(
         string orgao,
@@ -154,7 +173,8 @@ public sealed class AtoNormativo : IForensicEntity
         DateTimeOffset registradoEm,
         ReferenciaVersaoConfiguracao? versaoInvocada,
         Guid? atoRetificadoId = null,
-        string? motivoRetificacao = null)
+        string? motivoRetificacao = null,
+        IEnumerable<(string EntidadeTipo, Guid EntidadeId)>? vinculos = null)
     {
         string orgaoNorm = ExigirTexto(orgao, OrgaoMaxLength, nameof(orgao));
         string serieNorm = ExigirTexto(serie, SerieMaxLength, nameof(serie));
@@ -190,7 +210,7 @@ public sealed class AtoNormativo : IForensicEntity
                 nameof(atoRetificadoId));
         }
 
-        return new AtoNormativo
+        AtoNormativo ato = new()
         {
             Orgao = orgaoNorm,
             Serie = serieNorm,
@@ -208,6 +228,27 @@ public sealed class AtoNormativo : IForensicEntity
             AtoRetificadoId = atoRetificadoId,
             MotivoRetificacao = motivoNorm,
         };
+
+        foreach ((string entidadeTipo, Guid entidadeId) in vinculos ?? [])
+        {
+            VinculoAtoEntidade vinculo = VinculoAtoEntidade.Criar(ato, entidadeTipo, entidadeId);
+
+            // O trio (ato, tipo, id) é único: repetir a mesma entidade no mesmo ato não
+            // acrescenta vínculo nenhum, e o índice único do banco recusaria a segunda
+            // linha. O validator já devolve 422 antes; aqui é a última linha.
+            if (ato._vinculos.Exists(v =>
+                    string.Equals(v.EntidadeTipo, vinculo.EntidadeTipo, StringComparison.Ordinal)
+                    && v.EntidadeId == vinculo.EntidadeId))
+            {
+                throw new ArgumentException(
+                    $"A entidade {vinculo.EntidadeTipo}/{vinculo.EntidadeId} está vinculada mais de uma vez ao mesmo ato.",
+                    nameof(vinculos));
+            }
+
+            ato._vinculos.Add(vinculo);
+        }
+
+        return ato;
     }
 
     private static string ExigirTexto(string valor, int maxLength, string paramName)

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/LinhagemUnicaPorObjeto.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/LinhagemUnicaPorObjeto.cs
@@ -1,0 +1,95 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+/// <summary>
+/// A vaga que um objeto reserva para uma única linhagem de atos de um tipo
+/// <c>unico_por_objeto</c> (ADR-0107). Materializa, numa chave que o banco sabe
+/// travar, a invariante "para tipos assim, um objeto é tratado por uma só linhagem
+/// de atos".
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Por que uma tabela, e não um índice sobre o vínculo.</b> A invariante atravessa
+/// duas tabelas — o atributo <c>unico_por_objeto</c> e a linhagem estão no ato; o objeto,
+/// no vínculo — e o Postgres não indexa unicidade entre tabelas. Denormalizar "este ato é
+/// raiz" no vínculo <b>não</b> resolve: bastaria publicar uma raiz sem vínculo e, na
+/// retificação dela, vincular o objeto já tratado por outra linhagem — a retificação não é
+/// raiz, escaparia do índice, e o objeto acabaria com duas linhagens vivas. A chave certa
+/// é a linhagem, não a posição do ato nela.
+/// </para>
+/// <para>
+/// <b>Linhagem, não ato.</b> <see cref="RaizId"/> identifica a cadeia de retificação
+/// inteira (o Id da sua raiz). Uma retificação da linhagem que já detém a vaga reencontra
+/// a mesma <see cref="RaizId"/> e segue; um ato de outra linhagem colide, e é recusado com
+/// 409 (ADR-0103: uma nova versão do ato vivo é uma retificação, não um ato novo).
+/// </para>
+/// <para>
+/// Insert-only (<see cref="IForensicEntity"/>, ADR-0063), como tudo neste módulo: a vaga
+/// não se transfere nem se libera — não há revogação de ato publicado.
+/// </para>
+/// </remarks>
+public sealed class LinhagemUnicaPorObjeto : IForensicEntity
+{
+    public Guid Id { get; private init; } = Guid.CreateVersion7();
+
+    /// <summary>Tipo da entidade tratada, opaco para o módulo (ver <see cref="VinculoAtoEntidade"/>).</summary>
+    public string EntidadeTipo { get; private init; } = null!;
+
+    /// <summary>Identificador da entidade tratada, opaco para o módulo.</summary>
+    public Guid EntidadeId { get; private init; }
+
+    /// <summary>
+    /// Código do tipo de ato, copiado por valor do ato (ADR-0075). A vaga é por
+    /// <c>(objeto, tipo)</c>: um processo seletivo tem um edital de abertura vivo e,
+    /// ainda assim, quantos avisos forem precisos.
+    /// </summary>
+    public string TipoCodigo { get; private init; } = null!;
+
+    /// <summary>Raiz da cadeia de retificação que ocupa a vaga — a identidade da linhagem.</summary>
+    public Guid RaizId { get; private init; }
+
+    /// <summary>
+    /// Ato que abriu a vaga. Não é necessariamente a raiz: uma raiz publicada sem vínculo
+    /// e vinculada só na retificação faz a própria retificação abrir a vaga — em nome da
+    /// linhagem, cuja raiz continua sendo <see cref="RaizId"/>.
+    /// </summary>
+    public Guid AtoId { get; private init; }
+
+    // EF Core materialization
+    private LinhagemUnicaPorObjeto()
+    {
+    }
+
+    /// <summary>
+    /// Abre a vaga do objeto de <paramref name="vinculo"/> em nome da linhagem
+    /// <paramref name="raizId"/>. O tipo de ato e o ato que a abre vêm do próprio
+    /// <paramref name="ato"/> — não são recebidos soltos, e por isso não podem divergir
+    /// dele.
+    /// </summary>
+    public static LinhagemUnicaPorObjeto Criar(AtoNormativo ato, VinculoAtoEntidade vinculo, Guid raizId)
+    {
+        ArgumentNullException.ThrowIfNull(ato);
+        ArgumentNullException.ThrowIfNull(vinculo);
+
+        if (raizId == Guid.Empty)
+        {
+            throw new ArgumentException("Raiz da linhagem não pode ser vazia.", nameof(raizId));
+        }
+
+        if (!ato.UnicoPorObjeto)
+        {
+            throw new InvalidOperationException(
+                "Só um ato de tipo único por objeto reserva a vaga de um objeto.");
+        }
+
+        return new LinhagemUnicaPorObjeto
+        {
+            EntidadeTipo = vinculo.EntidadeTipo,
+            EntidadeId = vinculo.EntidadeId,
+            TipoCodigo = ato.TipoCodigo,
+            RaizId = raizId,
+            AtoId = ato.Id,
+        };
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/TipoAtoPublicado.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/TipoAtoPublicado.cs
@@ -103,10 +103,19 @@ public sealed partial class TipoAtoPublicado : SoftDeletableEntity, IAuditableEn
     }
 
     /// <summary>
-    /// Atualiza os atributos da versão. O <c>Codigo</c> é editável, como no
-    /// <c>TipoDocumento</c>: o consumo é por cópia de valor no ato publicado, então
-    /// renomear o código vivo não altera nenhum ato já publicado.
+    /// Atualiza os atributos da versão. O <c>Codigo</c> é <b>imutável</b>: ele é a
+    /// identidade do tipo, não um rótulo dele.
     /// </summary>
+    /// <remarks>
+    /// Duas coisas dependem de o código não mudar. A série de vigências agrupa-se por
+    /// ele — é o <c>codigo</c> que a exclusion constraint compara para impedir duas
+    /// versões vivas no mesmo dia —, de modo que renomear uma versão a desgarraria das
+    /// demais, e o tipo se partiria em dois sem que ninguém o pedisse. E a vaga que um
+    /// objeto reserva para uma linhagem de atos únicos por objeto é chaveada pelo código
+    /// (ADR-0107): renomeá-lo abriria uma vaga nova no mesmo objeto, e o certame acabaria
+    /// com dois editais de abertura vivos. Renomear é criar outro tipo — não editar este.
+    /// Nome, atributos de consequência, vigência e base legal seguem editáveis.
+    /// </remarks>
     public Result Atualizar(
         string codigo,
         string nome,
@@ -124,6 +133,15 @@ public sealed partial class TipoAtoPublicado : SoftDeletableEntity, IAuditableEn
         if (validacao.IsFailure)
         {
             return validacao;
+        }
+
+        if (!string.Equals(codigo.Trim(), Codigo, StringComparison.Ordinal))
+        {
+            return Result.Failure(new DomainError(
+                TipoAtoPublicadoErrorCodes.CodigoImutavel,
+                "O código do tipo de ato é a sua identidade e não muda: a série de vigências "
+                + "agrupa-se por ele, e é por ele que um objeto reserva a vaga de um ato único. "
+                + "Para um tipo diferente, cadastre um tipo novo."));
         }
 
         AplicarCampos(

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/VinculoAtoEntidade.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Entities/VinculoAtoEntidade.cs
@@ -1,0 +1,107 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+using System.Text.RegularExpressions;
+
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+
+/// <summary>
+/// Vínculo entre um ato publicado e uma entidade de outro domínio — o par
+/// <c>(entidade_tipo, entidade_id)</c> que Publicações guarda <b>sem
+/// interpretar</b> (ADR-0105). É o que serve a consulta unificada "todos os atos
+/// deste certame" sem que o módulo documental conheça <c>ProcessoSeletivo</c>,
+/// <c>Chamada</c> ou configuração de certame.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>O tipo da entidade é opaco.</b> Não há enumerado fechado, tabela de valores
+/// permitidos nem chave estrangeira para tabela de domínio: só a <i>forma</i> do
+/// rótulo é verificada (UPPER_SNAKE). Quem dá sentido ao par é o domínio que o
+/// populou — <c>Selecao</c> ao publicar um edital, <c>Ingresso</c> ao convocar uma
+/// chamada. A única chave estrangeira desta entidade aponta para o próprio ato.
+/// </para>
+/// <para>
+/// <b>Append-only</b> (<see cref="IForensicEntity"/>, ADR-0063), como o ato que o
+/// carrega: o vínculo nasce no registro do ato, na mesma transação, e não se muta
+/// nem se remove. Um vínculo equivocado tem o mesmo destino de um ato equivocado —
+/// permanece, e a correção é publicar um novo ato.
+/// </para>
+/// <para>
+/// Construído exclusivamente a partir do próprio ato
+/// (<see cref="Criar(AtoNormativo, string, Guid)"/>): a identidade do ato não é
+/// recebida solta, e por isso não há como um vínculo apontar para um ato que não é
+/// o seu.
+/// </para>
+/// </remarks>
+public sealed partial class VinculoAtoEntidade : IForensicEntity
+{
+    private const int EntidadeTipoMaxLength = 60;
+
+    public Guid Id { get; private init; } = Guid.CreateVersion7();
+
+    /// <summary>Ato publicado a que este vínculo pertence. Única chave estrangeira da entidade.</summary>
+    public Guid AtoId { get; private init; }
+
+    /// <summary>
+    /// Rótulo opaco do tipo da entidade vinculada (ex.: o processo seletivo, a
+    /// chamada). Verificada apenas a forma — o módulo não sabe, e não deve saber,
+    /// o que o rótulo significa.
+    /// </summary>
+    public string EntidadeTipo { get; private init; } = null!;
+
+    /// <summary>Identificador da entidade vinculada, opaco para o módulo (sem chave estrangeira).</summary>
+    public Guid EntidadeId { get; private init; }
+
+    // EF Core materialization
+    private VinculoAtoEntidade()
+    {
+    }
+
+    /// <summary>
+    /// Cria o vínculo de <paramref name="ato"/> com a entidade
+    /// <paramref name="entidadeTipo"/>/<paramref name="entidadeId"/>. Invariantes de
+    /// última linha — o validator já recusa o mesmo antes, com 422.
+    /// </summary>
+    public static VinculoAtoEntidade Criar(AtoNormativo ato, string entidadeTipo, Guid entidadeId)
+    {
+        ArgumentNullException.ThrowIfNull(ato);
+        ArgumentException.ThrowIfNullOrWhiteSpace(entidadeTipo);
+
+        string tipoNorm = entidadeTipo.Trim();
+        if (tipoNorm.Length > EntidadeTipoMaxLength)
+        {
+            throw new ArgumentException(
+                $"Tipo da entidade deve ter no máximo {EntidadeTipoMaxLength} caracteres.",
+                nameof(entidadeTipo));
+        }
+
+        if (!FormatoDoTipo().IsMatch(tipoNorm))
+        {
+            throw new ArgumentException(
+                "Tipo da entidade deve ser um rótulo em UPPER_SNAKE.",
+                nameof(entidadeTipo));
+        }
+
+        if (entidadeId == Guid.Empty)
+        {
+            throw new ArgumentException(
+                "Identificador da entidade vinculada não pode ser vazio.",
+                nameof(entidadeId));
+        }
+
+        return new VinculoAtoEntidade
+        {
+            AtoId = ato.Id,
+            EntidadeTipo = tipoNorm,
+            EntidadeId = entidadeId,
+        };
+    }
+
+    /// <summary>
+    /// Forma do rótulo, não o seu valor: letras maiúsculas e dígitos em grupos
+    /// separados por <c>_</c>. Fixa uma grafia canônica — sem ela,
+    /// <c>PROCESSO_SELETIVO</c> e <c>processo-seletivo</c> seriam objetos distintos
+    /// na consulta, e a mesma entidade se partiria em duas.
+    /// </summary>
+    [GeneratedRegex(@"^[A-Z0-9]+(_[A-Z0-9]+)*$")]
+    private static partial Regex FormatoDoTipo();
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/AtoNormativoErrorCodes.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/AtoNormativoErrorCodes.cs
@@ -38,4 +38,13 @@ public static class AtoNormativoErrorCodes
     /// cadeia, não uma raiz já retificada. A mensagem nomeia o ato que já a retificou.
     /// </summary>
     public const string RaizJaRetificada = "AtoNormativo.RaizJaRetificada";
+
+    /// <summary>
+    /// O tipo do ato admite um único ato vivo por objeto (<c>unico_por_objeto</c>), e a
+    /// entidade vinculada já é tratada por outra linhagem de atos desse tipo. Não é o
+    /// payload que está incoerente — é o estado já gravado que não comporta uma segunda
+    /// linhagem; daí 409, e não 422. Uma nova versão do ato vivo é uma retificação da
+    /// própria linhagem (ADR-0103), não um ato novo.
+    /// </summary>
+    public const string ObjetoJaTemAtoVivoDoTipo = "AtoNormativo.ObjetoJaTemAtoVivoDoTipo";
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/TipoAtoPublicadoErrorCodes.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Errors/TipoAtoPublicadoErrorCodes.cs
@@ -5,6 +5,14 @@ public static class TipoAtoPublicadoErrorCodes
     public const string CodigoObrigatorio = "TipoAtoPublicado.CodigoObrigatorio";
     public const string CodigoTamanho = "TipoAtoPublicado.CodigoTamanho";
     public const string CodigoFormato = "TipoAtoPublicado.CodigoFormato";
+
+    /// <summary>
+    /// Tentou-se trocar o código de uma versão existente. O código é a identidade do
+    /// tipo: a série de vigências agrupa-se por ele (exclusion constraint), e a vaga que
+    /// um objeto reserva para uma linhagem de atos únicos por objeto é chaveada por ele
+    /// (ADR-0107). Renomear é criar outro tipo, não editar este.
+    /// </summary>
+    public const string CodigoImutavel = "TipoAtoPublicado.CodigoImutavel";
     public const string NomeObrigatorio = "TipoAtoPublicado.NomeObrigatorio";
     public const string NomeTamanho = "TipoAtoPublicado.NomeTamanho";
     public const string BaseLegalTamanho = "TipoAtoPublicado.BaseLegalTamanho";

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Interfaces/IAtoNormativoRepository.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Interfaces/IAtoNormativoRepository.cs
@@ -62,4 +62,77 @@ public interface IAtoNormativoRepository
         int limit,
         PaginationDirection direction,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Devolve a raiz da cadeia de retificação a que <paramref name="atoId"/> pertence —
+    /// o próprio <paramref name="atoId"/> quando ele não retifica ninguém. Identifica a
+    /// linhagem, que é a chave da vaga de <see cref="LinhagemUnicaPorObjeto"/>. Sobe pela
+    /// cadeia, que é linear e acíclica (ADR-0103).
+    /// </summary>
+    Task<Guid> ObterRaizDaCadeiaAsync(Guid atoId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Devolve a linhagem que ocupa a vaga do objeto
+    /// <paramref name="entidadeTipo"/>/<paramref name="entidadeId"/> para o tipo de ato
+    /// <paramref name="tipoCodigo"/>, ou <see langword="null"/> se a vaga está livre.
+    /// Dá a mensagem legível no caso comum; a garantia dura contra a corrida
+    /// check-then-act é o índice único da vaga, não esta consulta.
+    /// </summary>
+    Task<LinhagemUnicaPorObjeto?> ObterLinhagemDoObjetoAsync(
+        string entidadeTipo,
+        Guid entidadeId,
+        string tipoCodigo,
+        CancellationToken cancellationToken);
+
+    /// <summary>Reserva a vaga do objeto para uma linhagem. Persiste no <c>SalvarAlteracoesAsync</c> da unidade de trabalho.</summary>
+    Task AdicionarLinhagemAsync(LinhagemUnicaPorObjeto linhagem, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Devolve os pares <c>(tipo, id)</c> das entidades a que <paramref name="atoId"/>
+    /// está vinculado. Base da herança de vínculos pela retificação: quem emenda um ato
+    /// trata do mesmo objeto que ele — se a retificação não os herdasse, sumiria da
+    /// consulta do certame, e a consulta exibiria a versão superada escondendo a que
+    /// vale.
+    /// </summary>
+    Task<IReadOnlyList<(string EntidadeTipo, Guid EntidadeId)>> ListarVinculosDoAtoAsync(
+        Guid atoId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Devolve um ato do tipo <paramref name="tipoCodigo"/> já vinculado ao objeto
+    /// <paramref name="entidadeTipo"/>/<paramref name="entidadeId"/> e que <b>não</b>
+    /// pertence à cadeia <paramref name="idsDaPropriaCadeia"/>, ou <see langword="null"/>
+    /// se não há nenhum.
+    /// </summary>
+    /// <remarks>
+    /// Olha o histórico de atos, não a tabela de vagas — e é essa a razão de existir.
+    /// O atributo <c>unico_por_objeto</c> é editável no catálogo: um ato publicado quando
+    /// o tipo ainda <i>não</i> era único por objeto não reservou vaga alguma, e sem esta
+    /// consulta um ato posterior, publicado depois de o atributo virar, encontraria a vaga
+    /// livre e o objeto acabaria com duas linhagens vivas. A vaga
+    /// (<see cref="LinhagemUnicaPorObjeto"/>) continua sendo a garantia dura contra a
+    /// corrida entre transações concorrentes; esta consulta é a que enxerga o passado.
+    /// </remarks>
+    Task<AtoNormativo?> ObterAtoConflitanteNoObjetoAsync(
+        string entidadeTipo,
+        Guid entidadeId,
+        string tipoCodigo,
+        IReadOnlyCollection<Guid> idsDaPropriaCadeia,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista os atos vinculados a uma entidade, ordenados por data de publicação
+    /// ascendente com o <c>Id</c> (Guid v7) de desempate — a retificação republica a
+    /// mesma data, então a data sozinha não ordena de forma estável. Keyset ordenado
+    /// (ADR-0094) sob cursor opaco; as âncoras são o par <c>(data, id)</c>.
+    /// </summary>
+    Task<(IReadOnlyList<AtoNormativo> Itens, (string SortKey, Guid Id)? Anterior, (string SortKey, Guid Id)? Proximo)>
+        ListarPorEntidadeAsync(
+            string entidadeTipo,
+            Guid entidadeId,
+            string? afterSortKey,
+            Guid? afterId,
+            int limit,
+            PaginationDirection direction,
+            CancellationToken cancellationToken);
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/AtoNormativoConfiguration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/AtoNormativoConfiguration.cs
@@ -129,6 +129,15 @@ internal sealed class AtoNormativoConfiguration : IEntityTypeConfiguration<AtoNo
         builder.HasIndex(a => new { a.Orgao, a.Serie, a.Ano, a.Numero })
             .HasDatabaseName("ix_ato_normativo_numeracao");
 
+        // O agregado expõe os vínculos como coleção só-leitura; o EF materializa no
+        // campo de apoio, sem passar pela propriedade.
+        builder.Navigation(a => a.Vinculos).UsePropertyAccessMode(PropertyAccessMode.Field);
+
+        // Suporte ao seek do keyset ordenado da consulta por entidade (ADR-0094): a
+        // ordenação é (data_publicacao, id), e o índice casa a mesma expressão.
+        builder.HasIndex(a => new { a.DataPublicacao, a.Id })
+            .HasDatabaseName("ix_ato_normativo_data_publicacao");
+
         // Linearidade da cadeia (ADR-0103): um ato é retificado no máximo uma vez.
         // Índice único parcial — garantia dura à prova da corrida check-then-act do
         // handler. Parcial porque a maioria dos atos não retifica ninguém (nulo não

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/LinhagemUnicaPorObjetoConfiguration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/LinhagemUnicaPorObjetoConfiguration.cs
@@ -1,0 +1,80 @@
+namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+/// <summary>
+/// Persistência da vaga que um objeto reserva para uma única linhagem de atos de
+/// um tipo <c>unico_por_objeto</c> (ADR-0107). O índice único é a garantia dura;
+/// a consulta prévia do handler só existe para dar mensagem legível.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class LinhagemUnicaPorObjetoConfiguration : IEntityTypeConfiguration<LinhagemUnicaPorObjeto>
+{
+    private const int EntidadeTipoMaxLength = 60;
+    private const int TipoCodigoMaxLength = 60;
+
+    public void Configure(EntityTypeBuilder<LinhagemUnicaPorObjeto> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            "linhagem_unica_por_objeto",
+            t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_linhagem_unica_entidade_tipo_formato",
+                    "entidade_tipo ~ '^[A-Z0-9]+(_[A-Z0-9]+)*$'");
+
+                t.HasCheckConstraint(
+                    "ck_linhagem_unica_entidade_id_nao_zero",
+                    "entidade_id <> '00000000-0000-0000-0000-000000000000'");
+
+                t.HasCheckConstraint(
+                    "ck_linhagem_unica_raiz_nao_zero",
+                    "raiz_id <> '00000000-0000-0000-0000-000000000000'");
+            });
+
+        builder.HasKey(l => l.Id);
+
+        builder.Property(l => l.EntidadeTipo).HasMaxLength(EntidadeTipoMaxLength).IsRequired();
+        builder.Property(l => l.EntidadeId).IsRequired();
+        builder.Property(l => l.TipoCodigo).HasMaxLength(TipoCodigoMaxLength).IsRequired();
+        builder.Property(l => l.RaizId).IsRequired();
+        builder.Property(l => l.AtoId).IsRequired();
+
+        // FK para o ato que abriu a vaga — intra-módulo, como a self-ref da cadeia de
+        // retificação (a ADR-0061 só proíbe FK atravessando a fronteira de outro
+        // módulo). Restrict: coerente com o append-only, que já bloqueia DELETE.
+        // Não há FK para a entidade vinculada, e não pode haver: o objeto é opaco.
+        builder.HasOne<AtoNormativo>()
+            .WithMany()
+            .HasForeignKey(l => l.AtoId)
+            .HasConstraintName("fk_linhagem_unica_ato")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // A raiz da linhagem é um ato, não um identificador solto: sem esta chave, uma
+        // linha forjada reservaria a vaga em nome de uma linhagem inexistente, e nada a
+        // desmentiria. Que ela seja a raiz VERDADEIRA da cadeia do ato é o que o trigger
+        // de coerência verifica — a chave só garante que o ato existe.
+        builder.HasOne<AtoNormativo>()
+            .WithMany()
+            .HasForeignKey(l => l.RaizId)
+            .HasConstraintName("fk_linhagem_unica_raiz")
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // A garantia dura da invariante: um objeto tem, no máximo, UMA linhagem viva de
+        // atos de um dado tipo único por objeto. Índice único (não parcial): a linha só
+        // existe para tipo único por objeto — quem decide inseri-la é o handler, e um
+        // tipo que não é único por objeto nunca chega aqui. Fecha a corrida
+        // check-then-act entre duas transações que reservem a mesma vaga.
+        builder.HasIndex(l => new { l.EntidadeTipo, l.EntidadeId, l.TipoCodigo })
+            .IsUnique()
+            .HasDatabaseName("ux_linhagem_unica_por_objeto");
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/VinculoAtoEntidadeConfiguration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Configurations/VinculoAtoEntidadeConfiguration.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class VinculoAtoEntidadeConfiguration : IEntityTypeConfiguration<VinculoAtoEntidade>
+{
+    private const int EntidadeTipoMaxLength = 60;
+
+    public void Configure(EntityTypeBuilder<VinculoAtoEntidade> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            "vinculo_ato_entidade",
+            t =>
+            {
+                // Forma canônica do rótulo (a factory já recusa). O módulo não valida o
+                // VALOR — não há lista de tipos permitidos, e não pode haver: o rótulo é
+                // opaco (ADR-0105). O que se exige é grafia única, sem a qual a mesma
+                // entidade se partiria em duas na consulta.
+                t.HasCheckConstraint(
+                    "ck_vinculo_ato_entidade_tipo_formato",
+                    "entidade_tipo ~ '^[A-Z0-9]+(_[A-Z0-9]+)*$'");
+
+                // Um Guid.Empty não designa objeto algum — defesa contra insert cru.
+                t.HasCheckConstraint(
+                    "ck_vinculo_ato_entidade_id_nao_zero",
+                    "entidade_id <> '00000000-0000-0000-0000-000000000000'");
+            });
+
+        builder.HasKey(v => v.Id);
+
+        builder.Property(v => v.AtoId).IsRequired();
+        builder.Property(v => v.EntidadeTipo).HasMaxLength(EntidadeTipoMaxLength).IsRequired();
+        builder.Property(v => v.EntidadeId).IsRequired();
+
+        // A ÚNICA chave estrangeira do vínculo, e ela aponta para o próprio ato
+        // (contraprova estrutural da story #801). Não há — e não pode haver — FK para
+        // processo_seletivo, chamada ou aplicacao_prova: o módulo não conhece esses
+        // conceitos, e a ausência é travada por fitness test contra o banco real.
+        // Cascade: o vínculo é parte do ato; ambos são append-only, e nenhum DELETE
+        // chega até aqui (o trigger o bloqueia antes).
+        builder.HasOne<AtoNormativo>()
+            .WithMany(a => a.Vinculos)
+            .HasForeignKey(v => v.AtoId)
+            .HasConstraintName("fk_vinculo_ato_entidade_ato")
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Único por trio (ato, tipo da entidade, id da entidade): vincular a mesma
+        // entidade duas vezes ao mesmo ato não acrescenta vínculo nenhum.
+        builder.HasIndex(v => new { v.AtoId, v.EntidadeTipo, v.EntidadeId })
+            .IsUnique()
+            .HasDatabaseName("ux_vinculo_ato_entidade_trio");
+
+        // Suporte à consulta "todos os atos desta entidade": o predicado é
+        // (entidade_tipo, entidade_id), e o ato_id fecha o EXISTS sem tocar a heap.
+        builder.HasIndex(v => new { v.EntidadeTipo, v.EntidadeId, v.AtoId })
+            .HasDatabaseName("ix_vinculo_ato_entidade_objeto");
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260711211409_AddVinculoAtoEntidade.Designer.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260711211409_AddVinculoAtoEntidade.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(PublicacoesDbContext))]
-    partial class PublicacoesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711211409_AddVinculoAtoEntidade")]
+    partial class AddVinculoAtoEntidade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260711211409_AddVinculoAtoEntidade.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Migrations/20260711211409_AddVinculoAtoEntidade.cs
@@ -1,0 +1,416 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVinculoAtoEntidade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "linhagem_unica_por_objeto",
+                schema: "publicacoes",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    entidade_tipo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    entidade_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tipo_codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    raiz_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ato_id = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_linhagem_unica_por_objeto", x => x.id);
+                    table.CheckConstraint("ck_linhagem_unica_entidade_id_nao_zero", "entidade_id <> '00000000-0000-0000-0000-000000000000'");
+                    table.CheckConstraint("ck_linhagem_unica_entidade_tipo_formato", "entidade_tipo ~ '^[A-Z0-9]+(_[A-Z0-9]+)*$'");
+                    table.CheckConstraint("ck_linhagem_unica_raiz_nao_zero", "raiz_id <> '00000000-0000-0000-0000-000000000000'");
+                    table.ForeignKey(
+                        name: "fk_linhagem_unica_ato",
+                        column: x => x.ato_id,
+                        principalSchema: "publicacoes",
+                        principalTable: "ato_normativo",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_linhagem_unica_raiz",
+                        column: x => x.raiz_id,
+                        principalSchema: "publicacoes",
+                        principalTable: "ato_normativo",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "vinculo_ato_entidade",
+                schema: "publicacoes",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ato_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    entidade_tipo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    entidade_id = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_vinculo_ato_entidade", x => x.id);
+                    table.CheckConstraint("ck_vinculo_ato_entidade_id_nao_zero", "entidade_id <> '00000000-0000-0000-0000-000000000000'");
+                    table.CheckConstraint("ck_vinculo_ato_entidade_tipo_formato", "entidade_tipo ~ '^[A-Z0-9]+(_[A-Z0-9]+)*$'");
+                    table.ForeignKey(
+                        name: "fk_vinculo_ato_entidade_ato",
+                        column: x => x.ato_id,
+                        principalSchema: "publicacoes",
+                        principalTable: "ato_normativo",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_ato_normativo_data_publicacao",
+                schema: "publicacoes",
+                table: "ato_normativo",
+                columns: new[] { "data_publicacao", "id" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_linhagem_unica_por_objeto_ato_id",
+                schema: "publicacoes",
+                table: "linhagem_unica_por_objeto",
+                column: "ato_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_linhagem_unica_por_objeto_raiz_id",
+                schema: "publicacoes",
+                table: "linhagem_unica_por_objeto",
+                column: "raiz_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_linhagem_unica_por_objeto",
+                schema: "publicacoes",
+                table: "linhagem_unica_por_objeto",
+                columns: new[] { "entidade_tipo", "entidade_id", "tipo_codigo" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_vinculo_ato_entidade_objeto",
+                schema: "publicacoes",
+                table: "vinculo_ato_entidade",
+                columns: new[] { "entidade_tipo", "entidade_id", "ato_id" });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_vinculo_ato_entidade_trio",
+                schema: "publicacoes",
+                table: "vinculo_ato_entidade",
+                columns: new[] { "ato_id", "entidade_tipo", "entidade_id" },
+                unique: true);
+
+            // Append-only imposto pelo banco (ADR-0063), como no ato que estas duas
+            // tabelas acompanham. Mutar um vínculo reescreveria de que objeto o ato
+            // tratava; mutar uma vaga transferiria o objeto de uma linhagem para outra
+            // sem que ato algum o dissesse. As duas coisas corrompem a prova.
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION publicacoes.fn_vinculo_ato_entidade_somente_insercao()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $$
+                BEGIN
+                    RAISE EXCEPTION
+                        'vinculo_ato_entidade é append-only (ADR-0063): operação % é bloqueada; o vínculo é parte do ato publicado.', TG_OP
+                        USING ERRCODE = 'restrict_violation';
+                END;
+                $$;
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE TRIGGER trg_vinculo_ato_entidade_somente_insercao
+                    BEFORE UPDATE OR DELETE ON publicacoes.vinculo_ato_entidade
+                    FOR EACH ROW
+                    EXECUTE FUNCTION publicacoes.fn_vinculo_ato_entidade_somente_insercao();
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION publicacoes.fn_linhagem_unica_somente_insercao()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $$
+                BEGIN
+                    RAISE EXCEPTION
+                        'linhagem_unica_por_objeto é append-only (ADR-0107): operação % é bloqueada; a vaga do objeto não se transfere.', TG_OP
+                        USING ERRCODE = 'restrict_violation';
+                END;
+                $$;
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE TRIGGER trg_linhagem_unica_somente_insercao
+                    BEFORE UPDATE OR DELETE ON publicacoes.linhagem_unica_por_objeto
+                    FOR EACH ROW
+                    EXECUTE FUNCTION publicacoes.fn_linhagem_unica_somente_insercao();
+                """);
+
+            // Raiz da cadeia de retificação de um ato: sobe até quem não emenda ninguém.
+            //
+            // A aciclicidade NÃO é dada de graça pelo que já existe. A chave estrangeira
+            // de ato_retificado_id é imediata, mas é verificada ao fim do COMANDO, não a
+            // cada linha: um único INSERT com duas linhas — A retificando B, B retificando
+            // A — passa, porque quando a verificação corre ambos já existem. O CHECK de
+            // não-autorreferência só barra o ciclo de tamanho um, e o índice único da
+            // linearidade não vê ciclo nenhum (A→B e B→A são alvos distintos). O ciclo,
+            // uma vez gravado, seria irreparável (UPDATE e DELETE estão bloqueados) e
+            // faria qualquer travessia da cadeia girar para sempre.
+            //
+            // Daí a marcação dos visitados: a função detecta o ciclo em vez de contar
+            // passos — um teto de profundidade confundiria uma cadeia longa e legítima
+            // com corrupção, e ainda assim só falharia depois de percorrê-la inteira.
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION publicacoes.fn_raiz_da_cadeia(p_ato_id uuid)
+                RETURNS uuid
+                LANGUAGE plpgsql
+                STABLE
+                AS $$
+                DECLARE
+                    atual uuid := p_ato_id;
+                    pai uuid;
+                    visitados uuid[] := ARRAY[]::uuid[];
+                BEGIN
+                    LOOP
+                        IF atual = ANY(visitados) THEN
+                            RAISE EXCEPTION
+                                'a cadeia de retificação que passa por % é cíclica.', p_ato_id
+                                USING ERRCODE = 'restrict_violation';
+                        END IF;
+
+                        visitados := visitados || atual;
+
+                        SELECT ato_retificado_id INTO pai
+                        FROM publicacoes.ato_normativo WHERE id = atual;
+
+                        IF NOT FOUND THEN
+                            RAISE EXCEPTION 'ato % não existe.', atual
+                                USING ERRCODE = 'restrict_violation';
+                        END IF;
+
+                        EXIT WHEN pai IS NULL;
+
+                        atual := pai;
+                    END LOOP;
+
+                    RETURN atual;
+                END;
+                $$;
+                """);
+
+            // A cadeia de todo ato registrado termina numa raiz — verificado no fim da
+            // transação, quando as linhas do comando inteiro já existem. É este trigger,
+            // e não a chave estrangeira, que barra o INSERT multi-linha cíclico descrito
+            // acima. Custo por ato: subir a própria cadeia, que a linearidade mantém curta.
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION publicacoes.fn_ato_normativo_cadeia_aciclica()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $$
+                BEGIN
+                    PERFORM publicacoes.fn_raiz_da_cadeia(NEW.id);
+                    RETURN NEW;
+                END;
+                $$;
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE CONSTRAINT TRIGGER trg_ato_normativo_cadeia_aciclica
+                    AFTER INSERT ON publicacoes.ato_normativo
+                    DEFERRABLE INITIALLY DEFERRED
+                    FOR EACH ROW
+                    EXECUTE FUNCTION publicacoes.fn_ato_normativo_cadeia_aciclica();
+                """);
+
+            // O que a vaga afirma sobre o ato tem de ser verdade (ADR-0107). Sem isto,
+            // uma linha forjada — tipo que não é o do ato, raiz que não é a da sua
+            // cadeia, objeto a que o ato não se vincula, ou ato de tipo que nem é único
+            // por objeto — ocuparia a vaga de um objeto sem que ato publicado algum o
+            // justificasse. Nenhuma dessas coisas passa pelo agregado; o trigger fecha a
+            // brecha do INSERT cru, como os CHECKs do ato fecham a dele.
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION publicacoes.fn_linhagem_unica_coerente_com_ato()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $$
+                DECLARE
+                    v_unico boolean;
+                    v_tipo_codigo varchar(60);
+                BEGIN
+                    SELECT unico_por_objeto, tipo_codigo INTO v_unico, v_tipo_codigo
+                    FROM publicacoes.ato_normativo WHERE id = NEW.ato_id;
+
+                    IF NOT v_unico THEN
+                        RAISE EXCEPTION
+                            'o ato % não é de tipo único por objeto e não reserva vaga alguma.', NEW.ato_id
+                            USING ERRCODE = 'restrict_violation';
+                    END IF;
+
+                    IF v_tipo_codigo <> NEW.tipo_codigo THEN
+                        RAISE EXCEPTION
+                            'o tipo da vaga (%) diverge do tipo do ato % (%).', NEW.tipo_codigo, NEW.ato_id, v_tipo_codigo
+                            USING ERRCODE = 'restrict_violation';
+                    END IF;
+
+                    IF NEW.raiz_id <> publicacoes.fn_raiz_da_cadeia(NEW.ato_id) THEN
+                        RAISE EXCEPTION
+                            'a raiz declarada (%) não é a raiz da cadeia de retificação do ato %.', NEW.raiz_id, NEW.ato_id
+                            USING ERRCODE = 'restrict_violation';
+                    END IF;
+
+                    IF NOT EXISTS (
+                        SELECT 1 FROM publicacoes.vinculo_ato_entidade v
+                        WHERE v.ato_id = NEW.ato_id
+                          AND v.entidade_tipo = NEW.entidade_tipo
+                          AND v.entidade_id = NEW.entidade_id
+                    ) THEN
+                        RAISE EXCEPTION
+                            'o ato % não está vinculado à entidade %/%, cuja vaga a linha reserva.', NEW.ato_id, NEW.entidade_tipo, NEW.entidade_id
+                            USING ERRCODE = 'restrict_violation';
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $$;
+                """);
+
+            // A correspondência reversa, e é ela que faz o índice único valer alguma
+            // coisa: todo vínculo de um ato único por objeto tem de ter a vaga daquele
+            // objeto reservada em nome da sua linhagem. Sem isto, gravar o vínculo e
+            // omitir a vaga — um importador, um seed, uma regressão — deixaria o objeto
+            // livre para uma segunda linhagem, e o índice, que só vê as vagas que
+            // existem, nada acusaria.
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION publicacoes.fn_vinculo_exige_vaga_da_linhagem()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $$
+                DECLARE
+                    v_unico boolean;
+                    v_tipo_codigo varchar(60);
+                    v_raiz uuid;
+                BEGIN
+                    SELECT unico_por_objeto, tipo_codigo INTO v_unico, v_tipo_codigo
+                    FROM publicacoes.ato_normativo WHERE id = NEW.ato_id;
+
+                    IF NOT v_unico THEN
+                        RETURN NEW;
+                    END IF;
+
+                    v_raiz := publicacoes.fn_raiz_da_cadeia(NEW.ato_id);
+
+                    IF NOT EXISTS (
+                        SELECT 1 FROM publicacoes.linhagem_unica_por_objeto l
+                        WHERE l.entidade_tipo = NEW.entidade_tipo
+                          AND l.entidade_id = NEW.entidade_id
+                          AND l.tipo_codigo = v_tipo_codigo
+                          AND l.raiz_id = v_raiz
+                    ) THEN
+                        RAISE EXCEPTION
+                            'o ato % é de tipo único por objeto e vincula-se a %/% sem que a vaga do objeto esteja reservada para a linhagem %.',
+                            NEW.ato_id, NEW.entidade_tipo, NEW.entidade_id, v_raiz
+                            USING ERRCODE = 'restrict_violation';
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $$;
+                """);
+
+            // DEFERRABLE INITIALLY DEFERRED nos dois: o ato, o vínculo e a vaga entram na
+            // mesma transação, e a ordem em que o EF emite os INSERTs não é contratual —
+            // uma verificação imediata acusaria a ausência do que ainda não foi gravado.
+            // No fim da transação, ambas as pontas já existem.
+            migrationBuilder.Sql("""
+                CREATE CONSTRAINT TRIGGER trg_linhagem_unica_coerente_com_ato
+                    AFTER INSERT ON publicacoes.linhagem_unica_por_objeto
+                    DEFERRABLE INITIALLY DEFERRED
+                    FOR EACH ROW
+                    EXECUTE FUNCTION publicacoes.fn_linhagem_unica_coerente_com_ato();
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE CONSTRAINT TRIGGER trg_vinculo_exige_vaga_da_linhagem
+                    AFTER INSERT ON publicacoes.vinculo_ato_entidade
+                    DEFERRABLE INITIALLY DEFERRED
+                    FOR EACH ROW
+                    EXECUTE FUNCTION publicacoes.fn_vinculo_exige_vaga_da_linhagem();
+                """);
+
+            // TRUNCATE não é DELETE: não dispara trigger de linha, e esvaziaria as tabelas
+            // sem que o append-only percebesse. O trigger de statement fecha essa porta —
+            // inclusive na do ato publicado, que a tinha aberta desde que nasceu.
+            migrationBuilder.Sql("""
+                CREATE OR REPLACE FUNCTION publicacoes.fn_bloqueia_truncate()
+                RETURNS trigger
+                LANGUAGE plpgsql
+                AS $$
+                BEGIN
+                    RAISE EXCEPTION
+                        'TRUNCATE é bloqueado em %.%: o registro é append-only (ADR-0063).', TG_TABLE_SCHEMA, TG_TABLE_NAME
+                        USING ERRCODE = 'restrict_violation';
+                END;
+                $$;
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE TRIGGER trg_ato_normativo_bloqueia_truncate
+                    BEFORE TRUNCATE ON publicacoes.ato_normativo
+                    FOR EACH STATEMENT
+                    EXECUTE FUNCTION publicacoes.fn_bloqueia_truncate();
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE TRIGGER trg_vinculo_ato_entidade_bloqueia_truncate
+                    BEFORE TRUNCATE ON publicacoes.vinculo_ato_entidade
+                    FOR EACH STATEMENT
+                    EXECUTE FUNCTION publicacoes.fn_bloqueia_truncate();
+                """);
+
+            migrationBuilder.Sql("""
+                CREATE TRIGGER trg_linhagem_unica_bloqueia_truncate
+                    BEFORE TRUNCATE ON publicacoes.linhagem_unica_por_objeto
+                    FOR EACH STATEMENT
+                    EXECUTE FUNCTION publicacoes.fn_bloqueia_truncate();
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_linhagem_unica_bloqueia_truncate ON publicacoes.linhagem_unica_por_objeto;");
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_vinculo_ato_entidade_bloqueia_truncate ON publicacoes.vinculo_ato_entidade;");
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_ato_normativo_bloqueia_truncate ON publicacoes.ato_normativo;");
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_ato_normativo_cadeia_aciclica ON publicacoes.ato_normativo;");
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_vinculo_exige_vaga_da_linhagem ON publicacoes.vinculo_ato_entidade;");
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_linhagem_unica_coerente_com_ato ON publicacoes.linhagem_unica_por_objeto;");
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_linhagem_unica_somente_insercao ON publicacoes.linhagem_unica_por_objeto;");
+            migrationBuilder.Sql("DROP TRIGGER IF EXISTS trg_vinculo_ato_entidade_somente_insercao ON publicacoes.vinculo_ato_entidade;");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS publicacoes.fn_bloqueia_truncate();");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS publicacoes.fn_ato_normativo_cadeia_aciclica();");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS publicacoes.fn_vinculo_exige_vaga_da_linhagem();");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS publicacoes.fn_linhagem_unica_coerente_com_ato();");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS publicacoes.fn_linhagem_unica_somente_insercao();");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS publicacoes.fn_vinculo_ato_entidade_somente_insercao();");
+            migrationBuilder.Sql("DROP FUNCTION IF EXISTS publicacoes.fn_raiz_da_cadeia(uuid);");
+
+            migrationBuilder.DropTable(
+                name: "linhagem_unica_por_objeto",
+                schema: "publicacoes");
+
+            migrationBuilder.DropTable(
+                name: "vinculo_ato_entidade",
+                schema: "publicacoes");
+
+            migrationBuilder.DropIndex(
+                name: "ix_ato_normativo_data_publicacao",
+                schema: "publicacoes",
+                table: "ato_normativo");
+        }
+    }
+}

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/PublicacoesDbContext.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/PublicacoesDbContext.cs
@@ -11,11 +11,11 @@ using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
 /// DbContext do módulo Publicações — o registro central dos atos normativos
 /// publicados por Reitoria, CEPS e CRCA (ADR-0105).
 ///
-/// Hospeda o cadastro de tipos de ato, o ato normativo append-only e o cache de
-/// Idempotency-Key (ADR-0027) adjacente. O vínculo genérico ato↔entidade chega
-/// na story seguinte (#801). O módulo não conhece ProcessoSeletivo, Chamada nem
-/// configuração de certame — nenhuma coluna, nenhuma chave estrangeira desses
-/// conceitos entra aqui.
+/// Hospeda o cadastro de tipos de ato, o ato normativo append-only, o vínculo
+/// genérico ato↔entidade e o cache de Idempotency-Key (ADR-0027) adjacente. O
+/// módulo não conhece ProcessoSeletivo, Chamada nem configuração de certame —
+/// nenhuma coluna, nenhuma chave estrangeira desses conceitos entra aqui, e a
+/// ausência é travada por fitness test contra o banco real.
 /// </summary>
 public sealed class PublicacoesDbContext : DbContext, IPublicacoesUnitOfWork
 {
@@ -36,6 +36,18 @@ public sealed class PublicacoesDbContext : DbContext, IPublicacoesUnitOfWork
     /// Só recebe <c>INSERT</c>; <c>UPDATE</c>/<c>DELETE</c> são bloqueados por trigger.
     /// </summary>
     public DbSet<AtoNormativo> AtosNormativos => Set<AtoNormativo>();
+
+    /// <summary>
+    /// Vínculos genéricos ato ↔ entidade (ADR-0105) — o par opaco que serve a consulta
+    /// unificada sem que o módulo conheça os domínios.
+    /// </summary>
+    public DbSet<VinculoAtoEntidade> VinculosAtoEntidade => Set<VinculoAtoEntidade>();
+
+    /// <summary>
+    /// Vagas de linhagem única por objeto (ADR-0107) — a chave que o banco trava para
+    /// que um objeto não seja tratado por duas linhagens de atos do mesmo tipo único.
+    /// </summary>
+    public DbSet<LinhagemUnicaPorObjeto> LinhagensUnicasPorObjeto => Set<LinhagemUnicaPorObjeto>();
 
     /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no schema do módulo para permitir

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Repositories/AtoNormativoRepository.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/Repositories/AtoNormativoRepository.cs
@@ -2,6 +2,7 @@ namespace Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence.Repositories;
 
 using Microsoft.EntityFrameworkCore;
 
+using System.Globalization;
 using System.Linq;
 
 using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
@@ -48,10 +49,12 @@ public sealed class AtoNormativoRepository : IAtoNormativoRepository
     public async Task<IReadOnlyList<Guid>> ListarIdsDaCadeiaAsync(Guid atoId, CancellationToken cancellationToken)
     {
         // A cadeia de retificação é linear (garantida pelo índice único parcial em
-        // ato_retificado_id) e acíclica (append-only, CHECK de não-autorreferência).
+        // ato_retificado_id) e acíclica (trigger fn_ato_normativo_cadeia_aciclica).
         // Sobe de atoId até a raiz e desce dela até a cabeça, devolvendo a linhagem
         // inteira. A recursão em SQL é necessária: a profundidade é arbitrária e um
         // JOIN fixo não a cobre. O parâmetro é interpolado com segurança pelo EF.
+        // CYCLE nos dois sentidos: se um ciclo escapasse da escrita, a leitura o cortaria
+        // em vez de pendurar a conexão.
         FormattableString sql = $"""
             WITH RECURSIVE ancestrais AS (
                 SELECT id, ato_retificado_id
@@ -61,17 +64,19 @@ public sealed class AtoNormativoRepository : IAtoNormativoRepository
                 SELECT a.id, a.ato_retificado_id
                 FROM publicacoes.ato_normativo a
                 JOIN ancestrais an ON a.id = an.ato_retificado_id
-            ),
+            ) CYCLE id SET ciclo_acima USING caminho_acima,
             cadeia AS (
                 SELECT id, ato_retificado_id
                 FROM publicacoes.ato_normativo
-                WHERE id IN (SELECT id FROM ancestrais WHERE ato_retificado_id IS NULL)
+                WHERE id IN (
+                    SELECT id FROM ancestrais WHERE ato_retificado_id IS NULL AND NOT ciclo_acima
+                )
                 UNION ALL
                 SELECT a.id, a.ato_retificado_id
                 FROM publicacoes.ato_normativo a
                 JOIN cadeia c ON a.ato_retificado_id = c.id
-            )
-            SELECT id AS "Value" FROM cadeia
+            ) CYCLE id SET ciclo_abaixo USING caminho_abaixo
+            SELECT id AS "Value" FROM cadeia WHERE NOT ciclo_abaixo
             """;
 
         return await _dbContext.Database
@@ -124,4 +129,149 @@ public sealed class AtoNormativoRepository : IAtoNormativoRepository
 
         return (page.Items, page.PrevAfterId, page.NextAfterId);
     }
+
+    public async Task<Guid> ObterRaizDaCadeiaAsync(Guid atoId, CancellationToken cancellationToken)
+    {
+        // Sobe a cadeia até quem não retifica ninguém. O passo é fixo mas a profundidade
+        // não — daí SQL recursivo, não JOIN. CYCLE: a aciclicidade é imposta na escrita
+        // (trigger fn_ato_normativo_cadeia_aciclica), mas uma leitura que gira para
+        // sempre é pior do que uma que devolve erro — a cláusula corta o laço em vez de
+        // pendurar a conexão, se algum ciclo escapar.
+        FormattableString sql = $"""
+            WITH RECURSIVE ancestrais AS (
+                SELECT id, ato_retificado_id
+                FROM publicacoes.ato_normativo
+                WHERE id = {atoId}
+                UNION ALL
+                SELECT a.id, a.ato_retificado_id
+                FROM publicacoes.ato_normativo a
+                JOIN ancestrais an ON a.id = an.ato_retificado_id
+            ) CYCLE id SET ciclo USING caminho
+            SELECT id AS "Value" FROM ancestrais WHERE ato_retificado_id IS NULL AND NOT ciclo
+            """;
+
+        List<Guid> raizes = await _dbContext.Database
+            .SqlQuery<Guid>(sql)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Zero raízes só acontece se o ato não existe — o handler já o validou antes.
+        return raizes.Count == 1
+            ? raizes[0]
+            : throw new InvalidOperationException(
+                $"A cadeia de retificação do ato {atoId} não tem raiz única — a linearidade foi violada no banco.");
+    }
+
+    public Task<LinhagemUnicaPorObjeto?> ObterLinhagemDoObjetoAsync(
+        string entidadeTipo,
+        Guid entidadeId,
+        string tipoCodigo,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entidadeTipo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tipoCodigo);
+
+        string tipoNorm = entidadeTipo.Trim();
+        string codigoNorm = tipoCodigo.Trim();
+
+        return _dbContext.LinhagensUnicasPorObjeto
+            .AsNoTracking()
+            .FirstOrDefaultAsync(
+                l => l.EntidadeTipo == tipoNorm && l.EntidadeId == entidadeId && l.TipoCodigo == codigoNorm,
+                cancellationToken);
+    }
+
+    public async Task AdicionarLinhagemAsync(LinhagemUnicaPorObjeto linhagem, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(linhagem);
+        await _dbContext.LinhagensUnicasPorObjeto.AddAsync(linhagem, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<(string EntidadeTipo, Guid EntidadeId)>> ListarVinculosDoAtoAsync(
+        Guid atoId,
+        CancellationToken cancellationToken)
+    {
+        List<VinculoAtoEntidade> vinculos = await _dbContext.VinculosAtoEntidade
+            .AsNoTracking()
+            .Where(v => v.AtoId == atoId)
+            .OrderBy(v => v.EntidadeTipo)
+            .ThenBy(v => v.EntidadeId)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. vinculos.Select(v => (v.EntidadeTipo, v.EntidadeId))];
+    }
+
+    public Task<AtoNormativo?> ObterAtoConflitanteNoObjetoAsync(
+        string entidadeTipo,
+        Guid entidadeId,
+        string tipoCodigo,
+        IReadOnlyCollection<Guid> idsDaPropriaCadeia,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entidadeTipo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tipoCodigo);
+        ArgumentNullException.ThrowIfNull(idsDaPropriaCadeia);
+
+        string tipoNorm = entidadeTipo.Trim();
+        string codigoNorm = tipoCodigo.Trim();
+        Guid[] daPropriaCadeia = [.. idsDaPropriaCadeia];
+
+        return _dbContext.AtosNormativos
+            .AsNoTracking()
+            .Where(a => a.TipoCodigo == codigoNorm
+                && !daPropriaCadeia.Contains(a.Id)
+                && _dbContext.VinculosAtoEntidade
+                    .Any(v => v.AtoId == a.Id && v.EntidadeTipo == tipoNorm && v.EntidadeId == entidadeId))
+            .OrderBy(a => a.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<AtoNormativo> Itens, (string SortKey, Guid Id)? Anterior, (string SortKey, Guid Id)? Proximo)>
+        ListarPorEntidadeAsync(
+            string entidadeTipo,
+            Guid entidadeId,
+            string? afterSortKey,
+            Guid? afterId,
+            int limit,
+            PaginationDirection direction,
+            CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(entidadeTipo);
+
+        string tipoNorm = entidadeTipo.Trim();
+
+        // EXISTS sobre o vínculo, servido por ix_vinculo_ato_entidade_objeto — não um
+        // JOIN, que duplicaria o ato vinculado à mesma entidade por mais de um caminho.
+        IQueryable<AtoNormativo> query = _dbContext.AtosNormativos
+            .AsNoTracking()
+            .Where(a => _dbContext.VinculosAtoEntidade
+                .Any(v => v.AtoId == a.Id && v.EntidadeTipo == tipoNorm && v.EntidadeId == entidadeId));
+
+        KeysetOrdenadoPage<AtoNormativo> page = await KeysetOrdenadoCursor
+            .ApplyAsync(
+                query,
+                b => b.Ascending(a => a.DataPublicacao).Ascending(a => a.Id),
+                SortKeyDaData,
+                (sortKey, id) => new { DataPublicacao = DataDaSortKey(sortKey), Id = id },
+                afterSortKey,
+                afterId,
+                limit,
+                direction,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.Anterior, page.Proximo);
+    }
+
+    /// <summary>
+    /// Sort key da âncora: a data de publicação em ISO-8601 (<c>yyyy-MM-dd</c>). Ordem
+    /// lexicográfica e ordem cronológica coincidem nesse formato, e ele é estável entre
+    /// culturas. Nunca nula (ADR-0095): <c>data_publicacao</c> é coluna obrigatória.
+    /// </summary>
+    private static string SortKeyDaData(AtoNormativo ato) =>
+        ato.DataPublicacao.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static DateOnly DataDaSortKey(string sortKey) =>
+        DateOnly.ParseExact(sortKey, "yyyy-MM-dd", CultureInfo.InvariantCulture);
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorResourceTag.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/CursorResourceTag.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+
+using System.Globalization;
+
+/// <summary>
+/// Compõe a etiqueta de recurso que viaja dentro do cursor opaco
+/// (<see cref="CursorPayload.ResourceTag"/>, ADR-0026) — o campo que impede um cursor
+/// emitido num recurso de ser navegado noutro.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Na maioria dos recursos a etiqueta é uma constante (<c>"atos"</c>, <c>"editais"</c>).
+/// Ela deixa de bastar quando a coleção é <b>escopada por um segmento da rota</b>: os
+/// atos de um certame e os de outro são coleções distintas sob a mesma etiqueta, e um
+/// cursor emitido numa retomaria a paginação da outra — na âncora errada, com resultados
+/// que o cliente não pediu. Acrescentar os valores de rota ao escopo fecha isso.
+/// </para>
+/// <para>
+/// <b>Um só compositor, para os dois lados.</b> A etiqueta é montada na emissão (pelo
+/// controller) e conferida na leitura (pelo binder). Se cada lado a montasse à sua
+/// maneira, uma diferença de separador, de ordem ou de grafia invalidaria todos os
+/// cursores legítimos — e o sintoma seria um 400 inexplicável, não um erro de compilação.
+/// </para>
+/// <para>
+/// A normalização existe porque o binder lê o segmento <b>cru</b> da URL, e o controller,
+/// o valor já tipado: <c>…/8B3E…/atos</c> e <c>…/8b3e…/atos</c> designam a mesma entidade,
+/// e têm de produzir a mesma etiqueta. Um valor que seja um GUID é reduzido à forma
+/// canônica; os demais vão como estão, apenas sem espaços nas pontas.
+/// </para>
+/// </remarks>
+public static class CursorResourceTag
+{
+    private const char Separador = ':';
+
+    /// <summary>
+    /// Devolve <paramref name="resource"/> quando não há valores de escopo, ou
+    /// <c>recurso:valor1:valor2</c> na ordem dada.
+    /// </summary>
+    public static string Compose(string resource, IEnumerable<string?> valoresDeEscopo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(resource);
+        ArgumentNullException.ThrowIfNull(valoresDeEscopo);
+
+        string[] normalizados = [.. valoresDeEscopo.Select(Normalizar)];
+
+        return normalizados.Length == 0
+            ? resource
+            : string.Join(Separador, [resource, .. normalizados]);
+    }
+
+    private static string Normalizar(string? valor)
+    {
+        string bruto = valor?.Trim() ?? string.Empty;
+
+        return Guid.TryParse(bruto, CultureInfo.InvariantCulture, out Guid id)
+            ? id.ToString("D", CultureInfo.InvariantCulture)
+            : bruto;
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/FromCursorAttribute.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/FromCursorAttribute.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Infrastructure.Core.Pagination;
 
+using System.Diagnostics.CodeAnalysis;
+
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
@@ -39,4 +41,24 @@ public sealed class FromCursorAttribute : ModelBinderAttribute
     /// multi-coluna, nos quais a âncora é o par <c>(SortKey, Id)</c>.
     /// </summary>
     public bool RequireSortKey { get; init; }
+
+    /// <summary>
+    /// Nomes dos valores de rota que escopam a coleção (ex.:
+    /// <c>["entidadeTipo", "entidadeId"]</c> em
+    /// <c>/api/publicacoes/entidades/{entidadeTipo}/{entidadeId}/atos</c>). O binder
+    /// compõe a etiqueta esperada com eles (<see cref="CursorResourceTag"/>), de modo que
+    /// um cursor emitido para uma entidade não seja navegável na coleção de outra — mesmo
+    /// recurso, coleções distintas. Vazio na maioria dos recursos, cuja coleção é única e
+    /// a etiqueta, uma constante.
+    /// </summary>
+    /// <remarks>
+    /// Quem emite tem de compor a etiqueta com os <b>mesmos</b> valores, na mesma ordem,
+    /// pelo mesmo <see cref="CursorResourceTag.Compose"/> — senão nenhum cursor emitido
+    /// passa na conferência.
+    /// </remarks>
+    [SuppressMessage(
+        "Performance",
+        "CA1819:Properties should not return arrays",
+        Justification = "Argumento nomeado de atributo — a linguagem só admite array aqui.")]
+    public string[] ScopeRouteValues { get; init; } = [];
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/KeysetOrdenadoCursor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/KeysetOrdenadoCursor.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using MR.EntityFrameworkCore.KeysetPagination;
 
-using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
 using Unifesspa.UniPlus.Kernel.Pagination;
 
 /// <summary>
@@ -34,6 +34,11 @@ public sealed record KeysetOrdenadoPage<T>(
 /// <para><b>Flags bidirecionais (ADR-0089):</b> <c>EnsureCorrectOrder</c> restaura a ordem
 /// ascendente na navegação <c>Backward</c>; <c>HasPreviousAsync</c>/<c>HasNextAsync</c>
 /// resolvem os lados por <c>EXISTS</c> indexado (sem <c>COUNT</c>).</para>
+/// <para><b>Ciclo de vida da entidade é irrelevante aqui:</b> a restrição é
+/// <see cref="IIdentificavel"/>, a base comum de <c>EntityBase</c> e de
+/// <c>IForensicEntity</c> — o keyset só precisa de um <c>Id</c> ordenável para
+/// desempatar a chave de ordenação. Assim uma entidade append-only (ex.: o ato
+/// publicado) pagina pelo mesmo motor, sem herdar soft-delete nem auditoria.</para>
 /// </remarks>
 public static class KeysetOrdenadoCursor
 {
@@ -47,7 +52,7 @@ public static class KeysetOrdenadoCursor
         int limit,
         PaginationDirection direction,
         CancellationToken cancellationToken = default)
-        where T : EntityBase
+        where T : class, IIdentificavel
     {
         ArgumentNullException.ThrowIfNull(filtered);
         ArgumentNullException.ThrowIfNull(buildKeyset);

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PageRequestModelBinder.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Pagination/PageRequestModelBinder.cs
@@ -84,8 +84,20 @@ public sealed class PageRequestModelBinder : IModelBinder
                     return;
 
                 case CursorDecodeStatus.Success:
+                    // A etiqueta esperada inclui os valores de rota que escopam a coleção
+                    // (ADR-0026): sem isso, um cursor emitido na coleção de uma entidade
+                    // retomaria a paginação na coleção de outra, numa âncora que não é
+                    // dela. Coleção única (a maioria) ⇒ a etiqueta é a constante do
+                    // atributo, e nada muda.
+                    string etiquetaEsperada = CursorResourceTag.Compose(
+                        attribute.Resource,
+                        attribute.ScopeRouteValues.Select(nome =>
+                            bindingContext.ActionContext.RouteData.Values.TryGetValue(nome, out object? valor)
+                                ? valor?.ToString()
+                                : null));
+
                     if (!Guid.TryParse(decoded.Payload!.After, out Guid parsedAfter)
-                        || !string.Equals(decoded.Payload.ResourceTag, attribute.Resource, StringComparison.Ordinal))
+                        || !string.Equals(decoded.Payload.ResourceTag, etiquetaEsperada, StringComparison.Ordinal))
                     {
                         FailWith(bindingContext, CursorBindingErrorCodes.Invalido, "O cursor informado é inválido.");
                         return;

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/RegistrarAtoNormativoVinculosTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/RegistrarAtoNormativoVinculosTests.cs
@@ -1,0 +1,272 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.Commands;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
+using Unifesspa.UniPlus.Publicacoes.Application.Commands.AtosNormativos;
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
+using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
+
+/// <summary>
+/// O vínculo genérico no registro do ato (ADR-0105) e a vaga que a linhagem reserva
+/// (ADR-0107), do ponto de vista do handler: a herança de vínculos pela retificação, a
+/// reserva da vaga, e a recusa quando o objeto já é tratado por outra linhagem.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class RegistrarAtoNormativoVinculosTests
+{
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    private const string Tipo = "EDITAL_ABERTURA";
+    private const string ProcessoSeletivo = "PROCESSO_SELETIVO";
+    private static readonly DateOnly Publicacao = new(2026, 3, 13);
+    private static readonly DateTimeOffset Agora = new(2026, 3, 13, 19, 0, 0, TimeSpan.Zero);
+    private static readonly Guid Processo = Guid.CreateVersion7();
+
+    private readonly ITipoAtoPublicadoRepository _tipos = Substitute.For<ITipoAtoPublicadoRepository>();
+    private readonly IAtoNormativoRepository _atos = Substitute.For<IAtoNormativoRepository>();
+    private readonly IPublicacoesUnitOfWork _unitOfWork = Substitute.For<IPublicacoesUnitOfWork>();
+    private readonly TimeProvider _relogio = new RelogioFixo(Agora);
+
+    [Fact(DisplayName = "Registra o ato com os vínculos declarados")]
+    public async Task Handle_ComVinculos_Registra()
+    {
+        Vigente(unico: false);
+        SemConflitoDeNumero();
+
+        AtoNormativo? registrado = null;
+        await _atos.AdicionarAsync(Arg.Do<AtoNormativo>(a => registrado = a), Arg.Any<CancellationToken>());
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(Comando(vinculos: [new(ProcessoSeletivo, Processo)]));
+
+        resultado.IsSuccess.Should().BeTrue();
+        registrado!.Vinculos.Should().ContainSingle()
+            .Which.EntidadeId.Should().Be(Processo);
+    }
+
+    [Fact(DisplayName = "Tipo não único por objeto não reserva vaga alguma")]
+    public async Task Handle_TipoNaoUnico_NaoReservaVaga()
+    {
+        Vigente(unico: false);
+        SemConflitoDeNumero();
+
+        await Executar(Comando(vinculos: [new(ProcessoSeletivo, Processo)]));
+
+        await _atos.DidNotReceive().AdicionarLinhagemAsync(
+            Arg.Any<LinhagemUnicaPorObjeto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Tipo único por objeto reserva a vaga em nome da própria raiz")]
+    public async Task Handle_TipoUnico_ReservaVaga()
+    {
+        Vigente(unico: true);
+        SemConflitoDeNumero();
+        SemConflitoNoObjeto();
+        VagaLivre();
+
+        AtoNormativo? registrado = null;
+        await _atos.AdicionarAsync(Arg.Do<AtoNormativo>(a => registrado = a), Arg.Any<CancellationToken>());
+
+        LinhagemUnicaPorObjeto? vaga = null;
+        await _atos.AdicionarLinhagemAsync(
+            Arg.Do<LinhagemUnicaPorObjeto>(l => vaga = l), Arg.Any<CancellationToken>());
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando(vinculos: [new(ProcessoSeletivo, Processo)]));
+
+        resultado.IsSuccess.Should().BeTrue();
+        vaga.Should().NotBeNull();
+        vaga!.RaizId.Should().Be(registrado!.Id, "o ato não emenda ninguém: a linhagem nasce nele");
+        vaga.EntidadeId.Should().Be(Processo);
+        vaga.TipoCodigo.Should().Be(Tipo);
+    }
+
+    [Fact(DisplayName = "Tipo único por objeto sem vínculo não reserva vaga — sem objeto, não há vaga")]
+    public async Task Handle_TipoUnicoSemVinculo_NaoReservaVaga()
+    {
+        Vigente(unico: true);
+        SemConflitoDeNumero();
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(Comando(vinculos: null));
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _atos.DidNotReceive().AdicionarLinhagemAsync(
+            Arg.Any<LinhagemUnicaPorObjeto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Recusa com 409 quando outra linhagem já trata o objeto com um ato do mesmo tipo")]
+    public async Task Handle_ObjetoTratadoPorOutraLinhagem_Falha()
+    {
+        Vigente(unico: true);
+        SemConflitoDeNumero();
+        VagaLivre();
+
+        AtoNormativo deOutraLinhagem = AtoDeOutraLinhagem();
+        _atos.ObterAtoConflitanteNoObjetoAsync(
+                ProcessoSeletivo, Processo, Tipo, Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns(deOutraLinhagem);
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando(vinculos: [new(ProcessoSeletivo, Processo)]));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(AtoNormativoErrorCodes.ObjetoJaTemAtoVivoDoTipo);
+        resultado.Error.Message.Should().Contain(deOutraLinhagem.Id.ToString());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "A retificação herda os vínculos do ato que emenda")]
+    public async Task Handle_Retificacao_HerdaVinculos()
+    {
+        Vigente(unico: false);
+        SemConflitoDeNumero();
+
+        AtoNormativo retificado = AtoRetificado();
+        _atos.ObterPorIdParaLeituraAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(retificado);
+        _atos.ObterRetificadorAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns((AtoNormativo?)null);
+        _atos.ListarIdsDaCadeiaAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns([retificado.Id]);
+        _atos.ListarVinculosDoAtoAsync(retificado.Id, Arg.Any<CancellationToken>())
+            .Returns([(ProcessoSeletivo, Processo)]);
+
+        AtoNormativo? registrado = null;
+        await _atos.AdicionarAsync(Arg.Do<AtoNormativo>(a => registrado = a), Arg.Any<CancellationToken>());
+
+        // A retificação não declara vínculo nenhum: sem herança, sumiria da consulta do
+        // certame, e a consulta exibiria a versão superada escondendo a que a emenda.
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando(vinculos: null, atoRetificadoId: retificado.Id, motivo: "corrige o anexo"));
+
+        resultado.IsSuccess.Should().BeTrue();
+        registrado!.Vinculos.Should().ContainSingle()
+            .Which.EntidadeId.Should().Be(Processo);
+    }
+
+    [Fact(DisplayName = "A retificação reserva a vaga em nome da raiz da sua linhagem, não de si mesma")]
+    public async Task Handle_RetificacaoDeTipoUnico_ReservaVagaEmNomeDaRaiz()
+    {
+        Vigente(unico: true);
+        SemConflitoDeNumero();
+        SemConflitoNoObjeto();
+        VagaLivre();
+
+        AtoNormativo retificado = AtoRetificado();
+        Guid raiz = Guid.CreateVersion7();
+        _atos.ObterPorIdParaLeituraAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(retificado);
+        _atos.ObterRetificadorAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns((AtoNormativo?)null);
+        _atos.ListarIdsDaCadeiaAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns([raiz, retificado.Id]);
+        _atos.ObterRaizDaCadeiaAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(raiz);
+        _atos.ListarVinculosDoAtoAsync(retificado.Id, Arg.Any<CancellationToken>())
+            .Returns([(ProcessoSeletivo, Processo)]);
+
+        LinhagemUnicaPorObjeto? vaga = null;
+        await _atos.AdicionarLinhagemAsync(
+            Arg.Do<LinhagemUnicaPorObjeto>(l => vaga = l), Arg.Any<CancellationToken>());
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando(vinculos: null, atoRetificadoId: retificado.Id, motivo: "corrige o anexo"));
+
+        resultado.IsSuccess.Should().BeTrue();
+        vaga!.RaizId.Should().Be(raiz, "a vaga é da linhagem, e a linhagem é identificada pela sua raiz");
+    }
+
+    [Fact(DisplayName = "A vaga já ocupada pela própria linhagem não é reservada de novo")]
+    public async Task Handle_VagaDaPropriaLinhagem_NaoReservaDeNovo()
+    {
+        Vigente(unico: true);
+        SemConflitoDeNumero();
+        SemConflitoNoObjeto();
+
+        AtoNormativo retificado = AtoRetificado();
+        Guid raiz = retificado.Id;
+        _atos.ObterPorIdParaLeituraAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(retificado);
+        _atos.ObterRetificadorAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns((AtoNormativo?)null);
+        _atos.ListarIdsDaCadeiaAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns([raiz]);
+        _atos.ObterRaizDaCadeiaAsync(retificado.Id, Arg.Any<CancellationToken>()).Returns(raiz);
+        _atos.ListarVinculosDoAtoAsync(retificado.Id, Arg.Any<CancellationToken>())
+            .Returns([(ProcessoSeletivo, Processo)]);
+
+        AtoNormativo raizDaVaga = AtoRetificado();
+        VinculoAtoEntidade vinculoDaRaiz = raizDaVaga.Vinculos.First();
+        _atos.ObterLinhagemDoObjetoAsync(ProcessoSeletivo, Processo, Tipo, Arg.Any<CancellationToken>())
+            .Returns(LinhagemUnicaPorObjeto.Criar(raizDaVaga, vinculoDaRaiz, raiz));
+
+        Result<RegistrarAtoNormativoResult> resultado = await Executar(
+            Comando(vinculos: null, atoRetificadoId: retificado.Id, motivo: "corrige o anexo"));
+
+        resultado.IsSuccess.Should().BeTrue();
+        await _atos.DidNotReceive().AdicionarLinhagemAsync(
+            Arg.Any<LinhagemUnicaPorObjeto>(), Arg.Any<CancellationToken>());
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private Task<Result<RegistrarAtoNormativoResult>> Executar(RegistrarAtoNormativoCommand comando) =>
+        RegistrarAtoNormativoCommandHandler.Handle(
+            comando, _tipos, _atos, _unitOfWork, _relogio, CancellationToken.None);
+
+    private void Vigente(bool unico)
+    {
+        TipoAtoPublicado tipo = TipoAtoPublicado.Criar(
+            Tipo, "Edital de abertura", congelaConfiguracao: true, unicoPorObjeto: unico,
+            efeitoIrreversivel: false, new DateOnly(2026, 1, 1), null, null).Value!;
+        _tipos.ObterVigenteAsync(Tipo, Publicacao, Arg.Any<CancellationToken>()).Returns(tipo);
+    }
+
+    private void SemConflitoDeNumero() =>
+        _atos.ListarIdsComMesmaNumeracaoAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(),
+            Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+    private void SemConflitoNoObjeto() =>
+        _atos.ObterAtoConflitanteNoObjetoAsync(
+            Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(),
+            Arg.Any<IReadOnlyCollection<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns((AtoNormativo?)null);
+
+    private void VagaLivre() =>
+        _atos.ObterLinhagemDoObjetoAsync(
+            Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((LinhagemUnicaPorObjeto?)null);
+
+    private static AtoNormativo AtoDeOutraLinhagem() =>
+        AtoNormativo.Registrar(
+            "CEPS", "EDITAL", 2026, "99", Tipo,
+            congelaConfiguracao: true, efeitoIrreversivel: false, unicoPorObjeto: true,
+            dataPublicacao: Publicacao, documentoHash: HashValido, assinante: "Jairo Belchior",
+            registradoEm: Agora, versaoInvocada: null,
+            vinculos: [(ProcessoSeletivo, Processo)]);
+
+    private static AtoNormativo AtoRetificado() =>
+        AtoNormativo.Registrar(
+            "CEPS", "EDITAL", 2026, "13", Tipo,
+            congelaConfiguracao: true, efeitoIrreversivel: false, unicoPorObjeto: true,
+            dataPublicacao: Publicacao, documentoHash: HashValido, assinante: "Jairo Belchior",
+            registradoEm: Agora, versaoInvocada: null,
+            vinculos: [(ProcessoSeletivo, Processo)]);
+
+    private static RegistrarAtoNormativoCommand Comando(
+        IReadOnlyList<VinculoEntidadeInput>? vinculos,
+        Guid? atoRetificadoId = null,
+        string? motivo = null) =>
+        new(
+            Orgao: "CEPS",
+            Serie: "EDITAL",
+            Ano: 2026,
+            Numero: "13",
+            TipoCodigo: Tipo,
+            DataPublicacao: Publicacao,
+            DocumentoHash: HashValido,
+            Assinante: "Jairo Belchior",
+            AtoRetificadoId: atoRetificadoId,
+            MotivoRetificacao: motivo,
+            Vinculos: vinculos);
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/TipoAtoPublicadoTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/TipoAtoPublicadoTests.cs
@@ -140,9 +140,33 @@ public sealed class TipoAtoPublicadoTests
         tipo.Nome.Should().Be("Edital de abertura");
     }
 
-    [Fact(DisplayName = "Atualizar aceita novo código — o cadastro é editável")]
-    public void Atualizar_ComCodigoValido_Sucesso()
+    [Fact(DisplayName = "Atualizar edita nome e atributos, mantendo o código")]
+    public void Atualizar_ComMesmoCodigo_Sucesso()
     {
+        TipoAtoPublicado tipo = Novo().Value!;
+
+        Result resultado = tipo.Atualizar(
+            codigo: "EDITAL_ABERTURA",
+            nome: "Edital de abertura de processo seletivo",
+            congelaConfiguracao: true,
+            unicoPorObjeto: false,
+            efeitoIrreversivel: false,
+            vigenciaInicio: Inicio,
+            vigenciaFim: null,
+            baseLegal: null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        tipo.Nome.Should().Be("Edital de abertura de processo seletivo");
+        tipo.UnicoPorObjeto.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Atualizar recusa novo código — o código é a identidade do tipo")]
+    public void Atualizar_ComOutroCodigo_Recusa()
+    {
+        // A série de vigências agrupa-se pelo código (exclusion constraint), e a vaga que
+        // um objeto reserva para uma linhagem de atos únicos é chaveada por ele
+        // (ADR-0107). Renomear partiria o tipo em dois — e abriria uma segunda vaga no
+        // mesmo objeto. Renomear é criar outro tipo.
         TipoAtoPublicado tipo = Novo().Value!;
 
         Result resultado = tipo.Atualizar(
@@ -155,9 +179,9 @@ public sealed class TipoAtoPublicadoTests
             vigenciaFim: null,
             baseLegal: null);
 
-        resultado.IsSuccess.Should().BeTrue();
-        tipo.Codigo.Should().Be("EDITAL_RETIFICACAO");
-        tipo.UnicoPorObjeto.Should().BeFalse();
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.CodigoImutavel);
+        tipo.Codigo.Should().Be("EDITAL_ABERTURA");
     }
 
     [Theory(DisplayName = "A janela é semiaberta: o início entra, o fim não")]

--- a/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/VinculoAtoEntidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/VinculoAtoEntidadeTests.cs
@@ -1,0 +1,162 @@
+namespace Unifesspa.UniPlus.Publicacoes.Domain.UnitTests;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+
+/// <summary>
+/// Invariantes do vínculo genérico ato ↔ entidade (ADR-0105): o rótulo do tipo é
+/// opaco mas tem forma canônica, o identificador da entidade é obrigatório, o
+/// vínculo nasce do próprio ato, e um ato sem vínculo é válido.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit exige tipo de teste público.")]
+public sealed class VinculoAtoEntidadeTests
+{
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    private static readonly DateOnly Publicacao = new(2026, 3, 13);
+    private static readonly DateTimeOffset Registro = new(2026, 3, 13, 19, 0, 0, TimeSpan.Zero);
+    private static readonly Guid Processo = Guid.CreateVersion7();
+    private static readonly Guid Chamada = Guid.CreateVersion7();
+
+    [Fact(DisplayName = "Ato registrado sem vínculo é válido — há atos que não tratam de objeto algum")]
+    public void Registrar_SemVinculos_AtoValido()
+    {
+        AtoNormativo ato = Novo();
+
+        ato.Vinculos.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Um mesmo ato vincula-se a mais de uma entidade")]
+    public void Registrar_ComDuasEntidades_VinculaAsDuas()
+    {
+        AtoNormativo ato = Novo(vinculos:
+        [
+            ("PROCESSO_SELETIVO", Processo),
+            ("CHAMADA", Chamada),
+        ]);
+
+        ato.Vinculos.Should().HaveCount(2);
+        ato.Vinculos.Should().OnlyContain(v => v.AtoId == ato.Id);
+        ato.Vinculos.Select(v => v.EntidadeId).Should().BeEquivalentTo([Processo, Chamada]);
+    }
+
+    [Fact(DisplayName = "O vínculo aponta para o ato que o criou, e o tipo é normalizado")]
+    public void Criar_NormalizaTipoEAtrelaAoAto()
+    {
+        AtoNormativo ato = Novo(vinculos: [("  PROCESSO_SELETIVO  ", Processo)]);
+
+        VinculoAtoEntidade vinculo = ato.Vinculos.Single();
+        vinculo.AtoId.Should().Be(ato.Id);
+        vinculo.EntidadeTipo.Should().Be("PROCESSO_SELETIVO");
+        vinculo.EntidadeId.Should().Be(Processo);
+        vinculo.Id.Should().NotBe(Guid.Empty);
+    }
+
+    [Theory(DisplayName = "Tipo de entidade fora da forma canônica é recusado")]
+    [InlineData("processo_seletivo")]
+    [InlineData("Processo_Seletivo")]
+    [InlineData("PROCESSO-SELETIVO")]
+    [InlineData("PROCESSO SELETIVO")]
+    [InlineData("_PROCESSO")]
+    [InlineData("PROCESSO_")]
+    [InlineData("PROCESSO__SELETIVO")]
+    public void Criar_TipoForaDaFormaCanonica_Recusa(string tipo)
+    {
+        // O rótulo é opaco — o módulo não sabe o que significa —, mas a grafia é
+        // única: sem isso a mesma entidade se partiria em duas na consulta.
+        Action acao = () => Novo(vinculos: [(tipo, Processo)]);
+
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Fact(DisplayName = "Tipo de entidade com dígitos é aceito — o rótulo é opaco")]
+    public void Criar_TipoComDigitos_Aceita()
+    {
+        AtoNormativo ato = Novo(vinculos: [("APLICACAO_PROVA_2", Processo)]);
+
+        ato.Vinculos.Single().EntidadeTipo.Should().Be("APLICACAO_PROVA_2");
+    }
+
+    [Fact(DisplayName = "Identificador vazio de entidade é recusado")]
+    public void Criar_EntidadeIdVazio_Recusa()
+    {
+        Action acao = () => Novo(vinculos: [("PROCESSO_SELETIVO", Guid.Empty)]);
+
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Fact(DisplayName = "A mesma entidade vinculada duas vezes ao mesmo ato é recusada")]
+    public void Registrar_MesmaEntidadeDuasVezes_Recusa()
+    {
+        Action acao = () => Novo(vinculos:
+        [
+            ("PROCESSO_SELETIVO", Processo),
+            ("PROCESSO_SELETIVO", Processo),
+        ]);
+
+        acao.Should().Throw<ArgumentException>();
+    }
+
+    [Fact(DisplayName = "A mesma entidade em tipos distintos não é duplicata")]
+    public void Registrar_MesmoIdEmTiposDistintos_Aceita()
+    {
+        // O par (tipo, id) é a chave: o mesmo Guid sob rótulos diferentes designa
+        // objetos diferentes — o módulo não interpreta nenhum dos dois.
+        AtoNormativo ato = Novo(vinculos:
+        [
+            ("PROCESSO_SELETIVO", Processo),
+            ("CHAMADA", Processo),
+        ]);
+
+        ato.Vinculos.Should().HaveCount(2);
+    }
+
+    [Fact(DisplayName = "A vaga do objeto é reservada em nome da linhagem, não do ato")]
+    public void LinhagemUnicaPorObjeto_CriaComRaizDaLinhagem()
+    {
+        AtoNormativo raiz = Novo(unicoPorObjeto: true, vinculos: [("PROCESSO_SELETIVO", Processo)]);
+
+        LinhagemUnicaPorObjeto vaga = LinhagemUnicaPorObjeto.Criar(
+            raiz, raiz.Vinculos.Single(), raizId: raiz.Id);
+
+        vaga.EntidadeTipo.Should().Be("PROCESSO_SELETIVO");
+        vaga.EntidadeId.Should().Be(Processo);
+        vaga.TipoCodigo.Should().Be(raiz.TipoCodigo);
+        vaga.RaizId.Should().Be(raiz.Id);
+        vaga.AtoId.Should().Be(raiz.Id);
+    }
+
+    [Fact(DisplayName = "Um ato de tipo não único por objeto não reserva vaga alguma")]
+    public void LinhagemUnicaPorObjeto_AtoNaoUnico_Recusa()
+    {
+        AtoNormativo ato = Novo(unicoPorObjeto: false, vinculos: [("PROCESSO_SELETIVO", Processo)]);
+
+        Action acao = () => LinhagemUnicaPorObjeto.Criar(ato, ato.Vinculos.Single(), raizId: ato.Id);
+
+        acao.Should().Throw<InvalidOperationException>();
+    }
+
+    private static AtoNormativo Novo(
+        bool unicoPorObjeto = false,
+        IEnumerable<(string EntidadeTipo, Guid EntidadeId)>? vinculos = null) =>
+        AtoNormativo.Registrar(
+            orgao: "CEPS",
+            serie: "EDITAL",
+            ano: 2026,
+            numero: "13",
+            tipoCodigo: "EDITAL_ABERTURA",
+            congelaConfiguracao: true,
+            efeitoIrreversivel: false,
+            unicoPorObjeto: unicoPorObjeto,
+            dataPublicacao: Publicacao,
+            documentoHash: HashValido,
+            assinante: "Jairo Belchior",
+            registradoEm: Registro,
+            versaoInvocada: null,
+            vinculos: vinculos);
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtosDaEntidadeEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/AtosDaEntidadeEndpointTests.cs
@@ -1,0 +1,540 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.AtosNormativos;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// A consulta unificada (ADR-0105) e a unicidade de linhagem por objeto (ADR-0107),
+/// exercitadas por HTTP contra o monólito real: os atos de uma entidade em ordem
+/// cronológica, a herança de vínculos pela retificação, e as recusas que impedem um
+/// objeto de ser tratado por duas linhagens.
+/// </summary>
+[Collection(PublicacoesEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class AtosDaEntidadeEndpointTests
+{
+    private const string AdminAtos = "/api/publicacoes/admin/atos";
+    private const string AdminTipos = "/api/publicacoes/admin/tipos-ato";
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    private const string ProcessoSeletivo = "PROCESSO_SELETIVO";
+
+    private readonly PublicacoesEndpointFixture _fixture;
+
+    public AtosDaEntidadeEndpointTests(PublicacoesEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    // ── A consulta unificada ─────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Uma entidade acumula vários atos, devolvidos em ordem de data de publicação")]
+    public async Task Listar_VariosAtos_OrdenadosPorDataDePublicacao()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: false);
+        Guid chamada = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        // A chamada reúne convocação, retificação da convocação e homologação — o caso
+        // que a story cita, publicado fora de ordem de propósito.
+        Guid homologacao = await PostAtoIdAsync(client, PayloadAto(tipo, "20", "2026-04-10", [Vinculo(chamada)]));
+        Guid convocacao = await PostAtoIdAsync(client, PayloadAto(tipo, "10", "2026-03-01", [Vinculo(chamada)]));
+        Guid retificacao = await PostAtoIdAsync(
+            client, PayloadRetificacao(tipo, "10", "2026-03-05", convocacao, "corrige o horário", []));
+
+        JsonElement[] itens = await ListarDaEntidadeAsync(client, ProcessoSeletivo, chamada);
+
+        itens.Select(i => i.GetProperty("id").GetGuid())
+            .Should().Equal(convocacao, retificacao, homologacao);
+    }
+
+    [Fact(DisplayName = "A retificação herda o vínculo do ato que emenda — sem isso, sumiria da consulta")]
+    public async Task Listar_Retificacao_HerdaVinculoDoRetificado()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: false);
+        Guid processo = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid raiz = await PostAtoIdAsync(client, PayloadAto(tipo, "13", "2026-03-13", [Vinculo(processo)]));
+        // A retificação não declara vínculo algum.
+        Guid retificacao = await PostAtoIdAsync(
+            client, PayloadRetificacao(tipo, "13", "2026-03-14", raiz, "corrige o anexo", []));
+
+        JsonElement[] itens = await ListarDaEntidadeAsync(client, ProcessoSeletivo, processo);
+
+        itens.Select(i => i.GetProperty("id").GetGuid()).Should().Contain(retificacao);
+        itens.Should().HaveCount(2);
+    }
+
+    [Fact(DisplayName = "Entidade sem ato algum devolve coleção vazia — o módulo não sabe se ela existe")]
+    public async Task Listar_EntidadeSemAtos_DevolveVazio()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        JsonElement[] itens = await ListarDaEntidadeAsync(client, ProcessoSeletivo, Guid.CreateVersion7());
+
+        itens.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Tipo de entidade fora da grafia canônica devolve 400 — e não uma coleção vazia")]
+    public async Task Listar_TipoForaDaGrafiaCanonica_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage resposta = await client.GetAsync(
+            new Uri($"/api/publicacoes/entidades/processo-seletivo/{Guid.CreateVersion7()}/atos", UriKind.Relative));
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "Um ato vincula-se a mais de uma entidade, e aparece na consulta das duas")]
+    public async Task Listar_AtoComDoisVinculos_ApareceNasDuasConsultas()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: false);
+        Guid processo = Guid.CreateVersion7();
+        Guid chamada = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid ato = await PostAtoIdAsync(
+            client,
+            PayloadAto(tipo, "13", "2026-03-13", [Vinculo(processo), Vinculo(chamada, "CHAMADA")]));
+
+        (await ListarDaEntidadeAsync(client, ProcessoSeletivo, processo))
+            .Select(i => i.GetProperty("id").GetGuid()).Should().Equal(ato);
+        (await ListarDaEntidadeAsync(client, "CHAMADA", chamada))
+            .Select(i => i.GetProperty("id").GetGuid()).Should().Equal(ato);
+    }
+
+    [Fact(DisplayName = "O cursor de uma entidade não navega a coleção de outra")]
+    public async Task Listar_CursorDeOutraEntidade_Retorna400()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: false);
+        Guid processo = Guid.CreateVersion7();
+        Guid outroProcesso = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        await PostAtoIdAsync(client, PayloadAto(tipo, "1", "2026-03-01", [Vinculo(processo)]));
+        await PostAtoIdAsync(client, PayloadAto(tipo, "2", "2026-03-02", [Vinculo(processo)]));
+
+        // Página de tamanho 1 na coleção do primeiro processo: o link "next" carrega um
+        // cursor escopado àquela entidade.
+        HttpResponseMessage primeira = await client.GetAsync(
+            new Uri($"/api/publicacoes/entidades/{ProcessoSeletivo}/{processo}/atos?limit=1", UriKind.Relative));
+        primeira.StatusCode.Should().Be(HttpStatusCode.OK);
+        string cursor = ExtrairCursorDoLinkNext(primeira);
+
+        HttpResponseMessage naOutraColecao = await client.GetAsync(new Uri(
+            $"/api/publicacoes/entidades/{ProcessoSeletivo}/{outroProcesso}/atos?cursor={Uri.EscapeDataString(cursor)}&direction=next",
+            UriKind.Relative));
+
+        naOutraColecao.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "Cursor forjado devolve 400 — nunca 500")]
+    public async Task Listar_CursorForjado_Retorna400()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage resposta = await client.GetAsync(new Uri(
+            $"/api/publicacoes/entidades/{ProcessoSeletivo}/{Guid.CreateVersion7()}/atos?cursor=nao-e-um-cursor",
+            UriKind.Relative));
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact(DisplayName = "A paginação percorre a coleção da entidade em ordem, sem repetir nem pular")]
+    public async Task Listar_Paginado_PercorreEmOrdem()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: false);
+        Guid processo = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid a = await PostAtoIdAsync(client, PayloadAto(tipo, "1", "2026-03-01", [Vinculo(processo)]));
+        Guid b = await PostAtoIdAsync(client, PayloadAto(tipo, "2", "2026-03-02", [Vinculo(processo)]));
+        Guid c = await PostAtoIdAsync(client, PayloadAto(tipo, "3", "2026-03-03", [Vinculo(processo)]));
+
+        List<Guid> percorridos = [];
+        string url = $"/api/publicacoes/entidades/{ProcessoSeletivo}/{processo}/atos?limit=2";
+
+        while (true)
+        {
+            // O link de navegação vem absoluto (RFC 5988), o primeiro request é relativo.
+            HttpResponseMessage resposta = await client.GetAsync(new Uri(url, UriKind.RelativeOrAbsolute));
+            resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+            using JsonDocument corpo = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+            percorridos.AddRange(corpo.RootElement.EnumerateArray().Select(i => i.GetProperty("id").GetGuid()));
+
+            string? proxima = LinkDe(resposta, "next");
+            if (proxima is null)
+            {
+                break;
+            }
+
+            url = proxima;
+        }
+
+        percorridos.Should().Equal(a, b, c);
+    }
+
+    // ── Unicidade de linhagem por objeto (ADR-0107) ──────────────────────────
+
+    [Fact(DisplayName = "Duas linhagens do mesmo tipo único no mesmo objeto: a segunda recebe 409")]
+    public async Task Registrar_SegundaLinhagemNoMesmoObjeto_Retorna409()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: true);
+        Guid processo = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        await PostAtoIdAsync(client, PayloadAto(tipo, "13", "2026-03-13", [Vinculo(processo)]));
+
+        HttpResponseMessage segunda = await PostAtoAsync(
+            client, PayloadAto(tipo, "14", "2026-03-14", [Vinculo(processo)]));
+
+        segunda.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await segunda.Content.ReadAsStringAsync())
+            .Should().Contain("uniplus.publicacoes.ato_normativo.objeto_ja_tem_ato_vivo_do_tipo");
+    }
+
+    [Fact(DisplayName = "A retificação da linhagem que ocupa o objeto é aceita — a vaga é da linhagem, não do ato")]
+    public async Task Registrar_RetificacaoDaLinhagemQueOcupa_Retorna201()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: true);
+        Guid processo = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid raiz = await PostAtoIdAsync(client, PayloadAto(tipo, "13", "2026-03-13", [Vinculo(processo)]));
+
+        HttpResponseMessage retificacao = await PostAtoAsync(
+            client, PayloadRetificacao(tipo, "13", "2026-03-13", raiz, "corrige o anexo", [Vinculo(processo)]));
+
+        retificacao.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact(DisplayName = "Uma retificação de outra linhagem não invade o objeto ocupado (o furo do índice sobre a raiz)")]
+    public async Task Registrar_RetificacaoDeOutraLinhagemNoObjetoOcupado_Retorna409()
+    {
+        // Um índice único parcial filtrado por "o ato é raiz" deixaria isto passar: a
+        // retificação não é raiz e escaparia do filtro. A vaga é chaveada pela linhagem,
+        // e é isso que fecha o furo.
+        string tipo = await CriarTipoAsync(unicoPorObjeto: true);
+        Guid processo = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        await PostAtoIdAsync(client, PayloadAto(tipo, "13", "2026-03-13", [Vinculo(processo)]));
+
+        // Outra linhagem, publicada sem vínculo — passa, porque sem objeto não há vaga.
+        Guid raizSemVinculo = await PostAtoIdAsync(client, PayloadAto(tipo, "99", "2026-03-20", []));
+
+        // A retificação dela tenta vincular o objeto que a primeira linhagem já trata.
+        HttpResponseMessage invasora = await PostAtoAsync(
+            client,
+            PayloadRetificacao(tipo, "99", "2026-03-21", raizSemVinculo, "vincula o processo", [Vinculo(processo)]));
+
+        invasora.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await invasora.Content.ReadAsStringAsync())
+            .Should().Contain("uniplus.publicacoes.ato_normativo.objeto_ja_tem_ato_vivo_do_tipo");
+    }
+
+    [Fact(DisplayName = "Ato publicado antes de o tipo virar único por objeto ainda bloqueia a segunda linhagem")]
+    public async Task Registrar_AtoAnteriorAoAtributo_AindaBloqueia()
+    {
+        // O catálogo é editável: o primeiro ato não reservou vaga alguma, porque no seu
+        // instante o tipo não era único por objeto. É a consulta ao histórico de atos —
+        // não a tabela de vagas — que enxerga isso.
+        Guid processo = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        (string codigo, Guid tipoId) = await CriarTipoComIdAsync(unicoPorObjeto: false);
+        await PostAtoIdAsync(client, PayloadAto(codigo, "13", "2026-03-13", [Vinculo(processo)]));
+
+        await AtualizarTipoAsync(client, tipoId, codigo, unicoPorObjeto: true);
+
+        HttpResponseMessage segunda = await PostAtoAsync(
+            client, PayloadAto(codigo, "14", "2026-03-14", [Vinculo(processo)]));
+
+        segunda.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await segunda.Content.ReadAsStringAsync())
+            .Should().Contain("uniplus.publicacoes.ato_normativo.objeto_ja_tem_ato_vivo_do_tipo");
+    }
+
+    [Fact(DisplayName = "Um ato de tipo único retifica outro de tipo único distinto, e cada tipo tem a sua vaga no objeto")]
+    public async Task Registrar_RetificacaoDeTipoDistinto_ReservaVagaDoSeuProprioTipo()
+    {
+        // A ADR-0103 admite que um tipo emende outro (um aviso retifica um edital), desde
+        // que a classe de congelamento coincida. A vaga é por (objeto, tipo do ato): o
+        // aviso abre a sua própria vaga no mesmo objeto, sem disputar a do edital.
+        string edital = await CriarTipoAsync(unicoPorObjeto: true);
+        string aviso = await CriarTipoAsync(unicoPorObjeto: true);
+        Guid processo = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid raiz = await PostAtoIdAsync(client, PayloadAto(edital, "13", "2026-03-13", [Vinculo(processo)]));
+
+        HttpResponseMessage retificacao = await PostAtoAsync(
+            client, PayloadRetificacao(aviso, "50", "2026-03-20", raiz, "prorroga o prazo", []));
+
+        retificacao.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Os dois atos tratam do mesmo processo: o aviso herdou o vínculo do edital.
+        (await ListarDaEntidadeAsync(client, ProcessoSeletivo, processo)).Should().HaveCount(2);
+    }
+
+    [Fact(DisplayName = "Tipo único por objeto sem vínculo algum é registrável — sem objeto, não há vaga")]
+    public async Task Registrar_UnicoPorObjetoSemVinculo_Retorna201()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: true);
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        await PostAtoIdAsync(client, PayloadAto(tipo, "13", "2026-03-13", []));
+        HttpResponseMessage segundo = await PostAtoAsync(client, PayloadAto(tipo, "14", "2026-03-14", []));
+
+        segundo.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact(DisplayName = "Objetos distintos não disputam a mesma vaga")]
+    public async Task Registrar_ObjetosDistintos_Retorna201()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: true);
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        await PostAtoIdAsync(client, PayloadAto(tipo, "13", "2026-03-13", [Vinculo(Guid.CreateVersion7())]));
+        HttpResponseMessage outro = await PostAtoAsync(
+            client, PayloadAto(tipo, "14", "2026-03-14", [Vinculo(Guid.CreateVersion7())]));
+
+        outro.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact(DisplayName = "A mesma entidade vinculada duas vezes ao mesmo ato é recusada com 422")]
+    public async Task Registrar_VinculoDuplicadoNoPayload_Retorna422()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: false);
+        Guid processo = Guid.CreateVersion7();
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage resposta = await PostAtoAsync(
+            client, PayloadAto(tipo, "13", "2026-03-13", [Vinculo(processo), Vinculo(processo)]));
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "Elemento nulo na lista de vínculos é recusado com 422 — nunca 500")]
+    public async Task Registrar_VinculoNulo_Retorna422()
+    {
+        // A anotação de nulidade do record não impede um `"vinculos": [null]` no corpo.
+        string tipo = await CriarTipoAsync(unicoPorObjeto: false);
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage resposta = await PostAtoAsync(
+            client,
+            new
+            {
+                orgao = "CEPS",
+                serie = "EDITAL",
+                ano = 2026,
+                numero = "13",
+                tipoCodigo = tipo,
+                dataPublicacao = "2026-03-13",
+                documentoHash = HashValido,
+                assinante = "Jairo Belchior",
+                vinculos = new object?[] { null },
+            });
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "Rótulo de entidade fora da grafia canônica é recusado com 422")]
+    public async Task Registrar_RotuloForaDaGrafia_Retorna422()
+    {
+        string tipo = await CriarTipoAsync(unicoPorObjeto: false);
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage resposta = await PostAtoAsync(
+            client,
+            PayloadAto(tipo, "13", "2026-03-13", [Vinculo(Guid.CreateVersion7(), "processo-seletivo")]));
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static object Vinculo(Guid entidadeId, string entidadeTipo = ProcessoSeletivo) =>
+        new { entidadeTipo, entidadeId };
+
+    private static async Task<JsonElement[]> ListarDaEntidadeAsync(HttpClient client, string tipo, Guid id)
+    {
+        HttpResponseMessage resposta = await client.GetAsync(
+            new Uri($"/api/publicacoes/entidades/{tipo}/{id}/atos", UriKind.Relative));
+        resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument corpo = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        return [.. corpo.RootElement.EnumerateArray().Select(e => e.Clone())];
+    }
+
+    private static string ExtrairCursorDoLinkNext(HttpResponseMessage resposta)
+    {
+        string proxima = LinkDe(resposta, "next")
+            ?? throw new InvalidOperationException("A resposta não trouxe link 'next'.");
+
+        string query = new Uri(proxima, UriKind.RelativeOrAbsolute).IsAbsoluteUri
+            ? new Uri(proxima).Query
+            : proxima[proxima.IndexOf('?', StringComparison.Ordinal)..];
+
+        return Microsoft.AspNetCore.WebUtilities.QueryHelpers.ParseQuery(query)["cursor"]!;
+    }
+
+    private static string? LinkDe(HttpResponseMessage resposta, string rel)
+    {
+        if (!resposta.Headers.TryGetValues("Link", out IEnumerable<string>? valores))
+        {
+            return null;
+        }
+
+        foreach (string parte in string.Join(',', valores).Split(','))
+        {
+            if (!parte.Contains($"rel=\"{rel}\"", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            int abre = parte.IndexOf('<', StringComparison.Ordinal);
+            int fecha = parte.IndexOf('>', StringComparison.Ordinal);
+            return parte[(abre + 1)..fecha];
+        }
+
+        return null;
+    }
+
+    private async Task<string> CriarTipoAsync(bool unicoPorObjeto)
+    {
+        (string codigo, _) = await CriarTipoComIdAsync(unicoPorObjeto);
+        return codigo;
+    }
+
+    private async Task<(string Codigo, Guid Id)> CriarTipoComIdAsync(bool unicoPorObjeto)
+    {
+        // O código do tipo de ato admite só letras (UPPER_SNAKE, sem dígitos): mapeia os
+        // hexadígitos do Guid para letras, mantendo a unicidade entre os testes.
+        string codigo = "TIPO_" + string.Concat(
+            Guid.CreateVersion7().ToString("N")[..12].Select(c => (char)('A' + Convert.ToInt32(c.ToString(), 16))));
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminTipos, UriKind.Relative));
+        Autenticar(request);
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(new
+        {
+            codigo,
+            nome = "Tipo de teste",
+            congelaConfiguracao = true,
+            unicoPorObjeto,
+            efeitoIrreversivel = false,
+            vigenciaInicio = "2026-01-01",
+            vigenciaFim = (string?)null,
+            baseLegal = (string?)null,
+        });
+
+        HttpResponseMessage resposta = await client.SendAsync(request);
+        resposta.StatusCode.Should().Be(
+            HttpStatusCode.Created, "o corpo devolvido foi: " + await resposta.Content.ReadAsStringAsync());
+
+        // O endpoint devolve o identificador cru, não um objeto que o envolva.
+        using JsonDocument corpo = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        return (codigo, corpo.RootElement.GetGuid());
+    }
+
+    private static async Task AtualizarTipoAsync(HttpClient client, Guid id, string codigo, bool unicoPorObjeto)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Put, new Uri($"{AdminTipos}/{id}", UriKind.Relative));
+        Autenticar(request);
+        request.Content = JsonContent.Create(new
+        {
+            id,
+            codigo,
+            nome = "Tipo de teste",
+            congelaConfiguracao = true,
+            unicoPorObjeto,
+            efeitoIrreversivel = false,
+            vigenciaInicio = "2026-01-01",
+            vigenciaFim = (string?)null,
+            baseLegal = (string?)null,
+        });
+
+        HttpResponseMessage resposta = await client.SendAsync(request);
+        resposta.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    private static void Autenticar(HttpRequestMessage request, string role = "plataforma-admin")
+    {
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, role);
+    }
+
+    private static object PayloadAto(
+        string tipoCodigo, string numero, string dataPublicacao, IReadOnlyList<object> vinculos) =>
+        new
+        {
+            orgao = "CEPS",
+            serie = "EDITAL",
+            ano = 2026,
+            numero,
+            tipoCodigo,
+            dataPublicacao,
+            documentoHash = HashValido,
+            assinante = "Jairo Belchior",
+            vinculos,
+        };
+
+    private static object PayloadRetificacao(
+        string tipoCodigo,
+        string numero,
+        string dataPublicacao,
+        Guid atoRetificadoId,
+        string motivo,
+        IReadOnlyList<object> vinculos) =>
+        new
+        {
+            orgao = "CEPS",
+            serie = "EDITAL",
+            ano = 2026,
+            numero,
+            tipoCodigo,
+            dataPublicacao,
+            documentoHash = HashValido,
+            assinante = "Jairo Belchior",
+            atoRetificadoId,
+            motivoRetificacao = motivo,
+            vinculos,
+        };
+
+    private static async Task<HttpResponseMessage> PostAtoAsync(HttpClient client, object payload)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminAtos, UriKind.Relative));
+        Autenticar(request);
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(payload);
+
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<Guid> PostAtoIdAsync(HttpClient client, object payload)
+    {
+        HttpResponseMessage resposta = await PostAtoAsync(client, payload);
+        resposta.StatusCode.Should().Be(
+            HttpStatusCode.Created,
+            "o corpo devolvido foi: " + await resposta.Content.ReadAsStringAsync());
+
+        using JsonDocument corpo = JsonDocument.Parse(await resposta.Content.ReadAsStringAsync());
+        return corpo.RootElement.GetProperty("atoId").GetGuid();
+    }
+}
+

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/VinculoAtoEntidadePersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/AtosNormativos/VinculoAtoEntidadePersistenceTests.cs
@@ -1,0 +1,364 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests.AtosNormativos;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Npgsql;
+
+using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
+using Unifesspa.UniPlus.Publicacoes.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração do vínculo ato ↔ entidade e da vaga de linhagem única por objeto contra
+/// Postgres real: unicidade do trio, append-only imposto por trigger, e as duas travas
+/// que impedem o <c>INSERT</c> cru de forjar uma vaga ou de omiti-la (ADR-0107).
+/// </summary>
+[Collection(PublicacoesDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "INSERT cru escrito no próprio teste, com identificadores gerados nele — é o que se quer exercitar: a trava do banco contra escrita fora do agregado.")]
+public sealed class VinculoAtoEntidadePersistenceTests
+{
+    private const string HashValido = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    private const string RestrictViolation = "23001";
+    private const string UniqueViolation = "23505";
+    private const string ForeignKeyViolation = "23503";
+    private const string TipoUnico = "EDITAL_ABERTURA";
+    private static readonly DateOnly Publicacao = new(2026, 3, 13);
+    private static readonly DateTimeOffset Registro = new(2026, 3, 13, 19, 0, 0, TimeSpan.Zero);
+
+    private readonly PublicacoesDbFixture _fixture;
+
+    public VinculoAtoEntidadePersistenceTests(PublicacoesDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "O ato persiste com os seus vínculos, e o vínculo aponta para ele")]
+    public async Task Insert_PersisteVinculos()
+    {
+        Guid processo = Guid.CreateVersion7();
+        Guid chamada = Guid.CreateVersion7();
+        AtoNormativo ato = Novo(unicoPorObjeto: false, vinculos: [("PROCESSO_SELETIVO", processo), ("CHAMADA", chamada)]);
+
+        await Gravar(ato);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        List<VinculoAtoEntidade> vinculos = await ctx.VinculosAtoEntidade
+            .Where(v => v.AtoId == ato.Id)
+            .ToListAsync();
+
+        vinculos.Should().HaveCount(2);
+        vinculos.Select(v => v.EntidadeId).Should().BeEquivalentTo([processo, chamada]);
+    }
+
+    [Fact(DisplayName = "Um ato sem vínculo persiste — há atos que não tratam de objeto algum")]
+    public async Task Insert_SemVinculo_Persiste()
+    {
+        AtoNormativo ato = Novo(unicoPorObjeto: true);
+
+        await Gravar(ato);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        (await ctx.AtosNormativos.AnyAsync(a => a.Id == ato.Id)).Should().BeTrue();
+        (await ctx.VinculosAtoEntidade.AnyAsync(v => v.AtoId == ato.Id)).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "UPDATE cru no vínculo é bloqueado pelo trigger append-only")]
+    public async Task Update_Vinculo_Bloqueado()
+    {
+        AtoNormativo ato = Novo(unicoPorObjeto: false, vinculos: [("PROCESSO_SELETIVO", Guid.CreateVersion7())]);
+        await Gravar(ato);
+
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(() => ExecutarCruAsync(
+            $"UPDATE publicacoes.vinculo_ato_entidade SET entidade_id = '{Guid.CreateVersion7()}' WHERE ato_id = '{ato.Id}'"));
+
+        erro.SqlState.Should().Be(RestrictViolation);
+    }
+
+    [Fact(DisplayName = "DELETE cru no vínculo é bloqueado pelo trigger append-only")]
+    public async Task Delete_Vinculo_Bloqueado()
+    {
+        AtoNormativo ato = Novo(unicoPorObjeto: false, vinculos: [("PROCESSO_SELETIVO", Guid.CreateVersion7())]);
+        await Gravar(ato);
+
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(() => ExecutarCruAsync(
+            $"DELETE FROM publicacoes.vinculo_ato_entidade WHERE ato_id = '{ato.Id}'"));
+
+        erro.SqlState.Should().Be(RestrictViolation);
+    }
+
+    [Fact(DisplayName = "O mesmo objeto vinculado duas vezes ao mesmo ato colide no índice único do trio")]
+    public async Task Insert_TrioRepetido_Colide()
+    {
+        Guid processo = Guid.CreateVersion7();
+        AtoNormativo ato = Novo(unicoPorObjeto: false, vinculos: [("PROCESSO_SELETIVO", processo)]);
+        await Gravar(ato);
+
+        // O agregado e o validator já recusam antes; aqui prova-se a trava do banco.
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(() => ExecutarCruAsync(
+            $"""
+            INSERT INTO publicacoes.vinculo_ato_entidade (id, ato_id, entidade_tipo, entidade_id)
+            VALUES ('{Guid.CreateVersion7()}', '{ato.Id}', 'PROCESSO_SELETIVO', '{processo}')
+            """));
+
+        erro.SqlState.Should().Be(UniqueViolation);
+    }
+
+    [Fact(DisplayName = "Vínculo órfão — sem ato — é recusado pela chave estrangeira")]
+    public async Task Insert_VinculoOrfao_Recusado()
+    {
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(() => ExecutarCruAsync(
+            $"""
+            INSERT INTO publicacoes.vinculo_ato_entidade (id, ato_id, entidade_tipo, entidade_id)
+            VALUES ('{Guid.CreateVersion7()}', '{Guid.CreateVersion7()}', 'PROCESSO_SELETIVO', '{Guid.CreateVersion7()}')
+            """));
+
+        erro.SqlState.Should().Be(ForeignKeyViolation);
+    }
+
+    [Fact(DisplayName = "Duas linhagens não ocupam a vaga do mesmo objeto: o índice único recusa a segunda")]
+    public async Task Insert_SegundaVagaNoMesmoObjeto_Colide()
+    {
+        Guid processo = Guid.CreateVersion7();
+        AtoNormativo primeiro = await GravarComVaga(processo);
+        AtoNormativo segundo = Novo(unicoPorObjeto: true, vinculos: [("PROCESSO_SELETIVO", processo)]);
+
+        // Grava o ato e o vínculo do segundo por via crua (o handler o recusaria antes),
+        // para exercitar exatamente a trava do banco — e não a do handler.
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(async () =>
+        {
+            await using NpgsqlConnection conexao = new(_fixture.ConnectionString);
+            await conexao.OpenAsync();
+            await using NpgsqlTransaction tx = await conexao.BeginTransactionAsync();
+
+            await ExecutarAsync(conexao, tx, InsertAtoCru(segundo));
+            await ExecutarAsync(conexao, tx, InsertVinculoCru(segundo.Id, "PROCESSO_SELETIVO", processo));
+            await ExecutarAsync(conexao, tx, InsertVagaCru(segundo.Id, segundo.Id, "PROCESSO_SELETIVO", processo));
+
+            await tx.CommitAsync();
+        });
+
+        erro.SqlState.Should().Be(UniqueViolation);
+        erro.ConstraintName.Should().Be("ux_linhagem_unica_por_objeto");
+        primeiro.Id.Should().NotBe(segundo.Id);
+    }
+
+    [Fact(DisplayName = "Vaga forjada em nome de uma raiz que não é a da cadeia do ato é bloqueada")]
+    public async Task Insert_VagaComRaizFalsa_Bloqueada()
+    {
+        Guid processo = Guid.CreateVersion7();
+        AtoNormativo ato = Novo(unicoPorObjeto: true, vinculos: [("PROCESSO_SELETIVO", processo)]);
+        AtoNormativo outro = Novo(unicoPorObjeto: true);
+
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(async () =>
+        {
+            await using NpgsqlConnection conexao = new(_fixture.ConnectionString);
+            await conexao.OpenAsync();
+            await using NpgsqlTransaction tx = await conexao.BeginTransactionAsync();
+
+            await ExecutarAsync(conexao, tx, InsertAtoCru(ato));
+            await ExecutarAsync(conexao, tx, InsertAtoCru(outro));
+            await ExecutarAsync(conexao, tx, InsertVinculoCru(ato.Id, "PROCESSO_SELETIVO", processo));
+            // A raiz declarada é outro ato, que nada tem com a cadeia deste.
+            await ExecutarAsync(conexao, tx, InsertVagaCru(ato.Id, outro.Id, "PROCESSO_SELETIVO", processo));
+
+            await tx.CommitAsync();
+        });
+
+        erro.SqlState.Should().Be(RestrictViolation);
+    }
+
+    [Fact(DisplayName = "Vaga de objeto a que o ato não se vincula é bloqueada")]
+    public async Task Insert_VagaSemVinculo_Bloqueada()
+    {
+        Guid processo = Guid.CreateVersion7();
+        AtoNormativo ato = Novo(unicoPorObjeto: true);
+
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(async () =>
+        {
+            await using NpgsqlConnection conexao = new(_fixture.ConnectionString);
+            await conexao.OpenAsync();
+            await using NpgsqlTransaction tx = await conexao.BeginTransactionAsync();
+
+            await ExecutarAsync(conexao, tx, InsertAtoCru(ato));
+            await ExecutarAsync(conexao, tx, InsertVagaCru(ato.Id, ato.Id, "PROCESSO_SELETIVO", processo));
+
+            await tx.CommitAsync();
+        });
+
+        erro.SqlState.Should().Be(RestrictViolation);
+    }
+
+    [Fact(DisplayName = "Vínculo de ato único por objeto sem a vaga reservada é bloqueado — a correspondência é obrigatória")]
+    public async Task Insert_VinculoSemVaga_Bloqueado()
+    {
+        // É esta trava que faz o índice único valer alguma coisa: sem ela, gravar o
+        // vínculo e omitir a vaga deixaria o objeto livre para uma segunda linhagem, e o
+        // índice, que só vê as vagas que existem, nada acusaria.
+        Guid processo = Guid.CreateVersion7();
+        AtoNormativo ato = Novo(unicoPorObjeto: true);
+
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(async () =>
+        {
+            await using NpgsqlConnection conexao = new(_fixture.ConnectionString);
+            await conexao.OpenAsync();
+            await using NpgsqlTransaction tx = await conexao.BeginTransactionAsync();
+
+            await ExecutarAsync(conexao, tx, InsertAtoCru(ato));
+            await ExecutarAsync(conexao, tx, InsertVinculoCru(ato.Id, "PROCESSO_SELETIVO", processo));
+
+            await tx.CommitAsync();
+        });
+
+        erro.SqlState.Should().Be(RestrictViolation);
+    }
+
+    [Fact(DisplayName = "Ciclo de retificação inserido num único comando é bloqueado")]
+    public async Task Insert_CicloDeRetificacao_Bloqueado()
+    {
+        // A chave estrangeira não barra isto: ela é verificada ao fim do COMANDO, e no fim
+        // do comando os dois atos existem. O CHECK só cobre o ciclo de tamanho um, e o
+        // índice único da linearidade não vê ciclo nenhum (A→B e B→A são alvos distintos).
+        // Um ciclo gravado seria irreparável — UPDATE e DELETE estão bloqueados — e faria
+        // toda travessia da cadeia girar para sempre.
+        Guid a = Guid.CreateVersion7();
+        Guid b = Guid.CreateVersion7();
+
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(() => ExecutarCruAsync(
+            $"""
+            INSERT INTO publicacoes.ato_normativo
+                (id, orgao, serie, ano, numero, tipo_codigo, congela_configuracao, efeito_irreversivel,
+                 unico_por_objeto, data_publicacao, documento_hash, assinante, registrado_em,
+                 ato_retificado_id, motivo_retificacao)
+            VALUES
+                ('{a}', 'CEPS', 'EDITAL', 2026, NULL, '{TipoUnico}', true, false, false,
+                 DATE '2026-03-13', '{HashValido}', 'Jairo Belchior', now(), '{b}', 'ciclo'),
+                ('{b}', 'CEPS', 'EDITAL', 2026, NULL, '{TipoUnico}', true, false, false,
+                 DATE '2026-03-13', '{HashValido}', 'Jairo Belchior', now(), '{a}', 'ciclo')
+            """));
+
+        erro.SqlState.Should().Be(RestrictViolation);
+    }
+
+    [Fact(DisplayName = "TRUNCATE do vínculo é bloqueado — não é DELETE, e esvaziaria o registro sem disparar o append-only")]
+    public async Task Truncate_DoVinculo_Bloqueado()
+    {
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(() => ExecutarCruAsync(
+            "TRUNCATE publicacoes.vinculo_ato_entidade"));
+
+        erro.SqlState.Should().Be(RestrictViolation);
+    }
+
+    [Fact(DisplayName = "TRUNCATE do ato publicado também é bloqueado")]
+    public async Task Truncate_DoAto_Bloqueado()
+    {
+        PostgresException erro = await Assert.ThrowsAsync<PostgresException>(() => ExecutarCruAsync(
+            "TRUNCATE publicacoes.ato_normativo CASCADE"));
+
+        erro.SqlState.Should().Be(RestrictViolation);
+    }
+
+    [Fact(DisplayName = "Vínculo de ato não único por objeto dispensa vaga")]
+    public async Task Insert_VinculoDeAtoNaoUnico_NaoExigeVaga()
+    {
+        AtoNormativo ato = Novo(unicoPorObjeto: false, vinculos: [("CHAMADA", Guid.CreateVersion7())]);
+
+        await Gravar(ato);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        (await ctx.VinculosAtoEntidade.CountAsync(v => v.AtoId == ato.Id)).Should().Be(1);
+        (await ctx.LinhagensUnicasPorObjeto.AnyAsync(l => l.AtoId == ato.Id)).Should().BeFalse();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<AtoNormativo> GravarComVaga(Guid processo)
+    {
+        AtoNormativo ato = Novo(unicoPorObjeto: true, vinculos: [("PROCESSO_SELETIVO", processo)]);
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        ctx.AtosNormativos.Add(ato);
+        ctx.LinhagensUnicasPorObjeto.Add(
+            LinhagemUnicaPorObjeto.Criar(ato, ato.Vinculos.Single(), raizId: ato.Id));
+        await ctx.SaveChangesAsync();
+
+        return ato;
+    }
+
+    private async Task Gravar(AtoNormativo ato)
+    {
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext(userId: null);
+        ctx.AtosNormativos.Add(ato);
+        await ctx.SaveChangesAsync();
+    }
+
+    private async Task ExecutarCruAsync(string sql)
+    {
+        await using NpgsqlConnection conexao = new(_fixture.ConnectionString);
+        await conexao.OpenAsync();
+        await using NpgsqlCommand comando = conexao.CreateCommand();
+        comando.CommandText = sql;
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private static async Task ExecutarAsync(NpgsqlConnection conexao, NpgsqlTransaction transacao, string sql)
+    {
+        await using NpgsqlCommand comando = conexao.CreateCommand();
+        comando.Transaction = transacao;
+        comando.CommandText = sql;
+        await comando.ExecuteNonQueryAsync();
+    }
+
+    private static string InsertAtoCru(AtoNormativo ato) =>
+        $"""
+        INSERT INTO publicacoes.ato_normativo
+            (id, orgao, serie, ano, numero, tipo_codigo, congela_configuracao, efeito_irreversivel,
+             unico_por_objeto, data_publicacao, documento_hash, assinante, registrado_em)
+        VALUES
+            ('{ato.Id}', 'CEPS', 'EDITAL', 2026, NULL, '{ato.TipoCodigo}', true, false,
+             {(ato.UnicoPorObjeto ? "true" : "false")}, DATE '2026-03-13', '{HashValido}',
+             'Jairo Belchior', now())
+        """;
+
+    private static string InsertVinculoCru(Guid atoId, string entidadeTipo, Guid entidadeId) =>
+        $"""
+        INSERT INTO publicacoes.vinculo_ato_entidade (id, ato_id, entidade_tipo, entidade_id)
+        VALUES ('{Guid.CreateVersion7()}', '{atoId}', '{entidadeTipo}', '{entidadeId}')
+        """;
+
+    private static string InsertVagaCru(Guid atoId, Guid raizId, string entidadeTipo, Guid entidadeId) =>
+        $"""
+        INSERT INTO publicacoes.linhagem_unica_por_objeto
+            (id, entidade_tipo, entidade_id, tipo_codigo, raiz_id, ato_id)
+        VALUES ('{Guid.CreateVersion7()}', '{entidadeTipo}', '{entidadeId}', '{TipoUnico}', '{raizId}', '{atoId}')
+        """;
+
+    private static AtoNormativo Novo(
+        bool unicoPorObjeto,
+        IEnumerable<(string EntidadeTipo, Guid EntidadeId)>? vinculos = null) =>
+        AtoNormativo.Registrar(
+            orgao: "CEPS",
+            serie: "EDITAL",
+            ano: 2026,
+            numero: null,
+            tipoCodigo: TipoUnico,
+            congelaConfiguracao: true,
+            efeitoIrreversivel: false,
+            unicoPorObjeto: unicoPorObjeto,
+            dataPublicacao: Publicacao,
+            documentoHash: HashValido,
+            assinante: "Jairo Belchior",
+            registradoEm: Registro,
+            versaoInvocada: null,
+            vinculos: vinculos);
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/FronteiraDoModuloTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/FronteiraDoModuloTests.cs
@@ -1,0 +1,210 @@
+namespace Unifesspa.UniPlus.Publicacoes.IntegrationTests;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Npgsql;
+
+using Unifesspa.UniPlus.Publicacoes.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Contraprova estrutural da fronteira do módulo (ADR-0105), contra o banco real: o
+/// schema <c>publicacoes</c> não possui coluna de domínio alheio, e nenhuma das suas
+/// chaves estrangeiras atravessa a fronteira de outro módulo.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A ausência só vale como evidência se o detector <b>saberia</b> acusar a presença — e
+/// se o banco <b>aceitaria</b> o que se afirma não existir. Com schema por módulo no
+/// mesmo banco (ADR-0097), uma chave estrangeira de <c>publicacoes</c> para
+/// <c>selecao</c> é tecnicamente possível: nada na física a impede, só a decisão de
+/// modelagem. Por isso cada teste <b>planta o canário primeiro</b> — cria a violação,
+/// verifica que o Postgres a aceita e que a consulta a enxerga —, desfaz, e só então
+/// assere a ausência. Sem isso, um detector quebrado (ou um schema vazio) passaria
+/// trivialmente, e o teste seria decoração.
+/// </para>
+/// <para>
+/// O canário vive dentro de uma transação desfeita ao fim: no Postgres o DDL é
+/// transacional, então o <c>ROLLBACK</c> não deixa rastro no schema real.
+/// </para>
+/// </remarks>
+[Collection(PublicacoesDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL fixo, escrito no próprio teste — o canário e os detectores não recebem entrada externa.")]
+public sealed class FronteiraDoModuloTests
+{
+    /// <summary>
+    /// Colunas que denunciariam o módulo conhecendo os domínios. A ADR-0105 nomeia estas
+    /// três; a lista é a da própria decisão, não uma amostra.
+    /// </summary>
+    private static readonly string[] ColunasDeDominioAlheio =
+        ["processo_seletivo_id", "chamada_id", "aplicacao_prova_id"];
+
+    private const string ContaColunasDeDominio = """
+        SELECT count(*)
+        FROM information_schema.columns
+        WHERE table_schema = 'publicacoes'
+          AND column_name = ANY(@proibidas)
+        """;
+
+    private const string ListaChavesEstrangeirasCrossSchema = """
+        SELECT con.conname
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+        JOIN pg_class alvo ON alvo.oid = con.confrelid
+        JOIN pg_namespace ns_alvo ON ns_alvo.oid = alvo.relnamespace
+        WHERE con.contype = 'f'
+          AND ns.nspname = 'publicacoes'
+          AND ns_alvo.nspname <> 'publicacoes'
+        """;
+
+    private readonly PublicacoesDbFixture _fixture;
+
+    public FronteiraDoModuloTests(PublicacoesDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "ADR-0105: o schema publicacoes não tem coluna de domínio alheio (com canário)")]
+    public async Task Schema_NaoTemColunaDeDominioAlheio()
+    {
+        await using NpgsqlConnection conexao = new(_fixture.ConnectionString);
+        await conexao.OpenAsync();
+
+        // Canário: a coluna proibida, plantada — o banco a aceita, e o detector a acusa.
+        await using (NpgsqlTransaction canario = await conexao.BeginTransactionAsync())
+        {
+            await ExecutarAsync(
+                conexao,
+                canario,
+                "CREATE TABLE publicacoes.canario_dominio (id uuid PRIMARY KEY, processo_seletivo_id uuid)");
+
+            long comCanario = await ContarColunasDeDominioAsync(conexao, canario);
+            comCanario.Should().Be(
+                1, "sem acusar a violação plantada, a ausência de achados sobre o schema real não significaria nada");
+
+            await canario.RollbackAsync();
+        }
+
+        long noSchemaReal = await ContarColunasDeDominioAsync(conexao, transacao: null);
+
+        noSchemaReal.Should().Be(
+            0,
+            "o módulo não conhece ProcessoSeletivo, Chamada nem AplicacaoProva (ADR-0105): "
+            + "o vínculo com a entidade é um par opaco, não uma coluna de domínio");
+    }
+
+    [Fact(DisplayName = "ADR-0061: nenhuma chave estrangeira de publicacoes atravessa outro schema (com canário)")]
+    public async Task Schema_NaoTemChaveEstrangeiraCrossSchema()
+    {
+        await using NpgsqlConnection conexao = new(_fixture.ConnectionString);
+        await conexao.OpenAsync();
+
+        // Canário: a chave estrangeira cross-schema, plantada. Prova as duas coisas de
+        // que a asserção depende — que o banco a aceitaria (com schema por módulo,
+        // ADR-0097, nada na física a impede) e que a consulta a enxergaria.
+        await using (NpgsqlTransaction canario = await conexao.BeginTransactionAsync())
+        {
+            await ExecutarAsync(conexao, canario, "CREATE SCHEMA canario_vizinho");
+            await ExecutarAsync(conexao, canario, "CREATE TABLE canario_vizinho.alvo (id uuid PRIMARY KEY)");
+            await ExecutarAsync(
+                conexao,
+                canario,
+                """
+                CREATE TABLE publicacoes.canario_fk (
+                    id uuid PRIMARY KEY,
+                    alvo_id uuid NOT NULL REFERENCES canario_vizinho.alvo (id)
+                )
+                """);
+
+            IReadOnlyList<string> comCanario = await ListarChavesCrossSchemaAsync(conexao, canario);
+            comCanario.Should().ContainSingle(
+                "o Postgres aceita a chave estrangeira cross-schema — a ausência dela é decisão de "
+                + "modelagem (ADR-0061), não impedimento físico; e o detector precisa enxergá-la");
+
+            await canario.RollbackAsync();
+        }
+
+        IReadOnlyList<string> noSchemaReal = await ListarChavesCrossSchemaAsync(conexao, transacao: null);
+
+        noSchemaReal.Should().BeEmpty(
+            "nenhuma chave estrangeira do módulo atravessa a fronteira de outro módulo (ADR-0061): "
+            + "a referência cross-módulo é por valor");
+    }
+
+    [Fact(DisplayName = "ADR-0105: a única chave estrangeira do vínculo aponta para o próprio ato")]
+    public async Task Vinculo_SoTemChaveEstrangeiraParaOAto()
+    {
+        await using NpgsqlConnection conexao = new(_fixture.ConnectionString);
+        await conexao.OpenAsync();
+
+        await using NpgsqlCommand comando = conexao.CreateCommand();
+        comando.CommandText = """
+            SELECT alvo.relname
+            FROM pg_constraint con
+            JOIN pg_class rel ON rel.oid = con.conrelid
+            JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+            JOIN pg_class alvo ON alvo.oid = con.confrelid
+            WHERE con.contype = 'f'
+              AND ns.nspname = 'publicacoes'
+              AND rel.relname = 'vinculo_ato_entidade'
+            """;
+
+        List<string> alvos = [];
+        await using (NpgsqlDataReader leitor = await comando.ExecuteReaderAsync())
+        {
+            while (await leitor.ReadAsync())
+            {
+                alvos.Add(leitor.GetString(0));
+            }
+        }
+
+        alvos.Should().ContainSingle().Which.Should().Be(
+            "ato_normativo",
+            "o vínculo aponta para o ato e para mais nada: o objeto do outro lado é opaco, "
+            + "e uma chave estrangeira para ele reintroduziria o acoplamento que a ADR-0105 recusa");
+    }
+
+    private static async Task<long> ContarColunasDeDominioAsync(NpgsqlConnection conexao, NpgsqlTransaction? transacao)
+    {
+        await using NpgsqlCommand comando = conexao.CreateCommand();
+        comando.Transaction = transacao;
+        comando.CommandText = ContaColunasDeDominio;
+        comando.Parameters.AddWithValue("proibidas", ColunasDeDominioAlheio);
+
+        return (long)(await comando.ExecuteScalarAsync())!;
+    }
+
+    private static async Task<IReadOnlyList<string>> ListarChavesCrossSchemaAsync(
+        NpgsqlConnection conexao, NpgsqlTransaction? transacao)
+    {
+        await using NpgsqlCommand comando = conexao.CreateCommand();
+        comando.Transaction = transacao;
+        comando.CommandText = ListaChavesEstrangeirasCrossSchema;
+
+        List<string> nomes = [];
+        await using NpgsqlDataReader leitor = await comando.ExecuteReaderAsync();
+        while (await leitor.ReadAsync())
+        {
+            nomes.Add(leitor.GetString(0));
+        }
+
+        return nomes;
+    }
+
+    private static async Task ExecutarAsync(NpgsqlConnection conexao, NpgsqlTransaction transacao, string sql)
+    {
+        await using NpgsqlCommand comando = conexao.CreateCommand();
+        comando.Transaction = transacao;
+        comando.CommandText = sql;
+        await comando.ExecuteNonQueryAsync();
+    }
+}


### PR DESCRIPTION
## O que muda

Introduz o **vínculo genérico ato ↔ entidade** (ADR-0105) — o par `(tipo_entidade, entidade_id)` que Publicações guarda **sem interpretar** —, serve a **consulta unificada** dos atos de um certame, e fecha o critério herdado da #800: para tipos `unico_por_objeto`, **um objeto é tratado por uma só linhagem de atos**.

Closes #801
Refs #796, #795

## As duas decisões que o desenho exigiu

### 1. A unicidade por objeto é uma vaga que a **linhagem** reserva (ADR-0107)

O caminho óbvio — denormalizar "este ato é raiz" no vínculo e criar um índice único parcial — **não fecha a invariante**. Basta publicar uma raiz sem vínculo e, na retificação dela, vincular o objeto que outra linhagem já trata: a retificação não é raiz, escapa do filtro do índice, e o objeto acaba com duas linhagens vivas. A chave da regra é a linhagem, não a posição do ato dentro dela.

A tabela `linhagem_unica_por_objeto` guarda a vaga de `(objeto, tipo)` em nome da raiz da cadeia que a ocupa. O registro passa por **duas verificações, e cada uma vê o que a outra não vê**:

- **o histórico de atos** — um ato do mesmo tipo já vinculado ao objeto, fora desta linhagem, é conflito. Enxerga inclusive o ato publicado quando o tipo **ainda não era** `unico_por_objeto` (o catálogo é editável) e que, por isso, não reservou vaga alguma;
- **a vaga** — o índice único, que fecha a corrida entre transações concorrentes, invisível a qualquer consulta.

Quatro triggers sustentam a estrutura contra o `INSERT` cru: append-only nas duas tabelas novas, coerência da vaga com o ato (tipo, raiz verdadeira, objeto vinculado), e a **correspondência reversa** — todo vínculo de ato único por objeto exige a vaga reservada. É ela que faz o índice único valer alguma coisa: sem ela, gravar o vínculo e omitir a vaga deixaria o objeto livre para uma segunda linhagem, e o índice, que só vê as vagas que existem, nada acusaria.

Recusa é **409** (conflito com o estado gravado), não 422 — mesmo critério de `RaizJaRetificada`.

### 2. O código do tipo de ato passa a ser imutável

A vaga é chaveada por `tipo_codigo`. Se o código pudesse ser renomeado, bastaria renomeá-lo para abrir uma vaga nova no mesmo objeto — e o certame teria dois editais de abertura vivos. O código já era, de fato, a identidade do tipo: é por ele que a exclusion constraint agrupa a série de vigências, de modo que renomear uma versão a desgarraria das demais. **Renomear passa a ser criar outro tipo**; nome, atributos de consequência, vigência e base legal seguem editáveis.

Isso reverte uma premissa da #798 (`Codigo` editável) — o comentário que a afirmava foi substituído pela justificativa acima.

## Consulta unificada

`GET /api/publicacoes/entidades/{entidadeTipo}/{entidadeId}/atos` — pública, ordenada por data de publicação ascendente com o `Id` (Guid v7) de desempate (a retificação republica a mesma data, então a data sozinha não ordena de forma estável). Keyset ordenado (ADR-0094) sob cursor opaco.

- **A retificação herda os vínculos do ato que emenda.** Sem isso, uma retificação registrada sem repetir os vínculos sumiria da consulta do certame — e a consulta exibiria a versão superada, escondendo a que a emenda.
- **O cursor é escopado à entidade.** `FromCursorAttribute` ganhou `ScopeRouteValues`, e a etiqueta do cursor é composta pelo mesmo utilitário nos dois lados (emissão e conferência) — um cursor emitido na coleção de um certame não navega a de outro. Aditivo: os demais endpoints paginados seguem com etiqueta constante.
- **Entidade inexistente e entidade sem atos devolvem, ambas, coleção vazia** — nunca 404. Distingui-las exigiria perguntar a outro módulo, e é justamente essa pergunta que a fronteira proíbe.

## Contraprova estrutural (a fronteira, verificada)

Fitness tests contra Postgres real, cada um **plantando o canário antes de asserir a ausência**:

- nenhuma coluna `processo_seletivo_id` / `chamada_id` / `aplicacao_prova_id` no schema — o detector é primeiro alimentado com a coluna proibida, plantada numa transação desfeita;
- nenhuma chave estrangeira cruza a fronteira do módulo — o canário cria schema vizinho + tabela + FK cross-schema, **prova que o Postgres a aceita** (com schema por módulo, nada na física a impede — ADR-0097) e que o detector a enxerga, e só então a ausência vale como evidência;
- a única chave estrangeira do vínculo aponta para o próprio ato.

## Bônus arquitetural (fora do escopo da issue)

`KeysetOrdenadoCursor` (ADR-0094) exigia `EntityBase` e por isso não servia entidade forense. Relaxado para `class, IIdentificavel` — a mesma extensão aditiva que a #799 fez em `CursorKeyset`, e a razão de `IIdentificavel` existir. Era o único bloqueio para paginar o ato publicado por chave de ordenação.

## Limitação registrada (ADR-0107, § "A vaga é monotônica")

Ocupada, a vaga não se libera: não há revogação de ato publicado. Um ato publicado com o objeto errado ocupa a vaga daquele objeto **para sempre**, e o objeto errado fica impedido de receber um ato legítimo daquele tipo. Sem base em produção, o custo é nulo; quando houver, será preciso um mecanismo administrativo auditável e append-only (um ato de anulação de vínculo, não um `DELETE`) — story própria, cuja semântica institucional o CEPS ainda não decidiu.

## Testes

- **Domínio** (67): forma canônica do rótulo opaco, vínculo derivado do próprio ato, duplicata recusada, a vaga só existe para tipo único por objeto.
- **Application** (89): herança de vínculos pela retificação, vaga reservada em nome da raiz da linhagem, 409 quando outra linhagem trata o objeto, tipo não único não reserva vaga.
- **Integração** (126): os dois cenários de furo (retificação de outra linhagem invadindo o objeto; ato publicado antes de o atributo virar), triggers contra `INSERT` cru (vaga forjada, vaga sem vínculo, vínculo sem vaga), paginação ida-e-volta, cursor de outra entidade recusado, contraprovas estruturais com canário.
- Suíte completa verde localmente; baseline OpenAPI regenerada.

## O que a revisão prévia fechou (antes do primeiro commit)

O desenho passou por revisão adversarial de plano e de diff. Cinco achados eram reais e estão fechados no código:

1. **O índice sobre "o ato é raiz" não fechava a unicidade** — raiz sem vínculo + retificação vinculando o objeto de outra linhagem escapava do filtro. Virou a vaga chaveada pela linhagem.
2. **`unico_por_objeto` é editável no catálogo** — um ato publicado antes de o atributo virar não reservava vaga, e um ato posterior encontrava o objeto livre. Fechado pela consulta ao histórico de atos, não só à tabela de vagas.
3. **Ciclo de retificação inserível por `INSERT` multi-linha** — a chave estrangeira é verificada ao fim do comando, quando `A→B` e `B→A` já existem; o `CHECK` só cobre o ciclo de tamanho um. O ciclo seria irreparável (UPDATE/DELETE bloqueados) e faria toda travessia girar para sempre. Fechado por trigger diferido de aciclicidade + `CYCLE` nas travessias.
4. **Reserva parcial antes da recusa** — num ato com dois objetos em que só o segundo conflita, a vaga do primeiro ficava pendurada na unidade de trabalho. Virou duas fases: nada é reservado enquanto houver vínculo por examinar.
5. **`TRUNCATE` burlava o append-only** — não dispara trigger de linha. Bloqueado nas duas tabelas novas e também na do ato publicado, que tinha essa porta aberta desde que nasceu.

Mais dois de menor porte: cursor com âncora malformada devolvia 500 (agora 400, decodificação no boundary — ADR-0031), e `"vinculos": [null]` estouraria no handler (agora 422).
