### PR TITLE
feat(selecao): base legal 1:N por exigência com gate de publicação

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -3491,6 +3491,63 @@
           }
         }
       },
+      "BaseLegalDto": {
+        "required": [
+          "id",
+          "referencia",
+          "abrangencia",
+          "status",
+          "observacao"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "referencia": {
+            "type": "string"
+          },
+          "abrangencia": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "observacao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "BaseLegalInput": {
+        "required": [
+          "referencia",
+          "abrangencia",
+          "status",
+          "observacao"
+        ],
+        "type": "object",
+        "properties": {
+          "referencia": {
+            "type": "string"
+          },
+          "abrangencia": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "observacao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "CaraterEtapa": {
         "enum": [
           "nenhum",
@@ -4395,7 +4452,8 @@
           "obrigatorio",
           "consequenciaIndeferimento",
           "grupoSatisfacaoId",
-          "condicoes"
+          "condicoes",
+          "basesLegais"
         ],
         "type": "object",
         "properties": {
@@ -4443,6 +4501,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CondicaoGatilhoDto"
+            }
+          },
+          "basesLegais": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseLegalDto"
             }
           }
         }
@@ -4801,7 +4865,8 @@
           "obrigatorio",
           "consequenciaIndeferimento",
           "grupoSatisfacaoId",
-          "condicoes"
+          "condicoes",
+          "basesLegais"
         ],
         "type": "object",
         "properties": {
@@ -4836,6 +4901,12 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CondicaoGatilhoInput"
+            }
+          },
+          "basesLegais": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseLegalInput"
             }
           }
         }

--- a/openspec/changes/documentos-exigidos-gatilho-fase/tasks.md
+++ b/openspec/changes/documentos-exigidos-gatilho-fase/tasks.md
@@ -60,10 +60,10 @@ Fluxo obrigatório por PR (ver CLAUDE.md do repo + docs/guia-commits-e-integraca
 
 **Issue:** #549 (UNI-REQ-0059) · **Branch:** `feature/549-base-legal-exigencia` · **PR:** `Closes #549` + ref. #554
 
-- [ ] 4.1 Modelar `DocumentoExigidoBaseLegal` (EntityBase puro) 1:N, editada pelo PUT integral
-- [ ] 4.2 Gate de publicação: ≥1 base RESOLVIDO para quem determina resultado; INTERNA_EDITAL sozinha; só RESOLVIDO congela
-- [ ] 4.3 Migration EF Core + Configuration
-- [ ] 4.4 Testes: só-PENDENTE bloqueia; rebaixar/remover a única RESOLVIDO é apanhado na publicação
+- [x] 4.1 Modelar `DocumentoExigidoBaseLegal` (EntityBase puro) 1:N, editada pelo PUT integral
+- [x] 4.2 Gate de publicação: ≥1 base RESOLVIDO para quem determina resultado; INTERNA_EDITAL sozinha; só RESOLVIDO congela
+- [x] 4.3 Migration EF Core + Configuration
+- [x] 4.4 Testes: só-PENDENTE bloqueia; rebaixar/remover a única RESOLVIDO é apanhado na publicação
 - [ ] 4.5 Gates locais + revisão Codex; abrir PR `Closes #549`; `/review-pr` até zero pendências; merge sequencial
 
 ## 5. PR-d — Idade de emissão + formato + tamanho + guards de fase

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -339,11 +339,12 @@ public sealed class ProcessoSeletivoController : ControllerBase
     /// <summary>
     /// Substitui integralmente os documentos exigidos do processo (Story #554): fase,
     /// snapshot-copy do tipo de documento, aplicabilidade GERAL/CONDICIONAL,
-    /// obrigatoriedade, consequência de indeferimento, grupo de satisfação e o gatilho
-    /// DNF (dinâmico/multivalorado para MODALIDADE/CONDICAO_ATENDIMENTO, PR-b). A base
-    /// legal e a idade/formato/tamanho chegam em tasks-irmãs (PR-c/d). O <c>GET</c> vem
-    /// do endpoint agregado (<see cref="ObterPorId"/>) — não há rota aninhada própria de
-    /// leitura.
+    /// obrigatoriedade, consequência de indeferimento, grupo de satisfação, o gatilho
+    /// DNF (dinâmico/multivalorado para MODALIDADE/CONDICAO_ATENDIMENTO, PR-b) e a base
+    /// legal 1:N (PR-c) — validada apenas na FORMA aqui; o gate "≥1 RESOLVIDO por
+    /// exigência que determina resultado" é da publicação (ADR-0074). A idade/formato/
+    /// tamanho chega em task-irmã (PR-d). O <c>GET</c> vem do endpoint agregado
+    /// (<see cref="ObterPorId"/>) — não há rota aninhada própria de leitura.
     /// </summary>
     [HttpPut("{id:guid}/documentos-exigidos")]
     [RequiresIdempotencyKey]

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -313,6 +313,12 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("ProcessoSeletivo.ReferenciaTemporalFatosFaseInexistente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.referencia_temporal_fatos_fase_inexistente", "A fase âncora da referência temporal de fatos não pertence (mais) ao cronograma")),
         new("ProcessoSeletivo.ReferenciaTemporalFatosExtremoAusente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.referencia_temporal_fatos_extremo_ausente", "A fase âncora da referência temporal de fatos não tem o extremo (início/fim) definido")),
         new("ProcessoSeletivo.ReferenciaTemporalFatosFimInscricaoIndisponivel", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.referencia_temporal_fatos_fim_inscricao_indisponivel", "FIM_INSCRICAO exige uma fase que colete inscrição com Fim definido")),
+        // Base legal 1:N (Story #554, PR-c, issue #549, ADR-0074) — DocumentoExigidoBaseLegal
+        // e o gate de publicação (ValidadorBaseLegalExigencias) aflora pelo
+        // ProcessoSeletivo.ConformidadeInsuficiente já registrado acima, sem código novo.
+        new("DocumentoExigidoBaseLegal.ReferenciaObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido_base_legal.referencia_obrigatoria", "A referência da base legal é obrigatória")),
+        new("DocumentoExigidoBaseLegal.AbrangenciaObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido_base_legal.abrangencia_obrigatoria", "A abrangência da base legal é obrigatória")),
+        new("DocumentoExigidoBaseLegal.StatusObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido_base_legal.status_obrigatorio", "O status da base legal é obrigatório")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommand.cs
@@ -14,12 +14,24 @@ using Kernel.Results;
 public sealed record CondicaoGatilhoInput(int Clausula, string Fato, string Operador, string Valor);
 
 /// <summary>
+/// Entrada de uma base legal (Story #554, PR-c, issue #549, ADR-0074), usada por
+/// <see cref="ItemDocumentoExigidoInput"/>. <see cref="Abrangencia"/>/<see cref="Status"/>
+/// são tokens canônicos (<see cref="Domain.Enums.TipoAbrangenciaCodigo"/>/
+/// <see cref="Domain.Enums.StatusBaseLegalCodigo"/>). A validação de <b>gate</b> (≥1
+/// RESOLVIDO por exigência que determina resultado) é da publicação, não deste PUT —
+/// aqui só a forma de cada item é validada.
+/// </summary>
+public sealed record BaseLegalInput(string Referencia, string Abrangencia, string Status, string? Observacao);
+
+/// <summary>
 /// Entrada de uma exigência documental, usada por
 /// <see cref="DefinirDocumentosExigidosCommand"/>. O handler resolve
 /// <see cref="TipoDocumentoId"/> contra o módulo Configuração e congela os
 /// atributos vigentes por valor (snapshot-copy, ADR-0061) — o cliente não os
 /// declara diretamente. <see cref="Condicoes"/> vazia é coerente com GERAL e com
-/// CONDICIONAL "exigida de ninguém" (CA-01).
+/// CONDICIONAL "exigida de ninguém" (CA-01). <see cref="BasesLegais"/> vazia é um estado
+/// válido na escrita — só vira pendência na publicação, quando a exigência determina
+/// resultado (PR-c, CA-02).
 /// </summary>
 public sealed record ItemDocumentoExigidoInput(
     Guid ExigidoNaFaseId,
@@ -28,14 +40,15 @@ public sealed record ItemDocumentoExigidoInput(
     bool Obrigatorio,
     string? ConsequenciaIndeferimento,
     Guid? GrupoSatisfacaoId,
-    IReadOnlyList<CondicaoGatilhoInput> Condicoes);
+    IReadOnlyList<CondicaoGatilhoInput> Condicoes,
+    IReadOnlyList<BaseLegalInput> BasesLegais);
 
 /// <summary>
 /// Substitui integralmente a coleção de documentos exigidos do processo (Story #554 —
 /// núcleo da PR-a: fase, snapshot-copy do tipo de documento, aplicabilidade GERAL/
 /// CONDICIONAL, obrigatoriedade, consequência de indeferimento e grupo de satisfação;
-/// gatilho DNF dinâmico/multivalorado da PR-b). A base legal (PR-c) e a idade/formato/
-/// tamanho (PR-d) chegam em tasks-irmãs.
+/// gatilho DNF dinâmico/multivalorado da PR-b; base legal 1:N da PR-c). A idade/formato/
+/// tamanho (PR-d) chega em task-irmã.
 /// </summary>
 public sealed record DefinirDocumentosExigidosCommand(
     Guid ProcessoSeletivoId,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommandHandler.cs
@@ -88,6 +88,12 @@ public static class DefinirDocumentosExigidosCommandHandler
                 return Result<MutacaoAceita>.Failure(condicoesResult.Error!);
             }
 
+            Result<IReadOnlyList<DocumentoExigidoBaseLegal>> basesLegaisResult = ResolverBasesLegais(input.BasesLegais);
+            if (basesLegaisResult.IsFailure)
+            {
+                return Result<MutacaoAceita>.Failure(basesLegaisResult.Error!);
+            }
+
             Result<DocumentoExigido> itemResult = DocumentoExigido.Criar(
                 input.ExigidoNaFaseId,
                 tipoDocumento.Id,
@@ -98,7 +104,8 @@ public static class DefinirDocumentosExigidosCommandHandler
                 input.Obrigatorio,
                 input.ConsequenciaIndeferimento,
                 input.GrupoSatisfacaoId,
-                condicoesResult.Value!);
+                condicoesResult.Value!,
+                basesLegaisResult.Value!);
             if (itemResult.IsFailure)
             {
                 return Result<MutacaoAceita>.Failure(itemResult.Error!);
@@ -177,6 +184,33 @@ public static class DefinirDocumentosExigidosCommandHandler
         }
 
         return Result<IReadOnlyList<CondicaoGatilho>>.Success(condicoes);
+    }
+
+    /// <summary>
+    /// Resolve as bases legais de um item (Story #554, PR-c, issue #549) — só a forma de
+    /// cada base é validada aqui (referência não vazia, abrangência/status no domínio
+    /// fechado); o gate "≥1 RESOLVIDO por exigência que determina resultado" é da
+    /// publicação (<c>Domain.Services.ValidadorBaseLegalExigencias</c>), nunca da escrita.
+    /// </summary>
+    private static Result<IReadOnlyList<DocumentoExigidoBaseLegal>> ResolverBasesLegais(IReadOnlyList<BaseLegalInput> inputs)
+    {
+        List<DocumentoExigidoBaseLegal> basesLegais = [];
+        foreach (BaseLegalInput input in inputs)
+        {
+            TipoAbrangencia abrangencia = TipoAbrangenciaCodigo.FromCodigo(input.Abrangencia);
+            StatusBaseLegal status = StatusBaseLegalCodigo.FromCodigo(input.Status);
+
+            Result<DocumentoExigidoBaseLegal> baseLegalResult = DocumentoExigidoBaseLegal.Criar(
+                input.Referencia, abrangencia, status, input.Observacao);
+            if (baseLegalResult.IsFailure)
+            {
+                return Result<IReadOnlyList<DocumentoExigidoBaseLegal>>.Failure(baseLegalResult.Error!);
+            }
+
+            basesLegais.Add(baseLegalResult.Value!);
+        }
+
+        return Result<IReadOnlyList<DocumentoExigidoBaseLegal>>.Success(basesLegais);
     }
 
     /// <summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoExigidoDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoExigidoDto.cs
@@ -16,7 +16,8 @@ public sealed record DocumentoExigidoDto(
     bool Obrigatorio,
     string? ConsequenciaIndeferimento,
     Guid? GrupoSatisfacaoId,
-    IReadOnlyList<CondicaoGatilhoDto> Condicoes);
+    IReadOnlyList<CondicaoGatilhoDto> Condicoes,
+    IReadOnlyList<BaseLegalDto> BasesLegais);
 
 /// <summary>
 /// DTO de leitura de <see cref="Domain.Entities.CondicaoGatilho"/> (Story #554, PR-b,
@@ -26,3 +27,12 @@ public sealed record DocumentoExigidoDto(
 /// PUT (<c>DefinirDocumentosExigidosCommandHandler.InterpretarValor</c> o reparseia como JSON).
 /// </summary>
 public sealed record CondicaoGatilhoDto(Guid Id, int Clausula, string Fato, string Operador, string Valor);
+
+/// <summary>
+/// DTO de leitura de <see cref="Domain.Entities.DocumentoExigidoBaseLegal"/> (Story #554,
+/// PR-c, issue #549). Mesmo formato flat de <c>BaseLegalInput</c> (comando de escrita) —
+/// round-trip GET→PUT direto, incluindo bases <c>PENDENTE</c> (a projeção "somente
+/// RESOLVIDO" é interna ao domínio — <c>DocumentoExigido.BasesLegaisResolvidas</c> — e da
+/// materialização do envelope na PR-e, não deste DTO de edição).
+/// </summary>
+public sealed record BaseLegalDto(Guid Id, string Referencia, string Abrangencia, string Status, string? Observacao);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
@@ -194,7 +194,8 @@ public static class ObterProcessoSeletivoQueryHandler
         documento.Obrigatorio,
         documento.ConsequenciaIndeferimento,
         documento.GrupoSatisfacaoId,
-        [.. documento.Condicoes.OrderBy(c => c.Clausula).ThenBy(c => c.Id).Select(ProjectCondicaoGatilho)]);
+        [.. documento.Condicoes.OrderBy(c => c.Clausula).ThenBy(c => c.Id).Select(ProjectCondicaoGatilho)],
+        [.. documento.BasesLegais.OrderBy(b => b.Id).Select(ProjectBaseLegal)]);
 
     // Valor como texto JSON canônico (GetRawText) — o mesmo PUT que aceita este DTO de
     // volta (DefinirDocumentosExigidosCommandHandler.InterpretarValor) reparseia texto
@@ -205,6 +206,13 @@ public static class ObterProcessoSeletivoQueryHandler
         condicao.Fato,
         condicao.Operador.ToCodigo(),
         condicao.Valor.GetRawText());
+
+    private static BaseLegalDto ProjectBaseLegal(DocumentoExigidoBaseLegal baseLegal) => new(
+        baseLegal.Id,
+        baseLegal.Referencia,
+        baseLegal.Abrangencia.ToCodigo(),
+        baseLegal.Status.ToCodigo(),
+        baseLegal.Observacao);
 
     // Emite o mesmo token de wire aceito por DefinirDocumentosExigidosCommandValidator
     // ("GERAL"/"CONDICIONAL") — Aplicabilidade.ToString() produziria "Geral"/"Condicional"

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
@@ -94,6 +94,10 @@ public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidato
                 .NotNull()
                 .WithMessage("A lista de bases legais não pode ser nula.");
 
+            item.RuleForEach(i => i.BasesLegais)
+                .NotNull()
+                .WithMessage("Item de base legal não pode ser nulo.");
+
             item.RuleForEach(i => i.BasesLegais).ChildRules(baseLegal =>
             {
                 baseLegal.RuleFor(b => b.Referencia)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
@@ -28,6 +28,12 @@ public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidato
 
     private static readonly string[] StatusBaseLegalValidos = ["PENDENTE", "RESOLVIDO"];
 
+    // Espelham DocumentoExigidoBaseLegalConfiguration (HasMaxLength) — sem este teto aqui,
+    // um PUT com referência/observação longa demais passa pela validação de forma e só
+    // falha no SaveChanges (DbUpdateException/500), em vez de 400 acionável.
+    private const int ReferenciaBaseLegalMaxLength = 500;
+    private const int ObservacaoBaseLegalMaxLength = 1000;
+
     public DefinirDocumentosExigidosCommandValidator()
     {
         RuleFor(x => x.ProcessoSeletivoId)
@@ -92,7 +98,9 @@ public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidato
             {
                 baseLegal.RuleFor(b => b.Referencia)
                     .NotEmpty()
-                    .WithMessage("A referência da base legal é obrigatória.");
+                    .WithMessage("A referência da base legal é obrigatória.")
+                    .MaximumLength(ReferenciaBaseLegalMaxLength)
+                    .WithMessage($"A referência da base legal deve ter no máximo {ReferenciaBaseLegalMaxLength} caracteres.");
 
                 baseLegal.RuleFor(b => b.Abrangencia)
                     .Must(valor => AbrangenciasValidas.Contains(valor, StringComparer.Ordinal))
@@ -101,6 +109,11 @@ public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidato
                 baseLegal.RuleFor(b => b.Status)
                     .Must(valor => StatusBaseLegalValidos.Contains(valor, StringComparer.Ordinal))
                     .WithMessage($"Status da base legal deve ser um de: {string.Join(", ", StatusBaseLegalValidos)}.");
+
+                baseLegal.RuleFor(b => b.Observacao)
+                    .MaximumLength(ObservacaoBaseLegalMaxLength)
+                    .When(b => b.Observacao is not null)
+                    .WithMessage($"A observação da base legal deve ter no máximo {ObservacaoBaseLegalMaxLength} caracteres.");
             });
         });
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
@@ -24,6 +24,10 @@ public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidato
 
     private static readonly string[] OperadoresValidos = ["IGUAL", "EM", "MAIOR_IGUAL", "MENOR_IGUAL"];
 
+    private static readonly string[] AbrangenciasValidas = ["FEDERAL", "ESTADUAL", "MUNICIPAL", "INTERNA_NORMA", "INTERNA_EDITAL"];
+
+    private static readonly string[] StatusBaseLegalValidos = ["PENDENTE", "RESOLVIDO"];
+
     public DefinirDocumentosExigidosCommandValidator()
     {
         RuleFor(x => x.ProcessoSeletivoId)
@@ -78,6 +82,25 @@ public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidato
                 condicao.RuleFor(c => c.Valor)
                     .NotEmpty()
                     .WithMessage("O valor da condição é obrigatório.");
+            });
+
+            item.RuleFor(i => i.BasesLegais)
+                .NotNull()
+                .WithMessage("A lista de bases legais não pode ser nula.");
+
+            item.RuleForEach(i => i.BasesLegais).ChildRules(baseLegal =>
+            {
+                baseLegal.RuleFor(b => b.Referencia)
+                    .NotEmpty()
+                    .WithMessage("A referência da base legal é obrigatória.");
+
+                baseLegal.RuleFor(b => b.Abrangencia)
+                    .Must(valor => AbrangenciasValidas.Contains(valor, StringComparer.Ordinal))
+                    .WithMessage($"Abrangência da base legal deve ser um de: {string.Join(", ", AbrangenciasValidas)}.");
+
+                baseLegal.RuleFor(b => b.Status)
+                    .Must(valor => StatusBaseLegalValidos.Contains(valor, StringComparer.Ordinal))
+                    .WithMessage($"Status da base legal deve ser um de: {string.Join(", ", StatusBaseLegalValidos)}.");
             });
         });
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
 
+using System.Linq;
+
 using Enums;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Results;
@@ -14,8 +16,8 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <see cref="FaseCronograma"/>/<see cref="ModalidadeSelecionada"/>.
 /// </summary>
 /// <remarks>
-/// A base legal 1:N (<c>DocumentoExigidoBaseLegal</c>) e a idade máxima de emissão/
-/// formato/tamanho são entregues por tasks-irmãs (PR-c/PR-d) — não modeladas aqui.
+/// A idade máxima de emissão/formato/tamanho é entregue por task-irmã (PR-d) — não
+/// modelada aqui. A base legal 1:N (<see cref="BasesLegais"/>) chegou na PR-c (issue #549).
 /// </remarks>
 public sealed class DocumentoExigido : EntityBase
 {
@@ -63,6 +65,11 @@ public sealed class DocumentoExigido : EntityBase
     /// <summary>Gatilho DNF (Story #554, PR-b) — vazia significa "sem gatilho": GERAL é sempre exigida, CONDICIONAL vazia é exigida de ninguém.</summary>
     public IReadOnlyCollection<CondicaoGatilho> Condicoes => _condicoes.AsReadOnly();
 
+    private readonly List<DocumentoExigidoBaseLegal> _basesLegais = [];
+
+    /// <summary>Base legal 1:N (Story #554, PR-c, ADR-0074) — embasamento rastreável e auditável da exigência; validada no gate de publicação, não na escrita.</summary>
+    public IReadOnlyCollection<DocumentoExigidoBaseLegal> BasesLegais => _basesLegais.AsReadOnly();
+
     private DocumentoExigido() { }
 
     public static Result<DocumentoExigido> Criar(
@@ -75,9 +82,11 @@ public sealed class DocumentoExigido : EntityBase
         bool obrigatorio,
         string? consequenciaIndeferimento,
         Guid? grupoSatisfacaoId,
-        IReadOnlyList<CondicaoGatilho> condicoes)
+        IReadOnlyList<CondicaoGatilho> condicoes,
+        IReadOnlyList<DocumentoExigidoBaseLegal> basesLegais)
     {
         ArgumentNullException.ThrowIfNull(condicoes);
+        ArgumentNullException.ThrowIfNull(basesLegais);
         ArgumentException.ThrowIfNullOrWhiteSpace(tipoDocumentoCodigo);
         ArgumentException.ThrowIfNullOrWhiteSpace(tipoDocumentoNome);
         ArgumentException.ThrowIfNullOrWhiteSpace(tipoDocumentoCategoria);
@@ -141,6 +150,12 @@ public sealed class DocumentoExigido : EntityBase
             documento._condicoes.Add(condicao);
         }
 
+        foreach (DocumentoExigidoBaseLegal baseLegal in basesLegais)
+        {
+            baseLegal.VincularDocumentoExigido(documento.Id);
+            documento._basesLegais.Add(baseLegal);
+        }
+
         return Result<DocumentoExigido>.Success(documento);
     }
 
@@ -154,6 +169,14 @@ public sealed class DocumentoExigido : EntityBase
     /// publicação) e, futuramente, pelo gate de base legal (PR-c/#549).
     /// </summary>
     public bool DeterminaResultado() => Obrigatorio || ConsequenciaIndeferimento is not null;
+
+    /// <summary>
+    /// Projeção "somente <see cref="StatusBaseLegal.Resolvido"/>" (Story #554, PR-c, CA-06)
+    /// — o que a PR-e (#548) materializa no bloco congelado; bases
+    /// <see cref="StatusBaseLegal.Pendente"/> são rascunho e nunca aparecem aqui.
+    /// </summary>
+    public IEnumerable<DocumentoExigidoBaseLegal> BasesLegaisResolvidas() =>
+        _basesLegais.Where(static b => b.Status == StatusBaseLegal.Resolvido);
 
     /// <summary>
     /// Coerência entre <see cref="Aplicabilidade"/> e a existência de condição de gatilho

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigidoBaseLegal.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigidoBaseLegal.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using Enums;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Base legal de um <see cref="DocumentoExigido"/> (Story #554, PR-c, issue #549,
+/// ADR-0074) — relação 1:N: uma exigência pode ter mais de uma fonte de embasamento ao
+/// mesmo tempo (ex.: lei federal + cláusula do próprio edital). <c>EntityBase</c> puro
+/// (sem soft-delete) — filha de <see cref="DocumentoExigido"/>, substituível por inteiro
+/// junto com o mesmo <c>PUT {id}/documentos-exigidos</c> da PR-a; não há
+/// <c>Resolver()</c>/<c>Rebaixar()</c> próprios — "rebaixar" ou "remover" uma base é
+/// reenviar o payload da exigência sem aquele item, ou com <see cref="Status"/> alterado.
+/// </summary>
+public sealed class DocumentoExigidoBaseLegal : EntityBase
+{
+    public Guid DocumentoExigidoId { get; private set; }
+
+    /// <summary>Referência textual institucional (ex.: "Lei 12.711/2012, art. 3º") — não é PII.</summary>
+    public string Referencia { get; private set; } = string.Empty;
+
+    public TipoAbrangencia Abrangencia { get; private set; }
+
+    public StatusBaseLegal Status { get; private set; }
+
+    public string? Observacao { get; private set; }
+
+    private DocumentoExigidoBaseLegal() { }
+
+    public static Result<DocumentoExigidoBaseLegal> Criar(
+        string referencia, TipoAbrangencia abrangencia, StatusBaseLegal status, string? observacao)
+    {
+        if (string.IsNullOrWhiteSpace(referencia))
+        {
+            return Result<DocumentoExigidoBaseLegal>.Failure(new DomainError(
+                "DocumentoExigidoBaseLegal.ReferenciaObrigatoria",
+                "A referência da base legal é obrigatória."));
+        }
+
+        if (abrangencia == TipoAbrangencia.Nenhuma)
+        {
+            return Result<DocumentoExigidoBaseLegal>.Failure(new DomainError(
+                "DocumentoExigidoBaseLegal.AbrangenciaObrigatoria",
+                "A abrangência da base legal é obrigatória."));
+        }
+
+        if (status == StatusBaseLegal.Nenhuma)
+        {
+            return Result<DocumentoExigidoBaseLegal>.Failure(new DomainError(
+                "DocumentoExigidoBaseLegal.StatusObrigatorio",
+                "O status da base legal é obrigatório."));
+        }
+
+        return Result<DocumentoExigidoBaseLegal>.Success(new DocumentoExigidoBaseLegal
+        {
+            Referencia = referencia.Trim(),
+            Abrangencia = abrangencia,
+            Status = status,
+            Observacao = string.IsNullOrWhiteSpace(observacao) ? null : observacao.Trim(),
+        });
+    }
+
+    internal void VincularDocumentoExigido(Guid documentoExigidoId) =>
+        DocumentoExigidoId = documentoExigidoId;
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -685,6 +685,12 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             new ItemConformidade("Distribuição de vagas", _distribuicaoVagas.Count > 0),
             new ItemConformidade("Classificação", Classificacao is not null),
             new ItemConformidade("Cronograma de fases", _cronogramaFases.Count > 0),
+            // Story #554, PR-c (issue #549, ADR-0074): toda exigência que determina
+            // resultado precisa de ≥1 base legal RESOLVIDO — semântica vazia quando não há
+            // exigência que determine resultado (Services.ValidadorBaseLegalExigencias).
+            new ItemConformidade(
+                "Base legal das exigências documentais",
+                Services.ValidadorBaseLegalExigencias.TodasResolvidas(_documentosExigidos)),
         ];
 
         if (Classificacao is { RegraCalculo.Codigo: RegraCalculoCodigo.FormulaMediaPonderada })

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/StatusBaseLegal.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/StatusBaseLegal.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Status de uma <see cref="Entities.DocumentoExigidoBaseLegal"/> (Story #554, PR-c,
+/// issue #549, ADR-0074/ADR-0070). Somente bases <see cref="Resolvido"/> contam para o
+/// gate de publicação (<c>ValidadorBaseLegalExigencias</c>) e para a materialização do
+/// bloco congelado (PR-e, #548) — <see cref="Pendente"/> é rascunho.
+/// </summary>
+public enum StatusBaseLegal
+{
+    Nenhuma = 0,
+    Pendente = 1,
+    Resolvido = 2,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/StatusBaseLegalCodigo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/StatusBaseLegalCodigo.cs
@@ -1,0 +1,27 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento único entre <see cref="StatusBaseLegal"/> e o código textual canônico
+/// UPPER_SNAKE do wire de comando — mesma convenção de <see cref="TipoAbrangenciaCodigo"/>.
+/// </summary>
+public static class StatusBaseLegalCodigo
+{
+    public const string Pendente = "PENDENTE";
+    public const string Resolvido = "RESOLVIDO";
+
+    public static string ToCodigo(this StatusBaseLegal status) => status switch
+    {
+        StatusBaseLegal.Pendente => Pendente,
+        StatusBaseLegal.Resolvido => Resolvido,
+        StatusBaseLegal.Nenhuma => throw new ArgumentOutOfRangeException(
+            nameof(status), status, "StatusBaseLegal.Nenhuma é sentinela e não tem código canônico."),
+        _ => throw new ArgumentOutOfRangeException(nameof(status), status, "StatusBaseLegal desconhecido."),
+    };
+
+    public static StatusBaseLegal FromCodigo(string? codigo) => codigo switch
+    {
+        Pendente => StatusBaseLegal.Pendente,
+        Resolvido => StatusBaseLegal.Resolvido,
+        _ => StatusBaseLegal.Nenhuma,
+    };
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/TipoAbrangencia.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/TipoAbrangencia.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Abrangência de uma <see cref="Entities.DocumentoExigidoBaseLegal"/> (Story #554, PR-c,
+/// issue #549, ADR-0074). <c>InternaEdital</c> conta sozinha como base legal — as demais
+/// referenciam normas externas ao próprio edital.
+/// </summary>
+public enum TipoAbrangencia
+{
+    Nenhuma = 0,
+    Federal = 1,
+    Estadual = 2,
+    Municipal = 3,
+    InternaNorma = 4,
+    InternaEdital = 5,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/TipoAbrangenciaCodigo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/TipoAbrangenciaCodigo.cs
@@ -1,0 +1,38 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento único entre <see cref="TipoAbrangencia"/> e o código textual canônico
+/// UPPER_SNAKE do wire de comando (mesma convenção de <see cref="OperadorCodigo"/>) —
+/// fonte de verdade única do wire format. Também usado por <c>.HasConversion&lt;string&gt;()</c>
+/// na persistência (Story #554, PR-c).
+/// </summary>
+public static class TipoAbrangenciaCodigo
+{
+    public const string Federal = "FEDERAL";
+    public const string Estadual = "ESTADUAL";
+    public const string Municipal = "MUNICIPAL";
+    public const string InternaNorma = "INTERNA_NORMA";
+    public const string InternaEdital = "INTERNA_EDITAL";
+
+    public static string ToCodigo(this TipoAbrangencia abrangencia) => abrangencia switch
+    {
+        TipoAbrangencia.Federal => Federal,
+        TipoAbrangencia.Estadual => Estadual,
+        TipoAbrangencia.Municipal => Municipal,
+        TipoAbrangencia.InternaNorma => InternaNorma,
+        TipoAbrangencia.InternaEdital => InternaEdital,
+        TipoAbrangencia.Nenhuma => throw new ArgumentOutOfRangeException(
+            nameof(abrangencia), abrangencia, "TipoAbrangencia.Nenhuma é sentinela e não tem código canônico."),
+        _ => throw new ArgumentOutOfRangeException(nameof(abrangencia), abrangencia, "TipoAbrangencia desconhecido."),
+    };
+
+    public static TipoAbrangencia FromCodigo(string? codigo) => codigo switch
+    {
+        Federal => TipoAbrangencia.Federal,
+        Estadual => TipoAbrangencia.Estadual,
+        Municipal => TipoAbrangencia.Municipal,
+        InternaNorma => TipoAbrangencia.InternaNorma,
+        InternaEdital => TipoAbrangencia.InternaEdital,
+        _ => TipoAbrangencia.Nenhuma,
+    };
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ValidadorBaseLegalExigencias.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ValidadorBaseLegalExigencias.cs
@@ -1,0 +1,29 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Services;
+
+using Entities;
+using Enums;
+
+/// <summary>
+/// Domain service estático (Story #554, PR-c, issue #549, ADR-0074) — 5º item de
+/// <see cref="ProcessoSeletivo.AvaliarConformidade"/>: para toda exigência que
+/// <see cref="DocumentoExigido.DeterminaResultado"/>, exige ao menos uma
+/// <see cref="DocumentoExigidoBaseLegal"/> com <see cref="StatusBaseLegal.Resolvido"/>, de
+/// qualquer <see cref="TipoAbrangencia"/> — <c>InternaEdital</c> conta sozinha. Puro, sem
+/// I/O; a validação em runtime avalia a versão CONGELADA (ADR-0070) — este service só
+/// avalia o checklist estrutural na publicação/retificação.
+/// </summary>
+public static class ValidadorBaseLegalExigencias
+{
+    /// <summary>
+    /// Semântica vazia (vacuous truth): um processo sem nenhuma exigência que determina
+    /// resultado passa trivialmente — ausência de exigências não é, por si, pendência.
+    /// </summary>
+    public static bool TodasResolvidas(IReadOnlyCollection<DocumentoExigido> exigencias)
+    {
+        ArgumentNullException.ThrowIfNull(exigencias);
+
+        return exigencias
+            .Where(static e => e.DeterminaResultado())
+            .All(static e => e.BasesLegais.Any(static b => b.Status == StatusBaseLegal.Resolvido));
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoBaseLegalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoBaseLegalConfiguration.cs
@@ -1,0 +1,58 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Domain.Entities;
+using Domain.Enums;
+
+/// <summary>
+/// Configuração EF Core de <see cref="DocumentoExigidoBaseLegal"/> (Story #554, PR-c,
+/// issue #549) — entidade filha de <see cref="DocumentoExigido"/>, <c>EntityBase</c> puro
+/// (sem soft-delete), mesmo padrão de <see cref="CondicaoGatilho"/>. Sem CHECK de banco
+/// para <c>tipo_abrangencia</c>/<c>status</c> — integridade em C# (enum tipado +
+/// <c>.HasConversion&lt;string&gt;()</c> + guard de factory + FluentValidation no
+/// comando de substituição integral), mesmo padrão do restante do módulo.
+/// </summary>
+public sealed class DocumentoExigidoBaseLegalConfiguration : IEntityTypeConfiguration<DocumentoExigidoBaseLegal>
+{
+    private const int ReferenciaMaxLength = 500;
+    private const int AbrangenciaCodigoMaxLength = 20;
+    private const int StatusCodigoMaxLength = 20;
+    private const int ObservacaoMaxLength = 1000;
+
+    public void Configure(EntityTypeBuilder<DocumentoExigidoBaseLegal> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("documentos_exigidos_base_legal");
+        builder.HasKey(b => b.Id);
+        // Chave Guid v7 do domínio (EntityBase) — ValueGeneratedNever, mesmo padrão de
+        // DocumentoExigido/CondicaoGatilho.
+        builder.Property(b => b.Id).ValueGeneratedNever();
+
+        builder.Property(b => b.Referencia).HasMaxLength(ReferenciaMaxLength).IsRequired();
+
+        // Mesmo mapeamento canônico de OperadorCodigo/ReferenciaTipoCodigo usado no wire —
+        // nunca enum.ToString() cru: a coluna carrega o mesmo token FEDERAL/ESTADUAL/.../
+        // PENDENTE/RESOLVIDO que o PUT aceita e o GET devolve.
+        builder.Property(b => b.Abrangencia)
+            .HasConversion(AbrangenciaConverter)
+            .HasMaxLength(AbrangenciaCodigoMaxLength)
+            .IsRequired();
+
+        builder.Property(b => b.Status)
+            .HasConversion(StatusConverter)
+            .HasMaxLength(StatusCodigoMaxLength)
+            .IsRequired();
+
+        builder.Property(b => b.Observacao).HasMaxLength(ObservacaoMaxLength);
+    }
+
+    private static readonly ValueConverter<TipoAbrangencia, string> AbrangenciaConverter =
+        new(abrangencia => abrangencia.ToCodigo(), codigo => TipoAbrangenciaCodigo.FromCodigo(codigo));
+
+    private static readonly ValueConverter<StatusBaseLegal, string> StatusConverter =
+        new(status => status.ToCodigo(), codigo => StatusBaseLegalCodigo.FromCodigo(codigo));
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoConfiguration.cs
@@ -66,5 +66,15 @@ public sealed class DocumentoExigidoConfiguration : IEntityTypeConfiguration<Doc
 
         builder.Navigation(d => d.Condicoes)
             .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+        // Base legal 1:N (Story #554, PR-c) — substituível por inteiro junto com o próprio
+        // DocumentoExigido, mesmo padrão de Condicoes.
+        builder.HasMany(d => d.BasesLegais)
+            .WithOne()
+            .HasForeignKey(b => b.DocumentoExigidoId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(d => d.BasesLegais)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717063632_AddDocumentoExigidoBaseLegal.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717063632_AddDocumentoExigidoBaseLegal.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717063632_AddDocumentoExigidoBaseLegal")]
+    partial class AddDocumentoExigidoBaseLegal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717063632_AddDocumentoExigidoBaseLegal.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717063632_AddDocumentoExigidoBaseLegal.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDocumentoExigidoBaseLegal : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "documentos_exigidos_base_legal",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    documento_exigido_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    referencia = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    abrangencia = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    observacao = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_documentos_exigidos_base_legal", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_documentos_exigidos_base_legal_documento_exigido_documento_",
+                        column: x => x.documento_exigido_id,
+                        principalSchema: "selecao",
+                        principalTable: "documentos_exigidos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_documentos_exigidos_base_legal_documento_exigido_id",
+                schema: "selecao",
+                table: "documentos_exigidos_base_legal",
+                column: "documento_exigido_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "documentos_exigidos_base_legal",
+                schema: "selecao");
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
@@ -107,8 +107,13 @@ public sealed class ProcessoSeletivoRepository : IProcessoSeletivoRepository
             // antigas sobrevivem no banco, PUT acumula) e a guarda B-01/CA-01 sempre
             // veria zero exigências. Gatilho DNF (issue #892, PR-b) — mesmo raciocínio
             // para Condicoes: sem o ThenInclude, PendenciaDasExigenciasDocumentais veria
-            // sempre zero condições, e CA-01 (GERAL x condição) falharia aberta.
+            // sempre zero condições, e CA-01 (GERAL x condição) falharia aberta. Base
+            // legal (issue #549, PR-c) — mesmo raciocínio para BasesLegais: sem o
+            // ThenInclude, ValidadorBaseLegalExigencias veria sempre zero bases e o 5º
+            // item de AvaliarConformidade reprovaria toda exigência que determina
+            // resultado, mesmo com bases RESOLVIDO persistidas.
             .Include(p => p.DocumentosExigidos).ThenInclude(d => d.Condicoes)
+            .Include(p => p.DocumentosExigidos).ThenInclude(d => d.BasesLegais)
             // AsSplitQuery obrigatório a partir desta entrega: o produto cartesiano de
             // TODAS as coleções (etapas × condições × recursos × tipos × vagas ×
             // modalidades × desempate × eliminação × fases × bancas) num único JOIN

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirDocumentosExigidosCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirDocumentosExigidosCommandHandlerTests.cs
@@ -90,7 +90,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
         mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
             .Returns((TipoDocumentoView?)null);
 
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, []);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], []);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -111,7 +111,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
         mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
             .Returns(TipoDocumentoResultado(tipoDocumentoId));
 
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, []);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], []);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -137,7 +137,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
             .Returns((IReadOnlyList<FatoCandidatoView>)[FatoSexo()]);
 
         CondicaoGatilhoInput condicao = new(0, "SEXO", "IGUAL", "\"MASCULINO\"");
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao]);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], []);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -162,7 +162,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
             .Returns((IReadOnlyList<FatoCandidatoView>)[]);
 
         CondicaoGatilhoInput condicao = new(0, "FATO_INEXISTENTE", "IGUAL", "\"X\"");
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao]);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], []);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -187,12 +187,40 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
             .Returns((IReadOnlyList<FatoCandidatoView>)[FatoModalidade()]);
 
         CondicaoGatilhoInput condicao = new(0, "MODALIDADE", "IGUAL", "\"LB_PPI\"");
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao]);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], []);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("PredicadoDnf.ValorForaDoDominio");
+    }
+
+    [Fact(DisplayName = "CA-07 (Story #554, PR-c): mesma referência documental em exigências distintas preserva bases legais distintas, correlacionadas por identidade")]
+    public async Task Handle_MesmaReferenciaDocumental_BasesDistintasPorExigencia()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Handler", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        Guid tipoDocumentoId = Guid.CreateVersion7();
+        mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
+            .Returns(TipoDocumentoResultado(tipoDocumentoId));
+
+        BaseLegalInput baseFederal = new("Lei Federal X", "FEDERAL", "RESOLVIDO", null);
+        BaseLegalInput baseEdital = new("Cláusula do edital", "INTERNA_EDITAL", "RESOLVIDO", null);
+        ItemDocumentoExigidoInput primeiraExigencia = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [baseFederal]);
+        ItemDocumentoExigidoInput segundaExigencia = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [baseEdital]);
+        DefinirDocumentosExigidosCommand command = new(processo.Id, [primeiraExigencia, segundaExigencia], PrecondicaoIfMatch.Ausente);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.DocumentosExigidos.Should().HaveCount(2);
+        processo.DocumentosExigidos.Should().Contain(d => d.BasesLegais.Single().Referencia == "Lei Federal X");
+        processo.DocumentosExigidos.Should().Contain(d => d.BasesLegais.Single().Referencia == "Cláusula do edital");
+        processo.DocumentosExigidos.Select(d => d.Id).Should().OnlyHaveUniqueItems(
+            "a correlação é pela identidade da própria exigência (ADR-0072), não pelo tipo de documento");
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests.cs
@@ -41,7 +41,7 @@ public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, tipoDocumentoOrigemId, "IDENTIDADE", "Documento de identidade", "PESSOAL",
             aplicabilidade, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: []).Value!;
+            condicoes: [], basesLegais: []).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
@@ -69,7 +69,7 @@ public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "CERTIDAO_RESERVISTA", "Certidão de reservista", "MILITAR",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [condicaoEscalar, condicaoMultivalorada]).Value!;
+            condicoes: [condicaoEscalar, condicaoMultivalorada], basesLegais: []).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
@@ -124,5 +124,41 @@ public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
             new ObterProcessoSeletivoQuery(processo.Id), repository, CancellationToken.None);
 
         dto!.ReferenciaTemporalFatos.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Story #554/issue #549 (PR-c): projeta BasesLegais — round-trip GET→PUT, inclusive PENDENTE (a projeção 'só RESOLVIDO' é da PR-e, não deste DTO de edição)")]
+    public async Task Handle_BasesLegais_EmiteTokenDeWireERoundTrip()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Query", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        DocumentoExigidoBaseLegal baseResolvida = DocumentoExigidoBaseLegal.Criar(
+            "Lei 12.711/2012, art. 3º", TipoAbrangencia.Federal, StatusBaseLegal.Resolvido, "Observação").Value!;
+        DocumentoExigidoBaseLegal basePendente = DocumentoExigidoBaseLegal.Criar(
+            "Cláusula 5.2 do edital", TipoAbrangencia.InternaEdital, StatusBaseLegal.Pendente, null).Value!;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            fase.Id, Guid.CreateVersion7(), "IDENTIDADE", "Documento de identidade", "PESSOAL",
+            Aplicabilidade.Geral, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
+            condicoes: [], basesLegais: [baseResolvida, basePendente]).Value!;
+        processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
+        repository.ObterComConfiguracaoAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+
+        ProcessoSeletivoDto? dto = await ObterProcessoSeletivoQueryHandler.Handle(
+            new ObterProcessoSeletivoQuery(processo.Id), repository, CancellationToken.None);
+
+        DocumentoExigidoDto projetado = dto!.DocumentosExigidos.Should().ContainSingle().Which;
+        projetado.BasesLegais.Should().HaveCount(2);
+
+        BaseLegalDto resolvidaDto = projetado.BasesLegais.Should().ContainSingle(b => b.Status == "RESOLVIDO").Which;
+        resolvidaDto.Referencia.Should().Be("Lei 12.711/2012, art. 3º");
+        resolvidaDto.Abrangencia.Should().Be("FEDERAL");
+        resolvidaDto.Observacao.Should().Be("Observação");
+
+        BaseLegalDto pendenteDto = projetado.BasesLegais.Should().ContainSingle(b => b.Status == "PENDENTE").Which;
+        pendenteDto.Abrangencia.Should().Be("INTERNA_EDITAL");
+        pendenteDto.Observacao.Should().BeNull();
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
@@ -1,0 +1,83 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura de <see cref="DefinirDocumentosExigidosCommandValidator"/> para a base legal
+/// (Story #554, PR-c, issue #549) — valida apenas a FORMA de cada item; o gate "≥1
+/// RESOLVIDO por exigência que determina resultado" é do domínio, na publicação.
+/// </summary>
+public sealed class DefinirDocumentosExigidosCommandValidatorTests
+{
+    private static ItemDocumentoExigidoInput ItemCom(params BaseLegalInput[] basesLegais) => new(
+        Guid.CreateVersion7(), Guid.CreateVersion7(), "GERAL", true, null, null, [], basesLegais);
+
+    private static ValidationResult Validar(ItemDocumentoExigidoInput item) =>
+        new DefinirDocumentosExigidosCommandValidator().Validate(
+            new DefinirDocumentosExigidosCommand(Guid.CreateVersion7(), [item], PrecondicaoIfMatch.Ausente));
+
+    [Fact(DisplayName = "Item sem base legal (lista vazia) é aceito — a coerência com o gate é da publicação")]
+    public void Aceita_SemBaseLegal() =>
+        Validar(ItemCom()).IsValid.Should().BeTrue();
+
+    [Fact(DisplayName = "Base legal com dados coerentes é aceita")]
+    public void Aceita_BaseLegalValida() =>
+        Validar(ItemCom(new BaseLegalInput("Lei 12.711/2012, art. 3º", "FEDERAL", "RESOLVIDO", null))).IsValid.Should().BeTrue();
+
+    [Fact(DisplayName = "CA-01: referência vazia é rejeitada")]
+    public void Rejeita_ReferenciaBaseLegalVazia()
+    {
+        ValidationResult resultado = Validar(ItemCom(new BaseLegalInput("", "FEDERAL", "RESOLVIDO", null)));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("referência da base legal", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact(DisplayName = "CA-01: referência só de espaços é rejeitada")]
+    public void Rejeita_ReferenciaBaseLegalSoDeEspacos()
+    {
+        ValidationResult resultado = Validar(ItemCom(new BaseLegalInput("   ", "FEDERAL", "RESOLVIDO", null)));
+
+        resultado.IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Abrangência fora do domínio é rejeitada")]
+    public void Rejeita_AbrangenciaDesconhecida()
+    {
+        ValidationResult resultado = Validar(ItemCom(new BaseLegalInput("Lei X", "PLANETARIA", "RESOLVIDO", null)));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("Abrangência", StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "Status fora do domínio é rejeitado")]
+    public void Rejeita_StatusDesconhecido()
+    {
+        ValidationResult resultado = Validar(ItemCom(new BaseLegalInput("Lei X", "FEDERAL", "EM_ANALISE", null)));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("Status", StringComparison.Ordinal));
+    }
+
+    [Theory(DisplayName = "Todas as abrangências e status válidos são aceitos")]
+    [InlineData("FEDERAL", "PENDENTE")]
+    [InlineData("ESTADUAL", "RESOLVIDO")]
+    [InlineData("MUNICIPAL", "PENDENTE")]
+    [InlineData("INTERNA_NORMA", "RESOLVIDO")]
+    [InlineData("INTERNA_EDITAL", "RESOLVIDO")]
+    public void Aceita_TodasCombinacoesValidas(string abrangencia, string status) =>
+        Validar(ItemCom(new BaseLegalInput("Referência", abrangencia, status, "Observação"))).IsValid.Should().BeTrue();
+
+    [Fact(DisplayName = "Múltiplas bases legais no mesmo item são aceitas (1:N)")]
+    public void Aceita_MultiplasBasesLegais() =>
+        Validar(ItemCom(
+            new BaseLegalInput("Lei Federal X", "FEDERAL", "RESOLVIDO", null),
+            new BaseLegalInput("Cláusula do edital", "INTERNA_EDITAL", "PENDENTE", null)))
+            .IsValid.Should().BeTrue();
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
@@ -74,6 +74,32 @@ public sealed class DefinirDocumentosExigidosCommandValidatorTests
     public void Aceita_TodasCombinacoesValidas(string abrangencia, string status) =>
         Validar(ItemCom(new BaseLegalInput("Referência", abrangencia, status, "Observação"))).IsValid.Should().BeTrue();
 
+    [Fact(DisplayName = "Achado Codex P2 (PR #898): referência acima de 500 caracteres é rejeitada — o mesmo teto de DocumentoExigidoBaseLegalConfiguration")]
+    public void Rejeita_ReferenciaAcimaDoTetoDePersistencia()
+    {
+        string referenciaLonga = new('a', 501);
+
+        ValidationResult resultado = Validar(ItemCom(new BaseLegalInput(referenciaLonga, "FEDERAL", "RESOLVIDO", null)));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("500 caracteres", StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "Referência com exatamente 500 caracteres é aceita (contraprova do limite)")]
+    public void Aceita_ReferenciaNoTetoDePersistencia() =>
+        Validar(ItemCom(new BaseLegalInput(new string('a', 500), "FEDERAL", "RESOLVIDO", null))).IsValid.Should().BeTrue();
+
+    [Fact(DisplayName = "Achado Codex P2 (PR #898): observação acima de 1000 caracteres é rejeitada")]
+    public void Rejeita_ObservacaoAcimaDoTetoDePersistencia()
+    {
+        string observacaoLonga = new('a', 1001);
+
+        ValidationResult resultado = Validar(ItemCom(new BaseLegalInput("Referência", "FEDERAL", "RESOLVIDO", observacaoLonga)));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("1000 caracteres", StringComparison.Ordinal));
+    }
+
     [Fact(DisplayName = "Múltiplas bases legais no mesmo item são aceitas (1:N)")]
     public void Aceita_MultiplasBasesLegais() =>
         Validar(ItemCom(

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
@@ -100,6 +100,18 @@ public sealed class DefinirDocumentosExigidosCommandValidatorTests
         resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("1000 caracteres", StringComparison.Ordinal));
     }
 
+    [Fact(DisplayName = "Achado Codex P2 (PR #898, 2ª rodada): item de base legal nulo na lista é rejeitado")]
+    public void Rejeita_ItemDeBaseLegalNulo()
+    {
+        ItemDocumentoExigidoInput item = new(
+            Guid.CreateVersion7(), Guid.CreateVersion7(), "GERAL", true, null, null, [], [null!]);
+
+        ValidationResult resultado = Validar(item);
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("Item de base legal", StringComparison.Ordinal));
+    }
+
     [Fact(DisplayName = "Múltiplas bases legais no mesmo item são aceitas (1:N)")]
     public void Aceita_MultiplasBasesLegais() =>
         Validar(ItemCom(

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoBaseLegalTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoBaseLegalTests.cs
@@ -1,0 +1,85 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Cobertura de <see cref="DocumentoExigidoBaseLegal"/> (Story #554, PR-c, issue #549,
+/// ADR-0074): fábrica — CA-01 (referência não vazia, abrangência/status no domínio).
+/// </summary>
+public sealed class DocumentoExigidoBaseLegalTests
+{
+    [Fact(DisplayName = "CA-01: Criar aceita referência, abrangência e status coerentes")]
+    public void Criar_DadosCoerentes_Aceita()
+    {
+        Result<DocumentoExigidoBaseLegal> resultado = DocumentoExigidoBaseLegal.Criar(
+            "Lei 12.711/2012, art. 3º", TipoAbrangencia.Federal, StatusBaseLegal.Resolvido, "Observação livre");
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.Referencia.Should().Be("Lei 12.711/2012, art. 3º");
+        resultado.Value.Abrangencia.Should().Be(TipoAbrangencia.Federal);
+        resultado.Value.Status.Should().Be(StatusBaseLegal.Resolvido);
+        resultado.Value.Observacao.Should().Be("Observação livre");
+    }
+
+    [Fact(DisplayName = "CA-01: referência vazia é recusada")]
+    public void Criar_ReferenciaVazia_Recusa()
+    {
+        Result<DocumentoExigidoBaseLegal> resultado = DocumentoExigidoBaseLegal.Criar(
+            "", TipoAbrangencia.Federal, StatusBaseLegal.Resolvido, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigidoBaseLegal.ReferenciaObrigatoria");
+    }
+
+    [Fact(DisplayName = "CA-01: referência só de espaços é recusada")]
+    public void Criar_ReferenciaSoDeEspacos_Recusa()
+    {
+        Result<DocumentoExigidoBaseLegal> resultado = DocumentoExigidoBaseLegal.Criar(
+            "   ", TipoAbrangencia.Federal, StatusBaseLegal.Resolvido, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigidoBaseLegal.ReferenciaObrigatoria");
+    }
+
+    [Fact(DisplayName = "Abrangência Nenhuma é recusada")]
+    public void Criar_AbrangenciaNenhuma_Recusa()
+    {
+        Result<DocumentoExigidoBaseLegal> resultado = DocumentoExigidoBaseLegal.Criar(
+            "Lei X", TipoAbrangencia.Nenhuma, StatusBaseLegal.Resolvido, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigidoBaseLegal.AbrangenciaObrigatoria");
+    }
+
+    [Fact(DisplayName = "Status Nenhuma é recusado")]
+    public void Criar_StatusNenhuma_Recusa()
+    {
+        Result<DocumentoExigidoBaseLegal> resultado = DocumentoExigidoBaseLegal.Criar(
+            "Lei X", TipoAbrangencia.Federal, StatusBaseLegal.Nenhuma, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigidoBaseLegal.StatusObrigatorio");
+    }
+
+    [Theory(DisplayName = "Todas as abrangências e status válidos são aceitos")]
+    [InlineData(TipoAbrangencia.Federal, StatusBaseLegal.Pendente)]
+    [InlineData(TipoAbrangencia.Estadual, StatusBaseLegal.Resolvido)]
+    [InlineData(TipoAbrangencia.Municipal, StatusBaseLegal.Pendente)]
+    [InlineData(TipoAbrangencia.InternaNorma, StatusBaseLegal.Resolvido)]
+    [InlineData(TipoAbrangencia.InternaEdital, StatusBaseLegal.Resolvido)]
+    public void Criar_TodasCombinacoesValidas_Aceita(TipoAbrangencia abrangencia, StatusBaseLegal status) =>
+        DocumentoExigidoBaseLegal.Criar("Referência", abrangencia, status, null).IsSuccess.Should().BeTrue();
+
+    [Fact(DisplayName = "Observação em branco é normalizada para null")]
+    public void Criar_ObservacaoEmBranco_NormalizaParaNull()
+    {
+        DocumentoExigidoBaseLegal baseLegal = DocumentoExigidoBaseLegal.Criar(
+            "Lei X", TipoAbrangencia.Federal, StatusBaseLegal.Resolvido, "   ").Value!;
+
+        baseLegal.Observacao.Should().BeNull();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
@@ -18,7 +18,8 @@ public sealed class DocumentoExigidoTests
         Aplicabilidade aplicabilidade = Aplicabilidade.Geral,
         bool obrigatorio = false,
         string? consequenciaIndeferimento = null,
-        IReadOnlyList<CondicaoGatilho>? condicoes = null) =>
+        IReadOnlyList<CondicaoGatilho>? condicoes = null,
+        IReadOnlyList<DocumentoExigidoBaseLegal>? basesLegais = null) =>
         DocumentoExigido.Criar(
             exigidoNaFaseId: Guid.CreateVersion7(),
             tipoDocumentoOrigemId: Guid.CreateVersion7(),
@@ -29,7 +30,8 @@ public sealed class DocumentoExigidoTests
             obrigatorio: obrigatorio,
             consequenciaIndeferimento: consequenciaIndeferimento,
             grupoSatisfacaoId: null,
-            condicoes: condicoes ?? []);
+            condicoes: condicoes ?? [],
+            basesLegais: basesLegais ?? []);
 
     private static CondicaoGatilho CondicaoQualquer() => CondicaoGatilho.Criar(
         0, "SEXO", Operador.Igual, JsonSerializer.SerializeToElement("MASCULINO")).Value!;
@@ -132,5 +134,29 @@ public sealed class DocumentoExigidoTests
 
         exigencia.ConsequenciaIndeferimento.Should().BeNull();
         exigencia.DeterminaResultado().Should().BeFalse();
+    }
+
+    // ── Story #554/issue #549 (PR-c) — base legal 1:N ──
+
+    [Fact(DisplayName = "CA-06: BasesLegaisResolvidas exclui toda base PENDENTE")]
+    public void BasesLegaisResolvidas_ExcluiPendente()
+    {
+        DocumentoExigidoBaseLegal pendente = DocumentoExigidoBaseLegal.Criar(
+            "Referência pendente", TipoAbrangencia.Federal, StatusBaseLegal.Pendente, null).Value!;
+        DocumentoExigidoBaseLegal resolvida = DocumentoExigidoBaseLegal.Criar(
+            "Referência resolvida", TipoAbrangencia.Estadual, StatusBaseLegal.Resolvido, null).Value!;
+        DocumentoExigido exigencia = Exigencia(basesLegais: [pendente, resolvida]).Value!;
+
+        exigencia.BasesLegaisResolvidas().Should().ContainSingle().Which.Should().Be(resolvida);
+    }
+
+    [Fact(DisplayName = "BasesLegaisResolvidas retorna vazio quando só há PENDENTE (contraprova)")]
+    public void BasesLegaisResolvidas_SoPendente_RetornaVazio()
+    {
+        DocumentoExigidoBaseLegal pendente = DocumentoExigidoBaseLegal.Criar(
+            "Referência pendente", TipoAbrangencia.Federal, StatusBaseLegal.Pendente, null).Value!;
+        DocumentoExigido exigencia = Exigencia(basesLegais: [pendente]).Value!;
+
+        exigencia.BasesLegaisResolvidas().Should().BeEmpty();
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -48,7 +48,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
             obrigatorio: false,
             consequenciaIndeferimento: null,
             grupoSatisfacaoId: null,
-            condicoes: []).Value!;
+            condicoes: [], basesLegais: []).Value!;
 
     [Fact(DisplayName = "Fase que não pertence ao cronograma do processo é recusada")]
     public void DefinirDocumentosExigidos_FaseDeOutroProcesso_Recusa()
@@ -179,7 +179,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "IDENTIDADE", "Documento de identidade", "PESSOAL",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [CondicaoDe("MODALIDADE", "LB_PPI")]).Value!;
+            condicoes: [CondicaoDe("MODALIDADE", "LB_PPI")], basesLegais: []).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         Result resultado = processo.DefinirDistribuicaoVagas([DistribuicaoCom("AC")], PrecondicaoIfMatch.Ausente);
@@ -199,7 +199,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "IDENTIDADE", "Documento de identidade", "PESSOAL",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [CondicaoDe("MODALIDADE", "LB_PPI")]).Value!;
+            condicoes: [CondicaoDe("MODALIDADE", "LB_PPI")], basesLegais: []).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         Result resultado = processo.DefinirDistribuicaoVagas([DistribuicaoCom("LB_PPI", "AC", "LI_PPI")], PrecondicaoIfMatch.Ausente);
@@ -221,7 +221,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "LAUDO_MEDICO", "Laudo médico", "SAUDE",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [CondicaoDe("CONDICAO_ATENDIMENTO", "PCD")]).Value!;
+            condicoes: [CondicaoDe("CONDICAO_ATENDIMENTO", "PCD")], basesLegais: []).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         Result resultado = processo.DefinirOfertaAtendimento(
@@ -245,7 +245,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "LAUDO_MEDICO", "Laudo médico", "SAUDE",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [CondicaoDe("CONDICAO_ATENDIMENTO", "PCD")]).Value!;
+            condicoes: [CondicaoDe("CONDICAO_ATENDIMENTO", "PCD")], basesLegais: []).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         OfertaCondicao condicaoPcdNova = OfertaCondicao.Criar(Guid.CreateVersion7(), "PCD", "Pessoa com deficiência");

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoPublicarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoPublicarTests.cs
@@ -248,6 +248,15 @@ public sealed class ProcessoSeletivoPublicarTests
 
     // ── Story #554 (PR-a) — guarda fail-closed (B-01) e CA-01 ──
 
+    /// <summary>
+    /// Base legal RESOLVIDO qualquer (Story #554, PR-c) — as fixtures abaixo testam
+    /// checagens POSTERIORES ao 5º item de <see cref="ProcessoSeletivo.AvaliarConformidade"/>
+    /// (B-01/CA-01), então precisam satisfazer o gate de base legal primeiro, ou nunca o
+    /// alcançariam.
+    /// </summary>
+    private static DocumentoExigidoBaseLegal BaseLegalResolvidaQualquer() => DocumentoExigidoBaseLegal.Criar(
+        "Lei 12.711/2012, art. 3º", TipoAbrangencia.InternaEdital, StatusBaseLegal.Resolvido, null).Value!;
+
     private static DocumentoExigido ExigenciaCondicionalVaziaObrigatoria(Guid exigidoNaFaseId) => DocumentoExigido.Criar(
         exigidoNaFaseId,
         tipoDocumentoOrigemId: Guid.CreateVersion7(),
@@ -258,7 +267,7 @@ public sealed class ProcessoSeletivoPublicarTests
         obrigatorio: true,
         consequenciaIndeferimento: null,
         grupoSatisfacaoId: null,
-        condicoes: []).Value!;
+        condicoes: [], basesLegais: [BaseLegalResolvidaQualquer()]).Value!;
 
     private static DocumentoExigido ExigenciaGeral(Guid exigidoNaFaseId) => DocumentoExigido.Criar(
         exigidoNaFaseId,
@@ -270,7 +279,7 @@ public sealed class ProcessoSeletivoPublicarTests
         obrigatorio: true,
         consequenciaIndeferimento: null,
         grupoSatisfacaoId: null,
-        condicoes: []).Value!;
+        condicoes: [], basesLegais: [BaseLegalResolvidaQualquer()]).Value!;
 
     [Fact(DisplayName = "CA-01: publicar com exigência CONDICIONAL vazia obrigatória é bloqueado")]
     public void Publicar_CondicionalVaziaObrigatoria_Bloqueia()
@@ -329,7 +338,7 @@ public sealed class ProcessoSeletivoPublicarTests
             obrigatorio: true,
             consequenciaIndeferimento: null,
             grupoSatisfacaoId: null,
-            condicoes: [condicao]).Value!;
+            condicoes: [condicao], basesLegais: [BaseLegalResolvidaQualquer()]).Value!;
     }
 
     [Fact(DisplayName = "DefinirReferenciaTemporalFatos: fase de outro processo é recusada")]
@@ -404,6 +413,119 @@ public sealed class ProcessoSeletivoPublicarTests
             NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+
+    // ── Story #554/issue #549 (PR-c) — base legal 1:N, 5º item de AvaliarConformidade ──
+
+    private static DocumentoExigidoBaseLegal BaseLegalDe(StatusBaseLegal status) => DocumentoExigidoBaseLegal.Criar(
+        "Lei 12.711/2012, art. 3º", TipoAbrangencia.Federal, status, null).Value!;
+
+    private static DocumentoExigido ExigenciaObrigatoriaCom(Guid exigidoNaFaseId, params DocumentoExigidoBaseLegal[] basesLegais) => DocumentoExigido.Criar(
+        exigidoNaFaseId: exigidoNaFaseId,
+        tipoDocumentoOrigemId: Guid.CreateVersion7(),
+        tipoDocumentoCodigo: "IDENTIDADE",
+        tipoDocumentoNome: "Documento de identidade",
+        tipoDocumentoCategoria: "PESSOAL",
+        aplicabilidade: Aplicabilidade.Geral,
+        obrigatorio: true,
+        consequenciaIndeferimento: null,
+        grupoSatisfacaoId: null,
+        condicoes: [],
+        basesLegais: basesLegais).Value!;
+
+    [Fact(DisplayName = "CA-02: AvaliarConformidade inclui o item 'Base legal das exigências documentais'")]
+    public void AvaliarConformidade_IncluiItemBaseLegal()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => i.Item == "Base legal das exigências documentais");
+    }
+
+    [Fact(DisplayName = "CA-03 (semântica vazia): processo sem exigência que determina resultado tem o item satisfeito")]
+    public void AvaliarConformidade_SemExigenciaQueDeterminaResultado_ItemSatisfeito()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+
+        processo.AvaliarConformidade().Single(i => i.Item == "Base legal das exigências documentais").Ok.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Exigência que determina resultado sem base legal reprova o item")]
+    public void AvaliarConformidade_ExigenciaSemBaseLegal_ItemReprova()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        processo.DefinirDocumentosExigidos([ExigenciaObrigatoriaCom(faseId)], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Single(i => i.Item == "Base legal das exigências documentais").Ok.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "CA-02: exigência com base RESOLVIDO satisfaz o item")]
+    public void AvaliarConformidade_ExigenciaComBaseResolvida_ItemSatisfeito()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        processo.DefinirDocumentosExigidos([ExigenciaObrigatoriaCom(faseId, BaseLegalDe(StatusBaseLegal.Resolvido))], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Single(i => i.Item == "Base legal das exigências documentais").Ok.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Exigência com base só PENDENTE reprova o item")]
+    public void AvaliarConformidade_ExigenciaComBasePendente_ItemReprova()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        processo.DefinirDocumentosExigidos([ExigenciaObrigatoriaCom(faseId, BaseLegalDe(StatusBaseLegal.Pendente))], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Single(i => i.Item == "Base legal das exigências documentais").Ok.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "CA-05: reenviar o PUT rebaixando a única base resolvida para PENDENTE volta a reprovar o item")]
+    public void AvaliarConformidade_ReenviarRebaixandoUnicaBaseResolvida_VoltaAReprovar()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        processo.DefinirDocumentosExigidos([ExigenciaObrigatoriaCom(faseId, BaseLegalDe(StatusBaseLegal.Resolvido))], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+        processo.AvaliarConformidade().Single(i => i.Item == "Base legal das exigências documentais").Ok.Should().BeTrue();
+
+        processo.DefinirDocumentosExigidos([ExigenciaObrigatoriaCom(faseId, BaseLegalDe(StatusBaseLegal.Pendente))], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Single(i => i.Item == "Base legal das exigências documentais").Ok.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "CA-05: reenviar o PUT sem a única base resolvida volta a reprovar o item")]
+    public void AvaliarConformidade_ReenviarSemUnicaBaseResolvida_VoltaAReprovar()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        processo.DefinirDocumentosExigidos([ExigenciaObrigatoriaCom(faseId, BaseLegalDe(StatusBaseLegal.Resolvido))], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+        processo.AvaliarConformidade().Single(i => i.Item == "Base legal das exigências documentais").Ok.Should().BeTrue();
+
+        processo.DefinirDocumentosExigidos([ExigenciaObrigatoriaCom(faseId)], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Single(i => i.Item == "Base legal das exigências documentais").Ok.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Publicar bloqueia com ConformidadeInsuficiente quando exigência determina resultado sem base legal — antes de alcançar B-01")]
+    public void Publicar_ExigenciaSemBaseLegal_BloqueiaComConformidadeInsuficiente()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        processo.DefinirDocumentosExigidos([ExigenciaObrigatoriaCom(faseId)], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        Result<VersaoConfiguracao> resultado = processo.Publicar(
+            NovosDados(), BytesCanonicos, "1.0", "canonical-json/sha256@v1", HashFixo, "user-sub-123", TimeProvider.System);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.ConformidadeInsuficiente");
+        resultado.Error.Message.Should().Contain("Base legal das exigências documentais");
     }
 
     /// <summary>

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRestaurarConfiguracaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRestaurarConfiguracaoTests.cs
@@ -244,7 +244,7 @@ public sealed class ProcessoSeletivoRestaurarConfiguracaoTests
             obrigatorio: true,
             consequenciaIndeferimento: null,
             grupoSatisfacaoId: null,
-            condicoes: []).Value!;
+            condicoes: [], basesLegais: []).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Curinga)
             .IsSuccess.Should().BeTrue();
         processo.DocumentosExigidos.Should().ContainSingle();

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
@@ -363,6 +363,11 @@ public sealed class ProcessoSeletivoRetificarTests
         abertura.IsSuccess.Should().BeTrue(abertura.Error?.Message);
 
         Guid faseId = processo.CronogramaFases.Single().Id;
+        // Story #554, PR-c: a exigência determina resultado (Obrigatorio=true), então
+        // precisa de base legal RESOLVIDO para satisfazer o 5º item de AvaliarConformidade
+        // antes de alcançar a checagem B-01 sendo testada aqui.
+        DocumentoExigidoBaseLegal baseLegal = DocumentoExigidoBaseLegal.Criar(
+            "Lei 12.711/2012, art. 3º", TipoAbrangencia.InternaEdital, StatusBaseLegal.Resolvido, null).Value!;
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             faseId,
             tipoDocumentoOrigemId: Guid.CreateVersion7(),
@@ -373,7 +378,7 @@ public sealed class ProcessoSeletivoRetificarTests
             obrigatorio: true,
             consequenciaIndeferimento: null,
             grupoSatisfacaoId: null,
-            condicoes: []).Value!;
+            condicoes: [], basesLegais: [baseLegal]).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Curinga)
             .IsSuccess.Should().BeTrue("mutar a configuração viva durante a sessão é permitido — só o FECHAMENTO é bloqueado pela B-01");
 

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorBaseLegalExigenciasTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorBaseLegalExigenciasTests.cs
@@ -1,0 +1,109 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Services;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Services;
+
+/// <summary>
+/// Cobertura de <see cref="ValidadorBaseLegalExigencias"/> (Story #554, PR-c, issue #549,
+/// ADR-0074) — 5º item de <c>ProcessoSeletivo.AvaliarConformidade</c>.
+/// </summary>
+public sealed class ValidadorBaseLegalExigenciasTests
+{
+    private static DocumentoExigidoBaseLegal Base(TipoAbrangencia abrangencia, StatusBaseLegal status) =>
+        DocumentoExigidoBaseLegal.Criar("Referência qualquer", abrangencia, status, null).Value!;
+
+    private static DocumentoExigido Exigencia(
+        bool obrigatorio, string? consequenciaIndeferimento, params DocumentoExigidoBaseLegal[] basesLegais) =>
+        DocumentoExigido.Criar(
+            exigidoNaFaseId: Guid.CreateVersion7(),
+            tipoDocumentoOrigemId: Guid.CreateVersion7(),
+            tipoDocumentoCodigo: "IDENTIDADE",
+            tipoDocumentoNome: "Documento de identidade",
+            tipoDocumentoCategoria: "PESSOAL",
+            aplicabilidade: Aplicabilidade.Geral,
+            obrigatorio: obrigatorio,
+            consequenciaIndeferimento: consequenciaIndeferimento,
+            grupoSatisfacaoId: null,
+            condicoes: [],
+            basesLegais: basesLegais).Value!;
+
+    [Fact(DisplayName = "CA-03: processo sem exigência que determina resultado é trivialmente satisfeito (semântica vazia)")]
+    public void TodasResolvidas_SemExigenciaQueDeterminaResultado_RetornaTrue()
+    {
+        DocumentoExigido facultativa = Exigencia(obrigatorio: false, consequenciaIndeferimento: null);
+
+        ValidadorBaseLegalExigencias.TodasResolvidas([facultativa]).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Nenhuma exigência configurada é trivialmente satisfeita (contraprova)")]
+    public void TodasResolvidas_ColecaoVazia_RetornaTrue() =>
+        ValidadorBaseLegalExigencias.TodasResolvidas([]).Should().BeTrue();
+
+    [Fact(DisplayName = "CA-02: exigência obrigatória com base RESOLVIDO satisfaz o gate")]
+    public void TodasResolvidas_ObrigatoriaComBaseResolvida_RetornaTrue()
+    {
+        DocumentoExigido exigencia = Exigencia(
+            obrigatorio: true, consequenciaIndeferimento: null, Base(TipoAbrangencia.Federal, StatusBaseLegal.Resolvido));
+
+        ValidadorBaseLegalExigencias.TodasResolvidas([exigencia]).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "CA-04: InternaEdital RESOLVIDO conta sozinha")]
+    public void TodasResolvidas_InternaEditalResolvida_RetornaTrue()
+    {
+        DocumentoExigido exigencia = Exigencia(
+            obrigatorio: true, consequenciaIndeferimento: null, Base(TipoAbrangencia.InternaEdital, StatusBaseLegal.Resolvido));
+
+        ValidadorBaseLegalExigencias.TodasResolvidas([exigencia]).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Exigência que determina resultado por consequência (não por Obrigatorio) também exige base resolvida")]
+    public void TodasResolvidas_ComConsequenciaSemBase_RetornaFalse()
+    {
+        DocumentoExigido exigencia = Exigencia(obrigatorio: false, consequenciaIndeferimento: "ELIMINA");
+
+        ValidadorBaseLegalExigencias.TodasResolvidas([exigencia]).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Exigência que determina resultado sem nenhuma base legal reprova o gate")]
+    public void TodasResolvidas_SemBaseLegal_RetornaFalse()
+    {
+        DocumentoExigido exigencia = Exigencia(obrigatorio: true, consequenciaIndeferimento: null);
+
+        ValidadorBaseLegalExigencias.TodasResolvidas([exigencia]).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Exigência que determina resultado só com base PENDENTE reprova o gate")]
+    public void TodasResolvidas_SoBasePendente_RetornaFalse()
+    {
+        DocumentoExigido exigencia = Exigencia(
+            obrigatorio: true, consequenciaIndeferimento: null, Base(TipoAbrangencia.Federal, StatusBaseLegal.Pendente));
+
+        ValidadorBaseLegalExigencias.TodasResolvidas([exigencia]).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Mistura de PENDENTE e RESOLVIDO na mesma exigência satisfaz o gate (contraprova)")]
+    public void TodasResolvidas_PendenteEResolvidaJuntas_RetornaTrue()
+    {
+        DocumentoExigido exigencia = Exigencia(
+            obrigatorio: true,
+            consequenciaIndeferimento: null,
+            Base(TipoAbrangencia.Federal, StatusBaseLegal.Pendente),
+            Base(TipoAbrangencia.Estadual, StatusBaseLegal.Resolvido));
+
+        ValidadorBaseLegalExigencias.TodasResolvidas([exigencia]).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Uma exigência sem base entre várias reprova o gate mesmo com as outras satisfeitas")]
+    public void TodasResolvidas_UmaExigenciaSemBaseEntreVarias_RetornaFalse()
+    {
+        DocumentoExigido comBase = Exigencia(
+            obrigatorio: true, consequenciaIndeferimento: null, Base(TipoAbrangencia.Federal, StatusBaseLegal.Resolvido));
+        DocumentoExigido semBase = Exigencia(obrigatorio: true, consequenciaIndeferimento: null);
+
+        ValidadorBaseLegalExigencias.TodasResolvidas([comBase, semBase]).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Resumo

Story #554 (UNI-REQ-0016), PR-c — terceira entrega sobre o núcleo `DocumentoExigido` da PR-a (#547, PR #895) / PR-b (#892, PR #896).

- `DocumentoExigidoBaseLegal`: entidade real 1:N sobre `DocumentoExigido` (EntityBase puro, sem soft-delete) — `Referencia`, `Abrangencia ∈ {FEDERAL, ESTADUAL, MUNICIPAL, INTERNA_NORMA, INTERNA_EDITAL}`, `Status ∈ {PENDENTE, RESOLVIDO}`, `Observacao?`. Substituível por inteiro junto do mesmo `PUT {id}/documentos-exigidos` (payload de cada item ganha `basesLegais[]`) — sem comandos granulares (ADR-0074).
- `ValidadorBaseLegalExigencias` (domain service puro): 5º item de `ProcessoSeletivo.AvaliarConformidade()` — para toda exigência que `DeterminaResultado()`, exige ≥1 base `RESOLVIDO`, de qualquer abrangência; `INTERNA_EDITAL` conta sozinha. Semântica vazia quando não há exigência que determina resultado.
- A checagem roda **antes** da guarda B-01 (PR-a/#547) — aflora pelo código já existente `ProcessoSeletivo.ConformidadeInsuficiente` (422), sem código de domínio novo para o gate em si.
- GET agregado projeta `BasesLegais` (round-trip GET→PUT completo, incluindo bases `PENDENTE` — a projeção "só `RESOLVIDO`" é da materialização do envelope, PR-e/#548).
- Migration nova: tabela `documentos_exigidos_base_legal` (FK cascade para `documentos_exigidos`, sem colunas de soft-delete).

## Test plan

- [x] `dotnet build UniPlus.slnx` — 0 erros
- [x] `dotnet test` unitários (Domain 441/441, Application 165/165) — verdes
- [x] `Unifesspa.UniPlus.Selecao.ArchTests` (49/49, inclui F1 — cobertura de registro de erros) — verde
- [x] `Unifesspa.UniPlus.Selecao.IntegrationTests` (Testcontainers, migration real) — 417/417 verdes
- [x] Baseline OpenAPI (`contracts/openapi.selecao.json`) regenerado com `basesLegais`/`BasesLegais`

Closes #549