### PR TITLE
feat(selecao): adiciona núcleo de documentos exigidos com aplicabilidade

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -4169,6 +4169,7 @@
         "required": [
           "id",
           "exigidoNaFaseId",
+          "tipoDocumentoOrigemId",
           "tipoDocumentoCodigo",
           "tipoDocumentoNome",
           "tipoDocumentoCategoria",
@@ -4184,6 +4185,10 @@
             "format": "uuid"
           },
           "exigidoNaFaseId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tipoDocumentoOrigemId": {
             "type": "string",
             "format": "uuid"
           },

--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -2042,6 +2042,142 @@
         "x-uniplus-idempotent": true
       }
     },
+    "/api/selecao/processos-seletivos/{id}/documentos-exigidos": {
+      "put": {
+        "tags": [
+          "ProcessoSeletivo"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ItemDocumentoExigidoInput"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ItemDocumentoExigidoInput"
+                }
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ItemDocumentoExigidoInput"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "ETag": {
+                "description": "ETag forte da sess\u00E3o editorial de retifica\u00E7\u00E3o, no formato \u0022{idDaSessao}:{revisao}\u0022. Devolva-o no If-Match da pr\u00F3xima muta\u00E7\u00E3o. Toda muta\u00E7\u00E3o aceita INCREMENTA a revis\u00E3o e emite o tag novo aqui \u2014 o cliente encadeia sem um GET no meio. Ausente quando n\u00E3o h\u00E1 sess\u00E3o em curso (o processo em rascunho n\u00E3o tem precondi\u00E7\u00E3o a satisfazer).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Precondition Failed",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "Precondition Required",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Requisi\u00E7\u00E3o concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois \u2014 a opera\u00E7\u00E3o anterior ainda n\u00E3o concluiu."
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor."
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
     "/api/selecao/processos-seletivos/{id}/publicacao": {
       "post": {
         "tags": [
@@ -4029,6 +4165,58 @@
           }
         }
       },
+      "DocumentoExigidoDto": {
+        "required": [
+          "id",
+          "exigidoNaFaseId",
+          "tipoDocumentoCodigo",
+          "tipoDocumentoNome",
+          "tipoDocumentoCategoria",
+          "aplicabilidade",
+          "obrigatorio",
+          "consequenciaIndeferimento",
+          "grupoSatisfacaoId"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "exigidoNaFaseId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tipoDocumentoCodigo": {
+            "type": "string"
+          },
+          "tipoDocumentoNome": {
+            "type": "string"
+          },
+          "tipoDocumentoCategoria": {
+            "type": "string"
+          },
+          "aplicabilidade": {
+            "type": "string"
+          },
+          "obrigatorio": {
+            "type": "boolean"
+          },
+          "consequenciaIndeferimento": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "grupoSatisfacaoId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          }
+        }
+      },
       "EtapaProcessoDto": {
         "required": [
           "id",
@@ -4372,6 +4560,46 @@
           },
           "ok": {
             "type": "boolean"
+          }
+        }
+      },
+      "ItemDocumentoExigidoInput": {
+        "required": [
+          "exigidoNaFaseId",
+          "tipoDocumentoId",
+          "aplicabilidade",
+          "obrigatorio",
+          "consequenciaIndeferimento",
+          "grupoSatisfacaoId"
+        ],
+        "type": "object",
+        "properties": {
+          "exigidoNaFaseId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tipoDocumentoId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "aplicabilidade": {
+            "type": "string"
+          },
+          "obrigatorio": {
+            "type": "boolean"
+          },
+          "consequenciaIndeferimento": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "grupoSatisfacaoId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
           }
         }
       },
@@ -4870,6 +5098,7 @@
           "criteriosDesempate",
           "classificacao",
           "cronogramaFases",
+          "documentosExigidos",
           "criadoEm"
         ],
         "type": "object",
@@ -4942,6 +5171,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FaseCronogramaDto"
+            }
+          },
+          "documentosExigidos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentoExigidoDto"
             }
           },
           "criadoEm": {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -337,6 +337,37 @@ public sealed class ProcessoSeletivoController : ControllerBase
     }
 
     /// <summary>
+    /// Substitui integralmente os documentos exigidos do processo (Story #554, PR-a):
+    /// fase, snapshot-copy do tipo de documento, aplicabilidade GERAL/CONDICIONAL,
+    /// obrigatoriedade, consequência de indeferimento e grupo de satisfação. O gatilho
+    /// DNF, a base legal e a idade/formato/tamanho chegam em tasks-irmãs (PR-b/c/d). O
+    /// <c>GET</c> vem do endpoint agregado (<see cref="ObterPorId"/>) — não há rota
+    /// aninhada própria de leitura.
+    /// </summary>
+    [HttpPut("{id:guid}/documentos-exigidos")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status412PreconditionFailed)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status428PreconditionRequired)]
+    [EmiteETag]
+    public async Task<IActionResult> DefinirDocumentosExigidos(
+        Guid id,
+        [FromBody] IReadOnlyList<ItemDocumentoExigidoInput> itens,
+        [FromHeader(Name = "If-Match")] string? ifMatch,
+        CancellationToken cancellationToken)
+    {
+        if (!TentarLerPrecondicao(ifMatch, out PrecondicaoIfMatch precondicao, out IActionResult? malformada))
+            return malformada!;
+
+        Result<MutacaoAceita> resultado = await _commandBus.Send(
+            new DefinirDocumentosExigidosCommand(id, itens, precondicao), cancellationToken);
+        return ResponderMutacao(resultado);
+    }
+
+    /// <summary>
     /// Publica o processo (RN08): valida a conformidade, congela a versão 1 da
     /// configuração (append-only) e transita o status para Publicado, tudo na mesma
     /// transação — junto da requisição durável que registra o ato em Publicações

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -296,6 +296,7 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("DocumentoExigido.CondicionalVaziaDeterminaResultado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.condicional_vazia_determina_resultado", "Exigência CONDICIONAL sem condição viva que determina resultado nunca seria cobrada de ninguém")),
         new("DocumentoExigido.TipoDocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.tipo_documento_nao_encontrado", "Tipo de documento não encontrado ou não está mais vivo")),
         new("ProcessoSeletivo.ExigenciasDocumentaisNaoMaterializadas", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.exigencias_documentais_nao_materializadas", "Existem documentos exigidos configurados, mas o bloco de exigências do envelope ainda não foi materializado")),
+        new("FaseCronograma.ReferenciadaPorExigenciaViva", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fase_cronograma.referenciada_por_exigencia_viva", "O cronograma não pode ser redefinido enquanto existir documento exigido configurado")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -285,6 +285,17 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         // aceitava mutação da configuração em silêncio — a trava era uma denylist de um
         // elemento só, e todo estado novo nascia mutável por omissão.
         new("ProcessoSeletivo.MutacaoForaDeEstadoEditavel", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.mutacao_fora_de_estado_editavel", "O processo não está em um estado que aceite mutação da configuração")),
+        // Documentos exigidos (Story #554, PR-a) — núcleo: aplicabilidade GERAL/CONDICIONAL,
+        // fase, snapshot-copy do tipo de documento e a guarda fail-closed transitória (B-01)
+        // enquanto o bloco `documentosExigidos.exigencias` do envelope segue stub (removida
+        // na PR-e).
+        new("DocumentoExigido.AplicabilidadeObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.aplicabilidade_obrigatoria", "A aplicabilidade da exigência documental é obrigatória")),
+        new("DocumentoExigido.ConsequenciaIndeferimentoInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.consequencia_indeferimento_invalida", "Consequência de indeferimento fora do domínio conhecido")),
+        new("DocumentoExigido.GeralComCondicao", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.geral_com_condicao", "Exigência GERAL não pode conviver com condição de gatilho viva")),
+        new("DocumentoExigido.FaseNaoPertenceAoProcesso", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.fase_nao_pertence_ao_processo", "A fase informada não pertence ao cronograma deste processo")),
+        new("DocumentoExigido.CondicionalVaziaDeterminaResultado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.condicional_vazia_determina_resultado", "Exigência CONDICIONAL sem condição viva que determina resultado nunca seria cobrada de ninguém")),
+        new("DocumentoExigido.TipoDocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.tipo_documento_nao_encontrado", "Tipo de documento não encontrado ou não está mais vivo")),
+        new("ProcessoSeletivo.ExigenciasDocumentaisNaoMaterializadas", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.exigencias_documentais_nao_materializadas", "Existem documentos exigidos configurados, mas o bloco de exigências do envelope ainda não foi materializado")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -285,10 +285,10 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         // aceitava mutação da configuração em silêncio — a trava era uma denylist de um
         // elemento só, e todo estado novo nascia mutável por omissão.
         new("ProcessoSeletivo.MutacaoForaDeEstadoEditavel", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.mutacao_fora_de_estado_editavel", "O processo não está em um estado que aceite mutação da configuração")),
-        // Documentos exigidos (Story #554, PR-a) — núcleo: aplicabilidade GERAL/CONDICIONAL,
-        // fase, snapshot-copy do tipo de documento e a guarda fail-closed transitória (B-01)
-        // enquanto o bloco `documentosExigidos.exigencias` do envelope segue stub (removida
-        // na PR-e).
+        // Documentos exigidos (Story #554, issue #547, PR-a) — núcleo: aplicabilidade
+        // GERAL/CONDICIONAL, fase, snapshot-copy do tipo de documento e a guarda
+        // fail-closed transitória (B-01) enquanto o bloco `documentosExigidos.exigencias`
+        // do envelope segue stub (removida na PR-e, issue #548).
         new("DocumentoExigido.AplicabilidadeObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.aplicabilidade_obrigatoria", "A aplicabilidade da exigência documental é obrigatória")),
         new("DocumentoExigido.ConsequenciaIndeferimentoInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.consequencia_indeferimento_invalida", "Consequência de indeferimento fora do domínio conhecido")),
         new("DocumentoExigido.GeralComCondicao", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.geral_com_condicao", "Exigência GERAL não pode conviver com condição de gatilho viva")),

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoCodegenRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoCodegenRegistration.cs
@@ -92,5 +92,11 @@ public static class SelecaoCodegenRegistration
         opts.CodeGeneration.AlwaysUseServiceLocationFor<IFaseCanonicaReader>();
         opts.CodeGeneration.AlwaysUseServiceLocationFor<ITipoBancaReader>();
         opts.CodeGeneration.AlwaysUseServiceLocationFor<IPrecedenciaFaseReader>();
+
+        // Documentos exigidos (Story #554, PR-a): snapshot-copy de TipoDocumento
+        // (Configuração) para cada exigência. Mesmo motivo dos demais readers
+        // cross-módulo acima — o concreto TipoDocumentoReader é internal a
+        // Configuracao.Infrastructure.
+        opts.CodeGeneration.AlwaysUseServiceLocationFor<ITipoDocumentoReader>();
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommand.cs
@@ -1,0 +1,32 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Domain.ValueObjects;
+using Kernel.Results;
+
+/// <summary>
+/// Entrada de uma exigência documental, usada por
+/// <see cref="DefinirDocumentosExigidosCommand"/>. O handler resolve
+/// <see cref="TipoDocumentoId"/> contra o módulo Configuração e congela os
+/// atributos vigentes por valor (snapshot-copy, ADR-0061) — o cliente não os
+/// declara diretamente.
+/// </summary>
+public sealed record ItemDocumentoExigidoInput(
+    Guid ExigidoNaFaseId,
+    Guid TipoDocumentoId,
+    string Aplicabilidade,
+    bool Obrigatorio,
+    string? ConsequenciaIndeferimento,
+    Guid? GrupoSatisfacaoId);
+
+/// <summary>
+/// Substitui integralmente a coleção de documentos exigidos do processo (Story #554,
+/// PR-a — núcleo: fase, snapshot-copy do tipo de documento, aplicabilidade GERAL/
+/// CONDICIONAL, obrigatoriedade, consequência de indeferimento e grupo de satisfação
+/// como campos de transporte). O gatilho DNF (PR-b), a base legal (PR-c) e a idade/
+/// formato/tamanho (PR-d) chegam em tasks-irmãs.
+/// </summary>
+public sealed record DefinirDocumentosExigidosCommand(
+    Guid ProcessoSeletivoId,
+    IReadOnlyList<ItemDocumentoExigidoInput> Itens,
+    PrecondicaoIfMatch Precondicao) : ICommand<Result<MutacaoAceita>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommandHandler.cs
@@ -1,0 +1,94 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using Abstractions;
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Interfaces;
+using Kernel.Results;
+using Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Handler do <see cref="DefinirDocumentosExigidosCommand"/> (Story #554, PR-a): resolve
+/// o snapshot-copy de <c>TipoDocumento</c> (módulo Configuração, ADR-0056) para cada item
+/// e delega a montagem/validação ao domínio.
+/// </summary>
+public static class DefinirDocumentosExigidosCommandHandler
+{
+    public static async Task<Result<MutacaoAceita>> Handle(
+        DefinirDocumentosExigidosCommand command,
+        IProcessoSeletivoRepository processoSeletivoRepository,
+        ITipoDocumentoReader tipoDocumentoReader,
+        ISelecaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(processoSeletivoRepository);
+        ArgumentNullException.ThrowIfNull(tipoDocumentoReader);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        ProcessoSeletivo? processo = await processoSeletivoRepository
+            .ObterParaMutacaoAsync(command.ProcessoSeletivoId, cancellationToken)
+            .ConfigureAwait(false);
+        if (processo is null)
+        {
+            return Result<MutacaoAceita>.Failure(new DomainError(
+                "ProcessoSeletivo.NaoEncontrado",
+                $"Processo Seletivo {command.ProcessoSeletivoId} não encontrado."));
+        }
+
+        // A precondição precede a resolução de leituras externas (ADR-0110 D9) — mesma
+        // nota dos demais Definir*.
+        if (processo.MutacaoBloqueada(command.Precondicao) is { } bloqueio)
+        {
+            return Result<MutacaoAceita>.Failure(bloqueio);
+        }
+
+        List<DocumentoExigido> itens = [];
+        foreach (ItemDocumentoExigidoInput input in command.Itens)
+        {
+            TipoDocumentoView? tipoDocumento = await tipoDocumentoReader
+                .ObterPorIdAsync(input.TipoDocumentoId, cancellationToken)
+                .ConfigureAwait(false);
+            if (tipoDocumento is null)
+            {
+                return Result<MutacaoAceita>.Failure(new DomainError(
+                    "DocumentoExigido.TipoDocumentoNaoEncontrado",
+                    $"Tipo de documento {input.TipoDocumentoId} não encontrado ou não está mais vivo."));
+            }
+
+            Aplicabilidade aplicabilidade = input.Aplicabilidade switch
+            {
+                "GERAL" => Aplicabilidade.Geral,
+                "CONDICIONAL" => Aplicabilidade.Condicional,
+                _ => Aplicabilidade.Nenhuma,
+            };
+
+            Result<DocumentoExigido> itemResult = DocumentoExigido.Criar(
+                input.ExigidoNaFaseId,
+                tipoDocumento.Id,
+                tipoDocumento.Codigo,
+                tipoDocumento.Nome,
+                tipoDocumento.Categoria,
+                aplicabilidade,
+                input.Obrigatorio,
+                input.ConsequenciaIndeferimento,
+                input.GrupoSatisfacaoId);
+            if (itemResult.IsFailure)
+            {
+                return Result<MutacaoAceita>.Failure(itemResult.Error!);
+            }
+
+            itens.Add(itemResult.Value!);
+        }
+
+        Result definirResult = processo.DefinirDocumentosExigidos(itens, command.Precondicao);
+        if (definirResult.IsFailure)
+        {
+            return Result<MutacaoAceita>.Failure(definirResult.Error!);
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<MutacaoAceita>.Success(new MutacaoAceita(processo.ETagDaSessaoEditorial));
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoExigidoDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoExigidoDto.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+/// <summary>
+/// DTO de leitura de <see cref="Domain.Entities.DocumentoExigido"/> (Story #554, PR-a).
+/// Compõe <c>ProcessoSeletivoDto</c> — não há rota aninhada própria de leitura, mesmo
+/// padrão de <c>FaseCronogramaDto</c>.
+/// </summary>
+public sealed record DocumentoExigidoDto(
+    Guid Id,
+    Guid ExigidoNaFaseId,
+    string TipoDocumentoCodigo,
+    string TipoDocumentoNome,
+    string TipoDocumentoCategoria,
+    string Aplicabilidade,
+    bool Obrigatorio,
+    string? ConsequenciaIndeferimento,
+    Guid? GrupoSatisfacaoId);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoExigidoDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoExigidoDto.cs
@@ -8,6 +8,7 @@ namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
 public sealed record DocumentoExigidoDto(
     Guid Id,
     Guid ExigidoNaFaseId,
+    Guid TipoDocumentoOrigemId,
     string TipoDocumentoCodigo,
     string TipoDocumentoNome,
     string TipoDocumentoCategoria,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ProcessoSeletivoDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ProcessoSeletivoDto.cs
@@ -20,6 +20,7 @@ public sealed record ProcessoSeletivoDto(
     IReadOnlyList<CriterioDesempateDto> CriteriosDesempate,
     ConfiguracaoClassificacaoDto? Classificacao,
     IReadOnlyList<FaseCronogramaDto> CronogramaFases,
+    IReadOnlyList<DocumentoExigidoDto> DocumentosExigidos,
     DateTimeOffset CriadoEm)
 {
     /// <summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
@@ -40,6 +40,7 @@ public static class ObterProcessoSeletivoQueryHandler
         [.. processo.CriteriosDesempate.OrderBy(c => c.Ordem).Select(ProjectCriterioDesempate)],
         ProjectClassificacao(processo),
         [.. processo.CronogramaFases.OrderBy(f => f.Ordem).ThenBy(f => f.Id).Select(ProjectFaseCronograma)],
+        [.. processo.DocumentosExigidos.OrderBy(d => d.Id).Select(ProjectDocumentoExigido)],
         processo.CreatedAt);
 
     private static OfertaAtendimentoEspecializadoDto? ProjectOfertaAtendimento(OfertaAtendimentoEspecializado? oferta)
@@ -174,6 +175,17 @@ public static class ObterProcessoSeletivoQueryHandler
         fase.AtoProduzidoEfeitoIrreversivel,
         [.. fase.BancasRequeridas.Select(static b => new BancaRequeridaDto(b.Id, b.TipoBancaOrigemId, b.Codigo))],
         fase.RegraRecurso is { } regraRecurso ? ProjectRegraRecursoFase(regraRecurso) : null);
+
+    private static DocumentoExigidoDto ProjectDocumentoExigido(DocumentoExigido documento) => new(
+        documento.Id,
+        documento.ExigidoNaFaseId,
+        documento.TipoDocumentoCodigo,
+        documento.TipoDocumentoNome,
+        documento.TipoDocumentoCategoria,
+        documento.Aplicabilidade.ToString(),
+        documento.Obrigatorio,
+        documento.ConsequenciaIndeferimento,
+        documento.GrupoSatisfacaoId);
 
     private static RegraRecursoFaseDto ProjectRegraRecursoFase(RegraRecursoFase regraRecurso) => new(
         regraRecurso.Id,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
@@ -179,13 +179,24 @@ public static class ObterProcessoSeletivoQueryHandler
     private static DocumentoExigidoDto ProjectDocumentoExigido(DocumentoExigido documento) => new(
         documento.Id,
         documento.ExigidoNaFaseId,
+        documento.TipoDocumentoOrigemId,
         documento.TipoDocumentoCodigo,
         documento.TipoDocumentoNome,
         documento.TipoDocumentoCategoria,
-        documento.Aplicabilidade.ToString(),
+        ProjectAplicabilidade(documento.Aplicabilidade),
         documento.Obrigatorio,
         documento.ConsequenciaIndeferimento,
         documento.GrupoSatisfacaoId);
+
+    // Emite o mesmo token de wire aceito por DefinirDocumentosExigidosCommandValidator
+    // ("GERAL"/"CONDICIONAL") — Aplicabilidade.ToString() produziria "Geral"/"Condicional"
+    // (PascalCase), que o validator rejeitaria num reenvio direto do GET para o PUT.
+    private static string ProjectAplicabilidade(Aplicabilidade aplicabilidade) => aplicabilidade switch
+    {
+        Aplicabilidade.Geral => "GERAL",
+        Aplicabilidade.Condicional => "CONDICIONAL",
+        _ => throw new InvalidOperationException($"Aplicabilidade '{aplicabilidade}' não deveria estar persistida — DocumentoExigido.Criar recusa Aplicabilidade.Nenhuma."),
+    };
 
     private static RegraRecursoFaseDto ProjectRegraRecursoFase(RegraRecursoFase regraRecurso) => new(
         regraRecurso.Id,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+
+using FluentValidation;
+
+using Commands.ProcessosSeletivos;
+
+/// <summary>
+/// Validação de <b>forma</b> do <see cref="DefinirDocumentosExigidosCommand"/> — o que
+/// não depende de leitura externa. As invariantes de negócio (coerência de
+/// aplicabilidade, pertencimento da fase ao processo) são do domínio e do handler
+/// (ADR-0102).
+/// </summary>
+public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidator<DefinirDocumentosExigidosCommand>
+{
+    private static readonly string[] AplicabilidadesValidas = ["GERAL", "CONDICIONAL"];
+
+    private static readonly string[] ConsequenciasValidas =
+    [
+        "ELIMINA",
+        "RECLASSIFICA_AC",
+        "REMOVE_VANTAGEM",
+        "PENDENCIA_REENVIO",
+    ];
+
+    public DefinirDocumentosExigidosCommandValidator()
+    {
+        RuleFor(x => x.ProcessoSeletivoId)
+            .NotEmpty()
+            .WithMessage("ProcessoSeletivoId é obrigatório.");
+
+        RuleFor(x => x.Itens)
+            .NotNull()
+            .WithMessage("A lista de documentos exigidos não pode ser nula.");
+
+        RuleForEach(x => x.Itens)
+            .NotNull()
+            .WithMessage("Item de documento exigido não pode ser nulo.");
+
+        RuleForEach(x => x.Itens).ChildRules(item =>
+        {
+            item.RuleFor(i => i.ExigidoNaFaseId)
+                .NotEmpty()
+                .WithMessage("A fase em que o documento é exigido é obrigatória.");
+
+            item.RuleFor(i => i.TipoDocumentoId)
+                .NotEmpty()
+                .WithMessage("O id do tipo de documento é obrigatório.");
+
+            item.RuleFor(i => i.Aplicabilidade)
+                .Must(valor => AplicabilidadesValidas.Contains(valor, StringComparer.Ordinal))
+                .WithMessage($"Aplicabilidade deve ser um de: {string.Join(", ", AplicabilidadesValidas)}.");
+
+            item.RuleFor(i => i.ConsequenciaIndeferimento)
+                .Must(valor => ConsequenciasValidas.Contains(valor, StringComparer.Ordinal))
+                .When(i => !string.IsNullOrWhiteSpace(i.ConsequenciaIndeferimento))
+                .WithMessage($"Consequência de indeferimento deve ser um de: {string.Join(", ", ConsequenciasValidas)}.");
+        });
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
@@ -1,0 +1,145 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using Enums;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Exigência documental de um <see cref="ProcessoSeletivo"/> (Story #554, PR-a): declara
+/// qual documento é exigido, em que fase e com que aplicabilidade. <c>EntityBase</c>
+/// puro (sem soft-delete) — o regime append-only/forense pertence a
+/// <see cref="VersaoConfiguracao"/>, não à configuração viva; a coleção do agregado é
+/// substituível por inteiro (<see cref="ProcessoSeletivo.DefinirDocumentosExigidos"/>),
+/// mesmo padrão de <see cref="FaseCronograma"/>/<see cref="ModalidadeSelecionada"/>.
+/// </summary>
+/// <remarks>
+/// O gatilho DNF (<c>CondicaoGatilho</c>), a base legal 1:N
+/// (<c>DocumentoExigidoBaseLegal</c>) e a idade máxima de emissão/formato/tamanho são
+/// entregues por tasks-irmãs (PR-b/PR-c/PR-d) — não modelados aqui.
+/// </remarks>
+public sealed class DocumentoExigido : EntityBase
+{
+    private static readonly string[] ConsequenciasValidas =
+    [
+        "ELIMINA",
+        "RECLASSIFICA_AC",
+        "REMOVE_VANTAGEM",
+        "PENDENCIA_REENVIO",
+    ];
+
+    public Guid ProcessoSeletivoId { get; private set; }
+
+    /// <summary>Fase do cronograma do mesmo processo em que o documento é exigido — NOT NULL (Story #554).</summary>
+    public Guid ExigidoNaFaseId { get; private set; }
+
+    /// <summary>Id do <c>TipoDocumento</c> vivo no momento da configuração — snapshot-copy (ADR-0061), sem FK cross-módulo.</summary>
+    public Guid TipoDocumentoOrigemId { get; private set; }
+
+    /// <summary>Código classificatório congelado — snapshot-copy.</summary>
+    public string TipoDocumentoCodigo { get; private set; } = string.Empty;
+
+    /// <summary>Rótulo legível congelado — snapshot-copy.</summary>
+    public string TipoDocumentoNome { get; private set; } = string.Empty;
+
+    /// <summary>Categoria classificatória congelada — snapshot-copy.</summary>
+    public string TipoDocumentoCategoria { get; private set; } = string.Empty;
+
+    public Aplicabilidade Aplicabilidade { get; private set; }
+
+    public bool Obrigatorio { get; private set; }
+
+    /// <summary>
+    /// ∈ {ELIMINA, RECLASSIFICA_AC, REMOVE_VANTAGEM, PENDENCIA_REENVIO} quando presente
+    /// (ADR-0074). Campo de transporte — a coerência com <c>ModalidadeSelecionada.AcaoQuandoIndeferido</c>
+    /// é validada na PR-e (CA-05), sem duplicar campo.
+    /// </summary>
+    public string? ConsequenciaIndeferimento { get; private set; }
+
+    /// <summary>Escopo processo+fase — documentos do mesmo grupo são satisfeitos por uma única apresentação (semântica plena na PR-e).</summary>
+    public Guid? GrupoSatisfacaoId { get; private set; }
+
+    private DocumentoExigido() { }
+
+    public static Result<DocumentoExigido> Criar(
+        Guid exigidoNaFaseId,
+        Guid tipoDocumentoOrigemId,
+        string tipoDocumentoCodigo,
+        string tipoDocumentoNome,
+        string tipoDocumentoCategoria,
+        Aplicabilidade aplicabilidade,
+        bool obrigatorio,
+        string? consequenciaIndeferimento,
+        Guid? grupoSatisfacaoId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tipoDocumentoCodigo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tipoDocumentoNome);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tipoDocumentoCategoria);
+
+        if (exigidoNaFaseId == Guid.Empty)
+        {
+            throw new ArgumentException("A fase em que o documento é exigido é obrigatória.", nameof(exigidoNaFaseId));
+        }
+
+        if (tipoDocumentoOrigemId == Guid.Empty)
+        {
+            throw new ArgumentException("O id de origem do tipo de documento é obrigatório.", nameof(tipoDocumentoOrigemId));
+        }
+
+        if (aplicabilidade == Aplicabilidade.Nenhuma)
+        {
+            return Result<DocumentoExigido>.Failure(new DomainError(
+                "DocumentoExigido.AplicabilidadeObrigatoria",
+                "A aplicabilidade da exigência documental é obrigatória e deve ser GERAL ou CONDICIONAL."));
+        }
+
+        if (!string.IsNullOrWhiteSpace(consequenciaIndeferimento)
+            && !ConsequenciasValidas.Contains(consequenciaIndeferimento, StringComparer.Ordinal))
+        {
+            return Result<DocumentoExigido>.Failure(new DomainError(
+                "DocumentoExigido.ConsequenciaIndeferimentoInvalida",
+                $"Consequência de indeferimento '{consequenciaIndeferimento}' inválida — esperado um de: {string.Join(", ", ConsequenciasValidas)}."));
+        }
+
+        return Result<DocumentoExigido>.Success(new DocumentoExigido
+        {
+            ExigidoNaFaseId = exigidoNaFaseId,
+            TipoDocumentoOrigemId = tipoDocumentoOrigemId,
+            TipoDocumentoCodigo = tipoDocumentoCodigo.Trim(),
+            TipoDocumentoNome = tipoDocumentoNome.Trim(),
+            TipoDocumentoCategoria = tipoDocumentoCategoria.Trim(),
+            Aplicabilidade = aplicabilidade,
+            Obrigatorio = obrigatorio,
+            ConsequenciaIndeferimento = consequenciaIndeferimento,
+            GrupoSatisfacaoId = grupoSatisfacaoId,
+        });
+    }
+
+    internal void VincularProcesso(Guid processoSeletivoId) =>
+        ProcessoSeletivoId = processoSeletivoId;
+
+    /// <summary>
+    /// Determina se a exigência "conta" para efeito de resultado — obrigatória ou com
+    /// qualquer consequência de indeferimento declarada. Usado pela trava CA-01
+    /// (<c>CONDICIONAL</c> vazia que determina resultado bloqueia publicação) e,
+    /// futuramente, pelo gate de base legal (PR-c/#549).
+    /// </summary>
+    public bool DeterminaResultado() => Obrigatorio || ConsequenciaIndeferimento is not null;
+
+    /// <summary>
+    /// Coerência entre <see cref="Aplicabilidade"/> e a existência de condição de gatilho
+    /// viva (CA-01, ADR-0071): <c>GERAL</c> nunca convive com condição viva. O parâmetro é
+    /// sintético nesta task — <c>CondicaoGatilho</c> (PR-b) ainda não existe; a PR-b conecta
+    /// este guard à coleção real ao permitir cadastrar condições.
+    /// </summary>
+    public DomainError? GarantirCoerenciaAplicabilidade(bool possuiCondicaoViva)
+    {
+        if (Aplicabilidade == Aplicabilidade.Geral && possuiCondicaoViva)
+        {
+            return new DomainError(
+                "DocumentoExigido.GeralComCondicao",
+                $"A exigência '{TipoDocumentoCodigo}' é GERAL e não pode conviver com condição de gatilho viva.");
+        }
+
+        return null;
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
@@ -92,12 +92,19 @@ public sealed class DocumentoExigido : EntityBase
                 "A aplicabilidade da exigência documental é obrigatória e deve ser GERAL ou CONDICIONAL."));
         }
 
-        if (!string.IsNullOrWhiteSpace(consequenciaIndeferimento)
-            && !ConsequenciasValidas.Contains(consequenciaIndeferimento, StringComparer.Ordinal))
+        // Normaliza espaços-em-branco para null ANTES de validar — sem isso, " " escapa
+        // da checagem de domínio (não é "presente" o bastante para reprovar, nem null o
+        // bastante para DeterminaResultado() ignorar) e é persistido cru.
+        string? consequenciaNormalizada = string.IsNullOrWhiteSpace(consequenciaIndeferimento)
+            ? null
+            : consequenciaIndeferimento.Trim();
+
+        if (consequenciaNormalizada is not null
+            && !ConsequenciasValidas.Contains(consequenciaNormalizada, StringComparer.Ordinal))
         {
             return Result<DocumentoExigido>.Failure(new DomainError(
                 "DocumentoExigido.ConsequenciaIndeferimentoInvalida",
-                $"Consequência de indeferimento '{consequenciaIndeferimento}' inválida — esperado um de: {string.Join(", ", ConsequenciasValidas)}."));
+                $"Consequência de indeferimento '{consequenciaNormalizada}' inválida — esperado um de: {string.Join(", ", ConsequenciasValidas)}."));
         }
 
         return Result<DocumentoExigido>.Success(new DocumentoExigido
@@ -109,7 +116,7 @@ public sealed class DocumentoExigido : EntityBase
             TipoDocumentoCategoria = tipoDocumentoCategoria.Trim(),
             Aplicabilidade = aplicabilidade,
             Obrigatorio = obrigatorio,
-            ConsequenciaIndeferimento = consequenciaIndeferimento,
+            ConsequenciaIndeferimento = consequenciaNormalizada,
             GrupoSatisfacaoId = grupoSatisfacaoId,
         });
     }
@@ -119,17 +126,18 @@ public sealed class DocumentoExigido : EntityBase
 
     /// <summary>
     /// Determina se a exigência "conta" para efeito de resultado — obrigatória ou com
-    /// qualquer consequência de indeferimento declarada. Usado pela trava CA-01
-    /// (<c>CONDICIONAL</c> vazia que determina resultado bloqueia publicação) e,
-    /// futuramente, pelo gate de base legal (PR-c/#549).
+    /// qualquer consequência de indeferimento declarada. Usado pela trava CA-01 (Story
+    /// #554, issue #547: <c>CONDICIONAL</c> vazia que determina resultado bloqueia
+    /// publicação) e, futuramente, pelo gate de base legal (PR-c/#549).
     /// </summary>
     public bool DeterminaResultado() => Obrigatorio || ConsequenciaIndeferimento is not null;
 
     /// <summary>
     /// Coerência entre <see cref="Aplicabilidade"/> e a existência de condição de gatilho
-    /// viva (CA-01, ADR-0071): <c>GERAL</c> nunca convive com condição viva. O parâmetro é
-    /// sintético nesta task — <c>CondicaoGatilho</c> (PR-b) ainda não existe; a PR-b conecta
-    /// este guard à coleção real ao permitir cadastrar condições.
+    /// viva (CA-01, Story #554/issue #547, ADR-0071): <c>GERAL</c> nunca convive com
+    /// condição viva. O parâmetro é sintético nesta task — <c>CondicaoGatilho</c> (PR-b)
+    /// ainda não existe; a PR-b conecta este guard à coleção real ao permitir cadastrar
+    /// condições.
     /// </summary>
     public DomainError? GarantirCoerenciaAplicabilidade(bool possuiCondicaoViva)
     {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -53,6 +53,10 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     private readonly List<FaseCronograma> _cronogramaFases = [];
     public IReadOnlyCollection<FaseCronograma> CronogramaFases => _cronogramaFases.AsReadOnly();
 
+    /// <summary>Documentos exigidos do certame (0..*, Story #554/PR-a) — por fase e aplicabilidade.</summary>
+    private readonly List<DocumentoExigido> _documentosExigidos = [];
+    public IReadOnlyCollection<DocumentoExigido> DocumentosExigidos => _documentosExigidos.AsReadOnly();
+
     public OfertaAtendimentoEspecializado? OfertaAtendimento { get; private set; }
 
     private readonly List<ConfiguracaoDistribuicaoVagas> _distribuicaoVagas = [];
@@ -515,6 +519,49 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     }
 
     /// <summary>
+    /// Substitui integralmente a coleção de documentos exigidos do processo (Story #554,
+    /// PR-a): mesmo padrão dos demais <c>Definir*</c> — <see cref="MutacaoBloqueada"/>
+    /// primeiro, <see cref="Result"/> nunca exceção, substituição integral da coleção.
+    /// </summary>
+    /// <remarks>
+    /// Valida aqui o que só a raiz consegue provar: cada <see cref="DocumentoExigido.ExigidoNaFaseId"/>
+    /// referencia uma fase viva do cronograma do MESMO processo (§2 da issue #547). O
+    /// gatilho DNF (<c>CondicaoGatilho</c>, PR-b), a base legal (PR-c) e a idade/formato/
+    /// tamanho (PR-d) não são tocados aqui.
+    /// </remarks>
+    public Result DefinirDocumentosExigidos(
+        IReadOnlyList<DocumentoExigido> itens,
+        PrecondicaoIfMatch precondicao)
+    {
+        ArgumentNullException.ThrowIfNull(itens);
+
+        if (MutacaoBloqueada(precondicao) is { } bloqueio)
+        {
+            return Result.Failure(bloqueio);
+        }
+
+        foreach (DocumentoExigido item in itens)
+        {
+            if (!_cronogramaFases.Any(fase => fase.Id == item.ExigidoNaFaseId))
+            {
+                return Result.Failure(new DomainError(
+                    "DocumentoExigido.FaseNaoPertenceAoProcesso",
+                    $"A fase {item.ExigidoNaFaseId} não pertence ao cronograma deste processo."));
+            }
+        }
+
+        _documentosExigidos.Clear();
+        foreach (DocumentoExigido item in itens)
+        {
+            item.VincularProcesso(Id);
+            _documentosExigidos.Add(item);
+        }
+
+        Rascunho?.IncrementarRevisao();
+        return Result.Success();
+    }
+
+    /// <summary>
     /// Divisor da média da nota final: soma dos pesos das etapas que compõem
     /// a nota (caráter classificatória ou ambas, com peso declarado). Fórmula:
     /// <c>NOTA FINAL = Soma(Etapa × peso) / fator_de_divisão + bônus_regional</c>.
@@ -656,6 +703,54 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     }
 
     /// <summary>
+    /// Pendências dos documentos exigidos (Story #554). Chamado por
+    /// <see cref="Publicar"/> e por <see cref="SucederVersao"/> (Retificar/
+    /// FecharRetificacao), sempre <b>depois</b> de <see cref="PendenciaDoCronograma"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>CA-01</b> — uma exigência <c>CONDICIONAL</c> sem nenhuma condição de gatilho
+    /// viva que <see cref="DocumentoExigido.DeterminaResultado"/> é "exigência morta":
+    /// nunca seria cobrada de ninguém. Nesta PR (a), <c>CondicaoGatilho</c> ainda não
+    /// existe (PR-b) — toda exigência <c>CONDICIONAL</c> está, por definição, sem
+    /// condição viva, então esta trava já é integralmente exercitável.
+    /// </para>
+    /// <para>
+    /// <b>B-01 — guarda fail-closed transitória</b> (PR-a..PR-d): enquanto o bloco
+    /// <c>documentosExigidos.exigencias</c> do envelope continuar stub, publicar/
+    /// retificar/fechar retificação com qualquer <see cref="DocumentoExigido"/>
+    /// configurado congelaria uma versão que finge não ter documentos exigidos.
+    /// Removida na PR-e, quando o bloco rico substitui o stub.
+    /// </para>
+    /// </remarks>
+    private DomainError? PendenciaDasExigenciasDocumentais()
+    {
+        foreach (DocumentoExigido exigencia in _documentosExigidos)
+        {
+            // Parâmetro sintético: CondicaoGatilho (PR-b) ainda não existe, então nenhuma
+            // exigência CONDICIONAL tem condição viva nesta PR.
+            const bool possuiCondicaoViva = false;
+            if (exigencia.Aplicabilidade == Aplicabilidade.Condicional
+                && !possuiCondicaoViva
+                && exigencia.DeterminaResultado())
+            {
+                return new DomainError(
+                    "DocumentoExigido.CondicionalVaziaDeterminaResultado",
+                    $"A exigência '{exigencia.TipoDocumentoCodigo}' é CONDICIONAL, determina resultado, mas não tem nenhuma condição de gatilho viva — nunca seria cobrada de ninguém.");
+            }
+        }
+
+        if (_documentosExigidos.Count > 0)
+        {
+            return new DomainError(
+                "ProcessoSeletivo.ExigenciasDocumentaisNaoMaterializadas",
+                "Existem documentos exigidos configurados, mas o bloco de exigências do envelope canônico ainda não foi materializado (Story #554) — publicação bloqueada até a conclusão da Story.");
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Publica o processo (RN08, Story #759 T4): valida a transição e a
     /// conformidade estrutural, abre a cadeia de <see cref="VersaoConfiguracao"/>
     /// a partir dos bytes canônicos já produzidos pelo
@@ -715,6 +810,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         if (PendenciaDoCronograma() is { } pendenciaCronograma)
         {
             return Result<VersaoConfiguracao>.Failure(pendenciaCronograma);
+        }
+
+        if (PendenciaDasExigenciasDocumentais() is { } pendenciaExigencias)
+        {
+            return Result<VersaoConfiguracao>.Failure(pendenciaExigencias);
         }
 
         // UMA leitura do relógio para o ato e para a versão que ele cria. O instante
@@ -1030,6 +1130,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         if (PendenciaDoCronograma() is { } pendenciaCronograma)
         {
             return Result<VersaoConfiguracao>.Failure(pendenciaCronograma);
+        }
+
+        if (PendenciaDasExigenciasDocumentais() is { } pendenciaExigencias)
+        {
+            return Result<VersaoConfiguracao>.Failure(pendenciaExigencias);
         }
 
         // Uma única leitura do relógio para o ato e para a versão que ele cria — ver a nota

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -709,18 +709,18 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>CA-01</b> — uma exigência <c>CONDICIONAL</c> sem nenhuma condição de gatilho
-    /// viva que <see cref="DocumentoExigido.DeterminaResultado"/> é "exigência morta":
-    /// nunca seria cobrada de ninguém. Nesta PR (a), <c>CondicaoGatilho</c> ainda não
-    /// existe (PR-b) — toda exigência <c>CONDICIONAL</c> está, por definição, sem
-    /// condição viva, então esta trava já é integralmente exercitável.
+    /// <b>CA-01</b> (Story #554, issue #547) — uma exigência <c>CONDICIONAL</c> sem
+    /// nenhuma condição de gatilho viva que <see cref="DocumentoExigido.DeterminaResultado"/>
+    /// é "exigência morta": nunca seria cobrada de ninguém. Nesta PR (a), <c>CondicaoGatilho</c>
+    /// ainda não existe (PR-b, issue #892) — toda exigência <c>CONDICIONAL</c> está, por
+    /// definição, sem condição viva, então esta trava já é integralmente exercitável.
     /// </para>
     /// <para>
-    /// <b>B-01 — guarda fail-closed transitória</b> (PR-a..PR-d): enquanto o bloco
-    /// <c>documentosExigidos.exigencias</c> do envelope continuar stub, publicar/
-    /// retificar/fechar retificação com qualquer <see cref="DocumentoExigido"/>
+    /// <b>B-01 — guarda fail-closed transitória</b> (Story #554, issue #547; PR-a..PR-d):
+    /// enquanto o bloco <c>documentosExigidos.exigencias</c> do envelope continuar stub,
+    /// publicar/retificar/fechar retificação com qualquer <see cref="DocumentoExigido"/>
     /// configurado congelaria uma versão que finge não ter documentos exigidos.
-    /// Removida na PR-e, quando o bloco rico substitui o stub.
+    /// Removida na PR-e (issue #548), quando o bloco rico substitui o stub.
     /// </para>
     /// </remarks>
     private DomainError? PendenciaDasExigenciasDocumentais()

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -443,6 +443,22 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 "O processo deve ter ao menos uma fase no cronograma."));
         }
 
+        // Story #554/issue #547 (CA-04, guard parcial — a reconciliação por chave estável
+        // é da PR-d/#893): cada chamada aqui recria TODAS as fases com Id novo (mesmo
+        // padrão de DefinirDocumentosExigidos/DefinirEtapas — nenhum FaseCronogramaInput
+        // aceita Id, diferente de EtapaProcessoInput.Id opcional). Isso significa que a
+        // FK Restrict de documentos_exigidos.exigido_na_fase_id (DocumentoExigidoConfiguration)
+        // sempre estouraria DbUpdateException não tratada ao reconfigurar o cronograma
+        // enquanto existir exigência viva — a guarda troca o 500 por um 422 acionável. A
+        // PR-d reconcilia fases por chave estável (Ordem/FaseCanonicaOrigemId, mesmo
+        // padrão de AplicarGrafo) para permitir editar o cronograma sem apagar exigências.
+        if (_documentosExigidos.Count > 0)
+        {
+            return Result.Failure(new DomainError(
+                "FaseCronograma.ReferenciadaPorExigenciaViva",
+                "Existem documentos exigidos configurados referenciando o cronograma atual — remova-os antes de redefinir as fases, ou aguarde a reconciliação por chave estável (Story #554, PR-d)."));
+        }
+
         List<int> ordens = [.. fases.Select(f => f.Ordem)];
         if (ordens.Distinct().Count() != ordens.Count)
         {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -1569,6 +1569,18 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             fase.VincularProcesso(Id);
             _cronogramaFases.Add(fase);
         }
+
+        // Documentos exigidos (Story #554, issue #547) — o bloco `documentosExigidos.
+        // exigencias` do envelope ainda é stub (PR-a..PR-d): `GrafoConfiguracao` não tem
+        // como reconstruir esta coleção a partir de bytes que não a contêm. A guarda
+        // B-01 garante o invariante que sustenta o Clear() sozinho: TODA versão já
+        // congelada (Publicar/Retificar/FecharRetificacao) tem, necessariamente, zero
+        // `DocumentoExigido` — nenhuma passou pela guarda com exigência configurada.
+        // Descartar uma sessão que editou a coleção precisa repor esse mesmo estado
+        // vazio, não preservar o que a sessão editou. Quando a PR-e materializar o
+        // bloco, `GrafoConfiguracao` ganha `DocumentosExigidos` e este trecho passa a
+        // reconciliar por `exigencia_id`, como as demais coleções acima.
+        _documentosExigidos.Clear();
     }
 
     /// <summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/Aplicabilidade.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/Aplicabilidade.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Declara explicitamente a quem uma <see cref="Entities.DocumentoExigido"/> se aplica
+/// (ADR-0071) — nunca inferida da presença/ausência de condições de gatilho.
+/// </summary>
+public enum Aplicabilidade
+{
+    Nenhuma = 0,
+
+    /// <summary>Exigida de todos os candidatos — o gatilho não é avaliado.</summary>
+    Geral = 1,
+
+    /// <summary>Exigida apenas de quem satisfaz o gatilho — zero condições vivas significa, sem ambiguidade, exigida de ninguém.</summary>
+    Condicional = 2,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoConfiguration.cs
@@ -16,7 +16,10 @@ using Domain.Entities;
 public sealed class DocumentoExigidoConfiguration : IEntityTypeConfiguration<DocumentoExigido>
 {
     private const int TipoDocumentoCodigoMaxLength = 60;
-    private const int TipoDocumentoNomeMaxLength = 160;
+    // Espelha TipoDocumentoConfiguration.NomeMaxLength (Configuracao.Infrastructure) — um
+    // snapshot-copy mais curto que a origem trunca silenciosamente (ou falha no Postgres)
+    // um cadastro legítimo de até 200 caracteres.
+    private const int TipoDocumentoNomeMaxLength = 200;
     private const int TipoDocumentoCategoriaMaxLength = 60;
     private const int ConsequenciaIndeferimentoMaxLength = 30;
 
@@ -38,6 +41,18 @@ public sealed class DocumentoExigidoConfiguration : IEntityTypeConfiguration<Doc
         builder.Property(d => d.Aplicabilidade).HasConversion<int>().IsRequired();
         builder.Property(d => d.Obrigatorio).IsRequired();
         builder.Property(d => d.ConsequenciaIndeferimento).HasMaxLength(ConsequenciaIndeferimentoMaxLength);
+
+        // FK real para fases_cronograma — a checagem "fase viva do mesmo processo"
+        // (ProcessoSeletivo.DefinirDocumentosExigidos) é check-then-act não-atômico; a
+        // constraint do banco é a defesa realmente atômica (mesmo padrão de
+        // FaseCronogramaConfiguration). Restrict, não Cascade: reconfigurar o cronograma
+        // (DefinirCronogramaFases) não pode apagar silenciosamente uma fase ainda
+        // referenciada por uma exigência viva — falha explícita até a PR-d formalizar o
+        // guard de domínio equivalente (CA-04).
+        builder.HasOne<FaseCronograma>()
+            .WithMany()
+            .HasForeignKey(d => d.ExigidoNaFaseId)
+            .OnDelete(DeleteBehavior.Restrict);
 
         builder.HasIndex(d => d.ExigidoNaFaseId)
             .HasDatabaseName("ix_documentos_exigidos_exigido_na_fase_id");

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoConfiguration.cs
@@ -1,0 +1,45 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Domain.Entities;
+
+/// <summary>
+/// Configuração EF Core de <see cref="DocumentoExigido"/> (Story #554, PR-a) — entidade
+/// filha do agregado <see cref="ProcessoSeletivo"/>, <c>EntityBase</c> puro (sem
+/// soft-delete). Sem CHECK de banco para <c>aplicabilidade</c>/<c>consequencia_indeferimento</c>
+/// — o módulo Seleção só usa esse mecanismo em <c>versoes_configuracao</c> (guard rails
+/// forenses da ADR-0102); a integridade é C# (enum tipado + guard de domínio +
+/// FluentValidation), mesmo padrão de <see cref="FaseCronograma"/>/<see cref="ModalidadeSelecionada"/>.
+/// </summary>
+public sealed class DocumentoExigidoConfiguration : IEntityTypeConfiguration<DocumentoExigido>
+{
+    private const int TipoDocumentoCodigoMaxLength = 60;
+    private const int TipoDocumentoNomeMaxLength = 160;
+    private const int TipoDocumentoCategoriaMaxLength = 60;
+    private const int ConsequenciaIndeferimentoMaxLength = 30;
+
+    public void Configure(EntityTypeBuilder<DocumentoExigido> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("documentos_exigidos");
+        builder.HasKey(d => d.Id);
+        // Chave Guid v7 do domínio (EntityBase) — ValueGeneratedNever, mesmo padrão de
+        // FaseCronograma/ModalidadeSelecionada.
+        builder.Property(d => d.Id).ValueGeneratedNever();
+
+        builder.Property(d => d.ExigidoNaFaseId).IsRequired();
+        builder.Property(d => d.TipoDocumentoOrigemId).IsRequired();
+        builder.Property(d => d.TipoDocumentoCodigo).HasMaxLength(TipoDocumentoCodigoMaxLength).IsRequired();
+        builder.Property(d => d.TipoDocumentoNome).HasMaxLength(TipoDocumentoNomeMaxLength).IsRequired();
+        builder.Property(d => d.TipoDocumentoCategoria).HasMaxLength(TipoDocumentoCategoriaMaxLength).IsRequired();
+        builder.Property(d => d.Aplicabilidade).HasConversion<int>().IsRequired();
+        builder.Property(d => d.Obrigatorio).IsRequired();
+        builder.Property(d => d.ConsequenciaIndeferimento).HasMaxLength(ConsequenciaIndeferimentoMaxLength);
+
+        builder.HasIndex(d => d.ExigidoNaFaseId)
+            .HasDatabaseName("ix_documentos_exigidos_exigido_na_fase_id");
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
@@ -64,6 +64,12 @@ public sealed class ProcessoSeletivoConfiguration : IEntityTypeConfiguration<Pro
             .HasForeignKey(f => f.ProcessoSeletivoId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        // Documentos exigidos (Story #554, PR-a) — 0..*, mesmo padrão de Etapas/CronogramaFases.
+        builder.HasMany(p => p.DocumentosExigidos)
+            .WithOne()
+            .HasForeignKey(d => d.ProcessoSeletivoId)
+            .OnDelete(DeleteBehavior.Cascade);
+
         // A sessão editorial (ADR-0110 D3) — 1:1, como as demais filhas singulares. Ela é
         // efêmera (apagada no fechamento e no descarte) e não é evidência forense: a
         // auditoria com peso jurídico vive na VersaoConfiguracao, que é append-only.
@@ -82,6 +88,9 @@ public sealed class ProcessoSeletivoConfiguration : IEntityTypeConfiguration<Pro
             .UsePropertyAccessMode(PropertyAccessMode.Field);
 
         builder.Navigation(p => p.CronogramaFases)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+        builder.Navigation(p => p.DocumentosExigidos)
             .UsePropertyAccessMode(PropertyAccessMode.Field);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717020758_AddDocumentosExigidos.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717020758_AddDocumentosExigidos.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717020758_AddDocumentosExigidos")]
+    partial class AddDocumentosExigidos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717020758_AddDocumentosExigidos.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717020758_AddDocumentosExigidos.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentosExigidos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "documentos_exigidos",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    processo_seletivo_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    exigido_na_fase_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tipo_documento_origem_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    tipo_documento_codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    tipo_documento_nome = table.Column<string>(type: "character varying(160)", maxLength: 160, nullable: false),
+                    tipo_documento_categoria = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    aplicabilidade = table.Column<int>(type: "integer", nullable: false),
+                    obrigatorio = table.Column<bool>(type: "boolean", nullable: false),
+                    consequencia_indeferimento = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: true),
+                    grupo_satisfacao_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_documentos_exigidos", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_documentos_exigidos_processos_seletivos_processo_seletivo_id",
+                        column: x => x.processo_seletivo_id,
+                        principalSchema: "selecao",
+                        principalTable: "processos_seletivos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_documentos_exigidos_exigido_na_fase_id",
+                schema: "selecao",
+                table: "documentos_exigidos",
+                column: "exigido_na_fase_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_documentos_exigidos_processo_seletivo_id",
+                schema: "selecao",
+                table: "documentos_exigidos",
+                column: "processo_seletivo_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "documentos_exigidos",
+                schema: "selecao");
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717023019_AddDocumentosExigidos.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717023019_AddDocumentosExigidos.Designer.cs
@@ -12,7 +12,7 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    [Migration("20260717020758_AddDocumentosExigidos")]
+    [Migration("20260717023019_AddDocumentosExigidos")]
     partial class AddDocumentosExigidos
     {
         /// <inheritdoc />
@@ -422,8 +422,8 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 
                     b.Property<string>("TipoDocumentoNome")
                         .IsRequired()
-                        .HasMaxLength(160)
-                        .HasColumnType("character varying(160)")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)")
                         .HasColumnName("tipo_documento_nome");
 
                     b.Property<Guid>("TipoDocumentoOrigemId")
@@ -1959,6 +1959,13 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 
             modelBuilder.Entity("Unifesspa.UniPlus.Selecao.Domain.Entities.DocumentoExigido", b =>
                 {
+                    b.HasOne("Unifesspa.UniPlus.Selecao.Domain.Entities.FaseCronograma", null)
+                        .WithMany()
+                        .HasForeignKey("ExigidoNaFaseId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired()
+                        .HasConstraintName("fk_documentos_exigidos_fases_cronograma_exigido_na_fase_id");
+
                     b.HasOne("Unifesspa.UniPlus.Selecao.Domain.Entities.ProcessoSeletivo", null)
                         .WithMany("DocumentosExigidos")
                         .HasForeignKey("ProcessoSeletivoId")

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717023019_AddDocumentosExigidos.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717023019_AddDocumentosExigidos.cs
@@ -21,7 +21,7 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
                     exigido_na_fase_id = table.Column<Guid>(type: "uuid", nullable: false),
                     tipo_documento_origem_id = table.Column<Guid>(type: "uuid", nullable: false),
                     tipo_documento_codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
-                    tipo_documento_nome = table.Column<string>(type: "character varying(160)", maxLength: 160, nullable: false),
+                    tipo_documento_nome = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
                     tipo_documento_categoria = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
                     aplicabilidade = table.Column<int>(type: "integer", nullable: false),
                     obrigatorio = table.Column<bool>(type: "boolean", nullable: false),
@@ -33,6 +33,13 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
                 constraints: table =>
                 {
                     table.PrimaryKey("pk_documentos_exigidos", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_documentos_exigidos_fases_cronograma_exigido_na_fase_id",
+                        column: x => x.exigido_na_fase_id,
+                        principalSchema: "selecao",
+                        principalTable: "fases_cronograma",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
                     table.ForeignKey(
                         name: "fk_documentos_exigidos_processos_seletivos_processo_seletivo_id",
                         column: x => x.processo_seletivo_id,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/SelecaoDbContextModelSnapshot.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/SelecaoDbContextModelSnapshot.cs
@@ -419,8 +419,8 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 
                     b.Property<string>("TipoDocumentoNome")
                         .IsRequired()
-                        .HasMaxLength(160)
-                        .HasColumnType("character varying(160)")
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)")
                         .HasColumnName("tipo_documento_nome");
 
                     b.Property<Guid>("TipoDocumentoOrigemId")
@@ -1956,6 +1956,13 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 
             modelBuilder.Entity("Unifesspa.UniPlus.Selecao.Domain.Entities.DocumentoExigido", b =>
                 {
+                    b.HasOne("Unifesspa.UniPlus.Selecao.Domain.Entities.FaseCronograma", null)
+                        .WithMany()
+                        .HasForeignKey("ExigidoNaFaseId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired()
+                        .HasConstraintName("fk_documentos_exigidos_fases_cronograma_exigido_na_fase_id");
+
                     b.HasOne("Unifesspa.UniPlus.Selecao.Domain.Entities.ProcessoSeletivo", null)
                         .WithMany("DocumentosExigidos")
                         .HasForeignKey("ProcessoSeletivoId")

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
@@ -101,6 +101,12 @@ public sealed class ProcessoSeletivoRepository : IProcessoSeletivoRepository
             // regra de recurso 1:1) somadas às já existentes.
             .Include(p => p.CronogramaFases).ThenInclude(f => f.RegraRecurso)
             .Include(p => p.CronogramaFases).ThenInclude(f => f.BancasRequeridas)
+            // Documentos exigidos (Story #554, issue #547, PR-a) — sem o Include, a
+            // coleção tracked nasce vazia em todo carregamento novo do agregado:
+            // DefinirDocumentosExigidos faria Clear() num backing list já vazio (linhas
+            // antigas sobrevivem no banco, PUT acumula) e a guarda B-01/CA-01 sempre
+            // veria zero exigências.
+            .Include(p => p.DocumentosExigidos)
             // AsSplitQuery obrigatório a partir desta entrega: o produto cartesiano de
             // TODAS as coleções (etapas × condições × recursos × tipos × vagas ×
             // modalidades × desempate × eliminação × fases × bancas) num único JOIN

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirDocumentosExigidosCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirDocumentosExigidosCommandHandlerTests.cs
@@ -1,0 +1,112 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura do <see cref="DefinirDocumentosExigidosCommandHandler"/> (Story #554,
+/// PR-a): a resolução do snapshot-copy de <c>TipoDocumento</c> (Configuração,
+/// ADR-0056) e os erros nomeados que uma resolução malsucedida produz.
+/// </summary>
+public sealed class DefinirDocumentosExigidosCommandHandlerTests
+{
+    private sealed record Mocks(
+        IProcessoSeletivoRepository Repository,
+        ITipoDocumentoReader TipoDocumentoReader,
+        ISelecaoUnitOfWork UnitOfWork);
+
+    private static Mocks NovosMocks(ProcessoSeletivo? processo, Guid processoId)
+    {
+        IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
+        repository.ObterParaMutacaoAsync(processoId, Arg.Any<CancellationToken>()).Returns(processo);
+
+        return new Mocks(
+            repository,
+            Substitute.For<ITipoDocumentoReader>(),
+            Substitute.For<ISelecaoUnitOfWork>());
+    }
+
+    private static Task<Result<MutacaoAceita>> HandleAsync(Mocks mocks, DefinirDocumentosExigidosCommand command) =>
+        DefinirDocumentosExigidosCommandHandler.Handle(
+            command,
+            mocks.Repository,
+            mocks.TipoDocumentoReader,
+            mocks.UnitOfWork,
+            CancellationToken.None);
+
+    private static TipoDocumentoView TipoDocumentoResultado(Guid id) =>
+        new(id, "IDENTIDADE", "Documento de identidade", "PESSOAL");
+
+    private static FaseCronograma FaseQualquer() => FaseCronograma.Criar(
+        1, Guid.CreateVersion7(), "INSCRICAO", "CEPS", OrigemDataFase.Delegada,
+        agrupaEtapas: false, permiteComplementacao: false, produzResultado: false,
+        resultadoDefinitivo: false, coletaInscricao: false, inicio: null, fim: null,
+        atoProduzidoCodigo: null, atoProduzidoEfeitoIrreversivel: false,
+        bancasRequeridas: [], regraRecurso: null).Value!;
+
+    [Fact(DisplayName = "Handle com processo inexistente retorna ProcessoSeletivo.NaoEncontrado")]
+    public async Task Handle_ProcessoInexistente_RetornaNaoEncontrado()
+    {
+        Guid processoId = Guid.CreateVersion7();
+        Mocks mocks = NovosMocks(processo: null, processoId);
+        DefinirDocumentosExigidosCommand command = new(processoId, [], PrecondicaoIfMatch.Ausente);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.NaoEncontrado");
+    }
+
+    [Fact(DisplayName = "Handle com tipo de documento não encontrado retorna DocumentoExigido.TipoDocumentoNaoEncontrado")]
+    public async Task Handle_TipoDocumentoNaoEncontrado_RetornaErroNomeado()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Handler", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        Guid tipoDocumentoId = Guid.CreateVersion7();
+        mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
+            .Returns((TipoDocumentoView?)null);
+
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null);
+        DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.TipoDocumentoNaoEncontrado");
+    }
+
+    [Fact(DisplayName = "Handle com item válido define os documentos exigidos e persiste")]
+    public async Task Handle_ItemValido_DefineDocumentosExigidosEPersiste()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Handler", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        Guid tipoDocumentoId = Guid.CreateVersion7();
+        mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
+            .Returns(TipoDocumentoResultado(tipoDocumentoId));
+
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null);
+        DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.DocumentosExigidos.Should().ContainSingle(d => d.TipoDocumentoCodigo == "IDENTIDADE");
+        await mocks.UnitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests.cs
@@ -1,0 +1,54 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Queries;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Application.Queries.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura de <see cref="ObterProcessoSeletivoQueryHandler.Project"/> para
+/// <c>DocumentosExigidos</c> (Story #554, PR-a): a projeção precisa emitir o mesmo
+/// token de wire que <c>DefinirDocumentosExigidosCommandValidator</c> aceita — round-trip
+/// GET→PUT direto, sem transformação do cliente.
+/// </summary>
+public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
+{
+    private static FaseCronograma FaseQualquer() => FaseCronograma.Criar(
+        1, Guid.CreateVersion7(), "INSCRICAO", "CEPS", OrigemDataFase.Delegada,
+        agrupaEtapas: false, permiteComplementacao: false, produzResultado: false,
+        resultadoDefinitivo: false, coletaInscricao: false, inicio: null, fim: null,
+        atoProduzidoCodigo: null, atoProduzidoEfeitoIrreversivel: false,
+        bancasRequeridas: [], regraRecurso: null).Value!;
+
+    [Theory(DisplayName = "Projeta aplicabilidade no mesmo token de wire aceito pelo validator (GERAL/CONDICIONAL)")]
+    [InlineData(Aplicabilidade.Geral, "GERAL")]
+    [InlineData(Aplicabilidade.Condicional, "CONDICIONAL")]
+    public async Task Handle_Aplicabilidade_EmiteTokenDeWire(Aplicabilidade aplicabilidade, string tokenEsperado)
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Query", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Guid tipoDocumentoOrigemId = Guid.CreateVersion7();
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            fase.Id, tipoDocumentoOrigemId, "IDENTIDADE", "Documento de identidade", "PESSOAL",
+            aplicabilidade, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null).Value!;
+        processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
+        repository.ObterComConfiguracaoAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+
+        ProcessoSeletivoDto? dto = await ObterProcessoSeletivoQueryHandler.Handle(
+            new ObterProcessoSeletivoQuery(processo.Id), repository, CancellationToken.None);
+
+        DocumentoExigidoDto projetado = dto!.DocumentosExigidos.Should().ContainSingle().Which;
+        projetado.Aplicabilidade.Should().Be(tokenEsperado);
+        projetado.TipoDocumentoOrigemId.Should().Be(tipoDocumentoOrigemId);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
@@ -98,4 +98,13 @@ public sealed class DocumentoExigidoTests
     [Fact(DisplayName = "DeterminaResultado: facultativa e sem consequência não determina resultado (contraprova)")]
     public void DeterminaResultado_FacultativaSemConsequencia_RetornaFalse() =>
         Exigencia().Value!.DeterminaResultado().Should().BeFalse();
+
+    [Fact(DisplayName = "Consequência composta só de espaços é normalizada para null (não determina resultado)")]
+    public void Criar_ConsequenciaSoDeEspacos_NormalizaParaNull()
+    {
+        DocumentoExigido exigencia = Exigencia(consequenciaIndeferimento: "   ").Value!;
+
+        exigencia.ConsequenciaIndeferimento.Should().BeNull();
+        exigencia.DeterminaResultado().Should().BeFalse();
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
@@ -1,0 +1,101 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Cobertura de <see cref="DocumentoExigido"/> (Story #554, PR-a): fábrica, guard de
+/// coerência de aplicabilidade (CA-01) e <see cref="DocumentoExigido.DeterminaResultado"/>.
+/// </summary>
+public sealed class DocumentoExigidoTests
+{
+    private static Result<DocumentoExigido> Exigencia(
+        Aplicabilidade aplicabilidade = Aplicabilidade.Geral,
+        bool obrigatorio = false,
+        string? consequenciaIndeferimento = null) =>
+        DocumentoExigido.Criar(
+            exigidoNaFaseId: Guid.CreateVersion7(),
+            tipoDocumentoOrigemId: Guid.CreateVersion7(),
+            tipoDocumentoCodigo: "LAUDO_MEDICO",
+            tipoDocumentoNome: "Laudo médico",
+            tipoDocumentoCategoria: "SAUDE",
+            aplicabilidade: aplicabilidade,
+            obrigatorio: obrigatorio,
+            consequenciaIndeferimento: consequenciaIndeferimento,
+            grupoSatisfacaoId: null);
+
+    [Fact(DisplayName = "CA-01: aplicabilidade Nenhuma é recusada")]
+    public void Criar_AplicabilidadeNenhuma_Recusa()
+    {
+        Result<DocumentoExigido> resultado = Exigencia(Aplicabilidade.Nenhuma);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.AplicabilidadeObrigatoria");
+    }
+
+    [Fact(DisplayName = "GERAL/CONDICIONAL válidos são aceitos")]
+    public void Criar_ValoresValidos_Aceita()
+    {
+        Exigencia(Aplicabilidade.Geral).IsSuccess.Should().BeTrue();
+        Exigencia(Aplicabilidade.Condicional).IsSuccess.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Consequência de indeferimento fora do domínio é recusada")]
+    public void Criar_ConsequenciaInvalida_Recusa()
+    {
+        Result<DocumentoExigido> resultado = Exigencia(consequenciaIndeferimento: "REPROVA_TUDO");
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.ConsequenciaIndeferimentoInvalida");
+    }
+
+    [Theory(DisplayName = "Consequências válidas são aceitas")]
+    [InlineData("ELIMINA")]
+    [InlineData("RECLASSIFICA_AC")]
+    [InlineData("REMOVE_VANTAGEM")]
+    [InlineData("PENDENCIA_REENVIO")]
+    public void Criar_ConsequenciaValida_Aceita(string consequencia) =>
+        Exigencia(consequenciaIndeferimento: consequencia).IsSuccess.Should().BeTrue();
+
+    [Fact(DisplayName = "CA-01: GERAL com condição viva é recusada")]
+    public void GarantirCoerenciaAplicabilidade_GeralComCondicaoViva_Recusa()
+    {
+        DocumentoExigido exigencia = Exigencia(Aplicabilidade.Geral).Value!;
+
+        DomainError? erro = exigencia.GarantirCoerenciaAplicabilidade(possuiCondicaoViva: true);
+
+        erro.Should().NotBeNull();
+        erro!.Code.Should().Be("DocumentoExigido.GeralComCondicao");
+    }
+
+    [Fact(DisplayName = "CA-01: GERAL sem condição viva é coerente (contraprova)")]
+    public void GarantirCoerenciaAplicabilidade_GeralSemCondicaoViva_Aceita()
+    {
+        DocumentoExigido exigencia = Exigencia(Aplicabilidade.Geral).Value!;
+
+        exigencia.GarantirCoerenciaAplicabilidade(possuiCondicaoViva: false).Should().BeNull();
+    }
+
+    [Fact(DisplayName = "CA-01: CONDICIONAL com condição viva é coerente (contraprova)")]
+    public void GarantirCoerenciaAplicabilidade_CondicionalComCondicaoViva_Aceita()
+    {
+        DocumentoExigido exigencia = Exigencia(Aplicabilidade.Condicional).Value!;
+
+        exigencia.GarantirCoerenciaAplicabilidade(possuiCondicaoViva: true).Should().BeNull();
+    }
+
+    [Fact(DisplayName = "DeterminaResultado: obrigatória determina resultado")]
+    public void DeterminaResultado_Obrigatoria_RetornaTrue() =>
+        Exigencia(obrigatorio: true).Value!.DeterminaResultado().Should().BeTrue();
+
+    [Fact(DisplayName = "DeterminaResultado: com consequência determina resultado")]
+    public void DeterminaResultado_ComConsequencia_RetornaTrue() =>
+        Exigencia(consequenciaIndeferimento: "ELIMINA").Value!.DeterminaResultado().Should().BeTrue();
+
+    [Fact(DisplayName = "DeterminaResultado: facultativa e sem consequência não determina resultado (contraprova)")]
+    public void DeterminaResultado_FacultativaSemConsequencia_RetornaFalse() =>
+        Exigencia().Value!.DeterminaResultado().Should().BeFalse();
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -1,0 +1,105 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura de <see cref="ProcessoSeletivo.DefinirDocumentosExigidos"/> (Story #554,
+/// PR-a): substituição integral e pertencimento da fase ao cronograma do MESMO
+/// processo (§2 da issue #547).
+/// </summary>
+public sealed class ProcessoSeletivoDocumentosExigidosTests
+{
+    private static ProcessoSeletivo NovoProcesso() =>
+        ProcessoSeletivo.Criar("PS Documentos Exigidos", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+
+    private static FaseCronograma Fase(int ordem, string codigo) => FaseCronograma.Criar(
+        ordem,
+        Guid.CreateVersion7(),
+        codigo,
+        "CEPS",
+        OrigemDataFase.Delegada,
+        agrupaEtapas: false,
+        permiteComplementacao: false,
+        produzResultado: false,
+        resultadoDefinitivo: false,
+        coletaInscricao: false,
+        inicio: null,
+        fim: null,
+        atoProduzidoCodigo: null,
+        atoProduzidoEfeitoIrreversivel: false,
+        bancasRequeridas: [],
+        regraRecurso: null).Value!;
+
+    private static DocumentoExigido Exigencia(Guid exigidoNaFaseId, Aplicabilidade aplicabilidade = Aplicabilidade.Geral) =>
+        DocumentoExigido.Criar(
+            exigidoNaFaseId,
+            tipoDocumentoOrigemId: Guid.CreateVersion7(),
+            tipoDocumentoCodigo: "IDENTIDADE",
+            tipoDocumentoNome: "Documento de identidade",
+            tipoDocumentoCategoria: "PESSOAL",
+            aplicabilidade,
+            obrigatorio: false,
+            consequenciaIndeferimento: null,
+            grupoSatisfacaoId: null).Value!;
+
+    [Fact(DisplayName = "Fase que não pertence ao cronograma do processo é recusada")]
+    public void DefinirDocumentosExigidos_FaseDeOutroProcesso_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        DocumentoExigido exigencia = Exigencia(Guid.CreateVersion7());
+
+        Result resultado = processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.FaseNaoPertenceAoProcesso");
+    }
+
+    [Fact(DisplayName = "Fase viva do cronograma do próprio processo é aceita")]
+    public void DefinirDocumentosExigidos_FaseDoProprioProcesso_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = Fase(1, "INSCRICAO");
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        DocumentoExigido exigencia = Exigencia(fase.Id);
+        Result resultado = processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.DocumentosExigidos.Should().ContainSingle(d => d.Id == exigencia.Id);
+        exigencia.ProcessoSeletivoId.Should().Be(processo.Id);
+    }
+
+    [Fact(DisplayName = "Coleção vazia é um estado válido — nenhuma exigência configurada")]
+    public void DefinirDocumentosExigidos_ListaVazia_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        Result resultado = processo.DefinirDocumentosExigidos([], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.DocumentosExigidos.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "PUT idempotente: reenviar o mesmo payload substitui a coleção por inteiro, sem duplicar")]
+    public void DefinirDocumentosExigidos_ReenviarMesmoPayload_NaoDuplica()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = Fase(1, "INSCRICAO");
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        DocumentoExigido primeiraChamada = Exigencia(fase.Id);
+        processo.DefinirDocumentosExigidos([primeiraChamada], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        DocumentoExigido segundaChamada = Exigencia(fase.Id);
+        Result resultado = processo.DefinirDocumentosExigidos([segundaChamada], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.DocumentosExigidos.Should().HaveCount(1);
+        processo.DocumentosExigidos.Should().ContainSingle(d => d.Id == segundaChamada.Id);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -102,4 +102,31 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         processo.DocumentosExigidos.Should().HaveCount(1);
         processo.DocumentosExigidos.Should().ContainSingle(d => d.Id == segundaChamada.Id);
     }
+
+    [Fact(DisplayName = "CA-04 (guard parcial): redefinir o cronograma com exigência viva configurada é recusado")]
+    public void DefinirCronogramaFases_ComExigenciaViva_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = Fase(1, "INSCRICAO");
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirDocumentosExigidos([Exigencia(fase.Id)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Result resultado = processo.DefinirCronogramaFases([Fase(1, "INSCRICAO")], [], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue(
+            "toda chamada aqui recria as fases com Id novo — sem a guarda, a FK Restrict de " +
+            "documentos_exigidos.exigido_na_fase_id estouraria DbUpdateException não tratada");
+        resultado.Error!.Code.Should().Be("FaseCronograma.ReferenciadaPorExigenciaViva");
+    }
+
+    [Fact(DisplayName = "Redefinir o cronograma sem exigência viva é aceito (contraprova)")]
+    public void DefinirCronogramaFases_SemExigenciaViva_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        processo.DefinirCronogramaFases([Fase(1, "INSCRICAO")], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Result resultado = processo.DefinirCronogramaFases([Fase(1, "INSCRICAO")], [], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoPublicarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoPublicarTests.cs
@@ -217,6 +217,7 @@ public sealed class ProcessoSeletivoPublicarTests
     [InlineData("criteriosDesempate")]
     [InlineData("classificacao")]
     [InlineData("cronogramaFases")]
+    [InlineData("documentosExigidos")]
     public void DefinirX_ProcessoPublicado_RecusaMutacao(string dimensao)
     {
         ProcessoSeletivo processo = NovoProcessoConforme();
@@ -236,11 +237,77 @@ public sealed class ProcessoSeletivoPublicarTests
                 ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!,
                 1, []).Value!, PrecondicaoIfMatch.Ausente),
             "cronogramaFases" => processo.DefinirCronogramaFases([FaseConforme()], [], PrecondicaoIfMatch.Ausente),
+            "documentosExigidos" => processo.DefinirDocumentosExigidos([], PrecondicaoIfMatch.Ausente),
             _ => throw new InvalidOperationException("Dimensão desconhecida."),
         };
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada");
+    }
+
+    // ── Story #554 (PR-a) — guarda fail-closed (B-01) e CA-01 ──
+
+    private static DocumentoExigido ExigenciaCondicionalVaziaObrigatoria(Guid exigidoNaFaseId) => DocumentoExigido.Criar(
+        exigidoNaFaseId,
+        tipoDocumentoOrigemId: Guid.CreateVersion7(),
+        tipoDocumentoCodigo: "CERTIDAO_RESERVISTA",
+        tipoDocumentoNome: "Certidão de reservista",
+        tipoDocumentoCategoria: "MILITAR",
+        aplicabilidade: Aplicabilidade.Condicional,
+        obrigatorio: true,
+        consequenciaIndeferimento: null,
+        grupoSatisfacaoId: null).Value!;
+
+    private static DocumentoExigido ExigenciaGeral(Guid exigidoNaFaseId) => DocumentoExigido.Criar(
+        exigidoNaFaseId,
+        tipoDocumentoOrigemId: Guid.CreateVersion7(),
+        tipoDocumentoCodigo: "IDENTIDADE",
+        tipoDocumentoNome: "Documento de identidade",
+        tipoDocumentoCategoria: "PESSOAL",
+        aplicabilidade: Aplicabilidade.Geral,
+        obrigatorio: true,
+        consequenciaIndeferimento: null,
+        grupoSatisfacaoId: null).Value!;
+
+    [Fact(DisplayName = "CA-01: publicar com exigência CONDICIONAL vazia obrigatória é bloqueado")]
+    public void Publicar_CondicionalVaziaObrigatoria_Bloqueia()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        processo.DefinirDocumentosExigidos([ExigenciaCondicionalVaziaObrigatoria(faseId)], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        Result<VersaoConfiguracao> resultado = processo.Publicar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.CondicionalVaziaDeterminaResultado");
+    }
+
+    [Fact(DisplayName = "B-01: publicar com exigência GERAL configurada é bloqueado enquanto o bloco do envelope é stub")]
+    public void Publicar_ExigenciaGeralConfigurada_BloqueiaPorGuardaFailClosed()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        processo.DefinirDocumentosExigidos([ExigenciaGeral(faseId)], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        Result<VersaoConfiguracao> resultado = processo.Publicar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.ExigenciasDocumentaisNaoMaterializadas");
+    }
+
+    [Fact(DisplayName = "Publicar sem nenhum documento exigido configurado não é afetado pela guarda (contraprova)")]
+    public void Publicar_SemDocumentosExigidos_NaoBloqueiaPorExigencias()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+
+        Result<VersaoConfiguracao> resultado = processo.Publicar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
 
     /// <summary>

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRestaurarConfiguracaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRestaurarConfiguracaoTests.cs
@@ -219,6 +219,43 @@ public sealed class ProcessoSeletivoRestaurarConfiguracaoTests
                 "que o etapaRef do desempate e da eliminação referenciam");
     }
 
+    [Fact(DisplayName = "Story #554/issue #547 — restauração limpa DocumentosExigidos configurados durante a sessão")]
+    public void Restauracao_LimpaDocumentosExigidosDaSessao()
+    {
+        // O bloco documentosExigidos.exigencias do envelope ainda é stub (PR-a..PR-d) —
+        // GrafoConfiguracao não tem como reconstruir a coleção a partir de bytes que não
+        // a contêm. A guarda B-01 garante que TODA versão já congelada tem zero
+        // DocumentoExigido; a restauração precisa repor esse mesmo estado vazio, mesmo
+        // que a sessão editorial tenha configurado exigências.
+        ProcessoSeletivo processo = ProcessoPublicado(TipoProcesso.SiSU);
+        VersaoConfiguracao versao = VersaoDo(processo);
+        Guid faseId = processo.CronogramaFases.Single().Id;
+
+        processo.AbrirRetificacao("Incluir exigência documental", versao, "testes", DateTimeOffset.UnixEpoch)
+            .IsSuccess.Should().BeTrue();
+
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseId,
+            tipoDocumentoOrigemId: Guid.CreateVersion7(),
+            tipoDocumentoCodigo: "IDENTIDADE",
+            tipoDocumentoNome: "Documento de identidade",
+            tipoDocumentoCategoria: "PESSOAL",
+            aplicabilidade: Aplicabilidade.Geral,
+            obrigatorio: true,
+            consequenciaIndeferimento: null,
+            grupoSatisfacaoId: null).Value!;
+        processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+        processo.DocumentosExigidos.Should().ContainSingle();
+
+        Result resultado = processo.RestaurarConfiguracaoCongelada(versao, Grafo());
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.DocumentosExigidos.Should().BeEmpty(
+            "a versão congelada nunca poderia ter sido publicada com exigência configurada (B-01) — restaurar " +
+            "precisa repor esse estado vazio, não preservar o que a sessão descartada editou");
+    }
+
     // ── Fábrica de cenários ──
 
     private static ReferenciaRegra Regra(string codigo, char semente) =>

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
@@ -349,6 +349,43 @@ public sealed class ProcessoSeletivoRetificarTests
         segunda.Value!.NumeroVersao.Should().Be(3);
     }
 
+    // ── Story #554 (PR-a) — guarda fail-closed (B-01) via FecharRetificacao ──
+
+    [Fact(DisplayName = "B-01: fechar retificação com exigência configurada durante a sessão é bloqueado")]
+    public void FecharRetificacao_ExigenciaConfiguradaNaSessao_BloqueiaPorGuardaFailClosed()
+    {
+        RelogioManual clock = Relogio();
+        ProcessoSeletivo processo = NovoProcessoPublicado(clock, out VersaoConfiguracao versaoAbertura);
+        clock.Avancar(TimeSpan.FromMinutes(1));
+
+        Result<RascunhoRetificacao> abertura = processo.AbrirRetificacao(
+            "Incluir exigência documental", versaoAbertura, "user-sub-123", clock.GetUtcNow());
+        abertura.IsSuccess.Should().BeTrue(abertura.Error?.Message);
+
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseId,
+            tipoDocumentoOrigemId: Guid.CreateVersion7(),
+            tipoDocumentoCodigo: "IDENTIDADE",
+            tipoDocumentoNome: "Documento de identidade",
+            tipoDocumentoCategoria: "PESSOAL",
+            aplicabilidade: Aplicabilidade.Geral,
+            obrigatorio: true,
+            consequenciaIndeferimento: null,
+            grupoSatisfacaoId: null).Value!;
+        processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue("mutar a configuração viva durante a sessão é permitido — só o FECHAMENTO é bloqueado pela B-01");
+
+        clock.Avancar(TimeSpan.FromMinutes(1));
+        Result<VersaoConfiguracao> resultado = processo.FecharRetificacao(
+            NovosDados(), versaoAbertura, BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123",
+            PrecondicaoIfMatch.Curinga, clock);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.ExigenciasDocumentaisNaoMaterializadas");
+        processo.Rascunho.Should().NotBeNull("o fechamento recusado não encerra a sessão — a configuração continua editável");
+    }
+
     /// <summary>
     /// Relógio manual determinístico — evita depender de
     /// <c>Microsoft.Extensions.TimeProvider.Testing</c> na camada de teste do


### PR DESCRIPTION
## Resumo

- Núcleo `DocumentoExigido` (`EntityBase` puro, filha de `ProcessoSeletivo`, mesmo
  padrão de `FaseCronograma`/`ModalidadeSelecionada`): fase obrigatória do
  cronograma do próprio processo, snapshot-copy do tipo de documento (ADR-0061),
  aplicabilidade `GERAL`/`CONDICIONAL` (ADR-0071), obrigatoriedade, consequência
  de indeferimento e grupo de satisfação (campos de transporte).
- `PUT /api/selecao/processos-seletivos/{id}/documentos-exigidos` — idempotente,
  substituição integral da coleção.
- **CA-01:** exigência `CONDICIONAL` sem condição de gatilho viva que determina
  resultado (obrigatória ou com consequência) bloqueia a publicação. O gatilho
  DNF (`CondicaoGatilho`) é modelado na task seguinte (#892) — nesta PR toda
  `CONDICIONAL` nasce sem condição, então a trava já é integralmente testável.
- **Guarda fail-closed transitória (B-01):** enquanto o bloco
  `documentosExigidos.exigencias` do envelope canônico continuar stub,
  `Publicar`, `Retificar` **e** `FecharRetificacao` recusam qualquer processo
  com exigência configurada — contraprova nos 3 caminhos incluída nos testes.
  Será removida quando o bloco rico substituir o stub (#548).
- Opt-in de codegen Wolverine para `ITipoDocumentoReader` (ADR-0098).
- Migration `AddDocumentosExigidos`.

Parte da Story #554 (UNI-REQ-0016) — 1ª das 5 PRs sequenciais (a→b→c→d→e).

Closes #547

## Plano de teste

- [x] `dotnet build UniPlus.slnx` — 0 erros, 0 avisos
- [x] `dotnet test` (Selecao.Domain.UnitTests, Selecao.Application.UnitTests,
      Selecao.ArchTests) — todos verdes (367 + 138 + 49)
- [x] `dotnet ef migrations has-pending-model-changes` — sem pendência
- [x] Contraprova da guarda B-01 nos 3 caminhos (`Publicar`/`Retificar`/
      `FecharRetificacao`)
- [x] Contraprova CA-01 (CONDICIONAL vazia obrigatória bloqueia; facultativa sem
      consequência não é afetada pela trava de aplicabilidade)
- [x] `PUT` idempotente (reenviar o mesmo payload substitui sem duplicar)