### PR TITLE
docs(adr): promove ADR-0101 e ADR-0106 a superseded

### DIFF
--- a/docs/adrs/0059-sprint-3-decomposicao-estrategia-paralela.md
+++ b/docs/adrs/0059-sprint-3-decomposicao-estrategia-paralela.md
@@ -10,6 +10,8 @@ informed:
 
 # ADR-0059: Decomposição da Sprint 3 e estratégia paralela para entrega de Parametrizacao
 
+> **Nota de atualização.** Esta ADR registra o **plano de execução** de uma sprint encerrada; a estratégia de paralelização decidida aqui não muda. Parte dos símbolos citados na Lane C, porém, **não existe mais**: `ValidadorConformidadeEdital` e `EditalGovernanceSnapshot` foram removidos (#782), e as rotas `/api/editais/{id}/conformidade` não existem — o agregado `Edital` foi eliminado da Seleção (ver [ADR-0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md) e [ADR-0104](0104-versao-configuracao-como-agregado-proprio.md)). A avaliação de conformidade legal contra o `ProcessoSeletivo` é trabalho em aberto. Leia a Lane C como registro histórico do plano, não como descrição do código atual.
+
 ## Contexto e enunciado do problema
 
 A estratégia do módulo Parametrizacao (per ADRs [0055](0055-organizacao-institucional-bounded-context.md), [0056](0056-modulo-configuracao-e-read-side-via-reader.md), [0057](0057-areas-rbac-snapshot-historia-invariantes.md) e [0058](0058-obrigatoriedade-legal-validacao-data-driven.md)) envolve seis sub-features identificadas:

--- a/docs/adrs/0100-canonicalizacao-hash-snapshot-publicacao.md
+++ b/docs/adrs/0100-canonicalizacao-hash-snapshot-publicacao.md
@@ -7,6 +7,8 @@ decision-makers:
 
 # ADR-0100: Contrato de canonicalização e hash do snapshot de publicação (RN08)
 
+> **Nota de atualização.** A decisão desta ADR — o contrato de canonicalização e o hash reproduzível do congelamento — permanece **integralmente vigente**. Mudou apenas **onde o congelado mora**: a entidade `SnapshotPublicacao` citada abaixo não existe mais; o congelamento é uma **[`VersaoConfiguracao`](0104-versao-configuracao-como-agregado-proprio.md)**, agregado próprio e append-only, cujo par de bytes canônicos e hash é derivado exatamente pelas regras aqui definidas. O nome sobrevive no código apenas no `ISnapshotPublicacaoCanonicalizer` — resíduo de vocabulário, não uma entidade. Leia "snapshot de publicação" como "a configuração congelada de uma versão".
+
 ## Contexto e enunciado do problema
 
 RN08 exige que a publicação do `ProcessoSeletivo` (Story #759) congele a configuração de negócio num `SnapshotPublicacao` append-only, com um hash reproduzível: a mesma configuração deve produzir sempre o mesmo hash, em qualquer runtime, máquina ou momento — é a evidência que sustenta a integridade jurídica do resultado perante mandado de segurança ou processo administrativo. Sem contrato de canonicalização explícito, "mesma configuração" é ambíguo: strings com codificação Unicode equivalente mas bytes diferentes, decimais representados com precisão variável, instantes serializados com ou sem fração de segundo, ou apenas a ordem de serialização de um objeto já produzem hashes distintos para conteúdo logicamente idêntico.

--- a/docs/adrs/0101-retificacao-novo-edital-novo-snapshot-motivo.md
+++ b/docs/adrs/0101-retificacao-novo-edital-novo-snapshot-motivo.md
@@ -1,11 +1,15 @@
 ---
-status: "accepted"
+status: "superseded by ADR-0103"
 date: "2026-07-07"
 decision-makers:
   - "Tech Lead"
 ---
 
 # ADR-0101: Retificação de processo publicado é sempre novo Edital + novo snapshot + motivo
+
+> **Superada.** O *comportamento* decidido aqui continua valendo **no escopo em que foi decidido** — retificar o **ato congelante** de um processo publicado produz um novo ato, com motivo obrigatório, que congela uma nova configuração, e o congelado anterior permanece imutável. (A [ADR-0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md) generalizou o alcance: retificar um ato **não** congelante — uma convocação, por exemplo — **não** cria versão de configuração.) O que caducou é o **modelo** em que a decisão foi expressa: `Edital` como entidade da Seleção, `NaturezaEdital` e `SnapshotPublicacao` não existem mais.
+>
+> A decisão vigente está em **[ADR-0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md)** — a retificação é uma **relação entre atos**, não um tipo de ato, e o ato normativo vive no módulo `Publicacoes` — e em **[ADR-0104](0104-versao-configuracao-como-agregado-proprio.md)** — o congelamento é uma `VersaoConfiguracao` própria, cuja **vigência ordena as versões**. Leia esta ADR como registro histórico do raciocínio, não como contrato.
 
 ## Contexto e enunciado do problema
 

--- a/docs/adrs/0102-invariantes-coerencia-processo-guard-rails-422.md
+++ b/docs/adrs/0102-invariantes-coerencia-processo-guard-rails-422.md
@@ -8,6 +8,8 @@ decision-makers:
 # ADR-0102: Invariantes de coerência de processo como guard rails no banco, mapeadas a HTTP 422
 
 > **Emenda (ADR-0104):** a decisão — violação de guard rail de banco vira `DomainError` nomeado e 422, nunca 500 — permanece integralmente vigente, e ganhou guard rails novos (os da tabela `versoes_configuracao`). O que caducou foi um dos **exemplos**: a unicidade de `data_publicacao` entre editais do mesmo processo deixou de existir, e com ela o `Edital.DataPublicacaoDuplicada`. Aquela trava não era invariante de negócio — servia só para dar ordem total entre editais, papel que agora cabe a `UNIQUE(processo, numero_versao)` sobre as versões. Dois atos publicados no mesmo instante, e a retificação que republica a data do ato original, passam a ser estados válidos. Ver [ADR-0104](0104-versao-configuracao-como-agregado-proprio.md).
+>
+> **Emenda 2 (ADR-0103):** com a eliminação do agregado `Edital`, **todos** os guard rails citados abaixo que se ancoravam nele mudaram de casa — a unicidade do edital de abertura por processo passou a ser `UNIQUE(processo, numero_versao)`; a linearidade da cadeia de retificação e o contrato abertura×retificação passaram a ser `UNIQUE(ato_criador)` mais o trigger de sucessão sobre `versoes_configuracao`, na **mesma transação**. A decisão (guard rail de banco → 422 nomeado) é que não mudou; os exemplos concretos abaixo devem ser lidos pelo seu equivalente em `versoes_configuracao`.
 
 ## Contexto e enunciado do problema
 

--- a/docs/adrs/0106-orquestracao-sincrona-selecao-publicacoes-ato-primeiro.md
+++ b/docs/adrs/0106-orquestracao-sincrona-selecao-publicacoes-ato-primeiro.md
@@ -1,5 +1,5 @@
 ---
-status: "accepted"
+status: "superseded by ADR-0108"
 date: "2026-07-10"
 decision-makers:
   - "Tech Lead (CTIC)"

--- a/docs/adrs/0108-registro-do-ato-por-mensagem-duravel.md
+++ b/docs/adrs/0108-registro-do-ato-por-mensagem-duravel.md
@@ -109,8 +109,8 @@ Quatro propriedades, e nenhuma delas é suposta — todas foram **medidas** cont
 branch `spike/820-outbox-durable-queue`):
 
 1. **Atomicidade onde importa.** O envelope é persistido na mesma transação do agregado
-   ([ADR-0004](0004-outbox-transacional-via-wolverine.md)). Ou o Edital e a mensagem existem, ou nenhum dos
-   dois.
+   ([ADR-0004](0004-outbox-transacional-via-wolverine.md)). Ou a versão de configuração e a mensagem existem,
+   ou nenhuma das duas.
 2. **O órfão que trava o certame deixa de ser possível.** A vaga só é reservada quando o ato é criado. O modo
    de falha residual é o **inverso** — versão de configuração publicada com o ato ainda por registrar —, que é transitório,
    visível na dead letter e **recuperável**, e que **não impede** a publicação do certame.

--- a/docs/adrs/0108-registro-do-ato-por-mensagem-duravel.md
+++ b/docs/adrs/0108-registro-do-ato-por-mensagem-duravel.md
@@ -34,7 +34,7 @@ sobre o objeto errado "ocupa a vaga daquele objeto **para sempre**", e que o mec
 assunto de story própria, ainda não decidido.
 
 Compondo as duas ADRs: um ato registrado + uma falha na escrita de Seleção (crash entre os dois commits,
-erro inesperado no `SaveChanges`) deixa a vaga do certame ocupada por uma linhagem cujo Edital não existe.
+erro inesperado no `SaveChanges`) deixa a vaga do certame ocupada por uma linhagem cuja versão de configuração não existe.
 **O processo seletivo fica impublicável em definitivo.** A recuperação dependeria de o cliente retentar com
 exatamente a mesma `Idempotency-Key`; se ele desistir, o certame morre.
 
@@ -112,7 +112,7 @@ branch `spike/820-outbox-durable-queue`):
    ([ADR-0004](0004-outbox-transacional-via-wolverine.md)). Ou o Edital e a mensagem existem, ou nenhum dos
    dois.
 2. **O órfão que trava o certame deixa de ser possível.** A vaga só é reservada quando o ato é criado. O modo
-   de falha residual é o **inverso** — Edital publicado com o ato ainda por registrar —, que é transitório,
+   de falha residual é o **inverso** — versão de configuração publicada com o ato ainda por registrar —, que é transitório,
    visível na dead letter e **recuperável**, e que **não impede** a publicação do certame.
 3. **Idempotência por chave primária.** O `AtoId` é decidido pelo domínio e viaja na mensagem; uma reentrega
    (at-least-once) tenta gravar o mesmo id e não faz nada. Sem tabela de idempotência, sem hash do efeito.
@@ -135,7 +135,7 @@ para um ato de outro módulo. Não é contorno — é o desenho, agora usado com
 
 ### Negativas
 
-- **Consistência eventual.** Existe uma janela — tipicamente milissegundos — em que o Edital está publicado e
+- **Consistência eventual.** Existe uma janela — tipicamente milissegundos — em que a versão já está publicada e
   o ato ainda não aparece na consulta unificada de Publicações. É o preço, e é qualitativamente menor do que
   um certame impublicável para sempre.
 - Uma recusa legítima (tipo sem versão vigente, vaga já ocupada) só aflora **depois** do 2xx da publicação.
@@ -156,6 +156,6 @@ para um ato de outro módulo. Não é contorno — é o desenho, agora usado com
 Medido no spike, contra o host real, e replicado na implementação:
 
 - publicar registra o ato pela fila durável, com vínculo e vaga;
-- registro recusado **não** reserva a vaga do certame, e o Edital permanece publicado;
+- registro recusado **não** reserva a vaga do certame, e a versão de configuração permanece publicada;
 - reentrega da mesma requisição não duplica o ato;
 - a falha do handler chega à **dead letter** (verificado em `wolverine.wolverine_dead_letters`).

--- a/docs/adrs/0108-registro-do-ato-por-mensagem-duravel.md
+++ b/docs/adrs/0108-registro-do-ato-por-mensagem-duravel.md
@@ -95,7 +95,7 @@ que publicou.**
 ```text
 Seleção, UMA transação (a que o Wolverine já abre):
     AtoId = Guid.CreateVersion7()            ← o domínio decide o id
-    Edital + VersaoConfiguracao(AtoCriadorId = AtoId)
+    VersaoConfiguracao(AtoCriadorId = AtoId)
     + envelope RegistrarAtoNormativoRequisicao(AtoId, …) no OUTBOX
     COMMIT                                   ← ou tudo, ou nada
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -129,12 +129,12 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0098](0098-politica-de-service-location-do-codegen-wolverine.md) | Política de service location do codegen Wolverine (`NotAllowed` + allow-list por tipo) | accepted | 2026-06-26 |
 | [0099](0099-geo-como-repositorio-dedicado.md) | Geo como repositório e serviço transversal dedicado | accepted | 2026-06-26 |
 | [0100](0100-canonicalizacao-hash-snapshot-publicacao.md) | Contrato de canonicalização e hash do snapshot de publicação (RN08) | accepted | 2026-07-07 |
-| [0101](0101-retificacao-novo-edital-novo-snapshot-motivo.md) | Retificação de processo publicado é sempre novo Edital + novo snapshot + motivo | accepted | 2026-07-07 |
+| [0101](0101-retificacao-novo-edital-novo-snapshot-motivo.md) | Retificação de processo publicado é sempre novo Edital + novo snapshot + motivo | superseded by ADR-0103 | 2026-07-07 |
 | [0102](0102-invariantes-coerencia-processo-guard-rails-422.md) | Invariantes de coerência de processo como guard rails no banco, mapeadas a HTTP 422 | accepted | 2026-07-07 |
 | [0103](0103-ato-normativo-generalizado-retificacao-como-relacao.md) | Retificação é uma relação entre atos publicados, não um tipo de ato | accepted | 2026-07-09 |
 | [0104](0104-versao-configuracao-como-agregado-proprio.md) | A vigência da configuração ordena versões, não documentos | accepted | 2026-07-09 |
 | [0105](0105-modulo-publicacoes-registro-central-dos-atos.md) | O ato publicado pertence a um módulo `Publicacoes` que não conhece os domínios | accepted | 2026-07-09 |
-| [0106](0106-orquestracao-sincrona-selecao-publicacoes-ato-primeiro.md) | Publicar um Edital registra o ato em Publicações de forma síncrona, antes de concluir | accepted | 2026-07-10 |
+| [0106](0106-orquestracao-sincrona-selecao-publicacoes-ato-primeiro.md) | Publicar um Edital registra o ato em Publicações de forma síncrona, antes de concluir | superseded by ADR-0108 | 2026-07-10 |
 | [0107](0107-vaga-de-linhagem-unica-por-objeto.md) | A unicidade de ato por objeto é uma vaga que a linhagem reserva, não um índice sobre o ato | accepted | 2026-07-11 |
 | [0108](0108-registro-do-ato-por-mensagem-duravel.md) | O domínio registra o ato por mensagem durável, não por chamada síncrona (supersede a 0106 no mecanismo) | accepted | 2026-07-12 |
 
@@ -142,7 +142,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 
 ## Como adicionar um novo ADR
 
-1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0106`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
+1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0108`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
 2. Copie [`_template.md`](_template.md).
 3. Renomeie para `NNNN-titulo-em-slug.md` (slug ASCII em minúsculas, hífens como separador).
 4. Preencha frontmatter, contexto, drivers, opções, resultado da decisão (única), consequências.


### PR DESCRIPTION
Closes #855

## Contexto

A ADR é a autoridade do projeto — não o código existente. Duas ADRs continuavam com `status: accepted` descrevendo um modelo que a #804 eliminou (`Edital` como entidade da Seleção, `NaturezaEdital`, `SnapshotPublicacao`), e o índice as listava como vigentes. Quem consultasse `docs/adrs/README.md` concluiria que o modelo antigo ainda vale — que é exatamente o erro que a triagem da Feature #40 encontrou espalhado pelo backlog.

## O que muda

| ADR | De | Para | Por quê |
|---|---|---|---|
| **0101** | `accepted` | `superseded by ADR-0103` | A retificação é uma **relação entre atos**, não um tipo de ato (ADR-0103), e o congelamento é uma `VersaoConfiguracao` (ADR-0104) |
| **0106** | `accepted` | `superseded by ADR-0108` | O registro do ato viaja por **mensagem durável**, não por chamada síncrona. O corpo já trazia a nota; só o frontmatter divergia |

O `adr-lint` aceita `superseded by ADR-NNNN` com **um único** sucessor — por isso a 0101 aponta a 0103 no status e cita a 0104 no corpo.

**Importante:** o *comportamento* decidido na 0101 continua valendo no escopo em que foi decidido — retificar o **ato congelante** de um processo publicado produz novo ato, com motivo, congelando nova configuração, e o congelado anterior permanece imutável. O que caducou é o **modelo** em que foi expresso. (A 0103 generalizou o alcance: retificar ato **não** congelante — uma convocação — não cria versão.)

## Além do pedido da issue (CA-05)

O CA-05 exigia que nenhuma outra ADR `accepted` apresentasse o modelo morto como vigente. A verificação encontrou três — todas recebem **nota de atualização**, sem alterar a decisão que carregam:

- **ADR-0100** — a decisão (canonicalização e hash reproduzível) permanece **integral**; mudou só *onde o congelado mora*: `VersaoConfiguracao`, não a entidade `SnapshotPublicacao`. O nome sobrevive apenas no `ISnapshotPublicacaoCanonicalizer` — resíduo de vocabulário, tratado na #844.
- **ADR-0102** — os guard rails ancorados no `Edital` (unicidade do edital de abertura, contrato abertura×retificação) **mudaram de casa** para `versoes_configuracao`: `UNIQUE(processo, numero_versao)`, `UNIQUE(ato_criador)` e o trigger de sucessão, na mesma transação. A decisão (guard rail de banco → 422 nomeado) não mudou.
- **ADR-0108** — o diagrama da transação ainda escrevia `Edital + VersaoConfiguracao`. É **erro factual**: a #804 removeu a entidade depois que a 0108 foi escrita. Corrigido.
- **ADR-0059** — a Lane C planejava `ValidadorConformidadeEdital`, `EditalGovernanceSnapshot` e rotas `/api/editais/{id}/conformidade`, todos removidos.

## Validação

- `bash tools/adr-lint/validate.sh` → **0 erros** (110 arquivos; formato `superseded by ADR-NNNN` aceito)
- `markdownlint-cli2` → 0 erros
- Diff é 100% documentação — nenhum código, nenhum contrato, nenhuma migration

## Deferido

Revisão apontou (P3) exemplos ilustrativos antigos (`EditalController`, `PublicarEdital`) em ADRs cuja **decisão abstrata continua válida** — 0005, 0024, 0030, 0041, 0046, 0060, 0061, 0064. Não são o modelo apresentado como vigente, são exemplos datados. Ficam para a **#844** (erradicação do vocabulário `Edital`), que já tem esse inventário no escopo.