### PR TITLE
fix(selecao): substitui RECURSO-MULTI-INSTANCIA por prazo ancorado em ato

### DIFF
--- a/docs/adrs/0112-fronteira-append-only-do-catalogo-de-regras.md
+++ b/docs/adrs/0112-fronteira-append-only-do-catalogo-de-regras.md
@@ -1,0 +1,128 @@
+---
+status: "accepted"
+date: "2026-07-14"
+decision-makers:
+  - "Tech Lead"
+consulted:
+  - "CEPS (dono do processo)"
+informed:
+  - "Equipe Seleção"
+---
+
+# ADR-0112: Fronteira do append-only na correção do catálogo de regras
+
+## Contexto e enunciado do problema
+
+O catálogo `rol_de_regras` (Story #772) é uma biblioteca de regras tipadas,
+versionadas e content-addressable que a configuração do Processo Seletivo
+referencia por `(codigo, versao, hash)`. A configuração congelada de um certame
+(`VersaoConfiguracao`, ADR-0104) preserva essa referência para tornar o resultado
+reprodutível e auditável (RN08).
+
+Entre as 18 regras semeadas, `RECURSO-MULTI-INSTANCIA` conflacionava dois
+conceitos: a **gestão** de uma segunda instância de recurso — que o Uni+ não
+exerce, pois o julgamento em instância superior corre fora do sistema — e a
+**janela de suspensividade**, que é real e precisa ficar congelada por edital. O
+nome da regra negava o próprio conteúdo que deveria sobrar depois da correção.
+
+A pergunta é: pode-se **corrigir** uma linha do seed substituindo-a (removê-la e
+publicar outra com nome honesto), ou o append-only do catálogo obriga a
+acrescentar sempre uma nova versão, preservando a linha errada para sempre? A
+resposta não pode ser um caso a caso — precisa ser uma regra explícita, para não
+virar precedente de mutação arbitrária do catálogo.
+
+## Drivers da decisão
+
+- Reprodutibilidade e auditabilidade da configuração congelada (RN08).
+- Evitar poluir o catálogo com vocabulário que nenhuma configuração jamais usou.
+- Não abrir precedente para mutar regras das quais um certame já depende.
+- A verificação da fronteira deve ser mecânica, não um julgamento humano.
+
+## Opções consideradas
+
+- **Substituição incondicional** — corrigir a linha sempre que se julgar errada.
+- **Append-only estrito desde sempre** — nunca remover; toda correção é uma nova
+  versão que coexiste com a anterior.
+- **Substituição condicionada ao não-congelamento** — corrigível por substituição
+  enquanto nenhuma configuração congelada referenciar a linha; a partir do
+  primeiro congelamento que a referencie, append-only estrito.
+
+## Resultado da decisão
+
+**Escolhida:** "Substituição condicionada ao não-congelamento", porque o
+append-only existe para proteger **fatos congelados**, e uma linha de seed que
+nenhuma `VersaoConfiguracao` referencia ainda não é fato — é vocabulário, e
+vocabulário errado se corrige.
+
+A fronteira é esta: enquanto **nenhuma** configuração congelada referenciar uma
+linha do catálogo por `(codigo, versao)`, essa linha pode ser corrigida por
+substituição (remoção da entrada errada e publicação da correta, reusando o `Id`
+técnico do seed para manter o diff mínimo). A partir do **primeiro** congelamento
+que a referencie, a linha vira fato e vale **append-only estrito** (RN08): o
+passado não se muta, e qualquer evolução é uma nova versão que coexiste com a
+anterior. A verificação é mecânica — cruza-se o conjunto de `VersaoConfiguracao`
+com o `(codigo, versao)` que se pretende substituir; havendo qualquer referência,
+a substituição é proibida.
+
+No caso concreto que motivou esta ADR, `RECURSO-MULTI-INSTANCIA` tinha zero
+referências congeladas (nenhuma `VersaoConfiguracao`, nenhum consumidor de
+`TipoRegra.RegraPrazoRecurso`, sem produção), e por isso foi substituída por
+`RECURSO-PRAZO-ANCORADO-EM-ATO` — que preserva a janela de suspensividade, agora
+por instância, e ancora o prazo no instante de publicação de um ato.
+
+## Consequências
+
+### Positivas
+
+- O catálogo não carrega vocabulário morto: uma regra que nunca foi usada não
+  precisa sobreviver como registro histórico enganoso.
+- A proteção do append-only permanece intacta onde importa — a partir do primeiro
+  congelamento, a linha é imutável.
+- A fronteira é objetiva e testável, não um julgamento subjetivo por PR.
+
+### Negativas
+
+- Cria uma janela em que o comportamento de correção difere (substituição antes,
+  append-only depois) — exige que a verificação seja executada, não presumida.
+- Reusar o `Id` técnico numa substituição pode surpreender quem espera que `Id`
+  seja identidade de negócio; a identidade de negócio é `(codigo, versao)`.
+
+### Neutras
+
+- A regra vale para o `rol_de_regras`; outros catálogos append-only decidem sua
+  própria política, ainda que este seja o precedente natural.
+
+## Confirmação
+
+- Teste de integração `RegraCatalogoSeed_SubstituirRegraReferenciada_Falha`:
+  falha se alguma `VersaoConfiguracao` referenciar a regra que o seed substitui —
+  a trava que torna esta fronteira executável, e não conselho.
+- Fitness test `Migrations_NaoCriamGatilhoSobreRolDeRegras`: o append-only é por
+  convenção, sem gatilho de banco (coerente com o XML-doc corrigido de
+  `RegraCatalogo` e com `RegraCatalogoConfiguration`).
+
+## Prós e contras das opções
+
+### Substituição incondicional
+
+- Bom, porque é o diff mais simples.
+- Ruim, porque permitiria mutar uma regra da qual um certame já depende, quebrando
+  a reprodutibilidade (RN08).
+
+### Append-only estrito desde sempre
+
+- Bom, porque a regra é uniforme e não tem janela de exceção.
+- Ruim, porque preserva vocabulário nunca usado como se fosse fato, e o nome
+  errado de uma regra ficaria no catálogo para sempre.
+
+### Substituição condicionada ao não-congelamento
+
+- Bom, porque protege o que é fato e corrige o que ainda é só vocabulário.
+- Ruim, porque introduz uma condição que precisa ser verificada mecanicamente
+  antes de cada substituição.
+
+## Mais informações
+
+- RN08 (congelamento de parâmetros por edital).
+- ADR-0104 (a vigência da configuração ordena as versões).
+- Story #772 (a biblioteca `rol_de_regras`).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -139,12 +139,13 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0108](0108-registro-do-ato-por-mensagem-duravel.md) | O domínio registra o ato por mensagem durável, não por chamada síncrona (supersede a 0106 no mecanismo) | accepted | 2026-07-12 |
 | [0109](0109-envelope-canonico-v2-do-congelamento.md) | Contrato do envelope canônico do congelamento (v2) | accepted | 2026-07-13 |
 | [0110](0110-retificacao-como-sessao-editorial.md) | A retificação é uma sessão editorial sobre a configuração, não um estado do certame | accepted | 2026-07-13 |
+| [0112](0112-fronteira-append-only-do-catalogo-de-regras.md) | Fronteira do append-only na correção do catálogo de regras (substituível enquanto nada congelado referenciar) | accepted | 2026-07-14 |
 
-> **Nota de numeração:** a sequência de `0001` a `0110` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0111+`.
+> **Nota de numeração:** a sequência vai de `0001` a `0112`. A `0111` está **reservada** para a ADR do vocabulário fechado de fatos do candidato, em elaboração — entra junto com a sua issue. Ao adicionar uma ADR nova, use `0113+`.
 
 ## Como adicionar um novo ADR
 
-1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0110`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
+1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0112`; a `0111` está reservada). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
 2. Copie [`_template.md`](_template.md).
 3. Renomeie para `NNNN-titulo-em-slug.md` (slug ASCII em minúsculas, hífens como separador).
 4. Preencha frontmatter, contexto, drivers, opções, resultado da decisão (única), consequências.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/RegraCatalogo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/RegraCatalogo.cs
@@ -21,9 +21,19 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// as regras são semeadas (governadas por código) e a versão de uma regra é
 /// <em>imutável</em> — corrigir/evoluir o comportamento é publicar uma nova
 /// versão, nunca mutar a existente. Por isso a entidade deriva de
-/// <see cref="EntityBase"/> puro (sem soft-delete) e a imutabilidade é imposta
-/// no banco por gatilho <c>BEFORE UPDATE OR DELETE</c>; a própria linhagem de
-/// versões é a trilha de auditoria (sem histórico forense adicional).
+/// <see cref="EntityBase"/> puro (sem soft-delete). O append-only é imposto por
+/// <em>convenção</em> — ausência de API de mutação, leitura por
+/// <c>IRegraCatalogoReader</c> e fitness test —, não por gatilho de banco: não
+/// há <c>trigger</c> sobre <c>rol_de_regras</c> em migration alguma. A própria
+/// linhagem de versões é a trilha de auditoria (sem histórico forense adicional).
+/// </para>
+/// <para>
+/// <strong>Fronteira da correção do seed (ADR-0112).</strong> Enquanto nenhuma
+/// configuração congelada (<see cref="VersaoConfiguracao"/>) referenciar uma
+/// linha por <c>(codigo, versao)</c>, essa linha ainda é vocabulário de seed e
+/// pode ser corrigida por substituição. A partir do primeiro congelamento que a
+/// referencia, ela vira fato e vale append-only estrito (RN08) — o passado não
+/// se muta. A verificação é mecânica, contra o conjunto de versões congeladas.
 /// </para>
 /// <para>
 /// <strong>Hash content-addressable.</strong> O <see cref="Hash"/> é o SHA-256

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/RegraCatalogoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/RegraCatalogoConfiguration.cs
@@ -19,13 +19,16 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Seed;
 /// <remarks>
 /// <para>
 /// A tabela é <strong>append-only e seed-governada</strong>: não há CRUD de
-/// administrador, a versão de uma regra é imutável e a única escrita é o seed.
-/// Por isso a entidade deriva de <c>EntityBase</c> puro (sem soft-delete) e o
-/// índice <c>UNIQUE (codigo, versao)</c> é <strong>total</strong> (não parcial)
-/// — é justamente o que habilita <c>v1</c>/<c>v2</c> coexistentes referenciáveis.
-/// O append-only é imposto por convenção (ausência de API de mutação; leitura
-/// via <c>IRegraCatalogoReader</c>) e por fitness test, na linha do ADR-0063 —
-/// não por gatilho de banco (o repositório não usa gatilhos).
+/// administrador e a única escrita é o seed. Uma linha congelada por alguma
+/// <c>VersaoConfiguracao</c> é imutável; enquanto nenhuma a referencia, ainda é
+/// vocabulário de seed e pode ser corrigida por substituição (ADR-0112). Por isso
+/// a entidade deriva de <c>EntityBase</c> puro (sem soft-delete) e o índice
+/// <c>UNIQUE (codigo, versao)</c> é <strong>total</strong> (não parcial) — é
+/// justamente o que habilita versões coexistentes referenciáveis. O append-only é
+/// imposto por convenção (ausência de API de mutação; leitura via
+/// <c>IRegraCatalogoReader</c>) e por fitness test, na linha do ADR-0063 — não por
+/// gatilho de banco: não há gatilho sobre <c>rol_de_regras</c> (ao contrário de
+/// outras tabelas do módulo, como <c>versoes_configuracao</c>, que têm os seus).
 /// </para>
 /// <para>
 /// <c>esquema_args</c> (schema dos argumentos) e <c>invariantes</c> são

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260715024829_SubstituiRegraRecursoMultiInstancia.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260715024829_SubstituiRegraRecursoMultiInstancia.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715024829_SubstituiRegraRecursoMultiInstancia")]
+    partial class SubstituiRegraRecursoMultiInstancia
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260715024829_SubstituiRegraRecursoMultiInstancia.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260715024829_SubstituiRegraRecursoMultiInstancia.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class SubstituiRegraRecursoMultiInstancia : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                schema: "selecao",
+                table: "rol_de_regras",
+                keyColumn: "id",
+                keyValue: new Guid("d0a00000-0000-7000-8000-000000000018"),
+                columns: new[] { "base_legal", "codigo", "esquema_args", "hash", "invariantes" },
+                values: new object[] { "Lei 9.784/1999 art. 56 (cabimento do recurso administrativo) e art. 61 (efeito suspensivo por decisão fundamentada); prazo configurável por edital", "RECURSO-PRAZO-ANCORADO-EM-ATO", "{\"prazo_valor\":\"numeric (> 0)\",\"prazo_unidade\":\"HORAS|DIAS|DIAS_UTEIS (sem default — dado do edital)\",\"ato_ancora_codigo\":\"código do tipo de ato — o prazo conta do INSTANTE DE PUBLICAÇÃO do ato, nunca de data fixa; a âncora nunca é um ato que congela configuração\",\"suspensividade_primeira_instancia\":\"{valor:numeric, unidade:HORAS|DIAS|DIAS_UTEIS} | null — null = a pendência na fase não bloqueia atos irreversíveis\",\"suspensividade_segunda_instancia\":\"{valor:numeric, unidade:HORAS|DIAS|DIAS_UTEIS} | null — null = a pendência em instância superior não bloqueia (via judicial, prazo indeterminado)\"}", "94f2a02a12cccae0ebe98dabc9dc66b5aacac25053e91b768fdf0d47492e8240", "[\"o Uni+ gere apenas a 1ª instância — o julgamento em instância superior (administrativa ou judicial) corre FORA do sistema; a sua existência e o seu desfecho são REGISTRADOS como ato publicado\",\"a suspensividade é configurável por fase e por grau: null = a pendência não bloqueia atos irreversíveis\",\"a janela de suspensividade fecha no julgamento OU no fim do prazo, o que vier primeiro — recurso nunca julgado não trava o certame para sempre\",\"interposição só é aceita com a janela da fase de recurso aberta\",\"não cabe recurso contra resultado definitivo\",\"prazo ancorado no instante de publicação do ato âncora: se o ato atrasa, o prazo desliza junto, sem retificação\",\"a âncora nunca é um tipo de ato que congela configuração\",\"DIAS_UTEIS é recusado na INTERPOSIÇÃO enquanto não houver calendário — nunca aproximado em silêncio\",\"append-only: julgamento e retificação são NOVO fato, não sobrescrevem o passado\"]" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                schema: "selecao",
+                table: "rol_de_regras",
+                keyColumn: "id",
+                keyValue: new Guid("d0a00000-0000-7000-8000-000000000018"),
+                columns: new[] { "base_legal", "codigo", "esquema_args", "hash", "invariantes" },
+                values: new object[] { "Lei 9.784/1999 (processo administrativo federal); edital/processo (prazo configurável por edital); regimento CONSEPE (2ª instância)", "RECURSO-MULTI-INSTANCIA", "{\"prazo_valor\":\"numeric\",\"prazo_unidade\":\"HORAS|DIAS|DIAS_UTEIS (sem default — dado do edital)\",\"contra_ato\":\"codigo da fase produtora recorrível (NUNCA resultado definitivo)\",\"marco_inicial\":\"a partir de quando conta (ex.: publicacao_resultado)\",\"instancias\":\"lista ordenada [{instancia,dono,prazo_valor,prazo_unidade}] — 1ª CEPS, 2ª CONSEPE\"}", "660cf3fffe22069f5a7f302a98b1e44b96d2e992680f02304935a36548f95490", "[\"interposição GATED pela janela aberta (sem recurso a qualquer momento)\",\"sem recurso ao resultado definitivo (≠ recurso de habilitação CRCA)\",\"2ª instância (CONSEPE) só após indeferimento da 1ª; CONSEPE emite parecer externo, CEPS anexa e aplica (vinculante)\",\"processo PARALISA enquanto 2ª instância pendente; avanço só após expirar o prazo\",\"append-only: parecer/retificação = novo fato, não sobrescreve o passado\"]" });
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Seed/RegraCatalogoSeed.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Seed/RegraCatalogoSeed.cs
@@ -27,6 +27,14 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// literal — é derivado da definição via <see cref="Item.ComputarHash"/>,
 /// mantendo content-addressability por construção.
 /// </para>
+/// <para>
+/// A linha <c>SeedId(18)</c> (<c>RECURSO-PRAZO-ANCORADO-EM-ATO</c>) substituiu a
+/// antiga <c>RECURSO-MULTI-INSTANCIA</c>, que conflacionava a gestão de uma
+/// segunda instância — inexistente no Uni+ — com a janela de suspensividade.
+/// A ADR-0112 fixa a fronteira dessa correção: o seed é corrigível por
+/// substituição enquanto nenhuma configuração congelada o referenciar; a partir
+/// do primeiro congelamento, vale append-only estrito (RN08).
+/// </para>
 /// </remarks>
 public static class RegraCatalogoSeed
 {
@@ -147,15 +155,15 @@ public static class RegraCatalogoSeed
             """,
             "Portaria MEC 18/2012 art. 11, parágrafo único (red. PN 2.027/2023) — cap nas vagas da oferta + prioridade do inciso III (LB) sobre o inciso IV (LI); art. 10 II (mínimo 50%, piso)"),
 
-        // regra_prazo_recurso — prazo/janela/instâncias do recurso
-        new(SeedId(18), "RECURSO-MULTI-INSTANCIA", VersaoV1, TipoRegra.RegraPrazoRecurso,
+        // regra_prazo_recurso — prazo do recurso ancorado em ato + janela de suspensividade por instância
+        new(SeedId(18), "RECURSO-PRAZO-ANCORADO-EM-ATO", VersaoV1, TipoRegra.RegraPrazoRecurso,
             """
-            {"prazo_valor":"numeric","prazo_unidade":"HORAS|DIAS|DIAS_UTEIS (sem default — dado do edital)","contra_ato":"codigo da fase produtora recorrível (NUNCA resultado definitivo)","marco_inicial":"a partir de quando conta (ex.: publicacao_resultado)","instancias":"lista ordenada [{instancia,dono,prazo_valor,prazo_unidade}] — 1ª CEPS, 2ª CONSEPE"}
+            {"prazo_valor":"numeric (> 0)","prazo_unidade":"HORAS|DIAS|DIAS_UTEIS (sem default — dado do edital)","ato_ancora_codigo":"código do tipo de ato — o prazo conta do INSTANTE DE PUBLICAÇÃO do ato, nunca de data fixa; a âncora nunca é um ato que congela configuração","suspensividade_primeira_instancia":"{valor:numeric, unidade:HORAS|DIAS|DIAS_UTEIS} | null — null = a pendência na fase não bloqueia atos irreversíveis","suspensividade_segunda_instancia":"{valor:numeric, unidade:HORAS|DIAS|DIAS_UTEIS} | null — null = a pendência em instância superior não bloqueia (via judicial, prazo indeterminado)"}
             """,
             """
-            ["interposição GATED pela janela aberta (sem recurso a qualquer momento)","sem recurso ao resultado definitivo (≠ recurso de habilitação CRCA)","2ª instância (CONSEPE) só após indeferimento da 1ª; CONSEPE emite parecer externo, CEPS anexa e aplica (vinculante)","processo PARALISA enquanto 2ª instância pendente; avanço só após expirar o prazo","append-only: parecer/retificação = novo fato, não sobrescreve o passado"]
+            ["o Uni+ gere apenas a 1ª instância — o julgamento em instância superior (administrativa ou judicial) corre FORA do sistema; a sua existência e o seu desfecho são REGISTRADOS como ato publicado","a suspensividade é configurável por fase e por grau: null = a pendência não bloqueia atos irreversíveis","a janela de suspensividade fecha no julgamento OU no fim do prazo, o que vier primeiro — recurso nunca julgado não trava o certame para sempre","interposição só é aceita com a janela da fase de recurso aberta","não cabe recurso contra resultado definitivo","prazo ancorado no instante de publicação do ato âncora: se o ato atrasa, o prazo desliza junto, sem retificação","a âncora nunca é um tipo de ato que congela configuração","DIAS_UTEIS é recusado na INTERPOSIÇÃO enquanto não houver calendário — nunca aproximado em silêncio","append-only: julgamento e retificação são NOVO fato, não sobrescrevem o passado"]
             """,
-            "Lei 9.784/1999 (processo administrativo federal); edital/processo (prazo configurável por edital); regimento CONSEPE (2ª instância)"),
+            "Lei 9.784/1999 art. 56 (cabimento do recurso administrativo) e art. 61 (efeito suspensivo por decisão fundamentada); prazo configurável por edital"),
     ];
 }
 

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/RolDeRegrasSemGatilhoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/RolDeRegrasSemGatilhoTests.cs
@@ -1,0 +1,83 @@
+namespace Unifesspa.UniPlus.Selecao.ArchTests;
+
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+
+using AwesomeAssertions;
+
+/// <summary>
+/// Fitness test da fronteira append-only do <c>rol_de_regras</c> (#854): a
+/// imutabilidade do catálogo é imposta por <em>convenção</em> — ausência de API
+/// de mutação e leitura por <c>IRegraCatalogoReader</c> —, nunca por gatilho de
+/// banco. O XML-doc de <c>RegraCatalogo</c> chegou a afirmar um gatilho
+/// <c>BEFORE UPDATE OR DELETE</c> inexistente (o gatilho real protege
+/// <c>versoes_configuracao</c>); este teste trava a afirmação na verdade: se
+/// alguma migration passar a criar um gatilho sobre <c>rol_de_regras</c>, ele
+/// falha, forçando a correção do texto e a revisão da decisão.
+/// </summary>
+public sealed class RolDeRegrasSemGatilhoTests
+{
+    /// <summary>
+    /// Detecta um <c>CREATE TRIGGER</c> cujo alvo (<c>ON …</c>) é
+    /// <c>rol_de_regras</c>. Aceita as variantes válidas do PostgreSQL
+    /// (<c>OR REPLACE</c>, <c>CONSTRAINT</c>) para não deixar um gatilho real
+    /// escapar por forma sintática.
+    /// </summary>
+    private static readonly Regex GatilhoSobreRolDeRegras = new(
+        @"create\s+(or\s+replace\s+)?(constraint\s+)?trigger\b[^;]*?\bon\b[^;]*?rol_de_regras",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.CultureInvariant);
+
+    [Fact(DisplayName = "Nenhuma migration de Seleção cria gatilho de banco sobre rol_de_regras")]
+    public void Migrations_NaoCriamGatilhoSobreRolDeRegras()
+    {
+        string pastaDeMigrations = PastaDeMigrations();
+        Directory.Exists(pastaDeMigrations).Should().BeTrue(
+            $"as migrations do módulo Seleção vivem em {pastaDeMigrations}");
+
+        // Comentários C# são removidos antes do match: uma nota explicando a
+        // AUSÊNCIA de gatilho não pode ser lida como sua presença.
+        List<string> infratoras = Directory
+            .EnumerateFiles(pastaDeMigrations, "*.cs", SearchOption.TopDirectoryOnly)
+            .Where(arquivo => GatilhoSobreRolDeRegras.IsMatch(SemComentarios(arquivo)))
+            .Select(arquivo => Path.GetFileName(arquivo)!)
+            .ToList();
+
+        infratoras.Should().BeEmpty(
+            "o append-only do rol_de_regras é por convenção; nenhum gatilho o protege no banco — "
+            + $"e o XML-doc de RegraCatalogo depende disso. Migrations que criam gatilho: {string.Join(", ", infratoras)}");
+    }
+
+    [Theory(DisplayName = "O detector reconhece as formas válidas de CREATE TRIGGER sobre rol_de_regras")]
+    [InlineData("CREATE TRIGGER t BEFORE UPDATE ON selecao.rol_de_regras FOR EACH ROW EXECUTE FUNCTION f();")]
+    [InlineData("CREATE OR REPLACE TRIGGER t BEFORE UPDATE ON rol_de_regras FOR EACH ROW EXECUTE FUNCTION f();")]
+    [InlineData("create constraint trigger t after insert on selecao.rol_de_regras for each row execute function f();")]
+    public void Detector_ReconheceFormasValidas(string sql)
+    {
+        GatilhoSobreRolDeRegras.IsMatch(sql).Should().BeTrue(
+            "toda variante sintática de CREATE TRIGGER sobre rol_de_regras deve ser detectada");
+    }
+
+    [Theory(DisplayName = "O detector não confunde gatilho de outra tabela com um sobre rol_de_regras")]
+    [InlineData("CREATE TRIGGER t BEFORE UPDATE ON selecao.versoes_configuracao FOR EACH ROW EXECUTE FUNCTION f();")]
+    [InlineData("SELECT * FROM selecao.rol_de_regras;")]
+    public void Detector_NaoAcusaFalsoPositivo(string sql)
+    {
+        GatilhoSobreRolDeRegras.IsMatch(sql).Should().BeFalse(
+            "só um gatilho cujo alvo é rol_de_regras deve ser acusado");
+    }
+
+    private static string SemComentarios(string arquivo) => string.Join(
+        '\n',
+        File.ReadLines(arquivo).Where(static linha => !linha.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+    private static string PastaDeMigrations([CallerFilePath] string origem = "") =>
+        Path.GetFullPath(Path.Join(
+            Path.GetDirectoryName(origem)!,
+            "..",
+            "..",
+            "src",
+            "selecao",
+            "Unifesspa.UniPlus.Selecao.Infrastructure",
+            "Persistence",
+            "Migrations"));
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/RolDeRegras/RegraCatalogoSeedTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/RolDeRegras/RegraCatalogoSeedTests.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.IntegrationTests.RolDeRegras;
 
+using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 
 using AwesomeAssertions;
@@ -20,6 +22,10 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Seed;
 /// Postgres, a coexistência de versões (<c>UNIQUE (codigo, versao)</c>) e o
 /// <see cref="RegraCatalogoReader"/>.
 /// </summary>
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL fixo escrito no próprio teste; o único valor externo (o código da regra) entra por DbParameter.")]
 public sealed class RegraCatalogoSeedTests : IClassFixture<RegraCatalogoDbFixture>
 {
     private readonly RegraCatalogoDbFixture _fixture;
@@ -144,5 +150,111 @@ public sealed class RegraCatalogoSeedTests : IClassFixture<RegraCatalogoDbFixtur
         IReadOnlyList<RegraCatalogo> desempates = await reader.ListarPorTipoAsync(TipoRegra.CriterioDesempate, CancellationToken.None);
         desempates.Should().HaveCount(4);
         desempates.Should().OnlyContain(r => r.Tipo == TipoRegra.CriterioDesempate);
+    }
+
+    [Fact(DisplayName = "CA-07 — o reader resolve a regra nova e não resolve mais a antiga")]
+    public async Task Reader_ObterAsync_RegraNova_Resolve()
+    {
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+        RegraCatalogoReader reader = new(context);
+
+        RegraCatalogo? nova = await reader.ObterAsync("RECURSO-PRAZO-ANCORADO-EM-ATO", "v1", CancellationToken.None);
+        nova.Should().NotBeNull();
+        nova!.Tipo.Should().Be(TipoRegra.RegraPrazoRecurso);
+
+        RegraCatalogo? antiga = await reader.ObterAsync("RECURSO-MULTI-INSTANCIA", "v1", CancellationToken.None);
+        antiga.Should().BeNull("a regra que gere a segunda instância deixou de existir");
+    }
+
+    [Fact(DisplayName = "CA-08 — há exatamente uma regra de prazo de recurso — a nova")]
+    public async Task Reader_ListarPorTipo_PrazoRecurso_ExatamenteUma()
+    {
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+        RegraCatalogoReader reader = new(context);
+
+        IReadOnlyList<RegraCatalogo> regras = await reader.ListarPorTipoAsync(
+            TipoRegra.RegraPrazoRecurso, CancellationToken.None);
+
+        regras.Should().ContainSingle()
+            .Which.Codigo.Should().Be("RECURSO-PRAZO-ANCORADO-EM-ATO");
+    }
+
+    // O código da regra removida, como valor JSON — entre aspas. Casar o token
+    // aspado (e não a substring nua) impede que um OUTRO código que apenas
+    // contenha este como prefixo (ex.: RECURSO-MULTI-INSTANCIA-LEGACY) bloqueie a
+    // substituição por engano: o valor JSON só bate quando é igual, delimitado.
+    private const string TokenCodigoRemovido = "\"RECURSO-MULTI-INSTANCIA\"";
+
+    private const string DetectaReferenciaJsonb = """
+        WITH amostra(configuracao_congelada) AS (VALUES (@amostra::jsonb))
+        SELECT count(*) FROM amostra
+        WHERE configuracao_congelada::text LIKE '%' || @token || '%'
+        """;
+
+    private const string ContaReferenciasReais = """
+        SELECT count(*) FROM selecao.versoes_configuracao
+        WHERE configuracao_congelada::text LIKE '%' || @token || '%'
+        """;
+
+    [Fact(DisplayName = "CA-12 — nenhuma configuração congelada referencia a regra substituída (fronteira da ADR-0112)")]
+    public async Task RegraCatalogoSeed_SubstituirRegraReferenciada_Falha()
+    {
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+
+        // Canário positivo: o detector ENXERGA uma configuração que referencia a
+        // regra removida pelo seu valor de código. Sem esta prova, a ausência real
+        // abaixo não significaria nada — um detector quebrado passaria como verde.
+        long detectados = await ContarAsync(
+            context,
+            DetectaReferenciaJsonb,
+            amostra: """{"regra":{"codigo":"RECURSO-MULTI-INSTANCIA","versao":"v1"}}""");
+        detectados.Should().Be(1, "o detector precisa enxergar a referência para a ausência provar algo");
+
+        // Canário negativo: um código DISTINTO que apenas contém o removido como
+        // prefixo não pode ser confundido com ele — a fronteira da ADR-0112 é por
+        // identidade da regra, não por substring.
+        long falsosPositivos = await ContarAsync(
+            context,
+            DetectaReferenciaJsonb,
+            amostra: """{"regra":{"codigo":"RECURSO-MULTI-INSTANCIA-LEGACY","versao":"v1"}}""");
+        falsosPositivos.Should().Be(0, "um código diferente que contém o removido como prefixo não é o removido");
+
+        // Schema real (banco efêmero migrado): nenhuma VersaoConfiguracao congelada
+        // referencia a regra que o seed substituiu — é o que torna a substituição
+        // legítima no schema-alvo dos testes (ADR-0112). Para bases já implantadas,
+        // a verificação da fronteira roda como precondição do fluxo de migração,
+        // não neste teste.
+        long referenciasReais = await ContarAsync(context, ContaReferenciasReais, amostra: null);
+        referenciasReais.Should().Be(
+            0,
+            "substituir uma regra já congelada por uma configuração violaria o append-only (RN08)");
+    }
+
+    private static async Task<long> ContarAsync(SelecaoDbContext context, string sql, string? amostra)
+    {
+        DbConnection conexao = context.Database.GetDbConnection();
+        if (conexao.State != System.Data.ConnectionState.Open)
+        {
+            await conexao.OpenAsync(CancellationToken.None);
+        }
+
+        await using DbCommand comando = conexao.CreateCommand();
+        comando.CommandText = sql;
+        AdicionarParametro(comando, "token", TokenCodigoRemovido);
+        if (amostra is not null)
+        {
+            AdicionarParametro(comando, "amostra", amostra);
+        }
+
+        object? resultado = await comando.ExecuteScalarAsync(CancellationToken.None);
+        return Convert.ToInt64(resultado, System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static void AdicionarParametro(DbCommand comando, string nome, string valor)
+    {
+        DbParameter parametro = comando.CreateParameter();
+        parametro.ParameterName = nome;
+        parametro.Value = valor;
+        comando.Parameters.Add(parametro);
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/RolDeRegras/RegraCatalogoSubstituicaoRecursoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/RolDeRegras/RegraCatalogoSubstituicaoRecursoTests.cs
@@ -1,0 +1,171 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.RolDeRegras;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Seed;
+
+/// <summary>
+/// Cobertura da substituição da regra de prazo de recurso (#854): a antiga
+/// <c>RECURSO-MULTI-INSTANCIA</c> — que atribuía ao Uni+ a gestão de uma segunda
+/// instância inexistente — dá lugar a <c>RECURSO-PRAZO-ANCORADO-EM-ATO</c>, que
+/// preserva a janela de suspensividade (por instância) e ancora o prazo num ato
+/// publicado. Asserções sobre a fonte única do seed (<see cref="RegraCatalogoSeed.Itens"/>),
+/// sem tocar o banco — a materialização é coberta por <see cref="RegraCatalogoSeedTests"/>.
+/// </summary>
+public sealed class RegraCatalogoSubstituicaoRecursoTests
+{
+    private const string CodigoAntigo = "RECURSO-MULTI-INSTANCIA";
+    private const string CodigoNovo = "RECURSO-PRAZO-ANCORADO-EM-ATO";
+
+    /// <summary>
+    /// Hash da regra 18 no seed original (migration <c>AddRolDeRegras</c>), antes
+    /// da substituição — a contraprova de que o hash da regra nova mudou.
+    /// </summary>
+    private const string HashRegraRemovida =
+        "660cf3fffe22069f5a7f302a98b1e44b96d2e992680f02304935a36548f95490";
+
+    /// <summary>
+    /// Hash da regra nova, congelado na migration <c>SubstituiRegraRecursoMultiInstancia</c>.
+    /// Amarra a definição do seed ao literal da migration: editar o texto da regra
+    /// sem regenerar a migration quebra este teste.
+    /// </summary>
+    private const string HashRegraNova =
+        "94f2a02a12cccae0ebe98dabc9dc66b5aacac25053e91b768fdf0d47492e8240";
+
+    /// <summary>
+    /// Hashes das 17 regras não tocadas, como gravados na migration original — a
+    /// referência que prova que a substituição alterou UMA linha e só uma (CA-04).
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> HashesOriginaisDasDemais =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["FORMULA-MEDIA-PONDERADA"] = "a6fdc29bce533ef3cf8acb6cfdd7d67a99104541f6201d227f0d1c7051229ad6",
+            ["CLASSIFICACAO-IMPORTADA"] = "8e6f1f7b705c601991bf0617bbf881e39a3666c641abdfa4c1bd9ce2ecbcc85c",
+            ["PRECISAO-TRUNCAR"] = "66cbb932e61982f09fdd1d60a0db8411ea02dedc19bb72d1af23004f1e18360b",
+            ["PRECISAO-ARREDONDAR-CIMA"] = "efc491bf6a242a870c7bf9969048c198db88116ba39e72a44bcf1d5d5aebc4fb",
+            ["ELIM-NOTA-MINIMA-ETAPA"] = "b64f643eba9744efc20bf19221bde85c645da32262a7d2ef616f18bd7c2ed5ac",
+            ["ELIM-CORTE-REDACAO"] = "6a23db02c00878d5bb98a445e8dc72e209a95f2aa4a8bfd91de8fa08ee69c240",
+            ["ELIM-ZERO-EM-AREA"] = "75f4929b848138c8ed939a182e3664451ce38cd40a136adda438b62e1b6e3fb8",
+            ["BONUS-MULTIPLICATIVO"] = "d824fa64884e038e132f918dfd6efecf56d1df4cd4a1a1f86a78bf31718dae9b",
+            ["DESEMPATE-IDOSO"] = "6738b1a9ca4f063f7f215cabb837e055d8abafaf0835f0b3deeed1c97f0becd4",
+            ["DESEMPATE-MAIOR-NOTA-ETAPA"] = "1a988e6681b2970dc6c568c7372ceaf2f6e5ec0f7061ac47f656e1366a9ecad8",
+            ["DESEMPATE-MAIOR-IDADE"] = "1efa26eaeffc88baf31ce9e2030c05c9976fae125e9845fe0283168050dc1237",
+            ["DESEMPATE-PREDICADO-FATO"] = "d832d910826f25b6b50fd324f2f3cae472440c0e81e082be7c8d4fefe3de3f21",
+            ["ALOCACAO-OPCOES-RN04"] = "2bb69f0e34483e635aa0903f8d3ba19a4255e8f542c5f7090ac75cecf200c988",
+            ["RENDA-PER-CAPITA-LEI-12711"] = "5a1ad80627e354c03e4d6ef776a45db695a1203cea574a288dbcdf706ca58899",
+            ["DISTRIB-VAGAS-LEI-12711"] = "0eb12ca67af16ab666e0db0894d795ec725422326cf7dedba2e804f496e0d807",
+            ["DISTRIB-VAGAS-INSTITUCIONAL"] = "03b114eb3b559367b7d79f9edb1371f8164c5ede0c5f4b21809ee572c49c9451",
+            ["RECONCILIACAO-VAGAS-ART11-PU"] = "ad2d8012ddc1f2ea4d763034899d07590c4a49901744b852dca2e70cede8b1e9",
+        };
+
+    private static RegraCatalogoSeedItem RegraNova() =>
+        RegraCatalogoSeed.Itens.Single(i => i.Codigo == CodigoNovo);
+
+    [Fact(DisplayName = "CA-01 — a regra que gere a segunda instância não existe mais no catálogo")]
+    public void RegraCatalogoSeed_RecursoMultiInstancia_NaoExiste()
+    {
+        RegraCatalogoSeed.Itens.Should().NotContain(
+            i => i.Codigo == CodigoAntigo,
+            "a substituição remove RECURSO-MULTI-INSTANCIA em toda versão");
+    }
+
+    [Fact(DisplayName = "CA-02 — a regra nova declara prazo ancorado em ato, sem a chave 'instancias'")]
+    public void RegraCatalogoSeed_RecursoPrazoAncorado_EsquemaCorreto()
+    {
+        RegraCatalogoSeedItem nova = RegraNova();
+
+        nova.Versao.Should().Be(RegraCatalogoSeed.VersaoV1);
+        nova.Tipo.Should().Be(TipoRegra.RegraPrazoRecurso);
+
+        using JsonDocument esquema = JsonDocument.Parse(nova.EsquemaArgsJson);
+        JsonElement raiz = esquema.RootElement;
+
+        raiz.ValueKind.Should().Be(JsonValueKind.Object);
+        raiz.TryGetProperty("ato_ancora_codigo", out _).Should().BeTrue("o prazo ancora num ato publicado");
+        raiz.TryGetProperty("suspensividade_primeira_instancia", out _).Should().BeTrue();
+        raiz.TryGetProperty("suspensividade_segunda_instancia", out _).Should().BeTrue();
+        raiz.TryGetProperty("instancias", out _).Should().BeFalse(
+            "a lista de instâncias geridas pelo sistema foi descartada");
+    }
+
+    [Fact(DisplayName = "CA-03 — nenhum campo da regra nova reintroduz a gestão da segunda instância")]
+    public void RegraCatalogoSeed_RecursoPrazoAncorado_NaoGereSegundaInstancia()
+    {
+        RegraCatalogoSeedItem nova = RegraNova();
+
+        // Substrings que identificavam, na regra antiga, a GESTÃO de uma segunda
+        // instância dentro do Uni+ — a lista ordenada de instâncias, o órgão
+        // externo que ela nomeava e a paralisação do processo. Nenhuma pode
+        // ressurgir por acidente na definição da regra nova.
+        string[] marcasDaGestao = ["instancias", "CONSEPE", "PARALISA"];
+        string conteudo = string.Join(
+            '\n',
+            nova.EsquemaArgsJson,
+            nova.InvariantesJson,
+            nova.BaseLegal);
+
+        foreach (string marca in marcasDaGestao)
+        {
+            conteudo.Should().NotContainEquivalentOf(
+                marca,
+                $"a correção não pode reintroduzir a gestão da segunda instância ('{marca}')");
+        }
+    }
+
+    [Fact(DisplayName = "CA-06 — a janela de suspensividade sobrevive, por instância e anulável")]
+    public void RegraCatalogoSeed_RecursoPrazoAncorado_PreservaSuspensividade()
+    {
+        RegraCatalogoSeedItem nova = RegraNova();
+
+        using JsonDocument esquema = JsonDocument.Parse(nova.EsquemaArgsJson);
+        JsonElement raiz = esquema.RootElement;
+
+        string primeira = raiz.GetProperty("suspensividade_primeira_instancia").GetString()!;
+        string segunda = raiz.GetProperty("suspensividade_segunda_instancia").GetString()!;
+
+        // CA-06b: o nulo é a desativação — precisa estar declarado como válido nos
+        // dois graus (é a configuração da Habilitação/Ingresso, via judicial).
+        primeira.Should().Contain("null", "null = a pendência na fase não bloqueia atos irreversíveis");
+        segunda.Should().Contain("null", "null = a pendência em instância superior não bloqueia (via judicial)");
+    }
+
+    [Fact(DisplayName = "CA-09 — o hash da regra nova é estável e difere do da regra removida")]
+    public void RegraCatalogoSeed_HashDaRegraNova()
+    {
+        RegraCatalogoSeedItem nova = RegraNova();
+
+        nova.ComputarHash().Should().Be(
+            HashRegraNova,
+            "a definição do seed deve bater com o literal congelado na migration");
+        nova.ComputarHash().Should().NotBe(
+            HashRegraRemovida,
+            "trocar a definição da regra troca o hash content-addressable");
+    }
+
+    [Fact(DisplayName = "CA-04 — as outras 17 regras permanecem idênticas; a substituição toca uma linha")]
+    public void DemaisRegras_Inalteradas()
+    {
+        IReadOnlyList<RegraCatalogoSeedItem> itens = RegraCatalogoSeed.Itens;
+
+        itens.Should().HaveCount(18, "o catálogo continua com 18 linhas (CA-05)");
+        itens.Select(i => (i.Codigo, i.Versao)).Should().OnlyHaveUniqueItems("(codigo, versao) é único (CA-05)");
+
+        foreach (RegraCatalogoSeedItem item in itens.Where(i => i.Codigo != CodigoNovo))
+        {
+            HashesOriginaisDasDemais.Should().ContainKey(
+                item.Codigo,
+                "nenhuma regra além da substituída pode ter surgido ou mudado de código");
+            item.ComputarHash().Should().Be(
+                HashesOriginaisDasDemais[item.Codigo],
+                $"a regra {item.Codigo} não foi tocada pela substituição");
+        }
+
+        // A única linha alterada é a nova — e seu hash não coincide com nenhum dos
+        // 17 originais nem com o da regra removida.
+        HashesOriginaisDasDemais.Values.Should().NotContain(HashRegraNova);
+    }
+}


### PR DESCRIPTION
## Contexto

A regra `RECURSO-MULTI-INSTANCIA` do catálogo `rol_de_regras` (biblioteca de regras tipadas e content-addressable que a configuração do Processo Seletivo referencia por `(codigo, versao, hash)`) conflacionava dois conceitos distintos:

| O que a regra afirmava | Veredito |
|---|---|
| O Uni+ **gere** a instância superior (prazo, dono, lista ordenada de instâncias) | ❌ Não — o julgamento em instância superior (administrativa ou judicial) corre **fora** do sistema |
| O processo **paralisa** enquanto pende recurso | ✅ Sim, mas configurável — é a **janela de suspensividade** |

O nome `MULTI-INSTANCIA` negava o próprio conteúdo que deveria sobrar. Uma nova *versão* do mesmo código herdaria a confusão no nome.

## O que muda

- **Remove** `RECURSO-MULTI-INSTANCIA` e **publica** `RECURSO-PRAZO-ANCORADO-EM-ATO` (`v1`), reusando o `SeedId(18)` — o catálogo permanece com **18 linhas**, e a migration é um único `UpdateData` sobre a linha `...018` (as outras 17 ficam intactas).
- A regra nova ancora o prazo no **instante de publicação de um ato** (não em data fixa) e preserva a **suspensividade por instância**, anulável: `null` = a pendência não bloqueia atos irreversíveis. É a diferença entre Seleção (ambas as instâncias bloqueiam) e Habilitação/Ingresso (a superior, judicial, não bloqueia) — **sem** ramificar comportamento por módulo em código.
- **ADR-0112** fixa a fronteira do append-only: o seed é corrigível por substituição **enquanto nenhuma configuração congelada o referenciar**; a partir do primeiro congelamento, vale append-only estrito (RN08). A verificação é mecânica.
- Corrige o XML-doc de `RegraCatalogo`, que afirmava uma trava por **gatilho de banco inexistente** (o gatilho real protege `versoes_configuracao`) — o append-only do `rol_de_regras` é por **convenção**. Ajusta também o remarks de `RegraCatalogoConfiguration`, que generalizava "o repositório não usa gatilhos".

## Legitimidade da substituição

Nenhuma `VersaoConfiguracao` congelada referencia a regra removida, `TipoRegra.RegraPrazoRecurso` tem zero consumidores em produção e não há ambiente com envelope congelado. Uma linha de seed nunca referenciada é vocabulário, não fato — e vocabulário errado se corrige.

## Testes (CA-01 … CA-12)

- **Conteúdo do seed** (`RegraCatalogoSubstituicaoRecursoTests`): a regra antiga não existe (CA-01); a nova declara `ato_ancora_codigo` + suspensividade por instância, sem a chave `instancias` (CA-02); contraprova de que nenhum campo reintroduz a gestão da 2ª instância (CA-03); as outras 17 regras permanecem com hash idêntico e só uma muda (CA-04/05); a suspensividade sobrevive, anulável (CA-06/06b); o hash é estável e difere do removido (CA-09).
- **Integração** (`RegraCatalogoSeedTests`, Postgres via Testcontainers): o reader resolve a nova e não a antiga (CA-07); há exatamente uma regra de prazo de recurso (CA-08); **fronteira da ADR-0112** com canário positivo e negativo — nenhuma configuração congelada referencia a regra substituída (CA-12).
- **Arquitetura** (`RolDeRegrasSemGatilhoTests`): nenhuma migration cria gatilho sobre `rol_de_regras`, com contraprova das formas válidas de `CREATE TRIGGER` (CA-10).

## Verificação local

- `dotnet build UniPlus.slnx -warnaserror`: 0 warnings, 0 erros.
- Módulo Seleção completo verde: Domain 216, Application 110, Arch 33, Integration 410.
- `adr-lint` + markdownlint: sem erros.
- Revisão local prévia (Codex): 0 P1; achados P2/P3 aplicados (regex do fitness ampliado, CA-12 por identidade e não substring, remarks de `RegraCatalogoConfiguration` corrigido).

> **Nota de numeração de ADR:** esta ADR é a `0112`; a `0111` fica reservada para a ADR do vocabulário de fatos, em elaboração — sem lacuna ao final.

Closes #854
