### PR TITLE
feat(configuracao): catálogo de fatos do candidato (rol_de_fatos_candidato)

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -2089,6 +2089,113 @@
         }
       }
     },
+    "/api/configuracao/fatos-candidato": {
+      "get": {
+        "tags": [
+          "FatosCandidato"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FatoCandidatoView"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FatoCandidatoView"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FatoCandidatoView"
+                  }
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/fatos-candidato/{codigo}": {
+      "get": {
+        "tags": [
+          "FatosCandidato"
+        ],
+        "parameters": [
+          {
+            "name": "codigo",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/FatoCandidatoView"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FatoCandidatoView"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FatoCandidatoView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configuracao/locais-oferta": {
       "get": {
         "tags": [
@@ -7995,6 +8102,55 @@
           }
         }
       },
+      "FatoCandidatoView": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "descricao",
+          "dominio",
+          "natureza",
+          "cardinalidade",
+          "valoresDominio"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "dominio": {
+            "type": "string"
+          },
+          "natureza": {
+            "type": "string"
+          },
+          "cardinalidade": {
+            "type": "string"
+          },
+          "valoresDominio": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "IFormFile": {
         "type": "string",
         "format": "binary"
@@ -8750,6 +8906,9 @@
     },
     {
       "name": "FasesCanonicas"
+    },
+    {
+      "name": "FatosCandidato"
     },
     {
       "name": "LocaisOferta"

--- a/docs/adrs/0111-vocabulario-fechado-de-fatos-do-candidato.md
+++ b/docs/adrs/0111-vocabulario-fechado-de-fatos-do-candidato.md
@@ -89,7 +89,7 @@ deliberadamente, o oposto ("quando a lei muda, edita o catálogo — sem deploy"
 catálogo editável por administrador. O vocabulário de fatos diverge nesse ponto de
 propósito: um fato editável por tela nasceria inoperante.
 
-**Como versiona.** `Codigo`, `Dominio` e `Natureza` (quando categórico) são
+**Como versiona.** `Codigo`, `Dominio`, `Natureza` e `Cardinalidade` são
 **imutáveis desde a semeadura** — só o código entra, por valor, num predicado
 congelado (RN08); se o domínio de um código existente mudasse, um predicado antigo
 seria reinterpretado com outra semântica (a classe de risco que a ADR-0073 já
@@ -102,10 +102,30 @@ não uma regra executável — uma mudança incompatível é um **código novo**
 `RENDA_PER_CAPITA_V2`), não uma nova versão do mesmo código.
 
 **Domínios (enum fixado por esta ADR): três** — `Categorico`, `Booleano`,
-`Numerico`. Um fato categórico declara sua **Natureza**: `Estatico` (a lista de
-valores vive no próprio catálogo) ou `Dinamico` (os valores válidos vêm de um
-cadastro vivo, nomeado). Não há um quarto domínio "texto": um fato sem domínio
-decidível não é avaliável por predicado.
+`Numerico`. Não há um quarto domínio "texto": um fato sem domínio decidível não é
+avaliável por predicado.
+
+Um fato categórico é **estático** ou de **escopo-processo**, e essa distinção não
+é um campo próprio — é a **nulidade de `ValoresDominio`**: quando o conjunto de
+valores vive no próprio catálogo (ex.: `COR_RACA`, `SEXO`), `ValoresDominio` os
+enumera; quando os valores válidos vêm da oferta congelada do próprio processo
+(ex.: `MODALIDADE`, `CONDICAO_ATENDIMENTO`), `ValoresDominio` é **nulo** e quem os
+resolve é o consumidor, contra o snapshot. Booleano e numérico têm `ValoresDominio`
+sempre nulo. O nulo é significante — nunca confundido com lista vazia (proibida).
+
+Ortogonais ao domínio, cada fato declara ainda dois eixos próprios, ambos
+imutáveis desde a semeadura:
+
+- **`Natureza`** (origem do dado): `BrutoInformado` (respondido pelo candidato),
+  `DeVontade` (opção ou aceite manifestado, não afirmação de elegibilidade) ou
+  `Derivado` (computado pelo motor). Sustenta a invariante — feita cumprir pelo
+  avaliador — de que um fato `Derivado` não é insumo de si mesmo nem de um gatilho
+  avaliado antes da etapa que o produz. Os nove fatos desta colheita são todos
+  `BrutoInformado`; o eixo existe para fatos futuros de outra origem.
+- **`Cardinalidade`**: `Escalar` (um único valor) ou `Multivalorado` (um
+  conjunto). Torna a semântica dos operadores decidível sem que o avaliador
+  conheça o catálogo por dentro (ver "Cardinalidade e átomo canônico do predicado",
+  abaixo).
 
 ### Matriz de compatibilidade operador × domínio
 
@@ -113,7 +133,7 @@ decidível não é avaliável por predicado.
 |---|---|---|
 | `Booleano` | `IGUAL` | escalar `sim`/`não` |
 | `Numerico` | `IGUAL`, `MAIOR_IGUAL`, `MENOR_IGUAL` | escalar **inteiro** — decimal é rejeitado |
-| `Categorico` (estático ou dinâmico) | `IGUAL`, `EM` | `IGUAL`: um código do domínio; `EM`: lista **não vazia** de códigos do domínio |
+| `Categorico` (estático ou de escopo-processo) | `IGUAL`, `EM` | `IGUAL`: um código do domínio; `EM`: lista **não vazia** de códigos do domínio |
 
 A restrição "numérico é inteiro, rejeita decimal" aplica-se ao **valor configurado
 no predicado** e evita comparação de ponto flutuante no avaliador. A resolução do
@@ -134,9 +154,11 @@ condição para que o desempate a honre por inteiro.
 
 ### Cardinalidade e átomo canônico do predicado
 
-Fatos categóricos estáticos são escalares. `MODALIDADE` e
-`CONDICAO_ATENDIMENTO`, contudo, são **multivalorados**: uma inscrição pode ter
-mais de uma modalidade ou mais de uma condição de atendimento. Para esses fatos,
+O campo `Cardinalidade` do catálogo registra se o fato é escalar ou
+multivalorado. Os categóricos estáticos, o booleano e o numérico são escalares.
+`MODALIDADE` e `CONDICAO_ATENDIMENTO`, contudo, são **multivalorados**: uma
+inscrição pode ter mais de uma modalidade ou mais de uma condição de atendimento.
+Para esses fatos,
 `IGUAL X` significa que `X` pertence ao conjunto de valores do candidato e
 `EM [X, Y, ...]` significa que a interseção entre os valores do candidato e a
 lista configurada não é vazia. A lista de `EM` nunca é vazia. Não há redução
@@ -152,21 +174,27 @@ migração, um consumidor que só aceite string não pode configurar `EM`.
 
 ### O vocabulário (nove fatos)
 
-| Código | Domínio | Natureza | Valores / fonte | Base legal / observação |
+Todos os nove são de `Natureza` `BrutoInformado`; a coluna abaixo mostra a
+`Cardinalidade`, e a distinção estático × escopo-processo aparece na coluna
+"Valores / fonte" (valores enumerados = estático; "fonte: cadastro vivo" =
+escopo-processo, `ValoresDominio` nulo).
+
+| Código | Domínio | Cardinalidade | Valores / fonte | Base legal / observação |
 |---|---|---|---|---|
-| `COR_RACA` | Categórico | Estático | `BRANCA`, `PRETA`, `PARDA`, `AMARELA`, `INDIGENA`, `NAO_INFORMADO` (quesito IBGE, autodeclaração) | `NAO_INFORMADO` representa a opção válida de não declarar; o subconjunto `{PRETA, PARDA}` é o sujeito à banca de heteroidentificação da autodeclaração (Lei 12.711/2012 art. 3º e resoluções da Unifesspa que disciplinam o procedimento) |
-| `QUILOMBOLA` | Booleano | — | sim/não (autodeclaração) | Lei 12.711/2012 art. 3º (red. Lei 14.723/2023) — categoria autodeclarada **distinta** de cor/raça |
-| `PCD` | Booleano | — | sim/não | Lei 12.711/2012 art. 3º (red. Lei 14.723/2023) c/c Lei 13.409/2016 |
-| `MODALIDADE` | Categórico | Dinâmico | fonte: `Modalidade.Codigo` (cadastro vivo, `Configuracao`) | Validado no instante de configuração contra os códigos vivos, via leitor cross-módulo |
-| `CONDICAO_ATENDIMENTO` | Categórico | Dinâmico | fonte: `CondicaoAtendimentoEspecializado.Codigo` | Inclui o código reservado `PCD` (ADR-0067) |
-| `RENDA_PER_CAPITA` | Numérico | — | limiar inteiro em **centavos de real**; valor do candidato preserva a razão `renda_familiar_centavos / numero_integrantes` | Lei 12.711/2012 art. 1º, § único (red. Lei 14.723/2023) — comparação exata em moeda (ver nota abaixo) |
-| `EGRESSO_ESCOLA_PUBLICA` | Booleano | — | sim/não | Lei 12.711/2012 art. 1º |
-| `FAIXA_ETARIA` | Numérico | — | inteiro; anos completos calculados contra `dataReferenciaFatos` congelada | Consumido pela regra `DESEMPATE-IDOSO` (Lei 10.741/2003 art. 27); nunca é calculado contra o relógio da execução |
-| `SEXO` | Categórico | Estático | `FEMININO`, `MASCULINO`, `INTERSEXO` | Fato ativo: habilita gatilhos condicionados ao sexo — ex.: exigir o documento de reservista apenas quando `SEXO = MASCULINO` (Lei 4.375/1964, Serviço Militar). Dado sensível — ver nota LGPD |
+| `COR_RACA` | Categórico | Escalar | `BRANCA`, `PRETA`, `PARDA`, `AMARELA`, `INDIGENA`, `NAO_INFORMADO` (quesito IBGE, autodeclaração) | `NAO_INFORMADO` representa a opção válida de não declarar; o subconjunto `{PRETA, PARDA}` é o sujeito à banca de heteroidentificação da autodeclaração (Lei 12.711/2012 art. 3º e resoluções da Unifesspa que disciplinam o procedimento) |
+| `QUILOMBOLA` | Booleano | Escalar | sim/não (autodeclaração) | Lei 12.711/2012 art. 3º (red. Lei 14.723/2023) — categoria autodeclarada **distinta** de cor/raça |
+| `PCD` | Booleano | Escalar | sim/não | Lei 12.711/2012 art. 3º (red. Lei 14.723/2023) c/c Lei 13.409/2016 |
+| `MODALIDADE` | Categórico | Multivalorado | fonte: `Modalidade.Codigo` (cadastro vivo, `Configuracao`) | Validado no instante de configuração contra os códigos vivos, via leitor cross-módulo |
+| `CONDICAO_ATENDIMENTO` | Categórico | Multivalorado | fonte: `CondicaoAtendimentoEspecializado.Codigo` | Inclui o código reservado `PCD` (ADR-0067) |
+| `RENDA_PER_CAPITA` | Numérico | Escalar | limiar inteiro em **centavos de real**; valor do candidato preserva a razão `renda_familiar_centavos / numero_integrantes` | Lei 12.711/2012 art. 1º, § único (red. Lei 14.723/2023) — comparação exata em moeda (ver nota abaixo) |
+| `EGRESSO_ESCOLA_PUBLICA` | Booleano | Escalar | sim/não | Lei 12.711/2012 art. 1º |
+| `FAIXA_ETARIA` | Numérico | Escalar | inteiro; anos completos calculados contra `dataReferenciaFatos` congelada | Consumido pela regra `DESEMPATE-IDOSO` (Lei 10.741/2003 art. 27); nunca é calculado contra o relógio da execução |
+| `SEXO` | Categórico | Escalar | `FEMININO`, `MASCULINO`, `INTERSEXO` | Fato ativo: habilita gatilhos condicionados ao sexo — ex.: exigir o documento de reservista apenas quando `SEXO = MASCULINO` (Lei 4.375/1964, Serviço Militar). Dado sensível — ver nota LGPD |
 
-### Fato de domínio dinâmico: validação no cadastro é de configuração; o predicado publicado congela o código
+### Fato categórico de escopo-processo: validação no cadastro é de configuração; o predicado publicado congela o código
 
-Os dois fatos de domínio dinâmico (`MODALIDADE`, `CONDICAO_ATENDIMENTO`) resolvem
+Os dois fatos categóricos de escopo-processo (`MODALIDADE`,
+`CONDICAO_ATENDIMENTO`) — aqueles cujo `ValoresDominio` é nulo — resolvem
 seus valores válidos a partir de cadastros vivos de `Configuracao`
 (`Modalidade.Codigo`, `CondicaoAtendimentoEspecializado.Codigo`), que **são
 editáveis** — códigos não reservados podem ser renomeados ou removidos. O domínio
@@ -320,9 +348,9 @@ os protege.
 
 - O seed do catálogo (story seguinte) materializa, linha a linha, as nove entradas
   desta ADR; um teste confere seed contra ADR.
-- A entidade `FatoCandidato` (story seguinte) não expõe mutação de
-  `Codigo`/`Dominio`/`Natureza`, e `ValoresDominio` é só-aditivo — coberto por
-  testes de unidade.
+- A entidade `FatoCandidato` não expõe mutação de
+  `Codigo`/`Dominio`/`Natureza`/`Cardinalidade`, e `ValoresDominio` é só-aditivo —
+  coberto por testes de unidade.
 - O validador de `PredicadoDnf` (story seguinte) aplica a matriz operador ×
   domínio desta ADR.
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoCodegenRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoCodegenRegistration.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Configuracao.API;
 using System.Diagnostics.CodeAnalysis;
 
 using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Contracts;
 
 using Wolverine;
 
@@ -37,5 +38,11 @@ public static class ConfiguracaoCodegenRegistration
         ArgumentNullException.ThrowIfNull(opts);
 
         opts.CodeGeneration.AlwaysUseServiceLocationFor<IConfiguracaoUnitOfWork>();
+
+        // O leitor do catálogo de fatos é injetado no handler de query e sua
+        // implementação é internal — o codegen do Wolverine não a instancia
+        // diretamente, então o service location é o opt-in sancionado (ADR-0098),
+        // mesmo mecanismo dos readers cross-módulo consumidos pela Seleção.
+        opts.CodeGeneration.AlwaysUseServiceLocationFor<IFatoCandidatoReader>();
     }
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/FatosCandidatoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/FatosCandidatoController.cs
@@ -1,0 +1,71 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.FatosCandidato;
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+
+/// <summary>
+/// Endpoints públicos de leitura do catálogo <c>rol_de_fatos_candidato</c> — o
+/// vocabulário fechado de fatos do candidato (UNI-REQ-0077, ADR-0111).
+/// <strong>Somente leitura</strong>: o catálogo é seed-governado e append-only
+/// (adicionar um fato é um PR de desenvolvimento, nunca uma operação de tela), por
+/// isso não há rota admin de escrita.
+/// </summary>
+[ApiController]
+[Route("api/configuracao")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class FatosCandidatoController : ControllerBase
+{
+    private readonly IQueryBus _queryBus;
+
+    public FatosCandidatoController(IQueryBus queryBus)
+    {
+        _queryBus = queryBus;
+    }
+
+    /// <summary>
+    /// Lista o vocabulário completo de fatos do candidato, ordenado por código. É
+    /// um conjunto fechado e de baixo volume (nove fatos), portanto não paginado.
+    /// </summary>
+    [HttpGet("fatos-candidato")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "fato-candidato", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<FatoCandidatoView>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> Listar(CancellationToken cancellationToken)
+    {
+        ListarFatosCandidatoResult resultado = await _queryBus
+            .Send(new ListarFatosCandidatoQuery(), cancellationToken)
+            .ConfigureAwait(false);
+
+        return Ok(resultado.Itens);
+    }
+
+    /// <summary>
+    /// Obtém um fato pela sua chave natural — o código (ex.: <c>COR_RACA</c>).
+    /// Retorna 404 quando o código não existe no vocabulário.
+    /// </summary>
+    [HttpGet("fatos-candidato/{codigo}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "fato-candidato", Versions = [1])]
+    [ProducesResponseType(typeof(FatoCandidatoView), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorCodigo(string codigo, CancellationToken cancellationToken)
+    {
+        FatoCandidatoView? fato = await _queryBus
+            .Send(new ObterFatoCandidatoPorCodigoQuery(codigo), cancellationToken)
+            .ConfigureAwait(false);
+
+        return fato is null ? NotFound() : Ok(fato);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ListarFatosCandidatoQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ListarFatosCandidatoQuery.cs
@@ -1,0 +1,10 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FatosCandidato;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+
+/// <summary>
+/// Lista todos os fatos do catálogo <c>rol_de_fatos_candidato</c> (ADR-0111), ordenados
+/// por código. O vocabulário é fechado e de baixo volume (nove fatos), portanto a
+/// leitura não é paginada.
+/// </summary>
+public sealed record ListarFatosCandidatoQuery : IQuery<ListarFatosCandidatoResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ListarFatosCandidatoQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ListarFatosCandidatoQueryHandler.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FatosCandidato;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+
+public static class ListarFatosCandidatoQueryHandler
+{
+    public static async Task<ListarFatosCandidatoResult> Handle(
+        ListarFatosCandidatoQuery query,
+        IFatoCandidatoReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        IReadOnlyList<FatoCandidatoView> itens = await reader
+            .ListarAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new ListarFatosCandidatoResult(itens);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ListarFatosCandidatoResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ListarFatosCandidatoResult.cs
@@ -1,0 +1,10 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FatosCandidato;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Resultado da <see cref="ListarFatosCandidatoQuery"/>: o vocabulário fechado de
+/// fatos do candidato projetado em <see cref="FatoCandidatoView"/> (contrato de
+/// leitura cross-módulo). Não vaza a entidade de domínio.
+/// </summary>
+public sealed record ListarFatosCandidatoResult(IReadOnlyList<FatoCandidatoView> Itens);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ObterFatoCandidatoPorCodigoQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ObterFatoCandidatoPorCodigoQuery.cs
@@ -1,0 +1,11 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FatosCandidato;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Resolve um fato do catálogo pela sua chave natural — o <c>Codigo</c>
+/// (ex.: <c>COR_RACA</c>). Retorna <see langword="null"/> quando o código não
+/// existe no vocabulário.
+/// </summary>
+public sealed record ObterFatoCandidatoPorCodigoQuery(string Codigo) : IQuery<FatoCandidatoView?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ObterFatoCandidatoPorCodigoQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/FatosCandidato/ObterFatoCandidatoPorCodigoQueryHandler.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.FatosCandidato;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+
+public static class ObterFatoCandidatoPorCodigoQueryHandler
+{
+    public static async Task<FatoCandidatoView?> Handle(
+        ObterFatoCandidatoPorCodigoQuery query,
+        IFatoCandidatoReader reader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(reader);
+
+        return await reader
+            .ObterPorCodigoAsync(query.Codigo, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/FatoCandidatoView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/FatoCandidatoView.cs
@@ -1,0 +1,31 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only de <c>FatoCandidato</c> para consumo cross-módulo via
+/// <see cref="IFatoCandidatoReader"/> (ADR-0056, ADR-0111). Expõe o metadado do
+/// fato — domínio, natureza, cardinalidade e o conjunto de valores — que o Módulo
+/// Seleção lê ao validar um predicado de gatilho ou de desempate. Não carrega valor
+/// de candidato algum.
+/// </summary>
+/// <param name="Id">Identificador único (Guid v7).</param>
+/// <param name="Codigo">Código do fato, chave natural (ex.: "COR_RACA", "MODALIDADE").</param>
+/// <param name="Nome">Rótulo legível do fato.</param>
+/// <param name="Descricao">Descrição opcional (cosmética).</param>
+/// <param name="Dominio">Tipo de dado — token canônico UPPER_SNAKE (CATEGORICO, BOOLEANO, NUMERICO).</param>
+/// <param name="Natureza">Origem do dado — token canônico (BRUTO_INFORMADO, DE_VONTADE, DERIVADO).</param>
+/// <param name="Cardinalidade">Cardinalidade — token canônico (ESCALAR, MULTIVALORADO).</param>
+/// <param name="ValoresDominio">
+/// Conjunto fechado de valores de um categórico estático, ou <see langword="null"/>
+/// quando não há enumeração estática — booleano/numérico, ou categórico de
+/// escopo-processo (cujos valores válidos vêm da oferta congelada do processo). O
+/// <see langword="null"/> é significante e sobrevive ao round-trip (não é lista vazia).
+/// </param>
+public sealed record FatoCandidatoView(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string? Descricao,
+    string Dominio,
+    string Natureza,
+    string Cardinalidade,
+    IReadOnlyList<string>? ValoresDominio);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IFatoCandidatoReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IFatoCandidatoReader.cs
@@ -1,7 +1,7 @@
 namespace Unifesspa.UniPlus.Configuracao.Contracts;
 
 /// <summary>
-/// Leitor cross-módulo do catálogo <c>fato_candidato</c> (ADR-0056, ADR-0111).
+/// Leitor cross-módulo do catálogo <c>rol_de_fatos_candidato</c> (ADR-0056, ADR-0111).
 /// Expõe o vocabulário fechado de fatos do candidato para consumo por outros
 /// bounded contexts (ex.: o validador de predicado de desempate e o gatilho de
 /// exigência documental do Módulo Seleção) sem acesso direto ao banco de

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IFatoCandidatoReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/IFatoCandidatoReader.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo do catálogo <c>fato_candidato</c> (ADR-0056, ADR-0111).
+/// Expõe o vocabulário fechado de fatos do candidato para consumo por outros
+/// bounded contexts (ex.: o validador de predicado de desempate e o gatilho de
+/// exigência documental do Módulo Seleção) sem acesso direto ao banco de
+/// Configuração. Somente leitura — o catálogo é seed-governado e append-only.
+/// </summary>
+public interface IFatoCandidatoReader
+{
+    /// <summary>
+    /// Lista todos os fatos do catálogo, ordenados por <c>Codigo</c> ascendente para
+    /// determinismo cross-cliente.
+    /// </summary>
+    Task<IReadOnlyList<FatoCandidatoView>> ListarAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolve um fato pela sua <b>chave natural</b> — o consumidor tem o código
+    /// embutido no predicado, nunca um <see cref="Guid"/>. Retorna
+    /// <see langword="null"/> se o código não existir no vocabulário.
+    /// </summary>
+    Task<FatoCandidatoView?> ObterPorCodigoAsync(
+        string codigo,
+        CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/FatoCandidato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/FatoCandidato.cs
@@ -8,7 +8,7 @@ using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Entrada do vocabulário fechado de fatos do candidato — o catálogo
-/// <c>fato_candidato</c> (UNI-REQ-0077, ADR-0111). Descreve o que o sistema
+/// <c>rol_de_fatos_candidato</c> (UNI-REQ-0077, ADR-0111). Descreve o que o sistema
 /// <em>sabe perguntar</em> sobre um candidato: para cada fato, o seu
 /// <see cref="Dominio"/> (tipo de dado), a sua <see cref="Natureza"/> (origem do
 /// dado), a sua <see cref="Cardinalidade"/> (um valor ou um conjunto) e, quando
@@ -123,14 +123,29 @@ public sealed class FatoCandidato : EntityBase
             return Falha(FatoCandidatoErrorCodes.DominioObrigatorio, "Domínio do fato é obrigatório.");
         }
 
+        if (!Enum.IsDefined(dominio))
+        {
+            return Falha(FatoCandidatoErrorCodes.DominioInvalido, "Domínio do fato fora do vocabulário fechado.");
+        }
+
         if (natureza == NaturezaFato.Nenhuma)
         {
             return Falha(FatoCandidatoErrorCodes.NaturezaObrigatoria, "Natureza do fato é obrigatória.");
         }
 
+        if (!Enum.IsDefined(natureza))
+        {
+            return Falha(FatoCandidatoErrorCodes.NaturezaInvalida, "Natureza do fato fora do vocabulário fechado.");
+        }
+
         if (cardinalidade == CardinalidadeFato.Nenhuma)
         {
             return Falha(FatoCandidatoErrorCodes.CardinalidadeObrigatoria, "Cardinalidade do fato é obrigatória.");
+        }
+
+        if (!Enum.IsDefined(cardinalidade))
+        {
+            return Falha(FatoCandidatoErrorCodes.CardinalidadeInvalida, "Cardinalidade do fato fora do vocabulário fechado.");
         }
 
         Result<IReadOnlyList<string>?> valoresResult = ValidarValoresDominio(dominio, valoresDominio);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/FatoCandidato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/FatoCandidato.cs
@@ -1,0 +1,189 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Entrada do vocabulário fechado de fatos do candidato — o catálogo
+/// <c>fato_candidato</c> (UNI-REQ-0077, ADR-0111). Descreve o que o sistema
+/// <em>sabe perguntar</em> sobre um candidato: para cada fato, o seu
+/// <see cref="Dominio"/> (tipo de dado), a sua <see cref="Natureza"/> (origem do
+/// dado), a sua <see cref="Cardinalidade"/> (um valor ou um conjunto) e, quando
+/// aplicável, o conjunto fechado de <see cref="ValoresDominio"/>. Não armazena o
+/// valor de nenhum candidato — é metadado de classificação, sem PII.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Seed-governado e append-only</strong> (molde de <c>RegraCatalogo</c>):
+/// não é CRUD de administrador — as entradas são semeadas por código, e a entidade
+/// deriva de <see cref="EntityBase"/> puro (sem soft-delete) e <strong>não expõe
+/// método de mutação em runtime</strong>. A evolução do catálogo é feita por
+/// <em>seed + nova migration</em>, não por API: a ADR-0111 permite corrigir a
+/// <see cref="Descricao"/> (cosmética) e <strong>crescer</strong> (nunca remover
+/// nem renomear) os <see cref="ValoresDominio"/> de um categórico estático — porque
+/// remover um valor já citado orfanaria um predicado congelado (RN08).
+/// </para>
+/// <para>
+/// <strong>Estático × escopo-processo</strong> é a nulidade de
+/// <see cref="ValoresDominio"/>, não um campo próprio: um categórico com valores é
+/// de conjunto <em>global</em> (ex.: <c>COR_RACA</c>); um categórico com
+/// <see cref="ValoresDominio"/> nulo é de <em>escopo-processo</em> (ex.:
+/// <c>MODALIDADE</c>) — os valores válidos são os ofertados pelo processo, e quem
+/// os resolve é o consumidor, contra a oferta congelada no snapshot (ADR-0061).
+/// </para>
+/// </remarks>
+public sealed class FatoCandidato : EntityBase
+{
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+
+    public string Codigo { get; private set; } = null!;
+    public string Nome { get; private set; } = null!;
+    public string? Descricao { get; private set; }
+    public DominioFato Dominio { get; private set; }
+    public NaturezaFato Natureza { get; private set; }
+    public CardinalidadeFato Cardinalidade { get; private set; }
+
+    /// <summary>
+    /// Conjunto fechado de valores de um categórico <em>estático</em>. Nulo é
+    /// significante: para categórico, nulo = escopo-processo; para booleano/numérico,
+    /// é sempre nulo. Não confundir com lista vazia (proibida).
+    /// </summary>
+    public IReadOnlyList<string>? ValoresDominio { get; private set; }
+
+    // Construtor de materialização do EF Core.
+    private FatoCandidato()
+    {
+    }
+
+    private FatoCandidato(
+        string codigo,
+        string nome,
+        string? descricao,
+        DominioFato dominio,
+        NaturezaFato natureza,
+        CardinalidadeFato cardinalidade,
+        IReadOnlyList<string>? valoresDominio)
+    {
+        Codigo = codigo;
+        Nome = nome;
+        Descricao = descricao;
+        Dominio = dominio;
+        Natureza = natureza;
+        Cardinalidade = cardinalidade;
+        ValoresDominio = valoresDominio;
+    }
+
+    /// <summary>
+    /// Factory canônica (usada pelo seed): valida o código, o domínio, a natureza,
+    /// a cardinalidade e a coerência de <paramref name="valoresDominio"/> com o
+    /// domínio. Não há caminho de mutação após a criação.
+    /// </summary>
+    public static Result<FatoCandidato> Criar(
+        string codigo,
+        string nome,
+        string? descricao,
+        DominioFato dominio,
+        NaturezaFato natureza,
+        CardinalidadeFato cardinalidade,
+        IReadOnlyList<string>? valoresDominio)
+    {
+        Result<CodigoFatoCandidato> codigoResult = CodigoFatoCandidato.Criar(codigo);
+        if (codigoResult.IsFailure)
+        {
+            return Result<FatoCandidato>.Failure(codigoResult.Error!);
+        }
+
+        if (string.IsNullOrWhiteSpace(nome))
+        {
+            return Falha(FatoCandidatoErrorCodes.NomeObrigatorio, "Nome do fato é obrigatório.");
+        }
+
+        string nomeNormalizado = nome.Trim();
+        if (nomeNormalizado.Length > NomeMaxLength)
+        {
+            return Falha(
+                FatoCandidatoErrorCodes.NomeTamanho,
+                $"Nome do fato deve ter no máximo {NomeMaxLength} caracteres.");
+        }
+
+        string? descricaoNormalizada = string.IsNullOrWhiteSpace(descricao) ? null : descricao.Trim();
+        if (descricaoNormalizada is { Length: > DescricaoMaxLength })
+        {
+            return Falha(
+                FatoCandidatoErrorCodes.DescricaoTamanho,
+                $"Descrição do fato deve ter no máximo {DescricaoMaxLength} caracteres.");
+        }
+
+        if (dominio == DominioFato.Nenhum)
+        {
+            return Falha(FatoCandidatoErrorCodes.DominioObrigatorio, "Domínio do fato é obrigatório.");
+        }
+
+        if (natureza == NaturezaFato.Nenhuma)
+        {
+            return Falha(FatoCandidatoErrorCodes.NaturezaObrigatoria, "Natureza do fato é obrigatória.");
+        }
+
+        if (cardinalidade == CardinalidadeFato.Nenhuma)
+        {
+            return Falha(FatoCandidatoErrorCodes.CardinalidadeObrigatoria, "Cardinalidade do fato é obrigatória.");
+        }
+
+        Result<IReadOnlyList<string>?> valoresResult = ValidarValoresDominio(dominio, valoresDominio);
+        if (valoresResult.IsFailure)
+        {
+            return Result<FatoCandidato>.Failure(valoresResult.Error!);
+        }
+
+        return Result<FatoCandidato>.Success(new FatoCandidato(
+            codigoResult.Value!.Valor,
+            nomeNormalizado,
+            descricaoNormalizada,
+            dominio,
+            natureza,
+            cardinalidade,
+            valoresResult.Value));
+    }
+
+    private static Result<IReadOnlyList<string>?> ValidarValoresDominio(
+        DominioFato dominio,
+        IReadOnlyList<string>? valoresDominio)
+    {
+        if (valoresDominio is null)
+        {
+            return Result<IReadOnlyList<string>?>.Success(null);
+        }
+
+        if (dominio != DominioFato.Categorico)
+        {
+            return Result<IReadOnlyList<string>?>.Failure(new DomainError(
+                FatoCandidatoErrorCodes.ValoresDominioNaoPermitidosForaDeCategorico,
+                "Valores de domínio só são permitidos para fatos categóricos; "
+                + "booleano e numérico têm valores nulos."));
+        }
+
+        if (valoresDominio.Count == 0 || valoresDominio.Any(string.IsNullOrWhiteSpace))
+        {
+            return Result<IReadOnlyList<string>?>.Failure(new DomainError(
+                FatoCandidatoErrorCodes.ValoresDominioComItemEmBranco,
+                "A lista de valores de domínio, quando presente, deve ser não vazia e sem itens em branco."));
+        }
+
+        string[] normalizados = [.. valoresDominio.Select(v => v.Trim())];
+        if (normalizados.Distinct(StringComparer.Ordinal).Count() != normalizados.Length)
+        {
+            return Result<IReadOnlyList<string>?>.Failure(new DomainError(
+                FatoCandidatoErrorCodes.ValoresDominioComDuplicata,
+                "A lista de valores de domínio não pode conter duplicatas."));
+        }
+
+        return Result<IReadOnlyList<string>?>.Success(normalizados);
+    }
+
+    private static Result<FatoCandidato> Falha(string codigo, string mensagem) =>
+        Result<FatoCandidato>.Failure(new DomainError(codigo, mensagem));
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CardinalidadeFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CardinalidadeFato.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Cardinalidade do valor de um <see cref="Entities.FatoCandidato"/> sobre um
+/// candidato (ADR-0111) — se o fato assume um único valor ou um conjunto. Torna
+/// a semântica dos operadores decidível sem que o avaliador (#847) precise
+/// conhecer o catálogo por dentro: para um fato <see cref="Multivalorado"/>,
+/// <c>IGUAL X</c> significa "X pertence ao conjunto do candidato" e <c>EM [..]</c>
+/// significa "a interseção não é vazia"; para <see cref="Escalar"/>, comparação
+/// direta.
+/// </summary>
+public enum CardinalidadeFato
+{
+    /// <summary>Sentinela — cardinalidade não informada; rejeitada na criação.</summary>
+    Nenhuma = 0,
+
+    /// <summary>O candidato tem um único valor (ex.: COR_RACA, SEXO, RENDA_PER_CAPITA).</summary>
+    Escalar,
+
+    /// <summary>O candidato pode ter mais de um valor (ex.: MODALIDADE, CONDICAO_ATENDIMENTO).</summary>
+    Multivalorado,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CardinalidadesFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CardinalidadesFato.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="CardinalidadeFato"/> (PascalCase) e o token textual
+/// de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado por allowlist
+/// explícita (molde de <see cref="NaturezasLegais"/>). Fonte do CHECK de domínio
+/// em <c>fato_candidato.cardinalidade</c> e do value converter de persistência.
+/// </summary>
+public static class CardinalidadesFato
+{
+    private static readonly Dictionary<CardinalidadeFato, string> ParaToken = new()
+    {
+        [CardinalidadeFato.Escalar] = "ESCALAR",
+        [CardinalidadeFato.Multivalorado] = "MULTIVALORADO",
+    };
+
+    private static readonly Dictionary<string, CardinalidadeFato> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os dois tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de uma cardinalidade válida.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="cardinalidade"/> é <see cref="CardinalidadeFato.Nenhuma"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(CardinalidadeFato cardinalidade) =>
+        ParaToken.TryGetValue(cardinalidade, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(cardinalidade), cardinalidade, "Cardinalidade de fato fora do domínio fechado.");
+
+    /// <summary>Resolve um token textual (UPPER_SNAKE) à cardinalidade; <see langword="false"/> quando inválido.</summary>
+    public static bool TryAnalisar(string? token, out CardinalidadeFato cardinalidade)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out CardinalidadeFato resolvida))
+        {
+            cardinalidade = resolvida;
+            return true;
+        }
+
+        cardinalidade = CardinalidadeFato.Nenhuma;
+        return false;
+    }
+
+    /// <summary>Resolve um token à sua enum (reidratação fail-fast do value converter).</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="token"/> não é canônico.</exception>
+    public static CardinalidadeFato Analisar(string? token) =>
+        TryAnalisar(token, out CardinalidadeFato cardinalidade)
+            ? cardinalidade
+            : throw new ArgumentOutOfRangeException(
+                nameof(token), token, "Token de cardinalidade de fato fora do domínio fechado.");
+
+    /// <summary>Indica se <paramref name="token"/> é um dos dois tokens canônicos.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CardinalidadesFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/CardinalidadesFato.cs
@@ -4,7 +4,7 @@ namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
 /// Mapeamento entre <see cref="CardinalidadeFato"/> (PascalCase) e o token textual
 /// de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado por allowlist
 /// explícita (molde de <see cref="NaturezasLegais"/>). Fonte do CHECK de domínio
-/// em <c>fato_candidato.cardinalidade</c> e do value converter de persistência.
+/// em <c>rol_de_fatos_candidato.cardinalidade</c> e do value converter de persistência.
 /// </summary>
 public static class CardinalidadesFato
 {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DominioFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DominioFato.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Domínio (tipo de dado) de um <see cref="Entities.FatoCandidato"/> — decide
+/// quais operadores e que forma de valor um predicado sobre o fato aceita
+/// (ADR-0111). São <b>três</b>, fechados: o "texto" não é um domínio, é a
+/// ausência de domínio decidível. A distinção estático × escopo-processo de um
+/// fato categórico não é um quarto domínio — é o <c>ValoresDominio</c> nulo.
+/// </summary>
+public enum DominioFato
+{
+    /// <summary>Sentinela — domínio não informado; rejeitado na criação.</summary>
+    Nenhum = 0,
+
+    /// <summary>Conjunto fechado de códigos (estático no catálogo, ou de escopo-processo quando os valores são nulos).</summary>
+    Categorico,
+
+    /// <summary>Verdadeiro/falso.</summary>
+    Booleano,
+
+    /// <summary>Escalar numérico inteiro.</summary>
+    Numerico,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DominiosFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DominiosFato.cs
@@ -4,7 +4,7 @@ namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
 /// Mapeamento entre <see cref="DominioFato"/> (domínio, PascalCase) e o token
 /// textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado por
 /// allowlist explícita (molde de <see cref="NaturezasLegais"/>). Fonte do CHECK de
-/// domínio em <c>fato_candidato.dominio</c> e do value converter de persistência.
+/// domínio em <c>rol_de_fatos_candidato.dominio</c> e do value converter de persistência.
 /// </summary>
 public static class DominiosFato
 {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DominiosFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/DominiosFato.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="DominioFato"/> (domínio, PascalCase) e o token
+/// textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado por
+/// allowlist explícita (molde de <see cref="NaturezasLegais"/>). Fonte do CHECK de
+/// domínio em <c>fato_candidato.dominio</c> e do value converter de persistência.
+/// </summary>
+public static class DominiosFato
+{
+    private static readonly Dictionary<DominioFato, string> ParaToken = new()
+    {
+        [DominioFato.Categorico] = "CATEGORICO",
+        [DominioFato.Booleano] = "BOOLEANO",
+        [DominioFato.Numerico] = "NUMERICO",
+    };
+
+    private static readonly Dictionary<string, DominioFato> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os três tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de um domínio válido.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="dominio"/> é <see cref="DominioFato.Nenhum"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(DominioFato dominio) =>
+        ParaToken.TryGetValue(dominio, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(dominio), dominio, "Domínio de fato fora do domínio fechado.");
+
+    /// <summary>Resolve um token textual (UPPER_SNAKE) ao domínio; <see langword="false"/> quando inválido.</summary>
+    public static bool TryAnalisar(string? token, out DominioFato dominio)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out DominioFato resolvido))
+        {
+            dominio = resolvido;
+            return true;
+        }
+
+        dominio = DominioFato.Nenhum;
+        return false;
+    }
+
+    /// <summary>Resolve um token à sua enum (reidratação fail-fast do value converter).</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="token"/> não é canônico.</exception>
+    public static DominioFato Analisar(string? token) =>
+        TryAnalisar(token, out DominioFato dominio)
+            ? dominio
+            : throw new ArgumentOutOfRangeException(
+                nameof(token), token, "Token de domínio de fato fora do domínio fechado.");
+
+    /// <summary>Indica se <paramref name="token"/> é um dos três tokens canônicos.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezaFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezaFato.cs
@@ -15,9 +15,9 @@ public enum NaturezaFato
     /// <summary>Respondido pelo candidato (PCD, COR_RACA, RENDA_PER_CAPITA).</summary>
     BrutoInformado,
 
-    /// <summary>Declaração de desejo, não de elegibilidade (ex.: optar por concorrer numa cota).</summary>
+    /// <summary>Declaração de desejo, não de elegibilidade — uma opção ou aceite manifestado pelo candidato, que não afirma um fato apurável.</summary>
     DeVontade,
 
-    /// <summary>Computado pelo motor — não é coletado, é saída (ex.: modalidade derivada, cotista).</summary>
+    /// <summary>Computado pelo motor — não é coletado, é saída (ex.: a condição de cotista, derivada da renda e das cotas).</summary>
     Derivado,
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezaFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezaFato.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Origem do dado de um <see cref="Entities.FatoCandidato"/> — como o fato chega
+/// ao sistema (ADR-0111). É ortogonal ao domínio (tipo de dado) e à cardinalidade;
+/// serve à invariante, feita cumprir pelo avaliador, de que um fato
+/// <see cref="Derivado"/> não pode ser insumo de si mesmo nem de um gatilho
+/// avaliado antes da etapa que o produz.
+/// </summary>
+public enum NaturezaFato
+{
+    /// <summary>Sentinela — natureza não informada; rejeitada na criação.</summary>
+    Nenhuma = 0,
+
+    /// <summary>Respondido pelo candidato (PCD, COR_RACA, RENDA_PER_CAPITA).</summary>
+    BrutoInformado,
+
+    /// <summary>Declaração de desejo, não de elegibilidade (ex.: optar por concorrer numa cota).</summary>
+    DeVontade,
+
+    /// <summary>Computado pelo motor — não é coletado, é saída (ex.: modalidade derivada, cotista).</summary>
+    Derivado,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezasFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezasFato.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="NaturezaFato"/> (PascalCase) e o token textual de
+/// contrato/banco (UPPER_SNAKE), com parsing de domínio fechado por allowlist
+/// explícita (molde de <see cref="NaturezasLegais"/>). Fonte do CHECK de domínio
+/// em <c>fato_candidato.natureza</c> e do value converter de persistência.
+/// </summary>
+public static class NaturezasFato
+{
+    private static readonly Dictionary<NaturezaFato, string> ParaToken = new()
+    {
+        [NaturezaFato.BrutoInformado] = "BRUTO_INFORMADO",
+        [NaturezaFato.DeVontade] = "DE_VONTADE",
+        [NaturezaFato.Derivado] = "DERIVADO",
+    };
+
+    private static readonly Dictionary<string, NaturezaFato> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os três tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de uma natureza válida.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="natureza"/> é <see cref="NaturezaFato.Nenhuma"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(NaturezaFato natureza) =>
+        ParaToken.TryGetValue(natureza, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(natureza), natureza, "Natureza de fato fora do domínio fechado.");
+
+    /// <summary>Resolve um token textual (UPPER_SNAKE) à natureza; <see langword="false"/> quando inválido.</summary>
+    public static bool TryAnalisar(string? token, out NaturezaFato natureza)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out NaturezaFato resolvida))
+        {
+            natureza = resolvida;
+            return true;
+        }
+
+        natureza = NaturezaFato.Nenhuma;
+        return false;
+    }
+
+    /// <summary>Resolve um token à sua enum (reidratação fail-fast do value converter).</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="token"/> não é canônico.</exception>
+    public static NaturezaFato Analisar(string? token) =>
+        TryAnalisar(token, out NaturezaFato natureza)
+            ? natureza
+            : throw new ArgumentOutOfRangeException(
+                nameof(token), token, "Token de natureza de fato fora do domínio fechado.");
+
+    /// <summary>Indica se <paramref name="token"/> é um dos três tokens canônicos.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezasFato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/NaturezasFato.cs
@@ -4,7 +4,7 @@ namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
 /// Mapeamento entre <see cref="NaturezaFato"/> (PascalCase) e o token textual de
 /// contrato/banco (UPPER_SNAKE), com parsing de domínio fechado por allowlist
 /// explícita (molde de <see cref="NaturezasLegais"/>). Fonte do CHECK de domínio
-/// em <c>fato_candidato.natureza</c> e do value converter de persistência.
+/// em <c>rol_de_fatos_candidato.natureza</c> e do value converter de persistência.
 /// </summary>
 public static class NaturezasFato
 {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/FatoCandidatoErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/FatoCandidatoErrorCodes.cs
@@ -2,7 +2,7 @@ namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
 
 /// <summary>
 /// Códigos de erro de domínio do <see cref="Entities.FatoCandidato"/> — o catálogo
-/// <c>fato_candidato</c> (UNI-REQ-0077), prefixados por <c>FatoCandidato.</c>.
+/// <c>rol_de_fatos_candidato</c> (UNI-REQ-0077), prefixados por <c>FatoCandidato.</c>.
 /// Mapeados para status HTTP em <c>ConfiguracaoDomainErrorRegistration</c>:
 /// <list type="bullet">
 ///   <item><description><see cref="NaoEncontrado"/> → 404 Not Found</description></item>

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/FatoCandidatoErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/FatoCandidatoErrorCodes.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+/// <summary>
+/// Códigos de erro de domínio do <see cref="Entities.FatoCandidato"/> — o catálogo
+/// <c>fato_candidato</c> (UNI-REQ-0077), prefixados por <c>FatoCandidato.</c>.
+/// Mapeados para status HTTP em <c>ConfiguracaoDomainErrorRegistration</c>:
+/// <list type="bullet">
+///   <item><description><see cref="NaoEncontrado"/> → 404 Not Found</description></item>
+///   <item><description>demais → 422 Unprocessable Entity</description></item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// Não há <c>CodigoJaExiste</c> (409): o catálogo é seed-governado e append-only —
+/// não há caminho de escrita em runtime que possa colidir. A unicidade é garantida
+/// pelo índice único total e por teste sobre a fonte do seed. Os erros de validação
+/// são alcançáveis apenas pela semeadura em desenvolvimento (defesa em profundidade
+/// da factory), nunca por requisição de usuário.
+/// </remarks>
+public static class FatoCandidatoErrorCodes
+{
+    public const string CodigoObrigatorio = "FatoCandidato.CodigoObrigatorio";
+    public const string CodigoFormatoInvalido = "FatoCandidato.CodigoFormatoInvalido";
+    public const string NomeObrigatorio = "FatoCandidato.NomeObrigatorio";
+    public const string NomeTamanho = "FatoCandidato.NomeTamanho";
+    public const string DescricaoTamanho = "FatoCandidato.DescricaoTamanho";
+    public const string DominioObrigatorio = "FatoCandidato.DominioObrigatorio";
+    public const string DominioInvalido = "FatoCandidato.DominioInvalido";
+    public const string NaturezaObrigatoria = "FatoCandidato.NaturezaObrigatoria";
+    public const string NaturezaInvalida = "FatoCandidato.NaturezaInvalida";
+    public const string CardinalidadeObrigatoria = "FatoCandidato.CardinalidadeObrigatoria";
+    public const string CardinalidadeInvalida = "FatoCandidato.CardinalidadeInvalida";
+    public const string ValoresDominioNaoPermitidosForaDeCategorico =
+        "FatoCandidato.ValoresDominioNaoPermitidosForaDeCategorico";
+    public const string ValoresDominioComItemEmBranco = "FatoCandidato.ValoresDominioComItemEmBranco";
+    public const string ValoresDominioComDuplicata = "FatoCandidato.ValoresDominioComDuplicata";
+    public const string NaoEncontrado = "FatoCandidato.NaoEncontrado";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoFatoCandidato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoFatoCandidato.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+using System.Text.RegularExpressions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Código de um <see cref="Entities.FatoCandidato"/> (UNI-REQ-0077) — chave natural
+/// classificatória do vocabulário de fatos (ex.: <c>COR_RACA</c>, <c>PCD</c>,
+/// <c>MODALIDADE</c>). Value object com formato fechado <c>^[A-Z][A-Z0-9_]{1,49}$</c>
+/// — começa por letra maiúscula, seguido de maiúsculas, dígitos e sublinhado, de 2
+/// a 50 caracteres. Persistido como texto via conversor de valor (fail-fast na
+/// reidratação).
+/// </summary>
+/// <remarks>
+/// O código é <b>imutável</b>: é ele que entra, por valor, dentro de um predicado
+/// congelado num snapshot de publicação (RN08, ADR-0061) — renomear reinterpretaria
+/// o passado. A entidade não expõe método que o altere.
+/// </remarks>
+public sealed partial record CodigoFatoCandidato
+{
+    public string Valor { get; }
+
+    private CodigoFatoCandidato(string valor) => Valor = valor;
+
+    /// <summary>
+    /// Cria um <see cref="CodigoFatoCandidato"/> validando o formato fechado. Valor
+    /// nulo/em branco retorna <c>CodigoObrigatorio</c>; fora do formato retorna
+    /// <c>CodigoFormatoInvalido</c>. O valor é normalizado por <c>Trim</c> antes da
+    /// validação.
+    /// </summary>
+    public static Result<CodigoFatoCandidato> Criar(string valor)
+    {
+        if (string.IsNullOrWhiteSpace(valor))
+        {
+            return Result<CodigoFatoCandidato>.Failure(new DomainError(
+                FatoCandidatoErrorCodes.CodigoObrigatorio,
+                "Código do fato do candidato é obrigatório."));
+        }
+
+        string normalizado = valor.Trim();
+
+        if (!FormatoValido().IsMatch(normalizado))
+        {
+            return Result<CodigoFatoCandidato>.Failure(new DomainError(
+                FatoCandidatoErrorCodes.CodigoFormatoInvalido,
+                "Código do fato deve começar por letra maiúscula e conter apenas letras maiúsculas, "
+                + "dígitos e sublinhado, com 2 a 50 caracteres (ex.: COR_RACA, PCD, MODALIDADE)."));
+        }
+
+        return Result<CodigoFatoCandidato>.Success(new CodigoFatoCandidato(normalizado));
+    }
+
+    /// <summary>Indica se <paramref name="valor"/> respeita o formato fechado, sem alocar value object.</summary>
+    public static bool EhValido(string? valor) =>
+        !string.IsNullOrWhiteSpace(valor) && FormatoValido().IsMatch(valor.Trim());
+
+    public override string ToString() => Valor;
+
+    [GeneratedRegex("^[A-Z][A-Z0-9_]{1,49}$", RegexOptions.CultureInvariant)]
+    private static partial Regex FormatoValido();
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -58,6 +58,9 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<IFaseCanonicaReader, FaseCanonicaReader>();
         services.AddScoped<ITipoBancaReader, TipoBancaReader>();
         services.AddScoped<IOfertaCursoReader, OfertaCursoReader>();
+        // Catálogo seed-governado de fatos do candidato (ADR-0111): só leitura,
+        // sem repositório (não há escrita em runtime).
+        services.AddScoped<IFatoCandidatoReader, FatoCandidatoReader>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -56,6 +56,12 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
     public DbSet<OfertaCurso> OfertasCurso => Set<OfertaCurso>();
 
     /// <summary>
+    /// Catálogo seed-governado do vocabulário fechado de fatos do candidato
+    /// (UNI-REQ-0077, ADR-0111). Metadado de classificação, sem PII.
+    /// </summary>
+    public DbSet<FatoCandidato> FatosCandidato => Set<FatoCandidato>();
+
+    /// <summary>
     /// Cache de Idempotency-Key (ADR-0027). Vive no mesmo banco do módulo
     /// para permitir gravação adjacente no outbox.
     /// </summary>

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/FatoCandidatoConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/FatoCandidatoConfiguration.cs
@@ -1,0 +1,206 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Seed;
+
+/// <summary>
+/// Configuração EF Core do catálogo <see cref="FatoCandidato"/> — a tabela
+/// <c>rol_de_fatos_candidato</c> (UNI-REQ-0077, ADR-0111).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A tabela é <strong>seed-governada e append-only</strong>: não há CRUD de
+/// administrador, a única escrita é o seed, e a entidade deriva de
+/// <c>EntityBase</c> puro (sem soft-delete). Por isso o índice único
+/// <c>ux_rol_de_fatos_candidato_codigo</c> é <strong>total</strong> (não parcial, como o
+/// dos cadastros editáveis) — o código é chave natural imutável de uma linha que
+/// nunca é logicamente removida. O append-only é imposto por convenção (ausência
+/// de API de mutação; leitura via <c>IFatoCandidatoReader</c>), não por gatilho.
+/// </para>
+/// <para>
+/// <c>dominio</c>, <c>natureza</c> e <c>cardinalidade</c> são enums persistidos
+/// como token canônico UPPER_SNAKE por value converter (reidratação fail-fast); um
+/// CHECK por coluna restringe o texto ao domínio fechado. <c>valores_dominio</c> é
+/// <c>jsonb</c> <strong>anulável</strong>: o nulo é significante (categórico de
+/// escopo-processo, ou booleano/numérico) e é preservado no round-trip — não há
+/// default <c>'[]'</c> que o mascare. Um CHECK garante a coerência do preenchimento
+/// com o domínio.
+/// </para>
+/// </remarks>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class FatoCandidatoConfiguration : IEntityTypeConfiguration<FatoCandidato>
+{
+    private const int CodigoMaxLength = 50;
+    private const int NomeMaxLength = 200;
+    private const int DescricaoMaxLength = 1000;
+    private const int EnumTokenMaxLength = 20;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = false,
+    };
+
+    public void Configure(EntityTypeBuilder<FatoCandidato> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("rol_de_fatos_candidato", ConfigurarChecks);
+
+        builder.HasKey(f => f.Id);
+
+        // Chave Guid v7 gerada no domínio (EntityBase): ValueGeneratedNever força o
+        // EF a tratar a chave como fornecida pela aplicação (convenção do repo).
+        builder.Property(f => f.Id).ValueGeneratedNever();
+
+        builder.Property(f => f.Codigo).HasMaxLength(CodigoMaxLength).IsRequired();
+        builder.Property(f => f.Nome).HasMaxLength(NomeMaxLength).IsRequired();
+        builder.Property(f => f.Descricao).HasMaxLength(DescricaoMaxLength);
+
+        builder.Property(f => f.Dominio)
+            .HasConversion(DominioConverter)
+            .HasMaxLength(EnumTokenMaxLength)
+            .IsRequired();
+
+        builder.Property(f => f.Natureza)
+            .HasConversion(NaturezaConverter)
+            .HasMaxLength(EnumTokenMaxLength)
+            .IsRequired();
+
+        builder.Property(f => f.Cardinalidade)
+            .HasConversion(CardinalidadeConverter)
+            .HasMaxLength(EnumTokenMaxLength)
+            .IsRequired();
+
+        // valores_dominio: conjunto fechado de um categórico estático, serializado
+        // como jsonb anulável. Sem default '[]' — o nulo (escopo-processo, ou
+        // booleano/numérico) é significante e precisa sobreviver ao round-trip. O
+        // converter não-nulo é passado pelo overload não-genérico (a coluna
+        // anulável é encapsulada pelo EF: null → NULL, sem chamar o converter).
+        builder.Property(f => f.ValoresDominio)
+            .HasConversion((ValueConverter)ValoresDominioConverter, ValoresDominioComparer)
+            .HasColumnType("jsonb");
+
+        // UNIQUE total do código (chave natural imutável): o catálogo é append-only
+        // e sem soft-delete, então não há slot a liberar — a unicidade é absoluta.
+        builder.HasIndex(f => f.Codigo)
+            .IsUnique()
+            .HasDatabaseName("ux_rol_de_fatos_candidato_codigo");
+
+        builder.HasData(MaterializarSeed());
+    }
+
+    private static void ConfigurarChecks(TableBuilder<FatoCandidato> table)
+    {
+        // Domínios fechados dos enums (defesa em profundidade contra inserts crus).
+        table.HasCheckConstraint(
+            "ck_rol_de_fatos_candidato_dominio",
+            $"dominio IN ({TokensSql(DominiosFato.TokensCanonicos)})");
+
+        table.HasCheckConstraint(
+            "ck_rol_de_fatos_candidato_natureza",
+            $"natureza IN ({TokensSql(NaturezasFato.TokensCanonicos)})");
+
+        table.HasCheckConstraint(
+            "ck_rol_de_fatos_candidato_cardinalidade",
+            $"cardinalidade IN ({TokensSql(CardinalidadesFato.TokensCanonicos)})");
+
+        // Coerência valores_dominio × domínio (invariante da factory, replicada no
+        // banco): só categórico pode enumerar valores; quando enumera, é um array
+        // jsonb não vazio cujos elementos são todos strings não vazias (o jsonpath
+        // rejeita elemento de outro tipo, ex.: [1], e string em branco ASCII, ex.:
+        // ["  "] — que a factory recusa e que quebraria a desserialização do reader).
+        // Nulo é sempre válido (escopo-processo / não-categórico). O regex \s do
+        // jsonpath do Postgres cobre o whitespace ASCII; a paridade total com o
+        // char.IsWhiteSpace da factory (whitespace Unicode como NBSP) não é
+        // exprimível no like_regex (não há \p{Z}), então a factory permanece o guarda
+        // autoritativo — o CHECK é defesa em profundidade para os casos realistas de
+        // insert cru, e o seed jamais produz esses valores. A ausência de duplicatas,
+        // idem: garantida pela factory e pelo teste do seed.
+        table.HasCheckConstraint(
+            "ck_rol_de_fatos_candidato_valores_dominio_coerente",
+            """
+            valores_dominio IS NULL OR (
+                dominio = 'CATEGORICO'
+                AND jsonb_typeof(valores_dominio) = 'array'
+                AND valores_dominio <> '[]'::jsonb
+                AND NOT (valores_dominio @? '$[*] ? (@.type() != "string" || @ like_regex "^\\s*$")')
+            )
+            """);
+    }
+
+    private static string TokensSql(IReadOnlyList<string> tokens) =>
+        string.Join(", ", tokens.Select(token => $"'{token}'"));
+
+    /// <summary>
+    /// Projeta o seed (<see cref="FatoCandidatoSeed.Itens"/>) para linhas que o
+    /// <c>HasData</c> congela como literais na migration. O instante-âncora é fixo
+    /// (as linhas não passam pelo <c>AuditableInterceptor</c>); qualquer mudança
+    /// futura no seed exige uma nova migration (o EF detecta o diff), sem alterar
+    /// as bases já migradas.
+    /// </summary>
+    private static IEnumerable<object> MaterializarSeed()
+    {
+        // Instante-âncora fixo do seed (HasData exige valor determinístico).
+        DateTimeOffset seedCriadoEm = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        return FatoCandidatoSeed.Itens.Select(item => new
+        {
+            item.Id,
+            item.Codigo,
+            item.Nome,
+            item.Descricao,
+            item.Dominio,
+            item.Natureza,
+            item.Cardinalidade,
+            item.ValoresDominio,
+            CreatedAt = seedCriadoEm,
+        });
+    }
+
+    // ── Conversores/comparadores ──────────────────────────────────────────────
+
+    private static readonly ValueConverter<DominioFato, string> DominioConverter =
+        new(dominio => DominiosFato.ParaTokenCanonico(dominio), token => DominiosFato.Analisar(token));
+
+    private static readonly ValueConverter<NaturezaFato, string> NaturezaConverter =
+        new(natureza => NaturezasFato.ParaTokenCanonico(natureza), token => NaturezasFato.Analisar(token));
+
+    private static readonly ValueConverter<CardinalidadeFato, string> CardinalidadeConverter =
+        new(cardinalidade => CardinalidadesFato.ParaTokenCanonico(cardinalidade), token => CardinalidadesFato.Analisar(token));
+
+    // Lista de códigos serializada como jsonb. Nulo é encapsulado pelo EF (o
+    // converter cobre apenas o valor não-nulo) e persiste como NULL na coluna.
+    private static readonly ValueConverter<IReadOnlyList<string>, string> ValoresDominioConverter =
+        new(
+            valores => JsonSerializer.Serialize(valores, JsonOptions),
+            json => DeserializarValores(json));
+
+    // Null-aware: o nulo (escopo-processo / não-categórico) é distinto da lista
+    // vazia — nunca conflá-los, sob pena de o snapshot do change-tracker
+    // materializar um nulo como '[]' e violar a invariante da ADR-0111. Igualdade
+    // por sequência ordinal; snapshot preserva o nulo.
+    private static readonly ValueComparer<IReadOnlyList<string>> ValoresDominioComparer =
+        new(
+            (a, b) => a == null ? b == null : b != null && a.SequenceEqual(b, StringComparer.Ordinal),
+            v => v == null
+                ? 0
+                : v.Aggregate(0, (acc, item) => HashCode.Combine(acc, StringComparer.Ordinal.GetHashCode(item))),
+            v => v == null ? null! : v.ToList());
+
+    private static List<string> DeserializarValores(string json) =>
+        string.IsNullOrEmpty(json)
+            ? []
+            : JsonSerializer.Deserialize<List<string>>(json, JsonOptions) ?? [];
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260715160252_AddFatoCandidato.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260715160252_AddFatoCandidato.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715160252_AddFatoCandidato")]
+    partial class AddFatoCandidato
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260715160252_AddFatoCandidato.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260715160252_AddFatoCandidato.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFatoCandidato : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "rol_de_fatos_candidato",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    descricao = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    dominio = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    natureza = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    cardinalidade = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    valores_dominio = table.Column<string>(type: "jsonb", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_rol_de_fatos_candidato", x => x.id);
+                    table.CheckConstraint("ck_rol_de_fatos_candidato_cardinalidade", "cardinalidade IN ('ESCALAR', 'MULTIVALORADO')");
+                    table.CheckConstraint("ck_rol_de_fatos_candidato_dominio", "dominio IN ('CATEGORICO', 'BOOLEANO', 'NUMERICO')");
+                    table.CheckConstraint("ck_rol_de_fatos_candidato_natureza", "natureza IN ('BRUTO_INFORMADO', 'DE_VONTADE', 'DERIVADO')");
+                    table.CheckConstraint("ck_rol_de_fatos_candidato_valores_dominio_coerente", "valores_dominio IS NULL OR (\n    dominio = 'CATEGORICO'\n    AND jsonb_typeof(valores_dominio) = 'array'\n    AND valores_dominio <> '[]'::jsonb\n    AND NOT (valores_dominio @? '$[*] ? (@.type() != \"string\" || @ like_regex \"^\\\\s*$\")')\n)");
+                });
+
+            migrationBuilder.InsertData(
+                schema: "configuracao",
+                table: "rol_de_fatos_candidato",
+                columns: new[] { "id", "cardinalidade", "codigo", "created_at", "descricao", "dominio", "natureza", "nome", "updated_at", "valores_dominio" },
+                values: new object[,]
+                {
+                    { new Guid("fa700000-0000-7000-8000-000000000001"), "ESCALAR", "COR_RACA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "CATEGORICO", "BRUTO_INFORMADO", "Cor ou raça", null, "[\"BRANCA\",\"PRETA\",\"PARDA\",\"AMARELA\",\"INDIGENA\",\"NAO_INFORMADO\"]" },
+                    { new Guid("fa700000-0000-7000-8000-000000000002"), "ESCALAR", "QUILOMBOLA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "BOOLEANO", "BRUTO_INFORMADO", "Quilombola", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000003"), "ESCALAR", "PCD", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "BOOLEANO", "BRUTO_INFORMADO", "Pessoa com deficiência", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000004"), "ESCALAR", "EGRESSO_ESCOLA_PUBLICA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "BOOLEANO", "BRUTO_INFORMADO", "Egresso de escola pública", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000005"), "ESCALAR", "RENDA_PER_CAPITA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "NUMERICO", "BRUTO_INFORMADO", "Renda familiar per capita", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000006"), "ESCALAR", "FAIXA_ETARIA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "NUMERICO", "BRUTO_INFORMADO", "Faixa etária", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000007"), "ESCALAR", "SEXO", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "CATEGORICO", "BRUTO_INFORMADO", "Sexo", null, "[\"FEMININO\",\"MASCULINO\",\"INTERSEXO\"]" },
+                    { new Guid("fa700000-0000-7000-8000-000000000008"), "MULTIVALORADO", "MODALIDADE", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "CATEGORICO", "BRUTO_INFORMADO", "Modalidade de concorrência", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000009"), "MULTIVALORADO", "CONDICAO_ATENDIMENTO", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "CATEGORICO", "BRUTO_INFORMADO", "Condição de atendimento especializado", null, null }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_rol_de_fatos_candidato_codigo",
+                schema: "configuracao",
+                table: "rol_de_fatos_candidato",
+                column: "codigo",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "rol_de_fatos_candidato",
+                schema: "configuracao");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Seed/FatoCandidatoSeed.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Seed/FatoCandidatoSeed.cs
@@ -1,0 +1,97 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Seed;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Fonte única do seed do catálogo <c>rol_de_fatos_candidato</c> (UNI-REQ-0077,
+/// ADR-0111): os nove fatos do vocabulário fechado do candidato. Consumida tanto
+/// pela configuração EF Core (que materializa as linhas via <c>HasData</c> na
+/// migration) quanto pelos testes (que conferem o seed do banco contra esta
+/// lista), garantindo uma única definição por fato.
+/// </summary>
+/// <remarks>
+/// <para>
+/// O conteúdo é a modelagem da ADR-0111 (autoridade), portada linha a linha.
+/// Os <see cref="Guid"/> são fixos determinísticos (não <c>Guid.CreateVersion7</c>)
+/// porque seed precisa de identidade estável entre execuções — o mesmo molde de
+/// <c>RegraCatalogoSeed</c>.
+/// </para>
+/// <para>
+/// A distinção estático × escopo-processo de um categórico é a <b>nulidade</b> de
+/// <see cref="FatoCandidatoSeedItem.ValoresDominio"/>, não um campo próprio:
+/// <c>COR_RACA</c>/<c>SEXO</c> trazem o conjunto fechado; <c>MODALIDADE</c>/
+/// <c>CONDICAO_ATENDIMENTO</c> têm <see langword="null"/> (os valores válidos vêm
+/// da oferta congelada do processo, resolvidos pelo consumidor). Booleano e
+/// numérico têm sempre <see langword="null"/>.
+/// </para>
+/// <para>
+/// <see cref="NaturezaFato"/> (origem do dado) de todos os nove fatos desta
+/// colheita é <see cref="NaturezaFato.BrutoInformado"/> — dado respondido pelo
+/// candidato. O eixo existe para fatos futuros de outra origem (ex.: uma
+/// modalidade <see cref="NaturezaFato.Derivado"/> computada pelo motor), mas
+/// nenhum deles é semeado aqui.
+/// </para>
+/// </remarks>
+public static class FatoCandidatoSeed
+{
+    // Prefixo determinístico próprio do catálogo de fatos (distinto do
+    // rol_de_regras, para não confundir identidades entre tabelas).
+    private static Guid SeedId(int n) =>
+        Guid.Parse($"fa700000-0000-7000-8000-{n:D12}");
+
+    /// <summary>Os nove fatos do vocabulário, na ordem canônica da ADR-0111.</summary>
+    public static IReadOnlyList<FatoCandidatoSeedItem> Itens { get; } =
+    [
+        new(SeedId(1), "COR_RACA", "Cor ou raça", null,
+            DominioFato.Categorico, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar,
+            ["BRANCA", "PRETA", "PARDA", "AMARELA", "INDIGENA", "NAO_INFORMADO"]),
+
+        new(SeedId(2), "QUILOMBOLA", "Quilombola", null,
+            DominioFato.Booleano, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar,
+            null),
+
+        new(SeedId(3), "PCD", "Pessoa com deficiência", null,
+            DominioFato.Booleano, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar,
+            null),
+
+        new(SeedId(4), "EGRESSO_ESCOLA_PUBLICA", "Egresso de escola pública", null,
+            DominioFato.Booleano, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar,
+            null),
+
+        new(SeedId(5), "RENDA_PER_CAPITA", "Renda familiar per capita", null,
+            DominioFato.Numerico, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar,
+            null),
+
+        new(SeedId(6), "FAIXA_ETARIA", "Faixa etária", null,
+            DominioFato.Numerico, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar,
+            null),
+
+        new(SeedId(7), "SEXO", "Sexo", null,
+            DominioFato.Categorico, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar,
+            ["FEMININO", "MASCULINO", "INTERSEXO"]),
+
+        new(SeedId(8), "MODALIDADE", "Modalidade de concorrência", null,
+            DominioFato.Categorico, NaturezaFato.BrutoInformado, CardinalidadeFato.Multivalorado,
+            null),
+
+        new(SeedId(9), "CONDICAO_ATENDIMENTO", "Condição de atendimento especializado", null,
+            DominioFato.Categorico, NaturezaFato.BrutoInformado, CardinalidadeFato.Multivalorado,
+            null),
+    ];
+}
+
+/// <summary>
+/// Definição de um fato do seed (fonte única), na forma da entidade
+/// <c>FatoCandidato</c>. Não passa pela factory (seed materializa linhas
+/// diretamente); a coerência com as invariantes de domínio é garantida por
+/// teste de unidade sobre a factory e por CHECKs de banco sobre a tabela.
+/// </summary>
+public sealed record FatoCandidatoSeedItem(
+    Guid Id,
+    string Codigo,
+    string Nome,
+    string? Descricao,
+    DominioFato Dominio,
+    NaturezaFato Natureza,
+    CardinalidadeFato Cardinalidade,
+    IReadOnlyList<string>? ValoresDominio);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/FatoCandidatoReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/FatoCandidatoReader.cs
@@ -1,0 +1,65 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="IFatoCandidatoReader"/> (ADR-0056, ADR-0111):
+/// leitura direta do catálogo <c>rol_de_fatos_candidato</c> (<c>AsNoTracking</c>). Sem
+/// cache — o catálogo é de baixo volume (nove fatos), imutável (seed-governado), e
+/// o congelamento por valor no consumidor (ADR-0061) dispensa releitura quente
+/// (mesmo padrão do <c>TipoDocumentoReader</c>).
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class FatoCandidatoReader : IFatoCandidatoReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public FatoCandidatoReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<FatoCandidatoView>> ListarAsync(
+        CancellationToken cancellationToken = default)
+    {
+        List<FatoCandidato> fatos = await _dbContext.FatosCandidato
+            .AsNoTracking()
+            .OrderBy(f => f.Codigo)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. fatos.Select(ParaView)];
+    }
+
+    public async Task<FatoCandidatoView?> ObterPorCodigoAsync(
+        string codigo,
+        CancellationToken cancellationToken = default)
+    {
+        FatoCandidato? fato = await _dbContext.FatosCandidato
+            .AsNoTracking()
+            .FirstOrDefaultAsync(f => f.Codigo == codigo, cancellationToken)
+            .ConfigureAwait(false);
+
+        return fato is null ? null : ParaView(fato);
+    }
+
+    private static FatoCandidatoView ParaView(FatoCandidato f) =>
+        new(
+            f.Id,
+            f.Codigo,
+            f.Nome,
+            f.Descricao,
+            DominiosFato.ParaTokenCanonico(f.Dominio),
+            NaturezasFato.ParaTokenCanonico(f.Natureza),
+            CardinalidadesFato.ParaTokenCanonico(f.Cardinalidade),
+            f.ValoresDominio);
+}

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/FatoCandidatoCatalogoTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/FatoCandidatoCatalogoTests.cs
@@ -1,0 +1,102 @@
+namespace Unifesspa.UniPlus.ArchTests.SolutionRules;
+
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+
+using AwesomeAssertions;
+
+/// <summary>
+/// Fitness tests do catálogo <c>rol_de_fatos_candidato</c> (UNI-REQ-0077, ADR-0111): o
+/// vocabulário é seed-governado e append-only, consumido cross-módulo por leitor
+/// síncrono, sem FK cross-schema (ADR-0061). Estas regras travam duas fronteiras
+/// da decisão diretamente sobre o código-fonte:
+/// <list type="bullet">
+///   <item><description>o controller do catálogo não expõe rota de escrita —
+///   adicionar um fato é um PR de desenvolvimento (seed + código de resolução),
+///   nunca uma operação de tela;</description></item>
+///   <item><description>nenhuma migration de qualquer módulo cria uma chave
+///   estrangeira apontando para <c>rol_de_fatos_candidato</c> — a referência cross-módulo
+///   é por valor (snapshot-copy), não por FK cross-schema.</description></item>
+/// </list>
+/// </summary>
+public sealed class FatoCandidatoCatalogoTests
+{
+    /// <summary>
+    /// Detecta um verbo HTTP de escrita (<c>HttpPost</c>/<c>HttpPut</c>/
+    /// <c>HttpPatch</c>/<c>HttpDelete</c>) como atributo de ação.
+    /// </summary>
+    private static readonly Regex VerboDeEscrita = new(
+        @"\[Http(Post|Put|Patch|Delete)\b",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// Detecta uma FK cuja tabela-alvo é <c>rol_de_fatos_candidato</c> em qualquer
+    /// migration (<c>principalTable: "rol_de_fatos_candidato"</c>).
+    /// </summary>
+    private static readonly Regex FkParaFatoCandidato = new(
+        "principalTable:\\s*\"rol_de_fatos_candidato\"",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    [Fact(DisplayName = "O controller do catálogo de fatos não declara verbo HTTP de escrita")]
+    public void Controller_SomenteLeitura()
+    {
+        string controller = CaminhoDoController();
+        File.Exists(controller).Should().BeTrue($"o controller do catálogo vive em {controller}");
+
+        // Comentários C# removidos antes do match: uma nota que cite um verbo não
+        // pode ser lida como uma rota real.
+        VerboDeEscrita.IsMatch(SemComentarios(controller)).Should().BeFalse(
+            "o catálogo rol_de_fatos_candidato é seed-governado — nenhum POST/PUT/PATCH/DELETE o edita por HTTP");
+    }
+
+    [Fact(DisplayName = "Nenhuma migration cria FK cross-schema apontando para rol_de_fatos_candidato")]
+    public void Migrations_SemFkParaFatoCandidato()
+    {
+        string src = RaizSrc();
+        Directory.Exists(src).Should().BeTrue($"a árvore de código vive em {src}");
+
+        List<string> infratoras = Directory
+            .EnumerateFiles(src, "*.cs", SearchOption.AllDirectories)
+            .Where(arquivo => arquivo.Contains("Migrations", StringComparison.Ordinal))
+            .Where(arquivo => FkParaFatoCandidato.IsMatch(SemComentarios(arquivo)))
+            .Select(arquivo => Path.GetFileName(arquivo)!)
+            .ToList();
+
+        infratoras.Should().BeEmpty(
+            "a referência ao catálogo é por valor (ADR-0061), nunca por FK cross-schema. "
+            + $"Migrations com FK para rol_de_fatos_candidato: {string.Join(", ", infratoras)}");
+    }
+
+    [Theory(DisplayName = "O detector de verbo de escrita reconhece as formas de atributo")]
+    [InlineData("[HttpPost(\"admin/x\")]")]
+    [InlineData("[HttpPut(\"admin/x/{id}\")]")]
+    [InlineData("[HttpDelete]")]
+    [InlineData("[HttpPatch]")]
+    public void DetectorEscrita_ReconheceFormas(string linha) =>
+        VerboDeEscrita.IsMatch(linha).Should().BeTrue();
+
+    [Theory(DisplayName = "O detector de verbo de escrita não confunde leitura com escrita")]
+    [InlineData("[HttpGet(\"fatos-candidato\")]")]
+    [InlineData("[HttpGet(\"fatos-candidato/{codigo}\")]")]
+    public void DetectorEscrita_NaoAcusaLeitura(string linha) =>
+        VerboDeEscrita.IsMatch(linha).Should().BeFalse();
+
+    private static string SemComentarios(string arquivo) => string.Join(
+        '\n',
+        File.ReadLines(arquivo).Where(static linha => !linha.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+    private static string CaminhoDoController() => Path.GetFullPath(Path.Join(
+        RaizSrc(),
+        "configuracao",
+        "Unifesspa.UniPlus.Configuracao.API",
+        "Controllers",
+        "FatosCandidatoController.cs"));
+
+    private static string RaizSrc([CallerFilePath] string origem = "") =>
+        Path.GetFullPath(Path.Join(
+            Path.GetDirectoryName(origem)!,
+            "..",
+            "..",
+            "..",
+            "src"));
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/FatoCandidatoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/FatoCandidatoTests.cs
@@ -1,0 +1,225 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using System.Reflection;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Invariantes de domínio do catálogo <c>FatoCandidato</c> (ADR-0111): a factory
+/// valida código, domínio, natureza, cardinalidade e a coerência de
+/// <c>ValoresDominio</c> com o domínio; a entidade é imutável (seed-governada,
+/// sem soft-delete, sem mutação em runtime).
+/// </summary>
+public sealed class FatoCandidatoTests
+{
+    private static readonly IReadOnlyList<string> ValoresCorRaca =
+        ["BRANCA", "PRETA", "PARDA", "AMARELA", "INDIGENA", "NAO_INFORMADO"];
+
+    private static Result<FatoCandidato> Criar(
+        string codigo = "COR_RACA",
+        string nome = "Cor ou raça",
+        string? descricao = null,
+        DominioFato dominio = DominioFato.Categorico,
+        NaturezaFato natureza = NaturezaFato.BrutoInformado,
+        CardinalidadeFato cardinalidade = CardinalidadeFato.Escalar,
+        IReadOnlyList<string>? valoresDominio = null) =>
+        FatoCandidato.Criar(codigo, nome, descricao, dominio, natureza, cardinalidade, valoresDominio);
+
+    [Fact(DisplayName = "Criar categórico estático válido preenche os campos com Guid v7")]
+    public void Criar_CategoricoValido_Preenche()
+    {
+        FatoCandidato fato = Criar(descricao: "Cor ou raça autodeclarada", valoresDominio: ValoresCorRaca).Value!;
+
+        fato.Id.Should().NotBe(Guid.Empty);
+        fato.Codigo.Should().Be("COR_RACA");
+        fato.Nome.Should().Be("Cor ou raça");
+        fato.Descricao.Should().Be("Cor ou raça autodeclarada");
+        fato.Dominio.Should().Be(DominioFato.Categorico);
+        fato.Natureza.Should().Be(NaturezaFato.BrutoInformado);
+        fato.Cardinalidade.Should().Be(CardinalidadeFato.Escalar);
+        fato.ValoresDominio.Should().Equal(ValoresCorRaca);
+    }
+
+    [Theory(DisplayName = "Código ausente, em branco ou fora do formato é rejeitado")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("cor_raca")]      // minúsculo
+    [InlineData("1COR")]          // começa por dígito
+    [InlineData("COR-RACA")]      // hífen
+    [InlineData("A")]             // curto demais (< 2)
+    public void Criar_CodigoInvalido_Falha(string codigo)
+    {
+        Result<FatoCandidato> resultado = Criar(codigo: codigo);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().StartWith("FatoCandidato.Codigo");
+    }
+
+    [Fact(DisplayName = "Nome ausente é rejeitado")]
+    public void Criar_SemNome_Falha()
+    {
+        Result<FatoCandidato> resultado = Criar(nome: "   ");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.NomeObrigatorio);
+    }
+
+    [Fact(DisplayName = "Domínio Nenhum (não decidível — ex.: 'texto') é rejeitado")]
+    public void Criar_DominioNenhum_Falha()
+    {
+        Result<FatoCandidato> resultado = Criar(dominio: DominioFato.Nenhum, valoresDominio: null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.DominioObrigatorio);
+    }
+
+    [Fact(DisplayName = "Domínio fora do roster (cast inválido) é rejeitado como inválido, não aceito")]
+    public void Criar_DominioForaDoRoster_Falha()
+    {
+        Result<FatoCandidato> resultado = Criar(dominio: (DominioFato)999, valoresDominio: null);
+
+        resultado.IsFailure.Should().BeTrue("a factory não pode delegar a rejeição ao converter (que lançaria 500)");
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.DominioInvalido);
+    }
+
+    [Fact(DisplayName = "Natureza fora do roster (cast inválido) é rejeitada como inválida")]
+    public void Criar_NaturezaForaDoRoster_Falha()
+    {
+        Result<FatoCandidato> resultado = Criar(natureza: (NaturezaFato)999, valoresDominio: null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.NaturezaInvalida);
+    }
+
+    [Fact(DisplayName = "Cardinalidade fora do roster (cast inválido) é rejeitada como inválida")]
+    public void Criar_CardinalidadeForaDoRoster_Falha()
+    {
+        Result<FatoCandidato> resultado = Criar(cardinalidade: (CardinalidadeFato)999, valoresDominio: null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.CardinalidadeInvalida);
+    }
+
+    [Fact(DisplayName = "Natureza Nenhuma é rejeitada")]
+    public void Criar_NaturezaNenhuma_Falha()
+    {
+        Result<FatoCandidato> resultado = Criar(natureza: NaturezaFato.Nenhuma);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.NaturezaObrigatoria);
+    }
+
+    [Fact(DisplayName = "Cardinalidade Nenhuma é rejeitada")]
+    public void Criar_CardinalidadeNenhuma_Falha()
+    {
+        Result<FatoCandidato> resultado = Criar(cardinalidade: CardinalidadeFato.Nenhuma);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.CardinalidadeObrigatoria);
+    }
+
+    [Theory(DisplayName = "Fato não-categórico com valores de domínio é rejeitado")]
+    [InlineData(DominioFato.Booleano)]
+    [InlineData(DominioFato.Numerico)]
+    public void Criar_NaoCategoricoComValores_Falha(DominioFato dominio)
+    {
+        Result<FatoCandidato> resultado = Criar(dominio: dominio, valoresDominio: ["SIM", "NAO"]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.ValoresDominioNaoPermitidosForaDeCategorico);
+    }
+
+    [Theory(DisplayName = "Fato não-categórico sem valores é aceito")]
+    [InlineData(DominioFato.Booleano)]
+    [InlineData(DominioFato.Numerico)]
+    public void Criar_NaoCategoricoSemValores_Aceita(DominioFato dominio)
+    {
+        FatoCandidato fato = Criar(codigo: "PCD", nome: "PcD", dominio: dominio, valoresDominio: null).Value!;
+
+        fato.ValoresDominio.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Categórico sem valores é aceito (escopo-processo) e preserva o nulo")]
+    public void Criar_CategoricoSemValores_AceitaEscopoProcesso()
+    {
+        FatoCandidato fato = Criar(
+            codigo: "MODALIDADE",
+            nome: "Modalidade",
+            dominio: DominioFato.Categorico,
+            cardinalidade: CardinalidadeFato.Multivalorado,
+            valoresDominio: null).Value!;
+
+        fato.ValoresDominio.Should().BeNull("categórico sem valores é de escopo-processo, não lista vazia");
+    }
+
+    [Fact(DisplayName = "Categórico com lista vazia de valores é rejeitado (nulo ≠ vazio)")]
+    public void Criar_CategoricoListaVazia_Falha()
+    {
+        Result<FatoCandidato> resultado = Criar(valoresDominio: []);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.ValoresDominioComItemEmBranco);
+    }
+
+    [Theory(DisplayName = "Valores com item em branco são rejeitados")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_ValoresComItemEmBranco_Falha(string branco)
+    {
+        Result<FatoCandidato> resultado = Criar(valoresDominio: ["BRANCA", branco]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.ValoresDominioComItemEmBranco);
+    }
+
+    [Fact(DisplayName = "Valores com duplicata são rejeitados")]
+    public void Criar_ValoresComDuplicata_Falha()
+    {
+        Result<FatoCandidato> resultado = Criar(valoresDominio: ["BRANCA", "PRETA", "BRANCA"]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoCandidatoErrorCodes.ValoresDominioComDuplicata);
+    }
+
+    // ─── Imutabilidade (seed-governado, EntityBase puro, sem mutação) ──────────
+
+    [Fact(DisplayName = "FatoCandidato deriva de EntityBase puro — não é soft-deletable")]
+    public void FatoCandidato_EhEntityBasePuro()
+    {
+        typeof(EntityBase).IsAssignableFrom(typeof(FatoCandidato)).Should().BeTrue();
+        typeof(ISoftDeletable).IsAssignableFrom(typeof(FatoCandidato)).Should().BeFalse(
+            "o catálogo é append-only e seed-governado — nunca removido logicamente");
+    }
+
+    [Fact(DisplayName = "Todas as propriedades do FatoCandidato têm setter não-público (imutável)")]
+    public void FatoCandidato_PropriedadesImutaveis()
+    {
+        PropertyInfo[] propriedades = typeof(FatoCandidato)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        foreach (PropertyInfo propriedade in propriedades)
+        {
+            MethodInfo? setter = propriedade.GetSetMethod(nonPublic: false);
+            setter.Should().BeNull($"a propriedade '{propriedade.Name}' não pode ter setter público (entidade imutável)");
+        }
+    }
+
+    [Fact(DisplayName = "FatoCandidato não declara método de instância de mutação em runtime")]
+    public void FatoCandidato_SemMetodoDeMutacao()
+    {
+        MethodInfo[] metodos = typeof(FatoCandidato)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName) // exclui getters/setters de propriedade
+            .ToArray();
+
+        metodos.Should().BeEmpty(
+            "a única forma de nascer é a factory estática Criar; não há mutação de estado após a criação");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/FatoCandidatoEnumsTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Enums/FatoCandidatoEnumsTests.cs
@@ -1,0 +1,83 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Enums;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Parsing por allowlist textual dos três eixos do catálogo de fatos (ADR-0111):
+/// domínio, natureza (origem) e cardinalidade. Só os tokens canônicos UPPER_SNAKE
+/// são aceitos; tokens PascalCase e fora do domínio (ex.: <c>TEXTO</c>) são
+/// rejeitados — o que <c>Enum.TryParse</c> aceitaria por engano.
+/// </summary>
+public sealed class FatoCandidatoEnumsTests
+{
+    [Theory(DisplayName = "DominiosFato resolve os três tokens canônicos e o round-trip é estável")]
+    [InlineData("CATEGORICO", DominioFato.Categorico)]
+    [InlineData("BOOLEANO", DominioFato.Booleano)]
+    [InlineData("NUMERICO", DominioFato.Numerico)]
+    public void DominiosFato_TokenCanonico_Resolve(string token, DominioFato esperado)
+    {
+        DominiosFato.TryAnalisar(token, out DominioFato dominio).Should().BeTrue();
+        dominio.Should().Be(esperado);
+        DominiosFato.ParaTokenCanonico(dominio).Should().Be(token);
+    }
+
+    [Theory(DisplayName = "DominiosFato rejeita 'texto', PascalCase, vazio e nulo")]
+    [InlineData("TEXTO")]
+    [InlineData("Categorico")]
+    [InlineData("categorico")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void DominiosFato_ForaDoDominio_Rejeita(string? token)
+    {
+        DominiosFato.TryAnalisar(token, out DominioFato dominio).Should().BeFalse();
+        dominio.Should().Be(DominioFato.Nenhum);
+        DominiosFato.EhValido(token).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "DominiosFato expõe exatamente os três tokens canônicos")]
+    public void DominiosFato_TokensCanonicos() =>
+        DominiosFato.TokensCanonicos.Should().BeEquivalentTo(["CATEGORICO", "BOOLEANO", "NUMERICO"]);
+
+    [Theory(DisplayName = "NaturezasFato resolve os três tokens de origem-do-dado")]
+    [InlineData("BRUTO_INFORMADO", NaturezaFato.BrutoInformado)]
+    [InlineData("DE_VONTADE", NaturezaFato.DeVontade)]
+    [InlineData("DERIVADO", NaturezaFato.Derivado)]
+    public void NaturezasFato_TokenCanonico_Resolve(string token, NaturezaFato esperada)
+    {
+        NaturezasFato.TryAnalisar(token, out NaturezaFato natureza).Should().BeTrue();
+        natureza.Should().Be(esperada);
+        NaturezasFato.ParaTokenCanonico(natureza).Should().Be(token);
+    }
+
+    [Theory(DisplayName = "NaturezasFato rejeita token fora do domínio e nulo")]
+    [InlineData("ESTATICO")]
+    [InlineData("DINAMICO")]
+    [InlineData(null)]
+    public void NaturezasFato_ForaDoDominio_Rejeita(string? token)
+    {
+        NaturezasFato.TryAnalisar(token, out NaturezaFato natureza).Should().BeFalse();
+        natureza.Should().Be(NaturezaFato.Nenhuma);
+    }
+
+    [Theory(DisplayName = "CardinalidadesFato resolve os dois tokens canônicos")]
+    [InlineData("ESCALAR", CardinalidadeFato.Escalar)]
+    [InlineData("MULTIVALORADO", CardinalidadeFato.Multivalorado)]
+    public void CardinalidadesFato_TokenCanonico_Resolve(string token, CardinalidadeFato esperada)
+    {
+        CardinalidadesFato.TryAnalisar(token, out CardinalidadeFato cardinalidade).Should().BeTrue();
+        cardinalidade.Should().Be(esperada);
+        CardinalidadesFato.ParaTokenCanonico(cardinalidade).Should().Be(token);
+    }
+
+    [Theory(DisplayName = "CardinalidadesFato rejeita token fora do domínio e nulo")]
+    [InlineData("ARRAY")]
+    [InlineData("Escalar")]
+    [InlineData(null)]
+    public void CardinalidadesFato_ForaDoDominio_Rejeita(string? token)
+    {
+        CardinalidadesFato.TryAnalisar(token, out CardinalidadeFato cardinalidade).Should().BeFalse();
+        cardinalidade.Should().Be(CardinalidadeFato.Nenhuma);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FatosCandidato/FatoCandidatoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FatosCandidato/FatoCandidatoEndpointTests.cs
@@ -1,0 +1,79 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.FatosCandidato;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Smoke dos endpoints somente-leitura do catálogo <c>rol_de_fatos_candidato</c>
+/// (UNI-REQ-0077, ADR-0111) com Wolverine contra Postgres efêmero: routing, vendor
+/// media type, resolução do leitor cross-módulo via DI ponta-a-ponta, e 404 por
+/// chave natural inexistente.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class FatoCandidatoEndpointTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public FatoCandidatoEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/fatos-candidato retorna 200 com vendor MIME e os nove fatos")]
+    public async Task Listar_Retorna200ComOsNoveFatos()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/fatos-candidato", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType
+            .Should().Be("application/vnd.uniplus.fato-candidato.v1+json");
+
+        List<FatoCandidatoView>? fatos = await response.Content.ReadFromJsonAsync<List<FatoCandidatoView>>();
+        fatos.Should().NotBeNull();
+        fatos!.Should().HaveCount(9);
+        fatos.Select(f => f.Codigo).Should().BeInAscendingOrder(StringComparer.Ordinal);
+        fatos.Should().Contain(f => f.Codigo == "MODALIDADE" && f.Cardinalidade == "MULTIVALORADO" && f.ValoresDominio == null);
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/fatos-candidato/{codigo} resolve pela chave natural")]
+    public async Task ObterPorCodigo_Resolve()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/fatos-candidato/COR_RACA", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        FatoCandidatoView? fato = await response.Content.ReadFromJsonAsync<FatoCandidatoView>();
+        fato.Should().NotBeNull();
+        fato!.Codigo.Should().Be("COR_RACA");
+        fato.Dominio.Should().Be("CATEGORICO");
+        fato.ValoresDominio.Should().Contain("PRETA");
+    }
+
+    [Fact(DisplayName = "GET /api/configuracao/fatos-candidato/{codigo} retorna 404 para código inexistente")]
+    public async Task ObterPorCodigo_Inexistente_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri("/api/configuracao/fatos-candidato/NAO_EXISTE", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FatosCandidato/FatoCandidatoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FatosCandidato/FatoCandidatoPersistenceTests.cs
@@ -1,0 +1,288 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.FatosCandidato;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Seed;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta do catálogo <c>rol_de_fatos_candidato</c> contra Postgres real
+/// (UNI-REQ-0077, ADR-0111): seed dos nove fatos, leitor cross-módulo, ordenação,
+/// resolução por chave natural, sobrevivência do <c>valores_dominio</c> nulo ao
+/// round-trip, CHECKs de domínio/coerência e índice único total do código.
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+[SuppressMessage(
+    "Security",
+    "CA2100:Review SQL queries for security vulnerabilities",
+    Justification = "SQL fixo escrito no próprio teste; os valores externos entram por parâmetro interpolado (DbParameter).")]
+public sealed class FatoCandidatoPersistenceTests
+{
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public FatoCandidatoPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Seed materializa exatamente os nove fatos da ADR-0111, batendo com a fonte única")]
+    public async Task Seed_MaterializaNoveFatos()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        List<FatoCandidato> fatos = await ctx.FatosCandidato.AsNoTracking().ToListAsync();
+
+        fatos.Should().HaveCount(FatoCandidatoSeed.Itens.Count).And.HaveCount(9);
+        fatos.Select(f => f.Codigo).Should().OnlyHaveUniqueItems();
+
+        foreach (FatoCandidatoSeedItem item in FatoCandidatoSeed.Itens)
+        {
+            FatoCandidato persistido = fatos.Single(f => f.Codigo == item.Codigo);
+            persistido.Nome.Should().Be(item.Nome);
+            persistido.Dominio.Should().Be(item.Dominio);
+            persistido.Natureza.Should().Be(item.Natureza);
+            persistido.Cardinalidade.Should().Be(item.Cardinalidade);
+
+            if (item.ValoresDominio is null)
+            {
+                persistido.ValoresDominio.Should().BeNull($"{item.Codigo} tem valores nulos na fonte");
+            }
+            else
+            {
+                persistido.ValoresDominio.Should().Equal(item.ValoresDominio);
+            }
+        }
+    }
+
+    [Fact(DisplayName = "Cardinalidade: só MODALIDADE e CONDICAO_ATENDIMENTO são multivalorados; os demais escalares")]
+    public async Task Seed_CardinalidadeCoerente()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        List<FatoCandidato> fatos = await ctx.FatosCandidato.AsNoTracking().ToListAsync();
+
+        string[] multivalorados = [.. fatos
+            .Where(f => f.Cardinalidade == CardinalidadeFato.Multivalorado)
+            .Select(f => f.Codigo)
+            .OrderBy(c => c, StringComparer.Ordinal)];
+
+        multivalorados.Should().Equal("CONDICAO_ATENDIMENTO", "MODALIDADE");
+        fatos.Where(f => f.Cardinalidade != CardinalidadeFato.Multivalorado)
+            .Should().OnlyContain(f => f.Cardinalidade == CardinalidadeFato.Escalar);
+    }
+
+    [Fact(DisplayName = "valores_dominio nulo sobrevive ao round-trip jsonb (≠ lista vazia)")]
+    public async Task ValoresDominioNulo_SobreviveRoundTrip()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        FatoCandidato booleano = await ctx.FatosCandidato.AsNoTracking().SingleAsync(f => f.Codigo == "QUILOMBOLA");
+        booleano.ValoresDominio.Should().BeNull("booleano nunca enumera valores — o nulo é significante");
+
+        FatoCandidato escopoProcesso = await ctx.FatosCandidato.AsNoTracking().SingleAsync(f => f.Codigo == "MODALIDADE");
+        escopoProcesso.ValoresDominio.Should().BeNull("categórico de escopo-processo tem valores nulos, não vazios");
+
+        FatoCandidato estatico = await ctx.FatosCandidato.AsNoTracking().SingleAsync(f => f.Codigo == "COR_RACA");
+        estatico.ValoresDominio.Should().Equal("BRANCA", "PRETA", "PARDA", "AMARELA", "INDIGENA", "NAO_INFORMADO");
+    }
+
+    [Fact(DisplayName = "Reader (resolvível de fora do assembly) lista ordenado por código e projeta a view")]
+    public async Task Reader_Lista_OrdenadoPorCodigo()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var reader = new FatoCandidatoReader(ctx);
+
+        IReadOnlyList<FatoCandidatoView> views = await reader.ListarAsync();
+
+        views.Should().HaveCount(9);
+        views.Select(v => v.Codigo).Should().BeInAscendingOrder(StringComparer.Ordinal);
+
+        FatoCandidatoView corRaca = views.Single(v => v.Codigo == "COR_RACA");
+        corRaca.Dominio.Should().Be("CATEGORICO");
+        corRaca.Natureza.Should().Be("BRUTO_INFORMADO");
+        corRaca.Cardinalidade.Should().Be("ESCALAR");
+        corRaca.ValoresDominio.Should().Contain("INDIGENA");
+    }
+
+    [Fact(DisplayName = "Reader resolve por chave natural e devolve null para código inexistente")]
+    public async Task Reader_ObterPorCodigo_ResolveOuNull()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+        var reader = new FatoCandidatoReader(ctx);
+
+        FatoCandidatoView? sexo = await reader.ObterPorCodigoAsync("SEXO");
+        sexo.Should().NotBeNull();
+        sexo!.ValoresDominio.Should().Equal("FEMININO", "MASCULINO", "INTERSEXO");
+
+        FatoCandidatoView? inexistente = await reader.ObterPorCodigoAsync("NAO_EXISTE");
+        inexistente.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Índice único total recusa código duplicado (insert cru de um código já semeado)")]
+    public async Task IndiceUnicoTotal_RecusaDuplicata()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"""
+            INSERT INTO configuracao.rol_de_fatos_candidato (id, codigo, nome, dominio, natureza, cardinalidade, valores_dominio, created_at)
+            VALUES ({Guid.CreateVersion7()}, {"COR_RACA"}, {"Duplicata"}, {"BOOLEANO"}, {"BRUTO_INFORMADO"}, {"ESCALAR"}, NULL, {DateTimeOffset.UtcNow})
+            """);
+
+        Npgsql.PostgresException ex = (await act.Should().ThrowAsync<Npgsql.PostgresException>()).Which;
+        ex.SqlState.Should().Be("23505");
+        ex.ConstraintName.Should().Be("ux_rol_de_fatos_candidato_codigo");
+    }
+
+    [Fact(DisplayName = "CHECK de domínio recusa token fora do vocabulário via SQL cru")]
+    public async Task Check_RecusaDominioInvalido()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"""
+            INSERT INTO configuracao.rol_de_fatos_candidato (id, codigo, nome, dominio, natureza, cardinalidade, valores_dominio, created_at)
+            VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"TEXTO"}, {"BRUTO_INFORMADO"}, {"ESCALAR"}, NULL, {DateTimeOffset.UtcNow})
+            """);
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>("o CHECK ck_rol_de_fatos_candidato_dominio bloqueia 'TEXTO'");
+    }
+
+    [Fact(DisplayName = "CHECK de coerência recusa valores em fato não-categórico via SQL cru")]
+    public async Task Check_RecusaValoresEmNaoCategorico()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"""
+            INSERT INTO configuracao.rol_de_fatos_candidato (id, codigo, nome, dominio, natureza, cardinalidade, valores_dominio, created_at)
+            VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"BOOLEANO"}, {"BRUTO_INFORMADO"}, {"ESCALAR"}, {"[\"SIM\"]"}::jsonb, {DateTimeOffset.UtcNow})
+            """);
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de coerência só admite valores em fato CATEGORICO");
+    }
+
+    [Fact(DisplayName = "CHECK de coerência recusa array vazio em fato categórico via SQL cru")]
+    public async Task Check_RecusaArrayVazioEmCategorico()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"""
+            INSERT INTO configuracao.rol_de_fatos_candidato (id, codigo, nome, dominio, natureza, cardinalidade, valores_dominio, created_at)
+            VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"CATEGORICO"}, {"BRUTO_INFORMADO"}, {"ESCALAR"}, {"[]"}::jsonb, {DateTimeOffset.UtcNow})
+            """);
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK de coerência exige array não vazio quando valores_dominio é informado");
+    }
+
+    [Fact(DisplayName = "CHECK de coerência recusa elemento não-string no array via SQL cru")]
+    public async Task Check_RecusaElementoNaoString()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"""
+            INSERT INTO configuracao.rol_de_fatos_candidato (id, codigo, nome, dominio, natureza, cardinalidade, valores_dominio, created_at)
+            VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"CATEGORICO"}, {"BRUTO_INFORMADO"}, {"ESCALAR"}, {"[1]"}::jsonb, {DateTimeOffset.UtcNow})
+            """);
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "um elemento numérico quebraria a desserialização de IReadOnlyList<string> no reader");
+    }
+
+    [Fact(DisplayName = "CHECK de coerência recusa string em branco no array via SQL cru")]
+    public async Task Check_RecusaStringEmBranco()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx.Database.ExecuteSqlAsync(
+            $"""
+            INSERT INTO configuracao.rol_de_fatos_candidato (id, codigo, nome, dominio, natureza, cardinalidade, valores_dominio, created_at)
+            VALUES ({Guid.CreateVersion7()}, {CodigoUnico()}, {"X"}, {"CATEGORICO"}, {"BRUTO_INFORMADO"}, {"ESCALAR"}, {"[\"  \"]"}::jsonb, {DateTimeOffset.UtcNow})
+            """);
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "a factory recusa item em branco; o CHECK espelha a invariante");
+    }
+
+    [Fact(DisplayName = "ValueComparer distingue nulo de lista vazia e preserva o nulo no snapshot")]
+    public void ValueComparer_NuloDistintoDeVazio()
+    {
+        using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        Microsoft.EntityFrameworkCore.ChangeTracking.ValueComparer comparer =
+            ctx.Model.FindEntityType(typeof(FatoCandidato))!
+                .FindProperty(nameof(FatoCandidato.ValoresDominio))!
+                .GetValueComparer();
+
+        IReadOnlyList<string> vazia = [];
+
+        comparer.Equals(null, vazia).Should().BeFalse("nulo (escopo-processo) nunca é igual à lista vazia (ADR-0111)");
+        comparer.Equals(null, null).Should().BeTrue();
+        comparer.Snapshot(null).Should().BeNull("o snapshot de um nulo não pode virar lista vazia");
+    }
+
+    [Fact(DisplayName = "Seed bate com o roster literal independente da ADR-0111 (autoridade), não só com a própria fonte")]
+    public async Task Seed_BateComRosterIndependente()
+    {
+        // Expectativa literal declarada aqui — independente de FatoCandidatoSeed.Itens.
+        // Falha se a fonte do seed divergir da autoridade da ADR (código, id fixo,
+        // domínio, natureza, cardinalidade ou valores), não apenas se a migration
+        // divergir da fonte.
+        (string Codigo, string IdSufixo, DominioFato Dominio, NaturezaFato Natureza, CardinalidadeFato Cardinalidade, string[]? Valores)[] esperado =
+        [
+            ("COR_RACA", "001", DominioFato.Categorico, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar,
+                ["BRANCA", "PRETA", "PARDA", "AMARELA", "INDIGENA", "NAO_INFORMADO"]),
+            ("QUILOMBOLA", "002", DominioFato.Booleano, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar, null),
+            ("PCD", "003", DominioFato.Booleano, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar, null),
+            ("EGRESSO_ESCOLA_PUBLICA", "004", DominioFato.Booleano, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar, null),
+            ("RENDA_PER_CAPITA", "005", DominioFato.Numerico, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar, null),
+            ("FAIXA_ETARIA", "006", DominioFato.Numerico, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar, null),
+            ("SEXO", "007", DominioFato.Categorico, NaturezaFato.BrutoInformado, CardinalidadeFato.Escalar,
+                ["FEMININO", "MASCULINO", "INTERSEXO"]),
+            ("MODALIDADE", "008", DominioFato.Categorico, NaturezaFato.BrutoInformado, CardinalidadeFato.Multivalorado, null),
+            ("CONDICAO_ATENDIMENTO", "009", DominioFato.Categorico, NaturezaFato.BrutoInformado, CardinalidadeFato.Multivalorado, null),
+        ];
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+        List<FatoCandidato> fatos = await ctx.FatosCandidato.AsNoTracking().ToListAsync();
+
+        fatos.Should().HaveCount(esperado.Length);
+
+        foreach ((string codigo, string idSufixo, DominioFato dominio, NaturezaFato natureza, CardinalidadeFato cardinalidade, string[]? valores) in esperado)
+        {
+            FatoCandidato fato = fatos.Single(f => f.Codigo == codigo);
+            fato.Id.Should().Be(Guid.Parse($"fa700000-0000-7000-8000-{idSufixo.PadLeft(12, '0')}"));
+            fato.Dominio.Should().Be(dominio);
+            fato.Natureza.Should().Be(natureza, "todos os nove fatos desta colheita são BRUTO_INFORMADO (ADR-0111)");
+            fato.Cardinalidade.Should().Be(cardinalidade);
+
+            if (valores is null)
+            {
+                fato.ValoresDominio.Should().BeNull();
+            }
+            else
+            {
+                fato.ValoresDominio.Should().Equal(valores);
+            }
+        }
+    }
+
+    private static string CodigoUnico() => $"FATO_{Guid.NewGuid().ToString("N")[..12].ToUpperInvariant()}";
+}


### PR DESCRIPTION
## Objetivo

Materializa o **catálogo seed-governado de fatos do candidato** (`rol_de_fatos_candidato`) no módulo Configuração, conforme a **ADR-0111** (UNI-REQ-0077). É o vocabulário fechado que dá domínio decidível aos predicados sobre o candidato — hoje string livre — consumidos pelo gatilho de exigência documental (#554) e pelo desempate por predicado (`DESEMPATE-PREDICADO-FATO`).

Closes #846 · Refs #40

## O que entrega

- **Persistência** (`rol_de_fatos_candidato`): entidade `FatoCandidato` sobre `EntityBase` puro (append-only, sem soft-delete), enums persistidos como token canônico UPPER_SNAKE por value converter, `valores_dominio` **jsonb anulável** (o nulo é significante e sobrevive ao round-trip), **índice único total** do código e CHECKs de domínio, natureza, cardinalidade e coerência dos valores. Seed dos **nove fatos** como fonte única do `HasData`, com ids fixos determinísticos.
- **Leitor cross-módulo** `IFatoCandidatoReader` (ADR-0056), sem repositório — o catálogo não tem escrita em runtime.
- **Leitura HTTP** somente-leitura em `/api/configuracao/fatos-candidato` (lista + resolução por chave natural). Sem rota admin de escrita.
- **ADR-0111 alinhada** ao modelo implementado: a distinção estático × escopo-processo é a **nulidade de `ValoresDominio`**, não um campo; introduz os eixos `Natureza` (origem-do-dado) e `Cardinalidade` como campos próprios.

## Decisões de modelagem

- **Estático × escopo-processo = nulidade de `ValoresDominio`.** Categórico com valores = conjunto global estático (`COR_RACA`, `SEXO`); categórico com `ValoresDominio` nulo = escopo-processo, resolvido pelo consumidor contra a oferta congelada (`MODALIDADE`, `CONDICAO_ATENDIMENTO`). Booleano/numérico sempre nulos. Nulo ≠ lista vazia.
- **`Natureza`** = origem-do-dado (`BrutoInformado`/`DeVontade`/`Derivado`); os nove fatos desta colheita são todos `BrutoInformado`.
- **`Cardinalidade`** = campo (`Escalar`/`Multivalorado`) — só `MODALIDADE` e `CONDICAO_ATENDIMENTO` são multivalorados.
- **Nome da tabela** `rol_de_fatos_candidato`, seguindo a convenção `rol_de_*` dos catálogos seed-governados (como `rol_de_regras`), alinhada ao título da issue, à ADR-0111 e ao schema validado.

## Testes

- **Unidade (domínio):** formato do código, roster fechado dos três eixos (incl. cast fora do vocabulário → erro nomeado, não 500), coerência de valores com o domínio, imutabilidade da entidade; parsing dos enums de token.
- **Integração (Postgres real):** seed batendo com **roster literal independente da ADR**, `valores_dominio` nulo sobrevivendo ao round-trip, CHECKs de domínio e coerência (recusa de não-string e string em branco por insert cru), índice único total, distinção nulo × lista vazia no comparer, leitor e endpoints.
- **Fitness:** o controller do catálogo não expõe verbo de escrita; nenhuma migration cria FK cross-schema para a tabela.

## Notas de revisão

- Revisão local com Codex aplicada (2 rodadas): validação de enum na factory, comparer `null`-aware (nulo ≠ vazio), CHECK reforçada rejeitando elemento não-string e branco ASCII, e roster de seed literal independente. A paridade total do CHECK com whitespace Unicode (ex.: NBSP) não é exprimível no `like_regex` do jsonpath do Postgres (não há `\p{Z}`); a factory permanece o guarda autoritativo, com o CHECK como defesa em profundidade para os casos realistas.
- Baseline OpenAPI regenerada; `adr-lint`, `forbidden-deps` e a suíte completa de Configuração (integração, domínio, arch, application) verdes localmente.
