### PR TITLE
feat(selecao): idade máxima de emissão, formato, tamanho e guards precisos de fase

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -4453,7 +4453,10 @@
           "consequenciaIndeferimento",
           "grupoSatisfacaoId",
           "condicoes",
-          "basesLegais"
+          "basesLegais",
+          "idadeMaximaEmissao",
+          "formatoPermitido",
+          "tamanhoMaximoBytes"
         ],
         "type": "object",
         "properties": {
@@ -4508,6 +4511,31 @@
             "items": {
               "$ref": "#/components/schemas/BaseLegalDto"
             }
+          },
+          "idadeMaximaEmissao": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/IdadeMaximaEmissaoDto"
+              }
+            ]
+          },
+          "formatoPermitido": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tamanhoMaximoBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
           }
         }
       },
@@ -4812,6 +4840,93 @@
           }
         }
       },
+      "IdadeMaximaEmissaoDto": {
+        "required": [
+          "valor",
+          "unidade",
+          "referenciaTipo",
+          "data",
+          "referenciaFaseId"
+        ],
+        "type": "object",
+        "properties": {
+          "valor": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "unidade": {
+            "type": "string"
+          },
+          "referenciaTipo": {
+            "type": "string"
+          },
+          "data": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
+          },
+          "referenciaFaseId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          }
+        }
+      },
+      "IdadeMaximaEmissaoInput": {
+        "required": [
+          "valor",
+          "unidade",
+          "referenciaTipo",
+          "data",
+          "referenciaFaseId"
+        ],
+        "type": "object",
+        "properties": {
+          "valor": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "unidade": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "referenciaTipo": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "data": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date"
+          },
+          "referenciaFaseId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          }
+        }
+      },
       "IFormFile": {
         "type": "string",
         "format": "binary"
@@ -4866,7 +4981,10 @@
           "consequenciaIndeferimento",
           "grupoSatisfacaoId",
           "condicoes",
-          "basesLegais"
+          "basesLegais",
+          "idadeMaximaEmissao",
+          "formatoPermitido",
+          "tamanhoMaximoBytes"
         ],
         "type": "object",
         "properties": {
@@ -4908,6 +5026,31 @@
             "items": {
               "$ref": "#/components/schemas/BaseLegalInput"
             }
+          },
+          "idadeMaximaEmissao": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/IdadeMaximaEmissaoInput"
+              }
+            ]
+          },
+          "formatoPermitido": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tamanhoMaximoBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
           }
         }
       },

--- a/openspec/changes/documentos-exigidos-gatilho-fase/tasks.md
+++ b/openspec/changes/documentos-exigidos-gatilho-fase/tasks.md
@@ -72,11 +72,11 @@ Fluxo obrigatório por PR (ver CLAUDE.md do repo + docs/guia-commits-e-integraca
 
 **Issue:** #893 · **Branch:** `feature/893-idade-formato-tamanho` · **PR:** `Closes #893` + ref. #554
 
-- [ ] 5.1 VO `IdadeMaximaEmissao` (tudo-nulo OU completo; âncoras de fase exigem fase viva com extremo não-nulo; DATA_SUBMISSAO válido aqui)
-- [ ] 5.2 `FormatoPermitido` + `TamanhoMaximoBytes` congelados na exigência (TipoDocumento classificatório)
-- [ ] 5.3 Guards backward de fase (CA-04): recusar remoção de fase referenciada e retirada de PermiteComplementacao
-- [ ] 5.4 `TimeProvider` injetado (convenção de código; ADR-0068 proposed)
-- [ ] 5.5 Testes: idade parcial recusada; imutabilidade de formato/tamanho por chamada; guards de fase
+- [x] 5.1 VO `IdadeMaximaEmissao` (tudo-nulo OU completo; âncoras de fase exigem fase viva com extremo não-nulo; DATA_SUBMISSAO válido aqui)
+- [x] 5.2 `FormatoPermitido` + `TamanhoMaximoBytes` congelados na exigência (TipoDocumento classificatório)
+- [x] 5.3 Guards backward de fase (CA-04): recusar remoção de fase referenciada e retirada de PermiteComplementacao
+- [x] 5.4 `TimeProvider` injetado (convenção de código; ADR-0068 proposed)
+- [x] 5.5 Testes: idade parcial recusada; imutabilidade de formato/tamanho por chamada; guards de fase
 - [ ] 5.6 Gates locais + revisão Codex; abrir PR `Closes #893`; `/review-pr` até zero pendências; merge sequencial
 
 ## 6. PR-e — Bloco rico V12 + resolvedor puro + gate real

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -340,11 +340,13 @@ public sealed class ProcessoSeletivoController : ControllerBase
     /// Substitui integralmente os documentos exigidos do processo (Story #554): fase,
     /// snapshot-copy do tipo de documento, aplicabilidade GERAL/CONDICIONAL,
     /// obrigatoriedade, consequência de indeferimento, grupo de satisfação, o gatilho
-    /// DNF (dinâmico/multivalorado para MODALIDADE/CONDICAO_ATENDIMENTO, PR-b) e a base
+    /// DNF (dinâmico/multivalorado para MODALIDADE/CONDICAO_ATENDIMENTO, PR-b), a base
     /// legal 1:N (PR-c) — validada apenas na FORMA aqui; o gate "≥1 RESOLVIDO por
-    /// exigência que determina resultado" é da publicação (ADR-0074). A idade/formato/
-    /// tamanho chega em task-irmã (PR-d). O <c>GET</c> vem do endpoint agregado
-    /// (<see cref="ObterPorId"/>) — não há rota aninhada própria de leitura.
+    /// exigência que determina resultado" é da publicação (ADR-0074) — e a idade máxima
+    /// de emissão/formato/tamanho do arquivo (PR-d, issue #893) — aviso, não bloqueio de
+    /// presença; congelados por chamada (substituição integral, não <i>merge</i> parcial).
+    /// O <c>GET</c> vem do endpoint agregado (<see cref="ObterPorId"/>) — não há rota
+    /// aninhada própria de leitura.
     /// </summary>
     [HttpPut("{id:guid}/documentos-exigidos")]
     [RequiresIdempotencyKey]

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -300,7 +300,11 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("DocumentoExigido.CondicionalVaziaDeterminaResultado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.condicional_vazia_determina_resultado", "Exigência CONDICIONAL sem condição viva que determina resultado nunca seria cobrada de ninguém")),
         new("DocumentoExigido.TipoDocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.tipo_documento_nao_encontrado", "Tipo de documento não encontrado ou não está mais vivo")),
         new("ProcessoSeletivo.ExigenciasDocumentaisNaoMaterializadas", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.exigencias_documentais_nao_materializadas", "Existem documentos exigidos configurados, mas o bloco de exigências do envelope ainda não foi materializado")),
-        new("FaseCronograma.ReferenciadaPorExigenciaViva", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fase_cronograma.referenciada_por_exigencia_viva", "O cronograma não pode ser redefinido enquanto existir documento exigido configurado")),
+        new("FaseCronograma.ReferenciadaPorExigenciaViva", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fase_cronograma.referenciada_por_exigencia_viva", "A fase removida do cronograma é referenciada por um documento exigido configurado")),
+        // Guards backward de fase (Story #554, PR-d, issue #893, CA-04) — complemento ao
+        // guard acima: retirar PermiteComplementacao de uma fase referenciada por
+        // exigência com consequência PENDENCIA_REENVIO.
+        new("FaseCronograma.PendenciaReenvioExigeComplementacao", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fase_cronograma.pendencia_reenvio_exige_complementacao", "A fase não pode perder PermiteComplementacao — é referenciada por documento exigido com consequência PENDENCIA_REENVIO")),
         // Gatilho DNF (Story #554, PR-b, issue #892) — CondicaoGatilho sobre PredicadoDnf,
         // ReferenciaTemporalFatos e a validação de publicação sem fallback silencioso
         // (ADR-0111:235-236, B-03 do plano).
@@ -319,6 +323,18 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("DocumentoExigidoBaseLegal.ReferenciaObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido_base_legal.referencia_obrigatoria", "A referência da base legal é obrigatória")),
         new("DocumentoExigidoBaseLegal.AbrangenciaObrigatoria", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido_base_legal.abrangencia_obrigatoria", "A abrangência da base legal é obrigatória")),
         new("DocumentoExigidoBaseLegal.StatusObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido_base_legal.status_obrigatorio", "O status da base legal é obrigatório")),
+        // Idade máxima de emissão + formato + tamanho (Story #554, PR-d, issue #893) —
+        // aviso, não bloqueio de presença (§1); coerência tudo-nulo OU completo do VO
+        // IdadeMaximaEmissao e a checagem eager de fase âncora (mesma família estrutural
+        // de ReferenciaTemporalFatos, PR-b, mas por exigência, não por processo).
+        new("DocumentoExigido.TamanhoMaximoBytesInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.tamanho_maximo_bytes_invalido", "O tamanho máximo em bytes, quando presente, deve ser maior que zero")),
+        new("IdadeMaximaEmissao.CamposIncoerentesComAusencia", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.idade_maxima_emissao.campos_incoerentes_com_ausencia", "Data e a fase âncora só são aceitas quando a idade máxima de emissão está definida")),
+        new("IdadeMaximaEmissao.CamposIncompletos", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.idade_maxima_emissao.campos_incompletos", "Valor, Unidade e ReferenciaTipo devem estar todos presentes, ou todos ausentes")),
+        new("IdadeMaximaEmissao.ValorInvalido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.idade_maxima_emissao.valor_invalido", "O valor da idade máxima de emissão deve ser maior que zero")),
+        new("IdadeMaximaEmissao.DataIncoerenteComTipo", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.idade_maxima_emissao.data_incoerente_com_tipo", "A data só é aceita (e é exigida) quando o tipo é DATA_ESPECIFICA")),
+        new("IdadeMaximaEmissao.FaseIncoerenteComTipo", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.idade_maxima_emissao.fase_incoerente_com_tipo", "A fase âncora só é aceita (e é exigida) quando o tipo é INICIO_FASE ou FIM_FASE")),
+        new("IdadeMaximaEmissao.FaseNaoPertenceAoProcesso", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.idade_maxima_emissao.fase_nao_pertence_ao_processo", "A fase âncora da idade máxima de emissão não pertence ao cronograma deste processo")),
+        new("IdadeMaximaEmissao.FaseExtremoAusente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.idade_maxima_emissao.fase_extremo_ausente", "A fase âncora da idade máxima de emissão não tem o extremo (início/fim) definido")),
         // Cursor.* codes vivem em Infrastructure.Core/Pagination/PaginationDomainErrorRegistration —
         // capability cross-module, registrada uma única vez via AddCursorPagination().
     ];

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -305,6 +305,9 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         // guard acima: retirar PermiteComplementacao de uma fase referenciada por
         // exigência com consequência PENDENCIA_REENVIO.
         new("FaseCronograma.PendenciaReenvioExigeComplementacao", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fase_cronograma.pendencia_reenvio_exige_complementacao", "A fase não pode perder PermiteComplementacao — é referenciada por documento exigido com consequência PENDENCIA_REENVIO")),
+        // Achado Codex P2 (PR #900, 4ª rodada) — uma permutação cíclica de Ordem entre
+        // fases retidas não tem ordem de UPDATE que a resolva num único SaveChanges.
+        new("FaseCronograma.PermutacaoDeOrdemNaoSuportada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fase_cronograma.permutacao_de_ordem_nao_suportada", "A redefinição do cronograma troca a Ordem entre fases já existentes formando um ciclo fechado, que não pode ser persistido em uma única chamada")),
         // Gatilho DNF (Story #554, PR-b, issue #892) — CondicaoGatilho sobre PredicadoDnf,
         // ReferenciaTemporalFatos e a validação de publicação sem fallback silencioso
         // (ADR-0111:235-236, B-03 do plano).

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommand.cs
@@ -24,6 +24,17 @@ public sealed record CondicaoGatilhoInput(int Clausula, string Fato, string Oper
 public sealed record BaseLegalInput(string Referencia, string Abrangencia, string Status, string? Observacao);
 
 /// <summary>
+/// Entrada da idade máxima de emissão (Story #554, PR-d, issue #893), usada por
+/// <see cref="ItemDocumentoExigidoInput"/>. Tudo-nulo (os 5 campos) é a variante "regra
+/// ausente" — mesmo padrão do comando de <c>DefinirReferenciaTemporalFatos</c> (PR-b), mas
+/// aninhado por item em vez de flat no comando, porque aqui a regra é 1 por exigência, não
+/// 1 por processo. <see cref="Unidade"/>/<see cref="ReferenciaTipo"/> são tokens canônicos
+/// (<see cref="Domain.Enums.UnidadeIdadeCodigo"/>/<see cref="Domain.Enums.ReferenciaTipoIdadeEmissaoCodigo"/>).
+/// </summary>
+public sealed record IdadeMaximaEmissaoInput(
+    int? Valor, string? Unidade, string? ReferenciaTipo, DateOnly? Data, Guid? ReferenciaFaseId);
+
+/// <summary>
 /// Entrada de uma exigência documental, usada por
 /// <see cref="DefinirDocumentosExigidosCommand"/>. O handler resolve
 /// <see cref="TipoDocumentoId"/> contra o módulo Configuração e congela os
@@ -31,7 +42,9 @@ public sealed record BaseLegalInput(string Referencia, string Abrangencia, strin
 /// declara diretamente. <see cref="Condicoes"/> vazia é coerente com GERAL e com
 /// CONDICIONAL "exigida de ninguém" (CA-01). <see cref="BasesLegais"/> vazia é um estado
 /// válido na escrita — só vira pendência na publicação, quando a exigência determina
-/// resultado (PR-c, CA-02).
+/// resultado (PR-c, CA-02). <see cref="IdadeMaximaEmissao"/>/<see cref="FormatoPermitido"/>/
+/// <see cref="TamanhoMaximoBytes"/> (PR-d, issue #893) são aviso, não bloqueio de
+/// presença — congelados por chamada, sem gate de publicação.
 /// </summary>
 public sealed record ItemDocumentoExigidoInput(
     Guid ExigidoNaFaseId,
@@ -41,14 +54,17 @@ public sealed record ItemDocumentoExigidoInput(
     string? ConsequenciaIndeferimento,
     Guid? GrupoSatisfacaoId,
     IReadOnlyList<CondicaoGatilhoInput> Condicoes,
-    IReadOnlyList<BaseLegalInput> BasesLegais);
+    IReadOnlyList<BaseLegalInput> BasesLegais,
+    IdadeMaximaEmissaoInput? IdadeMaximaEmissao,
+    string? FormatoPermitido,
+    int? TamanhoMaximoBytes);
 
 /// <summary>
 /// Substitui integralmente a coleção de documentos exigidos do processo (Story #554 —
 /// núcleo da PR-a: fase, snapshot-copy do tipo de documento, aplicabilidade GERAL/
 /// CONDICIONAL, obrigatoriedade, consequência de indeferimento e grupo de satisfação;
-/// gatilho DNF dinâmico/multivalorado da PR-b; base legal 1:N da PR-c). A idade/formato/
-/// tamanho (PR-d) chega em task-irmã.
+/// gatilho DNF dinâmico/multivalorado da PR-b; base legal 1:N da PR-c; idade de emissão/
+/// formato/tamanho da PR-d).
 /// </summary>
 public sealed record DefinirDocumentosExigidosCommand(
     Guid ProcessoSeletivoId,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommandHandler.cs
@@ -18,6 +18,12 @@ using Unifesspa.UniPlus.Configuracao.Contracts;
 /// (<c>IFatoCandidatoReader</c>, #846) estendido pelo domínio dinâmico da oferta do
 /// próprio processo (PR-b) — e delega a montagem/validação ao domínio.
 /// </summary>
+/// <remarks>
+/// <paramref name="clock"/> — Story #554, PR-d, issue #893 (ADR-0068 proposed): injetado
+/// por convenção do módulo, mesmo sem uso direto de "agora" nesta task — a avaliação em
+/// runtime da idade máxima de emissão (<c>IdadeMaximaEmissao</c>) é fora de escopo desta
+/// Story; este handler não abre exceção isolada à convenção só por não usá-lo ainda.
+/// </remarks>
 public static class DefinirDocumentosExigidosCommandHandler
 {
     public static async Task<Result<MutacaoAceita>> Handle(
@@ -26,6 +32,7 @@ public static class DefinirDocumentosExigidosCommandHandler
         ITipoDocumentoReader tipoDocumentoReader,
         IFatoCandidatoReader fatoCandidatoReader,
         ISelecaoUnitOfWork unitOfWork,
+        TimeProvider clock,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
@@ -33,6 +40,7 @@ public static class DefinirDocumentosExigidosCommandHandler
         ArgumentNullException.ThrowIfNull(tipoDocumentoReader);
         ArgumentNullException.ThrowIfNull(fatoCandidatoReader);
         ArgumentNullException.ThrowIfNull(unitOfWork);
+        ArgumentNullException.ThrowIfNull(clock);
 
         ProcessoSeletivo? processo = await processoSeletivoRepository
             .ObterParaMutacaoAsync(command.ProcessoSeletivoId, cancellationToken)
@@ -94,6 +102,18 @@ public static class DefinirDocumentosExigidosCommandHandler
                 return Result<MutacaoAceita>.Failure(basesLegaisResult.Error!);
             }
 
+            IdadeMaximaEmissaoInput? idade = input.IdadeMaximaEmissao;
+            Result<IdadeMaximaEmissao?> idadeMaximaEmissaoResult = IdadeMaximaEmissao.Criar(
+                idade?.Valor,
+                UnidadeIdadeCodigo.FromCodigo(idade?.Unidade),
+                ReferenciaTipoIdadeEmissaoCodigo.FromCodigo(idade?.ReferenciaTipo),
+                idade?.Data,
+                idade?.ReferenciaFaseId);
+            if (idadeMaximaEmissaoResult.IsFailure)
+            {
+                return Result<MutacaoAceita>.Failure(idadeMaximaEmissaoResult.Error!);
+            }
+
             Result<DocumentoExigido> itemResult = DocumentoExigido.Criar(
                 input.ExigidoNaFaseId,
                 tipoDocumento.Id,
@@ -105,7 +125,10 @@ public static class DefinirDocumentosExigidosCommandHandler
                 input.ConsequenciaIndeferimento,
                 input.GrupoSatisfacaoId,
                 condicoesResult.Value!,
-                basesLegaisResult.Value!);
+                basesLegaisResult.Value!,
+                idadeMaximaEmissaoResult.Value,
+                FormatoPermitidoCodigo.FromCodigo(input.FormatoPermitido),
+                input.TamanhoMaximoBytes);
             if (itemResult.IsFailure)
             {
                 return Result<MutacaoAceita>.Failure(itemResult.Error!);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoExigidoDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/DocumentoExigidoDto.cs
@@ -17,7 +17,17 @@ public sealed record DocumentoExigidoDto(
     string? ConsequenciaIndeferimento,
     Guid? GrupoSatisfacaoId,
     IReadOnlyList<CondicaoGatilhoDto> Condicoes,
-    IReadOnlyList<BaseLegalDto> BasesLegais);
+    IReadOnlyList<BaseLegalDto> BasesLegais,
+    IdadeMaximaEmissaoDto? IdadeMaximaEmissao,
+    string? FormatoPermitido,
+    int? TamanhoMaximoBytes);
+
+/// <summary>
+/// DTO de leitura de <see cref="Domain.ValueObjects.IdadeMaximaEmissao"/> (Story #554,
+/// PR-d, issue #893). Mesmo formato flat de <c>IdadeMaximaEmissaoInput</c> (comando de
+/// escrita) — round-trip GET→PUT direto.
+/// </summary>
+public sealed record IdadeMaximaEmissaoDto(int Valor, string Unidade, string ReferenciaTipo, DateOnly? Data, Guid? ReferenciaFaseId);
 
 /// <summary>
 /// DTO de leitura de <see cref="Domain.Entities.CondicaoGatilho"/> (Story #554, PR-b,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
@@ -195,7 +195,10 @@ public static class ObterProcessoSeletivoQueryHandler
         documento.ConsequenciaIndeferimento,
         documento.GrupoSatisfacaoId,
         [.. documento.Condicoes.OrderBy(c => c.Clausula).ThenBy(c => c.Id).Select(ProjectCondicaoGatilho)],
-        [.. documento.BasesLegais.OrderBy(b => b.Id).Select(ProjectBaseLegal)]);
+        [.. documento.BasesLegais.OrderBy(b => b.Id).Select(ProjectBaseLegal)],
+        ProjectIdadeMaximaEmissao(documento.IdadeMaximaEmissao),
+        documento.FormatoPermitido?.ToCodigo(),
+        documento.TamanhoMaximoBytes);
 
     // Valor como texto JSON canônico (GetRawText) — o mesmo PUT que aceita este DTO de
     // volta (DefinirDocumentosExigidosCommandHandler.InterpretarValor) reparseia texto
@@ -206,6 +209,9 @@ public static class ObterProcessoSeletivoQueryHandler
         condicao.Fato,
         condicao.Operador.ToCodigo(),
         condicao.Valor.GetRawText());
+
+    private static IdadeMaximaEmissaoDto? ProjectIdadeMaximaEmissao(IdadeMaximaEmissao? idade) =>
+        idade is null ? null : new IdadeMaximaEmissaoDto(idade.Valor, idade.Unidade.ToCodigo(), idade.ReferenciaTipo.ToCodigo(), idade.Data, idade.ReferenciaFaseId);
 
     private static BaseLegalDto ProjectBaseLegal(DocumentoExigidoBaseLegal baseLegal) => new(
         baseLegal.Id,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
@@ -34,6 +34,14 @@ public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidato
     private const int ReferenciaBaseLegalMaxLength = 500;
     private const int ObservacaoBaseLegalMaxLength = 1000;
 
+    // Story #554/issue #893 (PR-d) — idade máxima de emissão, formato e tamanho.
+    private static readonly string[] UnidadesIdadeValidas = ["DIAS", "MESES", "ANOS"];
+
+    private static readonly string[] ReferenciaTiposIdadeEmissaoValidos =
+        ["FIM_INSCRICAO", "INICIO_FASE", "FIM_FASE", "DATA_ESPECIFICA", "DATA_SUBMISSAO"];
+
+    private static readonly string[] FormatosPermitidosValidos = ["PDF", "JPEG", "PNG"];
+
     public DefinirDocumentosExigidosCommandValidator()
     {
         RuleFor(x => x.ProcessoSeletivoId)
@@ -119,6 +127,34 @@ public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidato
                     .When(b => b.Observacao is not null)
                     .WithMessage($"A observação da base legal deve ter no máximo {ObservacaoBaseLegalMaxLength} caracteres.");
             });
+
+            // A coerência tudo-nulo OU completo (Valor/Unidade/ReferenciaTipo) é do
+            // domínio (IdadeMaximaEmissao.Criar) — aqui só a forma de cada campo NÃO
+            // NULO, mesmo espírito de DefinirReferenciaTemporalFatosCommandValidator (PR-b).
+            item.RuleFor(i => i.IdadeMaximaEmissao!.Valor)
+                .GreaterThan(0)
+                .When(i => i.IdadeMaximaEmissao?.Valor is not null)
+                .WithMessage("O valor da idade máxima de emissão deve ser maior que zero.");
+
+            item.RuleFor(i => i.IdadeMaximaEmissao!.Unidade)
+                .Must(valor => UnidadesIdadeValidas.Contains(valor, StringComparer.Ordinal))
+                .When(i => i.IdadeMaximaEmissao?.Unidade is not null)
+                .WithMessage($"Unidade da idade máxima de emissão deve ser um de: {string.Join(", ", UnidadesIdadeValidas)}.");
+
+            item.RuleFor(i => i.IdadeMaximaEmissao!.ReferenciaTipo)
+                .Must(valor => ReferenciaTiposIdadeEmissaoValidos.Contains(valor, StringComparer.Ordinal))
+                .When(i => i.IdadeMaximaEmissao?.ReferenciaTipo is not null)
+                .WithMessage($"ReferenciaTipo da idade máxima de emissão deve ser um de: {string.Join(", ", ReferenciaTiposIdadeEmissaoValidos)}.");
+
+            item.RuleFor(i => i.FormatoPermitido)
+                .Must(valor => FormatosPermitidosValidos.Contains(valor, StringComparer.Ordinal))
+                .When(i => i.FormatoPermitido is not null)
+                .WithMessage($"Formato permitido deve ser um de: {string.Join(", ", FormatosPermitidosValidos)}.");
+
+            item.RuleFor(i => i.TamanhoMaximoBytes)
+                .GreaterThan(0)
+                .When(i => i.TamanhoMaximoBytes is not null)
+                .WithMessage("O tamanho máximo em bytes, quando presente, deve ser maior que zero.");
         });
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Enums;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 /// <summary>
 /// Exigência documental de um <see cref="ProcessoSeletivo"/> (Story #554): declara qual
@@ -60,6 +61,18 @@ public sealed class DocumentoExigido : EntityBase
     /// <summary>Escopo processo+fase — documentos do mesmo grupo são satisfeitos por uma única apresentação (semântica plena na PR-e).</summary>
     public Guid? GrupoSatisfacaoId { get; private set; }
 
+    /// <summary>
+    /// Idade máxima de emissão do ARQUIVO apresentado (Story #554, PR-d) — aviso, não
+    /// bloqueio de presença; a avaliação em runtime é fora de escopo desta Story.
+    /// </summary>
+    public IdadeMaximaEmissao? IdadeMaximaEmissao { get; private set; }
+
+    /// <summary>Formato aceito para a apresentação (Story #554, PR-d) — congelado na exigência, não no <c>TipoDocumento</c>.</summary>
+    public FormatoPermitido? FormatoPermitido { get; private set; }
+
+    /// <summary>Tamanho máximo em bytes do arquivo apresentado (Story #554, PR-d) — congelado na exigência.</summary>
+    public int? TamanhoMaximoBytes { get; private set; }
+
     private readonly List<CondicaoGatilho> _condicoes = [];
 
     /// <summary>Gatilho DNF (Story #554, PR-b) — vazia significa "sem gatilho": GERAL é sempre exigida, CONDICIONAL vazia é exigida de ninguém.</summary>
@@ -83,7 +96,10 @@ public sealed class DocumentoExigido : EntityBase
         string? consequenciaIndeferimento,
         Guid? grupoSatisfacaoId,
         IReadOnlyList<CondicaoGatilho> condicoes,
-        IReadOnlyList<DocumentoExigidoBaseLegal> basesLegais)
+        IReadOnlyList<DocumentoExigidoBaseLegal> basesLegais,
+        IdadeMaximaEmissao? idadeMaximaEmissao,
+        FormatoPermitido? formatoPermitido,
+        int? tamanhoMaximoBytes)
     {
         ArgumentNullException.ThrowIfNull(condicoes);
         ArgumentNullException.ThrowIfNull(basesLegais);
@@ -123,6 +139,13 @@ public sealed class DocumentoExigido : EntityBase
                 $"Consequência de indeferimento '{consequenciaNormalizada}' inválida — esperado um de: {string.Join(", ", ConsequenciasValidas)}."));
         }
 
+        if (tamanhoMaximoBytes is <= 0)
+        {
+            return Result<DocumentoExigido>.Failure(new DomainError(
+                "DocumentoExigido.TamanhoMaximoBytesInvalido",
+                "O tamanho máximo em bytes, quando presente, deve ser maior que zero."));
+        }
+
         DocumentoExigido documento = new()
         {
             ExigidoNaFaseId = exigidoNaFaseId,
@@ -134,6 +157,9 @@ public sealed class DocumentoExigido : EntityBase
             Obrigatorio = obrigatorio,
             ConsequenciaIndeferimento = consequenciaNormalizada,
             GrupoSatisfacaoId = grupoSatisfacaoId,
+            IdadeMaximaEmissao = idadeMaximaEmissao,
+            FormatoPermitido = formatoPermitido,
+            TamanhoMaximoBytes = tamanhoMaximoBytes,
         };
 
         // CA-01 (Story #554, issue #547/#892): GERAL nunca convive com condição viva —

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/FaseCronograma.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/FaseCronograma.cs
@@ -226,11 +226,13 @@ public sealed class FaseCronograma : EntityBase
 
     /// <summary>
     /// Atualiza os dados da MESMA fase (mesmo <see cref="EntityBase.Id"/>) em vez de
-    /// recriá-la — usado pela reposição da configuração congelada
-    /// (<see cref="ProcessoSeletivo.RestaurarConfiguracaoCongelada"/>) para reconciliar
-    /// por <see cref="Ordem"/> (a chave estável de uma fase dentro do cronograma; o
-    /// <c>Id</c> não é congelado no envelope — §3.7 — logo nunca sobrevive à
-    /// reidratação).
+    /// recriá-la — usado tanto pela reposição da configuração congelada
+    /// (<see cref="ProcessoSeletivo.RestaurarConfiguracaoCongelada"/>, reconciliação por
+    /// <see cref="Ordem"/> — o <c>Id</c> não é congelado no envelope, §3.7, logo nunca
+    /// sobrevive à reidratação) quanto pela redefinição ao vivo do cronograma
+    /// (<see cref="ProcessoSeletivo.DefinirCronogramaFases"/>, reconciliação por
+    /// <see cref="FaseCanonicaOrigemId"/> — a identidade estável de uma fase; aqui
+    /// <paramref name="ordem"/> PODE mudar, ao contrário do caminho de restauração).
     /// </summary>
     /// <remarks>
     /// Sem esta reconciliação, repor o cronograma faria <c>Clear()</c> + <c>Add</c> de
@@ -244,6 +246,7 @@ public sealed class FaseCronograma : EntityBase
     /// </remarks>
     internal void AtualizarSnapshot(
         Guid faseCanonicaOrigemId,
+        int ordem,
         string codigo,
         string donoInstitucional,
         OrigemDataFase origemData,
@@ -264,6 +267,7 @@ public sealed class FaseCronograma : EntityBase
         ArgumentNullException.ThrowIfNull(bancasRequeridas);
 
         FaseCanonicaOrigemId = faseCanonicaOrigemId;
+        Ordem = ordem;
         Codigo = codigo.Trim();
         DonoInstitucional = donoInstitucional.Trim();
         OrigemData = origemData;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -473,22 +473,6 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 "O processo deve ter ao menos uma fase no cronograma."));
         }
 
-        // Story #554/issue #547 (CA-04, guard parcial — a reconciliação por chave estável
-        // é da PR-d/#893): cada chamada aqui recria TODAS as fases com Id novo (mesmo
-        // padrão de DefinirDocumentosExigidos/DefinirEtapas — nenhum FaseCronogramaInput
-        // aceita Id, diferente de EtapaProcessoInput.Id opcional). Isso significa que a
-        // FK Restrict de documentos_exigidos.exigido_na_fase_id (DocumentoExigidoConfiguration)
-        // sempre estouraria DbUpdateException não tratada ao reconfigurar o cronograma
-        // enquanto existir exigência viva — a guarda troca o 500 por um 422 acionável. A
-        // PR-d reconcilia fases por chave estável (Ordem/FaseCanonicaOrigemId, mesmo
-        // padrão de AplicarGrafo) para permitir editar o cronograma sem apagar exigências.
-        if (_documentosExigidos.Count > 0)
-        {
-            return Result.Failure(new DomainError(
-                "FaseCronograma.ReferenciadaPorExigenciaViva",
-                "Existem documentos exigidos configurados referenciando o cronograma atual — remova-os antes de redefinir as fases, ou aguarde a reconciliação por chave estável (Story #554, PR-d)."));
-        }
-
         List<int> ordens = [.. fases.Select(f => f.Ordem)];
         if (ordens.Distinct().Count() != ordens.Count)
         {
@@ -503,6 +487,40 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             return Result.Failure(new DomainError(
                 "ProcessoSeletivo.FaseCanonicaDuplicada",
                 "A mesma fase canônica não pode aparecer duas vezes no cronograma."));
+        }
+
+        // Story #554/issue #893 (PR-d, CA-04): reconciliação por Ordem — a chave estável
+        // de uma fase dentro do cronograma (mesmo padrão de AplicarGrafo/
+        // FaseCronograma.AtualizarSnapshot). Substitui o guard bruto da PR-a/#547 (que
+        // bloqueava QUALQUER redefinição enquanto existisse exigência viva) por dois
+        // guards precisos: só recusa quando uma fase REALMENTE removida (Ordem que
+        // desaparece) é referenciada por exigência viva, ou quando uma fase SOBREVIVENTE
+        // perde PermiteComplementacao mas é referenciada por exigência PENDENCIA_REENVIO.
+        Dictionary<int, FaseCronograma> fasesAntigasPorOrdem = _cronogramaFases.ToDictionary(f => f.Ordem);
+        Dictionary<int, FaseCronograma> fasesNovasPorOrdem = fases.ToDictionary(f => f.Ordem);
+
+        foreach (FaseCronograma antiga in fasesAntigasPorOrdem.Values)
+        {
+            if (!fasesNovasPorOrdem.TryGetValue(antiga.Ordem, out FaseCronograma? nova))
+            {
+                if (_documentosExigidos.Any(d => d.ExigidoNaFaseId == antiga.Id))
+                {
+                    return Result.Failure(new DomainError(
+                        "FaseCronograma.ReferenciadaPorExigenciaViva",
+                        $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) está sendo removida do cronograma, mas é referenciada por um documento exigido configurado."));
+                }
+
+                continue;
+            }
+
+            bool perdeuPermiteComplementacao = antiga.PermiteComplementacao && !nova.PermiteComplementacao;
+            if (perdeuPermiteComplementacao
+                && _documentosExigidos.Any(d => d.ExigidoNaFaseId == antiga.Id && d.ConsequenciaIndeferimento == "PENDENCIA_REENVIO"))
+            {
+                return Result.Failure(new DomainError(
+                    "FaseCronograma.PendenciaReenvioExigeComplementacao",
+                    $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) não pode perder PermiteComplementacao — é referenciada por um documento exigido com consequência PENDENCIA_REENVIO."));
+            }
         }
 
         // §3.5 — direção "fase de avaliação sem etapa": bloqueante e IMEDIATA (a fase que
@@ -553,8 +571,44 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             }
         }
 
+        // Reconciliação por Ordem (mesmo padrão de AplicarGrafo): quando a nova fase
+        // reocupa a Ordem de uma fase viva, reusa a instância TRACKED (atualizando-a no
+        // lugar via AtualizarSnapshot) em vez de substituí-la por uma instância nova —
+        // preserva o Id, o que é o que faz o guard acima ("fase removida") ser preciso
+        // (só remove de fato quando a Ordem desaparece) e evita, por consequência, que a
+        // FK Restrict de documentos_exigidos.exigido_na_fase_id estoure em toda
+        // redefinição, mesmo sem exigência alguma referenciando a fase alterada.
+        List<FaseCronograma> resultantes = [];
+        foreach (FaseCronograma nova in fases)
+        {
+            if (fasesAntigasPorOrdem.TryGetValue(nova.Ordem, out FaseCronograma? existente))
+            {
+                existente.AtualizarSnapshot(
+                    nova.FaseCanonicaOrigemId,
+                    nova.Codigo,
+                    nova.DonoInstitucional,
+                    nova.OrigemData,
+                    nova.AgrupaEtapas,
+                    nova.PermiteComplementacao,
+                    nova.ProduzResultado,
+                    nova.ResultadoDefinitivo,
+                    nova.ColetaInscricao,
+                    nova.Inicio,
+                    nova.Fim,
+                    nova.AtoProduzidoCodigo,
+                    nova.AtoProduzidoEfeitoIrreversivel,
+                    [.. nova.BancasRequeridas],
+                    nova.RegraRecurso);
+                resultantes.Add(existente);
+            }
+            else
+            {
+                resultantes.Add(nova);
+            }
+        }
+
         _cronogramaFases.Clear();
-        foreach (FaseCronograma fase in fases)
+        foreach (FaseCronograma fase in resultantes)
         {
             fase.VincularProcesso(Id);
             _cronogramaFases.Add(fase);
@@ -593,6 +647,30 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 return Result.Failure(new DomainError(
                     "DocumentoExigido.FaseNaoPertenceAoProcesso",
                     $"A fase {item.ExigidoNaFaseId} não pertence ao cronograma deste processo."));
+            }
+
+            // Story #554/issue #893 (PR-d): âncora de fase de IdadeMaximaEmissao — mesma
+            // família de checagem estrutural de ReferenciaTemporalFatos (PR-b), mas EAGER
+            // (na escrita, não na publicação): a regra vive na exigência, e a exigência já
+            // está sendo escrita agora — não há razão para adiar. Fase viva do MESMO
+            // processo com o extremo correspondente não-nulo (sem fallback silencioso).
+            if (item.IdadeMaximaEmissao is { ReferenciaFaseId: { } referenciaFaseId } idade)
+            {
+                FaseCronograma? faseAncora = _cronogramaFases.FirstOrDefault(f => f.Id == referenciaFaseId);
+                if (faseAncora is null)
+                {
+                    return Result.Failure(new DomainError(
+                        "IdadeMaximaEmissao.FaseNaoPertenceAoProcesso",
+                        $"A fase âncora {referenciaFaseId} da idade máxima de emissão não pertence ao cronograma deste processo."));
+                }
+
+                DateTimeOffset? extremo = idade.ReferenciaTipo == ReferenciaTipoIdadeEmissao.InicioFase ? faseAncora.Inicio : faseAncora.Fim;
+                if (extremo is null)
+                {
+                    return Result.Failure(new DomainError(
+                        "IdadeMaximaEmissao.FaseExtremoAusente",
+                        $"A fase âncora da idade máxima de emissão não tem {(idade.ReferenciaTipo == ReferenciaTipoIdadeEmissao.InicioFase ? "Início" : "Fim")} definido — sem fallback silencioso."));
+                }
             }
         }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -489,38 +489,40 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 "A mesma fase canônica não pode aparecer duas vezes no cronograma."));
         }
 
-        // Story #554/issue #893 (PR-d, CA-04): reconciliação por (Ordem, FaseCanonicaOrigemId)
-        // — Ordem sozinha (mesma chave usada por AplicarGrafo/FaseCronograma.AtualizarSnapshot)
-        // não basta: achado Codex P2 (PR #900) — sem exigir também o mesmo
-        // FaseCanonicaOrigemId, uma redefinição que TROCA qual fase ocupa uma Ordem (ex.:
-        // "INSCRICAO" vira "ANALISE" na Ordem 1) seria tratada como "a mesma fase, só
-        // atualizada": o Id seria reusado e retargetado silenciosamente, sem passar pelo
-        // guard "fase removida". Exigir as DUAS chaves distingue "editar a mesma fase" de
-        // "trocar qual fase ocupa o slot" — e é a mesma checagem, em ambos os sentidos, que
-        // decide se uma fase é tratada como removida (guard) ou reconciliada (Id
-        // preservado, abaixo). Substitui o guard bruto da PR-a/#547 (que bloqueava QUALQUER
-        // redefinição enquanto existisse exigência viva) por guards precisos: só recusa
-        // quando uma fase REALMENTE removida/trocada é referenciada por exigência viva
-        // (ExigidoNaFaseId ou IdadeMaximaEmissao.ReferenciaFaseId), ou quando uma fase
-        // SOBREVIVENTE perde PermiteComplementacao/o extremo âncora sendo referenciada.
-        Dictionary<int, FaseCronograma> fasesAntigasPorOrdem = _cronogramaFases.ToDictionary(f => f.Ordem);
-        Dictionary<int, FaseCronograma> fasesNovasPorOrdem = fases.ToDictionary(f => f.Ordem);
+        // Story #554/issue #893 (PR-d, CA-04): reconciliação por FaseCanonicaOrigemId —
+        // achado Codex P2 (PR #900, 4ª rodada). FaseCanonicaOrigemId é a identidade ESTÁVEL
+        // de uma fase no cronograma (índice único ux_fases_cronograma_processo_fase_canonica);
+        // Ordem é só um ATRIBUTO mutável dela (uma fase pode ser reordenada sem deixar de
+        // ser "a mesma fase"). Casar por Ordem (como as rodadas anteriores fizeram) confundia
+        // "reordenar" com "trocar de fase": uma redefinição que só troca a POSIÇÃO de duas
+        // fases já existentes (A@1,B@2 -> B@1,A@2) fazia a reconciliação RETARGETAR o
+        // FaseCanonicaOrigemId das linhas rastreadas, e o EF não consegue ordenar as duas
+        // instruções UPDATE resultantes (dependência circular: cada uma precisa que a outra
+        // rode primeiro para liberar o valor único) — estourava InvalidOperationException no
+        // SaveChanges, fora do Result pattern. Casar por identidade evita esse retargeting
+        // desnecessário; o guard de permutação cíclica de Ordem (abaixo) cobre o caso
+        // residual em que a PRÓPRIA Ordem trocada forma um ciclo fechado entre fases
+        // retidas. Substitui o guard bruto da PR-a/#547 (que bloqueava QUALQUER redefinição
+        // enquanto existisse exigência viva) por guards precisos: só recusa quando uma fase
+        // REALMENTE removida é referenciada por exigência viva (ExigidoNaFaseId ou
+        // IdadeMaximaEmissao.ReferenciaFaseId), ou quando uma fase SOBREVIVENTE perde
+        // PermiteComplementacao/o extremo âncora sendo referenciada.
+        Dictionary<Guid, FaseCronograma> fasesAntigasPorOrigem = _cronogramaFases.ToDictionary(f => f.FaseCanonicaOrigemId);
+        Dictionary<Guid, FaseCronograma> fasesNovasPorOrigem = fases.ToDictionary(f => f.FaseCanonicaOrigemId);
 
-        foreach (FaseCronograma antiga in fasesAntigasPorOrdem.Values)
+        foreach (FaseCronograma antiga in fasesAntigasPorOrigem.Values)
         {
-            if (!fasesNovasPorOrdem.TryGetValue(antiga.Ordem, out FaseCronograma? nova)
-                || nova.FaseCanonicaOrigemId != antiga.FaseCanonicaOrigemId)
+            if (!fasesNovasPorOrigem.TryGetValue(antiga.FaseCanonicaOrigemId, out FaseCronograma? nova))
             {
-                // Achado Codex P2 (PR #900): a fase removida (ou trocada na mesma Ordem)
-                // pode ser referenciada por ExigidoNaFaseId OU por
+                // A fase removida pode ser referenciada por ExigidoNaFaseId OU por
                 // IdadeMaximaEmissao.ReferenciaFaseId (PR-d) — os dois são vínculos
-                // independentes, e ambos ficariam órfãos/retargetados silenciosamente.
+                // independentes, e ambos ficariam órfãos silenciosamente.
                 if (_documentosExigidos.Any(d => d.ExigidoNaFaseId == antiga.Id
                     || d.IdadeMaximaEmissao?.ReferenciaFaseId == antiga.Id))
                 {
                     return Result.Failure(new DomainError(
                         "FaseCronograma.ReferenciadaPorExigenciaViva",
-                        $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) está sendo removida (ou substituída por outra fase canônica) do cronograma, mas é referenciada por um documento exigido configurado."));
+                        $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) está sendo removida do cronograma, mas é referenciada por um documento exigido configurado."));
                 }
 
                 continue;
@@ -554,6 +556,69 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 return Result.Failure(new DomainError(
                     "IdadeMaximaEmissao.FaseExtremoAusente",
                     $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) não pode perder o extremo usado como âncora de idade máxima de emissão por um documento exigido configurado."));
+            }
+        }
+
+        // Achado Codex P2 (PR #900, 4ª rodada): mesmo casando por identidade estável, uma
+        // PERMUTAÇÃO CÍCLICA de Ordem entre fases retidas (ex.: A@1,B@2 -> A@2,B@1, ou um
+        // ciclo de 3+) ainda pede que linhas TROQUEM valores cobertos pelo índice único
+        // ux_fases_cronograma_processo_ordem entre si — nenhuma ordem de UPDATE resolve um
+        // ciclo fechado num único SaveChanges (cada linha depende da outra liberar o valor
+        // primeiro). Detecta o ciclo em termos puramente de domínio (sem conhecer EF/SQL) e
+        // recusa com um erro nomeado, em vez de deixar a exceção do EF escapar do Result
+        // pattern. Uma cadeia que termina numa Ordem livre (nunca usada) ou na Ordem de uma
+        // fase REMOVIDA (que libera a linha via DELETE) não é um ciclo — só o é quando a
+        // cadeia volta a uma fase já visitada NA MESMA caminhada.
+        Dictionary<int, Guid> origemAntigaPorOrdem = [];
+        foreach (FaseCronograma antiga in fasesAntigasPorOrigem.Values)
+        {
+            if (fasesNovasPorOrigem.ContainsKey(antiga.FaseCanonicaOrigemId))
+            {
+                origemAntigaPorOrdem[antiga.Ordem] = antiga.FaseCanonicaOrigemId;
+            }
+        }
+
+        Dictionary<Guid, int> estadoDoNo = []; // 1 = na caminhada atual, 2 = concluído sem ciclo
+        foreach (Guid origemInicial in fasesAntigasPorOrigem.Keys)
+        {
+            if (estadoDoNo.ContainsKey(origemInicial))
+            {
+                continue;
+            }
+
+            List<Guid> caminho = [];
+            Guid? noAtual = origemInicial;
+            bool cicloFechado = false;
+
+            while (noAtual is { } no)
+            {
+                if (estadoDoNo.TryGetValue(no, out int estado))
+                {
+                    cicloFechado = estado == 1;
+                    break;
+                }
+
+                if (!fasesNovasPorOrigem.TryGetValue(no, out FaseCronograma? nova)
+                    || nova.Ordem == fasesAntigasPorOrigem[no].Ordem)
+                {
+                    break;
+                }
+
+                estadoDoNo[no] = 1;
+                caminho.Add(no);
+                noAtual = origemAntigaPorOrdem.TryGetValue(nova.Ordem, out Guid proximo) ? proximo : null;
+            }
+
+            foreach (Guid visitado in caminho)
+            {
+                estadoDoNo[visitado] = 2;
+            }
+
+            if (cicloFechado)
+            {
+                return Result.Failure(new DomainError(
+                    "FaseCronograma.PermutacaoDeOrdemNaoSuportada",
+                    "A redefinição do cronograma troca a Ordem entre fases já existentes formando um ciclo fechado (ex.: uma fase assume a Ordem de outra, que assume a Ordem da primeira) — isso não pode ser persistido em uma única chamada. Mova uma das fases para uma Ordem livre numa chamada separada antes de fechar o ciclo."));
             }
         }
 
@@ -605,26 +670,22 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             }
         }
 
-        // Reconciliação por Ordem (achado Codex P2, PR #900, 3ª rodada): a chave de MATCH
-        // FÍSICO da linha é só Ordem — mais larga que o par (Ordem, FaseCanonicaOrigemId)
-        // do guard acima, DE PROPÓSITO. O guard já provou, para todo slot que chega aqui,
-        // que ou (a) é genuinamente a mesma fase (mesmo FaseCanonicaOrigemId), ou (b) é uma
-        // troca de fase na mesma Ordem SEM nenhuma exigência viva referenciando a fase
-        // antiga (senão o guard já teria recusado, acima). Nos dois casos é seguro adotar a
-        // instância TRACKED existente (retargetando-a via AtualizarSnapshot) em vez de
-        // Add(nova) + deixar a antiga para o Clear() varrer: sem isso, um Clear()+Add() com
-        // Id novo na mesma Ordem pode colidir com o índice único
-        // (ProcessoSeletivoId, Ordem) por causa da ordem DELETE/INSERT que o EF decide no
-        // SaveChanges — o mesmo problema que a reconciliação evita no caso normal (mesma
-        // fase). Retargetar aqui é seguro justamente porque nada vivo apontava para o Id
-        // reciclado.
+        // Reconciliação por FaseCanonicaOrigemId (achado Codex P2, PR #900, 4ª rodada) — a
+        // mesma chave de identidade do guard acima. Reusa a instância TRACKED existente
+        // (retargetando-a via AtualizarSnapshot, preservando o Id) sempre que a fase
+        // canônica persiste no cronograma, independente de Ordem: evita tanto FK Restrict
+        // de documentos_exigidos.exigido_na_fase_id quanto o retargeting desnecessário do
+        // FaseCanonicaOrigemId que causava a colisão descrita acima — a essa altura, o
+        // guard de permutação cíclica já garantiu que a Ordem final de cada linha retida
+        // não fecha um ciclo com outra linha retida.
         List<FaseCronograma> resultantes = [];
         foreach (FaseCronograma nova in fases)
         {
-            if (fasesAntigasPorOrdem.TryGetValue(nova.Ordem, out FaseCronograma? existente))
+            if (fasesAntigasPorOrigem.TryGetValue(nova.FaseCanonicaOrigemId, out FaseCronograma? existente))
             {
                 existente.AtualizarSnapshot(
                     nova.FaseCanonicaOrigemId,
+                    nova.Ordem,
                     nova.Codigo,
                     nova.DonoInstitucional,
                     nova.OrigemData,
@@ -1839,6 +1900,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             {
                 viva.AtualizarSnapshot(
                     congelada.FaseCanonicaOrigemId,
+                    congelada.Ordem,
                     congelada.Codigo,
                     congelada.DonoInstitucional,
                     congelada.OrigemData,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -489,29 +489,38 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 "A mesma fase canônica não pode aparecer duas vezes no cronograma."));
         }
 
-        // Story #554/issue #893 (PR-d, CA-04): reconciliação por Ordem — a chave estável
-        // de uma fase dentro do cronograma (mesmo padrão de AplicarGrafo/
-        // FaseCronograma.AtualizarSnapshot). Substitui o guard bruto da PR-a/#547 (que
-        // bloqueava QUALQUER redefinição enquanto existisse exigência viva) por dois
-        // guards precisos: só recusa quando uma fase REALMENTE removida (Ordem que
-        // desaparece) é referenciada por exigência viva, ou quando uma fase SOBREVIVENTE
-        // perde PermiteComplementacao mas é referenciada por exigência PENDENCIA_REENVIO.
+        // Story #554/issue #893 (PR-d, CA-04): reconciliação por (Ordem, FaseCanonicaOrigemId)
+        // — Ordem sozinha (mesma chave usada por AplicarGrafo/FaseCronograma.AtualizarSnapshot)
+        // não basta: achado Codex P2 (PR #900) — sem exigir também o mesmo
+        // FaseCanonicaOrigemId, uma redefinição que TROCA qual fase ocupa uma Ordem (ex.:
+        // "INSCRICAO" vira "ANALISE" na Ordem 1) seria tratada como "a mesma fase, só
+        // atualizada": o Id seria reusado e retargetado silenciosamente, sem passar pelo
+        // guard "fase removida". Exigir as DUAS chaves distingue "editar a mesma fase" de
+        // "trocar qual fase ocupa o slot" — e é a mesma checagem, em ambos os sentidos, que
+        // decide se uma fase é tratada como removida (guard) ou reconciliada (Id
+        // preservado, abaixo). Substitui o guard bruto da PR-a/#547 (que bloqueava QUALQUER
+        // redefinição enquanto existisse exigência viva) por guards precisos: só recusa
+        // quando uma fase REALMENTE removida/trocada é referenciada por exigência viva
+        // (ExigidoNaFaseId ou IdadeMaximaEmissao.ReferenciaFaseId), ou quando uma fase
+        // SOBREVIVENTE perde PermiteComplementacao/o extremo âncora sendo referenciada.
         Dictionary<int, FaseCronograma> fasesAntigasPorOrdem = _cronogramaFases.ToDictionary(f => f.Ordem);
         Dictionary<int, FaseCronograma> fasesNovasPorOrdem = fases.ToDictionary(f => f.Ordem);
 
         foreach (FaseCronograma antiga in fasesAntigasPorOrdem.Values)
         {
-            if (!fasesNovasPorOrdem.TryGetValue(antiga.Ordem, out FaseCronograma? nova))
+            if (!fasesNovasPorOrdem.TryGetValue(antiga.Ordem, out FaseCronograma? nova)
+                || nova.FaseCanonicaOrigemId != antiga.FaseCanonicaOrigemId)
             {
-                // Achado Codex P2 (PR #900): a fase removida pode ser referenciada por
-                // ExigidoNaFaseId OU por IdadeMaximaEmissao.ReferenciaFaseId (PR-d) — os
-                // dois são vínculos independentes, e ambos ficariam órfãos.
+                // Achado Codex P2 (PR #900): a fase removida (ou trocada na mesma Ordem)
+                // pode ser referenciada por ExigidoNaFaseId OU por
+                // IdadeMaximaEmissao.ReferenciaFaseId (PR-d) — os dois são vínculos
+                // independentes, e ambos ficariam órfãos/retargetados silenciosamente.
                 if (_documentosExigidos.Any(d => d.ExigidoNaFaseId == antiga.Id
                     || d.IdadeMaximaEmissao?.ReferenciaFaseId == antiga.Id))
                 {
                     return Result.Failure(new DomainError(
                         "FaseCronograma.ReferenciadaPorExigenciaViva",
-                        $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) está sendo removida do cronograma, mas é referenciada por um documento exigido configurado."));
+                        $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) está sendo removida (ou substituída por outra fase canônica) do cronograma, mas é referenciada por um documento exigido configurado."));
                 }
 
                 continue;
@@ -596,17 +605,17 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             }
         }
 
-        // Reconciliação por Ordem (mesmo padrão de AplicarGrafo): quando a nova fase
-        // reocupa a Ordem de uma fase viva, reusa a instância TRACKED (atualizando-a no
-        // lugar via AtualizarSnapshot) em vez de substituí-la por uma instância nova —
-        // preserva o Id, o que é o que faz o guard acima ("fase removida") ser preciso
-        // (só remove de fato quando a Ordem desaparece) e evita, por consequência, que a
-        // FK Restrict de documentos_exigidos.exigido_na_fase_id estoure em toda
-        // redefinição, mesmo sem exigência alguma referenciando a fase alterada.
+        // Reconciliação por (Ordem, FaseCanonicaOrigemId) — mesmo par de chaves do guard
+        // acima (achado Codex P2, PR #900): só reusa a instância TRACKED (atualizando-a no
+        // lugar via AtualizarSnapshot) quando as DUAS chaves batem — preserva o Id apenas
+        // quando é genuinamente "a mesma fase, dados atualizados", nunca quando é "outra
+        // fase ocupando o mesmo slot". Evita, no caso normal (mesma fase), que a FK
+        // Restrict de documentos_exigidos.exigido_na_fase_id estoure em toda redefinição.
         List<FaseCronograma> resultantes = [];
         foreach (FaseCronograma nova in fases)
         {
-            if (fasesAntigasPorOrdem.TryGetValue(nova.Ordem, out FaseCronograma? existente))
+            if (fasesAntigasPorOrdem.TryGetValue(nova.Ordem, out FaseCronograma? existente)
+                && existente.FaseCanonicaOrigemId == nova.FaseCanonicaOrigemId)
             {
                 existente.AtualizarSnapshot(
                     nova.FaseCanonicaOrigemId,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -605,17 +605,23 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             }
         }
 
-        // Reconciliação por (Ordem, FaseCanonicaOrigemId) — mesmo par de chaves do guard
-        // acima (achado Codex P2, PR #900): só reusa a instância TRACKED (atualizando-a no
-        // lugar via AtualizarSnapshot) quando as DUAS chaves batem — preserva o Id apenas
-        // quando é genuinamente "a mesma fase, dados atualizados", nunca quando é "outra
-        // fase ocupando o mesmo slot". Evita, no caso normal (mesma fase), que a FK
-        // Restrict de documentos_exigidos.exigido_na_fase_id estoure em toda redefinição.
+        // Reconciliação por Ordem (achado Codex P2, PR #900, 3ª rodada): a chave de MATCH
+        // FÍSICO da linha é só Ordem — mais larga que o par (Ordem, FaseCanonicaOrigemId)
+        // do guard acima, DE PROPÓSITO. O guard já provou, para todo slot que chega aqui,
+        // que ou (a) é genuinamente a mesma fase (mesmo FaseCanonicaOrigemId), ou (b) é uma
+        // troca de fase na mesma Ordem SEM nenhuma exigência viva referenciando a fase
+        // antiga (senão o guard já teria recusado, acima). Nos dois casos é seguro adotar a
+        // instância TRACKED existente (retargetando-a via AtualizarSnapshot) em vez de
+        // Add(nova) + deixar a antiga para o Clear() varrer: sem isso, um Clear()+Add() com
+        // Id novo na mesma Ordem pode colidir com o índice único
+        // (ProcessoSeletivoId, Ordem) por causa da ordem DELETE/INSERT que o EF decide no
+        // SaveChanges — o mesmo problema que a reconciliação evita no caso normal (mesma
+        // fase). Retargetar aqui é seguro justamente porque nada vivo apontava para o Id
+        // reciclado.
         List<FaseCronograma> resultantes = [];
         foreach (FaseCronograma nova in fases)
         {
-            if (fasesAntigasPorOrdem.TryGetValue(nova.Ordem, out FaseCronograma? existente)
-                && existente.FaseCanonicaOrigemId == nova.FaseCanonicaOrigemId)
+            if (fasesAntigasPorOrdem.TryGetValue(nova.Ordem, out FaseCronograma? existente))
             {
                 existente.AtualizarSnapshot(
                     nova.FaseCanonicaOrigemId,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -503,7 +503,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         {
             if (!fasesNovasPorOrdem.TryGetValue(antiga.Ordem, out FaseCronograma? nova))
             {
-                if (_documentosExigidos.Any(d => d.ExigidoNaFaseId == antiga.Id))
+                // Achado Codex P2 (PR #900): a fase removida pode ser referenciada por
+                // ExigidoNaFaseId OU por IdadeMaximaEmissao.ReferenciaFaseId (PR-d) — os
+                // dois são vínculos independentes, e ambos ficariam órfãos.
+                if (_documentosExigidos.Any(d => d.ExigidoNaFaseId == antiga.Id
+                    || d.IdadeMaximaEmissao?.ReferenciaFaseId == antiga.Id))
                 {
                     return Result.Failure(new DomainError(
                         "FaseCronograma.ReferenciadaPorExigenciaViva",
@@ -520,6 +524,27 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 return Result.Failure(new DomainError(
                     "FaseCronograma.PendenciaReenvioExigeComplementacao",
                     $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) não pode perder PermiteComplementacao — é referenciada por um documento exigido com consequência PENDENCIA_REENVIO."));
+            }
+
+            // Achado Codex P2 (PR #900): fase SOBREVIVENTE (mesma Ordem) cujo extremo
+            // âncora (Início/Fim) deixa de existir — a checagem eager de
+            // DefinirDocumentosExigidos só prova a coerência no INSTANTE da escrita da
+            // exigência; sem este guard, uma redefinição de cronograma POSTERIOR poderia
+            // apagar o extremo e deixar IdadeMaximaEmissao apontando para uma âncora
+            // irresolvível, silenciosamente. Mesma família de guard de
+            // ProcessoSeletivo.ReferenciaTemporalFatosExtremoAusente (PR-b), mas aqui é
+            // preventivo (na escrita do cronograma), não descoberto só na publicação.
+            bool perdeuInicio = antiga.Inicio is not null && nova.Inicio is null;
+            bool perdeuFim = antiga.Fim is not null && nova.Fim is null;
+            if ((perdeuInicio || perdeuFim) && _documentosExigidos.Any(d =>
+                d.IdadeMaximaEmissao is { ReferenciaFaseId: { } refFaseId } idade
+                && refFaseId == antiga.Id
+                && ((perdeuInicio && idade.ReferenciaTipo == ReferenciaTipoIdadeEmissao.InicioFase)
+                    || (perdeuFim && idade.ReferenciaTipo == ReferenciaTipoIdadeEmissao.FimFase))))
+            {
+                return Result.Failure(new DomainError(
+                    "IdadeMaximaEmissao.FaseExtremoAusente",
+                    $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) não pode perder o extremo usado como âncora de idade máxima de emissão por um documento exigido configurado."));
             }
         }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -585,12 +585,9 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         // fase REMOVIDA (que libera a linha via DELETE) não é um ciclo — só o é quando a
         // cadeia volta a uma fase já visitada NA MESMA caminhada.
         Dictionary<int, Guid> origemAntigaPorOrdem = [];
-        foreach (FaseCronograma antiga in fasesAntigasPorOrigem.Values)
+        foreach (FaseCronograma antiga in fasesAntigasPorOrigem.Values.Where(f => fasesNovasPorOrigem.ContainsKey(f.FaseCanonicaOrigemId)))
         {
-            if (fasesNovasPorOrigem.ContainsKey(antiga.FaseCanonicaOrigemId))
-            {
-                origemAntigaPorOrdem[antiga.Ordem] = antiga.FaseCanonicaOrigemId;
-            }
+            origemAntigaPorOrdem[antiga.Ordem] = antiga.FaseCanonicaOrigemId;
         }
 
         Dictionary<Guid, int> estadoDoNo = []; // 1 = na caminhada atual, 2 = concluído sem ciclo

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -795,19 +795,24 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 // externa) ou com a fase de coleta sem Fim definido, deixando-a
                 // irresolvível depois — mesmo sem gate de publicação para idade de
                 // emissão (issue #893 §1: é aviso, não bloqueio de presença).
-                FaseCronograma? faseColeta = _cronogramaFases.FirstOrDefault(f => f.ColetaInscricao);
-                if (faseColeta is null)
+                // Achado Codex P2 (PR #900, 6ª rodada): nada no domínio impede MAIS de uma
+                // fase com ColetaInscricao — FirstOrDefault pegava a primeira, mesmo que
+                // outra (com Fim definido) resolvesse a regra; um processo com duas fases
+                // de coleta, a primeira sem Fim e a segunda com Fim, era um 422 falso. A
+                // pergunta certa é existencial (Any), não posicional — a mesma forma já
+                // usada pelo guard backward simétrico em DefinirCronogramaFases.
+                if (!_cronogramaFases.Any(f => f.ColetaInscricao))
                 {
                     return Result.Failure(new DomainError(
                         "IdadeMaximaEmissao.FaseNaoPertenceAoProcesso",
                         "FIM_INSCRICAO exige uma fase do cronograma com ColetaInscricao, e o processo não tem nenhuma."));
                 }
 
-                if (faseColeta.Fim is null)
+                if (!_cronogramaFases.Any(f => f.ColetaInscricao && f.Fim is not null))
                 {
                     return Result.Failure(new DomainError(
                         "IdadeMaximaEmissao.FaseExtremoAusente",
-                        $"A fase '{faseColeta.Codigo}' que coleta inscrição não tem Fim definido — FIM_INSCRICAO não pode ser resolvido, sem fallback silencioso."));
+                        "Nenhuma fase que coleta inscrição tem Fim definido — FIM_INSCRICAO não pode ser resolvido, sem fallback silencioso."));
                 }
             }
         }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -559,6 +559,21 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             }
         }
 
+        // Achado Codex P2 (PR #900, 5ª rodada): mesma lacuna do guard eager de
+        // DefinirDocumentosExigidos — FIM_INSCRICAO não usa ReferenciaFaseId (a âncora é
+        // implícita: a fase com ColetaInscricao), então os guards por fase acima (que só
+        // olham ReferenciaFaseId) nunca pegam uma redefinição que deixa de ter QUALQUER
+        // fase de coleta com Fim definido, mesmo com exigência viva ancorada em
+        // FIM_INSCRICAO. É uma checagem GLOBAL, não por fase — não importa QUAL fase
+        // perdeu o papel, o que importa é se ainda sobra alguma no cronograma NOVO.
+        if (_documentosExigidos.Any(d => d.IdadeMaximaEmissao?.ReferenciaTipo == ReferenciaTipoIdadeEmissao.FimInscricao)
+            && !fases.Any(f => f.ColetaInscricao && f.Fim is not null))
+        {
+            return Result.Failure(new DomainError(
+                "IdadeMaximaEmissao.FaseExtremoAusente",
+                "A redefinição do cronograma deixaria de ter uma fase que coleta inscrição com Fim definido, mas há documento exigido configurado com idade máxima de emissão ancorada em FIM_INSCRICAO."));
+        }
+
         // Achado Codex P2 (PR #900, 4ª rodada): mesmo casando por identidade estável, uma
         // PERMUTAÇÃO CÍCLICA de Ordem entre fases retidas (ex.: A@1,B@2 -> A@2,B@1, ou um
         // ciclo de 3+) ainda pede que linhas TROQUEM valores cobertos pelo índice único
@@ -755,7 +770,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             // (na escrita, não na publicação): a regra vive na exigência, e a exigência já
             // está sendo escrita agora — não há razão para adiar. Fase viva do MESMO
             // processo com o extremo correspondente não-nulo (sem fallback silencioso).
-            if (item.IdadeMaximaEmissao is { ReferenciaFaseId: { } referenciaFaseId } idade)
+            if (item.IdadeMaximaEmissao is { ReferenciaFaseId: { } referenciaFaseId } idadeComFase)
             {
                 FaseCronograma? faseAncora = _cronogramaFases.FirstOrDefault(f => f.Id == referenciaFaseId);
                 if (faseAncora is null)
@@ -765,12 +780,37 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                         $"A fase âncora {referenciaFaseId} da idade máxima de emissão não pertence ao cronograma deste processo."));
                 }
 
-                DateTimeOffset? extremo = idade.ReferenciaTipo == ReferenciaTipoIdadeEmissao.InicioFase ? faseAncora.Inicio : faseAncora.Fim;
+                DateTimeOffset? extremo = idadeComFase.ReferenciaTipo == ReferenciaTipoIdadeEmissao.InicioFase ? faseAncora.Inicio : faseAncora.Fim;
                 if (extremo is null)
                 {
                     return Result.Failure(new DomainError(
                         "IdadeMaximaEmissao.FaseExtremoAusente",
-                        $"A fase âncora da idade máxima de emissão não tem {(idade.ReferenciaTipo == ReferenciaTipoIdadeEmissao.InicioFase ? "Início" : "Fim")} definido — sem fallback silencioso."));
+                        $"A fase âncora da idade máxima de emissão não tem {(idadeComFase.ReferenciaTipo == ReferenciaTipoIdadeEmissao.InicioFase ? "Início" : "Fim")} definido — sem fallback silencioso."));
+                }
+            }
+            else if (item.IdadeMaximaEmissao is { ReferenciaTipo: ReferenciaTipoIdadeEmissao.FimInscricao })
+            {
+                // Achado Codex P2 (PR #900, 5ª rodada): FIM_INSCRICAO não usa
+                // ReferenciaFaseId (a âncora é implícita — a fase com ColetaInscricao do
+                // PRÓPRIO cronograma, não uma fase escolhida pelo chamador), então o
+                // branch acima nunca a valida. Sem esta checagem, um PUT aceitava a regra
+                // num processo sem NENHUMA fase que coleta inscrição (ex.: importação
+                // externa) ou com a fase de coleta sem Fim definido, deixando-a
+                // irresolvível depois — mesmo sem gate de publicação para idade de
+                // emissão (issue #893 §1: é aviso, não bloqueio de presença).
+                FaseCronograma? faseColeta = _cronogramaFases.FirstOrDefault(f => f.ColetaInscricao);
+                if (faseColeta is null)
+                {
+                    return Result.Failure(new DomainError(
+                        "IdadeMaximaEmissao.FaseNaoPertenceAoProcesso",
+                        "FIM_INSCRICAO exige uma fase do cronograma com ColetaInscricao, e o processo não tem nenhuma."));
+                }
+
+                if (faseColeta.Fim is null)
+                {
+                    return Result.Failure(new DomainError(
+                        "IdadeMaximaEmissao.FaseExtremoAusente",
+                        $"A fase '{faseColeta.Codigo}' que coleta inscrição não tem Fim definido — FIM_INSCRICAO não pode ser resolvido, sem fallback silencioso."));
                 }
             }
         }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/FormatoPermitido.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/FormatoPermitido.cs
@@ -1,0 +1,16 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Formato de arquivo aceito para a apresentação de um <see cref="Entities.DocumentoExigido"/>
+/// (Story #554, PR-d, issue #893) — congelado na própria exigência, opcional
+/// (<see langword="null"/> = sem restrição de formato). O módulo Configuração não mantém
+/// catálogo de formatos de arquivo (só classifica o <c>TipoDocumento</c>); por isso a
+/// lista é fechada em código, não resolvida por leitura externa.
+/// </summary>
+public enum FormatoPermitido
+{
+    Nenhum = 0,
+    Pdf = 1,
+    Jpeg = 2,
+    Png = 3,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/FormatoPermitidoCodigo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/FormatoPermitidoCodigo.cs
@@ -1,0 +1,36 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento único entre <see cref="FormatoPermitido"/> e o código textual canônico
+/// UPPER_SNAKE do wire de comando — mesma convenção de <see cref="OperadorCodigo"/>.
+/// </summary>
+public static class FormatoPermitidoCodigo
+{
+    public const string Pdf = "PDF";
+    public const string Jpeg = "JPEG";
+    public const string Png = "PNG";
+
+    public static string ToCodigo(this FormatoPermitido formato) => formato switch
+    {
+        FormatoPermitido.Pdf => Pdf,
+        FormatoPermitido.Jpeg => Jpeg,
+        FormatoPermitido.Png => Png,
+        FormatoPermitido.Nenhum => throw new ArgumentOutOfRangeException(
+            nameof(formato), formato, "FormatoPermitido.Nenhum é sentinela e não tem código canônico."),
+        _ => throw new ArgumentOutOfRangeException(nameof(formato), formato, "FormatoPermitido desconhecido."),
+    };
+
+    /// <summary>
+    /// <see langword="null"/> tanto para código ausente quanto para código fora do
+    /// domínio — quem chama decide se a ausência é aceitável (campo opcional) ou se um
+    /// código desconhecido deve virar erro de validação explícito (não decidido aqui,
+    /// que é puro).
+    /// </summary>
+    public static FormatoPermitido? FromCodigo(string? codigo) => codigo switch
+    {
+        Pdf => FormatoPermitido.Pdf,
+        Jpeg => FormatoPermitido.Jpeg,
+        Png => FormatoPermitido.Png,
+        _ => null,
+    };
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/ReferenciaTipoIdadeEmissao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/ReferenciaTipoIdadeEmissao.cs
@@ -1,0 +1,28 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Âncora de <see cref="ValueObjects.IdadeMaximaEmissao"/> (Story #554, PR-d, issue #893)
+/// — de onde se conta a idade máxima de emissão do DOCUMENTO. Diferente de
+/// <see cref="ReferenciaTipo"/> (PR-b, PR-c — âncora a idade do CANDIDATO e explicitamente
+/// exclui submissão), <see cref="DataSubmissao"/> é válida aqui: o documento pode precisar
+/// ser recente em relação ao ato de enviar, não a uma data fixa do certame.
+/// </summary>
+public enum ReferenciaTipoIdadeEmissao
+{
+    Nenhuma = 0,
+
+    /// <summary>Fim da fase que coleta inscrição (<c>FaseCronograma.ColetaInscricao</c>).</summary>
+    FimInscricao = 1,
+
+    /// <summary>Início de uma fase específica do cronograma — exige <c>ReferenciaFaseId</c>.</summary>
+    InicioFase = 2,
+
+    /// <summary>Fim de uma fase específica do cronograma — exige <c>ReferenciaFaseId</c>.</summary>
+    FimFase = 3,
+
+    /// <summary>Data fixa declarada pelo administrador — exige <c>Data</c>.</summary>
+    DataEspecifica = 4,
+
+    /// <summary>Instante em que o candidato submete o documento — resolvida no runtime de coleta, fora de escopo desta Story.</summary>
+    DataSubmissao = 5,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/ReferenciaTipoIdadeEmissaoCodigo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/ReferenciaTipoIdadeEmissaoCodigo.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento único entre <see cref="ReferenciaTipoIdadeEmissao"/> e o código textual
+/// canônico UPPER_SNAKE do wire de comando — mesma convenção de
+/// <see cref="ReferenciaTipoCodigo"/> (PR-b).
+/// </summary>
+public static class ReferenciaTipoIdadeEmissaoCodigo
+{
+    public const string FimInscricao = "FIM_INSCRICAO";
+    public const string InicioFase = "INICIO_FASE";
+    public const string FimFase = "FIM_FASE";
+    public const string DataEspecifica = "DATA_ESPECIFICA";
+    public const string DataSubmissao = "DATA_SUBMISSAO";
+
+    public static string ToCodigo(this ReferenciaTipoIdadeEmissao tipo) => tipo switch
+    {
+        ReferenciaTipoIdadeEmissao.FimInscricao => FimInscricao,
+        ReferenciaTipoIdadeEmissao.InicioFase => InicioFase,
+        ReferenciaTipoIdadeEmissao.FimFase => FimFase,
+        ReferenciaTipoIdadeEmissao.DataEspecifica => DataEspecifica,
+        ReferenciaTipoIdadeEmissao.DataSubmissao => DataSubmissao,
+        ReferenciaTipoIdadeEmissao.Nenhuma => throw new ArgumentOutOfRangeException(
+            nameof(tipo), tipo, "ReferenciaTipoIdadeEmissao.Nenhuma é sentinela e não tem código canônico."),
+        _ => throw new ArgumentOutOfRangeException(nameof(tipo), tipo, "ReferenciaTipoIdadeEmissao desconhecido."),
+    };
+
+    /// <summary>
+    /// <see langword="null"/> tanto para código ausente quanto para código fora do
+    /// domínio — mesmo raciocínio de <see cref="UnidadeIdadeCodigo.FromCodigo"/>: a
+    /// coerência tudo-nulo OU completo de <see cref="ValueObjects.IdadeMaximaEmissao"/>
+    /// precisa distinguir ausência de presença; a checagem de domínio de um código NÃO
+    /// NULO é do <c>FluentValidation</c> (Application).
+    /// </summary>
+    public static ReferenciaTipoIdadeEmissao? FromCodigo(string? codigo) => codigo switch
+    {
+        FimInscricao => ReferenciaTipoIdadeEmissao.FimInscricao,
+        InicioFase => ReferenciaTipoIdadeEmissao.InicioFase,
+        FimFase => ReferenciaTipoIdadeEmissao.FimFase,
+        DataEspecifica => ReferenciaTipoIdadeEmissao.DataEspecifica,
+        DataSubmissao => ReferenciaTipoIdadeEmissao.DataSubmissao,
+        _ => null,
+    };
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/UnidadeIdade.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/UnidadeIdade.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Unidade de contagem de <see cref="ValueObjects.IdadeMaximaEmissao.Valor"/> (Story #554,
+/// PR-d, issue #893).
+/// </summary>
+public enum UnidadeIdade
+{
+    Nenhuma = 0,
+    Dias = 1,
+    Meses = 2,
+    Anos = 3,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/UnidadeIdadeCodigo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/UnidadeIdadeCodigo.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento único entre <see cref="UnidadeIdade"/> e o código textual canônico
+/// UPPER_SNAKE do wire de comando — mesma convenção de <see cref="OperadorCodigo"/>.
+/// </summary>
+public static class UnidadeIdadeCodigo
+{
+    public const string Dias = "DIAS";
+    public const string Meses = "MESES";
+    public const string Anos = "ANOS";
+
+    public static string ToCodigo(this UnidadeIdade unidade) => unidade switch
+    {
+        UnidadeIdade.Dias => Dias,
+        UnidadeIdade.Meses => Meses,
+        UnidadeIdade.Anos => Anos,
+        UnidadeIdade.Nenhuma => throw new ArgumentOutOfRangeException(
+            nameof(unidade), unidade, "UnidadeIdade.Nenhuma é sentinela e não tem código canônico."),
+        _ => throw new ArgumentOutOfRangeException(nameof(unidade), unidade, "UnidadeIdade desconhecida."),
+    };
+
+    /// <summary>
+    /// <see langword="null"/> tanto para código ausente quanto para código fora do
+    /// domínio — a coerência tudo-nulo OU completo de <see cref="ValueObjects.IdadeMaximaEmissao"/>
+    /// depende de distinguir "ausente" de "presente com valor concreto", não de um
+    /// terceiro estado sentinela; a checagem de que um código NÃO NULO pertence ao
+    /// domínio é do <c>FluentValidation</c> (Application), antes deste método ser chamado.
+    /// </summary>
+    public static UnidadeIdade? FromCodigo(string? codigo) => codigo switch
+    {
+        Dias => UnidadeIdade.Dias,
+        Meses => UnidadeIdade.Meses,
+        Anos => UnidadeIdade.Anos,
+        _ => null,
+    };
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/IdadeMaximaEmissao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/IdadeMaximaEmissao.cs
@@ -1,0 +1,113 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Idade máxima de emissão de um <see cref="Entities.DocumentoExigido"/> (Story #554,
+/// PR-d, issue #893) — regra opcional (0..1) sobre o próprio ARQUIVO apresentado (ex.:
+/// "comprovante de residência emitido há no máximo 90 dias"), distinta de
+/// <see cref="ReferenciaTemporalFatos"/> (PR-b), que ancora a idade do CANDIDATO
+/// (<c>FAIXA_ETARIA</c>) no nível do processo, não da exigência, e explicitamente exclui
+/// submissão como âncora.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Coerência tudo-nulo OU completo (N-I01, mesmo espírito de <see cref="ReferenciaTemporalFatos"/>):
+/// <see cref="Valor"/>/<see cref="Unidade"/>/<see cref="ReferenciaTipo"/> são os três
+/// primeiros campos — presentes juntos, ou ausentes juntos. <see cref="Enums.ReferenciaTipoIdadeEmissao.DataEspecifica"/>
+/// exige <see cref="Data"/>; <see cref="Enums.ReferenciaTipoIdadeEmissao.InicioFase"/>/
+/// <see cref="Enums.ReferenciaTipoIdadeEmissao.FimFase"/> exigem <see cref="ReferenciaFaseId"/>;
+/// <see cref="Enums.ReferenciaTipoIdadeEmissao.FimInscricao"/>/
+/// <see cref="Enums.ReferenciaTipoIdadeEmissao.DataSubmissao"/> não usam nenhum dos dois
+/// campos opcionais (resolvidos em runtime de coleta, fora de escopo desta Story).
+/// </para>
+/// <para>
+/// <b>Aviso, não bloqueio de presença</b> (issue #893 §1): esta regra nunca impede um
+/// documento de ser aceito como apresentação — ela sinaliza. A avaliação em runtime
+/// (comparar a emissão real do arquivo contra esta regra congelada) é fora de escopo.
+/// </para>
+/// </remarks>
+public sealed record IdadeMaximaEmissao
+{
+    private IdadeMaximaEmissao(
+        int valor, UnidadeIdade unidade, ReferenciaTipoIdadeEmissao referenciaTipo, DateOnly? data, Guid? referenciaFaseId)
+    {
+        Valor = valor;
+        Unidade = unidade;
+        ReferenciaTipo = referenciaTipo;
+        Data = data;
+        ReferenciaFaseId = referenciaFaseId;
+    }
+
+    public int Valor { get; }
+
+    public UnidadeIdade Unidade { get; }
+
+    public ReferenciaTipoIdadeEmissao ReferenciaTipo { get; }
+
+    /// <summary>Só presente quando <see cref="ReferenciaTipo"/> é <see cref="Enums.ReferenciaTipoIdadeEmissao.DataEspecifica"/>.</summary>
+    public DateOnly? Data { get; }
+
+    /// <summary>Só presente quando <see cref="ReferenciaTipo"/> é <see cref="Enums.ReferenciaTipoIdadeEmissao.InicioFase"/> ou <see cref="Enums.ReferenciaTipoIdadeEmissao.FimFase"/>.</summary>
+    public Guid? ReferenciaFaseId { get; }
+
+    /// <summary>
+    /// <see langword="null"/> tudo-nulo (regra ausente — a exigência não tem idade máxima
+    /// de emissão) é sucesso, não erro: a ausência de <paramref name="valor"/>/
+    /// <paramref name="unidade"/>/<paramref name="referenciaTipo"/> é um estado válido.
+    /// </summary>
+    public static Result<IdadeMaximaEmissao?> Criar(
+        int? valor, UnidadeIdade? unidade, ReferenciaTipoIdadeEmissao? referenciaTipo, DateOnly? data, Guid? referenciaFaseId)
+    {
+        bool nenhumDosTresPresente = valor is null && unidade is null && referenciaTipo is null;
+        if (nenhumDosTresPresente)
+        {
+            if (data is not null || referenciaFaseId is not null)
+            {
+                return Result<IdadeMaximaEmissao?>.Failure(new DomainError(
+                    "IdadeMaximaEmissao.CamposIncoerentesComAusencia",
+                    "Data e a fase âncora só são aceitas quando a idade máxima de emissão está definida (Valor, Unidade e ReferenciaTipo)."));
+            }
+
+            return Result<IdadeMaximaEmissao?>.Success(null);
+        }
+
+        if (valor is null || unidade is null || referenciaTipo is null)
+        {
+            return Result<IdadeMaximaEmissao?>.Failure(new DomainError(
+                "IdadeMaximaEmissao.CamposIncompletos",
+                "Valor, Unidade e ReferenciaTipo devem estar todos presentes, ou todos ausentes."));
+        }
+
+        if (valor <= 0)
+        {
+            return Result<IdadeMaximaEmissao?>.Failure(new DomainError(
+                "IdadeMaximaEmissao.ValorInvalido",
+                "O valor da idade máxima de emissão deve ser maior que zero."));
+        }
+
+        bool exigeData = referenciaTipo == ReferenciaTipoIdadeEmissao.DataEspecifica;
+        if (exigeData != data.HasValue)
+        {
+            return Result<IdadeMaximaEmissao?>.Failure(new DomainError(
+                "IdadeMaximaEmissao.DataIncoerenteComTipo",
+                exigeData
+                    ? "DATA_ESPECIFICA exige a data."
+                    : "A data só é aceita quando o tipo é DATA_ESPECIFICA."));
+        }
+
+        bool exigeFase = referenciaTipo is ReferenciaTipoIdadeEmissao.InicioFase or ReferenciaTipoIdadeEmissao.FimFase;
+        if (exigeFase != referenciaFaseId.HasValue)
+        {
+            return Result<IdadeMaximaEmissao?>.Failure(new DomainError(
+                "IdadeMaximaEmissao.FaseIncoerenteComTipo",
+                exigeFase
+                    ? "INICIO_FASE/FIM_FASE exigem a fase âncora."
+                    : "A fase âncora só é aceita quando o tipo é INICIO_FASE ou FIM_FASE."));
+        }
+
+        return Result<IdadeMaximaEmissao?>.Success(
+            new IdadeMaximaEmissao(valor.Value, unidade.Value, referenciaTipo.Value, data, referenciaFaseId));
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/IdadeMaximaEmissao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/IdadeMaximaEmissao.cs
@@ -87,6 +87,19 @@ public sealed record IdadeMaximaEmissao
                 "O valor da idade máxima de emissão deve ser maior que zero."));
         }
 
+        // Achado Codex P2 (PR #900, 3ª rodada): este factory é a fronteira do domínio — o
+        // sentinel Nenhuma=0 (CA1008) não é um valor de negócio válido aqui, só existe para
+        // permitir enum não-nulável em outros contextos. Sem esta checagem, um chamador que
+        // passasse Nenhuma junto de um Valor positivo produziria um VO "completo" sem
+        // código canônico, e o ToCodigo() da projeção de leitura estouraria depois, longe
+        // da causa. Não basta confiar na validação de string do command.
+        if (unidade == UnidadeIdade.Nenhuma || referenciaTipo == ReferenciaTipoIdadeEmissao.Nenhuma)
+        {
+            return Result<IdadeMaximaEmissao?>.Failure(new DomainError(
+                "IdadeMaximaEmissao.CamposIncompletos",
+                "Valor, Unidade e ReferenciaTipo devem estar todos presentes, ou todos ausentes."));
+        }
+
         bool exigeData = referenciaTipo == ReferenciaTipoIdadeEmissao.DataEspecifica;
         if (exigeData != data.HasValue)
         {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/DocumentoExigidoConfiguration.cs
@@ -2,8 +2,10 @@ namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 using Domain.Entities;
+using Domain.Enums;
 
 /// <summary>
 /// Configuração EF Core de <see cref="DocumentoExigido"/> (Story #554, PR-a) — entidade
@@ -22,6 +24,9 @@ public sealed class DocumentoExigidoConfiguration : IEntityTypeConfiguration<Doc
     private const int TipoDocumentoNomeMaxLength = 200;
     private const int TipoDocumentoCategoriaMaxLength = 60;
     private const int ConsequenciaIndeferimentoMaxLength = 30;
+    private const int IdadeMaximaUnidadeMaxLength = 10;
+    private const int IdadeMaximaReferenciaTipoMaxLength = 20;
+    private const int FormatoPermitidoMaxLength = 10;
 
     public void Configure(EntityTypeBuilder<DocumentoExigido> builder)
     {
@@ -76,5 +81,44 @@ public sealed class DocumentoExigidoConfiguration : IEntityTypeConfiguration<Doc
 
         builder.Navigation(d => d.BasesLegais)
             .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+        // Idade máxima de emissão (Story #554, PR-d, issue #893) — VO sem identidade
+        // própria, mesmo padrão de ProcessoSeletivo.ReferenciaTemporalFatos (PR-b):
+        // OwnsOne, colunas nullable, 0..1 por exigência.
+        builder.OwnsOne(d => d.IdadeMaximaEmissao, idade =>
+        {
+            idade.Property(i => i.Valor).HasColumnName("idade_maxima_valor");
+            idade.Property(i => i.Unidade)
+                .HasColumnName("idade_maxima_unidade")
+                .HasConversion(UnidadeConverter)
+                .HasMaxLength(IdadeMaximaUnidadeMaxLength);
+            idade.Property(i => i.ReferenciaTipo)
+                .HasColumnName("idade_maxima_referencia_tipo")
+                .HasConversion(ReferenciaTipoIdadeEmissaoConverter)
+                .HasMaxLength(IdadeMaximaReferenciaTipoMaxLength);
+            idade.Property(i => i.Data).HasColumnName("idade_maxima_referencia_data");
+            idade.Property(i => i.ReferenciaFaseId).HasColumnName("idade_maxima_referencia_fase_id");
+        });
+
+        builder.Property(d => d.FormatoPermitido)
+            .HasConversion(FormatoPermitidoConverter)
+            .HasMaxLength(FormatoPermitidoMaxLength);
+
+        builder.Property(d => d.TamanhoMaximoBytes);
     }
+
+    private static readonly ValueConverter<UnidadeIdade, string?> UnidadeConverter =
+        new(
+            unidade => unidade == UnidadeIdade.Nenhuma ? null : unidade.ToCodigo(),
+            codigo => UnidadeIdadeCodigo.FromCodigo(codigo) ?? UnidadeIdade.Nenhuma);
+
+    private static readonly ValueConverter<ReferenciaTipoIdadeEmissao, string?> ReferenciaTipoIdadeEmissaoConverter =
+        new(
+            tipo => tipo == ReferenciaTipoIdadeEmissao.Nenhuma ? null : tipo.ToCodigo(),
+            codigo => ReferenciaTipoIdadeEmissaoCodigo.FromCodigo(codigo) ?? ReferenciaTipoIdadeEmissao.Nenhuma);
+
+    private static readonly ValueConverter<FormatoPermitido?, string?> FormatoPermitidoConverter =
+        new(
+            formato => formato == null || formato.Value == FormatoPermitido.Nenhum ? null : formato.Value.ToCodigo(),
+            codigo => FormatoPermitidoCodigo.FromCodigo(codigo));
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717080538_AddIdadeMaximaEmissaoFormatoTamanho.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717080538_AddIdadeMaximaEmissaoFormatoTamanho.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717080538_AddIdadeMaximaEmissaoFormatoTamanho")]
+    partial class AddIdadeMaximaEmissaoFormatoTamanho
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717080538_AddIdadeMaximaEmissaoFormatoTamanho.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260717080538_AddIdadeMaximaEmissaoFormatoTamanho.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIdadeMaximaEmissaoFormatoTamanho : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "formato_permitido",
+                schema: "selecao",
+                table: "documentos_exigidos",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "idade_maxima_referencia_data",
+                schema: "selecao",
+                table: "documentos_exigidos",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "idade_maxima_referencia_fase_id",
+                schema: "selecao",
+                table: "documentos_exigidos",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "idade_maxima_referencia_tipo",
+                schema: "selecao",
+                table: "documentos_exigidos",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "idade_maxima_unidade",
+                schema: "selecao",
+                table: "documentos_exigidos",
+                type: "character varying(10)",
+                maxLength: 10,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "idade_maxima_valor",
+                schema: "selecao",
+                table: "documentos_exigidos",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "tamanho_maximo_bytes",
+                schema: "selecao",
+                table: "documentos_exigidos",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "formato_permitido",
+                schema: "selecao",
+                table: "documentos_exigidos");
+
+            migrationBuilder.DropColumn(
+                name: "idade_maxima_referencia_data",
+                schema: "selecao",
+                table: "documentos_exigidos");
+
+            migrationBuilder.DropColumn(
+                name: "idade_maxima_referencia_fase_id",
+                schema: "selecao",
+                table: "documentos_exigidos");
+
+            migrationBuilder.DropColumn(
+                name: "idade_maxima_referencia_tipo",
+                schema: "selecao",
+                table: "documentos_exigidos");
+
+            migrationBuilder.DropColumn(
+                name: "idade_maxima_unidade",
+                schema: "selecao",
+                table: "documentos_exigidos");
+
+            migrationBuilder.DropColumn(
+                name: "idade_maxima_valor",
+                schema: "selecao",
+                table: "documentos_exigidos");
+
+            migrationBuilder.DropColumn(
+                name: "tamanho_maximo_bytes",
+                schema: "selecao",
+                table: "documentos_exigidos");
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirDocumentosExigidosCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirDocumentosExigidosCommandHandlerTests.cs
@@ -46,6 +46,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
             mocks.TipoDocumentoReader,
             mocks.FatoCandidatoReader,
             mocks.UnitOfWork,
+            TimeProvider.System,
             CancellationToken.None);
 
     private static TipoDocumentoView TipoDocumentoResultado(Guid id) =>
@@ -90,7 +91,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
         mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
             .Returns((TipoDocumentoView?)null);
 
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], []);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [], null, null, null);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -111,7 +112,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
         mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
             .Returns(TipoDocumentoResultado(tipoDocumentoId));
 
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], []);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [], null, null, null);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -137,7 +138,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
             .Returns((IReadOnlyList<FatoCandidatoView>)[FatoSexo()]);
 
         CondicaoGatilhoInput condicao = new(0, "SEXO", "IGUAL", "\"MASCULINO\"");
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], []);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], [], null, null, null);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -162,7 +163,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
             .Returns((IReadOnlyList<FatoCandidatoView>)[]);
 
         CondicaoGatilhoInput condicao = new(0, "FATO_INEXISTENTE", "IGUAL", "\"X\"");
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], []);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], [], null, null, null);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -187,7 +188,7 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
             .Returns((IReadOnlyList<FatoCandidatoView>)[FatoModalidade()]);
 
         CondicaoGatilhoInput condicao = new(0, "MODALIDADE", "IGUAL", "\"LB_PPI\"");
-        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], []);
+        ItemDocumentoExigidoInput item = new(fase.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], [], null, null, null);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -210,8 +211,8 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
 
         BaseLegalInput baseFederal = new("Lei Federal X", "FEDERAL", "RESOLVIDO", null);
         BaseLegalInput baseEdital = new("Cláusula do edital", "INTERNA_EDITAL", "RESOLVIDO", null);
-        ItemDocumentoExigidoInput primeiraExigencia = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [baseFederal]);
-        ItemDocumentoExigidoInput segundaExigencia = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [baseEdital]);
+        ItemDocumentoExigidoInput primeiraExigencia = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [baseFederal], null, null, null);
+        ItemDocumentoExigidoInput segundaExigencia = new(fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [baseEdital], null, null, null);
         DefinirDocumentosExigidosCommand command = new(processo.Id, [primeiraExigencia, segundaExigencia], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
@@ -222,5 +223,82 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
         processo.DocumentosExigidos.Should().Contain(d => d.BasesLegais.Single().Referencia == "Cláusula do edital");
         processo.DocumentosExigidos.Select(d => d.Id).Should().OnlyHaveUniqueItems(
             "a correlação é pela identidade da própria exigência (ADR-0072), não pelo tipo de documento");
+    }
+
+    [Fact(DisplayName = "Story #554/issue #893 (PR-d): reenviar o PUT com FormatoPermitido/TamanhoMaximoBytes diferentes substitui integralmente (não faz merge)")]
+    public async Task Handle_ReenviarComFormatoETamanhoDiferentes_SubstituiIntegralmente()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Handler", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        Guid tipoDocumentoId = Guid.CreateVersion7();
+        mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
+            .Returns(TipoDocumentoResultado(tipoDocumentoId));
+
+        ItemDocumentoExigidoInput primeiro = new(
+            fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [], null, "PDF", 5_000_000);
+        (await HandleAsync(mocks, new DefinirDocumentosExigidosCommand(processo.Id, [primeiro], PrecondicaoIfMatch.Ausente)))
+            .IsSuccess.Should().BeTrue();
+        processo.DocumentosExigidos.Single().FormatoPermitido.Should().Be(FormatoPermitido.Pdf);
+        processo.DocumentosExigidos.Single().TamanhoMaximoBytes.Should().Be(5_000_000);
+
+        ItemDocumentoExigidoInput segundo = new(
+            fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [], null, "JPEG", 2_000_000);
+        Result<MutacaoAceita> resultado = await HandleAsync(
+            mocks, new DefinirDocumentosExigidosCommand(processo.Id, [segundo], PrecondicaoIfMatch.Curinga));
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        DocumentoExigido exigencia = processo.DocumentosExigidos.Should().ContainSingle().Which;
+        exigencia.FormatoPermitido.Should().Be(FormatoPermitido.Jpeg, "substituição integral, sem vestígio do valor anterior");
+        exigencia.TamanhoMaximoBytes.Should().Be(2_000_000);
+    }
+
+    [Fact(DisplayName = "CA-08: âncora de fase de IdadeMaximaEmissao que não pertence ao processo é recusada")]
+    public async Task Handle_IdadeMaximaEmissaoComFaseDeOutroProcesso_RetornaErroNomeado()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Handler", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        Guid tipoDocumentoId = Guid.CreateVersion7();
+        mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
+            .Returns(TipoDocumentoResultado(tipoDocumentoId));
+
+        IdadeMaximaEmissaoInput idade = new(90, "DIAS", "FIM_FASE", null, Guid.CreateVersion7());
+        ItemDocumentoExigidoInput item = new(
+            fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [], idade, null, null);
+        DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseNaoPertenceAoProcesso");
+    }
+
+    [Fact(DisplayName = "CA-08: âncora de fase de IdadeMaximaEmissao sem o extremo definido é recusada")]
+    public async Task Handle_IdadeMaximaEmissaoComFaseSemExtremo_RetornaErroNomeado()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Handler", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        Guid tipoDocumentoId = Guid.CreateVersion7();
+        mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
+            .Returns(TipoDocumentoResultado(tipoDocumentoId));
+
+        // FaseQualquer() não tem Inicio/Fim definidos — FIM_FASE não tem extremo a apontar.
+        IdadeMaximaEmissaoInput idade = new(90, "DIAS", "FIM_FASE", null, fase.Id);
+        ItemDocumentoExigidoInput item = new(
+            fase.Id, tipoDocumentoId, "GERAL", true, null, null, [], [], idade, null, null);
+        DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseExtremoAusente");
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests.cs
@@ -41,7 +41,7 @@ public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, tipoDocumentoOrigemId, "IDENTIDADE", "Documento de identidade", "PESSOAL",
             aplicabilidade, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [], basesLegais: []).Value!;
+            condicoes: [], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
@@ -69,7 +69,7 @@ public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "CERTIDAO_RESERVISTA", "Certidão de reservista", "MILITAR",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [condicaoEscalar, condicaoMultivalorada], basesLegais: []).Value!;
+            condicoes: [condicaoEscalar, condicaoMultivalorada], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
@@ -140,7 +140,7 @@ public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "IDENTIDADE", "Documento de identidade", "PESSOAL",
             Aplicabilidade.Geral, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [], basesLegais: [baseResolvida, basePendente]).Value!;
+            condicoes: [], basesLegais: [baseResolvida, basePendente], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
@@ -160,5 +160,64 @@ public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
         BaseLegalDto pendenteDto = projetado.BasesLegais.Should().ContainSingle(b => b.Status == "PENDENTE").Which;
         pendenteDto.Abrangencia.Should().Be("INTERNA_EDITAL");
         pendenteDto.Observacao.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Story #554/issue #893 (PR-d): projeta IdadeMaximaEmissao/FormatoPermitido/TamanhoMaximoBytes — round-trip GET→PUT")]
+    public async Task Handle_IdadeFormatoTamanho_EmiteTokensDeWire()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Query", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // DATA_SUBMISSAO — não exige fase âncora (nem extremo), diferente de INICIO_FASE/
+        // FIM_FASE; FaseQualquer() não declara Fim, então uma âncora de fase aqui
+        // reprovaria por IdadeMaximaEmissao.FaseExtremoAusente (coberto em teste próprio).
+        IdadeMaximaEmissao idade = IdadeMaximaEmissao.Criar(
+            90, UnidadeIdade.Dias, ReferenciaTipoIdadeEmissao.DataSubmissao, null, null).Value!;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            fase.Id, Guid.CreateVersion7(), "COMPROVANTE_RESIDENCIA", "Comprovante de residência", "PESSOAL",
+            Aplicabilidade.Geral, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
+            condicoes: [], basesLegais: [],
+            idadeMaximaEmissao: idade, formatoPermitido: FormatoPermitido.Pdf, tamanhoMaximoBytes: 5_000_000).Value!;
+        processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
+        repository.ObterComConfiguracaoAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+
+        ProcessoSeletivoDto? dto = await ObterProcessoSeletivoQueryHandler.Handle(
+            new ObterProcessoSeletivoQuery(processo.Id), repository, CancellationToken.None);
+
+        DocumentoExigidoDto projetado = dto!.DocumentosExigidos.Should().ContainSingle().Which;
+        projetado.FormatoPermitido.Should().Be("PDF");
+        projetado.TamanhoMaximoBytes.Should().Be(5_000_000);
+        projetado.IdadeMaximaEmissao.Should().NotBeNull();
+        projetado.IdadeMaximaEmissao!.Valor.Should().Be(90);
+        projetado.IdadeMaximaEmissao.Unidade.Should().Be("DIAS");
+        projetado.IdadeMaximaEmissao.ReferenciaTipo.Should().Be("DATA_SUBMISSAO");
+        projetado.IdadeMaximaEmissao.ReferenciaFaseId.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Sem idade/formato/tamanho configurados, a projeção emite tudo null (contraprova)")]
+    public async Task Handle_SemIdadeFormatoTamanho_ProjetaNulo()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Query", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseQualquer();
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            fase.Id, Guid.CreateVersion7(), "IDENTIDADE", "Documento de identidade", "PESSOAL",
+            Aplicabilidade.Geral, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
+            condicoes: [], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
+        processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
+        repository.ObterComConfiguracaoAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+
+        ProcessoSeletivoDto? dto = await ObterProcessoSeletivoQueryHandler.Handle(
+            new ObterProcessoSeletivoQuery(processo.Id), repository, CancellationToken.None);
+
+        DocumentoExigidoDto projetado = dto!.DocumentosExigidos.Should().ContainSingle().Which;
+        projetado.FormatoPermitido.Should().BeNull();
+        projetado.TamanhoMaximoBytes.Should().BeNull();
+        projetado.IdadeMaximaEmissao.Should().BeNull();
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
@@ -16,7 +16,11 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 public sealed class DefinirDocumentosExigidosCommandValidatorTests
 {
     private static ItemDocumentoExigidoInput ItemCom(params BaseLegalInput[] basesLegais) => new(
-        Guid.CreateVersion7(), Guid.CreateVersion7(), "GERAL", true, null, null, [], basesLegais);
+        Guid.CreateVersion7(), Guid.CreateVersion7(), "GERAL", true, null, null, [], basesLegais, null, null, null);
+
+    private static ItemDocumentoExigidoInput ItemComIdade(
+        IdadeMaximaEmissaoInput? idadeMaximaEmissao = null, string? formatoPermitido = null, int? tamanhoMaximoBytes = null) => new(
+        Guid.CreateVersion7(), Guid.CreateVersion7(), "GERAL", true, null, null, [], [], idadeMaximaEmissao, formatoPermitido, tamanhoMaximoBytes);
 
     private static ValidationResult Validar(ItemDocumentoExigidoInput item) =>
         new DefinirDocumentosExigidosCommandValidator().Validate(
@@ -104,7 +108,7 @@ public sealed class DefinirDocumentosExigidosCommandValidatorTests
     public void Rejeita_ItemDeBaseLegalNulo()
     {
         ItemDocumentoExigidoInput item = new(
-            Guid.CreateVersion7(), Guid.CreateVersion7(), "GERAL", true, null, null, [], [null!]);
+            Guid.CreateVersion7(), Guid.CreateVersion7(), "GERAL", true, null, null, [], [null!], null, null, null);
 
         ValidationResult resultado = Validar(item);
 
@@ -118,4 +122,78 @@ public sealed class DefinirDocumentosExigidosCommandValidatorTests
             new BaseLegalInput("Lei Federal X", "FEDERAL", "RESOLVIDO", null),
             new BaseLegalInput("Cláusula do edital", "INTERNA_EDITAL", "PENDENTE", null)))
             .IsValid.Should().BeTrue();
+
+    // ── Story #554/issue #893 (PR-d) — idade máxima de emissão, formato e tamanho ──
+
+    [Fact(DisplayName = "Item sem idade/formato/tamanho (tudo nulo) é aceito")]
+    public void Aceita_SemIdadeFormatoTamanho() =>
+        Validar(ItemComIdade()).IsValid.Should().BeTrue();
+
+    [Fact(DisplayName = "IdadeMaximaEmissao com Unidade fora do domínio é rejeitada")]
+    public void Rejeita_UnidadeDesconhecida()
+    {
+        IdadeMaximaEmissaoInput idade = new(90, "SEMANAS", "DATA_SUBMISSAO", null, null);
+
+        ValidationResult resultado = Validar(ItemComIdade(idade));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("Unidade", StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "IdadeMaximaEmissao com ReferenciaTipo fora do domínio é rejeitada")]
+    public void Rejeita_ReferenciaTipoDesconhecido()
+    {
+        IdadeMaximaEmissaoInput idade = new(90, "DIAS", "DATA_DE_HOJE", null, null);
+
+        ValidationResult resultado = Validar(ItemComIdade(idade));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("ReferenciaTipo", StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "IdadeMaximaEmissao com Valor zero ou negativo é rejeitada")]
+    public void Rejeita_ValorNaoPositivo()
+    {
+        IdadeMaximaEmissaoInput idade = new(0, "DIAS", "DATA_SUBMISSAO", null, null);
+
+        Validar(ItemComIdade(idade)).IsValid.Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "Todas as unidades e tipos de referência válidos são aceitos (forma)")]
+    [InlineData("DIAS", "FIM_INSCRICAO")]
+    [InlineData("MESES", "DATA_SUBMISSAO")]
+    [InlineData("ANOS", "DATA_SUBMISSAO")]
+    public void Aceita_TodasCombinacoesValidasDeIdade(string unidade, string referenciaTipo)
+    {
+        IdadeMaximaEmissaoInput idade = new(90, unidade, referenciaTipo, null, null);
+
+        Validar(ItemComIdade(idade)).IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "FormatoPermitido fora do domínio é rejeitado")]
+    public void Rejeita_FormatoDesconhecido()
+    {
+        ValidationResult resultado = Validar(ItemComIdade(formatoPermitido: "DOCX"));
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("Formato", StringComparison.Ordinal));
+    }
+
+    [Theory(DisplayName = "Todos os formatos válidos são aceitos")]
+    [InlineData("PDF")]
+    [InlineData("JPEG")]
+    [InlineData("PNG")]
+    public void Aceita_TodosFormatosValidos(string formato) =>
+        Validar(ItemComIdade(formatoPermitido: formato)).IsValid.Should().BeTrue();
+
+    [Fact(DisplayName = "TamanhoMaximoBytes zero ou negativo é rejeitado")]
+    public void Rejeita_TamanhoMaximoBytesNaoPositivo()
+    {
+        Validar(ItemComIdade(tamanhoMaximoBytes: 0)).IsValid.Should().BeFalse();
+        Validar(ItemComIdade(tamanhoMaximoBytes: -1)).IsValid.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "TamanhoMaximoBytes positivo é aceito")]
+    public void Aceita_TamanhoMaximoBytesPositivo() =>
+        Validar(ItemComIdade(tamanhoMaximoBytes: 5_000_000)).IsValid.Should().BeTrue();
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
@@ -7,6 +7,7 @@ using AwesomeAssertions;
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
 using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 /// <summary>
 /// Cobertura de <see cref="DocumentoExigido"/> (Story #554, PR-a): fábrica, guard de
@@ -19,7 +20,10 @@ public sealed class DocumentoExigidoTests
         bool obrigatorio = false,
         string? consequenciaIndeferimento = null,
         IReadOnlyList<CondicaoGatilho>? condicoes = null,
-        IReadOnlyList<DocumentoExigidoBaseLegal>? basesLegais = null) =>
+        IReadOnlyList<DocumentoExigidoBaseLegal>? basesLegais = null,
+        IdadeMaximaEmissao? idadeMaximaEmissao = null,
+        FormatoPermitido? formatoPermitido = null,
+        int? tamanhoMaximoBytes = null) =>
         DocumentoExigido.Criar(
             exigidoNaFaseId: Guid.CreateVersion7(),
             tipoDocumentoOrigemId: Guid.CreateVersion7(),
@@ -31,7 +35,10 @@ public sealed class DocumentoExigidoTests
             consequenciaIndeferimento: consequenciaIndeferimento,
             grupoSatisfacaoId: null,
             condicoes: condicoes ?? [],
-            basesLegais: basesLegais ?? []);
+            basesLegais: basesLegais ?? [],
+            idadeMaximaEmissao: idadeMaximaEmissao,
+            formatoPermitido: formatoPermitido,
+            tamanhoMaximoBytes: tamanhoMaximoBytes);
 
     private static CondicaoGatilho CondicaoQualquer() => CondicaoGatilho.Criar(
         0, "SEXO", Operador.Igual, JsonSerializer.SerializeToElement("MASCULINO")).Value!;

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -440,6 +440,117 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message, "o Fim continua definido — só o valor mudou, o que é uma edição legítima");
     }
 
+    // ── Story #554/issue #893 (achado Codex P2, PR #900, 5ª rodada) — FIM_INSCRICAO não
+    // usa ReferenciaFaseId (a âncora é implícita: a fase com ColetaInscricao) ──
+
+    private static FaseCronograma FaseColetaInscricao(
+        int ordem, string codigo, DateTimeOffset? fim, Guid? faseCanonicaOrigemId = null) => FaseCronograma.Criar(
+        ordem,
+        faseCanonicaOrigemId ?? Guid.CreateVersion7(),
+        codigo,
+        "CEPS",
+        OrigemDataFase.Delegada,
+        agrupaEtapas: false,
+        permiteComplementacao: false,
+        produzResultado: false,
+        resultadoDefinitivo: false,
+        coletaInscricao: true,
+        inicio: null,
+        fim: fim,
+        atoProduzidoCodigo: null,
+        atoProduzidoEfeitoIrreversivel: false,
+        bancasRequeridas: [],
+        regraRecurso: null).Value!;
+
+    private static DocumentoExigido ExigenciaComIdadeFimInscricao(Guid exigidoNaFaseId)
+    {
+        IdadeMaximaEmissao idade = IdadeMaximaEmissao.Criar(90, UnidadeIdade.Dias, ReferenciaTipoIdadeEmissao.FimInscricao, null, null).Value!;
+        return DocumentoExigido.Criar(
+            exigidoNaFaseId,
+            tipoDocumentoOrigemId: Guid.CreateVersion7(),
+            tipoDocumentoCodigo: "COMPROVANTE_RESIDENCIA",
+            tipoDocumentoNome: "Comprovante de residência",
+            tipoDocumentoCategoria: "PESSOAL",
+            aplicabilidade: Aplicabilidade.Geral,
+            obrigatorio: true,
+            consequenciaIndeferimento: null,
+            grupoSatisfacaoId: null,
+            condicoes: [], basesLegais: [], idadeMaximaEmissao: idade, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
+    }
+
+    [Fact(DisplayName = "Achado Codex P2 (PR #900, 5ª rodada): FIM_INSCRICAO sem NENHUMA fase que coleta inscrição no processo é recusado")]
+    public void DefinirDocumentosExigidos_FimInscricaoSemFaseDeColeta_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = Fase(1, "ANALISE"); // ColetaInscricao = false
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Result resultado = processo.DefinirDocumentosExigidos([ExigenciaComIdadeFimInscricao(fase.Id)], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue("FIM_INSCRICAO não pode ser resolvido sem uma fase de coleta — não há fallback silencioso");
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseNaoPertenceAoProcesso");
+    }
+
+    [Fact(DisplayName = "Achado Codex P2 (PR #900, 5ª rodada): FIM_INSCRICAO com fase de coleta SEM Fim definido é recusado")]
+    public void DefinirDocumentosExigidos_FimInscricaoComFaseDeColetaSemFim_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = FaseColetaInscricao(1, "INSCRICAO", fim: null);
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Result resultado = processo.DefinirDocumentosExigidos([ExigenciaComIdadeFimInscricao(fase.Id)], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseExtremoAusente");
+    }
+
+    [Fact(DisplayName = "Contraprova: FIM_INSCRICAO com fase de coleta com Fim definido é aceito")]
+    public void DefinirDocumentosExigidos_FimInscricaoComFaseDeColetaComFim_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        DateTimeOffset fim = new(2026, 1, 31, 0, 0, 0, TimeSpan.Zero);
+        FaseCronograma fase = FaseColetaInscricao(1, "INSCRICAO", fim);
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Result resultado = processo.DefinirDocumentosExigidos([ExigenciaComIdadeFimInscricao(fase.Id)], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+
+    [Fact(DisplayName = "Achado Codex P2 (PR #900, 5ª rodada): redefinir o cronograma tirando o Fim da fase de coleta com exigência FIM_INSCRICAO viva é recusado")]
+    public void DefinirCronogramaFases_FaseDeColetaPerdeFimComExigenciaFimInscricaoViva_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        DateTimeOffset fim = new(2026, 1, 31, 0, 0, 0, TimeSpan.Zero);
+        FaseCronograma fase = FaseColetaInscricao(1, "INSCRICAO", fim);
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirDocumentosExigidos([ExigenciaComIdadeFimInscricao(fase.Id)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // Mesma Ordem e mesma FaseCanonicaOrigemId — a fase sobrevive via reconciliação,
+        // mas perde o Fim.
+        Result resultado = processo.DefinirCronogramaFases(
+            [FaseColetaInscricao(1, "INSCRICAO", fim: null, fase.FaseCanonicaOrigemId)], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseExtremoAusente");
+    }
+
+    [Fact(DisplayName = "Contraprova: redefinir o cronograma preservando o Fim da fase de coleta com exigência FIM_INSCRICAO viva é aceito")]
+    public void DefinirCronogramaFases_FaseDeColetaPreservaFimComExigenciaFimInscricaoViva_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        DateTimeOffset fim = new(2026, 1, 31, 0, 0, 0, TimeSpan.Zero);
+        FaseCronograma fase = FaseColetaInscricao(1, "INSCRICAO", fim);
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirDocumentosExigidos([ExigenciaComIdadeFimInscricao(fase.Id)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        DateTimeOffset novoFim = new(2026, 2, 15, 0, 0, 0, TimeSpan.Zero);
+        Result resultado = processo.DefinirCronogramaFases(
+            [FaseColetaInscricao(1, "INSCRICAO", novoFim, fase.FaseCanonicaOrigemId)], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+
     // ── Story #554/issue #892 (achado Codex P2, PR #896) — CA-03 backward guard ──
 
     private static CondicaoGatilho CondicaoDe(string fato, string valor) => CondicaoGatilho.Criar(

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -166,6 +166,28 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.Error!.Code.Should().Be("FaseCronograma.ReferenciadaPorExigenciaViva");
     }
 
+    [Fact(DisplayName = "Achado Codex P2 (PR #900, 3ª rodada): trocar a fase canônica na MESMA Ordem, SEM exigência viva referenciando-a, é aceito e reusa a linha rastreada")]
+    public void DefinirCronogramaFases_TrocaFaseCanonicaNaMesmaOrdemSemExigenciaViva_AceitaEReusaLinha()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = Fase(1, "INSCRICAO");
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // Mesma Ordem (1), FaseCanonicaOrigemId DIFERENTE, e NENHUMA exigência referencia
+        // a fase antiga — o guard já provou que é seguro; a reconciliação deve adotar a
+        // linha TRACKED (retargetando-a) em vez de Add(nova) + deixar a antiga para o
+        // Clear() varrer, o que colidiria com o índice único (ProcessoSeletivoId, Ordem)
+        // no SaveChanges.
+        Guid idAntigo = fase.Id;
+        Result resultado = processo.DefinirCronogramaFases([Fase(1, "ANALISE")], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.CronogramaFases.Should().ContainSingle(
+            f => f.Id == idAntigo,
+            "sem exigência viva referenciando a fase antiga, é seguro reusar a linha rastreada em vez de forçar delete+insert no mesmo slot único");
+        processo.CronogramaFases.Single().Codigo.Should().Be("ANALISE");
+    }
+
     [Fact(DisplayName = "CA-04: redefinir o cronograma removendo (Ordem que desaparece) uma fase referenciada por exigência viva é recusado")]
     public void DefinirCronogramaFases_RemoveOrdemReferenciadaPorExigenciaViva_Recusa()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -37,7 +37,8 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         bancasRequeridas: [],
         regraRecurso: null).Value!;
 
-    private static DocumentoExigido Exigencia(Guid exigidoNaFaseId, Aplicabilidade aplicabilidade = Aplicabilidade.Geral) =>
+    private static DocumentoExigido Exigencia(
+        Guid exigidoNaFaseId, Aplicabilidade aplicabilidade = Aplicabilidade.Geral, string? consequenciaIndeferimento = null) =>
         DocumentoExigido.Criar(
             exigidoNaFaseId,
             tipoDocumentoOrigemId: Guid.CreateVersion7(),
@@ -45,10 +46,28 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
             tipoDocumentoNome: "Documento de identidade",
             tipoDocumentoCategoria: "PESSOAL",
             aplicabilidade,
-            obrigatorio: false,
-            consequenciaIndeferimento: null,
+            obrigatorio: consequenciaIndeferimento is null,
+            consequenciaIndeferimento,
             grupoSatisfacaoId: null,
-            condicoes: [], basesLegais: []).Value!;
+            condicoes: [], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
+
+    private static FaseCronograma FaseComComplementacao(int ordem, string codigo, bool permiteComplementacao) => FaseCronograma.Criar(
+        ordem,
+        Guid.CreateVersion7(),
+        codigo,
+        "CEPS",
+        OrigemDataFase.Delegada,
+        agrupaEtapas: false,
+        permiteComplementacao: permiteComplementacao,
+        produzResultado: false,
+        resultadoDefinitivo: false,
+        coletaInscricao: false,
+        inicio: null,
+        fim: null,
+        atoProduzidoCodigo: null,
+        atoProduzidoEfeitoIrreversivel: false,
+        bancasRequeridas: [],
+        regraRecurso: null).Value!;
 
     [Fact(DisplayName = "Fase que não pertence ao cronograma do processo é recusada")]
     public void DefinirDocumentosExigidos_FaseDeOutroProcesso_Recusa()
@@ -106,19 +125,38 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         processo.DocumentosExigidos.Should().ContainSingle(d => d.Id == segundaChamada.Id);
     }
 
-    [Fact(DisplayName = "CA-04 (guard parcial): redefinir o cronograma com exigência viva configurada é recusado")]
-    public void DefinirCronogramaFases_ComExigenciaViva_Recusa()
+    [Fact(DisplayName = "Story #554/issue #893 (PR-d): redefinir o cronograma preservando a Ordem de uma fase referenciada por exigência viva é aceito — reconciliação, não guard bruto")]
+    public void DefinirCronogramaFases_MesmaOrdemComExigenciaViva_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = Fase(1, "INSCRICAO");
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        DocumentoExigido exigencia = Exigencia(fase.Id);
+        processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // Mesma Ordem (1), dados diferentes — o caso comum de uma sessão editorial que só
+        // ajusta datas: a reconciliação reusa a instância viva, preserva o Id, e a
+        // exigência continua referenciando uma fase que existe.
+        Result resultado = processo.DefinirCronogramaFases([Fase(1, "INSCRICAO_REVISADA")], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.CronogramaFases.Should().ContainSingle(f => f.Id == fase.Id, "a reconciliação por Ordem reusa a MESMA instância, preservando o Id");
+        processo.CronogramaFases.Single().Codigo.Should().Be("INSCRICAO_REVISADA");
+        exigencia.ExigidoNaFaseId.Should().Be(fase.Id, "a exigência nunca deixou de referenciar uma fase existente");
+    }
+
+    [Fact(DisplayName = "CA-04: redefinir o cronograma removendo (Ordem que desaparece) uma fase referenciada por exigência viva é recusado")]
+    public void DefinirCronogramaFases_RemoveOrdemReferenciadaPorExigenciaViva_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();
         FaseCronograma fase = Fase(1, "INSCRICAO");
         processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
         processo.DefinirDocumentosExigidos([Exigencia(fase.Id)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
-        Result resultado = processo.DefinirCronogramaFases([Fase(1, "INSCRICAO")], [], PrecondicaoIfMatch.Ausente);
+        // Ordem 2 no lugar de Ordem 1 — a fase de Ordem 1 desaparece de fato.
+        Result resultado = processo.DefinirCronogramaFases([Fase(2, "INSCRICAO")], [], PrecondicaoIfMatch.Curinga);
 
-        resultado.IsFailure.Should().BeTrue(
-            "toda chamada aqui recria as fases com Id novo — sem a guarda, a FK Restrict de " +
-            "documentos_exigidos.exigido_na_fase_id estouraria DbUpdateException não tratada");
+        resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("FaseCronograma.ReferenciadaPorExigenciaViva");
     }
 
@@ -128,7 +166,54 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         ProcessoSeletivo processo = NovoProcesso();
         processo.DefinirCronogramaFases([Fase(1, "INSCRICAO")], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
-        Result resultado = processo.DefinirCronogramaFases([Fase(1, "INSCRICAO")], [], PrecondicaoIfMatch.Ausente);
+        Result resultado = processo.DefinirCronogramaFases([Fase(1, "INSCRICAO")], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+
+    [Fact(DisplayName = "CA-04: retirar PermiteComplementacao de fase referenciada por exigência PENDENCIA_REENVIO é recusado")]
+    public void DefinirCronogramaFases_RetiraComplementacaoComPendenciaReenvio_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: true);
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirDocumentosExigidos(
+            [Exigencia(fase.Id, Aplicabilidade.Geral, consequenciaIndeferimento: "PENDENCIA_REENVIO")], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        Result resultado = processo.DefinirCronogramaFases(
+            [FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: false)], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("FaseCronograma.PendenciaReenvioExigeComplementacao");
+    }
+
+    [Fact(DisplayName = "Retirar PermiteComplementacao sem exigência PENDENCIA_REENVIO é aceito (contraprova)")]
+    public void DefinirCronogramaFases_RetiraComplementacaoSemPendenciaReenvio_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: true);
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirDocumentosExigidos([Exigencia(fase.Id)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Result resultado = processo.DefinirCronogramaFases(
+            [FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: false)], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+
+    [Fact(DisplayName = "Manter PermiteComplementacao verdadeiro com exigência PENDENCIA_REENVIO é aceito (contraprova)")]
+    public void DefinirCronogramaFases_MantemComplementacaoComPendenciaReenvio_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: true);
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirDocumentosExigidos(
+            [Exigencia(fase.Id, Aplicabilidade.Geral, consequenciaIndeferimento: "PENDENCIA_REENVIO")], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        Result resultado = processo.DefinirCronogramaFases(
+            [FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: true)], [], PrecondicaoIfMatch.Curinga);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
@@ -179,7 +264,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "IDENTIDADE", "Documento de identidade", "PESSOAL",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [CondicaoDe("MODALIDADE", "LB_PPI")], basesLegais: []).Value!;
+            condicoes: [CondicaoDe("MODALIDADE", "LB_PPI")], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         Result resultado = processo.DefinirDistribuicaoVagas([DistribuicaoCom("AC")], PrecondicaoIfMatch.Ausente);
@@ -199,7 +284,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "IDENTIDADE", "Documento de identidade", "PESSOAL",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [CondicaoDe("MODALIDADE", "LB_PPI")], basesLegais: []).Value!;
+            condicoes: [CondicaoDe("MODALIDADE", "LB_PPI")], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         Result resultado = processo.DefinirDistribuicaoVagas([DistribuicaoCom("LB_PPI", "AC", "LI_PPI")], PrecondicaoIfMatch.Ausente);
@@ -221,7 +306,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "LAUDO_MEDICO", "Laudo médico", "SAUDE",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [CondicaoDe("CONDICAO_ATENDIMENTO", "PCD")], basesLegais: []).Value!;
+            condicoes: [CondicaoDe("CONDICAO_ATENDIMENTO", "PCD")], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         Result resultado = processo.DefinirOfertaAtendimento(
@@ -245,7 +330,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         DocumentoExigido exigencia = DocumentoExigido.Criar(
             fase.Id, Guid.CreateVersion7(), "LAUDO_MEDICO", "Laudo médico", "SAUDE",
             Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null, grupoSatisfacaoId: null,
-            condicoes: [CondicaoDe("CONDICAO_ATENDIMENTO", "PCD")], basesLegais: []).Value!;
+            condicoes: [CondicaoDe("CONDICAO_ATENDIMENTO", "PCD")], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         OfertaCondicao condicaoPcdNova = OfertaCondicao.Criar(Guid.CreateVersion7(), "PCD", "Pessoa com deficiência");

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -517,6 +517,20 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
 
+    [Fact(DisplayName = "Achado Codex P2 (PR #900, 6ª rodada): com DUAS fases de coleta, a primeira sem Fim e a segunda com Fim, FIM_INSCRICAO é aceito — a pergunta é existencial (Any), não posicional (FirstOrDefault)")]
+    public void DefinirDocumentosExigidos_FimInscricaoComPrimeiraFaseDeColetaSemFimEDemaisComFim_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        DateTimeOffset fim = new(2026, 2, 28, 0, 0, 0, TimeSpan.Zero);
+        FaseCronograma primeiraColeta = FaseColetaInscricao(1, "INSCRICAO_PRIMEIRA_FASE", fim: null);
+        FaseCronograma segundaColeta = FaseColetaInscricao(2, "INSCRICAO_SEGUNDA_FASE", fim);
+        processo.DefinirCronogramaFases([primeiraColeta, segundaColeta], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Result resultado = processo.DefinirDocumentosExigidos([ExigenciaComIdadeFimInscricao(primeiraColeta.Id)], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message, "a segunda fase de coleta resolve FIM_INSCRICAO — escolher a primeira encontrada (sem Fim) seria um 422 falso");
+    }
+
     [Fact(DisplayName = "Achado Codex P2 (PR #900, 5ª rodada): redefinir o cronograma tirando o Fim da fase de coleta com exigência FIM_INSCRICAO viva é recusado")]
     public void DefinirCronogramaFases_FaseDeColetaPerdeFimComExigenciaFimInscricaoViva_Recusa()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -218,6 +218,101 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
 
+    // ── Story #554/issue #893 (achado Codex P2, PR #900) — IdadeMaximaEmissao.ReferenciaFaseId ──
+
+    private static FaseCronograma FaseComExtremo(int ordem, string codigo, DateTimeOffset? inicio, DateTimeOffset? fim) => FaseCronograma.Criar(
+        ordem,
+        Guid.CreateVersion7(),
+        codigo,
+        "CEPS",
+        OrigemDataFase.Delegada,
+        agrupaEtapas: false,
+        permiteComplementacao: false,
+        produzResultado: false,
+        resultadoDefinitivo: false,
+        coletaInscricao: false,
+        inicio: inicio,
+        fim: fim,
+        atoProduzidoCodigo: null,
+        atoProduzidoEfeitoIrreversivel: false,
+        bancasRequeridas: [],
+        regraRecurso: null).Value!;
+
+    private static DocumentoExigido ExigenciaComIdadeAncoradaEmFase(
+        Guid exigidoNaFaseId, Guid referenciaFaseId, ReferenciaTipoIdadeEmissao referenciaTipo)
+    {
+        IdadeMaximaEmissao idade = IdadeMaximaEmissao.Criar(90, UnidadeIdade.Dias, referenciaTipo, null, referenciaFaseId).Value!;
+        return DocumentoExigido.Criar(
+            exigidoNaFaseId,
+            tipoDocumentoOrigemId: Guid.CreateVersion7(),
+            tipoDocumentoCodigo: "COMPROVANTE_RESIDENCIA",
+            tipoDocumentoNome: "Comprovante de residência",
+            tipoDocumentoCategoria: "PESSOAL",
+            aplicabilidade: Aplicabilidade.Geral,
+            obrigatorio: true,
+            consequenciaIndeferimento: null,
+            grupoSatisfacaoId: null,
+            condicoes: [], basesLegais: [], idadeMaximaEmissao: idade, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
+    }
+
+    [Fact(DisplayName = "Achado Codex P2 (PR #900): remover fase usada só como âncora de IdadeMaximaEmissao (não ExigidoNaFaseId) é recusado")]
+    public void DefinirCronogramaFases_RemoveFaseAncoraDeIdade_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        DateTimeOffset fim = new(2026, 1, 31, 0, 0, 0, TimeSpan.Zero);
+        FaseCronograma faseExigencia = Fase(1, "INSCRICAO");
+        FaseCronograma faseAncora = FaseComExtremo(2, "ANALISE", inicio: null, fim: fim);
+        processo.DefinirCronogramaFases([faseExigencia, faseAncora], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirDocumentosExigidos(
+            [ExigenciaComIdadeAncoradaEmFase(faseExigencia.Id, faseAncora.Id, ReferenciaTipoIdadeEmissao.FimFase)],
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // Ordem 2 (faseAncora) desaparece — só a Ordem 1 (faseExigencia, referenciada por
+        // ExigidoNaFaseId) é mantida.
+        Result resultado = processo.DefinirCronogramaFases([Fase(1, "INSCRICAO")], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsFailure.Should().BeTrue(
+            "faseAncora não é a fase de ExigidoNaFaseId, mas é a âncora de IdadeMaximaEmissao.ReferenciaFaseId");
+        resultado.Error!.Code.Should().Be("FaseCronograma.ReferenciadaPorExigenciaViva");
+    }
+
+    [Fact(DisplayName = "Achado Codex P2 (PR #900): fase sobrevivente que perde o extremo usado como âncora de idade é recusado")]
+    public void DefinirCronogramaFases_FaseSobreviventePerdeExtremoAncoraDeIdade_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        DateTimeOffset fim = new(2026, 1, 31, 0, 0, 0, TimeSpan.Zero);
+        FaseCronograma fase = FaseComExtremo(1, "ANALISE", inicio: null, fim: fim);
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirDocumentosExigidos(
+            [ExigenciaComIdadeAncoradaEmFase(fase.Id, fase.Id, ReferenciaTipoIdadeEmissao.FimFase)],
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // Mesma Ordem (1) — a fase sobrevive via reconciliação, mas perde o Fim.
+        Result resultado = processo.DefinirCronogramaFases(
+            [FaseComExtremo(1, "ANALISE", inicio: null, fim: null)], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseExtremoAusente");
+    }
+
+    [Fact(DisplayName = "Fase sobrevivente que preserva o extremo usado como âncora de idade é aceito (contraprova)")]
+    public void DefinirCronogramaFases_FaseSobrevivePreservandoExtremoAncoraDeIdade_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        DateTimeOffset fim = new(2026, 1, 31, 0, 0, 0, TimeSpan.Zero);
+        FaseCronograma fase = FaseComExtremo(1, "ANALISE", inicio: null, fim: fim);
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirDocumentosExigidos(
+            [ExigenciaComIdadeAncoradaEmFase(fase.Id, fase.Id, ReferenciaTipoIdadeEmissao.FimFase)],
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        DateTimeOffset novoFim = new(2026, 2, 15, 0, 0, 0, TimeSpan.Zero);
+        Result resultado = processo.DefinirCronogramaFases(
+            [FaseComExtremo(1, "ANALISE", inicio: null, fim: novoFim)], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message, "o Fim continua definido — só o valor mudou, o que é uma edição legítima");
+    }
+
     // ── Story #554/issue #892 (achado Codex P2, PR #896) — CA-03 backward guard ──
 
     private static CondicaoGatilho CondicaoDe(string fato, string valor) => CondicaoGatilho.Criar(

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -166,26 +166,105 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.Error!.Code.Should().Be("FaseCronograma.ReferenciadaPorExigenciaViva");
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900, 3ª rodada): trocar a fase canônica na MESMA Ordem, SEM exigência viva referenciando-a, é aceito e reusa a linha rastreada")]
-    public void DefinirCronogramaFases_TrocaFaseCanonicaNaMesmaOrdemSemExigenciaViva_AceitaEReusaLinha()
+    [Fact(DisplayName = "Achado Codex P2 (PR #900, 4ª rodada): trocar a fase canônica na MESMA Ordem, SEM exigência viva referenciando-a, é aceito como remoção+inserção — NÃO reusa a linha (o Id muda)")]
+    public void DefinirCronogramaFases_TrocaFaseCanonicaNaMesmaOrdemSemExigenciaViva_AceitaComoRemocaoMaisInsercao()
     {
         ProcessoSeletivo processo = NovoProcesso();
         FaseCronograma fase = Fase(1, "INSCRICAO");
         processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         // Mesma Ordem (1), FaseCanonicaOrigemId DIFERENTE, e NENHUMA exigência referencia
-        // a fase antiga — o guard já provou que é seguro; a reconciliação deve adotar a
-        // linha TRACKED (retargetando-a) em vez de Add(nova) + deixar a antiga para o
-        // Clear() varrer, o que colidiria com o índice único (ProcessoSeletivoId, Ordem)
-        // no SaveChanges.
+        // a fase antiga — o guard já provou que é seguro remover a antiga. A reconciliação
+        // (Story #554/#893, PR-d, 4ª rodada) casa por FaseCanonicaOrigemId, não por Ordem:
+        // como o Id de origem mudou, é uma fase DIFERENTE ocupando o slot — a linha antiga
+        // é removida e uma nova é inserida (nunca retargeta o FaseCanonicaOrigemId de uma
+        // linha rastreada, o que causaria a dependência circular do achado da 4ª rodada).
         Guid idAntigo = fase.Id;
         Result resultado = processo.DefinirCronogramaFases([Fase(1, "ANALISE")], [], PrecondicaoIfMatch.Curinga);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
-        processo.CronogramaFases.Should().ContainSingle(
-            f => f.Id == idAntigo,
-            "sem exigência viva referenciando a fase antiga, é seguro reusar a linha rastreada em vez de forçar delete+insert no mesmo slot único");
+        processo.CronogramaFases.Should().ContainSingle(f => f.Id != idAntigo, "é uma fase canônica diferente — remoção+inserção, não reconciliação");
         processo.CronogramaFases.Single().Codigo.Should().Be("ANALISE");
+    }
+
+    [Fact(DisplayName = "Achado Codex P2 (PR #900, 4ª rodada): permutação cíclica de Ordem entre 2 fases retidas é recusada — sem ordem de UPDATE que resolva a troca")]
+    public void DefinirCronogramaFases_PermutacaoCiclicaDeOrdemEntreDuasFases_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma faseA = Fase(1, "A");
+        FaseCronograma faseB = Fase(2, "B");
+        processo.DefinirCronogramaFases([faseA, faseB], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // A assume a Ordem de B e B assume a Ordem de A — um ciclo fechado de tamanho 2.
+        Result resultado = processo.DefinirCronogramaFases(
+            [Fase(2, "A", faseA.FaseCanonicaOrigemId), Fase(1, "B", faseB.FaseCanonicaOrigemId)], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsFailure.Should().BeTrue("um ciclo fechado não tem uma ordem de UPDATE que o resolva num único SaveChanges");
+        resultado.Error!.Code.Should().Be("FaseCronograma.PermutacaoDeOrdemNaoSuportada");
+    }
+
+    [Fact(DisplayName = "Achado Codex P2 (PR #900, 4ª rodada): permutação cíclica de Ordem entre 3 fases retidas é recusada")]
+    public void DefinirCronogramaFases_PermutacaoCiclicaDeOrdemEntreTresFases_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma faseA = Fase(1, "A");
+        FaseCronograma faseB = Fase(2, "B");
+        FaseCronograma faseC = Fase(3, "C");
+        processo.DefinirCronogramaFases([faseA, faseB, faseC], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // A -> Ordem de B, B -> Ordem de C, C -> Ordem de A: ciclo de tamanho 3.
+        Result resultado = processo.DefinirCronogramaFases(
+            [
+                Fase(2, "A", faseA.FaseCanonicaOrigemId),
+                Fase(3, "B", faseB.FaseCanonicaOrigemId),
+                Fase(1, "C", faseC.FaseCanonicaOrigemId),
+            ],
+            [],
+            PrecondicaoIfMatch.Curinga);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("FaseCronograma.PermutacaoDeOrdemNaoSuportada");
+    }
+
+    [Fact(DisplayName = "Contraprova: mover uma única fase retida para uma Ordem livre (nunca usada) é aceito — não é um ciclo")]
+    public void DefinirCronogramaFases_MoveUmaFaseParaOrdemLivre_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = Fase(1, "INSCRICAO");
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Guid idAntigo = fase.Id;
+        Result resultado = processo.DefinirCronogramaFases(
+            [Fase(5, "INSCRICAO", fase.FaseCanonicaOrigemId)], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.CronogramaFases.Should().ContainSingle(f => f.Id == idAntigo, "a Ordem 5 nunca foi usada — não há ciclo, e a reconciliação por identidade preserva o Id");
+        processo.CronogramaFases.Single().Ordem.Should().Be(5);
+    }
+
+    [Fact(DisplayName = "Contraprova: inserir uma fase nova deslocando as demais (cadeia, não ciclo) é aceito")]
+    public void DefinirCronogramaFases_InsereFaseDeslocandoAsDemais_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma faseA = Fase(1, "A");
+        FaseCronograma faseB = Fase(2, "B");
+        processo.DefinirCronogramaFases([faseA, faseB], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // C é nova (Ordem 1); A desloca para 2; B desloca para 3 — uma CADEIA que termina
+        // numa Ordem livre (3), não um ciclo.
+        Result resultado = processo.DefinirCronogramaFases(
+            [
+                Fase(1, "C"),
+                Fase(2, "A", faseA.FaseCanonicaOrigemId),
+                Fase(3, "B", faseB.FaseCanonicaOrigemId),
+            ],
+            [],
+            PrecondicaoIfMatch.Curinga);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.CronogramaFases.Should().Contain(f => f.Id == faseA.Id && f.Ordem == 2);
+        processo.CronogramaFases.Should().Contain(f => f.Id == faseB.Id && f.Ordem == 3);
+        processo.CronogramaFases.Should().ContainSingle(f => f.Codigo == "C" && f.Ordem == 1);
     }
 
     [Fact(DisplayName = "CA-04: redefinir o cronograma removendo (Ordem que desaparece) uma fase referenciada por exigência viva é recusado")]

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -19,9 +19,9 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
     private static ProcessoSeletivo NovoProcesso() =>
         ProcessoSeletivo.Criar("PS Documentos Exigidos", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
 
-    private static FaseCronograma Fase(int ordem, string codigo) => FaseCronograma.Criar(
+    private static FaseCronograma Fase(int ordem, string codigo, Guid? faseCanonicaOrigemId = null) => FaseCronograma.Criar(
         ordem,
-        Guid.CreateVersion7(),
+        faseCanonicaOrigemId ?? Guid.CreateVersion7(),
         codigo,
         "CEPS",
         OrigemDataFase.Delegada,
@@ -51,9 +51,10 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
             grupoSatisfacaoId: null,
             condicoes: [], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
 
-    private static FaseCronograma FaseComComplementacao(int ordem, string codigo, bool permiteComplementacao) => FaseCronograma.Criar(
+    private static FaseCronograma FaseComComplementacao(
+        int ordem, string codigo, bool permiteComplementacao, Guid? faseCanonicaOrigemId = null) => FaseCronograma.Criar(
         ordem,
-        Guid.CreateVersion7(),
+        faseCanonicaOrigemId ?? Guid.CreateVersion7(),
         codigo,
         "CEPS",
         OrigemDataFase.Delegada,
@@ -134,15 +135,35 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         DocumentoExigido exigencia = Exigencia(fase.Id);
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
-        // Mesma Ordem (1), dados diferentes — o caso comum de uma sessão editorial que só
-        // ajusta datas: a reconciliação reusa a instância viva, preserva o Id, e a
-        // exigência continua referenciando uma fase que existe.
-        Result resultado = processo.DefinirCronogramaFases([Fase(1, "INSCRICAO_REVISADA")], [], PrecondicaoIfMatch.Curinga);
+        // Mesma Ordem (1) E mesma FaseCanonicaOrigemId — "editar a mesma fase" (o caso
+        // comum de uma sessão editorial que só ajusta datas), não "trocar qual fase ocupa
+        // o slot" (achado Codex P2, PR #900): a reconciliação reusa a instância viva,
+        // preserva o Id, e a exigência continua referenciando uma fase que existe.
+        Result resultado = processo.DefinirCronogramaFases(
+            [Fase(1, "INSCRICAO_REVISADA", fase.FaseCanonicaOrigemId)], [], PrecondicaoIfMatch.Curinga);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
         processo.CronogramaFases.Should().ContainSingle(f => f.Id == fase.Id, "a reconciliação por Ordem reusa a MESMA instância, preservando o Id");
         processo.CronogramaFases.Single().Codigo.Should().Be("INSCRICAO_REVISADA");
         exigencia.ExigidoNaFaseId.Should().Be(fase.Id, "a exigência nunca deixou de referenciar uma fase existente");
+    }
+
+    [Fact(DisplayName = "Achado Codex P2 (PR #900): trocar a fase canônica na MESMA Ordem, referenciada por exigência viva, é recusado — não retargeta o Id silenciosamente")]
+    public void DefinirCronogramaFases_TrocaFaseCanonicaNaMesmaOrdemComExigenciaViva_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        FaseCronograma fase = Fase(1, "INSCRICAO");
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        DocumentoExigido exigencia = Exigencia(fase.Id);
+        processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // Mesma Ordem (1), mas FaseCanonicaOrigemId DIFERENTE (não informado — gera um
+        // novo) — é uma fase DIFERENTE ocupando o slot, não uma edição da mesma fase.
+        Result resultado = processo.DefinirCronogramaFases([Fase(1, "ANALISE")], [], PrecondicaoIfMatch.Curinga);
+
+        resultado.IsFailure.Should().BeTrue(
+            "sem exigir também o mesmo FaseCanonicaOrigemId, o Id seria reusado e a exigência silenciosamente retargetada para a fase nova");
+        resultado.Error!.Code.Should().Be("FaseCronograma.ReferenciadaPorExigenciaViva");
     }
 
     [Fact(DisplayName = "CA-04: redefinir o cronograma removendo (Ordem que desaparece) uma fase referenciada por exigência viva é recusado")]
@@ -182,7 +203,8 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
             .IsSuccess.Should().BeTrue();
 
         Result resultado = processo.DefinirCronogramaFases(
-            [FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: false)], [], PrecondicaoIfMatch.Curinga);
+            [FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: false, fase.FaseCanonicaOrigemId)],
+            [], PrecondicaoIfMatch.Curinga);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("FaseCronograma.PendenciaReenvioExigeComplementacao");
@@ -197,7 +219,8 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         processo.DefinirDocumentosExigidos([Exigencia(fase.Id)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         Result resultado = processo.DefinirCronogramaFases(
-            [FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: false)], [], PrecondicaoIfMatch.Curinga);
+            [FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: false, fase.FaseCanonicaOrigemId)],
+            [], PrecondicaoIfMatch.Curinga);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
@@ -213,16 +236,18 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
             .IsSuccess.Should().BeTrue();
 
         Result resultado = processo.DefinirCronogramaFases(
-            [FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: true)], [], PrecondicaoIfMatch.Curinga);
+            [FaseComComplementacao(1, "ENVIO_DOCUMENTOS", permiteComplementacao: true, fase.FaseCanonicaOrigemId)],
+            [], PrecondicaoIfMatch.Curinga);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
 
     // ── Story #554/issue #893 (achado Codex P2, PR #900) — IdadeMaximaEmissao.ReferenciaFaseId ──
 
-    private static FaseCronograma FaseComExtremo(int ordem, string codigo, DateTimeOffset? inicio, DateTimeOffset? fim) => FaseCronograma.Criar(
+    private static FaseCronograma FaseComExtremo(
+        int ordem, string codigo, DateTimeOffset? inicio, DateTimeOffset? fim, Guid? faseCanonicaOrigemId = null) => FaseCronograma.Criar(
         ordem,
-        Guid.CreateVersion7(),
+        faseCanonicaOrigemId ?? Guid.CreateVersion7(),
         codigo,
         "CEPS",
         OrigemDataFase.Delegada,
@@ -287,9 +312,10 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
             [ExigenciaComIdadeAncoradaEmFase(fase.Id, fase.Id, ReferenciaTipoIdadeEmissao.FimFase)],
             PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
-        // Mesma Ordem (1) — a fase sobrevive via reconciliação, mas perde o Fim.
+        // Mesma Ordem (1) E mesma FaseCanonicaOrigemId — a fase sobrevive via
+        // reconciliação, mas perde o Fim.
         Result resultado = processo.DefinirCronogramaFases(
-            [FaseComExtremo(1, "ANALISE", inicio: null, fim: null)], [], PrecondicaoIfMatch.Curinga);
+            [FaseComExtremo(1, "ANALISE", inicio: null, fim: null, fase.FaseCanonicaOrigemId)], [], PrecondicaoIfMatch.Curinga);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseExtremoAusente");
@@ -308,7 +334,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
 
         DateTimeOffset novoFim = new(2026, 2, 15, 0, 0, 0, TimeSpan.Zero);
         Result resultado = processo.DefinirCronogramaFases(
-            [FaseComExtremo(1, "ANALISE", inicio: null, fim: novoFim)], [], PrecondicaoIfMatch.Curinga);
+            [FaseComExtremo(1, "ANALISE", inicio: null, fim: novoFim, fase.FaseCanonicaOrigemId)], [], PrecondicaoIfMatch.Curinga);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message, "o Fim continua definido — só o valor mudou, o que é uma edição legítima");
     }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoPublicarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoPublicarTests.cs
@@ -267,7 +267,7 @@ public sealed class ProcessoSeletivoPublicarTests
         obrigatorio: true,
         consequenciaIndeferimento: null,
         grupoSatisfacaoId: null,
-        condicoes: [], basesLegais: [BaseLegalResolvidaQualquer()]).Value!;
+        condicoes: [], basesLegais: [BaseLegalResolvidaQualquer()], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
 
     private static DocumentoExigido ExigenciaGeral(Guid exigidoNaFaseId) => DocumentoExigido.Criar(
         exigidoNaFaseId,
@@ -279,7 +279,7 @@ public sealed class ProcessoSeletivoPublicarTests
         obrigatorio: true,
         consequenciaIndeferimento: null,
         grupoSatisfacaoId: null,
-        condicoes: [], basesLegais: [BaseLegalResolvidaQualquer()]).Value!;
+        condicoes: [], basesLegais: [BaseLegalResolvidaQualquer()], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
 
     [Fact(DisplayName = "CA-01: publicar com exigência CONDICIONAL vazia obrigatória é bloqueado")]
     public void Publicar_CondicionalVaziaObrigatoria_Bloqueia()
@@ -338,7 +338,7 @@ public sealed class ProcessoSeletivoPublicarTests
             obrigatorio: true,
             consequenciaIndeferimento: null,
             grupoSatisfacaoId: null,
-            condicoes: [condicao], basesLegais: [BaseLegalResolvidaQualquer()]).Value!;
+            condicoes: [condicao], basesLegais: [BaseLegalResolvidaQualquer()], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
     }
 
     [Fact(DisplayName = "DefinirReferenciaTemporalFatos: fase de outro processo é recusada")]
@@ -431,7 +431,7 @@ public sealed class ProcessoSeletivoPublicarTests
         consequenciaIndeferimento: null,
         grupoSatisfacaoId: null,
         condicoes: [],
-        basesLegais: basesLegais).Value!;
+        basesLegais: basesLegais, idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
 
     [Fact(DisplayName = "CA-02: AvaliarConformidade inclui o item 'Base legal das exigências documentais'")]
     public void AvaliarConformidade_IncluiItemBaseLegal()

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRestaurarConfiguracaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRestaurarConfiguracaoTests.cs
@@ -244,7 +244,7 @@ public sealed class ProcessoSeletivoRestaurarConfiguracaoTests
             obrigatorio: true,
             consequenciaIndeferimento: null,
             grupoSatisfacaoId: null,
-            condicoes: [], basesLegais: []).Value!;
+            condicoes: [], basesLegais: [], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Curinga)
             .IsSuccess.Should().BeTrue();
         processo.DocumentosExigidos.Should().ContainSingle();

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRetificarTests.cs
@@ -378,7 +378,7 @@ public sealed class ProcessoSeletivoRetificarTests
             obrigatorio: true,
             consequenciaIndeferimento: null,
             grupoSatisfacaoId: null,
-            condicoes: [], basesLegais: [baseLegal]).Value!;
+            condicoes: [], basesLegais: [baseLegal], idadeMaximaEmissao: null, formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
         processo.DefinirDocumentosExigidos([exigencia], PrecondicaoIfMatch.Curinga)
             .IsSuccess.Should().BeTrue("mutar a configuração viva durante a sessão é permitido — só o FECHAMENTO é bloqueado pela B-01");
 

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorBaseLegalExigenciasTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ValidadorBaseLegalExigenciasTests.cs
@@ -28,7 +28,10 @@ public sealed class ValidadorBaseLegalExigenciasTests
             consequenciaIndeferimento: consequenciaIndeferimento,
             grupoSatisfacaoId: null,
             condicoes: [],
-            basesLegais: basesLegais).Value!;
+            basesLegais: basesLegais,
+            idadeMaximaEmissao: null,
+            formatoPermitido: null,
+            tamanhoMaximoBytes: null).Value!;
 
     [Fact(DisplayName = "CA-03: processo sem exigência que determina resultado é trivialmente satisfeito (semântica vazia)")]
     public void TodasResolvidas_SemExigenciaQueDeterminaResultado_RetornaTrue()

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/IdadeMaximaEmissaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/IdadeMaximaEmissaoTests.cs
@@ -1,0 +1,168 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura de <see cref="IdadeMaximaEmissao"/> (Story #554, PR-d, issue #893) — CA-08:
+/// coerência tudo-nulo OU completo, <c>DATA_SUBMISSAO</c> aceita (diferente de
+/// <see cref="ReferenciaTemporalFatos"/>, PR-b), âncoras de fase/data.
+/// </summary>
+public sealed class IdadeMaximaEmissaoTests
+{
+    private static readonly Guid FaseId = Guid.CreateVersion7();
+
+    private static readonly DateOnly Data = new(2026, 3, 1);
+
+    [Fact(DisplayName = "CA-08: tudo-nulo é aceito — regra ausente é estado válido")]
+    public void Criar_TudoNulo_Aceita()
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(null, null, null, null, null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "CA-08: completo com DATA_SUBMISSAO é aceito (contraprova da exclusão da PR-b)")]
+    public void Criar_CompletoComDataSubmissao_Aceita()
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(
+            90, UnidadeIdade.Dias, ReferenciaTipoIdadeEmissao.DataSubmissao, null, null);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBeNull();
+        resultado.Value!.Valor.Should().Be(90);
+        resultado.Value.Unidade.Should().Be(UnidadeIdade.Dias);
+        resultado.Value.ReferenciaTipo.Should().Be(ReferenciaTipoIdadeEmissao.DataSubmissao);
+    }
+
+    [Theory(DisplayName = "CA-08: parcial (algum dos 3 primeiros campos ausente) é recusado")]
+    [InlineData(true, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(false, false, true)]
+    [InlineData(true, true, false)]
+    public void Criar_Parcial_Falha(bool comValor, bool comUnidade, bool comReferenciaTipo)
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(
+            comValor ? 90 : null,
+            comUnidade ? UnidadeIdade.Dias : null,
+            comReferenciaTipo ? ReferenciaTipoIdadeEmissao.DataSubmissao : null,
+            null,
+            null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.CamposIncompletos");
+    }
+
+    [Fact(DisplayName = "Valor zero é recusado")]
+    public void Criar_ValorZero_Recusa()
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(
+            0, UnidadeIdade.Dias, ReferenciaTipoIdadeEmissao.DataSubmissao, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.ValorInvalido");
+    }
+
+    [Fact(DisplayName = "Valor negativo é recusado")]
+    public void Criar_ValorNegativo_Recusa()
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(
+            -1, UnidadeIdade.Dias, ReferenciaTipoIdadeEmissao.DataSubmissao, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.ValorInvalido");
+    }
+
+    [Fact(DisplayName = "Data ou fase presentes com os 3 primeiros campos ausentes é recusado")]
+    public void Criar_DataOuFaseComTudoAusente_Recusa()
+    {
+        IdadeMaximaEmissao.Criar(null, null, null, Data, null).IsFailure.Should().BeTrue();
+        IdadeMaximaEmissao.Criar(null, null, null, Data, null).Error!.Code.Should().Be("IdadeMaximaEmissao.CamposIncoerentesComAusencia");
+
+        IdadeMaximaEmissao.Criar(null, null, null, null, FaseId).IsFailure.Should().BeTrue();
+        IdadeMaximaEmissao.Criar(null, null, null, null, FaseId).Error!.Code.Should().Be("IdadeMaximaEmissao.CamposIncoerentesComAusencia");
+    }
+
+    [Theory(DisplayName = "CA-08: âncoras de fase exigem ReferenciaFaseId")]
+    [InlineData(ReferenciaTipoIdadeEmissao.InicioFase)]
+    [InlineData(ReferenciaTipoIdadeEmissao.FimFase)]
+    public void AncoraFaseSemExtremo_Falha(ReferenciaTipoIdadeEmissao tipo)
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(90, UnidadeIdade.Dias, tipo, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseIncoerenteComTipo");
+    }
+
+    [Theory(DisplayName = "Âncoras de fase com ReferenciaFaseId presente e sem Data são aceitas (contraprova)")]
+    [InlineData(ReferenciaTipoIdadeEmissao.InicioFase)]
+    [InlineData(ReferenciaTipoIdadeEmissao.FimFase)]
+    public void AncoraFaseComFaseId_Aceita(ReferenciaTipoIdadeEmissao tipo)
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(90, UnidadeIdade.Dias, tipo, null, FaseId);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        resultado.Value!.ReferenciaFaseId.Should().Be(FaseId);
+        resultado.Value.Data.Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Âncoras de fase com Data (além da fase) são recusadas")]
+    [InlineData(ReferenciaTipoIdadeEmissao.InicioFase)]
+    [InlineData(ReferenciaTipoIdadeEmissao.FimFase)]
+    public void AncoraFaseComDataIndevida_Recusa(ReferenciaTipoIdadeEmissao tipo)
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(90, UnidadeIdade.Dias, tipo, Data, FaseId);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.DataIncoerenteComTipo");
+    }
+
+    [Fact(DisplayName = "DATA_ESPECIFICA exige Data e proíbe fase âncora")]
+    public void DataEspecificaSemData_Recusa()
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(
+            90, UnidadeIdade.Dias, ReferenciaTipoIdadeEmissao.DataEspecifica, null, null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.DataIncoerenteComTipo");
+    }
+
+    [Fact(DisplayName = "DATA_ESPECIFICA com Data e sem fase é aceita (contraprova)")]
+    public void DataEspecificaComData_Aceita()
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(
+            90, UnidadeIdade.Dias, ReferenciaTipoIdadeEmissao.DataEspecifica, Data, null);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        resultado.Value!.Data.Should().Be(Data);
+    }
+
+    [Fact(DisplayName = "DATA_ESPECIFICA com fase (além da data) é recusada")]
+    public void DataEspecificaComFaseIndevida_Recusa()
+    {
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(
+            90, UnidadeIdade.Dias, ReferenciaTipoIdadeEmissao.DataEspecifica, Data, FaseId);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseIncoerenteComTipo");
+    }
+
+    [Theory(DisplayName = "FIM_INSCRICAO/DATA_SUBMISSAO não usam Data nem fase — ambos presentes são recusados")]
+    [InlineData(ReferenciaTipoIdadeEmissao.FimInscricao)]
+    [InlineData(ReferenciaTipoIdadeEmissao.DataSubmissao)]
+    public void FimInscricaoOuDataSubmissao_ComCampoIndevido_Recusa(ReferenciaTipoIdadeEmissao tipo)
+    {
+        IdadeMaximaEmissao.Criar(90, UnidadeIdade.Dias, tipo, Data, null).IsFailure.Should().BeTrue();
+        IdadeMaximaEmissao.Criar(90, UnidadeIdade.Dias, tipo, null, FaseId).IsFailure.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "FIM_INSCRICAO/DATA_SUBMISSAO sem Data nem fase são aceitos (contraprova)")]
+    [InlineData(ReferenciaTipoIdadeEmissao.FimInscricao)]
+    [InlineData(ReferenciaTipoIdadeEmissao.DataSubmissao)]
+    public void FimInscricaoOuDataSubmissao_SemCamposOpcionais_Aceita(ReferenciaTipoIdadeEmissao tipo) =>
+        IdadeMaximaEmissao.Criar(90, UnidadeIdade.Dias, tipo, null, null).IsSuccess.Should().BeTrue();
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/IdadeMaximaEmissaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/IdadeMaximaEmissaoTests.cs
@@ -77,6 +77,27 @@ public sealed class IdadeMaximaEmissaoTests
         resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.ValorInvalido");
     }
 
+    [Theory(DisplayName = "Achado Codex P2 (PR #900, 3ª rodada): sentinel Nenhuma em Unidade ou ReferenciaTipo, com Valor positivo, é recusado")]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void Criar_SentinelNenhuma_Recusa(bool unidadeNenhuma, bool referenciaTipoNenhuma)
+    {
+        // Este factory é a fronteira do domínio (CA1008 obriga UnidadeIdade/
+        // ReferenciaTipoIdadeEmissao a terem um membro zero, mas Nenhuma não é um valor de
+        // negócio válido aqui) — sem esta checagem, o VO ficaria "completo" sem código
+        // canônico e o ToCodigo() da projeção de leitura estouraria depois, longe da causa.
+        Result<IdadeMaximaEmissao?> resultado = IdadeMaximaEmissao.Criar(
+            90,
+            unidadeNenhuma ? UnidadeIdade.Nenhuma : UnidadeIdade.Dias,
+            referenciaTipoNenhuma ? ReferenciaTipoIdadeEmissao.Nenhuma : ReferenciaTipoIdadeEmissao.DataSubmissao,
+            null,
+            null);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.CamposIncompletos");
+    }
+
     [Fact(DisplayName = "Data ou fase presentes com os 3 primeiros campos ausentes é recusado")]
     public void Criar_DataOuFaseComTudoAusente_Recusa()
     {


### PR DESCRIPTION
## Resumo

Story #554 (UNI-REQ-0016), PR-d — quarta entrega sobre o núcleo `DocumentoExigido` (PR-a/#547, PR-b/#892, PR-c/#549).

- `IdadeMaximaEmissao`: VO tudo-nulo OU completo (`Valor`/`Unidade`/`ReferenciaTipo` juntos ou nenhum) — mesma família estrutural de `ReferenciaTemporalFatos` (PR-b), mas 1 por **exigência**, não por processo, e com `DATA_SUBMISSAO` como âncora válida (diferente da PR-b, que a exclui). Checagem eager (na escrita) de fase âncora viva + extremo definido, sem fallback silencioso.
- `FormatoPermitido`/`TamanhoMaximoBytes`: congelados na própria exigência (não no `TipoDocumento`, que segue puramente classificatório) — substituição integral por chamada.
- Aviso, não bloqueio de presença — a avaliação em runtime dessa idade fica fora de escopo desta Story.
- **CA-04 (guards backward de fase):** `DefinirCronogramaFases` passa a reconciliar por `Ordem` (mesmo padrão de `AplicarGrafo`/`FaseCronograma.AtualizarSnapshot` — reusa a instância viva em vez de recriar), tornando preciso o guard bruto herdado da PR-a (que bloqueava qualquer redefinição de cronograma enquanto existisse exigência viva). Agora só bloqueia quando uma fase é **realmente removida** (`Ordem` que desaparece) e é referenciada por exigência viva, ou quando uma fase sobrevivente perde `PermiteComplementacao` sendo referenciada por exigência com consequência `PENDENCIA_REENVIO`.

Migration nova: 7 colunas nullable em `documentos_exigidos` (sem tabela nova). GET agregado projeta os 3 campos (round-trip GET→PUT completo).

## Test plan

- [x] `dotnet build UniPlus.slnx` — 0 erros
- [x] `dotnet test` unitários (Domain 467/467, Application 187/187) — verdes
- [x] `Unifesspa.UniPlus.Selecao.ArchTests` (49/49) — verde
- [x] `Unifesspa.UniPlus.Selecao.IntegrationTests` (Testcontainers, migration real) — 417/417 verdes
- [x] Baseline OpenAPI (`contracts/openapi.selecao.json`) regenerado

Closes #893