### PR TITLE
fix(storage): registra IMinioClient interno e público como keyed

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/DependencyInjection/StorageServiceCollectionExtensions.cs
@@ -72,7 +72,18 @@ public static class StorageServiceCollectionExtensions
                 "Storage:PublicEndpoint must be host:port without scheme — control HTTPS via Storage:PublicUseSSL.")
             .ValidateOnStart();
 
-        services.AddSingleton<IMinioClient>(sp =>
+        // Ambos os clientes são registrados KEYED — inclusive o interno, que não tem
+        // motivo funcional para ser keyed sozinho. Achado de revisão (smoke test manual
+        // via Newman, Story #554): um consumidor com DOIS parâmetros de construtor do
+        // MESMO tipo (IMinioClient), um deles keyed via [FromKeyedServices] e o outro
+        // "ambient" (sem atributo, resolvido pelo registro AddSingleton<IMinioClient>
+        // não-keyed), faz o container de DI (Microsoft.Extensions.DependencyInjection)
+        // injetar a instância KEYED nos dois parâmetros — reproduzido de forma
+        // determinística (log de diagnóstico mostrou os dois campos com o mesmo
+        // GetHashCode(), sempre a instância "storage-public"). Nomear os dois registros
+        // evita a ambiguidade na raiz: nenhum consumidor injeta mais um IMinioClient
+        // "sem chave" que possa ser confundido com o keyed.
+        services.AddKeyedSingleton<IMinioClient>(StorageInternalClientKey, (sp, _) =>
         {
             StorageOptions opts = sp.GetRequiredService<IOptions<StorageOptions>>().Value;
             return BuildClient(opts, opts.Endpoint, opts.UseSSL);
@@ -93,7 +104,7 @@ public static class StorageServiceCollectionExtensions
             bool sslIgual = opts.PublicUseSSL is null || opts.PublicUseSSL == opts.UseSSL;
             if (endpointIgual && sslIgual)
             {
-                return sp.GetRequiredService<IMinioClient>();
+                return sp.GetRequiredKeyedService<IMinioClient>(StorageInternalClientKey);
             }
 
             string endpointResolvido = string.IsNullOrWhiteSpace(opts.PublicEndpoint) ? opts.Endpoint : opts.PublicEndpoint;
@@ -111,6 +122,15 @@ public static class StorageServiceCollectionExtensions
 
     /// <summary>Chave do <see cref="IMinioClient"/> keyed usado para assinar URLs devolvidas a clientes externos.</summary>
     public const string StoragePublicClientKey = "storage-public";
+
+    /// <summary>
+    /// Chave do <see cref="IMinioClient"/> keyed usado para chamadas internas (dentro da rede
+    /// Docker/cluster) — <c>Storage:Endpoint</c>. Keyed mesmo sendo o único consumidor "normal"
+    /// porque um consumidor com este e o <see cref="StoragePublicClientKey"/> como dois
+    /// parâmetros de construtor do mesmo tipo IMinioClient precisa que AMBOS sejam
+    /// inequivocamente identificados — ver a nota em <see cref="AddUniPlusStorage"/>.
+    /// </summary>
+    public const string StorageInternalClientKey = "storage-internal";
 
     [SuppressMessage(
         "Reliability",

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/HealthChecks/MinioHealthCheck.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/HealthChecks/MinioHealthCheck.cs
@@ -2,15 +2,19 @@ namespace Unifesspa.UniPlus.Infrastructure.Core.HealthChecks;
 
 using System.Diagnostics.CodeAnalysis;
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 using Minio;
+
+using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 
 public sealed class MinioHealthCheck : IHealthCheck
 {
     private readonly IMinioClient _minioClient;
 
-    public MinioHealthCheck(IMinioClient minioClient)
+    public MinioHealthCheck(
+        [FromKeyedServices(StorageServiceCollectionExtensions.StorageInternalClientKey)] IMinioClient minioClient)
     {
         _minioClient = minioClient;
     }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Storage/MinioStorageService.cs
@@ -19,7 +19,7 @@ public sealed class MinioStorageService : IStorageService
     private readonly IHttpClientFactory _httpClientFactory;
 
     public MinioStorageService(
-        IMinioClient minioClient,
+        [FromKeyedServices(StorageServiceCollectionExtensions.StorageInternalClientKey)] IMinioClient minioClient,
         [FromKeyedServices(StorageServiceCollectionExtensions.StoragePublicClientKey)] IMinioClient presignClient,
         IHttpClientFactory httpClientFactory)
     {
@@ -146,6 +146,20 @@ public sealed class MinioStorageService : IStorageService
         // _presignClient: mesma razão de GerarUrlTemporariaAsync — o upload
         // direto é feito pelo cliente externo, então a URL precisa ser
         // alcançável e assinada por ele (endpoint público).
+        //
+        // Limitação conhecida do SDK Minio (achado de revisão, smoke test manual): a URL
+        // pré-assinada resultante traz um parâmetro de query espúrio
+        // `content-type=Minio.DataModel.Args.PresignedPutObjectArgs` — o SDK (todas as
+        // versões lançadas até 7.0.0, ObjectOperations.PresignedPutObjectAsync) passa
+        // `Convert.ToString(args.GetType())` (o NOME DO TIPO .NET) onde deveria passar o
+        // metaData real; o `Content-Type` de `WithHeaders` acima nunca chega lá. Inofensivo
+        // na prática: `X-Amz-SignedHeaders=host` só assina o header `Host`, então o servidor
+        // MinIO nunca valida esse parâmetro — confirmado que o PUT funciona normalmente com
+        // o `Content-Type` real enviado pelo cliente. NÃO reescrever a URL para remover o
+        // parâmetro: ele faz parte do canonical request da assinatura SigV4 (confirmado por
+        // teste: removê-lo devolve 403 SignatureDoesNotMatch). Sem correção disponível via
+        // versão do pacote — o `master` do SDK reescreveu esse trecho por completo, mas
+        // ainda não tem release; nenhuma versão publicada (6.x/7.0.0) está livre do bug.
         return await _presignClient.PresignedPutObjectAsync(args).ConfigureAwait(false);
     }
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/StorageServiceCollectionExtensionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/DependencyInjection/StorageServiceCollectionExtensionsTests.cs
@@ -59,13 +59,13 @@ public sealed class StorageServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddUniPlusStorage_ConfigCompleta_ResolveIMinioClient()
+    public void AddUniPlusStorage_ConfigCompleta_ResolveIMinioClientInterno()
     {
         ServiceCollection services = new();
         services.AddUniPlusStorage(BuildConfig(CompleteConfig()), Env(Environments.Production));
 
         using ServiceProvider sp = services.BuildServiceProvider();
-        IMinioClient client = sp.GetRequiredService<IMinioClient>();
+        IMinioClient client = sp.GetRequiredKeyedService<IMinioClient>(StorageServiceCollectionExtensions.StorageInternalClientKey);
 
         client.Should().NotBeNull();
     }
@@ -84,16 +84,84 @@ public sealed class StorageServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void AddUniPlusStorage_IMinioClient_DeveSerSingleton()
+    public void AddUniPlusStorage_IMinioClientInterno_DeveSerSingleton()
     {
         ServiceCollection services = new();
         services.AddUniPlusStorage(BuildConfig(CompleteConfig()), Env(Environments.Production));
 
         using ServiceProvider sp = services.BuildServiceProvider();
-        IMinioClient first = sp.GetRequiredService<IMinioClient>();
-        IMinioClient second = sp.GetRequiredService<IMinioClient>();
+        IMinioClient first = sp.GetRequiredKeyedService<IMinioClient>(StorageServiceCollectionExtensions.StorageInternalClientKey);
+        IMinioClient second = sp.GetRequiredKeyedService<IMinioClient>(StorageServiceCollectionExtensions.StorageInternalClientKey);
 
         second.Should().BeSameAs(first);
+    }
+
+    /// <summary>
+    /// Achado de revisão (smoke test manual via Newman, Story #554): quando
+    /// <c>Storage:Endpoint</c> ≠ <c>Storage:PublicEndpoint</c>, <see cref="MinioStorageService"/>
+    /// tinha DOIS parâmetros de construtor do tipo <see cref="IMinioClient"/> — um "ambient"
+    /// (sem chave, resolvido pelo registro <c>AddSingleton</c> não-keyed) e um explicitamente
+    /// keyed via <c>[FromKeyedServices]</c>. O container de DI injetava a instância KEYED nos
+    /// DOIS parâmetros — reproduzido de forma determinística contra o stack real (upload de
+    /// documento do Edital falhava com <c>Connection refused</c> porque o cliente "interno"
+    /// acabava usando o endpoint público). Registrar os dois clientes como keyed (nenhum
+    /// consumidor injeta mais um <see cref="IMinioClient"/> "sem chave") elimina a ambiguidade.
+    /// Este teste prova que os dois clientes resolvidos por chave são instâncias DISTINTAS,
+    /// cada uma com o endpoint correto — a regressão apareceria como as duas instâncias
+    /// colapsando na mesma (<c>BeSameAs</c>) ou com o endpoint interno errado.
+    /// </summary>
+    [Fact]
+    public void AddUniPlusStorage_EndpointDiferenteDePublicEndpoint_ClientesInternoEPublicoSaoDistintosComEndpointCorreto()
+    {
+        Dictionary<string, string?> values = new(CompleteConfig())
+        {
+            ["Storage:PublicEndpoint"] = "localhost:9000",
+        };
+
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(values), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        IMinioClient interno = sp.GetRequiredKeyedService<IMinioClient>(StorageServiceCollectionExtensions.StorageInternalClientKey);
+        IMinioClient publico = sp.GetRequiredKeyedService<IMinioClient>(StorageServiceCollectionExtensions.StoragePublicClientKey);
+
+        publico.Should().NotBeSameAs(interno,
+            "Endpoint (minio:9000) e PublicEndpoint (localhost:9000) divergem — devem ser instâncias " +
+            "de MinioClient distintas, cada uma assinando com o próprio host");
+        interno.Config.BaseUrl.Should().Be("minio:9000",
+            "o cliente interno precisa continuar usando Storage:Endpoint mesmo quando o público existe");
+        publico.Config.BaseUrl.Should().Be("localhost:9000");
+    }
+
+    /// <summary>
+    /// Regressão direta do bug: resolve <see cref="MinioStorageService"/> por inteiro (o
+    /// consumidor real com os dois parâmetros <see cref="IMinioClient"/> no construtor) e prova
+    /// que cada campo interno aponta para o cliente com o endpoint certo — não apenas que os
+    /// dois registros keyed, isolados, estão corretos.
+    /// </summary>
+    [Fact]
+    public void AddUniPlusStorage_MinioStorageService_RecebeClienteInternoEPublicoCorretos()
+    {
+        Dictionary<string, string?> values = new(CompleteConfig())
+        {
+            ["Storage:PublicEndpoint"] = "localhost:9000",
+            ["Storage:BucketName"] = "uniplus-documentos",
+        };
+
+        ServiceCollection services = new();
+        services.AddUniPlusStorage(BuildConfig(values), Env(Environments.Production));
+
+        using ServiceProvider sp = services.BuildServiceProvider();
+        using IServiceScope scope = sp.CreateScope();
+        MinioStorageService storage = (MinioStorageService)scope.ServiceProvider.GetRequiredService<IStorageService>();
+
+        IMinioClient internoEsperado = sp.GetRequiredKeyedService<IMinioClient>(StorageServiceCollectionExtensions.StorageInternalClientKey);
+        IMinioClient publicoEsperado = sp.GetRequiredKeyedService<IMinioClient>(StorageServiceCollectionExtensions.StoragePublicClientKey);
+
+        typeof(MinioStorageService).GetField("_minioClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(storage).Should().BeSameAs(internoEsperado);
+        typeof(MinioStorageService).GetField("_presignClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(storage).Should().BeSameAs(publicoEsperado);
     }
 
     [Fact]


### PR DESCRIPTION
## Resumo

- Corrige resolução de DI ambígua entre os dois `IMinioClient` de `MinioStorageService`: quando `Storage:Endpoint` ≠ `Storage:PublicEndpoint` (cenário real de dev), o container injetava a instância **keyed** (endpoint público) no parâmetro "ambient" (sem chave) também — o cliente interno acabava tentando conectar no endpoint público, de dentro do container, onde nada escuta. Upload de documento do Edital falhava com 500 (`Connection refused`) de forma determinística.
- Registra os dois clientes como keyed (`storage-internal`/`storage-public`), eliminando a ambiguidade na raiz.
- Documenta (sem tentar corrigir — confirmado não corrigível sem reimplementar SigV4 na mão) um achado secundário do próprio SDK Minio: a URL pré-assinada de upload traz um parâmetro de query com o nome do tipo .NET em vez do `Content-Type` real. Inofensivo (fora dos headers assinados), presente em todas as versões lançadas do SDK.

Achado durante smoke test manual via Newman do módulo Seleção (Story #554, task 7.2 de verificação final) — diagnóstico completo na issue.

## Test plan

- [x] `dotnet build UniPlus.slnx` — sem erros
- [x] `dotnet test tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests` — 604/604 (3 testes novos de regressão)
- [x] `dotnet test tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests` — 26/26 (Testcontainers MinIO real)
- [x] Reproduzido o bug original contra o stack docker local, confirmado eliminado após o fix — fluxo completo de upload de Edital (`IniciarUpload` → `PUT` na URL pré-assinada → `Confirmar`) funcionando ponta a ponta com `Storage:Endpoint` ≠ `Storage:PublicEndpoint`

Closes #904